### PR TITLE
feat(s3): add Range header support for GetObject

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -368,6 +368,7 @@ public class S3Controller {
                               @HeaderParam("If-None-Match") String ifNoneMatch,
                               @HeaderParam("If-Modified-Since") String ifModifiedSince,
                               @HeaderParam("If-Unmodified-Since") String ifUnmodifiedSince,
+                              @HeaderParam("Range") String rangeHeader,
                               @Context UriInfo uriInfo,
                               @Context HttpHeaders httpHeaders) {
         try {
@@ -399,11 +400,17 @@ public class S3Controller {
                 }
             }
             S3Object obj = s3Service.getObject(bucket, key, versionId);
+
+            if (rangeHeader != null && rangeHeader.startsWith("bytes=")) {
+                return handleRangeRequest(obj, rangeHeader);
+            }
+
             var resp = Response.ok(obj.getData())
                     .header("Content-Type", obj.getContentType())
                     .header("Content-Length", obj.getSize())
                     .header("ETag", obj.getETag())
-                    .header("Last-Modified", RFC_822.format(obj.getLastModified()));
+                    .header("Last-Modified", RFC_822.format(obj.getLastModified()))
+                    .header("Accept-Ranges", "bytes");
             if (obj.getVersionId() != null) {
                 resp.header("x-amz-version-id", obj.getVersionId());
             }
@@ -412,6 +419,69 @@ public class S3Controller {
         } catch (AwsException e) {
             return xmlErrorResponse(e);
         }
+    }
+
+    private Response handleRangeRequest(S3Object obj, String rangeHeader) {
+        byte[] data = obj.getData();
+        int totalSize = data.length;
+        String rangeSpec = rangeHeader.substring("bytes=".length()).trim();
+
+        int start, end;
+        try {
+            int dash = rangeSpec.indexOf('-');
+            if (dash < 0) {
+                return invalidRangeResponse(totalSize);
+            }
+            String before = rangeSpec.substring(0, dash);
+            String after = rangeSpec.substring(dash + 1);
+            if (before.isEmpty() && after.isEmpty()) {
+                return invalidRangeResponse(totalSize);
+            }
+            if (before.isEmpty()) {
+                int suffix = Integer.parseInt(after);
+                if (suffix <= 0) {
+                    return invalidRangeResponse(totalSize);
+                }
+                start = Math.max(0, totalSize - suffix);
+                end = totalSize - 1;
+            } else {
+                start = Integer.parseInt(before);
+                end = after.isEmpty() ? totalSize - 1 : Math.min(Integer.parseInt(after), totalSize - 1);
+            }
+        } catch (NumberFormatException e) {
+            return invalidRangeResponse(totalSize);
+        }
+
+        if (start < 0 || start >= totalSize || start > end) {
+            return invalidRangeResponse(totalSize);
+        }
+
+        byte[] rangeData = java.util.Arrays.copyOfRange(data, start, end + 1);
+        return Response.status(206)
+                .entity(rangeData)
+                .header("Content-Type", obj.getContentType())
+                .header("Content-Length", rangeData.length)
+                .header("Content-Range", "bytes " + start + "-" + end + "/" + totalSize)
+                .header("ETag", obj.getETag())
+                .header("Last-Modified", RFC_822.format(obj.getLastModified()))
+                .header("Accept-Ranges", "bytes")
+                .build();
+    }
+
+    private Response invalidRangeResponse(int totalSize) {
+        String xml = new XmlBuilder()
+                .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+                .start("Error")
+                .elem("Code", "InvalidRange")
+                .elem("Message", "The requested range is not satisfiable.")
+                .elem("RequestId", java.util.UUID.randomUUID().toString())
+                .end("Error")
+                .build();
+        return Response.status(416)
+                .entity(xml)
+                .type(MediaType.APPLICATION_XML)
+                .header("Content-Range", "bytes */" + totalSize)
+                .build();
     }
 
     @HEAD
