### PR TITLE
feat(ses): add ConfigurationSet CRUD on v1 Query and v2 REST JSON

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesConfigurationSetTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesConfigurationSetTest.java
@@ -1,0 +1,228 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.ses.SesClient;
+import software.amazon.awssdk.services.ses.model.ConfigurationSet;
+import software.amazon.awssdk.services.ses.model.CreateConfigurationSetRequest;
+import software.amazon.awssdk.services.ses.model.DeleteConfigurationSetRequest;
+import software.amazon.awssdk.services.ses.model.DescribeConfigurationSetRequest;
+import software.amazon.awssdk.services.ses.model.DescribeConfigurationSetResponse;
+import software.amazon.awssdk.services.ses.model.ListConfigurationSetsRequest;
+import software.amazon.awssdk.services.ses.model.ListConfigurationSetsResponse;
+
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.GetConfigurationSetRequest;
+import software.amazon.awssdk.services.sesv2.model.GetConfigurationSetResponse;
+import software.amazon.awssdk.services.sesv2.model.Tag;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * SES ConfigurationSet compatibility tests against the V1 (query) SES API
+ * and the V2 (REST JSON) SESv2 API.
+ */
+@DisplayName("SES Configuration Sets")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesConfigurationSetTest {
+
+    private static SesClient sesV1;
+    private static SesV2Client sesV2;
+    private static String v1Name;
+    private static String v2Name;
+
+    @BeforeAll
+    static void setup() {
+        sesV1 = TestFixtures.sesClient();
+        sesV2 = TestFixtures.sesV2Client();
+        String suffix = TestFixtures.uniqueName();
+        v1Name = "sdk-v1-cs-" + suffix;
+        v2Name = "sdk-v2-cs-" + suffix;
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (sesV1 != null) {
+            safelyDeleteV1(v1Name);
+            sesV1.close();
+        }
+        if (sesV2 != null) {
+            safelyDeleteV2(v2Name);
+            sesV2.close();
+        }
+    }
+
+    // ─────────────────────────── V2 (SESv2) ───────────────────────────
+
+    @Test
+    @Order(1)
+    void v2CreateAndGetConfigurationSet() {
+        sesV2.createConfigurationSet(software.amazon.awssdk.services.sesv2.model.CreateConfigurationSetRequest.builder()
+                .configurationSetName(v2Name)
+                .tags(Tag.builder().key("env").value("test").build())
+                .build());
+
+        GetConfigurationSetResponse response = sesV2.getConfigurationSet(GetConfigurationSetRequest.builder()
+                .configurationSetName(v2Name)
+                .build());
+        assertThat(response.configurationSetName()).isEqualTo(v2Name);
+        assertThat(response.tags()).anyMatch(t -> "env".equals(t.key()) && "test".equals(t.value()));
+    }
+
+    @Test
+    @Order(2)
+    void v2CreateDuplicateRejectedWith400() {
+        assertThatThrownBy(() -> sesV2.createConfigurationSet(software.amazon.awssdk.services.sesv2.model.CreateConfigurationSetRequest.builder()
+                .configurationSetName(v2Name)
+                .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(400);
+    }
+
+    @Test
+    @Order(3)
+    void v2GetUnknownReturns404() {
+        assertThatThrownBy(() -> sesV2.getConfigurationSet(GetConfigurationSetRequest.builder()
+                .configurationSetName("sdk-v2-cs-missing-" + System.currentTimeMillis())
+                .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(404);
+    }
+
+    @Test
+    @Order(4)
+    void v2ListConfigurationSetsIncludesCreated() {
+        software.amazon.awssdk.services.sesv2.model.ListConfigurationSetsResponse response =
+                sesV2.listConfigurationSets(software.amazon.awssdk.services.sesv2.model.ListConfigurationSetsRequest.builder().build());
+        assertThat(response.configurationSets()).contains(v2Name);
+    }
+
+    @Test
+    @Order(5)
+    void v2DeleteConfigurationSet() {
+        sesV2.deleteConfigurationSet(software.amazon.awssdk.services.sesv2.model.DeleteConfigurationSetRequest.builder()
+                .configurationSetName(v2Name)
+                .build());
+
+        assertThatThrownBy(() -> sesV2.getConfigurationSet(GetConfigurationSetRequest.builder()
+                .configurationSetName(v2Name)
+                .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(404);
+    }
+
+    // ─────────────────────────── V1 (SES) ───────────────────────────
+
+    @Test
+    @Order(10)
+    void v1CreateAndDescribeConfigurationSet() {
+        sesV1.createConfigurationSet(CreateConfigurationSetRequest.builder()
+                .configurationSet(ConfigurationSet.builder().name(v1Name).build())
+                .build());
+
+        DescribeConfigurationSetResponse response = sesV1.describeConfigurationSet(
+                DescribeConfigurationSetRequest.builder()
+                        .configurationSetName(v1Name)
+                        .build());
+        assertThat(response.configurationSet().name()).isEqualTo(v1Name);
+    }
+
+    @Test
+    @Order(11)
+    void v1CreateDuplicateRaises() {
+        assertThatThrownBy(() -> sesV1.createConfigurationSet(CreateConfigurationSetRequest.builder()
+                .configurationSet(ConfigurationSet.builder().name(v1Name).build())
+                .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(400);
+    }
+
+    @Test
+    @Order(12)
+    void v1DescribeUnknownRaises() {
+        assertThatThrownBy(() -> sesV1.describeConfigurationSet(DescribeConfigurationSetRequest.builder()
+                .configurationSetName("sdk-v1-cs-missing-" + System.currentTimeMillis())
+                .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(400);
+    }
+
+    @Test
+    @Order(13)
+    void v1ListConfigurationSetsIncludesCreated() {
+        ListConfigurationSetsResponse response = sesV1.listConfigurationSets(
+                ListConfigurationSetsRequest.builder().build());
+        assertThat(response.configurationSets())
+                .anyMatch(cs -> v1Name.equals(cs.name()));
+    }
+
+    @Test
+    @Order(14)
+    void v1DeleteConfigurationSet() {
+        sesV1.deleteConfigurationSet(DeleteConfigurationSetRequest.builder()
+                .configurationSetName(v1Name)
+                .build());
+
+        assertThatThrownBy(() -> sesV1.describeConfigurationSet(DescribeConfigurationSetRequest.builder()
+                .configurationSetName(v1Name)
+                .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(400);
+    }
+
+    // ────────────────────────── Validation ──────────────────────────
+
+    @Test
+    @Order(20)
+    void v2CreateRejectsInvalidName() {
+        assertThatThrownBy(() -> sesV2.createConfigurationSet(software.amazon.awssdk.services.sesv2.model.CreateConfigurationSetRequest.builder()
+                .configurationSetName("invalid name!")
+                .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(400);
+    }
+
+    @Test
+    @Order(21)
+    void v1CreateRejectsInvalidName() {
+        assertThatThrownBy(() -> sesV1.createConfigurationSet(CreateConfigurationSetRequest.builder()
+                .configurationSet(ConfigurationSet.builder().name("invalid name!").build())
+                .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(400);
+    }
+
+    // ─────────────────────────── Helpers ───────────────────────────
+
+    private static void safelyDeleteV1(String name) {
+        try {
+            sesV1.deleteConfigurationSet(DeleteConfigurationSetRequest.builder()
+                    .configurationSetName(name)
+                    .build());
+        } catch (Exception ignored) {}
+    }
+
+    private static void safelyDeleteV2(String name) {
+        try {
+            sesV2.deleteConfigurationSet(software.amazon.awssdk.services.sesv2.model.DeleteConfigurationSetRequest.builder()
+                    .configurationSetName(name)
+                    .build());
+        } catch (Exception ignored) {}
+    }
+}

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -31,6 +31,10 @@ Floci exposes the classic Amazon SES Query API used by `aws ses ...` commands an
 | `SetIdentityNotificationTopic`      | Store SNS notification topic ARNs for an identity         |
 | `GetIdentityNotificationAttributes` | Read stored notification topic settings                   |
 | `GetIdentityDkimAttributes`         | Return DKIM status for identities                         |
+| `CreateConfigurationSet`            | Create a configuration set                                |
+| `DescribeConfigurationSet`          | Read a configuration set                                  |
+| `ListConfigurationSets`             | List configuration sets                                   |
+| `DeleteConfigurationSet`            | Delete a configuration set                                |
 
 ## Configuration
 
@@ -178,5 +182,9 @@ Alongside the classic Query API, Floci implements a subset of the SES v2 REST JS
 | `GET` | `/v2/email/templates/{templateName}` | `GetEmailTemplate` |
 | `PUT` | `/v2/email/templates/{templateName}` | `UpdateEmailTemplate` |
 | `DELETE` | `/v2/email/templates/{templateName}` | `DeleteEmailTemplate` |
+| `POST` | `/v2/email/configuration-sets` | `CreateConfigurationSet` |
+| `GET` | `/v2/email/configuration-sets` | `ListConfigurationSets` |
+| `GET` | `/v2/email/configuration-sets/{name}` | `GetConfigurationSet` |
+| `DELETE` | `/v2/email/configuration-sets/{name}` | `DeleteConfigurationSet` |
 
-Identity, template, and sent-message state is shared between the v1 Query API and the v2 REST JSON API, so a template created with `CreateTemplate` resolves through `SendEmail` on v2 (and vice versa), and every send appears in the same `GET /_aws/ses` inspection mailbox.
+Identity, template, configuration-set, and sent-message state is shared between the v1 Query API and the v2 REST JSON API, so a template created with `CreateTemplate` resolves through `SendEmail` on v2 (and vice versa), a configuration set created with `CreateConfigurationSet` is visible to both `DescribeConfigurationSet` (v1) and `GetConfigurationSet` (v2), and every send appears in the same `GET /_aws/ses` inspection mailbox.

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -279,7 +279,9 @@ public class AwsQueryController {
             "SetIdentityNotificationTopic", "GetIdentityNotificationAttributes",
             "GetIdentityDkimAttributes",
             "CreateTemplate", "UpdateTemplate", "GetTemplate", "DeleteTemplate",
-            "ListTemplates", "SendTemplatedEmail"
+            "ListTemplates", "SendTemplatedEmail",
+            "CreateConfigurationSet", "DescribeConfigurationSet",
+            "ListConfigurationSets", "DeleteConfigurationSet"
     );
 
     private static final Set<String> COGNITO_ACTIONS = Set.of(

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.ses;
 
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -364,6 +365,92 @@ public class SesController {
         }
     }
 
+    // ──────────────────────── Configuration Sets ───────────────────────
+
+    @POST
+    @Path("/configuration-sets")
+    public Response createConfigurationSet(@Context HttpHeaders headers, String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode request = objectMapper.readTree(body);
+            String name = request.path("ConfigurationSetName").asText(null);
+            if (name == null || name.isBlank()) {
+                throw new AwsException("BadRequestException", "ConfigurationSetName is required.", 400);
+            }
+            ConfigurationSet cs = new ConfigurationSet(name);
+            JsonNode tags = request.get("Tags");
+            if (tags != null && !tags.isNull()) {
+                if (!tags.isArray()) {
+                    throw new AwsException("BadRequestException",
+                            "Tags must be an array.", 400);
+                }
+                List<ConfigurationSet.Tag> tagList = new ArrayList<>();
+                for (JsonNode t : tags) {
+                    tagList.add(new ConfigurationSet.Tag(
+                            t.path("Key").asText(null),
+                            t.path("Value").asText(null)));
+                }
+                cs.setTags(tagList);
+            }
+            sesService.createConfigurationSet(cs, region);
+            LOG.infov("SES V2 CreateConfigurationSet: {0}", name);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        } catch (Exception e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @GET
+    @Path("/configuration-sets")
+    public Response listConfigurationSets(@Context HttpHeaders headers) {
+        String region = regionResolver.resolveRegion(headers);
+        List<ConfigurationSet> all = sesService.listConfigurationSets(region);
+        ObjectNode result = objectMapper.createObjectNode();
+        ArrayNode arr = result.putArray("ConfigurationSets");
+        for (ConfigurationSet cs : all) {
+            arr.add(cs.getName());
+        }
+        return Response.ok(result).build();
+    }
+
+    @GET
+    @Path("/configuration-sets/{configurationSetName}")
+    public Response getConfigurationSet(@Context HttpHeaders headers,
+                                         @PathParam("configurationSetName") String name) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            ConfigurationSet cs = sesService.getConfigurationSet(name, region);
+            ObjectNode result = objectMapper.createObjectNode();
+            result.put("ConfigurationSetName", cs.getName());
+            ArrayNode tags = result.putArray("Tags");
+            for (ConfigurationSet.Tag t : cs.getTags()) {
+                ObjectNode tagNode = objectMapper.createObjectNode();
+                tagNode.put("Key", t.key());
+                tagNode.put("Value", t.value());
+                tags.add(tagNode);
+            }
+            return Response.ok(result).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        }
+    }
+
+    @DELETE
+    @Path("/configuration-sets/{configurationSetName}")
+    public Response deleteConfigurationSet(@Context HttpHeaders headers,
+                                            @PathParam("configurationSetName") String name) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            sesService.deleteConfigurationSet(name, region);
+            LOG.infov("SES V2 DeleteConfigurationSet: {0}", name);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        }
+    }
+
     // ──────────────────────────── Account ────────────────────────────
 
     @GET
@@ -509,9 +596,9 @@ public class SesController {
         return switch (e.getErrorCode()) {
             case "InvalidParameterValue", "InvalidTemplate" ->
                     new AwsException("BadRequestException", e.getMessage(), 400);
-            case "TemplateDoesNotExist" ->
+            case "TemplateDoesNotExist", "ConfigurationSetDoesNotExist" ->
                     new AwsException("NotFoundException", e.getMessage(), 404);
-            case "AlreadyExists" ->
+            case "AlreadyExists", "ConfigurationSetAlreadyExists" ->
                     new AwsException("AlreadyExistsException", e.getMessage(), 400);
             default -> e;
         };

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.AwsNamespaces;
 import io.github.hectorvent.floci.core.common.AwsQueryResponse;
 import io.github.hectorvent.floci.core.common.XmlBuilder;
+import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -62,6 +63,10 @@ public class SesQueryHandler {
                 case "DeleteTemplate" -> handleDeleteTemplate(params, region);
                 case "ListTemplates" -> handleListTemplates(region);
                 case "SendTemplatedEmail" -> handleSendTemplatedEmail(params, region);
+                case "CreateConfigurationSet" -> handleCreateConfigurationSet(params, region);
+                case "DescribeConfigurationSet" -> handleDescribeConfigurationSet(params, region);
+                case "ListConfigurationSets" -> handleListConfigurationSets(region);
+                case "DeleteConfigurationSet" -> handleDeleteConfigurationSet(params, region);
                 default -> AwsQueryResponse.error("UnsupportedOperation",
                         "Operation " + action + " is not supported by SES.", AwsNamespaces.SES, 400);
             };
@@ -334,6 +339,48 @@ public class SesQueryHandler {
 
         String result = new XmlBuilder().elem("MessageId", messageId).build();
         return Response.ok(AwsQueryResponse.envelope("SendTemplatedEmail", AwsNamespaces.SES, result)).build();
+    }
+
+    private Response handleCreateConfigurationSet(MultivaluedMap<String, String> params, String region) {
+        String name = getParam(params, "ConfigurationSet.Name");
+        if (name == null || name.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "ConfigurationSet.Name is required.", 400);
+        }
+        sesService.createConfigurationSet(new ConfigurationSet(name), region);
+        return Response.ok(AwsQueryResponse.envelopeEmptyResult("CreateConfigurationSet", AwsNamespaces.SES)).build();
+    }
+
+    private Response handleDescribeConfigurationSet(MultivaluedMap<String, String> params, String region) {
+        String name = getParam(params, "ConfigurationSetName");
+        if (name == null || name.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "ConfigurationSetName is required.", 400);
+        }
+        ConfigurationSet cs = sesService.getConfigurationSet(name, region);
+        String result = new XmlBuilder()
+                .start("ConfigurationSet")
+                    .elem("Name", cs.getName())
+                .end("ConfigurationSet")
+                .build();
+        return Response.ok(AwsQueryResponse.envelope("DescribeConfigurationSet", AwsNamespaces.SES, result)).build();
+    }
+
+    private Response handleListConfigurationSets(String region) {
+        List<ConfigurationSet> all = sesService.listConfigurationSets(region);
+        XmlBuilder xml = new XmlBuilder().start("ConfigurationSets");
+        for (ConfigurationSet cs : all) {
+            xml.start("member").elem("Name", cs.getName()).end("member");
+        }
+        xml.end("ConfigurationSets");
+        return Response.ok(AwsQueryResponse.envelope("ListConfigurationSets", AwsNamespaces.SES, xml.build())).build();
+    }
+
+    private Response handleDeleteConfigurationSet(MultivaluedMap<String, String> params, String region) {
+        String name = getParam(params, "ConfigurationSetName");
+        if (name == null || name.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "ConfigurationSetName is required.", 400);
+        }
+        sesService.deleteConfigurationSet(name, region);
+        return Response.ok(AwsQueryResponse.envelopeEmptyResult("DeleteConfigurationSet", AwsNamespaces.SES)).build();
     }
 
     private EmailTemplate readTemplateParams(MultivaluedMap<String, String> params) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -395,10 +395,7 @@ public class SesService {
                     "Tag Key must be 1-128 characters.", 400);
         }
         String value = tag.value();
-        if (value == null) {
-            throw new AwsException("InvalidParameterValue", "Tag Value is required.", 400);
-        }
-        if (value.length() > 256) {
+        if (value != null && value.length() > 256) {
             throw new AwsException("InvalidParameterValue",
                     "Tag Value must be 0-256 characters.", 400);
         }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.ses;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.SentEmail;
@@ -33,6 +34,7 @@ public class SesService {
     private final StorageBackend<String, SentEmail> emailStore;
     private final StorageBackend<String, Boolean> accountSettingsStore;
     private final StorageBackend<String, EmailTemplate> templateStore;
+    private final StorageBackend<String, ConfigurationSet> configSetStore;
     private final SmtpRelay smtpRelay;
 
     @Inject
@@ -45,6 +47,8 @@ public class SesService {
                 new TypeReference<Map<String, Boolean>>() {});
         this.templateStore = storageFactory.create("ses", "ses-templates.json",
                 new TypeReference<Map<String, EmailTemplate>>() {});
+        this.configSetStore = storageFactory.create("ses", "ses-config-sets.json",
+                new TypeReference<Map<String, ConfigurationSet>>() {});
         this.smtpRelay = smtpRelay;
     }
 
@@ -52,11 +56,13 @@ public class SesService {
                StorageBackend<String, SentEmail> emailStore,
                StorageBackend<String, Boolean> accountSettingsStore,
                StorageBackend<String, EmailTemplate> templateStore,
+               StorageBackend<String, ConfigurationSet> configSetStore,
                SmtpRelay smtpRelay) {
         this.identityStore = identityStore;
         this.emailStore = emailStore;
         this.accountSettingsStore = accountSettingsStore;
         this.templateStore = templateStore;
+        this.configSetStore = configSetStore;
         this.smtpRelay = smtpRelay;
     }
 
@@ -306,6 +312,96 @@ public class SesService {
                 .thenComparing(EmailTemplate::getTemplateName,
                         Comparator.nullsLast(Comparator.naturalOrder())));
         return all;
+    }
+
+    public ConfigurationSet createConfigurationSet(ConfigurationSet configSet, String region) {
+        if (configSet == null) {
+            throw new AwsException("InvalidParameterValue",
+                    "ConfigurationSetName is required.", 400);
+        }
+        String key = configSetKey(region, configSet.getName());
+        if (configSet.getTags() != null) {
+            for (ConfigurationSet.Tag tag : configSet.getTags()) {
+                validateTag(tag);
+            }
+        }
+        if (configSetStore.get(key).isPresent()) {
+            throw new AwsException("ConfigurationSetAlreadyExists",
+                    "Configuration set " + configSet.getName() + " already exists.", 400);
+        }
+        if (configSet.getCreatedTimestamp() == null) {
+            configSet.setCreatedTimestamp(Instant.now());
+        }
+        configSetStore.put(key, configSet);
+        LOG.infov("Created SES configuration set: {0} in region {1}", configSet.getName(), region);
+        return configSet;
+    }
+
+    public ConfigurationSet getConfigurationSet(String name, String region) {
+        return configSetStore.get(configSetKey(region, name))
+                .orElseThrow(() -> new AwsException("ConfigurationSetDoesNotExist",
+                        "Configuration set " + name + " does not exist.", 400));
+    }
+
+    public List<ConfigurationSet> listConfigurationSets(String region) {
+        String prefix = "configSet::" + region + "::";
+        List<ConfigurationSet> all = new ArrayList<>(configSetStore.scan(k -> k.startsWith(prefix)));
+        all.sort(Comparator.comparing(ConfigurationSet::getCreatedTimestamp,
+                        Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(ConfigurationSet::getName,
+                        Comparator.nullsLast(Comparator.naturalOrder())));
+        return all;
+    }
+
+    public void deleteConfigurationSet(String name, String region) {
+        String key = configSetKey(region, name);
+        if (configSetStore.get(key).isEmpty()) {
+            throw new AwsException("ConfigurationSetDoesNotExist",
+                    "Configuration set " + name + " does not exist.", 400);
+        }
+        configSetStore.delete(key);
+        LOG.infov("Deleted SES configuration set: {0} in region {1}", name, region);
+    }
+
+    private static final Pattern CONFIG_SET_NAME = Pattern.compile("^[A-Za-z0-9_-]{1,64}$");
+
+    private static String configSetKey(String region, String name) {
+        validateConfigurationSetName(name);
+        return "configSet::" + region + "::" + name;
+    }
+
+    static void validateConfigurationSetName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new AwsException("InvalidParameterValue",
+                    "ConfigurationSetName is required.", 400);
+        }
+        if (!CONFIG_SET_NAME.matcher(name).matches()) {
+            throw new AwsException("InvalidParameterValue",
+                    "ConfigurationSetName must be 1-64 characters and may only contain "
+                            + "alphanumeric characters, underscores, and hyphens.", 400);
+        }
+    }
+
+    static void validateTag(ConfigurationSet.Tag tag) {
+        if (tag == null) {
+            throw new AwsException("InvalidParameterValue", "Tag must not be null.", 400);
+        }
+        String key = tag.key();
+        if (key == null || key.isEmpty()) {
+            throw new AwsException("InvalidParameterValue", "Tag Key is required.", 400);
+        }
+        if (key.length() > 128) {
+            throw new AwsException("InvalidParameterValue",
+                    "Tag Key must be 1-128 characters.", 400);
+        }
+        String value = tag.value();
+        if (value == null) {
+            throw new AwsException("InvalidParameterValue", "Tag Value is required.", 400);
+        }
+        if (value.length() > 256) {
+            throw new AwsException("InvalidParameterValue",
+                    "Tag Value must be 0-256 characters.", 400);
+        }
     }
 
     public String sendTemplatedEmail(String source, List<String> toAddresses, List<String> ccAddresses,

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/ConfigurationSet.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/ConfigurationSet.java
@@ -1,0 +1,45 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ConfigurationSet {
+
+    @JsonProperty("Name")
+    private String name;
+
+    @JsonProperty("CreatedTimestamp")
+    private Instant createdTimestamp;
+
+    @JsonProperty("Tags")
+    private List<Tag> tags = new ArrayList<>();
+
+    public ConfigurationSet() {}
+
+    public ConfigurationSet(String name) {
+        this.name = name;
+        this.createdTimestamp = Instant.now();
+    }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public Instant getCreatedTimestamp() { return createdTimestamp; }
+    public void setCreatedTimestamp(Instant createdTimestamp) { this.createdTimestamp = createdTimestamp; }
+
+    public List<Tag> getTags() { return tags; }
+    public void setTags(List<Tag> tags) { this.tags = tags != null ? tags : new ArrayList<>(); }
+
+    @RegisterForReflection
+    public record Tag(
+            @JsonProperty("Key") String key,
+            @JsonProperty("Value") String value) {
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV1IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV1IntegrationTest.java
@@ -1,0 +1,192 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * Integration tests for SES V1 Query-protocol ConfigurationSet CRUD.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesConfigurationSetV1IntegrationTest {
+
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/email/aws4_request";
+
+    @Test
+    @Order(1)
+    void createConfigurationSet() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateConfigurationSet")
+            .formParam("ConfigurationSet.Name", "v1-cs-alpha")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("CreateConfigurationSetResponse"));
+    }
+
+    @Test
+    @Order(2)
+    void createConfigurationSet_duplicateRejected() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateConfigurationSet")
+            .formParam("ConfigurationSet.Name", "v1-cs-alpha")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>ConfigurationSetAlreadyExists</Code>"));
+    }
+
+    @Test
+    @Order(3)
+    void describeConfigurationSet() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "DescribeConfigurationSet")
+            .formParam("ConfigurationSetName", "v1-cs-alpha")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Name>v1-cs-alpha</Name>"));
+    }
+
+    @Test
+    @Order(4)
+    void describeConfigurationSet_unknownReturns400() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "DescribeConfigurationSet")
+            .formParam("ConfigurationSetName", "v1-cs-ghost")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>ConfigurationSetDoesNotExist</Code>"));
+    }
+
+    @Test
+    @Order(5)
+    void listConfigurationSets() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateConfigurationSet")
+            .formParam("ConfigurationSet.Name", "v1-cs-beta")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "ListConfigurationSets")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Name>v1-cs-alpha</Name>"))
+            .body(containsString("<Name>v1-cs-beta</Name>"));
+    }
+
+    @Test
+    @Order(6)
+    void deleteConfigurationSet() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "DeleteConfigurationSet")
+            .formParam("ConfigurationSetName", "v1-cs-alpha")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("DeleteConfigurationSetResponse"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "DescribeConfigurationSet")
+            .formParam("ConfigurationSetName", "v1-cs-alpha")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>ConfigurationSetDoesNotExist</Code>"));
+    }
+
+    @Test
+    @Order(7)
+    void deleteConfigurationSet_unknownReturns400() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "DeleteConfigurationSet")
+            .formParam("ConfigurationSetName", "v1-cs-ghost")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>ConfigurationSetDoesNotExist</Code>"));
+    }
+
+    @Test
+    @Order(8)
+    void createConfigurationSet_missingName() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateConfigurationSet")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>InvalidParameterValue</Code>"));
+    }
+
+    @Test
+    @Order(9)
+    void createConfigurationSet_invalidNameCharacters() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateConfigurationSet")
+            .formParam("ConfigurationSet.Name", "bad name!")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>InvalidParameterValue</Code>"));
+    }
+
+    @Test
+    @Order(10)
+    void createConfigurationSet_nameTooLong() {
+        String longName = "a".repeat(65);
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateConfigurationSet")
+            .formParam("ConfigurationSet.Name", longName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>InvalidParameterValue</Code>"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV2IntegrationTest.java
@@ -202,7 +202,33 @@ class SesConfigurationSetV2IntegrationTest {
 
     @Test
     @Order(12)
-    void createConfigurationSet_tagWithMissingKey() {
+    void createConfigurationSet_tagWithMissingValue_roundTripsAsAbsent() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "ConfigurationSetName": "v2-cs-tag-no-value",
+                  "Tags": [{"Key": "env"}]
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/configuration-sets/v2-cs-tag-no-value")
+        .then()
+            .statusCode(200)
+            .body("Tags[0].Key", equalTo("env"));
+    }
+
+    @Test
+    @Order(13)
+    void createConfigurationSet_tagWithMissingKey_returns400() {
         given()
             .contentType("application/json")
             .header("Authorization", AUTH_HEADER)
@@ -220,7 +246,7 @@ class SesConfigurationSetV2IntegrationTest {
     }
 
     @Test
-    @Order(13)
+    @Order(14)
     void createConfigurationSet_tagKeyTooLong() {
         String longKey = "k".repeat(129);
         given()
@@ -240,7 +266,7 @@ class SesConfigurationSetV2IntegrationTest {
     }
 
     @Test
-    @Order(14)
+    @Order(15)
     void createConfigurationSet_tagValueTooLong() {
         String longValue = "v".repeat(257);
         given()

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV2IntegrationTest.java
@@ -1,0 +1,261 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+/**
+ * Integration tests for SES V2 ConfigurationSet endpoints under /v2/email/configuration-sets.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesConfigurationSetV2IntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/ses/aws4_request";
+
+    @Test
+    @Order(1)
+    void createConfigurationSet() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "ConfigurationSetName": "v2-cs-alpha",
+                  "Tags": [{"Key": "env", "Value": "test"}]
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void createConfigurationSet_duplicateRejected() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"ConfigurationSetName": "v2-cs-alpha"}
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("AlreadyExistsException"));
+    }
+
+    @Test
+    @Order(3)
+    void createConfigurationSet_tagsNotArray() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "ConfigurationSetName": "v2-cs-bad-tags",
+                  "Tags": "not-an-array"
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(4)
+    void createConfigurationSet_missingName() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("{}")
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(5)
+    void getConfigurationSet_returnsRoundTrip() {
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/configuration-sets/v2-cs-alpha")
+        .then()
+            .statusCode(200)
+            .body("ConfigurationSetName", equalTo("v2-cs-alpha"))
+            .body("Tags[0].Key", equalTo("env"))
+            .body("Tags[0].Value", equalTo("test"));
+    }
+
+    @Test
+    @Order(6)
+    void getConfigurationSet_unknownReturns404() {
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/configuration-sets/v2-cs-ghost")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"));
+    }
+
+    @Test
+    @Order(7)
+    void listConfigurationSets() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"ConfigurationSetName": "v2-cs-beta"}
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/configuration-sets")
+        .then()
+            .statusCode(200)
+            .body("ConfigurationSets", hasItem("v2-cs-alpha"))
+            .body("ConfigurationSets", hasItem("v2-cs-beta"));
+    }
+
+    @Test
+    @Order(8)
+    void deleteConfigurationSet() {
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .delete("/v2/email/configuration-sets/v2-cs-alpha")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/configuration-sets/v2-cs-alpha")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(9)
+    void deleteConfigurationSet_unknownReturns404() {
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .delete("/v2/email/configuration-sets/v2-cs-ghost")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"));
+    }
+
+    @Test
+    @Order(10)
+    void createConfigurationSet_invalidNameCharacters() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"ConfigurationSetName": "bad name!"}
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(11)
+    void createConfigurationSet_nameTooLong() {
+        String longName = "a".repeat(65);
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"ConfigurationSetName": "%s"}
+                """.formatted(longName))
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(12)
+    void createConfigurationSet_tagWithMissingKey() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "ConfigurationSetName": "v2-cs-bad-tag-key",
+                  "Tags": [{"Value": "v"}]
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(13)
+    void createConfigurationSet_tagKeyTooLong() {
+        String longKey = "k".repeat(129);
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "ConfigurationSetName": "v2-cs-long-tag-key",
+                  "Tags": [{"Key": "%s", "Value": "v"}]
+                }
+                """.formatted(longKey))
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(14)
+    void createConfigurationSet_tagValueTooLong() {
+        String longValue = "v".repeat(257);
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "ConfigurationSetName": "v2-cs-long-tag-value",
+                  "Tags": [{"Key": "k", "Value": "%s"}]
+                }
+                """.formatted(longValue))
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSmtpTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSmtpTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.ses;
 
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.SentEmail;
@@ -31,6 +32,7 @@ class SesServiceSmtpTest {
                 emailStore,
                 new InMemoryStorage<String, Boolean>(),
                 new InMemoryStorage<String, EmailTemplate>(),
+                new InMemoryStorage<String, ConfigurationSet>(),
                 smtpRelay);
     }
 


### PR DESCRIPTION
## Summary

Adds Configuration Set name management on both SES protocols:

- **v1 Query**: `CreateConfigurationSet`, `DescribeConfigurationSet`, `ListConfigurationSets`, `DeleteConfigurationSet`
- **v2 REST JSON**: `POST` / `GET` (single) / `GET` (list) / `DELETE` under `/v2/email/configuration-sets[/{name}]`

Storage is region-scoped and shared across both protocols, with name as the primary key. `Tags` are persisted on v2 create and returned on v2 get; v1 only round-trips the name (real SES v1 has no tags on configuration sets). Errors map `ConfigurationSetAlreadyExists` / `ConfigurationSetDoesNotExist` (v1) onto `AlreadyExistsException` 400 and `NotFoundException` 404 (v2) via the existing `SesController` remap helper.

Field validation (per AWS limits): `ConfigurationSetName` must match `^[A-Za-z0-9_-]{1,64}$`; each Tag `Key` is 1-128 chars and each Tag `Value` is 0-256 chars; non-array `Tags` are rejected with `BadRequestException`.

**Out of scope (future PRs)**:
- `SendingOptions`, `EventDestinations`, `TrackingOptions`, `DeliveryOptions`, `ReputationOptions`, `SuppressionOptions`, `VdmOptions`
- `ConfigurationSetName` validation in the `Send*` APIs (intentionally left lax to match LocalStack's behaviour, where the name is also accepted without an existence check)

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

- **v1**: validated against `software.amazon.awssdk.services.ses.SesClient` — `createConfigurationSet`, `describeConfigurationSet`, `listConfigurationSets`, `deleteConfigurationSet`. v1 wire codes `<Code>ConfigurationSetAlreadyExists</Code>` and `<Code>ConfigurationSetDoesNotExist</Code>` returned with HTTP 400 as on real SES.
- **v2**: validated against `software.amazon.awssdk.services.sesv2.SesV2Client` — `createConfigurationSet` (with `Tags`), `getConfigurationSet`, `listConfigurationSets`, `deleteConfigurationSet`. Errors emit `__type: "AlreadyExistsException"` (400) and `__type: "NotFoundException"` (404). Malformed shapes (non-array `Tags`, name violating regex/length) emit `__type: "BadRequestException"` (400).

## Checklist

- [x] `./mvnw test` passes locally — 2971 tests, 0 failures (24 new across two `SesConfigurationSetV{1,2}IntegrationTest` classes; existing `SesServiceSmtpTest` updated for the new constructor parameter)
- [x] New or updated integration test added
- [x] Compatibility test added: 12 cases in new `compatibility-tests/sdk-test-java/.../SesConfigurationSetTest.java` exercising v1 (`SesClient`) and v2 (`SesV2Client`) including invalid-name validation
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)