### PR TITLE
fix(s3): enforce conditional writes

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -410,6 +410,8 @@ public class S3Controller {
                               @HeaderParam("Content-Encoding") String contentEncoding,
                               @HeaderParam("x-amz-content-sha256") String contentSha256,
                               @HeaderParam("x-amz-copy-source") String copySource,
+                              @HeaderParam("If-Match") String ifMatch,
+                              @HeaderParam("If-None-Match") String ifNoneMatch,
                               @QueryParam("uploadId") String uploadId,
                               @QueryParam("partNumber") Integer partNumber,
                               @Context UriInfo uriInfo,
@@ -447,6 +449,11 @@ public class S3Controller {
 
             if (copySource != null && !copySource.isEmpty()) {
                 return handleCopyObject(copySource, bucket, key, contentType, httpHeaders);
+            }
+
+            Response preconditionResponse = checkWritePreconditions(bucket, key, ifMatch, ifNoneMatch);
+            if (preconditionResponse != null) {
+                return preconditionResponse;
             }
 
             String lockMode = httpHeaders.getHeaderString("x-amz-object-lock-mode");
@@ -788,6 +795,8 @@ public class S3Controller {
                                          @QueryParam("uploadId") String uploadId,
                                          @QueryParam("versionId") String versionId,
                                          @HeaderParam("Content-Type") String contentType,
+                                         @HeaderParam("If-Match") String ifMatch,
+                                         @HeaderParam("If-None-Match") String ifNoneMatch,
                                          @Context HttpHeaders httpHeaders,
                                          @Context UriInfo uriInfo,
                                          byte[] body) {
@@ -827,6 +836,10 @@ public class S3Controller {
 
             if (uploadId != null) {
                 List<Integer> partNumbers = parseCompleteMultipartBody(new String(body));
+                Response preconditionResponse = checkWritePreconditions(bucket, key, ifMatch, ifNoneMatch);
+                if (preconditionResponse != null) {
+                    return preconditionResponse;
+                }
                 S3Object obj = s3Service.completeMultipartUpload(bucket, key, uploadId, partNumbers);
                 String baseUrl = uriInfo.getBaseUri().toString();
                 if (baseUrl.endsWith("/")) {
@@ -1700,6 +1713,30 @@ public class S3Controller {
         return null;
     }
 
+    private Response checkWritePreconditions(String bucket, String key, String ifMatch, String ifNoneMatch) {
+        if (ifMatch == null && ifNoneMatch == null) {
+            return null;
+        }
+
+        S3Object existing;
+        try {
+            existing = s3Service.headObject(bucket, key);
+        } catch (AwsException e) {
+            if ("NoSuchKey".equals(e.getErrorCode()) && ifMatch == null) {
+                return null;
+            }
+            throw e;
+        }
+
+        if (ifMatch != null && !eTagMatches(ifMatch, existing.getETag())) {
+            return preconditionFailedResponse();
+        }
+        if (ifNoneMatch != null && eTagMatches(ifNoneMatch, existing.getETag())) {
+            return preconditionFailedResponse();
+        }
+        return null;
+    }
+
     private boolean hasPreconditions(String ifMatch, String ifNoneMatch,
                                       String ifModifiedSince, String ifUnmodifiedSince) {
         return ifMatch != null || ifNoneMatch != null || ifModifiedSince != null || ifUnmodifiedSince != null;
@@ -1718,15 +1755,28 @@ public class S3Controller {
     }
 
     private boolean eTagMatches(String headerValue, String eTag) {
-        if ("*".equals(headerValue.trim())) {
-            return true;
-        }
+        String normalizedETag = normalizeEntityTag(eTag);
         for (String candidate : headerValue.split(",")) {
-            if (candidate.trim().equals(eTag)) {
+            String normalizedCandidate = normalizeEntityTag(candidate);
+            if ("*".equals(normalizedCandidate) || normalizedCandidate.equals(normalizedETag)) {
                 return true;
             }
         }
         return false;
+    }
+
+    private static String normalizeEntityTag(String value) {
+        if (value == null) {
+            return "";
+        }
+        String normalized = value.trim();
+        if (normalized.startsWith("W/")) {
+            normalized = normalized.substring(2).trim();
+        }
+        if (normalized.length() >= 2 && normalized.startsWith("\"") && normalized.endsWith("\"")) {
+            normalized = normalized.substring(1, normalized.length() - 1);
+        }
+        return normalized;
     }
 
     private Instant parseHttpDate(String dateStr) {

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ConditionalWriteIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ConditionalWriteIntegrationTest.java
@@ -1,0 +1,275 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+@QuarkusTest
+class S3ConditionalWriteIntegrationTest {
+
+    @Test
+    void putObject_ifNoneMatchStar_succeedsWhenKeyMissing() {
+        String bucket = createBucket("put-if-none-missing");
+
+        given()
+            .header("If-None-Match", "*")
+            .body("first")
+        .when()
+            .put("/" + bucket + "/object.txt")
+        .then()
+            .statusCode(200)
+            .header("ETag", notNullValue());
+
+        assertObjectBody(bucket, "object.txt", "first");
+    }
+
+    @Test
+    void putObject_ifNoneMatchStar_412WhenKeyExistsAndDoesNotOverwrite() {
+        String bucket = createBucket("put-if-none-existing");
+        putObject(bucket, "object.txt", "first");
+
+        given()
+            .header("If-None-Match", "*")
+            .body("second")
+        .when()
+            .put("/" + bucket + "/object.txt")
+        .then()
+            .statusCode(412)
+            .body(containsString("PreconditionFailed"));
+
+        assertObjectBody(bucket, "object.txt", "first");
+    }
+
+    @Test
+    void putObject_ifNoneMatchEtag_succeedsWhenEtagDiffers() {
+        String bucket = createBucket("put-if-none-different");
+        putObject(bucket, "object.txt", "first");
+
+        given()
+            .header("If-None-Match", "\"not-the-current-etag\"")
+            .body("second")
+        .when()
+            .put("/" + bucket + "/object.txt")
+        .then()
+            .statusCode(200);
+
+        assertObjectBody(bucket, "object.txt", "second");
+    }
+
+    @Test
+    void putObject_ifNoneMatchEtag_412WhenEtagMatches() {
+        String bucket = createBucket("put-if-none-match");
+        String eTag = putObject(bucket, "object.txt", "first");
+
+        given()
+            .header("If-None-Match", eTag)
+            .body("second")
+        .when()
+            .put("/" + bucket + "/object.txt")
+        .then()
+            .statusCode(412)
+            .body(containsString("PreconditionFailed"));
+
+        assertObjectBody(bucket, "object.txt", "first");
+    }
+
+    @Test
+    void putObject_ifMatch_succeedsOnMatch() {
+        String bucket = createBucket("put-if-match");
+        String eTag = putObject(bucket, "object.txt", "first");
+
+        given()
+            .header("If-Match", eTag)
+            .body("second")
+        .when()
+            .put("/" + bucket + "/object.txt")
+        .then()
+            .statusCode(200);
+
+        assertObjectBody(bucket, "object.txt", "second");
+    }
+
+    @Test
+    void putObject_ifMatch_412OnMismatch() {
+        String bucket = createBucket("put-if-match-wrong");
+        putObject(bucket, "object.txt", "first");
+
+        given()
+            .header("If-Match", "\"not-the-current-etag\"")
+            .body("second")
+        .when()
+            .put("/" + bucket + "/object.txt")
+        .then()
+            .statusCode(412)
+            .body(containsString("PreconditionFailed"));
+
+        assertObjectBody(bucket, "object.txt", "first");
+    }
+
+    @Test
+    void putObject_headerValueWithAndWithoutQuotes_bothHonoured() {
+        String bucket = createBucket("put-quotes");
+        String eTag = putObject(bucket, "object.txt", "first");
+
+        given()
+            .header("If-Match", stripQuotes(eTag))
+            .body("second")
+        .when()
+            .put("/" + bucket + "/object.txt")
+        .then()
+            .statusCode(200);
+
+        String currentETag = given()
+            .when()
+                .head("/" + bucket + "/object.txt")
+            .then()
+                .statusCode(200)
+                .extract().header("ETag");
+
+        given()
+            .header("If-None-Match", stripQuotes(currentETag))
+            .body("third")
+        .when()
+            .put("/" + bucket + "/object.txt")
+        .then()
+            .statusCode(412)
+            .body(containsString("PreconditionFailed"));
+
+        given()
+            .header("If-None-Match", "\"*\"")
+            .body("third")
+        .when()
+            .put("/" + bucket + "/object.txt")
+        .then()
+            .statusCode(412)
+            .body(containsString("PreconditionFailed"));
+
+        assertObjectBody(bucket, "object.txt", "second");
+    }
+
+    @Test
+    void completeMultipartUpload_ifNoneMatchStar_412WhenKeyExists() {
+        String bucket = createBucket("mpu-if-none-existing");
+        putObject(bucket, "object.txt", "first");
+        String uploadId = initiateMultipartUpload(bucket, "object.txt");
+        uploadPart(bucket, "object.txt", uploadId, 1, "second");
+
+        given()
+            .contentType("application/xml")
+            .header("If-None-Match", "*")
+            .body(completeMultipartXml(1))
+        .when()
+            .post("/" + bucket + "/object.txt?uploadId=" + uploadId)
+        .then()
+            .statusCode(412)
+            .body(containsString("PreconditionFailed"));
+
+        assertObjectBody(bucket, "object.txt", "first");
+    }
+
+    @Test
+    void completeMultipartUpload_ifMatch_succeedsOnMatch() {
+        String bucket = createBucket("mpu-if-match");
+        String eTag = putObject(bucket, "object.txt", "first");
+        String uploadId = initiateMultipartUpload(bucket, "object.txt");
+        uploadPart(bucket, "object.txt", uploadId, 1, "second");
+
+        given()
+            .contentType("application/xml")
+            .header("If-Match", eTag)
+            .body(completeMultipartXml(1))
+        .when()
+            .post("/" + bucket + "/object.txt?uploadId=" + uploadId)
+        .then()
+            .statusCode(200)
+            .body(containsString("<CompleteMultipartUploadResult"));
+
+        assertObjectBody(bucket, "object.txt", "second");
+    }
+
+    @Test
+    void completeMultipartUpload_ifMatch_412OnMismatchAndDoesNotOverwrite() {
+        String bucket = createBucket("mpu-if-match-wrong");
+        putObject(bucket, "object.txt", "first");
+        String uploadId = initiateMultipartUpload(bucket, "object.txt");
+        uploadPart(bucket, "object.txt", uploadId, 1, "second");
+
+        given()
+            .contentType("application/xml")
+            .header("If-Match", "\"not-the-current-etag\"")
+            .body(completeMultipartXml(1))
+        .when()
+            .post("/" + bucket + "/object.txt?uploadId=" + uploadId)
+        .then()
+            .statusCode(412)
+            .body(containsString("PreconditionFailed"));
+
+        assertObjectBody(bucket, "object.txt", "first");
+    }
+
+    private static String createBucket(String label) {
+        String bucket = "cond-" + label + "-" + UUID.randomUUID().toString().substring(0, 8);
+        given()
+        .when()
+            .put("/" + bucket)
+        .then()
+            .statusCode(200);
+        return bucket;
+    }
+
+    private static String putObject(String bucket, String key, String body) {
+        return given()
+            .body(body)
+        .when()
+            .put("/" + bucket + "/" + key)
+        .then()
+            .statusCode(200)
+            .extract().header("ETag");
+    }
+
+    private static void assertObjectBody(String bucket, String key, String body) {
+        given()
+        .when()
+            .get("/" + bucket + "/" + key)
+        .then()
+            .statusCode(200)
+            .body(equalTo(body));
+    }
+
+    private static String initiateMultipartUpload(String bucket, String key) {
+        return given()
+            .contentType("application/octet-stream")
+        .when()
+            .post("/" + bucket + "/" + key + "?uploads")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath().getString("InitiateMultipartUploadResult.UploadId");
+    }
+
+    private static void uploadPart(String bucket, String key, String uploadId, int partNumber, String body) {
+        given()
+            .body(body)
+        .when()
+            .put("/" + bucket + "/" + key + "?uploadId=" + uploadId + "&partNumber=" + partNumber)
+        .then()
+            .statusCode(200)
+            .header("ETag", notNullValue());
+    }
+
+    private static String completeMultipartXml(int partNumber) {
+        return """
+                <CompleteMultipartUpload>
+                    <Part><PartNumber>%d</PartNumber><ETag>etag</ETag></Part>
+                </CompleteMultipartUpload>""".formatted(partNumber);
+    }
+
+    private static String stripQuotes(String eTag) {
+        return eTag.replace("\"", "");
+    }
+}


### PR DESCRIPTION
## Summary

Enforce S3 conditional write headers on `PutObject` and `CompleteMultipartUpload`.

- Apply `If-None-Match` before writing so `If-None-Match: *` does not overwrite an existing object
- Apply `If-Match` before writes for ETag-based optimistic concurrency
- Add integration coverage for put object and multipart completion conditional writes

Fixes #565

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Real S3 returns `412 PreconditionFailed` for failed conditional writes and leaves the existing object unchanged.

Docs:

- https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
- https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
- https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes.html

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)