### PR TITLE
feat(scheduler): add EventBridge Scheduler service

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 | EC2 (VPCs, instances, security groups) | ✅ | ⚠️ Partial |
 | Native binary | ✅ ~40 MB | ❌ |
 
-**27 services. 1,873 automated compatibility tests. Free forever.**
+**28 services. 1,873 automated compatibility tests. Free forever.**
 
 ## Architecture Overview
 
@@ -66,7 +66,7 @@ flowchart LR
         Router["HTTP Router\n(JAX-RS / Vert.x)"]
 
         subgraph Stateless ["Stateless Services"]
-            A["SSM · SQS · SNS\nIAM · STS · KMS\nSecrets Manager · SES\nCognito · Kinesis · OpenSearch\nEventBridge · CloudWatch\nStep Functions · CloudFormation\nACM · API Gateway · EC2"]
+            A["SSM · SQS · SNS\nIAM · STS · KMS\nSecrets Manager · SES\nCognito · Kinesis · OpenSearch\nEventBridge · Scheduler\nCloudWatch · Step Functions\nCloudFormation · ACM\nAPI Gateway · EC2"]
         end
 
         subgraph Stateful ["Stateful Services"]
@@ -110,6 +110,7 @@ flowchart LR
 | **Step Functions** | 11 | In-process | ASL execution, task tokens, execution history |
 | **CloudFormation** | 12 | In-process | Stacks, change sets, resource provisioning |
 | **EventBridge** | 14 | In-process | Custom buses, rules, targets (SQS / SNS / Lambda) |
+| **EventBridge Scheduler** | 9 | In-process | Schedule groups, schedules, flexible time windows, retry policies, dead-letter queues |
 | **CloudWatch Logs** | 14 | In-process | Log groups, streams, ingestion, filtering |
 | **CloudWatch Metrics** | 5 | In-process | Custom metrics, statistics, alarms |
 | **ElastiCache** | 9 | **Real Docker containers** | Redis / Valkey, IAM auth, SigV4 validation |

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -156,6 +156,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ecs</artifactId>
         </dependency>
+        <!-- EventBridge Scheduler client -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>scheduler</artifactId>
+        </dependency>
         <!-- CloudFormation client -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.services.apigatewayv2.ApiGatewayV2Client;
 import software.amazon.awssdk.services.elasticache.ElastiCacheClient;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ecs.EcsClient;
+import software.amazon.awssdk.services.scheduler.SchedulerClient;
 
 import java.net.URI;
 import java.util.UUID;
