### PR TITLE
feat(ses): add SendBulkEmail (v2) and SendBulkTemplatedEmail (v1)

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesTemplateTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesTemplateTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.ses.SesClient;
+import software.amazon.awssdk.services.ses.model.BulkEmailDestination;
 import software.amazon.awssdk.services.ses.model.CreateTemplateRequest;
 import software.amazon.awssdk.services.ses.model.DeleteIdentityRequest;
 import software.amazon.awssdk.services.ses.model.DeleteTemplateRequest;
@@ -17,12 +18,16 @@ import software.amazon.awssdk.services.ses.model.GetTemplateRequest;
 import software.amazon.awssdk.services.ses.model.GetTemplateResponse;
 import software.amazon.awssdk.services.ses.model.ListTemplatesRequest;
 import software.amazon.awssdk.services.ses.model.ListTemplatesResponse;
+import software.amazon.awssdk.services.ses.model.SendBulkTemplatedEmailRequest;
+import software.amazon.awssdk.services.ses.model.SendBulkTemplatedEmailResponse;
 import software.amazon.awssdk.services.ses.model.SendTemplatedEmailRequest;
 import software.amazon.awssdk.services.ses.model.SendTemplatedEmailResponse;
 import software.amazon.awssdk.services.ses.model.UpdateTemplateRequest;
 import software.amazon.awssdk.services.ses.model.VerifyEmailIdentityRequest;
 
 import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.BulkEmailContent;
+import software.amazon.awssdk.services.sesv2.model.BulkEmailEntry;
 import software.amazon.awssdk.services.sesv2.model.CreateEmailIdentityRequest;
 import software.amazon.awssdk.services.sesv2.model.CreateEmailTemplateRequest;
 import software.amazon.awssdk.services.sesv2.model.DeleteEmailIdentityRequest;
@@ -34,6 +39,8 @@ import software.amazon.awssdk.services.sesv2.model.GetEmailTemplateRequest;
 import software.amazon.awssdk.services.sesv2.model.GetEmailTemplateResponse;
 import software.amazon.awssdk.services.sesv2.model.ListEmailTemplatesRequest;
 import software.amazon.awssdk.services.sesv2.model.ListEmailTemplatesResponse;
+import software.amazon.awssdk.services.sesv2.model.SendBulkEmailRequest;
+import software.amazon.awssdk.services.sesv2.model.SendBulkEmailResponse;
 import software.amazon.awssdk.services.sesv2.model.SendEmailRequest;
 import software.amazon.awssdk.services.sesv2.model.SendEmailResponse;
 import software.amazon.awssdk.services.sesv2.model.Template;
@@ -437,6 +444,139 @@ class SesTemplateTest {
         } finally {
             safelyDeleteV1Template(name);
         }
