### PR TITLE
feat(lambda): add PutFunctionConcurrency stub

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaConcurrencyTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaConcurrencyTest.java
@@ -1,0 +1,138 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.*;
+import software.amazon.awssdk.services.lambda.model.Runtime;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("Lambda - PutFunctionConcurrency")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class LambdaConcurrencyTest {
+
+    private static final String FUNCTION_NAME = "sdk-test-concurrency-fn";
+    private static final String ROLE = "arn:aws:iam::000000000000:role/lambda-role";
+
+    private static LambdaClient lambda;
+
+    @BeforeAll
+    static void setup() {
+        lambda = TestFixtures.lambdaClient();
+        lambda.createFunction(CreateFunctionRequest.builder()
+                .functionName(FUNCTION_NAME)
+                .runtime(Runtime.NODEJS20_X)
+                .role(ROLE)
+                .handler("index.handler")
+                .code(FunctionCode.builder()
+                        .zipFile(SdkBytes.fromByteArray(LambdaUtils.minimalZip()))
+                        .build())
+                .build());
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (lambda != null) {
+            try {
+                lambda.deleteFunction(DeleteFunctionRequest.builder()
+                        .functionName(FUNCTION_NAME).build());
+            } catch (Exception ignored) {}
+            lambda.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void getFunctionConcurrency_unset_returnsEmpty() {
+        GetFunctionConcurrencyResponse response = lambda.getFunctionConcurrency(
+                GetFunctionConcurrencyRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .build());
+
+        assertThat(response.reservedConcurrentExecutions()).isNull();
+    }
+
+    @Test
+    @Order(2)
+    void putFunctionConcurrency_setsAndReturnsValue() {
+        PutFunctionConcurrencyResponse response = lambda.putFunctionConcurrency(
+                PutFunctionConcurrencyRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .reservedConcurrentExecutions(5)
+                        .build());
+
+        assertThat(response.reservedConcurrentExecutions()).isEqualTo(5);
+    }
+
+    @Test
+    @Order(3)
+    void getFunctionConcurrency_afterPut_returnsValue() {
+        GetFunctionConcurrencyResponse response = lambda.getFunctionConcurrency(
+                GetFunctionConcurrencyRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .build());
+
+        assertThat(response.reservedConcurrentExecutions()).isEqualTo(5);
+    }
+
+    @Test
+    @Order(4)
+    void putFunctionConcurrency_updatesExistingValue() {
+        PutFunctionConcurrencyResponse response = lambda.putFunctionConcurrency(
+                PutFunctionConcurrencyRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .reservedConcurrentExecutions(10)
+                        .build());
+
+        assertThat(response.reservedConcurrentExecutions()).isEqualTo(10);
+    }
+
+    @Test
+    @Order(5)
+    void putFunctionConcurrency_zeroIsAllowed() {
+        PutFunctionConcurrencyResponse response = lambda.putFunctionConcurrency(
+                PutFunctionConcurrencyRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .reservedConcurrentExecutions(0)
+                        .build());
+
+        assertThat(response.reservedConcurrentExecutions()).isEqualTo(0);
+    }
+
+    @Test
+    @Order(6)
+    void deleteFunctionConcurrency_clearsValue() {
+        lambda.deleteFunctionConcurrency(DeleteFunctionConcurrencyRequest.builder()
+                .functionName(FUNCTION_NAME)
+                .build());
+
+        GetFunctionConcurrencyResponse response = lambda.getFunctionConcurrency(
+                GetFunctionConcurrencyRequest.builder()
+                        .functionName(FUNCTION_NAME)
+                        .build());
+
+        assertThat(response.reservedConcurrentExecutions()).isNull();
+    }
+
+    @Test
+    @Order(7)
+    void putFunctionConcurrency_unknownFunction_throws404() {
+        assertThatThrownBy(() -> lambda.putFunctionConcurrency(
+                PutFunctionConcurrencyRequest.builder()
+                        .functionName("does-not-exist")
+                        .reservedConcurrentExecutions(5)
+                        .build()))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    @Order(8)
+    void getFunctionConcurrency_unknownFunction_throws404() {
+        assertThatThrownBy(() -> lambda.getFunctionConcurrency(
+                GetFunctionConcurrencyRequest.builder()
+                        .functionName("does-not-exist")
+                        .build()))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaConcurrencyTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaConcurrencyTest.java
@@ -8,7 +8,7 @@ import software.amazon.awssdk.services.lambda.model.Runtime;
 
 import static org.assertj.core.api.Assertions.*;
 
-@DisplayName("Lambda - PutFunctionConcurrency")
+@DisplayName("Lambda - Function concurrency")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class LambdaConcurrencyTest {
 

--- a/docs/services/lambda.md
+++ b/docs/services/lambda.md
@@ -39,6 +39,14 @@ Lambda runs your function code inside real Docker containers — the same way re
 | `ListTags` | List tags on a function |
 | `TagResource` | Tag a function |
 | `UntagResource` | Untag a function |
+| `PutFunctionConcurrency` | Set reserved concurrent executions (stub — value stored but not enforced) |
+| `GetFunctionConcurrency` | Get reserved concurrent executions |
+| `DeleteFunctionConcurrency` | Clear reserved concurrent executions |
+
+!!! note "Concurrency is a stub"
+    `PutFunctionConcurrency` persists `ReservedConcurrentExecutions` on the function
+    and echoes it back, but Floci does not enforce the limit at invocation time and
+    does not validate against the account-level concurrent execution limit.
 
 Function URLs are also reachable directly on `/{proxy:.*}` under the Lambda URL controller, which routes the request into the normal `Invoke` path.
 
@@ -49,7 +57,7 @@ Function URLs are also reachable directly on `/{proxy:.*}` under the Lambda URL 
 These AWS Lambda operations have no handler in Floci. Calls will return `404` or an error:
 
 - Layers (`PublishLayerVersion`, `DeleteLayerVersion`, `GetLayerVersion`, `GetLayerVersionByArn`, `AddLayerVersionPermission`, `RemoveLayerVersionPermission`, `GetLayerVersionPolicy`)
-- Concurrency controls (`PutFunctionConcurrency`, `GetFunctionConcurrency`, `DeleteFunctionConcurrency`, `PutProvisionedConcurrencyConfig`, `GetProvisionedConcurrencyConfig`, `ListProvisionedConcurrencyConfigs`, `DeleteProvisionedConcurrencyConfig`)
+- Provisioned concurrency (`PutProvisionedConcurrencyConfig`, `GetProvisionedConcurrencyConfig`, `ListProvisionedConcurrencyConfigs`, `DeleteProvisionedConcurrencyConfig`)
 - `UpdateFunctionConfiguration` (use `UpdateFunctionCode` for code-only updates; configuration-only updates are not separately supported)
 - Dead-letter, async invoke config, and event invoke config operations
 - `InvokeWithResponseStream`

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaConcurrencyController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaConcurrencyController.java
@@ -1,0 +1,101 @@
+package io.github.hectorvent.floci.services.lambda;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.lambda.model.LambdaFunction;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.Map;
+
+/**
+ * Lambda reserved concurrency endpoints. These span two API version prefixes:
+ *
+ * PutFunctionConcurrency:    PUT    /2017-10-31/functions/{FunctionName}/concurrency
+ * DeleteFunctionConcurrency: DELETE /2017-10-31/functions/{FunctionName}/concurrency
+ * GetFunctionConcurrency:    GET    /2019-09-30/functions/{FunctionName}/concurrency
+ *
+ * The class-level {@code @Path("/")} lets each method declare its own absolute
+ * version prefix rather than inheriting a single one.
+ *
+ * The stored value is not enforced at invocation time — this is a stub so that
+ * tools and SDKs expecting the endpoint to exist can proceed.
+ */
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class LambdaConcurrencyController {
+
+    private final LambdaService lambdaService;
+    private final RegionResolver regionResolver;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public LambdaConcurrencyController(LambdaService lambdaService,
+                                       RegionResolver regionResolver,
+                                       ObjectMapper objectMapper) {
+        this.lambdaService = lambdaService;
+        this.regionResolver = regionResolver;
+        this.objectMapper = objectMapper;
+    }
+
+    @PUT
+    @Path("/2017-10-31/functions/{functionName}/concurrency")
+    public Response putFunctionConcurrency(@Context HttpHeaders headers,
+                                           @PathParam("functionName") String functionName,
+                                           String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> request = objectMapper.readValue(body, Map.class);
+            Object raw = request.get("ReservedConcurrentExecutions");
+            if (!(raw instanceof Number)) {
+                throw new AwsException("InvalidParameterValueException",
+                        "ReservedConcurrentExecutions is required", 400);
+            }
+            LambdaFunction fn = lambdaService.putFunctionConcurrency(
+                    region, functionName, ((Number) raw).intValue());
+            ObjectNode root = objectMapper.createObjectNode();
+            root.put("ReservedConcurrentExecutions", fn.getReservedConcurrentExecutions());
+            return Response.ok(root).build();
+        } catch (AwsException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AwsException("InvalidParameterValueException", e.getMessage(), 400);
+        }
+    }
+
+    @GET
+    @Path("/2019-09-30/functions/{functionName}/concurrency")
+    public Response getFunctionConcurrency(@Context HttpHeaders headers,
+                                           @PathParam("functionName") String functionName) {
+        String region = regionResolver.resolveRegion(headers);
+        Integer reserved = lambdaService.getFunctionConcurrency(region, functionName);
+        ObjectNode root = objectMapper.createObjectNode();
+        if (reserved != null) {
+            root.put("ReservedConcurrentExecutions", reserved);
+        }
+        return Response.ok(root).build();
+    }
+
+    @DELETE
+    @Path("/2017-10-31/functions/{functionName}/concurrency")
+    public Response deleteFunctionConcurrency(@Context HttpHeaders headers,
+                                              @PathParam("functionName") String functionName) {
+        String region = regionResolver.resolveRegion(headers);
+        lambdaService.deleteFunctionConcurrency(region, functionName);
+        return Response.noContent().build();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaConcurrencyController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaConcurrencyController.java
@@ -60,13 +60,26 @@ public class LambdaConcurrencyController {
         try {
             @SuppressWarnings("unchecked")
             Map<String, Object> request = objectMapper.readValue(body, Map.class);
-            Object raw = request.get("ReservedConcurrentExecutions");
-            if (!(raw instanceof Number)) {
+            if (!request.containsKey("ReservedConcurrentExecutions")
+                    || request.get("ReservedConcurrentExecutions") == null) {
                 throw new AwsException("InvalidParameterValueException",
                         "ReservedConcurrentExecutions is required", 400);
             }
+            Object raw = request.get("ReservedConcurrentExecutions");
+            // Jackson parses JSON integer literals as Integer or Long. Anything else
+            // (Double, BigDecimal, String, etc.) must be rejected — AWS does not
+            // silently truncate 1.5 to 1.
+            if (!(raw instanceof Integer) && !(raw instanceof Long)) {
+                throw new AwsException("InvalidParameterValueException",
+                        "ReservedConcurrentExecutions must be an integer", 400);
+            }
+            long longValue = ((Number) raw).longValue();
+            if (longValue < Integer.MIN_VALUE || longValue > Integer.MAX_VALUE) {
+                throw new AwsException("InvalidParameterValueException",
+                        "ReservedConcurrentExecutions is out of range", 400);
+            }
             LambdaFunction fn = lambdaService.putFunctionConcurrency(
-                    region, functionName, ((Number) raw).intValue());
+                    region, functionName, (int) longValue);
             ObjectNode root = objectMapper.createObjectNode();
             root.put("ReservedConcurrentExecutions", fn.getReservedConcurrentExecutions());
             return Response.ok(root).build();

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -583,6 +583,28 @@ public class LambdaService {
         }
     }
 
+    public LambdaFunction putFunctionConcurrency(String region, String functionName, Integer reservedConcurrentExecutions) {
+        if (reservedConcurrentExecutions == null || reservedConcurrentExecutions < 0) {
+            throw new AwsException("InvalidParameterValueException",
+                    "ReservedConcurrentExecutions must be a non-negative integer", 400);
+        }
+        LambdaFunction fn = getFunction(region, functionName);
+        fn.setReservedConcurrentExecutions(reservedConcurrentExecutions);
+        functionStore.save(region, fn);
+        return fn;
+    }
+
+    public Integer getFunctionConcurrency(String region, String functionName) {
+        LambdaFunction fn = getFunction(region, functionName);
+        return fn.getReservedConcurrentExecutions();
+    }
+
+    public void deleteFunctionConcurrency(String region, String functionName) {
+        LambdaFunction fn = getFunction(region, functionName);
+        fn.setReservedConcurrentExecutions(null);
+        functionStore.save(region, fn);
+    }
+
     public LambdaFunction getFunctionByUrlId(String urlId) {
         return functionStore.getByUrlId(urlId)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException", "Function not found for URL ID: " + urlId, 404));

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/model/LambdaFunction.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/model/LambdaFunction.java
@@ -35,6 +35,7 @@ public class LambdaFunction {
     private String revisionId;
     private String version = "$LATEST";
     private LambdaUrlConfig urlConfig;
+    private Integer reservedConcurrentExecutions;
 
     @JsonIgnore
     private volatile ContainerState containerState = ContainerState.COLD;
@@ -107,6 +108,9 @@ public class LambdaFunction {
 
     public LambdaUrlConfig getUrlConfig() { return urlConfig; }
     public void setUrlConfig(LambdaUrlConfig urlConfig) { this.urlConfig = urlConfig; }
+
+    public Integer getReservedConcurrentExecutions() { return reservedConcurrentExecutions; }
+    public void setReservedConcurrentExecutions(Integer reservedConcurrentExecutions) { this.reservedConcurrentExecutions = reservedConcurrentExecutions; }
 
     @JsonIgnore
     public ContainerState getContainerState() { return containerState; }


### PR DESCRIPTION
## Summary

Add `PutFunctionConcurrency`, `GetFunctionConcurrency`, and `DeleteFunctionConcurrency` endpoints. These span two API version prefixes:

- `PUT    /2017-10-31/functions/{FunctionName}/concurrency`
- `DELETE /2017-10-31/functions/{FunctionName}/concurrency`
- `GET    /2019-09-30/functions/{FunctionName}/concurrency`

This is a **stub implementation**: `reservedConcurrentExecutions` is persisted on `LambdaFunction` and echoed back, but it does not affect actual execution — invocation slots in `LambdaExecutorService` / `WarmPool` are not enforced, and the account-level limit (default 1000) is not validated.

Out of scope (follow-ups):
- Runtime enforcement of reserved concurrency
- Account-level concurrent execution limit validation
- Exposing `Concurrency.ReservedConcurrentExecutions` on `GetFunction`

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified wire protocol against AWS SDK for Java v2 (`software.amazon.awssdk:lambda:2.31.8`) using `PutFunctionConcurrencyRequest` / `GetFunctionConcurrencyResponse` / `DeleteFunctionConcurrencyRequest` in the new `LambdaConcurrencyTest`. Endpoint paths and API version prefixes match the AWS Lambda API reference (Put/Delete under `2017-10-31`, Get under `2019-09-30`).

## Checklist

- [x] `./mvnw test` passes locally (8/8 in `LambdaConcurrencyTest`)
- [x] New or updated integration test added (`compatibility-tests/sdk-test-java/.../LambdaConcurrencyTest.java`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)