@@ -283,6 +284,14 @@ public final class TestFixtures {
 
     public static EcsClient ecsClient() {
         return EcsClient.builder()
+                .endpointOverride(ENDPOINT)
+                .region(REGION)
+                .credentialsProvider(CREDENTIALS)
+                .build();
+    }
+
+    public static SchedulerClient schedulerClient() {
+        return SchedulerClient.builder()
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
                 .credentialsProvider(CREDENTIALS)

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SchedulerTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SchedulerTest.java
@@ -6,12 +6,13 @@ import software.amazon.awssdk.services.scheduler.model.*;
 
 import static org.assertj.core.api.Assertions.*;
 
-@DisplayName("EventBridge Scheduler ScheduleGroup")
+@DisplayName("EventBridge Scheduler")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class SchedulerTest {
 
     private static SchedulerClient scheduler;
     private static final String GROUP_NAME = "test-schedule-group";
+    private static final String SCHEDULE_NAME = "test-schedule";
 
     @BeforeAll
     static void setup() {
@@ -21,6 +22,14 @@ class SchedulerTest {
     @AfterAll
     static void cleanup() {
         if (scheduler != null) {
+            try {
+                scheduler.deleteSchedule(DeleteScheduleRequest.builder()
+                        .name(SCHEDULE_NAME).build());
+            } catch (Exception ignored) {}
+            try {
+                scheduler.deleteSchedule(DeleteScheduleRequest.builder()
+                        .name("grouped-schedule").groupName(GROUP_NAME).build());
+            } catch (Exception ignored) {}
             try {
                 scheduler.deleteScheduleGroup(DeleteScheduleGroupRequest.builder()
                         .name(GROUP_NAME).build());
@@ -103,28 +112,239 @@ class SchedulerTest {
                 .isInstanceOf(ResourceNotFoundException.class);
     }
 
+    // ──────────────────────────── Schedule CRUD ────────────────────────────
+
     @Test
-    @Order(7)
-    @DisplayName("DeleteScheduleGroup - delete group")
-    void deleteScheduleGroup() {
-        scheduler.deleteScheduleGroup(DeleteScheduleGroupRequest.builder()
-                .name(GROUP_NAME)
+    @Order(10)
+    @DisplayName("CreateSchedule - create in default group")
+    void createSchedule() {
+        CreateScheduleResponse resp = scheduler.createSchedule(CreateScheduleRequest.builder()
+                .name(SCHEDULE_NAME)
+                .scheduleExpression("rate(1 hour)")
+                .flexibleTimeWindow(FlexibleTimeWindow.builder().mode(FlexibleTimeWindowMode.OFF).build())
+                .target(Target.builder()
+                        .arn("arn:aws:lambda:us-east-1:000000000000:function:my-func")
+                        .roleArn("arn:aws:iam::000000000000:role/scheduler-role")
+                        .build())
                 .build());
+
+        assertThat(resp.scheduleArn()).isNotNull().contains(SCHEDULE_NAME);
     }
 
     @Test
-    @Order(8)
-    @DisplayName("GetScheduleGroup - after delete returns NotFound or DELETING")
-    void getScheduleGroupAfterDelete() {
+    @Order(11)
+    @DisplayName("CreateSchedule - create in custom group")
+    void createScheduleInGroup() {
+        // Re-create the group (was tested above but may have been deleted)
+        try {
+            scheduler.createScheduleGroup(CreateScheduleGroupRequest.builder()
+                    .name(GROUP_NAME).build());
+        } catch (ConflictException ignored) {}
+
+        CreateScheduleResponse resp = scheduler.createSchedule(CreateScheduleRequest.builder()
+                .name("grouped-schedule")
+                .groupName(GROUP_NAME)
+                .scheduleExpression("rate(5 minutes)")
+                .flexibleTimeWindow(FlexibleTimeWindow.builder()
+                        .mode(FlexibleTimeWindowMode.FLEXIBLE)
+                        .maximumWindowInMinutes(10)
+                        .build())
+                .target(Target.builder()
+                        .arn("arn:aws:sqs:us-east-1:000000000000:my-queue")
+                        .roleArn("arn:aws:iam::000000000000:role/r")
+                        .input("{\"key\":\"value\"}")
+                        .build())
+                .state(ScheduleState.DISABLED)
+                .description("test schedule in group")
+                .build());
+
+        assertThat(resp.scheduleArn()).isNotNull().contains(GROUP_NAME);
+    }
+
+    @Test
+    @Order(12)
+    @DisplayName("CreateSchedule - duplicate returns ConflictException")
+    void createScheduleDuplicate() {
+        assertThatThrownBy(() -> scheduler.createSchedule(CreateScheduleRequest.builder()
+                .name(SCHEDULE_NAME)
+                .scheduleExpression("rate(1 hour)")
+                .flexibleTimeWindow(FlexibleTimeWindow.builder().mode(FlexibleTimeWindowMode.OFF).build())
+                .target(Target.builder().arn("arn:t").roleArn("arn:r").build())
+                .build()))
+                .isInstanceOf(ConflictException.class);
+    }
+
+    @Test
+    @Order(13)
+    @DisplayName("GetSchedule - get created schedule")
+    void getSchedule() {
+        GetScheduleResponse resp = scheduler.getSchedule(GetScheduleRequest.builder()
+                .name(SCHEDULE_NAME)
+                .build());
+
+        assertThat(resp.name()).isEqualTo(SCHEDULE_NAME);
+        assertThat(resp.groupName()).isEqualTo("default");
+        assertThat(resp.state()).isEqualTo(ScheduleState.ENABLED);
+        assertThat(resp.scheduleExpression()).isEqualTo("rate(1 hour)");
+        assertThat(resp.flexibleTimeWindow().mode()).isEqualTo(FlexibleTimeWindowMode.OFF);
+        assertThat(resp.target().arn()).contains("function:my-func");
+        assertThat(resp.creationDate()).isNotNull();
+        assertThat(resp.lastModificationDate()).isNotNull();
+    }
+
+    @Test
+    @Order(14)
+    @DisplayName("GetSchedule - in custom group")
+    void getScheduleInGroup() {
+        GetScheduleResponse resp = scheduler.getSchedule(GetScheduleRequest.builder()
+                .name("grouped-schedule")
+                .groupName(GROUP_NAME)
+                .build());
+
+        assertThat(resp.name()).isEqualTo("grouped-schedule");
+        assertThat(resp.groupName()).isEqualTo(GROUP_NAME);
+        assertThat(resp.state()).isEqualTo(ScheduleState.DISABLED);
+        assertThat(resp.description()).isEqualTo("test schedule in group");
+    }
+
+    @Test
+    @Order(15)
+    @DisplayName("GetSchedule - non-existent returns ResourceNotFoundException")
+    void getScheduleNotFound() {
+        assertThatThrownBy(() -> scheduler.getSchedule(GetScheduleRequest.builder()
+                .name("does-not-exist-schedule")
+                .build()))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    @Order(16)
+    @DisplayName("ListSchedules - default group contains schedule")
+    void listSchedules() {
+        ListSchedulesResponse resp = scheduler.listSchedules(ListSchedulesRequest.builder().build());
+
+        boolean found = resp.schedules().stream()
+                .anyMatch(s -> SCHEDULE_NAME.equals(s.name()));
+        assertThat(found).isTrue();
+    }
+
+    @Test
+    @Order(17)
+    @DisplayName("ListSchedules - filter by group")
+    void listSchedulesInGroup() {
+        ListSchedulesResponse resp = scheduler.listSchedules(ListSchedulesRequest.builder()
+                .groupName(GROUP_NAME)
+                .build());
+
+        assertThat(resp.schedules()).isNotEmpty();
+        boolean found = resp.schedules().stream()
+                .anyMatch(s -> "grouped-schedule".equals(s.name()));
+        assertThat(found).isTrue();
+        // Should NOT contain schedules from default group
+        boolean hasDefault = resp.schedules().stream()
+                .anyMatch(s -> SCHEDULE_NAME.equals(s.name()));
+        assertThat(hasDefault).isFalse();
+    }
+
+    @Test
+    @Order(18)
+    @DisplayName("UpdateSchedule - update expression and state")
+    void updateSchedule() {
+        UpdateScheduleResponse resp = scheduler.updateSchedule(UpdateScheduleRequest.builder()
+                .name(SCHEDULE_NAME)
+                .scheduleExpression("rate(30 minutes)")
+                .flexibleTimeWindow(FlexibleTimeWindow.builder()
+                        .mode(FlexibleTimeWindowMode.FLEXIBLE)
+                        .maximumWindowInMinutes(5)
+                        .build())
+                .target(Target.builder()
+                        .arn("arn:aws:lambda:us-east-1:000000000000:function:updated-func")
+                        .roleArn("arn:aws:iam::000000000000:role/updated-role")
+                        .build())
+                .state(ScheduleState.DISABLED)
+                .description("updated description")
+                .build());
+
+        assertThat(resp.scheduleArn()).isNotNull().contains(SCHEDULE_NAME);
+
+        // Verify the update
+        GetScheduleResponse get = scheduler.getSchedule(GetScheduleRequest.builder()
+                .name(SCHEDULE_NAME).build());
+        assertThat(get.scheduleExpression()).isEqualTo("rate(30 minutes)");
+        assertThat(get.state()).isEqualTo(ScheduleState.DISABLED);
+        assertThat(get.description()).isEqualTo("updated description");
+        assertThat(get.flexibleTimeWindow().mode()).isEqualTo(FlexibleTimeWindowMode.FLEXIBLE);
+        assertThat(get.flexibleTimeWindow().maximumWindowInMinutes()).isEqualTo(5);
+    }
+
+    @Test
+    @Order(19)
+    @DisplayName("UpdateSchedule - non-existent returns ResourceNotFoundException")
+    void updateScheduleNotFound() {
+        assertThatThrownBy(() -> scheduler.updateSchedule(UpdateScheduleRequest.builder()
+                .name("does-not-exist-schedule")
+                .scheduleExpression("rate(1 hour)")
+                .flexibleTimeWindow(FlexibleTimeWindow.builder().mode(FlexibleTimeWindowMode.OFF).build())
+                .target(Target.builder().arn("arn:t").roleArn("arn:r").build())
+                .build()))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    @Order(20)
+    @DisplayName("DeleteSchedule - delete schedule")
+    void deleteSchedule() {
+        scheduler.deleteSchedule(DeleteScheduleRequest.builder()
+                .name(SCHEDULE_NAME)
+                .build());
+
+        assertThatThrownBy(() -> scheduler.getSchedule(GetScheduleRequest.builder()
+                .name(SCHEDULE_NAME).build()))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    @Order(21)
+    @DisplayName("DeleteSchedule - non-existent returns ResourceNotFoundException")
+    void deleteScheduleNotFound() {
+        assertThatThrownBy(() -> scheduler.deleteSchedule(DeleteScheduleRequest.builder()
+                .name("does-not-exist-schedule")
+                .build()))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    @Order(22)
+    @DisplayName("DeleteSchedule - delete schedule in group")
+    void deleteScheduleInGroup() {
+        scheduler.deleteSchedule(DeleteScheduleRequest.builder()
+                .name("grouped-schedule")
+                .groupName(GROUP_NAME)
+                .build());
+
+        assertThatThrownBy(() -> scheduler.getSchedule(GetScheduleRequest.builder()
+                .name("grouped-schedule")
+                .groupName(GROUP_NAME)
+                .build()))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    @Order(23)
+    @DisplayName("DeleteScheduleGroup - cleanup test group")
+    void deleteScheduleGroupCleanup() {
+        scheduler.deleteScheduleGroup(DeleteScheduleGroupRequest.builder()
+                .name(GROUP_NAME)
+                .build());
+
         try {
             GetScheduleGroupResponse resp = scheduler.getScheduleGroup(
                     GetScheduleGroupRequest.builder()
                             .name(GROUP_NAME)
                             .build());
-            // AWS may briefly return the group with state=DELETING before it disappears
             assertThat(resp.state()).isEqualTo(ScheduleGroupState.DELETING);
         } catch (ResourceNotFoundException e) {
-            // Expected — group is already gone
+            // Expected
         }
     }
 }

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SchedulerTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SchedulerTest.java
@@ -1,0 +1,130 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.services.scheduler.SchedulerClient;
+import software.amazon.awssdk.services.scheduler.model.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("EventBridge Scheduler ScheduleGroup")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SchedulerTest {
+
+    private static SchedulerClient scheduler;
+    private static final String GROUP_NAME = "test-schedule-group";
+
+    @BeforeAll
+    static void setup() {
+        scheduler = TestFixtures.schedulerClient();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (scheduler != null) {
+            try {
+                scheduler.deleteScheduleGroup(DeleteScheduleGroupRequest.builder()
+                        .name(GROUP_NAME).build());
+            } catch (Exception ignored) {}
+            scheduler.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("CreateScheduleGroup - create group")
+    void createScheduleGroup() {
+        CreateScheduleGroupResponse resp = scheduler.createScheduleGroup(
+                CreateScheduleGroupRequest.builder()
+                        .name(GROUP_NAME)
+                        .build());
+
+        assertThat(resp.scheduleGroupArn()).isNotNull().contains(GROUP_NAME);
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("GetScheduleGroup - get created group")
+    void getScheduleGroup() {
+        GetScheduleGroupResponse resp = scheduler.getScheduleGroup(
+                GetScheduleGroupRequest.builder()
+                        .name(GROUP_NAME)
+                        .build());
+
+        assertThat(resp.name()).isEqualTo(GROUP_NAME);
+        assertThat(resp.arn()).isNotNull().contains(GROUP_NAME);
+        assertThat(resp.state()).isEqualTo(ScheduleGroupState.ACTIVE);
+        assertThat(resp.creationDate()).isNotNull();
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("ListScheduleGroups - created group is present")
+    void listScheduleGroupsContainsGroup() {
+        ListScheduleGroupsResponse resp = scheduler.listScheduleGroups(
+                ListScheduleGroupsRequest.builder().build());
+
+        boolean found = resp.scheduleGroups().stream()
+                .anyMatch(g -> GROUP_NAME.equals(g.name()));
+        assertThat(found).isTrue();
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("ListScheduleGroups - namePrefix filter works")
+    void listScheduleGroupsNamePrefixFilter() {
+        ListScheduleGroupsResponse resp = scheduler.listScheduleGroups(
+                ListScheduleGroupsRequest.builder()
+                        .namePrefix("test-schedule")
+                        .build());
+
+        assertThat(resp.scheduleGroups()).isNotEmpty();
+        assertThat(resp.scheduleGroups()).allMatch(g -> g.name().startsWith("test-schedule"));
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("CreateScheduleGroup - duplicate returns ConflictException")
+    void createScheduleGroupDuplicate() {
+        assertThatThrownBy(() -> scheduler.createScheduleGroup(
+                CreateScheduleGroupRequest.builder()
+                        .name(GROUP_NAME)
+                        .build()))
+                .isInstanceOf(ConflictException.class);
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("GetScheduleGroup - non-existent returns ResourceNotFoundException")
+    void getScheduleGroupNotFound() {
+        assertThatThrownBy(() -> scheduler.getScheduleGroup(
+                GetScheduleGroupRequest.builder()
+                        .name("does-not-exist-group")
+                        .build()))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("DeleteScheduleGroup - delete group")
+    void deleteScheduleGroup() {
+        scheduler.deleteScheduleGroup(DeleteScheduleGroupRequest.builder()
+                .name(GROUP_NAME)
+                .build());
+    }
+
+    @Test
+    @Order(8)
+    @DisplayName("GetScheduleGroup - after delete returns NotFound or DELETING")
+    void getScheduleGroupAfterDelete() {
+        try {
+            GetScheduleGroupResponse resp = scheduler.getScheduleGroup(
+                    GetScheduleGroupRequest.builder()
+                            .name(GROUP_NAME)
+                            .build());
+            // AWS may briefly return the group with state=DELETING before it disappears
+            assertThat(resp.state()).isEqualTo(ScheduleGroupState.DELETING);
+        } catch (ResourceNotFoundException e) {
+            // Expected — group is already gone
+        }
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SchedulerTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SchedulerTest.java
@@ -374,14 +374,10 @@ class SchedulerTest {
                 .name(GROUP_NAME)
                 .build());
 
-        try {
-            GetScheduleGroupResponse resp = scheduler.getScheduleGroup(
-                    GetScheduleGroupRequest.builder()
-                            .name(GROUP_NAME)
-                            .build());
-            assertThat(resp.state()).isEqualTo(ScheduleGroupState.DELETING);
-        } catch (ResourceNotFoundException e) {
-            // Expected
-        }
+        assertThatThrownBy(() -> scheduler.getScheduleGroup(
+                GetScheduleGroupRequest.builder()
+                        .name(GROUP_NAME)
+                        .build()))
+                .isInstanceOf(ResourceNotFoundException.class);
     }
 }

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SchedulerTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SchedulerTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.*;
 import software.amazon.awssdk.services.scheduler.SchedulerClient;
 import software.amazon.awssdk.services.scheduler.model.*;
 
+import java.time.Instant;
+
 import static org.assertj.core.api.Assertions.*;
 
 @DisplayName("EventBridge Scheduler")
@@ -29,6 +31,14 @@ class SchedulerTest {
             try {
                 scheduler.deleteSchedule(DeleteScheduleRequest.builder()
                         .name("dlc-schedule").build());
+            } catch (Exception ignored) {}
+            try {
+                scheduler.deleteSchedule(DeleteScheduleRequest.builder()
+                        .name("rp-schedule").build());
+            } catch (Exception ignored) {}
+            try {
+                scheduler.deleteSchedule(DeleteScheduleRequest.builder()
+                        .name("dated-schedule").build());
             } catch (Exception ignored) {}
             try {
                 scheduler.deleteSchedule(DeleteScheduleRequest.builder()
@@ -284,7 +294,71 @@ class SchedulerTest {
     }
 
     @Test
+    @Order(19)
+    @DisplayName("CreateSchedule - with RetryPolicy")
+    void createScheduleWithRetryPolicy() {
+        CreateScheduleResponse resp = scheduler.createSchedule(CreateScheduleRequest.builder()
+                .name("rp-schedule")
+                .scheduleExpression("rate(10 minutes)")
+                .flexibleTimeWindow(FlexibleTimeWindow.builder().mode(FlexibleTimeWindowMode.OFF).build())
+                .target(Target.builder()
+                        .arn("arn:aws:lambda:us-east-1:000000000000:function:rp-func")
+                        .roleArn("arn:aws:iam::000000000000:role/r")
+                        .retryPolicy(software.amazon.awssdk.services.scheduler.model.RetryPolicy.builder()
+                                .maximumEventAgeInSeconds(3600)
+                                .maximumRetryAttempts(5)
+                                .build())
+                        .build())
+                .build());
+
+        assertThat(resp.scheduleArn()).isNotNull().contains("rp-schedule");
+
+        GetScheduleResponse get = scheduler.getSchedule(GetScheduleRequest.builder()
+                .name("rp-schedule").build());
+        assertThat(get.target().retryPolicy()).isNotNull();
+        assertThat(get.target().retryPolicy().maximumEventAgeInSeconds()).isEqualTo(3600);
+        assertThat(get.target().retryPolicy().maximumRetryAttempts()).isEqualTo(5);
+
+        // Cleanup
+        scheduler.deleteSchedule(DeleteScheduleRequest.builder()
+                .name("rp-schedule").build());
+    }
+
+    @Test
     @Order(20)
+    @DisplayName("CreateSchedule - with StartDate and EndDate")
+    void createScheduleWithStartAndEndDate() {
+        Instant start = Instant.parse("2026-06-01T00:00:00Z");
+        Instant end = Instant.parse("2026-12-31T23:59:59Z");
+
+        CreateScheduleResponse resp = scheduler.createSchedule(CreateScheduleRequest.builder()
+                .name("dated-schedule")
+                .scheduleExpression("rate(1 hour)")
+                .flexibleTimeWindow(FlexibleTimeWindow.builder().mode(FlexibleTimeWindowMode.OFF).build())
+                .target(Target.builder()
+                        .arn("arn:aws:lambda:us-east-1:000000000000:function:dated-func")
+                        .roleArn("arn:aws:iam::000000000000:role/r")
+                        .build())
+                .startDate(start)
+                .endDate(end)
+                .build());
+
+        assertThat(resp.scheduleArn()).isNotNull().contains("dated-schedule");
+
+        GetScheduleResponse get = scheduler.getSchedule(GetScheduleRequest.builder()
+                .name("dated-schedule").build());
+        assertThat(get.startDate()).isNotNull();
+        assertThat(get.startDate().getEpochSecond()).isEqualTo(start.getEpochSecond());
+        assertThat(get.endDate()).isNotNull();
+        assertThat(get.endDate().getEpochSecond()).isEqualTo(end.getEpochSecond());
+
+        // Cleanup
+        scheduler.deleteSchedule(DeleteScheduleRequest.builder()
+                .name("dated-schedule").build());
+    }
+
+    @Test
+    @Order(21)
     @DisplayName("UpdateSchedule - update expression and state")
     void updateSchedule() {
         UpdateScheduleResponse resp = scheduler.updateSchedule(UpdateScheduleRequest.builder()
@@ -315,7 +389,7 @@ class SchedulerTest {
     }
 
     @Test
-    @Order(21)
+    @Order(22)
     @DisplayName("UpdateSchedule - non-existent returns ResourceNotFoundException")
     void updateScheduleNotFound() {
         assertThatThrownBy(() -> scheduler.updateSchedule(UpdateScheduleRequest.builder()
@@ -328,7 +402,7 @@ class SchedulerTest {
     }
 
     @Test
-    @Order(22)
+    @Order(23)
     @DisplayName("DeleteSchedule - delete schedule")
     void deleteSchedule() {
         scheduler.deleteSchedule(DeleteScheduleRequest.builder()
@@ -341,7 +415,7 @@ class SchedulerTest {
     }
 
     @Test
-    @Order(23)
+    @Order(24)
     @DisplayName("DeleteSchedule - non-existent returns ResourceNotFoundException")
     void deleteScheduleNotFound() {
         assertThatThrownBy(() -> scheduler.deleteSchedule(DeleteScheduleRequest.builder()
@@ -351,7 +425,7 @@ class SchedulerTest {
     }
 
     @Test
-    @Order(24)
+    @Order(25)
     @DisplayName("DeleteSchedule - delete schedule in group")
     void deleteScheduleInGroup() {
         scheduler.deleteSchedule(DeleteScheduleRequest.builder()
@@ -367,7 +441,7 @@ class SchedulerTest {
     }
 
     @Test
-    @Order(25)
+    @Order(26)
     @DisplayName("DeleteScheduleGroup - cleanup test group")
     void deleteScheduleGroupCleanup() {
         scheduler.deleteScheduleGroup(DeleteScheduleGroupRequest.builder()

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SchedulerTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SchedulerTest.java
@@ -219,13 +219,16 @@ class SchedulerTest {
 
     @Test
     @Order(16)
-    @DisplayName("ListSchedules - default group contains schedule")
+    @DisplayName("ListSchedules - no group returns all schedules across groups")
     void listSchedules() {
         ListSchedulesResponse resp = scheduler.listSchedules(ListSchedulesRequest.builder().build());
 
-        boolean found = resp.schedules().stream()
+        boolean foundDefault = resp.schedules().stream()
                 .anyMatch(s -> SCHEDULE_NAME.equals(s.name()));
-        assertThat(found).isTrue();
+        assertThat(foundDefault).isTrue();
+        boolean foundGrouped = resp.schedules().stream()
+                .anyMatch(s -> "grouped-schedule".equals(s.name()));
+        assertThat(foundGrouped).isTrue();
     }
 
     @Test

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SchedulerTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SchedulerTest.java
@@ -28,6 +28,10 @@ class SchedulerTest {
             } catch (Exception ignored) {}
             try {
                 scheduler.deleteSchedule(DeleteScheduleRequest.builder()
+                        .name("dlc-schedule").build());
+            } catch (Exception ignored) {}
+            try {
+                scheduler.deleteSchedule(DeleteScheduleRequest.builder()
                         .name("grouped-schedule").groupName(GROUP_NAME).build());
             } catch (Exception ignored) {}
             try {
@@ -251,6 +255,36 @@ class SchedulerTest {
 
     @Test
     @Order(18)
+    @DisplayName("CreateSchedule - with DeadLetterConfig")
+    void createScheduleWithDeadLetterConfig() {
+        CreateScheduleResponse resp = scheduler.createSchedule(CreateScheduleRequest.builder()
+                .name("dlc-schedule")
+                .scheduleExpression("rate(10 minutes)")
+                .flexibleTimeWindow(FlexibleTimeWindow.builder().mode(FlexibleTimeWindowMode.OFF).build())
+                .target(Target.builder()
+                        .arn("arn:aws:lambda:us-east-1:000000000000:function:dlc-func")
+                        .roleArn("arn:aws:iam::000000000000:role/r")
+                        .deadLetterConfig(DeadLetterConfig.builder()
+                                .arn("arn:aws:sqs:us-east-1:000000000000:my-dlq")
+                                .build())
+                        .build())
+                .build());
+
+        assertThat(resp.scheduleArn()).isNotNull().contains("dlc-schedule");
+
+        GetScheduleResponse get = scheduler.getSchedule(GetScheduleRequest.builder()
+                .name("dlc-schedule").build());
+        assertThat(get.target().deadLetterConfig()).isNotNull();
+        assertThat(get.target().deadLetterConfig().arn())
+                .isEqualTo("arn:aws:sqs:us-east-1:000000000000:my-dlq");
+
+        // Cleanup
+        scheduler.deleteSchedule(DeleteScheduleRequest.builder()
+                .name("dlc-schedule").build());
+    }
+
+    @Test
+    @Order(20)
     @DisplayName("UpdateSchedule - update expression and state")
     void updateSchedule() {
         UpdateScheduleResponse resp = scheduler.updateSchedule(UpdateScheduleRequest.builder()
@@ -281,7 +315,7 @@ class SchedulerTest {
     }
 
     @Test
-    @Order(19)
+    @Order(21)
     @DisplayName("UpdateSchedule - non-existent returns ResourceNotFoundException")
     void updateScheduleNotFound() {
         assertThatThrownBy(() -> scheduler.updateSchedule(UpdateScheduleRequest.builder()
@@ -294,7 +328,7 @@ class SchedulerTest {
     }
 
     @Test
-    @Order(20)
+    @Order(22)
     @DisplayName("DeleteSchedule - delete schedule")
     void deleteSchedule() {
         scheduler.deleteSchedule(DeleteScheduleRequest.builder()
@@ -307,7 +341,7 @@ class SchedulerTest {
     }
 
     @Test
-    @Order(21)
+    @Order(23)
     @DisplayName("DeleteSchedule - non-existent returns ResourceNotFoundException")
     void deleteScheduleNotFound() {
         assertThatThrownBy(() -> scheduler.deleteSchedule(DeleteScheduleRequest.builder()
@@ -317,7 +351,7 @@ class SchedulerTest {
     }
 
     @Test
-    @Order(22)
+    @Order(24)
     @DisplayName("DeleteSchedule - delete schedule in group")
     void deleteScheduleInGroup() {
         scheduler.deleteSchedule(DeleteScheduleRequest.builder()
@@ -333,7 +367,7 @@ class SchedulerTest {
     }
 
     @Test
-    @Order(23)
+    @Order(25)
     @DisplayName("DeleteScheduleGroup - cleanup test group")
     void deleteScheduleGroupCleanup() {
         scheduler.deleteScheduleGroup(DeleteScheduleGroupRequest.builder()

--- a/docs/configuration/docker-compose.md
+++ b/docs/configuration/docker-compose.md
@@ -2,7 +2,7 @@
 
 ## Minimal Setup
 
-For most services (SSM, SQS, SNS, S3, DynamoDB, Lambda, API Gateway, Cognito, KMS, Kinesis, Secrets Manager, CloudFormation, Step Functions, IAM, STS, EventBridge, CloudWatch) a single port is enough:
+For most services (SSM, SQS, SNS, S3, DynamoDB, Lambda, API Gateway, Cognito, KMS, Kinesis, Secrets Manager, CloudFormation, Step Functions, IAM, STS, EventBridge, Scheduler, CloudWatch) a single port is enough:
 
 ```yaml title="docker-compose.yml"
 services:

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ Floci is a fast, free, and open-source local AWS service emulator built for deve
 | ElastiCache (Redis) | Query + RESP proxy |
 | RDS (PostgreSQL / MySQL) | Query + wire proxy |
 | EventBridge | JSON 1.1 |
+| EventBridge Scheduler | REST JSON |
 | CloudWatch Logs & Metrics | JSON 1.1 / Query |
 
 ## Why Floci?

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -1,6 +1,6 @@
 # Services Overview
 
-Floci emulates 26 AWS services on a single port (`4566`). All services use the real AWS wire protocol — your existing AWS CLI commands and SDK clients work without modification.
+Floci emulates 27 AWS services on a single port (`4566`). All services use the real AWS wire protocol — your existing AWS CLI commands and SDK clients work without modification.
 
 ## Service Matrix
 
@@ -27,6 +27,7 @@ Floci emulates 26 AWS services on a single port (`4566`). All services use the r
 | [ElastiCache](elasticache.md) | `POST /` with `Action=` param + TCP proxy | Query + RESP | 8 |
 | [RDS](rds.md) | `POST /` with `Action=` param + TCP proxy | Query + wire | 13 |
 | [EventBridge](eventbridge.md) | `POST /` + `X-Amz-Target: AmazonEventBridge.*` | JSON 1.1 | 14 |
+| [EventBridge Scheduler](scheduler.md) | `/schedules/*`, `/schedule-groups/*` | REST JSON | 9 |
 | [CloudWatch Logs](cloudwatch.md) | `POST /` + `X-Amz-Target: Logs.*` | JSON 1.1 | 14 |
 | [CloudWatch Metrics](cloudwatch.md#metrics) | `POST /` with `Action=` or JSON 1.1 | Query / JSON | 8 |
 | [ACM](acm.md) | `POST /` + `X-Amz-Target: CertificateManager.*` | JSON 1.1 | 12 |

--- a/docs/services/scheduler.md
+++ b/docs/services/scheduler.md
@@ -1,0 +1,94 @@
+# EventBridge Scheduler
+
+**Protocol:** REST JSON
+**Endpoint:** `http://localhost:4566/`
+
+## Supported Actions
+
+| Action | Method | Path | Description |
+|---|---|---|---|
+| `CreateScheduleGroup` | `POST` | `/schedule-groups/{Name}` | Create a schedule group |
+| `GetScheduleGroup` | `GET` | `/schedule-groups/{Name}` | Get schedule group details |
+| `DeleteScheduleGroup` | `DELETE` | `/schedule-groups/{Name}` | Delete a schedule group and its schedules |
+| `ListScheduleGroups` | `GET` | `/schedule-groups` | List schedule groups |
+| `CreateSchedule` | `POST` | `/schedules/{Name}` | Create a schedule |
+| `GetSchedule` | `GET` | `/schedules/{Name}` | Get schedule details |
+| `UpdateSchedule` | `PUT` | `/schedules/{Name}` | Update a schedule |
+| `DeleteSchedule` | `DELETE` | `/schedules/{Name}` | Delete a schedule |
+| `ListSchedules` | `GET` | `/schedules` | List schedules |
+
+## Not Yet Supported
+
+- `TagResource` / `UntagResource` / `ListTagsForResource`
+- Schedule invocation (triggering targets on schedule)
+- `NextToken`-based pagination for List operations
+
+## Examples
+
+```bash
+export AWS_ENDPOINT=http://localhost:4566
+
+# Create a schedule group
+aws scheduler create-schedule-group \
+  --name my-group \
+  --endpoint-url $AWS_ENDPOINT
+
+# List schedule groups
+aws scheduler list-schedule-groups \
+  --endpoint-url $AWS_ENDPOINT
+
+# Create a schedule in the default group
+aws scheduler create-schedule \
+  --name my-schedule \
+  --schedule-expression "rate(1 hour)" \
+  --flexible-time-window '{"Mode":"OFF"}' \
+  --target '{
+    "Arn": "arn:aws:lambda:us-east-1:000000000000:function:my-func",
+    "RoleArn": "arn:aws:iam::000000000000:role/scheduler-role"
+  }' \
+  --endpoint-url $AWS_ENDPOINT
+
+# Create a schedule with retry policy and dead-letter queue
+aws scheduler create-schedule \
+  --name my-resilient-schedule \
+  --schedule-expression "rate(5 minutes)" \
+  --flexible-time-window '{"Mode":"FLEXIBLE","MaximumWindowInMinutes":10}' \
+  --target '{
+    "Arn": "arn:aws:sqs:us-east-1:000000000000:my-queue",
+    "RoleArn": "arn:aws:iam::000000000000:role/scheduler-role",
+    "RetryPolicy": {"MaximumEventAgeInSeconds":3600,"MaximumRetryAttempts":5},
+    "DeadLetterConfig": {"Arn":"arn:aws:sqs:us-east-1:000000000000:my-dlq"}
+  }' \
+  --endpoint-url $AWS_ENDPOINT
+
+# Get a schedule
+aws scheduler get-schedule \
+  --name my-schedule \
+  --endpoint-url $AWS_ENDPOINT
+
+# Update a schedule
+aws scheduler update-schedule \
+  --name my-schedule \
+  --schedule-expression "rate(30 minutes)" \
+  --flexible-time-window '{"Mode":"OFF"}' \
+  --target '{
+    "Arn": "arn:aws:lambda:us-east-1:000000000000:function:my-func",
+    "RoleArn": "arn:aws:iam::000000000000:role/scheduler-role"
+  }' \
+  --state DISABLED \
+  --endpoint-url $AWS_ENDPOINT
+
+# Delete a schedule
+aws scheduler delete-schedule \
+  --name my-schedule \
+  --endpoint-url $AWS_ENDPOINT
+
+# Delete a schedule group (cascades to all schedules in the group)
+aws scheduler delete-schedule-group \
+  --name my-group \
+  --endpoint-url $AWS_ENDPOINT
+```
+
+## Default Schedule Group
+
+A `default` schedule group is automatically created on first access. Schedules created without specifying a group are placed in the default group. The default group cannot be deleted.

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -178,6 +178,7 @@ public interface EmulatorConfig {
         ElastiCacheServiceConfig elasticache();
         RdsServiceConfig rds();
         EventBridgeServiceConfig eventbridge();
+        SchedulerServiceConfig scheduler();
         CloudWatchLogsServiceConfig cloudwatchlogs();
         CloudWatchMetricsServiceConfig cloudwatchmetrics();
         SecretsManagerServiceConfig secretsmanager();
@@ -282,6 +283,11 @@ public interface EmulatorConfig {
     }
 
     interface EventBridgeServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
+    }
+
+    interface SchedulerServiceConfig {
         @WithDefault("true")
         boolean enabled();
     }

--- a/src/main/java/io/github/hectorvent/floci/core/common/ServiceRegistry.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ServiceRegistry.java
@@ -38,6 +38,7 @@ public class ServiceRegistry {
             case "elasticache" -> config.services().elasticache().enabled();
             case "rds" -> config.services().rds().enabled();
             case "events" -> config.services().eventbridge().enabled();
+            case "scheduler" -> config.services().scheduler().enabled();
             case "logs" -> config.services().cloudwatchlogs().enabled();
             case "monitoring" -> config.services().cloudwatchmetrics().enabled();
             case "secretsmanager" -> config.services().secretsmanager().enabled();
@@ -69,6 +70,7 @@ public class ServiceRegistry {
         if (config.services().elasticache().enabled()) enabled.add("elasticache");
         if (config.services().rds().enabled()) enabled.add("rds");
         if (config.services().eventbridge().enabled()) enabled.add("events");
+        if (config.services().scheduler().enabled()) enabled.add("scheduler");
         if (config.services().cloudwatchlogs().enabled()) enabled.add("logs");
         if (config.services().cloudwatchmetrics().enabled()) enabled.add("monitoring");
         if (config.services().secretsmanager().enabled()) enabled.add("secretsmanager");
@@ -100,6 +102,7 @@ public class ServiceRegistry {
         services.put("elasticache", status(config.services().elasticache().enabled()));
         services.put("rds", status(config.services().rds().enabled()));
         services.put("events", status(config.services().eventbridge().enabled()));
+        services.put("scheduler", status(config.services().scheduler().enabled()));
         services.put("logs", status(config.services().cloudwatchlogs().enabled()));
         services.put("monitoring", status(config.services().cloudwatchmetrics().enabled()));
         services.put("secretsmanager", status(config.services().secretsmanager().enabled()));

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
@@ -236,10 +236,10 @@ public class SchedulerController {
         response.put("Arn", group.getArn());
         response.put("State", group.getState());
         if (group.getCreationDate() != null) {
-            response.put("CreationDate", group.getCreationDate().getEpochSecond());
+            response.put("CreationDate", toEpochDouble(group.getCreationDate()));
         }
         if (group.getLastModificationDate() != null) {
-            response.put("LastModificationDate", group.getLastModificationDate().getEpochSecond());
+            response.put("LastModificationDate", toEpochDouble(group.getLastModificationDate()));
         }
         return response;
     }
@@ -295,19 +295,19 @@ public class SchedulerController {
             r.put("ActionAfterCompletion", s.getActionAfterCompletion());
         }
         if (s.getStartDate() != null) {
-            r.put("StartDate", s.getStartDate().getEpochSecond());
+            r.put("StartDate", toEpochDouble(s.getStartDate()));
         }
         if (s.getEndDate() != null) {
-            r.put("EndDate", s.getEndDate().getEpochSecond());
+            r.put("EndDate", toEpochDouble(s.getEndDate()));
         }
         if (s.getKmsKeyArn() != null) {
             r.put("KmsKeyArn", s.getKmsKeyArn());
         }
         if (s.getCreationDate() != null) {
-            r.put("CreationDate", s.getCreationDate().getEpochSecond());
+            r.put("CreationDate", toEpochDouble(s.getCreationDate()));
         }
         if (s.getLastModificationDate() != null) {
-            r.put("LastModificationDate", s.getLastModificationDate().getEpochSecond());
+            r.put("LastModificationDate", toEpochDouble(s.getLastModificationDate()));
         }
         return r;
     }
@@ -319,10 +319,10 @@ public class SchedulerController {
         r.put("GroupName", s.getGroupName());
         r.put("State", s.getState());
         if (s.getCreationDate() != null) {
-            r.put("CreationDate", s.getCreationDate().getEpochSecond());
+            r.put("CreationDate", toEpochDouble(s.getCreationDate()));
         }
         if (s.getLastModificationDate() != null) {
-            r.put("LastModificationDate", s.getLastModificationDate().getEpochSecond());
+            r.put("LastModificationDate", toEpochDouble(s.getLastModificationDate()));
         }
         if (s.getTarget() != null) {
             Map<String, Object> t = new HashMap<>();
@@ -330,6 +330,10 @@ public class SchedulerController {
             r.put("Target", t);
         }
         return r;
+    }
+
+    private double toEpochDouble(Instant instant) {
+        return instant.getEpochSecond() + instant.getNano() / 1_000_000_000.0;
     }
 
     private String textField(JsonNode node, String field) {

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.services.scheduler.model.FlexibleTimeWindow;
 import io.github.hectorvent.floci.services.scheduler.model.RetryPolicy;
 import io.github.hectorvent.floci.services.scheduler.model.Schedule;
 import io.github.hectorvent.floci.services.scheduler.model.ScheduleGroup;
+import io.github.hectorvent.floci.services.scheduler.model.ScheduleRequest;
 import io.github.hectorvent.floci.services.scheduler.model.Target;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -126,21 +127,9 @@ public class SchedulerController {
         String region = regionResolver.resolveRegion(headers);
         try {
             JsonNode node = objectMapper.readTree(body != null ? body : "{}");
-            Schedule schedule = schedulerService.createSchedule(
-                    name,
-                    textField(node, "GroupName"),
-                    textField(node, "ScheduleExpression"),
-                    textField(node, "ScheduleExpressionTimezone"),
-                    parseFlexibleTimeWindow(node.get("FlexibleTimeWindow")),
-                    parseTarget(node.get("Target")),
-                    textField(node, "Description"),
-                    textField(node, "State"),
-                    textField(node, "ActionAfterCompletion"),
-                    instantField(node, "StartDate"),
-                    instantField(node, "EndDate"),
-                    textField(node, "KmsKeyArn"),
-                    region
-            );
+            ScheduleRequest req = parseScheduleRequest(node);
+            req.setName(name);
+            Schedule schedule = schedulerService.createSchedule(req, region);
             ObjectNode response = objectMapper.createObjectNode();
             response.put("ScheduleArn", schedule.getArn());
             return Response.ok(response).build();
@@ -173,21 +162,9 @@ public class SchedulerController {
         String region = regionResolver.resolveRegion(headers);
         try {
             JsonNode node = objectMapper.readTree(body != null ? body : "{}");
-            Schedule schedule = schedulerService.updateSchedule(
-                    name,
-                    textField(node, "GroupName"),
-                    textField(node, "ScheduleExpression"),
-                    textField(node, "ScheduleExpressionTimezone"),
-                    parseFlexibleTimeWindow(node.get("FlexibleTimeWindow")),
-                    parseTarget(node.get("Target")),
-                    textField(node, "Description"),
-                    textField(node, "State"),
-                    textField(node, "ActionAfterCompletion"),
-                    instantField(node, "StartDate"),
-                    instantField(node, "EndDate"),
-                    textField(node, "KmsKeyArn"),
-                    region
-            );
+            ScheduleRequest req = parseScheduleRequest(node);
+            req.setName(name);
+            Schedule schedule = schedulerService.updateSchedule(req, region);
             ObjectNode response = objectMapper.createObjectNode();
             response.put("ScheduleArn", schedule.getArn());
             return Response.ok(response).build();
@@ -349,6 +326,22 @@ public class SchedulerController {
             return Instant.ofEpochSecond(secs, nanos);
         }
         return null;
+    }
+
+    private ScheduleRequest parseScheduleRequest(JsonNode node) {
+        ScheduleRequest req = new ScheduleRequest();
+        req.setGroupName(textField(node, "GroupName"));
+        req.setScheduleExpression(textField(node, "ScheduleExpression"));
+        req.setScheduleExpressionTimezone(textField(node, "ScheduleExpressionTimezone"));
+        req.setFlexibleTimeWindow(parseFlexibleTimeWindow(node.get("FlexibleTimeWindow")));
+        req.setTarget(parseTarget(node.get("Target")));
+        req.setDescription(textField(node, "Description"));
+        req.setState(textField(node, "State"));
+        req.setActionAfterCompletion(textField(node, "ActionAfterCompletion"));
+        req.setStartDate(instantField(node, "StartDate"));
+        req.setEndDate(instantField(node, "EndDate"));
+        req.setKmsKeyArn(textField(node, "KmsKeyArn"));
+        return req;
     }
 
     private FlexibleTimeWindow parseFlexibleTimeWindow(JsonNode node) {

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
@@ -2,7 +2,12 @@ package io.github.hectorvent.floci.services.scheduler;
 
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.scheduler.model.FlexibleTimeWindow;
+import io.github.hectorvent.floci.services.scheduler.model.RetryPolicy;
+import io.github.hectorvent.floci.services.scheduler.model.Schedule;
 import io.github.hectorvent.floci.services.scheduler.model.ScheduleGroup;
+import io.github.hectorvent.floci.services.scheduler.model.Target;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -11,6 +16,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -21,6 +27,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -108,6 +115,118 @@ public class SchedulerController {
         return Response.ok(response).build();
     }
 
+    // ──────────────────────────── CreateSchedule ────────────────────────────
+
+    @POST
+    @Path("/schedules/{name}")
+    public Response createSchedule(@Context HttpHeaders headers,
+                                   @PathParam("name") String name,
+                                   String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode node = objectMapper.readTree(body != null ? body : "{}");
+            Schedule schedule = schedulerService.createSchedule(
+                    name,
+                    textField(node, "GroupName"),
+                    textField(node, "ScheduleExpression"),
+                    textField(node, "ScheduleExpressionTimezone"),
+                    parseFlexibleTimeWindow(node.get("FlexibleTimeWindow")),
+                    parseTarget(node.get("Target")),
+                    textField(node, "Description"),
+                    textField(node, "State"),
+                    textField(node, "ActionAfterCompletion"),
+                    instantField(node, "StartDate"),
+                    instantField(node, "EndDate"),
+                    textField(node, "KmsKeyArn"),
+                    region
+            );
+            ObjectNode response = objectMapper.createObjectNode();
+            response.put("ScheduleArn", schedule.getArn());
+            return Response.ok(response).build();
+        } catch (AwsException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AwsException("ValidationException", e.getMessage(), 400);
+        }
+    }
+
+    // ──────────────────────────── GetSchedule ────────────────────────────
+
+    @GET
+    @Path("/schedules/{name}")
+    public Response getSchedule(@Context HttpHeaders headers,
+                                @PathParam("name") String name,
+                                @QueryParam("groupName") String groupName) {
+        String region = regionResolver.resolveRegion(headers);
+        Schedule schedule = schedulerService.getSchedule(name, groupName, region);
+        return Response.ok(buildScheduleResponse(schedule)).build();
+    }
+
+    // ──────────────────────────── UpdateSchedule ────────────────────────────
+
+    @PUT
+    @Path("/schedules/{name}")
+    public Response updateSchedule(@Context HttpHeaders headers,
+                                   @PathParam("name") String name,
+                                   String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode node = objectMapper.readTree(body != null ? body : "{}");
+            Schedule schedule = schedulerService.updateSchedule(
+                    name,
+                    textField(node, "GroupName"),
+                    textField(node, "ScheduleExpression"),
+                    textField(node, "ScheduleExpressionTimezone"),
+                    parseFlexibleTimeWindow(node.get("FlexibleTimeWindow")),
+                    parseTarget(node.get("Target")),
+                    textField(node, "Description"),
+                    textField(node, "State"),
+                    textField(node, "ActionAfterCompletion"),
+                    instantField(node, "StartDate"),
+                    instantField(node, "EndDate"),
+                    textField(node, "KmsKeyArn"),
+                    region
+            );
+            ObjectNode response = objectMapper.createObjectNode();
+            response.put("ScheduleArn", schedule.getArn());
+            return Response.ok(response).build();
+        } catch (AwsException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AwsException("ValidationException", e.getMessage(), 400);
+        }
+    }
+
+    // ──────────────────────────── DeleteSchedule ────────────────────────────
+
+    @DELETE
+    @Path("/schedules/{name}")
+    public Response deleteSchedule(@Context HttpHeaders headers,
+                                   @PathParam("name") String name,
+                                   @QueryParam("groupName") String groupName) {
+        String region = regionResolver.resolveRegion(headers);
+        schedulerService.deleteSchedule(name, groupName, region);
+        return Response.ok().build();
+    }
+
+    // ──────────────────────────── ListSchedules ────────────────────────────
+
+    @GET
+    @Path("/schedules")
+    public Response listSchedules(@Context HttpHeaders headers,
+                                  @QueryParam("ScheduleGroup") String groupName,
+                                  @QueryParam("NamePrefix") String namePrefix,
+                                  @QueryParam("State") String state) {
+        String region = regionResolver.resolveRegion(headers);
+        List<Schedule> schedules = schedulerService.listSchedules(groupName, namePrefix, state, region);
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode items = response.putArray("Schedules");
+        for (Schedule schedule : schedules) {
+            items.add(objectMapper.valueToTree(buildScheduleSummary(schedule)));
+        }
+        return Response.ok(response).build();
+    }
+
     // ──────────────────────────── Helpers ────────────────────────────
 
     private Map<String, Object> buildGroupResponse(ScheduleGroup group) {
@@ -122,6 +241,144 @@ public class SchedulerController {
             response.put("LastModificationDate", group.getLastModificationDate().getEpochSecond());
         }
         return response;
+    }
+
+    private Map<String, Object> buildScheduleResponse(Schedule s) {
+        Map<String, Object> r = new HashMap<>();
+        r.put("Name", s.getName());
+        r.put("Arn", s.getArn());
+        r.put("GroupName", s.getGroupName());
+        r.put("State", s.getState());
+        r.put("ScheduleExpression", s.getScheduleExpression());
+        if (s.getScheduleExpressionTimezone() != null) {
+            r.put("ScheduleExpressionTimezone", s.getScheduleExpressionTimezone());
+        }
+        if (s.getFlexibleTimeWindow() != null) {
+            Map<String, Object> ftw = new HashMap<>();
+            ftw.put("Mode", s.getFlexibleTimeWindow().getMode());
+            if (s.getFlexibleTimeWindow().getMaximumWindowInMinutes() != null) {
+                ftw.put("MaximumWindowInMinutes", s.getFlexibleTimeWindow().getMaximumWindowInMinutes());
+            }
+            r.put("FlexibleTimeWindow", ftw);
+        }
+        if (s.getTarget() != null) {
+            Map<String, Object> t = new HashMap<>();
+            t.put("Arn", s.getTarget().getArn());
+            t.put("RoleArn", s.getTarget().getRoleArn());
+            if (s.getTarget().getInput() != null) {
+                t.put("Input", s.getTarget().getInput());
+            }
+            if (s.getTarget().getRetryPolicy() != null) {
+                Map<String, Object> rp = new HashMap<>();
+                if (s.getTarget().getRetryPolicy().getMaximumEventAgeInSeconds() != null) {
+                    rp.put("MaximumEventAgeInSeconds", s.getTarget().getRetryPolicy().getMaximumEventAgeInSeconds());
+                }
+                if (s.getTarget().getRetryPolicy().getMaximumRetryAttempts() != null) {
+                    rp.put("MaximumRetryAttempts", s.getTarget().getRetryPolicy().getMaximumRetryAttempts());
+                }
+                if (!rp.isEmpty()) {
+                    t.put("RetryPolicy", rp);
+                }
+            }
+            r.put("Target", t);
+        }
+        if (s.getDescription() != null) {
+            r.put("Description", s.getDescription());
+        }
+        if (s.getActionAfterCompletion() != null) {
+            r.put("ActionAfterCompletion", s.getActionAfterCompletion());
+        }
+        if (s.getStartDate() != null) {
+            r.put("StartDate", s.getStartDate().getEpochSecond());
+        }
+        if (s.getEndDate() != null) {
+            r.put("EndDate", s.getEndDate().getEpochSecond());
+        }
+        if (s.getKmsKeyArn() != null) {
+            r.put("KmsKeyArn", s.getKmsKeyArn());
+        }
+        if (s.getCreationDate() != null) {
+            r.put("CreationDate", s.getCreationDate().getEpochSecond());
+        }
+        if (s.getLastModificationDate() != null) {
+            r.put("LastModificationDate", s.getLastModificationDate().getEpochSecond());
+        }
+        return r;
+    }
+
+    private Map<String, Object> buildScheduleSummary(Schedule s) {
+        Map<String, Object> r = new HashMap<>();
+        r.put("Name", s.getName());
+        r.put("Arn", s.getArn());
+        r.put("GroupName", s.getGroupName());
+        r.put("State", s.getState());
+        if (s.getCreationDate() != null) {
+            r.put("CreationDate", s.getCreationDate().getEpochSecond());
+        }
+        if (s.getLastModificationDate() != null) {
+            r.put("LastModificationDate", s.getLastModificationDate().getEpochSecond());
+        }
+        if (s.getTarget() != null) {
+            Map<String, Object> t = new HashMap<>();
+            t.put("Arn", s.getTarget().getArn());
+            r.put("Target", t);
+        }
+        return r;
+    }
+
+    private String textField(JsonNode node, String field) {
+        JsonNode f = node.get(field);
+        return (f != null && !f.isNull()) ? f.asText() : null;
+    }
+
+    private Instant instantField(JsonNode node, String field) {
+        JsonNode f = node.get(field);
+        if (f != null && !f.isNull() && f.isNumber()) {
+            return Instant.ofEpochSecond(f.longValue());
+        }
+        return null;
+    }
+
+    private FlexibleTimeWindow parseFlexibleTimeWindow(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        FlexibleTimeWindow ftw = new FlexibleTimeWindow();
+        if (node.has("Mode")) {
+            ftw.setMode(node.get("Mode").asText());
+        }
+        if (node.has("MaximumWindowInMinutes") && !node.get("MaximumWindowInMinutes").isNull()) {
+            ftw.setMaximumWindowInMinutes(node.get("MaximumWindowInMinutes").asInt());
+        }
+        return ftw;
+    }
+
+    private Target parseTarget(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        Target target = new Target();
+        if (node.has("Arn")) {
+            target.setArn(node.get("Arn").asText());
+        }
+        if (node.has("RoleArn")) {
+            target.setRoleArn(node.get("RoleArn").asText());
+        }
+        if (node.has("Input") && !node.get("Input").isNull()) {
+            target.setInput(node.get("Input").asText());
+        }
+        if (node.has("RetryPolicy") && !node.get("RetryPolicy").isNull()) {
+            JsonNode rpNode = node.get("RetryPolicy");
+            RetryPolicy rp = new RetryPolicy();
+            if (rpNode.has("MaximumEventAgeInSeconds") && !rpNode.get("MaximumEventAgeInSeconds").isNull()) {
+                rp.setMaximumEventAgeInSeconds(rpNode.get("MaximumEventAgeInSeconds").asInt());
+            }
+            if (rpNode.has("MaximumRetryAttempts") && !rpNode.get("MaximumRetryAttempts").isNull()) {
+                rp.setMaximumRetryAttempts(rpNode.get("MaximumRetryAttempts").asInt());
+            }
+            target.setRetryPolicy(rp);
+        }
+        return target;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
@@ -27,8 +27,6 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import org.jboss.logging.Logger;
-
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -42,8 +40,6 @@ import java.util.Map;
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class SchedulerController {
-
-    private static final Logger LOG = Logger.getLogger(SchedulerController.class);
 
     private final SchedulerService schedulerService;
     private final RegionResolver regionResolver;

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.services.scheduler.model.Schedule;
 import io.github.hectorvent.floci.services.scheduler.model.ScheduleGroup;
 import io.github.hectorvent.floci.services.scheduler.model.ScheduleRequest;
 import io.github.hectorvent.floci.services.scheduler.model.Target;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -70,7 +71,7 @@ public class SchedulerController {
             return Response.ok(response).build();
         } catch (AwsException e) {
             throw e;
-        } catch (Exception e) {
+        } catch (JsonProcessingException e) {
             throw new AwsException("ValidationException", e.getMessage(), 400);
         }
     }
@@ -131,7 +132,7 @@ public class SchedulerController {
             return Response.ok(response).build();
         } catch (AwsException e) {
             throw e;
-        } catch (Exception e) {
+        } catch (JsonProcessingException e) {
             throw new AwsException("ValidationException", e.getMessage(), 400);
         }
     }
@@ -166,7 +167,7 @@ public class SchedulerController {
             return Response.ok(response).build();
         } catch (AwsException e) {
             throw e;
-        } catch (Exception e) {
+        } catch (JsonProcessingException e) {
             throw new AwsException("ValidationException", e.getMessage(), 400);
         }
     }
@@ -391,7 +392,7 @@ public class SchedulerController {
     }
 
     @SuppressWarnings("unchecked")
-    private Map<String, String> parseTags(String body) throws Exception {
+    private Map<String, String> parseTags(String body) throws JsonProcessingException {
         if (body == null || body.isBlank()) {
             return Map.of();
         }

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
@@ -1,0 +1,149 @@
+package io.github.hectorvent.floci.services.scheduler;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.scheduler.model.ScheduleGroup;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * AWS EventBridge Scheduler REST endpoints.
+ * Paths mirror the AWS SDK v2 SchedulerClient (e.g. {@code POST /schedule-groups/{Name}}).
+ */
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class SchedulerController {
+
+    private static final Logger LOG = Logger.getLogger(SchedulerController.class);
+
+    private final SchedulerService schedulerService;
+    private final RegionResolver regionResolver;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public SchedulerController(SchedulerService schedulerService,
+                               RegionResolver regionResolver,
+                               ObjectMapper objectMapper) {
+        this.schedulerService = schedulerService;
+        this.regionResolver = regionResolver;
+        this.objectMapper = objectMapper;
+    }
+
+    // ──────────────────────────── CreateScheduleGroup ────────────────────────────
+
+    @POST
+    @Path("/schedule-groups/{name}")
+    public Response createScheduleGroup(@Context HttpHeaders headers,
+                                        @PathParam("name") String name,
+                                        String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            Map<String, String> tags = parseTags(body);
+            ScheduleGroup group = schedulerService.createScheduleGroup(name, tags, region);
+            ObjectNode response = objectMapper.createObjectNode();
+            response.put("ScheduleGroupArn", group.getArn());
+            return Response.ok(response).build();
+        } catch (AwsException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AwsException("ValidationException", e.getMessage(), 400);
+        }
+    }
+
+    // ──────────────────────────── GetScheduleGroup ────────────────────────────
+
+    @GET
+    @Path("/schedule-groups/{name}")
+    public Response getScheduleGroup(@Context HttpHeaders headers,
+                                     @PathParam("name") String name) {
+        String region = regionResolver.resolveRegion(headers);
+        ScheduleGroup group = schedulerService.getScheduleGroup(name, region);
+        return Response.ok(buildGroupResponse(group)).build();
+    }
+
+    // ──────────────────────────── DeleteScheduleGroup ────────────────────────────
+
+    @DELETE
+    @Path("/schedule-groups/{name}")
+    public Response deleteScheduleGroup(@Context HttpHeaders headers,
+                                        @PathParam("name") String name) {
+        String region = regionResolver.resolveRegion(headers);
+        schedulerService.deleteScheduleGroup(name, region);
+        return Response.ok().build();
+    }
+
+    // ──────────────────────────── ListScheduleGroups ────────────────────────────
+
+    @GET
+    @Path("/schedule-groups")
+    public Response listScheduleGroups(@Context HttpHeaders headers,
+                                       @QueryParam("NamePrefix") String namePrefix) {
+        String region = regionResolver.resolveRegion(headers);
+        List<ScheduleGroup> groups = schedulerService.listScheduleGroups(namePrefix, region);
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode items = response.putArray("ScheduleGroups");
+        for (ScheduleGroup group : groups) {
+            items.add(objectMapper.valueToTree(buildGroupResponse(group)));
+        }
+        return Response.ok(response).build();
+    }
+
+    // ──────────────────────────── Helpers ────────────────────────────
+
+    private Map<String, Object> buildGroupResponse(ScheduleGroup group) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("Name", group.getName());
+        response.put("Arn", group.getArn());
+        response.put("State", group.getState());
+        if (group.getCreationDate() != null) {
+            response.put("CreationDate", group.getCreationDate().getEpochSecond());
+        }
+        if (group.getLastModificationDate() != null) {
+            response.put("LastModificationDate", group.getLastModificationDate().getEpochSecond());
+        }
+        return response;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> parseTags(String body) throws Exception {
+        if (body == null || body.isBlank()) {
+            return Map.of();
+        }
+        Map<String, Object> parsed = objectMapper.readValue(body, Map.class);
+        Object tagsObj = parsed.get("Tags");
+        if (!(tagsObj instanceof List<?> tagList)) {
+            return Map.of();
+        }
+        Map<String, String> tags = new HashMap<>();
+        for (Object entry : tagList) {
+            if (entry instanceof Map<?, ?> tagMap) {
+                Object key = tagMap.get("Key");
+                Object value = tagMap.get("Value");
+                if (key != null && value != null) {
+                    tags.put(key.toString(), value.toString());
+                }
+            }
+        }
+        return tags;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
@@ -344,7 +344,9 @@ public class SchedulerController {
     private Instant instantField(JsonNode node, String field) {
         JsonNode f = node.get(field);
         if (f != null && !f.isNull() && f.isNumber()) {
-            return Instant.ofEpochSecond(f.longValue());
+            long secs = f.longValue();
+            long nanos = (long) ((f.doubleValue() - secs) * 1_000_000_000);
+            return Instant.ofEpochSecond(secs, nanos);
         }
         return null;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
@@ -318,9 +318,8 @@ public class SchedulerController {
     private Instant instantField(JsonNode node, String field) {
         JsonNode f = node.get(field);
         if (f != null && !f.isNull() && f.isNumber()) {
-            long secs = f.longValue();
-            long nanos = (long) ((f.doubleValue() - secs) * 1_000_000_000);
-            return Instant.ofEpochSecond(secs, nanos);
+            long millis = Math.round(f.doubleValue() * 1_000);
+            return Instant.ofEpochMilli(millis);
         }
         return null;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.scheduler;
 
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.scheduler.model.DeadLetterConfig;
 import io.github.hectorvent.floci.services.scheduler.model.FlexibleTimeWindow;
 import io.github.hectorvent.floci.services.scheduler.model.RetryPolicy;
 import io.github.hectorvent.floci.services.scheduler.model.Schedule;
@@ -280,6 +281,11 @@ public class SchedulerController {
                     t.put("RetryPolicy", rp);
                 }
             }
+            if (s.getTarget().getDeadLetterConfig() != null) {
+                Map<String, Object> dlc = new HashMap<>();
+                dlc.put("Arn", s.getTarget().getDeadLetterConfig().getArn());
+                t.put("DeadLetterConfig", dlc);
+            }
             r.put("Target", t);
         }
         if (s.getDescription() != null) {
@@ -377,6 +383,14 @@ public class SchedulerController {
                 rp.setMaximumRetryAttempts(rpNode.get("MaximumRetryAttempts").asInt());
             }
             target.setRetryPolicy(rp);
+        }
+        if (node.has("DeadLetterConfig") && !node.get("DeadLetterConfig").isNull()) {
+            JsonNode dlcNode = node.get("DeadLetterConfig");
+            DeadLetterConfig dlc = new DeadLetterConfig();
+            if (dlcNode.has("Arn") && !dlcNode.get("Arn").isNull()) {
+                dlc.setArn(dlcNode.get("Arn").asText());
+            }
+            target.setDeadLetterConfig(dlc);
         }
         return target;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
@@ -115,8 +115,17 @@ public class SchedulerService {
         groupStore.get(key)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
                         "ScheduleGroup not found: " + name, 404));
+
+        // Cascade-delete all schedules in this group (matches AWS behavior)
+        String schedulePrefix = "schedule:" + region + ":" + name + ":";
+        List<String> orphanKeys = scheduleStore.scan(k -> k.startsWith(schedulePrefix))
+                .stream()
+                .map(s -> scheduleKey(region, name, s.getName()))
+                .toList();
+        orphanKeys.forEach(scheduleStore::delete);
+
         groupStore.delete(key);
-        LOG.infov("Deleted schedule group: {0}", name);
+        LOG.infov("Deleted schedule group: {0} (removed {1} schedules)", name, orphanKeys.size());
     }
 
     public java.util.List<ScheduleGroup> listScheduleGroups(String namePrefix, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
@@ -284,6 +284,26 @@ public class SchedulerService {
             throw new AwsException("ValidationException",
                     "1 validation error detected: Value null at 'flexibleTimeWindow' failed to satisfy constraint: Member must not be null", 400);
         }
+        String flexibleTimeWindowMode = req.getFlexibleTimeWindow().getMode();
+        if (flexibleTimeWindowMode == null || flexibleTimeWindowMode.isBlank()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value null at 'flexibleTimeWindow.mode' failed to satisfy constraint: Member must not be null", 400);
+        }
+        flexibleTimeWindowMode = flexibleTimeWindowMode.trim();
+        if (!"OFF".equals(flexibleTimeWindowMode) && !"FLEXIBLE".equals(flexibleTimeWindowMode)) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '" + flexibleTimeWindowMode + "' at 'flexibleTimeWindow.mode' failed to satisfy constraint: Member must satisfy enum value set: [OFF, FLEXIBLE]", 400);
+        }
+        if ("FLEXIBLE".equals(flexibleTimeWindowMode)
+                && req.getFlexibleTimeWindow().getMaximumWindowInMinutes() == null) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value null at 'flexibleTimeWindow.maximumWindowInMinutes' failed to satisfy constraint: Member must not be null", 400);
+        }
+        if ("OFF".equals(flexibleTimeWindowMode)
+                && req.getFlexibleTimeWindow().getMaximumWindowInMinutes() != null) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value at 'flexibleTimeWindow.maximumWindowInMinutes' failed to satisfy constraint: Member must be null when flexibleTimeWindow.mode is OFF", 400);
+        }
         if (req.getTarget() == null) {
             throw new AwsException("ValidationException",
                     "1 validation error detected: Value null at 'target' failed to satisfy constraint: Member must not be null", 400);
@@ -295,6 +315,12 @@ public class SchedulerService {
         if (req.getTarget().getRoleArn() == null || req.getTarget().getRoleArn().isBlank()) {
             throw new AwsException("ValidationException",
                     "1 validation error detected: Value null at 'target.roleArn' failed to satisfy constraint: Member must not be null", 400);
+        }
+        if (req.getTarget().getDeadLetterConfig() != null
+                && (req.getTarget().getDeadLetterConfig().getArn() == null
+                || req.getTarget().getDeadLetterConfig().getArn().isBlank())) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value null at 'target.deadLetterConfig.arn' failed to satisfy constraint: Member must not be null", 400);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.scheduler.model.Schedule;
 import io.github.hectorvent.floci.services.scheduler.model.ScheduleGroup;
 import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -11,6 +12,7 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -24,6 +26,7 @@ public class SchedulerService {
     private static final String DEFAULT_GROUP = "default";
 
     private final StorageBackend<String, ScheduleGroup> groupStore;
+    private final StorageBackend<String, Schedule> scheduleStore;
     private final RegionResolver regionResolver;
 
     @Inject
@@ -31,12 +34,17 @@ public class SchedulerService {
         this(
                 storageFactory.create("scheduler", "scheduler-groups.json",
                         new TypeReference<Map<String, ScheduleGroup>>() {}),
+                storageFactory.create("scheduler", "scheduler-schedules.json",
+                        new TypeReference<Map<String, Schedule>>() {}),
                 regionResolver
         );
     }
 
-    SchedulerService(StorageBackend<String, ScheduleGroup> groupStore, RegionResolver regionResolver) {
+    SchedulerService(StorageBackend<String, ScheduleGroup> groupStore,
+                     StorageBackend<String, Schedule> scheduleStore,
+                     RegionResolver regionResolver) {
         this.groupStore = groupStore;
+        this.scheduleStore = scheduleStore;
         this.regionResolver = regionResolver;
     }
 
@@ -126,6 +134,130 @@ public class SchedulerService {
         });
     }
 
+    // ──────────────────────────── Schedules ────────────────────────────
+
+    public Schedule createSchedule(String name, String groupName, String scheduleExpression,
+                                   String scheduleExpressionTimezone,
+                                   io.github.hectorvent.floci.services.scheduler.model.FlexibleTimeWindow flexibleTimeWindow,
+                                   io.github.hectorvent.floci.services.scheduler.model.Target target,
+                                   String description, String state, String actionAfterCompletion,
+                                   Instant startDate, Instant endDate, String kmsKeyArn,
+                                   String region) {
+        validateName(name);
+        String effectiveGroup = (groupName == null || groupName.isBlank()) ? DEFAULT_GROUP : groupName;
+        getScheduleGroup(effectiveGroup, region); // verify group exists
+
+        String key = scheduleKey(region, effectiveGroup, name);
+        if (scheduleStore.get(key).isPresent()) {
+            throw new AwsException("ConflictException",
+                    "Schedule already exists: " + name, 409);
+        }
+
+        Instant now = Instant.now();
+        Schedule schedule = new Schedule();
+        schedule.setName(name);
+        schedule.setArn(buildScheduleArn(region, effectiveGroup, name));
+        schedule.setGroupName(effectiveGroup);
+        schedule.setState(state != null ? state : "ENABLED");
+        schedule.setScheduleExpression(scheduleExpression);
+        schedule.setScheduleExpressionTimezone(scheduleExpressionTimezone);
+        schedule.setFlexibleTimeWindow(flexibleTimeWindow);
+        schedule.setTarget(target);
+        schedule.setDescription(description);
+        schedule.setActionAfterCompletion(actionAfterCompletion);
+        schedule.setStartDate(startDate);
+        schedule.setEndDate(endDate);
+        schedule.setKmsKeyArn(kmsKeyArn);
+        schedule.setCreationDate(now);
+        schedule.setLastModificationDate(now);
+
+        scheduleStore.put(key, schedule);
+        LOG.infov("Created schedule: {0} in group {1}, region {2}", name, effectiveGroup, region);
+        return schedule;
+    }
+
+    public Schedule getSchedule(String name, String groupName, String region) {
+        if (name == null || name.isBlank()) {
+            throw new AwsException("ValidationException", "Name is required.", 400);
+        }
+        String effectiveGroup = (groupName == null || groupName.isBlank()) ? DEFAULT_GROUP : groupName;
+        return scheduleStore.get(scheduleKey(region, effectiveGroup, name))
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "Schedule not found: " + name, 404));
+    }
+
+    public Schedule updateSchedule(String name, String groupName, String scheduleExpression,
+                                   String scheduleExpressionTimezone,
+                                   io.github.hectorvent.floci.services.scheduler.model.FlexibleTimeWindow flexibleTimeWindow,
+                                   io.github.hectorvent.floci.services.scheduler.model.Target target,
+                                   String description, String state, String actionAfterCompletion,
+                                   Instant startDate, Instant endDate, String kmsKeyArn,
+                                   String region) {
+        if (name == null || name.isBlank()) {
+            throw new AwsException("ValidationException", "Name is required.", 400);
+        }
+        String effectiveGroup = (groupName == null || groupName.isBlank()) ? DEFAULT_GROUP : groupName;
+        String key = scheduleKey(region, effectiveGroup, name);
+        Schedule existing = scheduleStore.get(key)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "Schedule not found: " + name, 404));
+
+        Instant now = Instant.now();
+        Schedule updated = new Schedule();
+        updated.setName(name);
+        updated.setArn(existing.getArn());
+        updated.setGroupName(effectiveGroup);
+        updated.setState(state != null ? state : "ENABLED");
+        updated.setScheduleExpression(scheduleExpression);
+        updated.setScheduleExpressionTimezone(scheduleExpressionTimezone);
+        updated.setFlexibleTimeWindow(flexibleTimeWindow);
+        updated.setTarget(target);
+        updated.setDescription(description);
+        updated.setActionAfterCompletion(actionAfterCompletion);
+        updated.setStartDate(startDate);
+        updated.setEndDate(endDate);
+        updated.setKmsKeyArn(kmsKeyArn);
+        updated.setCreationDate(existing.getCreationDate());
+        updated.setLastModificationDate(now);
+
+        scheduleStore.put(key, updated);
+        LOG.infov("Updated schedule: {0} in group {1}", name, effectiveGroup);
+        return updated;
+    }
+
+    public void deleteSchedule(String name, String groupName, String region) {
+        if (name == null || name.isBlank()) {
+            throw new AwsException("ValidationException", "Name is required.", 400);
+        }
+        String effectiveGroup = (groupName == null || groupName.isBlank()) ? DEFAULT_GROUP : groupName;
+        String key = scheduleKey(region, effectiveGroup, name);
+        scheduleStore.get(key)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "Schedule not found: " + name, 404));
+        scheduleStore.delete(key);
+        LOG.infov("Deleted schedule: {0} in group {1}", name, effectiveGroup);
+    }
+
+    public List<Schedule> listSchedules(String groupName, String namePrefix, String state, String region) {
+        String effectiveGroup = (groupName == null || groupName.isBlank()) ? DEFAULT_GROUP : groupName;
+        String storagePrefix = "schedule:" + region + ":" + effectiveGroup + ":";
+        return scheduleStore.scan(k -> {
+            if (!k.startsWith(storagePrefix)) {
+                return false;
+            }
+            String scheduleName = k.substring(storagePrefix.length());
+            if (namePrefix != null && !namePrefix.isBlank() && !scheduleName.startsWith(namePrefix)) {
+                return false;
+            }
+            return true;
+        }).stream().filter(s -> {
+            if (state != null && !state.isBlank()) {
+                return state.equals(s.getState());
+            }
+            return true;
+        }).toList();
+    }
+
     // ──────────────────────────── Helpers ────────────────────────────
 
     private void validateName(String name) {
@@ -144,5 +276,13 @@ public class SchedulerService {
 
     private static String groupKey(String region, String name) {
         return "group:" + region + ":" + name;
+    }
+
+    private String buildScheduleArn(String region, String groupName, String name) {
+        return regionResolver.buildArn("scheduler", region, "schedule/" + groupName + "/" + name);
+    }
+
+    private static String scheduleKey(String region, String groupName, String name) {
+        return "schedule:" + region + ":" + groupName + ":" + name;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
@@ -4,10 +4,9 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
-import io.github.hectorvent.floci.services.scheduler.model.FlexibleTimeWindow;
 import io.github.hectorvent.floci.services.scheduler.model.Schedule;
 import io.github.hectorvent.floci.services.scheduler.model.ScheduleGroup;
-import io.github.hectorvent.floci.services.scheduler.model.Target;
+import io.github.hectorvent.floci.services.scheduler.model.ScheduleRequest;
 import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -147,43 +146,38 @@ public class SchedulerService {
 
     // ──────────────────────────── Schedules ────────────────────────────
 
-    public Schedule createSchedule(String name, String groupName, String scheduleExpression,
-                                   String scheduleExpressionTimezone,
-                                   FlexibleTimeWindow flexibleTimeWindow,
-                                   Target target,
-                                   String description, String state, String actionAfterCompletion,
-                                   Instant startDate, Instant endDate, String kmsKeyArn,
-                                   String region) {
-        validateName(name);
-        String effectiveGroup = (groupName == null || groupName.isBlank()) ? DEFAULT_GROUP : groupName;
+    public Schedule createSchedule(ScheduleRequest req, String region) {
+        validateName(req.getName());
+        String effectiveGroup = (req.getGroupName() == null || req.getGroupName().isBlank())
+                ? DEFAULT_GROUP : req.getGroupName();
         getScheduleGroup(effectiveGroup, region); // verify group exists
 
-        String key = scheduleKey(region, effectiveGroup, name);
+        String key = scheduleKey(region, effectiveGroup, req.getName());
         if (scheduleStore.get(key).isPresent()) {
             throw new AwsException("ConflictException",
-                    "Schedule already exists: " + name, 409);
+                    "Schedule already exists: " + req.getName(), 409);
         }
 
         Instant now = Instant.now();
         Schedule schedule = new Schedule();
-        schedule.setName(name);
-        schedule.setArn(buildScheduleArn(region, effectiveGroup, name));
+        schedule.setName(req.getName());
+        schedule.setArn(buildScheduleArn(region, effectiveGroup, req.getName()));
         schedule.setGroupName(effectiveGroup);
-        schedule.setState(state != null ? state : "ENABLED");
-        schedule.setScheduleExpression(scheduleExpression);
-        schedule.setScheduleExpressionTimezone(scheduleExpressionTimezone);
-        schedule.setFlexibleTimeWindow(flexibleTimeWindow);
-        schedule.setTarget(target);
-        schedule.setDescription(description);
-        schedule.setActionAfterCompletion(actionAfterCompletion);
-        schedule.setStartDate(startDate);
-        schedule.setEndDate(endDate);
-        schedule.setKmsKeyArn(kmsKeyArn);
+        schedule.setState(req.getState() != null ? req.getState() : "ENABLED");
+        schedule.setScheduleExpression(req.getScheduleExpression());
+        schedule.setScheduleExpressionTimezone(req.getScheduleExpressionTimezone());
+        schedule.setFlexibleTimeWindow(req.getFlexibleTimeWindow());
+        schedule.setTarget(req.getTarget());
+        schedule.setDescription(req.getDescription());
+        schedule.setActionAfterCompletion(req.getActionAfterCompletion());
+        schedule.setStartDate(req.getStartDate());
+        schedule.setEndDate(req.getEndDate());
+        schedule.setKmsKeyArn(req.getKmsKeyArn());
         schedule.setCreationDate(now);
         schedule.setLastModificationDate(now);
 
         scheduleStore.put(key, schedule);
-        LOG.infov("Created schedule: {0} in group {1}, region {2}", name, effectiveGroup, region);
+        LOG.infov("Created schedule: {0} in group {1}, region {2}", req.getName(), effectiveGroup, region);
         return schedule;
     }
 
@@ -197,42 +191,37 @@ public class SchedulerService {
                         "Schedule not found: " + name, 404));
     }
 
-    public Schedule updateSchedule(String name, String groupName, String scheduleExpression,
-                                   String scheduleExpressionTimezone,
-                                   FlexibleTimeWindow flexibleTimeWindow,
-                                   Target target,
-                                   String description, String state, String actionAfterCompletion,
-                                   Instant startDate, Instant endDate, String kmsKeyArn,
-                                   String region) {
-        if (name == null || name.isBlank()) {
+    public Schedule updateSchedule(ScheduleRequest req, String region) {
+        if (req.getName() == null || req.getName().isBlank()) {
             throw new AwsException("ValidationException", "Name is required.", 400);
         }
-        String effectiveGroup = (groupName == null || groupName.isBlank()) ? DEFAULT_GROUP : groupName;
-        String key = scheduleKey(region, effectiveGroup, name);
+        String effectiveGroup = (req.getGroupName() == null || req.getGroupName().isBlank())
+                ? DEFAULT_GROUP : req.getGroupName();
+        String key = scheduleKey(region, effectiveGroup, req.getName());
         Schedule existing = scheduleStore.get(key)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "Schedule not found: " + name, 404));
+                        "Schedule not found: " + req.getName(), 404));
 
         Instant now = Instant.now();
         Schedule updated = new Schedule();
-        updated.setName(name);
+        updated.setName(req.getName());
         updated.setArn(existing.getArn());
         updated.setGroupName(effectiveGroup);
-        updated.setState(state != null ? state : "ENABLED");
-        updated.setScheduleExpression(scheduleExpression);
-        updated.setScheduleExpressionTimezone(scheduleExpressionTimezone);
-        updated.setFlexibleTimeWindow(flexibleTimeWindow);
-        updated.setTarget(target);
-        updated.setDescription(description);
-        updated.setActionAfterCompletion(actionAfterCompletion);
-        updated.setStartDate(startDate);
-        updated.setEndDate(endDate);
-        updated.setKmsKeyArn(kmsKeyArn);
+        updated.setState(req.getState() != null ? req.getState() : "ENABLED");
+        updated.setScheduleExpression(req.getScheduleExpression());
+        updated.setScheduleExpressionTimezone(req.getScheduleExpressionTimezone());
+        updated.setFlexibleTimeWindow(req.getFlexibleTimeWindow());
+        updated.setTarget(req.getTarget());
+        updated.setDescription(req.getDescription());
+        updated.setActionAfterCompletion(req.getActionAfterCompletion());
+        updated.setStartDate(req.getStartDate());
+        updated.setEndDate(req.getEndDate());
+        updated.setKmsKeyArn(req.getKmsKeyArn());
         updated.setCreationDate(existing.getCreationDate());
         updated.setLastModificationDate(now);
 
         scheduleStore.put(key, updated);
-        LOG.infov("Updated schedule: {0} in group {1}", name, effectiveGroup);
+        LOG.infov("Updated schedule: {0} in group {1}", req.getName(), effectiveGroup);
         return updated;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
@@ -4,8 +4,10 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.scheduler.model.FlexibleTimeWindow;
 import io.github.hectorvent.floci.services.scheduler.model.Schedule;
 import io.github.hectorvent.floci.services.scheduler.model.ScheduleGroup;
+import io.github.hectorvent.floci.services.scheduler.model.Target;
 import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -128,7 +130,7 @@ public class SchedulerService {
         LOG.infov("Deleted schedule group: {0} (removed {1} schedules)", name, orphanKeys.size());
     }
 
-    public java.util.List<ScheduleGroup> listScheduleGroups(String namePrefix, String region) {
+    public List<ScheduleGroup> listScheduleGroups(String namePrefix, String region) {
         getOrCreateDefaultGroup(region);
         String storagePrefix = "group:" + region + ":";
         return groupStore.scan(k -> {
@@ -147,8 +149,8 @@ public class SchedulerService {
 
     public Schedule createSchedule(String name, String groupName, String scheduleExpression,
                                    String scheduleExpressionTimezone,
-                                   io.github.hectorvent.floci.services.scheduler.model.FlexibleTimeWindow flexibleTimeWindow,
-                                   io.github.hectorvent.floci.services.scheduler.model.Target target,
+                                   FlexibleTimeWindow flexibleTimeWindow,
+                                   Target target,
                                    String description, String state, String actionAfterCompletion,
                                    Instant startDate, Instant endDate, String kmsKeyArn,
                                    String region) {
@@ -197,8 +199,8 @@ public class SchedulerService {
 
     public Schedule updateSchedule(String name, String groupName, String scheduleExpression,
                                    String scheduleExpressionTimezone,
-                                   io.github.hectorvent.floci.services.scheduler.model.FlexibleTimeWindow flexibleTimeWindow,
-                                   io.github.hectorvent.floci.services.scheduler.model.Target target,
+                                   FlexibleTimeWindow flexibleTimeWindow,
+                                   Target target,
                                    String description, String state, String actionAfterCompletion,
                                    Instant startDate, Instant endDate, String kmsKeyArn,
                                    String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
@@ -1,0 +1,148 @@
+package io.github.hectorvent.floci.services.scheduler;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.scheduler.model.ScheduleGroup;
+import com.fasterxml.jackson.core.type.TypeReference;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+@ApplicationScoped
+public class SchedulerService {
+
+    private static final Logger LOG = Logger.getLogger(SchedulerService.class);
+
+    // AWS EventBridge Scheduler name constraints: [0-9a-zA-Z-_.]+, 1-64 chars.
+    private static final Pattern NAME_PATTERN = Pattern.compile("[0-9a-zA-Z\\-_.]{1,64}");
+    private static final String DEFAULT_GROUP = "default";
+
+    private final StorageBackend<String, ScheduleGroup> groupStore;
+    private final RegionResolver regionResolver;
+
+    @Inject
+    public SchedulerService(StorageFactory storageFactory, RegionResolver regionResolver) {
+        this(
+                storageFactory.create("scheduler", "scheduler-groups.json",
+                        new TypeReference<Map<String, ScheduleGroup>>() {}),
+                regionResolver
+        );
+    }
+
+    SchedulerService(StorageBackend<String, ScheduleGroup> groupStore, RegionResolver regionResolver) {
+        this.groupStore = groupStore;
+        this.regionResolver = regionResolver;
+    }
+
+    // ──────────────────────────── Schedule Groups ────────────────────────────
+
+    public ScheduleGroup getOrCreateDefaultGroup(String region) {
+        String key = groupKey(region, DEFAULT_GROUP);
+        return groupStore.get(key).orElseGet(() -> {
+            Instant now = Instant.now();
+            ScheduleGroup group = new ScheduleGroup(
+                    DEFAULT_GROUP,
+                    buildGroupArn(region, DEFAULT_GROUP),
+                    "ACTIVE",
+                    now,
+                    now
+            );
+            groupStore.put(key, group);
+            return group;
+        });
+    }
+
+    public ScheduleGroup createScheduleGroup(String name, Map<String, String> tags, String region) {
+        validateName(name);
+        if (DEFAULT_GROUP.equals(name)) {
+            throw new AwsException("ConflictException",
+                    "ScheduleGroup already exists: " + name, 409);
+        }
+        String key = groupKey(region, name);
+        if (groupStore.get(key).isPresent()) {
+            throw new AwsException("ConflictException",
+                    "ScheduleGroup already exists: " + name, 409);
+        }
+        Instant now = Instant.now();
+        ScheduleGroup group = new ScheduleGroup(
+                name,
+                buildGroupArn(region, name),
+                "ACTIVE",
+                now,
+                now
+        );
+        if (tags != null) {
+            group.getTags().putAll(tags);
+        }
+        groupStore.put(key, group);
+        LOG.infov("Created schedule group: {0} in region {1}", name, region);
+        return group;
+    }
+
+    public ScheduleGroup getScheduleGroup(String name, String region) {
+        String effectiveName = (name == null || name.isBlank()) ? DEFAULT_GROUP : name;
+        if (DEFAULT_GROUP.equals(effectiveName)) {
+            return getOrCreateDefaultGroup(region);
+        }
+        return groupStore.get(groupKey(region, effectiveName))
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "ScheduleGroup not found: " + effectiveName, 404));
+    }
+
+    public void deleteScheduleGroup(String name, String region) {
+        if (name == null || name.isBlank()) {
+            throw new AwsException("ValidationException", "Name is required.", 400);
+        }
+        if (DEFAULT_GROUP.equals(name)) {
+            throw new AwsException("ValidationException",
+                    "Cannot delete the default schedule group.", 400);
+        }
+        String key = groupKey(region, name);
+        groupStore.get(key)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "ScheduleGroup not found: " + name, 404));
+        groupStore.delete(key);
+        LOG.infov("Deleted schedule group: {0}", name);
+    }
+
+    public java.util.List<ScheduleGroup> listScheduleGroups(String namePrefix, String region) {
+        getOrCreateDefaultGroup(region);
+        String storagePrefix = "group:" + region + ":";
+        return groupStore.scan(k -> {
+            if (!k.startsWith(storagePrefix)) {
+                return false;
+            }
+            if (namePrefix == null || namePrefix.isBlank()) {
+                return true;
+            }
+            String groupName = k.substring(storagePrefix.length());
+            return groupName.startsWith(namePrefix);
+        });
+    }
+
+    // ──────────────────────────── Helpers ────────────────────────────
+
+    private void validateName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new AwsException("ValidationException", "Name is required.", 400);
+        }
+        if (!NAME_PATTERN.matcher(name).matches()) {
+            throw new AwsException("ValidationException",
+                    "Name must match pattern [0-9a-zA-Z-_.]{1,64}: " + name, 400);
+        }
+    }
+
+    private String buildGroupArn(String region, String name) {
+        return regionResolver.buildArn("scheduler", region, "schedule-group/" + name);
+    }
+
+    private static String groupKey(String region, String name) {
+        return "group:" + region + ":" + name;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
@@ -193,9 +193,7 @@ public class SchedulerService {
     }
 
     public Schedule updateSchedule(ScheduleRequest req, String region) {
-        if (req.getName() == null || req.getName().isBlank()) {
-            throw new AwsException("ValidationException", "Name is required.", 400);
-        }
+        validateName(req.getName());
         validateScheduleRequest(req);
         String effectiveGroup = (req.getGroupName() == null || req.getGroupName().isBlank())
                 ? DEFAULT_GROUP : req.getGroupName();

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
@@ -148,6 +148,7 @@ public class SchedulerService {
 
     public Schedule createSchedule(ScheduleRequest req, String region) {
         validateName(req.getName());
+        validateScheduleRequest(req);
         String effectiveGroup = (req.getGroupName() == null || req.getGroupName().isBlank())
                 ? DEFAULT_GROUP : req.getGroupName();
         getScheduleGroup(effectiveGroup, region); // verify group exists
@@ -195,6 +196,7 @@ public class SchedulerService {
         if (req.getName() == null || req.getName().isBlank()) {
             throw new AwsException("ValidationException", "Name is required.", 400);
         }
+        validateScheduleRequest(req);
         String effectiveGroup = (req.getGroupName() == null || req.getGroupName().isBlank())
                 ? DEFAULT_GROUP : req.getGroupName();
         String key = scheduleKey(region, effectiveGroup, req.getName());
@@ -272,6 +274,29 @@ public class SchedulerService {
         if (!NAME_PATTERN.matcher(name).matches()) {
             throw new AwsException("ValidationException",
                     "Name must match pattern [0-9a-zA-Z-_.]{1,64}: " + name, 400);
+        }
+    }
+
+    private void validateScheduleRequest(ScheduleRequest req) {
+        if (req.getScheduleExpression() == null || req.getScheduleExpression().isBlank()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value null at 'scheduleExpression' failed to satisfy constraint: Member must not be null", 400);
+        }
+        if (req.getFlexibleTimeWindow() == null) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value null at 'flexibleTimeWindow' failed to satisfy constraint: Member must not be null", 400);
+        }
+        if (req.getTarget() == null) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value null at 'target' failed to satisfy constraint: Member must not be null", 400);
+        }
+        if (req.getTarget().getArn() == null || req.getTarget().getArn().isBlank()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value null at 'target.arn' failed to satisfy constraint: Member must not be null", 400);
+        }
+        if (req.getTarget().getRoleArn() == null || req.getTarget().getRoleArn().isBlank()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value null at 'target.roleArn' failed to satisfy constraint: Member must not be null", 400);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
@@ -105,9 +105,7 @@ public class SchedulerService {
     }
 
     public void deleteScheduleGroup(String name, String region) {
-        if (name == null || name.isBlank()) {
-            throw new AwsException("ValidationException", "Name is required.", 400);
-        }
+        validateName(name);
         if (DEFAULT_GROUP.equals(name)) {
             throw new AwsException("ValidationException",
                     "Cannot delete the default schedule group.", 400);
@@ -149,8 +147,14 @@ public class SchedulerService {
     public Schedule createSchedule(ScheduleRequest req, String region) {
         validateName(req.getName());
         validateScheduleRequest(req);
-        String effectiveGroup = (req.getGroupName() == null || req.getGroupName().isBlank())
-                ? DEFAULT_GROUP : req.getGroupName();
+        boolean hasExplicitGroup = req.getGroupName() != null && !req.getGroupName().isBlank();
+        String effectiveGroup;
+        if (hasExplicitGroup) {
+            validateName(req.getGroupName());
+            effectiveGroup = req.getGroupName();
+        } else {
+            effectiveGroup = DEFAULT_GROUP;
+        }
         getScheduleGroup(effectiveGroup, region); // verify group exists
 
         String key = scheduleKey(region, effectiveGroup, req.getName());
@@ -195,8 +199,14 @@ public class SchedulerService {
     public Schedule updateSchedule(ScheduleRequest req, String region) {
         validateName(req.getName());
         validateScheduleRequest(req);
-        String effectiveGroup = (req.getGroupName() == null || req.getGroupName().isBlank())
-                ? DEFAULT_GROUP : req.getGroupName();
+        boolean hasExplicitGroup = req.getGroupName() != null && !req.getGroupName().isBlank();
+        String effectiveGroup;
+        if (hasExplicitGroup) {
+            validateName(req.getGroupName());
+            effectiveGroup = req.getGroupName();
+        } else {
+            effectiveGroup = DEFAULT_GROUP;
+        }
         String key = scheduleKey(region, effectiveGroup, req.getName());
         Schedule existing = scheduleStore.get(key)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
@@ -239,13 +239,18 @@ public class SchedulerService {
     }
 
     public List<Schedule> listSchedules(String groupName, String namePrefix, String state, String region) {
-        String effectiveGroup = (groupName == null || groupName.isBlank()) ? DEFAULT_GROUP : groupName;
-        String storagePrefix = "schedule:" + region + ":" + effectiveGroup + ":";
+        String storagePrefix;
+        if (groupName != null && !groupName.isBlank()) {
+            storagePrefix = "schedule:" + region + ":" + groupName + ":";
+        } else {
+            storagePrefix = "schedule:" + region + ":";
+        }
         return scheduleStore.scan(k -> {
             if (!k.startsWith(storagePrefix)) {
                 return false;
             }
-            String scheduleName = k.substring(storagePrefix.length());
+            // Extract schedule name (last segment after the last colon)
+            String scheduleName = k.substring(k.lastIndexOf(':') + 1);
             if (namePrefix != null && !namePrefix.isBlank() && !scheduleName.startsWith(namePrefix)) {
                 return false;
             }

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
@@ -99,6 +99,7 @@ public class SchedulerService {
         if (DEFAULT_GROUP.equals(effectiveName)) {
             return getOrCreateDefaultGroup(region);
         }
+        validateName(effectiveName);
         return groupStore.get(groupKey(region, effectiveName))
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
                         "ScheduleGroup not found: " + effectiveName, 404));
@@ -147,14 +148,7 @@ public class SchedulerService {
     public Schedule createSchedule(ScheduleRequest req, String region) {
         validateName(req.getName());
         validateScheduleRequest(req);
-        boolean hasExplicitGroup = req.getGroupName() != null && !req.getGroupName().isBlank();
-        String effectiveGroup;
-        if (hasExplicitGroup) {
-            validateName(req.getGroupName());
-            effectiveGroup = req.getGroupName();
-        } else {
-            effectiveGroup = DEFAULT_GROUP;
-        }
+        String effectiveGroup = resolveAndValidateGroup(req.getGroupName());
         getScheduleGroup(effectiveGroup, region); // verify group exists
 
         String key = scheduleKey(region, effectiveGroup, req.getName());
@@ -187,10 +181,8 @@ public class SchedulerService {
     }
 
     public Schedule getSchedule(String name, String groupName, String region) {
-        if (name == null || name.isBlank()) {
-            throw new AwsException("ValidationException", "Name is required.", 400);
-        }
-        String effectiveGroup = (groupName == null || groupName.isBlank()) ? DEFAULT_GROUP : groupName;
+        validateName(name);
+        String effectiveGroup = resolveAndValidateGroup(groupName);
         return scheduleStore.get(scheduleKey(region, effectiveGroup, name))
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
                         "Schedule not found: " + name, 404));
@@ -199,14 +191,7 @@ public class SchedulerService {
     public Schedule updateSchedule(ScheduleRequest req, String region) {
         validateName(req.getName());
         validateScheduleRequest(req);
-        boolean hasExplicitGroup = req.getGroupName() != null && !req.getGroupName().isBlank();
-        String effectiveGroup;
-        if (hasExplicitGroup) {
-            validateName(req.getGroupName());
-            effectiveGroup = req.getGroupName();
-        } else {
-            effectiveGroup = DEFAULT_GROUP;
-        }
+        String effectiveGroup = resolveAndValidateGroup(req.getGroupName());
         String key = scheduleKey(region, effectiveGroup, req.getName());
         Schedule existing = scheduleStore.get(key)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
@@ -236,10 +221,8 @@ public class SchedulerService {
     }
 
     public void deleteSchedule(String name, String groupName, String region) {
-        if (name == null || name.isBlank()) {
-            throw new AwsException("ValidationException", "Name is required.", 400);
-        }
-        String effectiveGroup = (groupName == null || groupName.isBlank()) ? DEFAULT_GROUP : groupName;
+        validateName(name);
+        String effectiveGroup = resolveAndValidateGroup(groupName);
         String key = scheduleKey(region, effectiveGroup, name);
         scheduleStore.get(key)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
@@ -251,6 +234,7 @@ public class SchedulerService {
     public List<Schedule> listSchedules(String groupName, String namePrefix, String state, String region) {
         String storagePrefix;
         if (groupName != null && !groupName.isBlank()) {
+            validateName(groupName);
             storagePrefix = "schedule:" + region + ":" + groupName + ":";
         } else {
             storagePrefix = "schedule:" + region + ":";
@@ -283,6 +267,14 @@ public class SchedulerService {
             throw new AwsException("ValidationException",
                     "Name must match pattern [0-9a-zA-Z-_.]{1,64}: " + name, 400);
         }
+    }
+
+    private String resolveAndValidateGroup(String groupName) {
+        if (groupName == null || groupName.isBlank()) {
+            return DEFAULT_GROUP;
+        }
+        validateName(groupName);
+        return groupName;
     }
 
     private void validateScheduleRequest(ScheduleRequest req) {

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/model/DeadLetterConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/model/DeadLetterConfig.java
@@ -1,0 +1,18 @@
+package io.github.hectorvent.floci.services.scheduler.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class DeadLetterConfig {
+
+    private String arn;
+
+    public DeadLetterConfig() {}
+
+    public DeadLetterConfig(String arn) {
+        this.arn = arn;
+    }
+
+    public String getArn() { return arn; }
+    public void setArn(String arn) { this.arn = arn; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/model/FlexibleTimeWindow.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/model/FlexibleTimeWindow.java
@@ -1,0 +1,23 @@
+package io.github.hectorvent.floci.services.scheduler.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class FlexibleTimeWindow {
+
+    private String mode;
+    private Integer maximumWindowInMinutes;
+
+    public FlexibleTimeWindow() {}
+
+    public FlexibleTimeWindow(String mode, Integer maximumWindowInMinutes) {
+        this.mode = mode;
+        this.maximumWindowInMinutes = maximumWindowInMinutes;
+    }
+
+    public String getMode() { return mode; }
+    public void setMode(String mode) { this.mode = mode; }
+
+    public Integer getMaximumWindowInMinutes() { return maximumWindowInMinutes; }
+    public void setMaximumWindowInMinutes(Integer maximumWindowInMinutes) { this.maximumWindowInMinutes = maximumWindowInMinutes; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/model/RetryPolicy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/model/RetryPolicy.java
@@ -1,0 +1,23 @@
+package io.github.hectorvent.floci.services.scheduler.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class RetryPolicy {
+
+    private Integer maximumEventAgeInSeconds;
+    private Integer maximumRetryAttempts;
+
+    public RetryPolicy() {}
+
+    public RetryPolicy(Integer maximumEventAgeInSeconds, Integer maximumRetryAttempts) {
+        this.maximumEventAgeInSeconds = maximumEventAgeInSeconds;
+        this.maximumRetryAttempts = maximumRetryAttempts;
+    }
+
+    public Integer getMaximumEventAgeInSeconds() { return maximumEventAgeInSeconds; }
+    public void setMaximumEventAgeInSeconds(Integer maximumEventAgeInSeconds) { this.maximumEventAgeInSeconds = maximumEventAgeInSeconds; }
+
+    public Integer getMaximumRetryAttempts() { return maximumRetryAttempts; }
+    public void setMaximumRetryAttempts(Integer maximumRetryAttempts) { this.maximumRetryAttempts = maximumRetryAttempts; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/model/Schedule.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/model/Schedule.java
@@ -1,0 +1,72 @@
+package io.github.hectorvent.floci.services.scheduler.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+
+@RegisterForReflection
+public class Schedule {
+
+    private String name;
+    private String arn;
+    private String groupName;
+    private String state;
+    private String scheduleExpression;
+    private String scheduleExpressionTimezone;
+    private FlexibleTimeWindow flexibleTimeWindow;
+    private Target target;
+    private String description;
+    private String actionAfterCompletion;
+    private Instant startDate;
+    private Instant endDate;
+    private String kmsKeyArn;
+    private Instant creationDate;
+    private Instant lastModificationDate;
+
+    public Schedule() {}
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getArn() { return arn; }
+    public void setArn(String arn) { this.arn = arn; }
+
+    public String getGroupName() { return groupName; }
+    public void setGroupName(String groupName) { this.groupName = groupName; }
+
+    public String getState() { return state; }
+    public void setState(String state) { this.state = state; }
+
+    public String getScheduleExpression() { return scheduleExpression; }
+    public void setScheduleExpression(String scheduleExpression) { this.scheduleExpression = scheduleExpression; }
+
+    public String getScheduleExpressionTimezone() { return scheduleExpressionTimezone; }
+    public void setScheduleExpressionTimezone(String scheduleExpressionTimezone) { this.scheduleExpressionTimezone = scheduleExpressionTimezone; }
+
+    public FlexibleTimeWindow getFlexibleTimeWindow() { return flexibleTimeWindow; }
+    public void setFlexibleTimeWindow(FlexibleTimeWindow flexibleTimeWindow) { this.flexibleTimeWindow = flexibleTimeWindow; }
+
+    public Target getTarget() { return target; }
+    public void setTarget(Target target) { this.target = target; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getActionAfterCompletion() { return actionAfterCompletion; }
+    public void setActionAfterCompletion(String actionAfterCompletion) { this.actionAfterCompletion = actionAfterCompletion; }
+
+    public Instant getStartDate() { return startDate; }
+    public void setStartDate(Instant startDate) { this.startDate = startDate; }
+
+    public Instant getEndDate() { return endDate; }
+    public void setEndDate(Instant endDate) { this.endDate = endDate; }
+
+    public String getKmsKeyArn() { return kmsKeyArn; }
+    public void setKmsKeyArn(String kmsKeyArn) { this.kmsKeyArn = kmsKeyArn; }
+
+    public Instant getCreationDate() { return creationDate; }
+    public void setCreationDate(Instant creationDate) { this.creationDate = creationDate; }
+
+    public Instant getLastModificationDate() { return lastModificationDate; }
+    public void setLastModificationDate(Instant lastModificationDate) { this.lastModificationDate = lastModificationDate; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/model/ScheduleGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/model/ScheduleGroup.java
@@ -1,0 +1,47 @@
+package io.github.hectorvent.floci.services.scheduler.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+@RegisterForReflection
+public class ScheduleGroup {
+
+    private String name;
+    private String arn;
+    private String state;
+    private Instant creationDate;
+    private Instant lastModificationDate;
+    private Map<String, String> tags = new HashMap<>();
+
+    public ScheduleGroup() {}
+
+    public ScheduleGroup(String name, String arn, String state,
+                         Instant creationDate, Instant lastModificationDate) {
+        this.name = name;
+        this.arn = arn;
+        this.state = state;
+        this.creationDate = creationDate;
+        this.lastModificationDate = lastModificationDate;
+    }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getArn() { return arn; }
+    public void setArn(String arn) { this.arn = arn; }
+
+    public String getState() { return state; }
+    public void setState(String state) { this.state = state; }
+
+    public Instant getCreationDate() { return creationDate; }
+    public void setCreationDate(Instant creationDate) { this.creationDate = creationDate; }
+
+    public Instant getLastModificationDate() { return lastModificationDate; }
+    public void setLastModificationDate(Instant lastModificationDate) { this.lastModificationDate = lastModificationDate; }
+
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) { this.tags = tags; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/model/ScheduleRequest.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/model/ScheduleRequest.java
@@ -1,0 +1,55 @@
+package io.github.hectorvent.floci.services.scheduler.model;
+
+import java.time.Instant;
+
+public class ScheduleRequest {
+
+    private String name;
+    private String groupName;
+    private String scheduleExpression;
+    private String scheduleExpressionTimezone;
+    private FlexibleTimeWindow flexibleTimeWindow;
+    private Target target;
+    private String description;
+    private String state;
+    private String actionAfterCompletion;
+    private Instant startDate;
+    private Instant endDate;
+    private String kmsKeyArn;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getGroupName() { return groupName; }
+    public void setGroupName(String groupName) { this.groupName = groupName; }
+
+    public String getScheduleExpression() { return scheduleExpression; }
+    public void setScheduleExpression(String scheduleExpression) { this.scheduleExpression = scheduleExpression; }
+
+    public String getScheduleExpressionTimezone() { return scheduleExpressionTimezone; }
+    public void setScheduleExpressionTimezone(String scheduleExpressionTimezone) { this.scheduleExpressionTimezone = scheduleExpressionTimezone; }
+
+    public FlexibleTimeWindow getFlexibleTimeWindow() { return flexibleTimeWindow; }
+    public void setFlexibleTimeWindow(FlexibleTimeWindow flexibleTimeWindow) { this.flexibleTimeWindow = flexibleTimeWindow; }
+
+    public Target getTarget() { return target; }
+    public void setTarget(Target target) { this.target = target; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getState() { return state; }
+    public void setState(String state) { this.state = state; }
+
+    public String getActionAfterCompletion() { return actionAfterCompletion; }
+    public void setActionAfterCompletion(String actionAfterCompletion) { this.actionAfterCompletion = actionAfterCompletion; }
+
+    public Instant getStartDate() { return startDate; }
+    public void setStartDate(Instant startDate) { this.startDate = startDate; }
+
+    public Instant getEndDate() { return endDate; }
+    public void setEndDate(Instant endDate) { this.endDate = endDate; }
+
+    public String getKmsKeyArn() { return kmsKeyArn; }
+    public void setKmsKeyArn(String kmsKeyArn) { this.kmsKeyArn = kmsKeyArn; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/model/ScheduleRequest.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/model/ScheduleRequest.java
@@ -1,7 +1,10 @@
 package io.github.hectorvent.floci.services.scheduler.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 
+@RegisterForReflection
 public class ScheduleRequest {
 
     private String name;

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/model/Target.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/model/Target.java
@@ -1,0 +1,33 @@
+package io.github.hectorvent.floci.services.scheduler.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class Target {
+
+    private String arn;
+    private String roleArn;
+    private String input;
+    private RetryPolicy retryPolicy;
+
+    public Target() {}
+
+    public Target(String arn, String roleArn, String input, RetryPolicy retryPolicy) {
+        this.arn = arn;
+        this.roleArn = roleArn;
+        this.input = input;
+        this.retryPolicy = retryPolicy;
+    }
+
+    public String getArn() { return arn; }
+    public void setArn(String arn) { this.arn = arn; }
+
+    public String getRoleArn() { return roleArn; }
+    public void setRoleArn(String roleArn) { this.roleArn = roleArn; }
+
+    public String getInput() { return input; }
+    public void setInput(String input) { this.input = input; }
+
+    public RetryPolicy getRetryPolicy() { return retryPolicy; }
+    public void setRetryPolicy(RetryPolicy retryPolicy) { this.retryPolicy = retryPolicy; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/model/Target.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/model/Target.java
@@ -9,6 +9,7 @@ public class Target {
     private String roleArn;
     private String input;
     private RetryPolicy retryPolicy;
+    private DeadLetterConfig deadLetterConfig;
 
     public Target() {}
 
@@ -30,4 +31,7 @@ public class Target {
 
     public RetryPolicy getRetryPolicy() { return retryPolicy; }
     public void setRetryPolicy(RetryPolicy retryPolicy) { this.retryPolicy = retryPolicy; }
+
+    public DeadLetterConfig getDeadLetterConfig() { return deadLetterConfig; }
+    public void setDeadLetterConfig(DeadLetterConfig deadLetterConfig) { this.deadLetterConfig = deadLetterConfig; }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -96,6 +96,8 @@ floci:
       default-mariadb-image: "mariadb:11"
     eventbridge:
       enabled: true
+    scheduler:
+      enabled: true
     cloudwatchlogs:
       enabled: true
       max-events-per-query: 10000

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/HealthControllerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/HealthControllerIntegrationTest.java
@@ -26,6 +26,7 @@ class HealthControllerIntegrationTest {
                 "elasticache": "running",
                 "rds": "running",
                 "events": "running",
+                "scheduler": "running",
                 "logs": "running",
                 "monitoring": "running",
                 "secretsmanager": "running",

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerIntegrationTest.java
@@ -171,4 +171,247 @@ class SchedulerIntegrationTest {
         .then()
             .statusCode(404);
     }
+
+    // ──────────────────────────── Schedule tests ────────────────────────────
+
+    @Test
+    @Order(20)
+    void createSchedule() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "ScheduleExpression": "rate(1 hour)",
+                    "FlexibleTimeWindow": {"Mode": "OFF"},
+                    "Target": {
+                        "Arn": "arn:aws:lambda:us-east-1:000000000000:function:my-func",
+                        "RoleArn": "arn:aws:iam::000000000000:role/scheduler-role"
+                    }
+                }
+                """)
+        .when()
+            .post("/schedules/my-schedule")
+        .then()
+            .statusCode(200)
+            .body("ScheduleArn", containsString("schedule/default/my-schedule"));
+    }
+
+    @Test
+    @Order(21)
+    void createScheduleInGroup() {
+        // First create the group
+        given()
+            .contentType("application/json")
+            .body("{}")
+        .when()
+            .post("/schedule-groups/sched-test-group")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "GroupName": "sched-test-group",
+                    "ScheduleExpression": "rate(5 minutes)",
+                    "FlexibleTimeWindow": {"Mode": "FLEXIBLE", "MaximumWindowInMinutes": 10},
+                    "Target": {
+                        "Arn": "arn:aws:sqs:us-east-1:000000000000:my-queue",
+                        "RoleArn": "arn:aws:iam::000000000000:role/r",
+                        "Input": "hello"
+                    },
+                    "Description": "test schedule",
+                    "State": "DISABLED"
+                }
+                """)
+        .when()
+            .post("/schedules/grouped-schedule")
+        .then()
+            .statusCode(200)
+            .body("ScheduleArn", containsString("schedule/sched-test-group/grouped-schedule"));
+    }
+
+    @Test
+    @Order(22)
+    void createScheduleDuplicateReturns409() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "ScheduleExpression": "rate(1 hour)",
+                    "FlexibleTimeWindow": {"Mode": "OFF"},
+                    "Target": {"Arn": "arn:t", "RoleArn": "arn:r"}
+                }
+                """)
+        .when()
+            .post("/schedules/my-schedule")
+        .then()
+            .statusCode(409);
+    }
+
+    @Test
+    @Order(23)
+    void getSchedule() {
+        given()
+        .when()
+            .get("/schedules/my-schedule")
+        .then()
+            .statusCode(200)
+            .body("Name", equalTo("my-schedule"))
+            .body("GroupName", equalTo("default"))
+            .body("State", equalTo("ENABLED"))
+            .body("ScheduleExpression", equalTo("rate(1 hour)"))
+            .body("FlexibleTimeWindow.Mode", equalTo("OFF"))
+            .body("Target.Arn", containsString("function:my-func"))
+            .body("Target.RoleArn", containsString("role/scheduler-role"))
+            .body("CreationDate", notNullValue())
+            .body("LastModificationDate", notNullValue());
+    }
+
+    @Test
+    @Order(24)
+    void getScheduleInGroup() {
+        given()
+            .queryParam("groupName", "sched-test-group")
+        .when()
+            .get("/schedules/grouped-schedule")
+        .then()
+            .statusCode(200)
+            .body("Name", equalTo("grouped-schedule"))
+            .body("GroupName", equalTo("sched-test-group"))
+            .body("State", equalTo("DISABLED"))
+            .body("Description", equalTo("test schedule"));
+    }
+
+    @Test
+    @Order(25)
+    void getScheduleNotFoundReturns404() {
+        given()
+        .when()
+            .get("/schedules/nonexistent-schedule")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(26)
+    void listSchedules() {
+        given()
+        .when()
+            .get("/schedules")
+        .then()
+            .statusCode(200)
+            .body("Schedules.Name", hasItem("my-schedule"));
+    }
+
+    @Test
+    @Order(27)
+    void listSchedulesInGroup() {
+        given()
+            .queryParam("ScheduleGroup", "sched-test-group")
+        .when()
+            .get("/schedules")
+        .then()
+            .statusCode(200)
+            .body("Schedules.Name", hasItem("grouped-schedule"))
+            .body("Schedules.Name", not(hasItem("my-schedule")));
+    }
+
+    @Test
+    @Order(28)
+    void updateSchedule() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "ScheduleExpression": "rate(30 minutes)",
+                    "FlexibleTimeWindow": {"Mode": "FLEXIBLE", "MaximumWindowInMinutes": 5},
+                    "Target": {
+                        "Arn": "arn:aws:lambda:us-east-1:000000000000:function:updated-func",
+                        "RoleArn": "arn:aws:iam::000000000000:role/updated-role"
+                    },
+                    "State": "DISABLED",
+                    "Description": "updated description"
+                }
+                """)
+        .when()
+            .put("/schedules/my-schedule")
+        .then()
+            .statusCode(200)
+            .body("ScheduleArn", containsString("schedule/default/my-schedule"));
+
+        // Verify the update
+        given()
+        .when()
+            .get("/schedules/my-schedule")
+        .then()
+            .statusCode(200)
+            .body("ScheduleExpression", equalTo("rate(30 minutes)"))
+            .body("State", equalTo("DISABLED"))
+            .body("Description", equalTo("updated description"))
+            .body("FlexibleTimeWindow.Mode", equalTo("FLEXIBLE"))
+            .body("FlexibleTimeWindow.MaximumWindowInMinutes", equalTo(5));
+    }
+
+    @Test
+    @Order(29)
+    void updateScheduleNotFoundReturns404() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "ScheduleExpression": "rate(1 hour)",
+                    "FlexibleTimeWindow": {"Mode": "OFF"},
+                    "Target": {"Arn": "arn:t", "RoleArn": "arn:r"}
+                }
+                """)
+        .when()
+            .put("/schedules/nonexistent-schedule")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(30)
+    void deleteSchedule() {
+        given()
+        .when()
+            .delete("/schedules/my-schedule")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/schedules/my-schedule")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(31)
+    void deleteScheduleNotFoundReturns404() {
+        given()
+        .when()
+            .delete("/schedules/already-gone-schedule")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(32)
+    void deleteScheduleInGroup() {
+        given()
+            .queryParam("groupName", "sched-test-group")
+        .when()
+            .delete("/schedules/grouped-schedule")
+        .then()
+            .statusCode(200);
+
+        given()
+            .queryParam("groupName", "sched-test-group")
+        .when()
+            .get("/schedules/grouped-schedule")
+        .then()
+            .statusCode(404);
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerIntegrationTest.java
@@ -360,6 +360,84 @@ class SchedulerIntegrationTest {
 
     @Test
     @Order(29)
+    void createScheduleWithRetryPolicy() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "ScheduleExpression": "rate(10 minutes)",
+                    "FlexibleTimeWindow": {"Mode": "OFF"},
+                    "Target": {
+                        "Arn": "arn:aws:lambda:us-east-1:000000000000:function:rp-func",
+                        "RoleArn": "arn:aws:iam::000000000000:role/r",
+                        "RetryPolicy": {
+                            "MaximumEventAgeInSeconds": 3600,
+                            "MaximumRetryAttempts": 5
+                        }
+                    }
+                }
+                """)
+        .when()
+            .post("/schedules/rp-schedule")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/schedules/rp-schedule")
+        .then()
+            .statusCode(200)
+            .body("Target.RetryPolicy.MaximumEventAgeInSeconds", equalTo(3600))
+            .body("Target.RetryPolicy.MaximumRetryAttempts", equalTo(5));
+
+        // Cleanup
+        given()
+        .when()
+            .delete("/schedules/rp-schedule")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(30)
+    void createScheduleWithStartAndEndDate() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "ScheduleExpression": "rate(1 hour)",
+                    "FlexibleTimeWindow": {"Mode": "OFF"},
+                    "Target": {
+                        "Arn": "arn:aws:lambda:us-east-1:000000000000:function:dated-func",
+                        "RoleArn": "arn:aws:iam::000000000000:role/r"
+                    },
+                    "StartDate": 1780329600.0,
+                    "EndDate": 1798761599.0
+                }
+                """)
+        .when()
+            .post("/schedules/dated-schedule")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/schedules/dated-schedule")
+        .then()
+            .statusCode(200)
+            .body("StartDate", notNullValue())
+            .body("EndDate", notNullValue());
+
+        // Cleanup
+        given()
+        .when()
+            .delete("/schedules/dated-schedule")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(31)
     void updateSchedule() {
         given()
             .contentType("application/json")
@@ -395,7 +473,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(30)
+    @Order(32)
     void updateScheduleNotFoundReturns404() {
         given()
             .contentType("application/json")
@@ -413,7 +491,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(31)
+    @Order(33)
     void deleteSchedule() {
         given()
         .when()
@@ -429,7 +507,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(32)
+    @Order(34)
     void deleteScheduleNotFoundReturns404() {
         given()
         .when()
@@ -439,7 +517,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(33)
+    @Order(35)
     void deleteScheduleInGroup() {
         given()
             .queryParam("groupName", "sched-test-group")

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerIntegrationTest.java
@@ -1,0 +1,174 @@
+package io.github.hectorvent.floci.services.scheduler;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SchedulerIntegrationTest {
+
+    @Test
+    @Order(1)
+    void createScheduleGroup() {
+        given()
+            .contentType("application/json")
+            .body("{\"ClientToken\":\"ct-1\"}")
+        .when()
+            .post("/schedule-groups/my-group")
+        .then()
+            .statusCode(200)
+            .body("ScheduleGroupArn", containsString("schedule-group/my-group"))
+            .body("ScheduleGroupArn", containsString(":scheduler:"));
+    }
+
+    @Test
+    @Order(2)
+    void createScheduleGroupWithTags() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "ClientToken": "ct-2",
+                    "Tags": [
+                        {"Key": "env", "Value": "test"},
+                        {"Key": "team", "Value": "platform"}
+                    ]
+                }
+                """)
+        .when()
+            .post("/schedule-groups/tagged-group")
+        .then()
+            .statusCode(200)
+            .body("ScheduleGroupArn", containsString("schedule-group/tagged-group"));
+    }
+
+    @Test
+    @Order(3)
+    void createScheduleGroupDuplicateReturns409() {
+        given()
+            .contentType("application/json")
+            .body("{}")
+        .when()
+            .post("/schedule-groups/my-group")
+        .then()
+            .statusCode(409);
+    }
+
+    @Test
+    @Order(4)
+    void createScheduleGroupReservedDefaultNameReturns409() {
+        given()
+            .contentType("application/json")
+            .body("{}")
+        .when()
+            .post("/schedule-groups/default")
+        .then()
+            .statusCode(409);
+    }
+
+    @Test
+    @Order(5)
+    void getScheduleGroup() {
+        given()
+        .when()
+            .get("/schedule-groups/my-group")
+        .then()
+            .statusCode(200)
+            .body("Name", equalTo("my-group"))
+            .body("State", equalTo("ACTIVE"))
+            .body("Arn", containsString("schedule-group/my-group"))
+            .body("CreationDate", notNullValue())
+            .body("LastModificationDate", notNullValue());
+    }
+
+    @Test
+    @Order(6)
+    void getDefaultScheduleGroupIsAutoCreated() {
+        given()
+        .when()
+            .get("/schedule-groups/default")
+        .then()
+            .statusCode(200)
+            .body("Name", equalTo("default"))
+            .body("State", equalTo("ACTIVE"));
+    }
+
+    @Test
+    @Order(7)
+    void getScheduleGroupNotFoundReturns404() {
+        given()
+        .when()
+            .get("/schedule-groups/nonexistent-group")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(8)
+    void listScheduleGroupsIncludesDefault() {
+        given()
+        .when()
+            .get("/schedule-groups")
+        .then()
+            .statusCode(200)
+            .body("ScheduleGroups.Name", hasItem("default"))
+            .body("ScheduleGroups.Name", hasItem("my-group"))
+            .body("ScheduleGroups.Name", hasItem("tagged-group"));
+    }
+
+    @Test
+    @Order(9)
+    void listScheduleGroupsWithPrefix() {
+        given()
+            .queryParam("NamePrefix", "tag")
+        .when()
+            .get("/schedule-groups")
+        .then()
+            .statusCode(200)
+            .body("ScheduleGroups.Name", hasItem("tagged-group"))
+            .body("ScheduleGroups.Name", not(hasItem("my-group")))
+            .body("ScheduleGroups.Name", not(hasItem("default")));
+    }
+
+    @Test
+    @Order(10)
+    void deleteScheduleGroup() {
+        given()
+        .when()
+            .delete("/schedule-groups/my-group")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/schedule-groups/my-group")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(11)
+    void deleteDefaultScheduleGroupReturns400() {
+        given()
+        .when()
+            .delete("/schedule-groups/default")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(12)
+    void deleteScheduleGroupNotFoundReturns404() {
+        given()
+        .when()
+            .delete("/schedule-groups/already-gone")
+        .then()
+            .statusCode(404);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerIntegrationTest.java
@@ -320,6 +320,46 @@ class SchedulerIntegrationTest {
 
     @Test
     @Order(28)
+    void createScheduleWithDeadLetterConfig() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "ScheduleExpression": "rate(10 minutes)",
+                    "FlexibleTimeWindow": {"Mode": "OFF"},
+                    "Target": {
+                        "Arn": "arn:aws:lambda:us-east-1:000000000000:function:dlc-func",
+                        "RoleArn": "arn:aws:iam::000000000000:role/r",
+                        "DeadLetterConfig": {
+                            "Arn": "arn:aws:sqs:us-east-1:000000000000:my-dlq"
+                        }
+                    }
+                }
+                """)
+        .when()
+            .post("/schedules/dlc-schedule")
+        .then()
+            .statusCode(200)
+            .body("ScheduleArn", containsString("schedule/default/dlc-schedule"));
+
+        // Verify DeadLetterConfig is returned on get
+        given()
+        .when()
+            .get("/schedules/dlc-schedule")
+        .then()
+            .statusCode(200)
+            .body("Target.DeadLetterConfig.Arn", equalTo("arn:aws:sqs:us-east-1:000000000000:my-dlq"));
+
+        // Cleanup
+        given()
+        .when()
+            .delete("/schedules/dlc-schedule")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(29)
     void updateSchedule() {
         given()
             .contentType("application/json")
@@ -355,7 +395,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(29)
+    @Order(30)
     void updateScheduleNotFoundReturns404() {
         given()
             .contentType("application/json")
@@ -373,7 +413,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(30)
+    @Order(31)
     void deleteSchedule() {
         given()
         .when()
@@ -389,7 +429,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(31)
+    @Order(32)
     void deleteScheduleNotFoundReturns404() {
         given()
         .when()
@@ -399,7 +439,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(32)
+    @Order(33)
     void deleteScheduleInGroup() {
         given()
             .queryParam("groupName", "sched-test-group")

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerIntegrationTest.java
@@ -301,7 +301,8 @@ class SchedulerIntegrationTest {
             .get("/schedules")
         .then()
             .statusCode(200)
-            .body("Schedules.Name", hasItem("my-schedule"));
+            .body("Schedules.Name", hasItem("my-schedule"))
+            .body("Schedules.Name", hasItem("grouped-schedule"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerServiceTest.java
@@ -123,6 +123,24 @@ class SchedulerServiceTest {
     }
 
     @Test
+    void deleteScheduleGroupCascadesSchedules() {
+        service.createScheduleGroup("cascade-grp", null, REGION);
+        service.createSchedule("s1", "cascade-grp", "rate(1 hour)", null,
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:t", "arn:r", null, null),
+                null, null, null, null, null, null, REGION);
+        service.createSchedule("s2", "cascade-grp", "rate(1 hour)", null,
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:t", "arn:r", null, null),
+                null, null, null, null, null, null, REGION);
+        service.deleteScheduleGroup("cascade-grp", REGION);
+        assertThrows(AwsException.class, () ->
+                service.getSchedule("s1", "cascade-grp", REGION));
+        assertThrows(AwsException.class, () ->
+                service.getSchedule("s2", "cascade-grp", REGION));
+    }
+
+    @Test
     void deleteDefaultGroupThrows() {
         AwsException e = assertThrows(AwsException.class, () ->
                 service.deleteScheduleGroup("default", REGION));

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerServiceTest.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.services.scheduler.model.DeadLetterConfig;
 import io.github.hectorvent.floci.services.scheduler.model.FlexibleTimeWindow;
 import io.github.hectorvent.floci.services.scheduler.model.Schedule;
 import io.github.hectorvent.floci.services.scheduler.model.ScheduleGroup;
+import io.github.hectorvent.floci.services.scheduler.model.ScheduleRequest;
 import io.github.hectorvent.floci.services.scheduler.model.Target;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,17 @@ class SchedulerServiceTest {
                 new InMemoryStorage<>(),
                 new RegionResolver("us-east-1", "000000000000")
         );
+    }
+
+    private ScheduleRequest newRequest(String name, String groupName, String expression,
+                                       FlexibleTimeWindow ftw, Target target) {
+        ScheduleRequest req = new ScheduleRequest();
+        req.setName(name);
+        req.setGroupName(groupName);
+        req.setScheduleExpression(expression);
+        req.setFlexibleTimeWindow(ftw);
+        req.setTarget(target);
+        return req;
     }
 
     @Test
@@ -125,14 +137,16 @@ class SchedulerServiceTest {
     @Test
     void deleteScheduleGroupCascadesSchedules() {
         service.createScheduleGroup("cascade-grp", null, REGION);
-        service.createSchedule("s1", "cascade-grp", "rate(1 hour)", null,
-                new FlexibleTimeWindow("OFF", null),
-                new Target("arn:t", "arn:r", null, null),
-                null, null, null, null, null, null, REGION);
-        service.createSchedule("s2", "cascade-grp", "rate(1 hour)", null,
-                new FlexibleTimeWindow("OFF", null),
-                new Target("arn:t", "arn:r", null, null),
-                null, null, null, null, null, null, REGION);
+        service.createSchedule(
+                newRequest("s1", "cascade-grp", "rate(1 hour)",
+                        new FlexibleTimeWindow("OFF", null),
+                        new Target("arn:t", "arn:r", null, null)),
+                REGION);
+        service.createSchedule(
+                newRequest("s2", "cascade-grp", "rate(1 hour)",
+                        new FlexibleTimeWindow("OFF", null),
+                        new Target("arn:t", "arn:r", null, null)),
+                REGION);
         service.deleteScheduleGroup("cascade-grp", REGION);
         assertThrows(AwsException.class, () ->
                 service.getSchedule("s1", "cascade-grp", REGION));
@@ -181,11 +195,11 @@ class SchedulerServiceTest {
 
     @Test
     void createSchedule() {
-        Schedule s = service.createSchedule("my-schedule", null, "rate(1 hour)", null,
+        ScheduleRequest req = newRequest("my-schedule", null, "rate(1 hour)",
                 new FlexibleTimeWindow("OFF", null),
                 new Target("arn:aws:lambda:us-east-1:000000000000:function:my-func",
-                        "arn:aws:iam::000000000000:role/my-role", null, null),
-                null, null, null, null, null, null, REGION);
+                        "arn:aws:iam::000000000000:role/my-role", null, null));
+        Schedule s = service.createSchedule(req, REGION);
         assertEquals("my-schedule", s.getName());
         assertEquals("default", s.getGroupName());
         assertEquals("ENABLED", s.getState());
@@ -197,45 +211,49 @@ class SchedulerServiceTest {
     @Test
     void createScheduleInCustomGroup() {
         service.createScheduleGroup("custom", null, REGION);
-        Schedule s = service.createSchedule("my-schedule", "custom", "rate(5 minutes)", null,
+        ScheduleRequest req = newRequest("my-schedule", "custom", "rate(5 minutes)",
                 new FlexibleTimeWindow("OFF", null),
                 new Target("arn:aws:sqs:us-east-1:000000000000:my-queue",
-                        "arn:aws:iam::000000000000:role/r", null, null),
-                null, null, null, null, null, null, REGION);
+                        "arn:aws:iam::000000000000:role/r", null, null));
+        Schedule s = service.createSchedule(req, REGION);
         assertEquals("custom", s.getGroupName());
         assertTrue(s.getArn().contains("schedule/custom/my-schedule"));
     }
 
     @Test
     void createScheduleDuplicateThrows() {
-        service.createSchedule("dup", null, "rate(1 hour)", null,
-                new FlexibleTimeWindow("OFF", null),
-                new Target("arn:t", "arn:r", null, null),
-                null, null, null, null, null, null, REGION);
-        AwsException e = assertThrows(AwsException.class, () ->
-                service.createSchedule("dup", null, "rate(1 hour)", null,
+        service.createSchedule(
+                newRequest("dup", null, "rate(1 hour)",
                         new FlexibleTimeWindow("OFF", null),
-                        new Target("arn:t", "arn:r", null, null),
-                        null, null, null, null, null, null, REGION));
+                        new Target("arn:t", "arn:r", null, null)),
+                REGION);
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.createSchedule(
+                        newRequest("dup", null, "rate(1 hour)",
+                                new FlexibleTimeWindow("OFF", null),
+                                new Target("arn:t", "arn:r", null, null)),
+                        REGION));
         assertEquals("ConflictException", e.getErrorCode());
     }
 
     @Test
     void createScheduleInNonExistentGroupThrows() {
         AwsException e = assertThrows(AwsException.class, () ->
-                service.createSchedule("s", "no-such-group", "rate(1 hour)", null,
-                        new FlexibleTimeWindow("OFF", null),
-                        new Target("arn:t", "arn:r", null, null),
-                        null, null, null, null, null, null, REGION));
+                service.createSchedule(
+                        newRequest("s", "no-such-group", "rate(1 hour)",
+                                new FlexibleTimeWindow("OFF", null),
+                                new Target("arn:t", "arn:r", null, null)),
+                        REGION));
         assertEquals("ResourceNotFoundException", e.getErrorCode());
     }
 
     @Test
     void getSchedule() {
-        service.createSchedule("find-me", null, "rate(1 hour)", null,
-                new FlexibleTimeWindow("OFF", null),
-                new Target("arn:t", "arn:r", null, null),
-                null, null, null, null, null, null, REGION);
+        service.createSchedule(
+                newRequest("find-me", null, "rate(1 hour)",
+                        new FlexibleTimeWindow("OFF", null),
+                        new Target("arn:t", "arn:r", null, null)),
+                REGION);
         Schedule s = service.getSchedule("find-me", null, REGION);
         assertEquals("find-me", s.getName());
     }
@@ -249,14 +267,19 @@ class SchedulerServiceTest {
 
     @Test
     void updateSchedule() {
-        service.createSchedule("upd", null, "rate(1 hour)", null,
+        ScheduleRequest createReq = newRequest("upd", null, "rate(1 hour)",
                 new FlexibleTimeWindow("OFF", null),
-                new Target("arn:t", "arn:r", null, null),
-                "original desc", null, null, null, null, null, REGION);
-        Schedule updated = service.updateSchedule("upd", null, "rate(5 minutes)", "UTC",
+                new Target("arn:t", "arn:r", null, null));
+        createReq.setDescription("original desc");
+        service.createSchedule(createReq, REGION);
+
+        ScheduleRequest updateReq = newRequest("upd", null, "rate(5 minutes)",
                 new FlexibleTimeWindow("FLEXIBLE", 10),
-                new Target("arn:t2", "arn:r2", "{}", null),
-                "updated desc", "DISABLED", null, null, null, null, REGION);
+                new Target("arn:t2", "arn:r2", "{}", null));
+        updateReq.setScheduleExpressionTimezone("UTC");
+        updateReq.setDescription("updated desc");
+        updateReq.setState("DISABLED");
+        Schedule updated = service.updateSchedule(updateReq, REGION);
         assertEquals("rate(5 minutes)", updated.getScheduleExpression());
         assertEquals("DISABLED", updated.getState());
         assertEquals("updated desc", updated.getDescription());
@@ -267,19 +290,21 @@ class SchedulerServiceTest {
     @Test
     void updateScheduleNotFoundThrows() {
         AwsException e = assertThrows(AwsException.class, () ->
-                service.updateSchedule("missing", null, "rate(1 hour)", null,
-                        new FlexibleTimeWindow("OFF", null),
-                        new Target("arn:t", "arn:r", null, null),
-                        null, null, null, null, null, null, REGION));
+                service.updateSchedule(
+                        newRequest("missing", null, "rate(1 hour)",
+                                new FlexibleTimeWindow("OFF", null),
+                                new Target("arn:t", "arn:r", null, null)),
+                        REGION));
         assertEquals("ResourceNotFoundException", e.getErrorCode());
     }
 
     @Test
     void deleteSchedule() {
-        service.createSchedule("to-del", null, "rate(1 hour)", null,
-                new FlexibleTimeWindow("OFF", null),
-                new Target("arn:t", "arn:r", null, null),
-                null, null, null, null, null, null, REGION);
+        service.createSchedule(
+                newRequest("to-del", null, "rate(1 hour)",
+                        new FlexibleTimeWindow("OFF", null),
+                        new Target("arn:t", "arn:r", null, null)),
+                REGION);
         service.deleteSchedule("to-del", null, REGION);
         assertThrows(AwsException.class, () ->
                 service.getSchedule("to-del", null, REGION));
@@ -294,14 +319,16 @@ class SchedulerServiceTest {
 
     @Test
     void listSchedules() {
-        service.createSchedule("s1", null, "rate(1 hour)", null,
-                new FlexibleTimeWindow("OFF", null),
-                new Target("arn:t", "arn:r", null, null),
-                null, null, null, null, null, null, REGION);
-        service.createSchedule("s2", null, "rate(2 hours)", null,
-                new FlexibleTimeWindow("OFF", null),
-                new Target("arn:t", "arn:r", null, null),
-                null, null, null, null, null, null, REGION);
+        service.createSchedule(
+                newRequest("s1", null, "rate(1 hour)",
+                        new FlexibleTimeWindow("OFF", null),
+                        new Target("arn:t", "arn:r", null, null)),
+                REGION);
+        service.createSchedule(
+                newRequest("s2", null, "rate(2 hours)",
+                        new FlexibleTimeWindow("OFF", null),
+                        new Target("arn:t", "arn:r", null, null)),
+                REGION);
         List<Schedule> result = service.listSchedules(null, null, null, REGION);
         assertEquals(2, result.size());
     }
@@ -309,14 +336,16 @@ class SchedulerServiceTest {
     @Test
     void listSchedulesAcrossGroups() {
         service.createScheduleGroup("group-a", null, REGION);
-        service.createSchedule("s-default", null, "rate(1 hour)", null,
-                new FlexibleTimeWindow("OFF", null),
-                new Target("arn:t", "arn:r", null, null),
-                null, null, null, null, null, null, REGION);
-        service.createSchedule("s-group-a", "group-a", "rate(1 hour)", null,
-                new FlexibleTimeWindow("OFF", null),
-                new Target("arn:t", "arn:r", null, null),
-                null, null, null, null, null, null, REGION);
+        service.createSchedule(
+                newRequest("s-default", null, "rate(1 hour)",
+                        new FlexibleTimeWindow("OFF", null),
+                        new Target("arn:t", "arn:r", null, null)),
+                REGION);
+        service.createSchedule(
+                newRequest("s-group-a", "group-a", "rate(1 hour)",
+                        new FlexibleTimeWindow("OFF", null),
+                        new Target("arn:t", "arn:r", null, null)),
+                REGION);
         List<Schedule> result = service.listSchedules(null, null, null, REGION);
         assertEquals(2, result.size());
         assertTrue(result.stream().anyMatch(s -> "s-default".equals(s.getName())));
@@ -326,14 +355,16 @@ class SchedulerServiceTest {
     @Test
     void listSchedulesFilteredByGroup() {
         service.createScheduleGroup("group-b", null, REGION);
-        service.createSchedule("s-in-default", null, "rate(1 hour)", null,
-                new FlexibleTimeWindow("OFF", null),
-                new Target("arn:t", "arn:r", null, null),
-                null, null, null, null, null, null, REGION);
-        service.createSchedule("s-in-group-b", "group-b", "rate(1 hour)", null,
-                new FlexibleTimeWindow("OFF", null),
-                new Target("arn:t", "arn:r", null, null),
-                null, null, null, null, null, null, REGION);
+        service.createSchedule(
+                newRequest("s-in-default", null, "rate(1 hour)",
+                        new FlexibleTimeWindow("OFF", null),
+                        new Target("arn:t", "arn:r", null, null)),
+                REGION);
+        service.createSchedule(
+                newRequest("s-in-group-b", "group-b", "rate(1 hour)",
+                        new FlexibleTimeWindow("OFF", null),
+                        new Target("arn:t", "arn:r", null, null)),
+                REGION);
         List<Schedule> result = service.listSchedules("group-b", null, null, REGION);
         assertEquals(1, result.size());
         assertEquals("s-in-group-b", result.get(0).getName());
@@ -341,18 +372,21 @@ class SchedulerServiceTest {
 
     @Test
     void listSchedulesWithNamePrefix() {
-        service.createSchedule("alpha-1", null, "rate(1 hour)", null,
-                new FlexibleTimeWindow("OFF", null),
-                new Target("arn:t", "arn:r", null, null),
-                null, null, null, null, null, null, REGION);
-        service.createSchedule("alpha-2", null, "rate(1 hour)", null,
-                new FlexibleTimeWindow("OFF", null),
-                new Target("arn:t", "arn:r", null, null),
-                null, null, null, null, null, null, REGION);
-        service.createSchedule("beta-1", null, "rate(1 hour)", null,
-                new FlexibleTimeWindow("OFF", null),
-                new Target("arn:t", "arn:r", null, null),
-                null, null, null, null, null, null, REGION);
+        service.createSchedule(
+                newRequest("alpha-1", null, "rate(1 hour)",
+                        new FlexibleTimeWindow("OFF", null),
+                        new Target("arn:t", "arn:r", null, null)),
+                REGION);
+        service.createSchedule(
+                newRequest("alpha-2", null, "rate(1 hour)",
+                        new FlexibleTimeWindow("OFF", null),
+                        new Target("arn:t", "arn:r", null, null)),
+                REGION);
+        service.createSchedule(
+                newRequest("beta-1", null, "rate(1 hour)",
+                        new FlexibleTimeWindow("OFF", null),
+                        new Target("arn:t", "arn:r", null, null)),
+                REGION);
         List<Schedule> result = service.listSchedules(null, "alpha", null, REGION);
         assertEquals(2, result.size());
         assertTrue(result.stream().allMatch(s -> s.getName().startsWith("alpha")));
@@ -360,14 +394,18 @@ class SchedulerServiceTest {
 
     @Test
     void listSchedulesWithStateFilter() {
-        service.createSchedule("enabled-1", null, "rate(1 hour)", null,
+        ScheduleRequest enabledReq = newRequest("enabled-1", null, "rate(1 hour)",
                 new FlexibleTimeWindow("OFF", null),
-                new Target("arn:t", "arn:r", null, null),
-                null, "ENABLED", null, null, null, null, REGION);
-        service.createSchedule("disabled-1", null, "rate(1 hour)", null,
+                new Target("arn:t", "arn:r", null, null));
+        enabledReq.setState("ENABLED");
+        service.createSchedule(enabledReq, REGION);
+
+        ScheduleRequest disabledReq = newRequest("disabled-1", null, "rate(1 hour)",
                 new FlexibleTimeWindow("OFF", null),
-                new Target("arn:t", "arn:r", null, null),
-                null, "DISABLED", null, null, null, null, REGION);
+                new Target("arn:t", "arn:r", null, null));
+        disabledReq.setState("DISABLED");
+        service.createSchedule(disabledReq, REGION);
+
         List<Schedule> result = service.listSchedules(null, null, "DISABLED", REGION);
         assertEquals(1, result.size());
         assertEquals("disabled-1", result.get(0).getName());
@@ -378,9 +416,9 @@ class SchedulerServiceTest {
         Target target = new Target("arn:aws:lambda:us-east-1:000000000000:function:my-func",
                 "arn:aws:iam::000000000000:role/my-role", null, null);
         target.setDeadLetterConfig(new DeadLetterConfig("arn:aws:sqs:us-east-1:000000000000:dlq"));
-        Schedule s = service.createSchedule("dlc-schedule", null, "rate(1 hour)", null,
-                new FlexibleTimeWindow("OFF", null), target,
-                null, null, null, null, null, null, REGION);
+        ScheduleRequest req = newRequest("dlc-schedule", null, "rate(1 hour)",
+                new FlexibleTimeWindow("OFF", null), target);
+        Schedule s = service.createSchedule(req, REGION);
         assertNotNull(s.getTarget().getDeadLetterConfig());
         assertEquals("arn:aws:sqs:us-east-1:000000000000:dlq",
                 s.getTarget().getDeadLetterConfig().getArn());
@@ -390,25 +428,27 @@ class SchedulerServiceTest {
     void updateSchedulePreservesDeadLetterConfig() {
         Target target = new Target("arn:t", "arn:r", null, null);
         target.setDeadLetterConfig(new DeadLetterConfig("arn:aws:sqs:us-east-1:000000000000:dlq"));
-        service.createSchedule("dlc-upd", null, "rate(1 hour)", null,
-                new FlexibleTimeWindow("OFF", null), target,
-                null, null, null, null, null, null, REGION);
+        service.createSchedule(
+                newRequest("dlc-upd", null, "rate(1 hour)",
+                        new FlexibleTimeWindow("OFF", null), target),
+                REGION);
 
         Target updatedTarget = new Target("arn:t2", "arn:r2", null, null);
         updatedTarget.setDeadLetterConfig(new DeadLetterConfig("arn:aws:sqs:us-east-1:000000000000:dlq-updated"));
-        Schedule updated = service.updateSchedule("dlc-upd", null, "rate(5 minutes)", null,
-                new FlexibleTimeWindow("OFF", null), updatedTarget,
-                null, null, null, null, null, null, REGION);
+        ScheduleRequest updateReq = newRequest("dlc-upd", null, "rate(5 minutes)",
+                new FlexibleTimeWindow("OFF", null), updatedTarget);
+        Schedule updated = service.updateSchedule(updateReq, REGION);
         assertEquals("arn:aws:sqs:us-east-1:000000000000:dlq-updated",
                 updated.getTarget().getDeadLetterConfig().getArn());
     }
 
     @Test
     void schedulesAreRegionScoped() {
-        service.createSchedule("regional", null, "rate(1 hour)", null,
-                new FlexibleTimeWindow("OFF", null),
-                new Target("arn:t", "arn:r", null, null),
-                null, null, null, null, null, null, "us-east-1");
+        service.createSchedule(
+                newRequest("regional", null, "rate(1 hour)",
+                        new FlexibleTimeWindow("OFF", null),
+                        new Target("arn:t", "arn:r", null, null)),
+                "us-east-1");
         assertThrows(AwsException.class, () ->
                 service.getSchedule("regional", null, "us-west-2"));
     }

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerServiceTest.java
@@ -3,7 +3,10 @@ package io.github.hectorvent.floci.services.scheduler;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.scheduler.model.FlexibleTimeWindow;
+import io.github.hectorvent.floci.services.scheduler.model.Schedule;
 import io.github.hectorvent.floci.services.scheduler.model.ScheduleGroup;
+import io.github.hectorvent.floci.services.scheduler.model.Target;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -21,6 +24,7 @@ class SchedulerServiceTest {
     @BeforeEach
     void setUp() {
         service = new SchedulerService(
+                new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
                 new RegionResolver("us-east-1", "000000000000")
         );
@@ -152,5 +156,178 @@ class SchedulerServiceTest {
         service.createScheduleGroup("shared", null, "us-east-1");
         assertThrows(AwsException.class, () ->
                 service.getScheduleGroup("shared", "us-west-2"));
+    }
+
+    // ──────────────────────────── Schedule tests ────────────────────────────
+
+    @Test
+    void createSchedule() {
+        Schedule s = service.createSchedule("my-schedule", null, "rate(1 hour)", null,
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:aws:lambda:us-east-1:000000000000:function:my-func",
+                        "arn:aws:iam::000000000000:role/my-role", null, null),
+                null, null, null, null, null, null, REGION);
+        assertEquals("my-schedule", s.getName());
+        assertEquals("default", s.getGroupName());
+        assertEquals("ENABLED", s.getState());
+        assertTrue(s.getArn().contains("schedule/default/my-schedule"));
+        assertNotNull(s.getCreationDate());
+        assertNotNull(s.getLastModificationDate());
+    }
+
+    @Test
+    void createScheduleInCustomGroup() {
+        service.createScheduleGroup("custom", null, REGION);
+        Schedule s = service.createSchedule("my-schedule", "custom", "rate(5 minutes)", null,
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:aws:sqs:us-east-1:000000000000:my-queue",
+                        "arn:aws:iam::000000000000:role/r", null, null),
+                null, null, null, null, null, null, REGION);
+        assertEquals("custom", s.getGroupName());
+        assertTrue(s.getArn().contains("schedule/custom/my-schedule"));
+    }
+
+    @Test
+    void createScheduleDuplicateThrows() {
+        service.createSchedule("dup", null, "rate(1 hour)", null,
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:t", "arn:r", null, null),
+                null, null, null, null, null, null, REGION);
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.createSchedule("dup", null, "rate(1 hour)", null,
+                        new FlexibleTimeWindow("OFF", null),
+                        new Target("arn:t", "arn:r", null, null),
+                        null, null, null, null, null, null, REGION));
+        assertEquals("ConflictException", e.getErrorCode());
+    }
+
+    @Test
+    void createScheduleInNonExistentGroupThrows() {
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.createSchedule("s", "no-such-group", "rate(1 hour)", null,
+                        new FlexibleTimeWindow("OFF", null),
+                        new Target("arn:t", "arn:r", null, null),
+                        null, null, null, null, null, null, REGION));
+        assertEquals("ResourceNotFoundException", e.getErrorCode());
+    }
+
+    @Test
+    void getSchedule() {
+        service.createSchedule("find-me", null, "rate(1 hour)", null,
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:t", "arn:r", null, null),
+                null, null, null, null, null, null, REGION);
+        Schedule s = service.getSchedule("find-me", null, REGION);
+        assertEquals("find-me", s.getName());
+    }
+
+    @Test
+    void getScheduleNotFoundThrows() {
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.getSchedule("missing", null, REGION));
+        assertEquals("ResourceNotFoundException", e.getErrorCode());
+    }
+
+    @Test
+    void updateSchedule() {
+        service.createSchedule("upd", null, "rate(1 hour)", null,
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:t", "arn:r", null, null),
+                "original desc", null, null, null, null, null, REGION);
+        Schedule updated = service.updateSchedule("upd", null, "rate(5 minutes)", "UTC",
+                new FlexibleTimeWindow("FLEXIBLE", 10),
+                new Target("arn:t2", "arn:r2", "{}", null),
+                "updated desc", "DISABLED", null, null, null, null, REGION);
+        assertEquals("rate(5 minutes)", updated.getScheduleExpression());
+        assertEquals("DISABLED", updated.getState());
+        assertEquals("updated desc", updated.getDescription());
+        assertNotNull(updated.getCreationDate());
+        assertTrue(updated.getLastModificationDate().compareTo(updated.getCreationDate()) >= 0);
+    }
+
+    @Test
+    void updateScheduleNotFoundThrows() {
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.updateSchedule("missing", null, "rate(1 hour)", null,
+                        new FlexibleTimeWindow("OFF", null),
+                        new Target("arn:t", "arn:r", null, null),
+                        null, null, null, null, null, null, REGION));
+        assertEquals("ResourceNotFoundException", e.getErrorCode());
+    }
+
+    @Test
+    void deleteSchedule() {
+        service.createSchedule("to-del", null, "rate(1 hour)", null,
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:t", "arn:r", null, null),
+                null, null, null, null, null, null, REGION);
+        service.deleteSchedule("to-del", null, REGION);
+        assertThrows(AwsException.class, () ->
+                service.getSchedule("to-del", null, REGION));
+    }
+
+    @Test
+    void deleteScheduleNotFoundThrows() {
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.deleteSchedule("missing", null, REGION));
+        assertEquals("ResourceNotFoundException", e.getErrorCode());
+    }
+
+    @Test
+    void listSchedules() {
+        service.createSchedule("s1", null, "rate(1 hour)", null,
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:t", "arn:r", null, null),
+                null, null, null, null, null, null, REGION);
+        service.createSchedule("s2", null, "rate(2 hours)", null,
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:t", "arn:r", null, null),
+                null, null, null, null, null, null, REGION);
+        List<Schedule> result = service.listSchedules(null, null, null, REGION);
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void listSchedulesWithNamePrefix() {
+        service.createSchedule("alpha-1", null, "rate(1 hour)", null,
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:t", "arn:r", null, null),
+                null, null, null, null, null, null, REGION);
+        service.createSchedule("alpha-2", null, "rate(1 hour)", null,
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:t", "arn:r", null, null),
+                null, null, null, null, null, null, REGION);
+        service.createSchedule("beta-1", null, "rate(1 hour)", null,
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:t", "arn:r", null, null),
+                null, null, null, null, null, null, REGION);
+        List<Schedule> result = service.listSchedules(null, "alpha", null, REGION);
+        assertEquals(2, result.size());
+        assertTrue(result.stream().allMatch(s -> s.getName().startsWith("alpha")));
+    }
+
+    @Test
+    void listSchedulesWithStateFilter() {
+        service.createSchedule("enabled-1", null, "rate(1 hour)", null,
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:t", "arn:r", null, null),
+                null, "ENABLED", null, null, null, null, REGION);
+        service.createSchedule("disabled-1", null, "rate(1 hour)", null,
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:t", "arn:r", null, null),
+                null, "DISABLED", null, null, null, null, REGION);
+        List<Schedule> result = service.listSchedules(null, null, "DISABLED", REGION);
+        assertEquals(1, result.size());
+        assertEquals("disabled-1", result.get(0).getName());
+    }
+
+    @Test
+    void schedulesAreRegionScoped() {
+        service.createSchedule("regional", null, "rate(1 hour)", null,
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:t", "arn:r", null, null),
+                null, null, null, null, null, null, "us-east-1");
+        assertThrows(AwsException.class, () ->
+                service.getSchedule("regional", null, "us-west-2"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerServiceTest.java
@@ -276,6 +276,62 @@ class SchedulerServiceTest {
     }
 
     @Test
+    void createScheduleMissingFlexibleTimeWindowModeThrows() {
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.createSchedule(
+                        newRequest("s", null, "rate(1 hour)",
+                                new FlexibleTimeWindow(null, null),
+                                new Target("arn:t", "arn:r", null, null)),
+                        REGION));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
+    void createScheduleInvalidFlexibleTimeWindowModeThrows() {
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.createSchedule(
+                        newRequest("s", null, "rate(1 hour)",
+                                new FlexibleTimeWindow("INVALID", null),
+                                new Target("arn:t", "arn:r", null, null)),
+                        REGION));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
+    void createScheduleFlexibleMissingMaxWindowThrows() {
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.createSchedule(
+                        newRequest("s", null, "rate(1 hour)",
+                                new FlexibleTimeWindow("FLEXIBLE", null),
+                                new Target("arn:t", "arn:r", null, null)),
+                        REGION));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
+    void createScheduleOffModeWithMaxWindowThrows() {
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.createSchedule(
+                        newRequest("s", null, "rate(1 hour)",
+                                new FlexibleTimeWindow("OFF", 10),
+                                new Target("arn:t", "arn:r", null, null)),
+                        REGION));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
+    void createScheduleDeadLetterConfigMissingArnThrows() {
+        Target target = new Target("arn:t", "arn:r", null, null);
+        target.setDeadLetterConfig(new DeadLetterConfig(null));
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.createSchedule(
+                        newRequest("s", null, "rate(1 hour)",
+                                new FlexibleTimeWindow("OFF", null), target),
+                        REGION));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
     void updateScheduleMissingRequiredFieldsThrows() {
         service.createSchedule(
                 newRequest("val-upd", null, "rate(1 hour)",

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerServiceTest.java
@@ -1,0 +1,156 @@
+package io.github.hectorvent.floci.services.scheduler;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.scheduler.model.ScheduleGroup;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SchedulerServiceTest {
+
+    private static final String REGION = "us-east-1";
+
+    private SchedulerService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SchedulerService(
+                new InMemoryStorage<>(),
+                new RegionResolver("us-east-1", "000000000000")
+        );
+    }
+
+    @Test
+    void getOrCreateDefaultGroup() {
+        ScheduleGroup group = service.getOrCreateDefaultGroup(REGION);
+        assertEquals("default", group.getName());
+        assertEquals("ACTIVE", group.getState());
+        assertTrue(group.getArn().contains("schedule-group/default"));
+        assertTrue(group.getArn().contains(":scheduler:"));
+    }
+
+    @Test
+    void getOrCreateDefaultGroupIsIdempotent() {
+        ScheduleGroup first = service.getOrCreateDefaultGroup(REGION);
+        ScheduleGroup second = service.getOrCreateDefaultGroup(REGION);
+        assertEquals(first.getArn(), second.getArn());
+        assertEquals(first.getCreationDate(), second.getCreationDate());
+    }
+
+    @Test
+    void createScheduleGroup() {
+        ScheduleGroup group = service.createScheduleGroup("my-group", null, REGION);
+        assertEquals("my-group", group.getName());
+        assertEquals("ACTIVE", group.getState());
+        assertTrue(group.getArn().contains("schedule-group/my-group"));
+    }
+
+    @Test
+    void createScheduleGroupWithTags() {
+        ScheduleGroup group = service.createScheduleGroup(
+                "tagged", Map.of("env", "test"), REGION);
+        assertEquals("test", group.getTags().get("env"));
+    }
+
+    @Test
+    void createScheduleGroupDuplicateThrows() {
+        service.createScheduleGroup("dup", null, REGION);
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.createScheduleGroup("dup", null, REGION));
+        assertEquals("ConflictException", e.getErrorCode());
+        assertEquals(409, e.getHttpStatus());
+    }
+
+    @Test
+    void createScheduleGroupReservedDefaultNameThrows() {
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.createScheduleGroup("default", null, REGION));
+        assertEquals("ConflictException", e.getErrorCode());
+    }
+
+    @Test
+    void createScheduleGroupBlankNameThrows() {
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.createScheduleGroup("", null, REGION));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
+    void createScheduleGroupInvalidCharactersThrows() {
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.createScheduleGroup("bad name!", null, REGION));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
+    void getScheduleGroup() {
+        service.createScheduleGroup("find-me", null, REGION);
+        ScheduleGroup group = service.getScheduleGroup("find-me", REGION);
+        assertEquals("find-me", group.getName());
+    }
+
+    @Test
+    void getScheduleGroupNotFoundThrows() {
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.getScheduleGroup("missing", REGION));
+        assertEquals("ResourceNotFoundException", e.getErrorCode());
+        assertEquals(404, e.getHttpStatus());
+    }
+
+    @Test
+    void getScheduleGroupBlankReturnsDefault() {
+        ScheduleGroup group = service.getScheduleGroup("", REGION);
+        assertEquals("default", group.getName());
+    }
+
+    @Test
+    void deleteScheduleGroup() {
+        service.createScheduleGroup("to-delete", null, REGION);
+        service.deleteScheduleGroup("to-delete", REGION);
+        assertThrows(AwsException.class, () ->
+                service.getScheduleGroup("to-delete", REGION));
+    }
+
+    @Test
+    void deleteDefaultGroupThrows() {
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.deleteScheduleGroup("default", REGION));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
+    void deleteScheduleGroupNotFoundThrows() {
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.deleteScheduleGroup("missing", REGION));
+        assertEquals("ResourceNotFoundException", e.getErrorCode());
+    }
+
+    @Test
+    void listScheduleGroupsIncludesDefault() {
+        List<ScheduleGroup> groups = service.listScheduleGroups(null, REGION);
+        assertTrue(groups.stream().anyMatch(g -> "default".equals(g.getName())));
+    }
+
+    @Test
+    void listScheduleGroupsWithPrefix() {
+        service.createScheduleGroup("alpha-1", null, REGION);
+        service.createScheduleGroup("alpha-2", null, REGION);
+        service.createScheduleGroup("beta-1", null, REGION);
+        List<ScheduleGroup> result = service.listScheduleGroups("alpha", REGION);
+        assertEquals(2, result.size());
+        assertTrue(result.stream().allMatch(g -> g.getName().startsWith("alpha")));
+    }
+
+    @Test
+    void scheduleGroupsAreRegionScoped() {
+        service.createScheduleGroup("shared", null, "us-east-1");
+        assertThrows(AwsException.class, () ->
+                service.getScheduleGroup("shared", "us-west-2"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerServiceTest.java
@@ -5,6 +5,7 @@ import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.scheduler.model.DeadLetterConfig;
 import io.github.hectorvent.floci.services.scheduler.model.FlexibleTimeWindow;
+import io.github.hectorvent.floci.services.scheduler.model.RetryPolicy;
 import io.github.hectorvent.floci.services.scheduler.model.Schedule;
 import io.github.hectorvent.floci.services.scheduler.model.ScheduleGroup;
 import io.github.hectorvent.floci.services.scheduler.model.ScheduleRequest;
@@ -12,6 +13,7 @@ import io.github.hectorvent.floci.services.scheduler.model.Target;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -509,6 +511,36 @@ class SchedulerServiceTest {
         Schedule updated = service.updateSchedule(updateReq, REGION);
         assertEquals("arn:aws:sqs:us-east-1:000000000000:dlq-updated",
                 updated.getTarget().getDeadLetterConfig().getArn());
+    }
+
+    @Test
+    void createScheduleWithRetryPolicy() {
+        Target target = new Target("arn:t", "arn:r", null, null);
+        target.setRetryPolicy(new RetryPolicy(3600, 5));
+        ScheduleRequest req = newRequest("retry-schedule", null, "rate(1 hour)",
+                new FlexibleTimeWindow("OFF", null), target);
+        Schedule s = service.createSchedule(req, REGION);
+        assertNotNull(s.getTarget().getRetryPolicy());
+        assertEquals(3600, s.getTarget().getRetryPolicy().getMaximumEventAgeInSeconds());
+        assertEquals(5, s.getTarget().getRetryPolicy().getMaximumRetryAttempts());
+    }
+
+    @Test
+    void createScheduleWithStartAndEndDate() {
+        Instant start = Instant.parse("2026-06-01T00:00:00Z");
+        Instant end = Instant.parse("2026-12-31T23:59:59Z");
+        ScheduleRequest req = newRequest("dated-schedule", null, "rate(1 hour)",
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:t", "arn:r", null, null));
+        req.setStartDate(start);
+        req.setEndDate(end);
+        Schedule s = service.createSchedule(req, REGION);
+        assertEquals(start, s.getStartDate());
+        assertEquals(end, s.getEndDate());
+
+        Schedule fetched = service.getSchedule("dated-schedule", null, REGION);
+        assertEquals(start, fetched.getStartDate());
+        assertEquals(end, fetched.getEndDate());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerServiceTest.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.scheduler;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.scheduler.model.DeadLetterConfig;
 import io.github.hectorvent.floci.services.scheduler.model.FlexibleTimeWindow;
 import io.github.hectorvent.floci.services.scheduler.model.Schedule;
 import io.github.hectorvent.floci.services.scheduler.model.ScheduleGroup;
@@ -352,6 +353,36 @@ class SchedulerServiceTest {
         List<Schedule> result = service.listSchedules(null, null, "DISABLED", REGION);
         assertEquals(1, result.size());
         assertEquals("disabled-1", result.get(0).getName());
+    }
+
+    @Test
+    void createScheduleWithDeadLetterConfig() {
+        Target target = new Target("arn:aws:lambda:us-east-1:000000000000:function:my-func",
+                "arn:aws:iam::000000000000:role/my-role", null, null);
+        target.setDeadLetterConfig(new DeadLetterConfig("arn:aws:sqs:us-east-1:000000000000:dlq"));
+        Schedule s = service.createSchedule("dlc-schedule", null, "rate(1 hour)", null,
+                new FlexibleTimeWindow("OFF", null), target,
+                null, null, null, null, null, null, REGION);
+        assertNotNull(s.getTarget().getDeadLetterConfig());
+        assertEquals("arn:aws:sqs:us-east-1:000000000000:dlq",
+                s.getTarget().getDeadLetterConfig().getArn());
+    }
+
+    @Test
+    void updateSchedulePreservesDeadLetterConfig() {
+        Target target = new Target("arn:t", "arn:r", null, null);
+        target.setDeadLetterConfig(new DeadLetterConfig("arn:aws:sqs:us-east-1:000000000000:dlq"));
+        service.createSchedule("dlc-upd", null, "rate(1 hour)", null,
+                new FlexibleTimeWindow("OFF", null), target,
+                null, null, null, null, null, null, REGION);
+
+        Target updatedTarget = new Target("arn:t2", "arn:r2", null, null);
+        updatedTarget.setDeadLetterConfig(new DeadLetterConfig("arn:aws:sqs:us-east-1:000000000000:dlq-updated"));
+        Schedule updated = service.updateSchedule("dlc-upd", null, "rate(5 minutes)", null,
+                new FlexibleTimeWindow("OFF", null), updatedTarget,
+                null, null, null, null, null, null, REGION);
+        assertEquals("arn:aws:sqs:us-east-1:000000000000:dlq-updated",
+                updated.getTarget().getDeadLetterConfig().getArn());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerServiceTest.java
@@ -288,6 +288,39 @@ class SchedulerServiceTest {
     }
 
     @Test
+    void listSchedulesAcrossGroups() {
+        service.createScheduleGroup("group-a", null, REGION);
+        service.createSchedule("s-default", null, "rate(1 hour)", null,
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:t", "arn:r", null, null),
+                null, null, null, null, null, null, REGION);
+        service.createSchedule("s-group-a", "group-a", "rate(1 hour)", null,
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:t", "arn:r", null, null),
+                null, null, null, null, null, null, REGION);
+        List<Schedule> result = service.listSchedules(null, null, null, REGION);
+        assertEquals(2, result.size());
+        assertTrue(result.stream().anyMatch(s -> "s-default".equals(s.getName())));
+        assertTrue(result.stream().anyMatch(s -> "s-group-a".equals(s.getName())));
+    }
+
+    @Test
+    void listSchedulesFilteredByGroup() {
+        service.createScheduleGroup("group-b", null, REGION);
+        service.createSchedule("s-in-default", null, "rate(1 hour)", null,
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:t", "arn:r", null, null),
+                null, null, null, null, null, null, REGION);
+        service.createSchedule("s-in-group-b", "group-b", "rate(1 hour)", null,
+                new FlexibleTimeWindow("OFF", null),
+                new Target("arn:t", "arn:r", null, null),
+                null, null, null, null, null, null, REGION);
+        List<Schedule> result = service.listSchedules("group-b", null, null, REGION);
+        assertEquals(1, result.size());
+        assertEquals("s-in-group-b", result.get(0).getName());
+    }
+
+    @Test
     void listSchedulesWithNamePrefix() {
         service.createSchedule("alpha-1", null, "rate(1 hour)", null,
                 new FlexibleTimeWindow("OFF", null),

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerServiceTest.java
@@ -496,7 +496,7 @@ class SchedulerServiceTest {
     }
 
     @Test
-    void updateSchedulePreservesDeadLetterConfig() {
+    void updateScheduleOverwritesDeadLetterConfig() {
         Target target = new Target("arn:t", "arn:r", null, null);
         target.setDeadLetterConfig(new DeadLetterConfig("arn:aws:sqs:us-east-1:000000000000:dlq"));
         service.createSchedule(

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerServiceTest.java
@@ -221,6 +221,75 @@ class SchedulerServiceTest {
     }
 
     @Test
+    void createScheduleMissingExpressionThrows() {
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.createSchedule(
+                        newRequest("s", null, null,
+                                new FlexibleTimeWindow("OFF", null),
+                                new Target("arn:t", "arn:r", null, null)),
+                        REGION));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
+    void createScheduleMissingFlexibleTimeWindowThrows() {
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.createSchedule(
+                        newRequest("s", null, "rate(1 hour)", null,
+                                new Target("arn:t", "arn:r", null, null)),
+                        REGION));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
+    void createScheduleMissingTargetThrows() {
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.createSchedule(
+                        newRequest("s", null, "rate(1 hour)",
+                                new FlexibleTimeWindow("OFF", null), null),
+                        REGION));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
+    void createScheduleMissingTargetArnThrows() {
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.createSchedule(
+                        newRequest("s", null, "rate(1 hour)",
+                                new FlexibleTimeWindow("OFF", null),
+                                new Target(null, "arn:r", null, null)),
+                        REGION));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
+    void createScheduleMissingTargetRoleArnThrows() {
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.createSchedule(
+                        newRequest("s", null, "rate(1 hour)",
+                                new FlexibleTimeWindow("OFF", null),
+                                new Target("arn:t", null, null, null)),
+                        REGION));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
+    void updateScheduleMissingRequiredFieldsThrows() {
+        service.createSchedule(
+                newRequest("val-upd", null, "rate(1 hour)",
+                        new FlexibleTimeWindow("OFF", null),
+                        new Target("arn:t", "arn:r", null, null)),
+                REGION);
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.updateSchedule(
+                        newRequest("val-upd", null, null,
+                                new FlexibleTimeWindow("OFF", null),
+                                new Target("arn:t", "arn:r", null, null)),
+                        REGION));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
     void createScheduleDuplicateThrows() {
         service.createSchedule(
                 newRequest("dup", null, "rate(1 hour)",

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -76,6 +76,8 @@ floci:
       default-mariadb-image: "mariadb:11"
     eventbridge:
       enabled: true
+    scheduler:
+      enabled: true
     cloudwatchlogs:
       enabled: true
       max-events-per-query: 10000


### PR DESCRIPTION
## Summary

Add initial EventBridge Scheduler service with ScheduleGroup and Schedule CRUD operations.

Implemented actions:
- `CreateScheduleGroup` / `GetScheduleGroup` / `DeleteScheduleGroup` / `ListScheduleGroups`
- `CreateSchedule` / `GetSchedule` / `UpdateSchedule` / `DeleteSchedule` / `ListSchedules`

Includes `DeadLetterConfig`, `RetryPolicy`, and `FlexibleTimeWindow` support on Schedule Target.

**Not included in this PR** (can be added incrementally):
- `TagResource` / `UntagResource` / `ListTagsForResource`
- Schedule invocation (actually triggering targets on schedule)
- `NextToken`-based pagination for List operations
- `GetScheduleGroup` returning `DELETING` state during async deletion

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified with AWS Java SDK v2 (`software.amazon.awssdk:scheduler`) in the SDK compatibility test suite (`compatibility-tests/sdk-test-java`).

Closes #7 

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)