+    }
+
+    // ───────────────────────── Bulk send (V2 / V1) ─────────────────────────
+
+    @Test
+    @Order(25)
+    void v2SendBulkEmailWithStoredTemplateAndPerEntryReplacement() {
+        String name = "sdk-v2-bulk-" + TestFixtures.uniqueName();
+        try {
+            sesV2.createEmailTemplate(CreateEmailTemplateRequest.builder()
+                    .templateName(name)
+                    .templateContent(EmailTemplateContent.builder()
+                            .subject("Hello {{name}}")
+                            .text("Hi {{name}}, team {{team}}!")
+                            .build())
+                    .build());
+
+            SendBulkEmailResponse response = sesV2.sendBulkEmail(SendBulkEmailRequest.builder()
+                    .fromEmailAddress(v2Sender)
+                    .defaultContent(BulkEmailContent.builder()
+                            .template(Template.builder()
+                                    .templateName(name)
+                                    .templateData("{\"team\":\"floci\"}")
+                                    .build())
+                            .build())
+                    .bulkEmailEntries(
+                            BulkEmailEntry.builder()
+                                    .destination(Destination.builder()
+                                            .toAddresses("alice@example.com")
+                                            .build())
+                                    .replacementEmailContent(rec -> rec
+                                            .replacementTemplate(rt -> rt
+                                                    .replacementTemplateData("{\"name\":\"Alice\"}")))
+                                    .build(),
+                            BulkEmailEntry.builder()
+                                    .destination(Destination.builder()
+                                            .toAddresses("bob@example.com")
+                                            .build())
+                                    .replacementEmailContent(rec -> rec
+                                            .replacementTemplate(rt -> rt
+                                                    .replacementTemplateData(
+                                                            "{\"name\":\"Bob\",\"team\":\"override\"}")))
+                                    .build())
+                    .build());
+
+            assertThat(response.bulkEmailEntryResults()).hasSize(2);
+            assertThat(response.bulkEmailEntryResults().get(0).statusAsString()).isEqualTo("SUCCESS");
+            assertThat(response.bulkEmailEntryResults().get(0).messageId()).isNotBlank();
+            assertThat(response.bulkEmailEntryResults().get(1).statusAsString()).isEqualTo("SUCCESS");
+            assertThat(response.bulkEmailEntryResults().get(1).messageId()).isNotBlank();
+            assertThat(response.bulkEmailEntryResults().get(0).messageId())
+                    .isNotEqualTo(response.bulkEmailEntryResults().get(1).messageId());
+        } finally {
+            safelyDeleteV2Template(name);
+        }
+    }
+
+    @Test
+    @Order(26)
+    void v2SendBulkEmailWithUnknownTemplateReturns404() {
+        assertThatThrownBy(() -> sesV2.sendBulkEmail(SendBulkEmailRequest.builder()
+                .fromEmailAddress(v2Sender)
+                .defaultContent(BulkEmailContent.builder()
+                        .template(Template.builder()
+                                .templateName("sdk-v2-bulk-missing-" + System.currentTimeMillis())
+                                .build())
+                        .build())
+                .bulkEmailEntries(BulkEmailEntry.builder()
+                        .destination(Destination.builder()
+                                .toAddresses("alice@example.com")
+                                .build())
+                        .build())
+                .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(404);
+    }
+
+    @Test
+    @Order(35)
+    void v1SendBulkTemplatedEmailWithPerEntryReplacement() {
+        String name = "sdk-v1-bulk-" + TestFixtures.uniqueName();
+        try {
+            sesV1.createTemplate(CreateTemplateRequest.builder()
+                    .template(software.amazon.awssdk.services.ses.model.Template.builder()
+                            .templateName(name)
+                            .subjectPart("Hello {{name}}")
+                            .textPart("Hi {{name}}, team {{team}}!")
+                            .build())
+                    .build());
+
+            SendBulkTemplatedEmailResponse response = sesV1.sendBulkTemplatedEmail(
+                    SendBulkTemplatedEmailRequest.builder()
+                            .source(v1Sender)
+                            .template(name)
+                            .defaultTemplateData("{\"team\":\"floci\"}")
+                            .destinations(
+                                    BulkEmailDestination.builder()
+                                            .destination(d -> d.toAddresses("alice@example.com"))
+                                            .replacementTemplateData("{\"name\":\"Alice\"}")
+                                            .build(),
+                                    BulkEmailDestination.builder()
+                                            .destination(d -> d.toAddresses("bob@example.com"))
+                                            .replacementTemplateData(
+                                                    "{\"name\":\"Bob\",\"team\":\"override\"}")
+                                            .build())
+                            .build());
+
+            assertThat(response.status()).hasSize(2);
+            assertThat(response.status().get(0).statusAsString()).isEqualTo("Success");
+            assertThat(response.status().get(0).messageId()).isNotBlank();
+            assertThat(response.status().get(1).statusAsString()).isEqualTo("Success");
+            assertThat(response.status().get(1).messageId()).isNotBlank();
+            assertThat(response.status().get(0).messageId())
+                    .isNotEqualTo(response.status().get(1).messageId());
+        } finally {
+            safelyDeleteV1Template(name);
+        }
+    }
+
+    @Test
+    @Order(36)
+    void v1SendBulkTemplatedEmailWithUnknownTemplateRaises() {
+        assertThatThrownBy(() -> sesV1.sendBulkTemplatedEmail(SendBulkTemplatedEmailRequest.builder()
+                .source(v1Sender)
+                .template("sdk-v1-bulk-missing-" + System.currentTimeMillis())
+                .destinations(BulkEmailDestination.builder()
+                        .destination(d -> d.toAddresses("alice@example.com"))
+                        .build())
+                .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(400);
     }
 
     // ─────────────────────────────── Helpers ───────────────────────────────

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -18,6 +18,7 @@ Floci exposes the classic Amazon SES Query API used by `aws ses ...` commands an
 | `SendEmail`                         | Send a structured email with text or HTML body            |
 | `SendRawEmail`                      | Send a raw MIME payload                                   |
 | `SendTemplatedEmail`                | Send an email by resolving a stored template             |
+| `SendBulkTemplatedEmail`            | Send a templated email to multiple destinations          |
 | `CreateTemplate`                    | Create an email template with subject / text / html parts |
 | `GetTemplate`                       | Read a stored template                                    |
 | `UpdateTemplate`                    | Replace the content of a stored template                  |
@@ -175,6 +176,7 @@ Alongside the classic Query API, Floci implements a subset of the SES v2 REST JS
 | `PUT` | `/v2/email/identities/{emailIdentity}/dkim` | `PutEmailIdentityDkimAttributes` |
 | `PUT` | `/v2/email/identities/{emailIdentity}/feedback` | `PutEmailIdentityFeedbackAttributes` |
 | `POST` | `/v2/email/outbound-emails` | `SendEmail` (simple / raw / templated) |
+| `POST` | `/v2/email/outbound-bulk-emails` | `SendBulkEmail` (templated, multiple destinations) |
 | `GET` | `/v2/email/account` | `GetAccount` |
 | `PUT` | `/v2/email/account/sending` | `PutAccountSendingAttributes` |
 | `POST` | `/v2/email/templates` | `CreateEmailTemplate` |

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -279,7 +279,7 @@ public class AwsQueryController {
             "SetIdentityNotificationTopic", "GetIdentityNotificationAttributes",
             "GetIdentityDkimAttributes",
             "CreateTemplate", "UpdateTemplate", "GetTemplate", "DeleteTemplate",
-            "ListTemplates", "SendTemplatedEmail",
+            "ListTemplates", "SendTemplatedEmail", "SendBulkTemplatedEmail",
             "CreateConfigurationSet", "DescribeConfigurationSet",
             "ListConfigurationSets", "DeleteConfigurationSet"
     );

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -2,6 +2,8 @@ package io.github.hectorvent.floci.services.ses;
 
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.ses.model.BulkEmailEntry;
+import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
@@ -271,6 +273,112 @@ public class SesController {
             LOG.infov("SES V2 SendEmail: from={0}, to={1}, messageId={2}",
                     fromEmailAddress, toAddresses, messageId);
             return Response.ok(result).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        } catch (Exception e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @POST
+    @Path("/outbound-bulk-emails")
+    public Response sendBulkEmail(@Context HttpHeaders headers, String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            if (!sesService.isAccountSendingEnabled(region)) {
+                throw new AwsException("SendingPausedException",
+                        "Account sending is disabled.", 400);
+            }
+
+            JsonNode request = objectMapper.readTree(body);
+            String fromEmailAddress = request.path("FromEmailAddress").asText(null);
+            if (fromEmailAddress == null || fromEmailAddress.isBlank()) {
+                throw new AwsException("BadRequestException",
+                        "FromEmailAddress is required.", 400);
+            }
+            List<String> replyToAddresses = jsonArrayToList(request.path("ReplyToAddresses"));
+
+            JsonNode template = request.path("DefaultContent").path("Template");
+            if (template.isMissingNode() || template.isNull()) {
+                throw new AwsException("BadRequestException",
+                        "DefaultContent.Template is required.", 400);
+            }
+            String templateName = template.path("TemplateName").asText(null);
+            String templateArn = template.path("TemplateArn").asText(null);
+            boolean hasName = templateName != null && !templateName.isBlank();
+            boolean hasArn = templateArn != null && !templateArn.isBlank();
+            boolean hasInline = template.has("TemplateContent");
+            int selectorCount = (hasName ? 1 : 0) + (hasArn ? 1 : 0) + (hasInline ? 1 : 0);
+            if (selectorCount > 1) {
+                throw new AwsException("BadRequestException",
+                        "DefaultContent.Template must specify exactly one of TemplateName, TemplateArn, or TemplateContent.",
+                        400);
+            }
+            if (selectorCount == 0) {
+                throw new AwsException("BadRequestException",
+                        "DefaultContent.Template requires TemplateName, TemplateArn, or TemplateContent.", 400);
+            }
+
+            String subject;
+            String text;
+            String html;
+            if (hasInline) {
+                JsonNode inline = template.path("TemplateContent");
+                subject = inline.path("Subject").asText(null);
+                text = inline.path("Text").asText(null);
+                html = inline.path("Html").asText(null);
+            } else {
+                String resolvedName = hasName
+                        ? templateName
+                        : SesService.templateNameFromArn(templateArn);
+                EmailTemplate stored = sesService.getTemplate(resolvedName, region);
+                subject = stored.getSubject();
+                text = stored.getTextPart();
+                html = stored.getHtmlPart();
+            }
+
+            JsonNode defaultTemplateData = parseTemplateData(template.path("TemplateData").asText(""));
+
+            JsonNode bulkEntries = request.path("BulkEmailEntries");
+            if (!bulkEntries.isArray() || bulkEntries.isEmpty()) {
+                throw new AwsException("BadRequestException",
+                        "BulkEmailEntries must be a non-empty array.", 400);
+            }
+
+            List<BulkEmailEntry> entries = new ArrayList<>();
+            for (JsonNode node : bulkEntries) {
+                JsonNode dest = node.path("Destination");
+                List<String> to = jsonArrayToList(dest.path("ToAddresses"));
+                List<String> cc = jsonArrayToList(dest.path("CcAddresses"));
+                List<String> bcc = jsonArrayToList(dest.path("BccAddresses"));
+                String replacementRaw = node.path("ReplacementEmailContent")
+                        .path("ReplacementTemplate")
+                        .path("ReplacementTemplateData")
+                        .asText("");
+                entries.add(new BulkEmailEntry(to, cc, bcc, parseTemplateData(replacementRaw)));
+            }
+
+            List<BulkEmailEntryResult> results = sesService.sendBulkTemplatedEmail(fromEmailAddress,
+                    replyToAddresses, subject, text, html,
+                    defaultTemplateData, entries, region);
+
+            ObjectNode response = objectMapper.createObjectNode();
+            ArrayNode arr = response.putArray("BulkEmailEntryResults");
+            for (BulkEmailEntryResult r : results) {
+                ObjectNode item = objectMapper.createObjectNode();
+                item.put("Status", r.getStatus().name());
+                if (r.getMessageId() != null) {
+                    item.put("MessageId", r.getMessageId());
+                }
+                if (r.getError() != null) {
+                    item.put("Error", r.getError());
+                }
+                arr.add(item);
+            }
+
+            LOG.infov("SES V2 SendBulkEmail: from={0}, entries={1}",
+                    fromEmailAddress, entries.size());
+            return Response.ok(response).build();
         } catch (AwsException e) {
             throw remapV1Exception(e);
         } catch (Exception e) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
@@ -140,6 +140,10 @@ public class SesQueryHandler {
     }
 
     private Response handleSendEmail(MultivaluedMap<String, String> params, String region) {
+        if (!sesService.isAccountSendingEnabled(region)) {
+            throw new AwsException("AccountSendingPausedException",
+                    "Account sending is disabled.", 400);
+        }
         String source = getParam(params, "Source");
         List<String> toAddresses = extractMembers(params, "Destination.ToAddresses");
         List<String> ccAddresses = extractMembers(params, "Destination.CcAddresses");
@@ -157,6 +161,10 @@ public class SesQueryHandler {
     }
 
     private Response handleSendRawEmail(MultivaluedMap<String, String> params, String region) {
+        if (!sesService.isAccountSendingEnabled(region)) {
+            throw new AwsException("AccountSendingPausedException",
+                    "Account sending is disabled.", 400);
+        }
         String source = getParam(params, "Source");
         List<String> destinations = extractMembers(params, "Destinations");
         String rawMessage = getParam(params, "RawMessage.Data");
@@ -319,6 +327,10 @@ public class SesQueryHandler {
     }
 
     private Response handleSendTemplatedEmail(MultivaluedMap<String, String> params, String region) {
+        if (!sesService.isAccountSendingEnabled(region)) {
+            throw new AwsException("AccountSendingPausedException",
+                    "Account sending is disabled.", 400);
+        }
         String source = getParam(params, "Source");
         List<String> toAddresses = extractMembers(params, "Destination.ToAddresses");
         List<String> ccAddresses = extractMembers(params, "Destination.CcAddresses");

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
@@ -4,6 +4,8 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.AwsNamespaces;
 import io.github.hectorvent.floci.core.common.AwsQueryResponse;
 import io.github.hectorvent.floci.core.common.XmlBuilder;
+import io.github.hectorvent.floci.services.ses.model.BulkEmailEntry;
+import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
@@ -63,6 +65,7 @@ public class SesQueryHandler {
                 case "DeleteTemplate" -> handleDeleteTemplate(params, region);
                 case "ListTemplates" -> handleListTemplates(region);
                 case "SendTemplatedEmail" -> handleSendTemplatedEmail(params, region);
+                case "SendBulkTemplatedEmail" -> handleSendBulkTemplatedEmail(params, region);
                 case "CreateConfigurationSet" -> handleCreateConfigurationSet(params, region);
                 case "DescribeConfigurationSet" -> handleDescribeConfigurationSet(params, region);
                 case "ListConfigurationSets" -> handleListConfigurationSets(region);
@@ -339,6 +342,63 @@ public class SesQueryHandler {
 
         String result = new XmlBuilder().elem("MessageId", messageId).build();
         return Response.ok(AwsQueryResponse.envelope("SendTemplatedEmail", AwsNamespaces.SES, result)).build();
+    }
+
+    private Response handleSendBulkTemplatedEmail(MultivaluedMap<String, String> params, String region) {
+        if (!sesService.isAccountSendingEnabled(region)) {
+            throw new AwsException("AccountSendingPausedException",
+                    "Account sending is disabled.", 400);
+        }
+        String source = getParam(params, "Source");
+        List<String> replyToAddresses = extractMembers(params, "ReplyToAddresses");
+        String templateName = getParam(params, "Template");
+        String templateArn = getParam(params, "TemplateArn");
+        String defaultDataRaw = getParam(params, "DefaultTemplateData");
+
+        boolean hasName = templateName != null && !templateName.isBlank();
+        boolean hasArn = templateArn != null && !templateArn.isBlank();
+        if (!hasName && !hasArn) {
+            throw new AwsException("InvalidParameterValue",
+                    "Template or TemplateArn is required.", 400);
+        }
+        String resolvedName = hasName ? templateName : SesService.templateNameFromArn(templateArn);
+        EmailTemplate template = sesService.getTemplate(resolvedName, region);
+        JsonNode defaultTemplateData = parseTemplateData(defaultDataRaw);
+
+        List<BulkEmailEntry> entries = new ArrayList<>();
+        for (int i = 1; ; i++) {
+            String destPrefix = "Destinations.member." + i;
+            List<String> to = extractMembers(params, destPrefix + ".Destination.ToAddresses");
+            List<String> cc = extractMembers(params, destPrefix + ".Destination.CcAddresses");
+            List<String> bcc = extractMembers(params, destPrefix + ".Destination.BccAddresses");
+            String replacementRaw = getParam(params, destPrefix + ".ReplacementTemplateData");
+            if (to.isEmpty() && cc.isEmpty() && bcc.isEmpty() && replacementRaw == null) {
+                break;
+            }
+            entries.add(new BulkEmailEntry(to, cc, bcc, parseTemplateData(replacementRaw)));
+        }
+        if (entries.isEmpty()) {
+            throw new AwsException("InvalidParameterValue",
+                    "At least one destination is required.", 400);
+        }
+
+        List<BulkEmailEntryResult> results = sesService.sendBulkTemplatedEmail(source, replyToAddresses,
+                template.getSubject(), template.getTextPart(), template.getHtmlPart(),
+                defaultTemplateData, entries, region);
+
+        XmlBuilder xml = new XmlBuilder().start("Status");
+        for (BulkEmailEntryResult result : results) {
+            xml.start("member").elem("Status", result.getStatus().toV1String());
+            if (result.getMessageId() != null) {
+                xml.elem("MessageId", result.getMessageId());
+            }
+            if (result.getError() != null) {
+                xml.elem("Error", result.getError());
+            }
+            xml.end("member");
+        }
+        xml.end("Status");
+        return Response.ok(AwsQueryResponse.envelope("SendBulkTemplatedEmail", AwsNamespaces.SES, xml.build())).build();
     }
 
     private Response handleCreateConfigurationSet(MultivaluedMap<String, String> params, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -3,12 +3,15 @@ package io.github.hectorvent.floci.services.ses;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.ses.model.BulkEmailEntry;
+import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.SentEmail;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -29,6 +32,9 @@ public class SesService {
     private static final Logger LOG = Logger.getLogger(SesService.class);
 
     private static final Pattern TEMPLATE_VARIABLE = Pattern.compile("\\{\\{\\s*([\\w-]+)\\s*\\}\\}");
+
+    private static final int MAX_BULK_DESTINATIONS = 50;
+    private static final int MAX_RECIPIENTS_PER_DESTINATION = 50;
 
     private final StorageBackend<String, Identity> identityStore;
     private final StorageBackend<String, SentEmail> emailStore;
@@ -426,6 +432,98 @@ public class SesService {
                 applyTemplateData(textPart, templateData),
                 applyTemplateData(htmlPart, templateData),
                 region);
+    }
+
+    public List<BulkEmailEntryResult> sendBulkTemplatedEmail(String source,
+                                                              List<String> replyToAddresses,
+                                                              String subject, String textPart, String htmlPart,
+                                                              JsonNode defaultTemplateData,
+                                                              List<BulkEmailEntry> entries,
+                                                              String region) {
+        if (source == null || source.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "Source email is required.", 400);
+        }
+        boolean hasSubject = subject != null && !subject.isBlank();
+        boolean hasText = textPart != null && !textPart.isBlank();
+        boolean hasHtml = htmlPart != null && !htmlPart.isBlank();
+        if (!hasSubject && !hasText && !hasHtml) {
+            throw new AwsException("InvalidTemplate",
+                    "Template must have at least a subject, text, or html part.", 400);
+        }
+        if (entries == null || entries.isEmpty()) {
+            throw new AwsException("InvalidParameterValue",
+                    "At least one destination entry is required.", 400);
+        }
+        if (entries.size() > MAX_BULK_DESTINATIONS) {
+            throw new AwsException("MessageRejected",
+                    "Number of destinations (" + entries.size() + ") exceeds the maximum of "
+                            + MAX_BULK_DESTINATIONS + ".", 400);
+        }
+        for (BulkEmailEntry entry : entries) {
+            int recipientCount = sizeOf(entry.toAddresses())
+                    + sizeOf(entry.ccAddresses())
+                    + sizeOf(entry.bccAddresses());
+            if (recipientCount > MAX_RECIPIENTS_PER_DESTINATION) {
+                throw new AwsException("MessageRejected",
+                        "Recipient count (" + recipientCount + ") in a destination exceeds the maximum of "
+                                + MAX_RECIPIENTS_PER_DESTINATION + ".", 400);
+            }
+        }
+
+        List<BulkEmailEntryResult> results = new ArrayList<>(entries.size());
+        for (BulkEmailEntry entry : entries) {
+            try {
+                JsonNode merged = mergeTemplateData(defaultTemplateData, entry.replacementTemplateData());
+                String messageId = sendEmail(source,
+                        entry.toAddresses(), entry.ccAddresses(), entry.bccAddresses(),
+                        replyToAddresses,
+                        applyTemplateData(subject, merged),
+                        applyTemplateData(textPart, merged),
+                        applyTemplateData(htmlPart, merged),
+                        region);
+                results.add(BulkEmailEntryResult.success(messageId));
+            } catch (AwsException e) {
+                results.add(BulkEmailEntryResult.failure(
+                        mapErrorCodeToBulkStatus(e.getErrorCode()), e.getMessage()));
+            } catch (Exception e) {
+                results.add(BulkEmailEntryResult.failure(BulkEmailEntryResult.Status.FAILED, e.getMessage()));
+            }
+        }
+        return results;
+    }
+
+    private static int sizeOf(List<?> list) {
+        return list == null ? 0 : list.size();
+    }
+
+    static BulkEmailEntryResult.Status mapErrorCodeToBulkStatus(String errorCode) {
+        if ("InvalidParameterValue".equals(errorCode)) {
+            return BulkEmailEntryResult.Status.INVALID_PARAMETER;
+        }
+        return BulkEmailEntryResult.Status.FAILED;
+    }
+
+    static JsonNode mergeTemplateData(JsonNode defaults, JsonNode replacement) {
+        boolean hasDefault = defaults != null && defaults.isObject();
+        boolean hasReplacement = replacement != null && replacement.isObject();
+        if (!hasDefault && !hasReplacement) {
+            return null;
+        }
+        if (!hasReplacement) {
+            return defaults;
+        }
+        if (!hasDefault) {
+            return replacement;
+        }
+        if (replacement.isEmpty()) {
+            return defaults;
+        }
+        if (defaults.isEmpty()) {
+            return replacement;
+        }
+        ObjectNode merged = ((ObjectNode) defaults).deepCopy();
+        replacement.fields().forEachRemaining(e -> merged.set(e.getKey(), e.getValue()));
+        return merged;
     }
 
     static String applyTemplateData(String text, JsonNode data) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/BulkEmailEntry.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/BulkEmailEntry.java
@@ -1,0 +1,14 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+
+@RegisterForReflection
+public record BulkEmailEntry(
+        List<String> toAddresses,
+        List<String> ccAddresses,
+        List<String> bccAddresses,
+        JsonNode replacementTemplateData
+) {}

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/BulkEmailEntryResult.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/BulkEmailEntryResult.java
@@ -1,0 +1,66 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class BulkEmailEntryResult {
+
+    public enum Status {
+        SUCCESS,
+        MESSAGE_REJECTED,
+        MAIL_FROM_DOMAIN_NOT_VERIFIED,
+        CONFIGURATION_SET_DOES_NOT_EXIST,
+        TEMPLATE_DOES_NOT_EXIST,
+        ACCOUNT_SUSPENDED,
+        ACCOUNT_THROTTLED,
+        ACCOUNT_DAILY_QUOTA_EXCEEDED,
+        INVALID_SENDING_POOL_NAME,
+        ACCOUNT_SENDING_PAUSED,
+        CONFIGURATION_SET_SENDING_PAUSED,
+        INVALID_PARAMETER,
+        TRANSIENT_FAILURE,
+        FAILED;
+
+        public String toV1String() {
+            if (this == INVALID_PARAMETER) {
+                return "InvalidParameterValue";
+            }
+            StringBuilder sb = new StringBuilder();
+            for (String part : name().split("_")) {
+                sb.append(part.charAt(0));
+                sb.append(part.substring(1).toLowerCase());
+            }
+            return sb.toString();
+        }
+    }
+
+    private final Status status;
+    private final String messageId;
+    private final String error;
+
+    private BulkEmailEntryResult(Status status, String messageId, String error) {
+        this.status = status;
+        this.messageId = messageId;
+        this.error = error;
+    }
+
+    public static BulkEmailEntryResult success(String messageId) {
+        return new BulkEmailEntryResult(Status.SUCCESS, messageId, null);
+    }
+
+    public static BulkEmailEntryResult failure(Status status, String error) {
+        return new BulkEmailEntryResult(status, null, error);
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public String getMessageId() {
+        return messageId;
+    }
+
+    public String getError() {
+        return error;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesBulkV1IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesBulkV1IntegrationTest.java
@@ -1,0 +1,254 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Integration tests for SES V1 Query-protocol SendBulkTemplatedEmail.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesBulkV1IntegrationTest {
+
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/email/aws4_request";
+
+    private static final Pattern MESSAGE_ID_PATTERN =
+            Pattern.compile("<MessageId>([^<]+)</MessageId>");
+
+    @Test
+    @Order(1)
+    void createTemplate() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateTemplate")
+            .formParam("Template.TemplateName", "v1-bulk-welcome")
+            .formParam("Template.SubjectPart", "Hello {{name}}")
+            .formParam("Template.TextPart", "Hi {{name}}, team {{team}}!")
+            .formParam("Template.HtmlPart", "<p>Hi <b>{{name}}</b> ({{team}})</p>")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void sendBulkTemplatedEmail_perDestinationReplacement() {
+        String body = given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SendBulkTemplatedEmail")
+            .formParam("Source", "bulk@example.com")
+            .formParam("Template", "v1-bulk-welcome")
+            .formParam("DefaultTemplateData", "{\"team\":\"floci\"}")
+            .formParam("Destinations.member.1.Destination.ToAddresses.member.1", "alice@example.com")
+            .formParam("Destinations.member.1.ReplacementTemplateData", "{\"name\":\"Alice\"}")
+            .formParam("Destinations.member.2.Destination.ToAddresses.member.1", "bob@example.com")
+            .formParam("Destinations.member.2.ReplacementTemplateData", "{\"name\":\"Bob\",\"team\":\"override\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("SendBulkTemplatedEmailResponse"))
+            .extract().body().asString();
+
+        long successCount = body.split("<Status>Success</Status>", -1).length - 1L;
+        assertEquals(2L, successCount, "expected two Success entries");
+
+        List<String> messageIds = new ArrayList<>();
+        Matcher m = MESSAGE_ID_PATTERN.matcher(body);
+        while (m.find()) {
+            messageIds.add(m.group(1));
+        }
+        assertEquals(2, messageIds.size(), "expected two MessageIds");
+        assertNotEquals(messageIds.get(0), messageIds.get(1), "MessageIds must be unique");
+
+        // First entry inherits team=floci from defaults; second overrides.
+        given()
+            .queryParam("id", messageIds.get(0))
+        .when()
+            .get("/_aws/ses")
+        .then()
+            .statusCode(200)
+            .body("messages[0].Subject", equalTo("Hello Alice"))
+            .body("messages[0].Body.text_part", equalTo("Hi Alice, team floci!"));
+
+        given()
+            .queryParam("id", messageIds.get(1))
+        .when()
+            .get("/_aws/ses")
+        .then()
+            .statusCode(200)
+            .body("messages[0].Subject", equalTo("Hello Bob"))
+            .body("messages[0].Body.text_part", equalTo("Hi Bob, team override!"));
+    }
+
+    @Test
+    @Order(3)
+    void sendBulkTemplatedEmail_unknownTemplate() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SendBulkTemplatedEmail")
+            .formParam("Source", "bulk@example.com")
+            .formParam("Template", "ghost")
+            .formParam("Destinations.member.1.Destination.ToAddresses.member.1", "alice@example.com")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>TemplateDoesNotExist</Code>"));
+    }
+
+    @Test
+    @Order(4)
+    void sendBulkTemplatedEmail_missingDestinations() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SendBulkTemplatedEmail")
+            .formParam("Source", "bulk@example.com")
+            .formParam("Template", "v1-bulk-welcome")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>InvalidParameterValue</Code>"));
+    }
+
+    @Test
+    @Order(5)
+    void sendBulkTemplatedEmail_missingTemplate() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SendBulkTemplatedEmail")
+            .formParam("Source", "bulk@example.com")
+            .formParam("Destinations.member.1.Destination.ToAddresses.member.1", "alice@example.com")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>InvalidParameterValue</Code>"));
+    }
+
+    @Test
+    @Order(6)
+    void sendBulkTemplatedEmail_perEntryMissingDestination_mapsToInvalidParameterValue() {
+        // An entry with only ReplacementTemplateData (no recipient) reaches sendEmail,
+        // which throws AwsException("InvalidParameterValue", ...). Expected per-entry
+        // Status string in v1 is "InvalidParameterValue", not "Failed" or "InvalidParameter".
+        String body = given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SendBulkTemplatedEmail")
+            .formParam("Source", "bulk@example.com")
+            .formParam("Template", "v1-bulk-welcome")
+            .formParam("Destinations.member.1.ReplacementTemplateData", "{\"name\":\"Ghost\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().body().asString();
+
+        assertEquals(1L, body.split("<Status>InvalidParameterValue</Status>", -1).length - 1L,
+                "expected per-entry Status=InvalidParameterValue");
+    }
+
+    @Test
+    @Order(7)
+    void sendBulkTemplatedEmail_accountSendingPaused_returnsTopLevelError() {
+        // Disable account sending via the v2 endpoint, then expect v1 SendBulkTemplatedEmail
+        // to fail with AccountSendingPausedException without sending any mail.
+        try {
+            given()
+                .contentType("application/json")
+                .body("{\"SendingEnabled\":false}")
+            .when()
+                .put("/v2/email/account/sending")
+            .then()
+                .statusCode(200);
+
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .header("Authorization", AUTH)
+                .formParam("Action", "SendBulkTemplatedEmail")
+                .formParam("Source", "bulk@example.com")
+                .formParam("Template", "v1-bulk-welcome")
+                .formParam("Destinations.member.1.Destination.ToAddresses.member.1", "alice@example.com")
+            .when()
+                .post("/")
+            .then()
+                .statusCode(400)
+                .body(containsString("<Code>AccountSendingPausedException</Code>"));
+        } finally {
+            given()
+                .contentType("application/json")
+                .body("{\"SendingEnabled\":true}")
+            .when()
+                .put("/v2/email/account/sending")
+            .then()
+                .statusCode(200);
+        }
+    }
+
+    @Test
+    @Order(8)
+    void sendBulkTemplatedEmail_destinationsExceeds50_returnsMessageRejected() {
+        var spec = given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SendBulkTemplatedEmail")
+            .formParam("Source", "bulk@example.com")
+            .formParam("Template", "v1-bulk-welcome");
+        for (int i = 1; i <= 51; i++) {
+            spec = spec.formParam(
+                    "Destinations.member." + i + ".Destination.ToAddresses.member.1",
+                    "user" + i + "@example.com");
+        }
+        spec
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>MessageRejected</Code>"));
+    }
+
+    @Test
+    @Order(9)
+    void sendBulkTemplatedEmail_recipientsExceeds50_returnsMessageRejected() {
+        var spec = given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SendBulkTemplatedEmail")
+            .formParam("Source", "bulk@example.com")
+            .formParam("Template", "v1-bulk-welcome");
+        for (int i = 1; i <= 51; i++) {
+            spec = spec.formParam(
+                    "Destinations.member.1.Destination.ToAddresses.member." + i,
+                    "user" + i + "@example.com");
+        }
+        spec
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>MessageRejected</Code>"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesBulkV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesBulkV2IntegrationTest.java
@@ -1,0 +1,313 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Integration tests for SES V2 SendBulkEmail at /v2/email/outbound-bulk-emails.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesBulkV2IntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/ses/aws4_request";
+
+    @Test
+    @Order(1)
+    void createTemplate() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "TemplateName": "v2-bulk-welcome",
+                  "TemplateContent": {
+                    "Subject": "Hello {{name}}",
+                    "Text": "Hi {{name}}, team {{team}}!",
+                    "Html": "<p>Hi <b>{{name}}</b> ({{team}})</p>"
+                  }
+                }
+                """)
+        .when()
+            .post("/v2/email/templates")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void sendBulkEmail_storedTemplate_perEntryReplacement() {
+        String firstId = given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "FromEmailAddress": "bulk@example.com",
+                  "DefaultContent": {
+                    "Template": {
+                      "TemplateName": "v2-bulk-welcome",
+                      "TemplateData": "{\\"team\\":\\"floci\\"}"
+                    }
+                  },
+                  "BulkEmailEntries": [
+                    {
+                      "Destination": {"ToAddresses": ["alice@example.com"]},
+                      "ReplacementEmailContent": {
+                        "ReplacementTemplate": {
+                          "ReplacementTemplateData": "{\\"name\\":\\"Alice\\"}"
+                        }
+                      }
+                    },
+                    {
+                      "Destination": {"ToAddresses": ["bob@example.com"]},
+                      "ReplacementEmailContent": {
+                        "ReplacementTemplate": {
+                          "ReplacementTemplateData": "{\\"name\\":\\"Bob\\",\\"team\\":\\"override\\"}"
+                        }
+                      }
+                    }
+                  ]
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-bulk-emails")
+        .then()
+            .statusCode(200)
+            .body("BulkEmailEntryResults", hasSize(2))
+            .body("BulkEmailEntryResults[0].Status", equalTo("SUCCESS"))
+            .body("BulkEmailEntryResults[0].MessageId", notNullValue())
+            .body("BulkEmailEntryResults[1].Status", equalTo("SUCCESS"))
+            .body("BulkEmailEntryResults[1].MessageId", notNullValue())
+            .extract().path("BulkEmailEntryResults[0].MessageId");
+
+        String secondId = given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "FromEmailAddress": "bulk2@example.com",
+                  "DefaultContent": {
+                    "Template": {
+                      "TemplateName": "v2-bulk-welcome",
+                      "TemplateData": "{\\"team\\":\\"floci\\"}"
+                    }
+                  },
+                  "BulkEmailEntries": [
+                    {
+                      "Destination": {"ToAddresses": ["carol@example.com"]},
+                      "ReplacementEmailContent": {
+                        "ReplacementTemplate": {
+                          "ReplacementTemplateData": "{\\"name\\":\\"Carol\\"}"
+                        }
+                      }
+                    }
+                  ]
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-bulk-emails")
+        .then()
+            .statusCode(200)
+            .body("BulkEmailEntryResults", hasSize(1))
+            .body("BulkEmailEntryResults[0].Status", equalTo("SUCCESS"))
+            .extract().path("BulkEmailEntryResults[0].MessageId");
+
+        given()
+            .queryParam("id", firstId)
+        .when()
+            .get("/_aws/ses")
+        .then()
+            .statusCode(200)
+            .body("messages[0].Subject", equalTo("Hello Alice"))
+            .body("messages[0].Body.text_part", equalTo("Hi Alice, team floci!"));
+
+        given()
+            .queryParam("id", secondId)
+        .when()
+            .get("/_aws/ses")
+        .then()
+            .statusCode(200)
+            .body("messages[0].Subject", equalTo("Hello Carol"));
+    }
+
+    @Test
+    @Order(3)
+    void sendBulkEmail_inlineTemplateContent() {
+        String messageId = given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "FromEmailAddress": "inline@example.com",
+                  "DefaultContent": {
+                    "Template": {
+                      "TemplateContent": {
+                        "Subject": "Inline {{name}}",
+                        "Text": "Body for {{name}}"
+                      },
+                      "TemplateData": "{\\"name\\":\\"Default\\"}"
+                    }
+                  },
+                  "BulkEmailEntries": [
+                    {
+                      "Destination": {"ToAddresses": ["dora@example.com"]},
+                      "ReplacementEmailContent": {
+                        "ReplacementTemplate": {
+                          "ReplacementTemplateData": "{\\"name\\":\\"Dora\\"}"
+                        }
+                      }
+                    }
+                  ]
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-bulk-emails")
+        .then()
+            .statusCode(200)
+            .body("BulkEmailEntryResults[0].Status", equalTo("SUCCESS"))
+            .extract().path("BulkEmailEntryResults[0].MessageId");
+
+        given()
+            .queryParam("id", messageId)
+        .when()
+            .get("/_aws/ses")
+        .then()
+            .statusCode(200)
+            .body("messages[0].Subject", equalTo("Inline Dora"))
+            .body("messages[0].Body.text_part", equalTo("Body for Dora"));
+    }
+
+    @Test
+    @Order(4)
+    void sendBulkEmail_unknownTemplate_returns404() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "FromEmailAddress": "bulk@example.com",
+                  "DefaultContent": {
+                    "Template": {"TemplateName": "ghost"}
+                  },
+                  "BulkEmailEntries": [
+                    {"Destination": {"ToAddresses": ["alice@example.com"]}}
+                  ]
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-bulk-emails")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"));
+    }
+
+    @Test
+    @Order(5)
+    void sendBulkEmail_emptyEntries_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "FromEmailAddress": "bulk@example.com",
+                  "DefaultContent": {
+                    "Template": {"TemplateName": "v2-bulk-welcome"}
+                  },
+                  "BulkEmailEntries": []
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-bulk-emails")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(6)
+    void sendBulkEmail_missingTemplate_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "FromEmailAddress": "bulk@example.com",
+                  "DefaultContent": {},
+                  "BulkEmailEntries": [
+                    {"Destination": {"ToAddresses": ["alice@example.com"]}}
+                  ]
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-bulk-emails")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(7)
+    void sendBulkEmail_entriesExceeds50_returnsMessageRejected() {
+        StringBuilder entries = new StringBuilder();
+        for (int i = 1; i <= 51; i++) {
+            if (i > 1) entries.append(",");
+            entries.append("{\"Destination\":{\"ToAddresses\":[\"user")
+                    .append(i).append("@example.com\"]}}");
+        }
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "FromEmailAddress": "bulk@example.com",
+                  "DefaultContent": {
+                    "Template": {"TemplateName": "v2-bulk-welcome"}
+                  },
+                  "BulkEmailEntries": [%s]
+                }
+                """.formatted(entries))
+        .when()
+            .post("/v2/email/outbound-bulk-emails")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("MessageRejected"));
+    }
+
+    @Test
+    @Order(8)
+    void sendBulkEmail_recipientsExceeds50_returnsMessageRejected() {
+        StringBuilder addrs = new StringBuilder();
+        for (int i = 1; i <= 51; i++) {
+            if (i > 1) addrs.append(",");
+            addrs.append("\"user").append(i).append("@example.com\"");
+        }
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "FromEmailAddress": "bulk@example.com",
+                  "DefaultContent": {
+                    "Template": {"TemplateName": "v2-bulk-welcome"}
+                  },
+                  "BulkEmailEntries": [
+                    {"Destination": {"ToAddresses": [%s]}}
+                  ]
+                }
+                """.formatted(addrs))
+        .when()
+            .post("/v2/email/outbound-bulk-emails")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("MessageRejected"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceMergeTemplateDataTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceMergeTemplateDataTest.java
@@ -1,0 +1,42 @@
+package io.github.hectorvent.floci.services.ses;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class SesServiceMergeTemplateDataTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void bothNull_returnsNull() {
+        assertNull(SesService.mergeTemplateData(null, null));
+    }
+
+    @Test
+    void emptyReplacement_returnsDefaultsWithoutCopy() {
+        JsonNode defaults = MAPPER.createObjectNode().put("team", "floci");
+        JsonNode replacement = MAPPER.createObjectNode();
+        assertSame(defaults, SesService.mergeTemplateData(defaults, replacement));
+    }
+
+    @Test
+    void emptyDefaults_returnsReplacementWithoutCopy() {
+        JsonNode defaults = MAPPER.createObjectNode();
+        JsonNode replacement = MAPPER.createObjectNode().put("name", "Alice");
+        assertSame(replacement, SesService.mergeTemplateData(defaults, replacement));
+    }
+
+    @Test
+    void bothNonEmpty_replacementOverridesDefaults() {
+        JsonNode defaults = MAPPER.createObjectNode().put("team", "floci").put("name", "default");
+        JsonNode replacement = MAPPER.createObjectNode().put("name", "Alice");
+        JsonNode merged = SesService.mergeTemplateData(defaults, replacement);
+        assertEquals("Alice", merged.path("name").asText());
+        assertEquals("floci", merged.path("team").asText());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesV1AccountSendingPausedTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesV1AccountSendingPausedTest.java
@@ -1,0 +1,92 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * Verifies that v1 Query SES send actions reject requests when account-level
+ * sending is disabled, matching v2 REST JSON behavior and AWS semantics.
+ */
+@QuarkusTest
+class SesV1AccountSendingPausedTest {
+
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/email/aws4_request";
+
+    @BeforeEach
+    void disableSending() {
+        given()
+            .contentType("application/json")
+            .body("{\"SendingEnabled\":false}")
+        .when()
+            .put("/v2/email/account/sending")
+        .then()
+            .statusCode(200);
+    }
+
+    @AfterEach
+    void restoreSending() {
+        given()
+            .contentType("application/json")
+            .body("{\"SendingEnabled\":true}")
+        .when()
+            .put("/v2/email/account/sending")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    void sendEmail_paused_returnsAccountSendingPausedException() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SendEmail")
+            .formParam("Source", "sender@example.com")
+            .formParam("Destination.ToAddresses.member.1", "recipient@example.com")
+            .formParam("Message.Subject.Data", "Subject")
+            .formParam("Message.Body.Text.Data", "Body")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>AccountSendingPausedException</Code>"));
+    }
+
+    @Test
+    void sendRawEmail_paused_returnsAccountSendingPausedException() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SendRawEmail")
+            .formParam("Source", "sender@example.com")
+            .formParam("Destinations.member.1", "recipient@example.com")
+            .formParam("RawMessage.Data", "Subject: Hello\r\n\r\nBody")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>AccountSendingPausedException</Code>"));
+    }
+
+    @Test
+    void sendTemplatedEmail_paused_returnsAccountSendingPausedException() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SendTemplatedEmail")
+            .formParam("Source", "sender@example.com")
+            .formParam("Destination.ToAddresses.member.1", "recipient@example.com")
+            .formParam("Template", "any-template")
+            .formParam("TemplateData", "{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>AccountSendingPausedException</Code>"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/model/BulkEmailEntryResultTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/model/BulkEmailEntryResultTest.java
@@ -1,0 +1,31 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BulkEmailEntryResultTest {
+
+    @Test
+    void toV1String_invalidParameter_mapsToInvalidParameterValue() {
+        // SES v1 SendBulkTemplatedEmail per-destination Status uses
+        // "InvalidParameterValue", not "InvalidParameter".
+        assertEquals("InvalidParameterValue",
+                BulkEmailEntryResult.Status.INVALID_PARAMETER.toV1String());
+    }
+
+    @Test
+    void toV1String_standardEnumsUseCamelCase() {
+        assertEquals("Success", BulkEmailEntryResult.Status.SUCCESS.toV1String());
+        assertEquals("MessageRejected", BulkEmailEntryResult.Status.MESSAGE_REJECTED.toV1String());
+        assertEquals("MailFromDomainNotVerified",
+                BulkEmailEntryResult.Status.MAIL_FROM_DOMAIN_NOT_VERIFIED.toV1String());
+        assertEquals("ConfigurationSetDoesNotExist",
+                BulkEmailEntryResult.Status.CONFIGURATION_SET_DOES_NOT_EXIST.toV1String());
+        assertEquals("AccountDailyQuotaExceeded",
+                BulkEmailEntryResult.Status.ACCOUNT_DAILY_QUOTA_EXCEEDED.toV1String());
+        assertEquals("TransientFailure",
+                BulkEmailEntryResult.Status.TRANSIENT_FAILURE.toV1String());
+        assertEquals("Failed", BulkEmailEntryResult.Status.FAILED.toV1String());
+    }
+}


### PR DESCRIPTION
## Summary

Adds bulk templated email support to SES on both protocols:

- **v1 Query API**: `SendBulkTemplatedEmail` action handled in `SesQueryHandler`.
- **v2 REST JSON API**: `POST /v2/email/outbound-bulk-emails` in `SesController`.

Both endpoints share a single `SesService.sendBulkTemplatedEmail` method that resolves the template upfront, merges `DefaultTemplateData` with each entry's `ReplacementTemplateData` at the JSON-key level (replacement wins, with empty-side short-circuits to skip deepCopy), renders subject/text/html via the existing `applyTemplateData` helper, and reuses `sendEmail` per destination so each successful entry appears in the existing `/_aws/ses` inspection mailbox with a unique `MessageId`.

Per-entry `BulkEmailEntryResult.Status` maps to the AWS wire format expected by each protocol — CamelCase for v1 (e.g. `Success`), SCREAMING_SNAKE for v2 (e.g. `SUCCESS`). Per-entry `AwsException` codes map to the closest status (e.g. `InvalidParameterValue` → `INVALID_PARAMETER`, which renders as `"InvalidParameterValue"` on v1), falling back to `FAILED` for unexpected exceptions.

Top-level error handling mirrors AWS:

- Template lookup failures → `TemplateDoesNotExist` (v1) / `NotFoundException` (v2)
- Account sending paused → `AccountSendingPausedException` (v1) / `SendingPausedException` (v2)
- Destinations or BulkEmailEntries > 50 → `MessageRejected` 400 on both protocols
- Combined recipients (To+Cc+Bcc) > 50 in a single destination → `MessageRejected` 400

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

- **v1**: validated against `software.amazon.awssdk.services.ses.SesClient.sendBulkTemplatedEmail(...)` (AWS SDK Java v2 2.31.8) — wire `Status` strings and `BulkEmailDestinationStatus[].MessageId` shape match real SES.
- **v2**: validated against `software.amazon.awssdk.services.sesv2.SesV2Client.sendBulkEmail(...)` — `BulkEmailEntryResults[].Status` and `MessageId` match.
- Default + per-entry replacement merge follows AWS docs: replacement wins on key conflicts; missing keys fall through to defaults; missing in both renders as empty string (existing `applyTemplateData` behavior).
- Bulk limits enforced (50 destinations / 50 recipients per destination) match the documented AWS SES bulk limits.

## Checklist

- [x] `./mvnw test` passes locally — 160/160 SES tests green
- [x] New or updated integration test added (9 v1 + 8 v2 + 6 unit covering merge, status mapping, and limits)
- [x] Compatibility test added in `compatibility-tests/sdk-test-java/.../SesTemplateTest.java` exercising v1 and v2 bulk sends via the AWS SDK Java v2
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)