### PR TITLE
fix(sqs): use correct error code in SqsService if queue does not exist

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -210,10 +210,8 @@ public class SqsService {
 
     public void deleteQueue(String queueUrl, String region) {
         String storageKey = regionKey(region, queueUrl);
-        if (queueStore.get(storageKey).isEmpty()) {
-            throw new AwsException("AWS.SimpleQueueService.NonExistentQueue",
-                    "The specified queue does not exist.", 400);
-        }
+        ensureQueueExists(storageKey);
+
         queueStore.delete(storageKey);
         messagesByQueue.remove(storageKey);
         deduplicationCache.remove(storageKey);
@@ -253,10 +251,7 @@ public class SqsService {
         String accountId = regionResolver.getAccountId();
         String queueUrl = baseUrl + "/" + accountId + "/" + queueName;
         String storageKey = regionKey(region, queueUrl);
-        if (queueStore.get(storageKey).isEmpty()) {
-            throw new AwsException("AWS.SimpleQueueService.NonExistentQueue",
-                    "The specified queue does not exist for this wsdl version.", 400);
-        }
+        ensureQueueExists(storageKey);
         return queueUrl;
     }
 
@@ -266,9 +261,7 @@ public class SqsService {
 
     public Map<String, String> getQueueAttributes(String queueUrl, List<String> attributeNames, String region) {
         String storageKey = regionKey(region, queueUrl);
-        Queue queue = queueStore.get(storageKey)
-                .orElseThrow(() -> new AwsException("AWS.SimpleQueueService.NonExistentQueue",
-                        "The specified queue does not exist.", 400));
+        Queue queue = getQueueOrThrowIfMissing(storageKey);
 
         Map<String, String> attrs = new java.util.LinkedHashMap<>(queue.getAttributes());
         // Add computed attributes
@@ -321,9 +314,7 @@ public class SqsService {
                                Map<String, MessageAttributeValue> messageAttributes,
                                String region) {
         String storageKey = regionKey(region, queueUrl);
-        Queue queue = queueStore.get(storageKey)
-                .orElseThrow(() -> new AwsException("AWS.SimpleQueueService.NonExistentQueue",
-                        "The specified queue does not exist.", 400));
+        Queue queue = getQueueOrThrowIfMissing(storageKey);
 
         if (body.length() > maxMessageSize) {
             throw new AwsException("InvalidParameterValue",
@@ -437,9 +428,7 @@ public class SqsService {
     public List<Message> receiveMessage(String queueUrl, int maxMessages, int visibilityTimeout,
                                         int waitTimeSeconds, String region) {
         String storageKey = regionKey(region, queueUrl);
-        queueStore.get(storageKey)
-                .orElseThrow(() -> new AwsException("AWS.SimpleQueueService.NonExistentQueue",
-                        "The specified queue does not exist.", 400));
+        ensureQueueExists(storageKey);
 
         if (maxMessages < 1 || maxMessages > 10) {
             maxMessages = 1;
@@ -663,9 +652,7 @@ public class SqsService {
 
     public void setQueueAttributes(String queueUrl, Map<String, String> attributes, String region) {
         String storageKey = regionKey(region, queueUrl);
-        Queue queue = queueStore.get(storageKey)
-                .orElseThrow(() -> new AwsException("AWS.SimpleQueueService.NonExistentQueue",
-                        "The specified queue does not exist.", 400));
+        Queue queue = getQueueOrThrowIfMissing(storageKey);
         if (attributes != null) {
             for (Map.Entry<String, String> entry : attributes.entrySet()) {
                 if (entry.getValue() == null || entry.getValue().isEmpty()) {
@@ -747,9 +734,7 @@ public class SqsService {
 
     public void tagQueue(String queueUrl, Map<String, String> tags, String region) {
         String storageKey = regionKey(region, queueUrl);
-        Queue queue = queueStore.get(storageKey)
-                .orElseThrow(() -> new AwsException("AWS.SimpleQueueService.NonExistentQueue",
-                        "The specified queue does not exist.", 400));
+        Queue queue = getQueueOrThrowIfMissing(storageKey);
         if (tags != null) {
             queue.getTags().putAll(tags);
         }
@@ -759,9 +744,7 @@ public class SqsService {
 
     public void untagQueue(String queueUrl, List<String> tagKeys, String region) {
         String storageKey = regionKey(region, queueUrl);
-        Queue queue = queueStore.get(storageKey)
-                .orElseThrow(() -> new AwsException("AWS.SimpleQueueService.NonExistentQueue",
-                        "The specified queue does not exist.", 400));
+        Queue queue = getQueueOrThrowIfMissing(storageKey);
         if (tagKeys != null) {
             for (String key : tagKeys) {
                 queue.getTags().remove(key);
@@ -773,9 +756,7 @@ public class SqsService {
 
     public Map<String, String> listQueueTags(String queueUrl, String region) {
         String storageKey = regionKey(region, queueUrl);
-        Queue queue = queueStore.get(storageKey)
-                .orElseThrow(() -> new AwsException("AWS.SimpleQueueService.NonExistentQueue",
-                        "The specified queue does not exist.", 400));
+        Queue queue = getQueueOrThrowIfMissing(storageKey);
         return new java.util.LinkedHashMap<>(queue.getTags());
     }
 
@@ -803,10 +784,13 @@ public class SqsService {
         return queueUrl.substring(pathStart);
     }
 
+    private Queue getQueueOrThrowIfMissing(String storageKey) {
+        return queueStore.get(storageKey)
+                .orElseThrow(() -> new AwsException("QueueDoesNotExist",
+                        "The specified queue does not exist.", 400));
+    }
+
     private void ensureQueueExists(String storageKey) {
-        if (queueStore.get(storageKey).isEmpty()) {
-            throw new AwsException("AWS.SimpleQueueService.NonExistentQueue",
-                    "The specified queue does not exist.", 400);
-        }
+        getQueueOrThrowIfMissing(storageKey);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -48,14 +48,16 @@ class SqsServiceTest {
     void deleteQueue() {
         Queue queue = sqsService.createQueue("test-queue", null);
         sqsService.deleteQueue(queue.getQueueUrl());
-        assertThrows(AwsException.class, () ->
+        var ex = assertThrows(AwsException.class, () ->
                 sqsService.getQueueUrl("test-queue"));
+        assertEquals("QueueDoesNotExist", ex.getErrorCode());
     }
 
     @Test
     void deleteQueueNotFound() {
-        assertThrows(AwsException.class, () ->
+        var ex = assertThrows(AwsException.class, () ->
                 sqsService.deleteQueue(BASE_URL + "/000000000000/nonexistent"));
+        assertEquals("QueueDoesNotExist", ex.getErrorCode());
     }
 
     @Test
@@ -80,8 +82,9 @@ class SqsServiceTest {
 
     @Test
     void getQueueUrlNotFound() {
-        assertThrows(AwsException.class, () ->
+        var ex = assertThrows(AwsException.class, () ->
                 sqsService.getQueueUrl("nonexistent"));
+        assertEquals("QueueDoesNotExist", ex.getErrorCode());
     }
 
     @Test
@@ -142,8 +145,9 @@ class SqsServiceTest {
 
     @Test
     void sendMessageToNonExistentQueue() {
-        assertThrows(AwsException.class, () ->
+        var ex = assertThrows(AwsException.class, () ->
                 sqsService.sendMessage(BASE_URL + "/000000000000/nonexistent", "msg", 0));
+        assertEquals("QueueDoesNotExist", ex.getErrorCode());
     }
 
     @Test


### PR DESCRIPTION
## Summary

PR fixes the error code that is used in SqsService if a queue does not exist

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The error code for a non-existing queue is for all SQS API operations "QueueDoesNotExist". For example look here: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueUrl.html#API_GetQueueUrl_Errors

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