@@ -433,7 +503,8 @@ public class S3Controller {
                     .header("Content-Type", obj.getContentType())
                     .header("Content-Length", obj.getSize())
                     .header("ETag", obj.getETag())
-                    .header("Last-Modified", RFC_822.format(obj.getLastModified()));
+                    .header("Last-Modified", RFC_822.format(obj.getLastModified()))
+                    .header("Accept-Ranges", "bytes");
             if (obj.getVersionId() != null) {
                 resp.header("x-amz-version-id", obj.getVersionId());
             }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -212,6 +212,130 @@ class S3IntegrationTest {
     }
 
     @Test
+    @Order(30)
+    void getObjectWithFullRange() {
+        given()
+            .header("Range", "bytes=0-4")
+        .when()
+            .get("/test-bucket/greeting.txt")
+        .then()
+            .statusCode(206)
+            .header("Content-Range", equalTo("bytes 0-4/20"))
+            .header("Content-Length", equalTo("5"))
+            .header("Accept-Ranges", equalTo("bytes"))
+            .body(equalTo("Hello"));
+    }
+
+    @Test
+    @Order(31)
+    void getObjectWithOpenEndedRange() {
+        given()
+            .header("Range", "bytes=15-")
+        .when()
+            .get("/test-bucket/greeting.txt")
+        .then()
+            .statusCode(206)
+            .header("Content-Range", equalTo("bytes 15-19/20"))
+            .body(equalTo("m S3!"));
+    }
+
+    @Test
+    @Order(32)
+    void getObjectWithSuffixRange() {
+        given()
+            .header("Range", "bytes=-4")
+        .when()
+            .get("/test-bucket/greeting.txt")
+        .then()
+            .statusCode(206)
+            .header("Content-Range", equalTo("bytes 16-19/20"))
+            .body(equalTo(" S3!"));
+    }
+
+    @Test
+    @Order(33)
+    void getObjectWithInvalidRange() {
+        given()
+            .header("Range", "bytes=50-100")
+        .when()
+            .get("/test-bucket/greeting.txt")
+        .then()
+            .statusCode(416)
+            .header("Content-Range", equalTo("bytes */20"))
+            .body(containsString("InvalidRange"));
+    }
+
+    @Test
+    @Order(34)
+    void getObjectWithMalformedRangeNoDash() {
+        given()
+            .header("Range", "bytes=0")
+        .when()
+            .get("/test-bucket/greeting.txt")
+        .then()
+            .statusCode(416)
+            .body(containsString("InvalidRange"));
+    }
+
+    @Test
+    @Order(35)
+    void getObjectWithMalformedRangeEmptySuffix() {
+        given()
+            .header("Range", "bytes=-")
+        .when()
+            .get("/test-bucket/greeting.txt")
+        .then()
+            .statusCode(416)
+            .body(containsString("InvalidRange"));
+    }
+
+    @Test
+    @Order(36)
+    void getObjectWithMalformedRangeNonNumeric() {
+        given()
+            .header("Range", "bytes=abc-def")
+        .when()
+            .get("/test-bucket/greeting.txt")
+        .then()
+            .statusCode(416)
+            .body(containsString("InvalidRange"));
+    }
+
+    @Test
+    @Order(37)
+    void getObjectWithMalformedRangeNegativeStart() {
+        given()
+            .header("Range", "bytes=-1-4")
+        .when()
+            .get("/test-bucket/greeting.txt")
+        .then()
+            .statusCode(416)
+            .body(containsString("InvalidRange"));
+    }
+
+    @Test
+    @Order(38)
+    void getObjectWithoutRangeReturnsAcceptRanges() {
+        given()
+        .when()
+            .get("/test-bucket/greeting.txt")
+        .then()
+            .statusCode(200)
+            .header("Accept-Ranges", equalTo("bytes"));
+    }
+
+    @Test
+    @Order(39)
+    void headObjectReturnsAcceptRanges() {
+        given()
+        .when()
+            .head("/test-bucket/greeting.txt")
+        .then()
+            .statusCode(200)
+            .header("Accept-Ranges", equalTo("bytes"));
+    }
+
+    @Test
     @Order(50)
     void getObjectIfNoneMatchReturns304() {
         String eTag = given()


### PR DESCRIPTION
Implement HTTP Range header parsing for S3 GetObject requests. Supports standard range formats: bytes=start-end, bytes=start-, and bytes=-suffix. Returns 206 Partial Content with Content-Range header for valid ranges, and 416 Range Not Satisfiable for invalid ranges. Also adds Accept-Ranges: bytes to GET and HEAD responses.

Fixes #40
## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
