### PR TITLE
feat(ses): add TestRenderTemplate (v1) and TestRenderEmailTemplate (v2)

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesTemplateTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesTemplateTest.java
@@ -18,10 +18,15 @@ import software.amazon.awssdk.services.ses.model.GetTemplateRequest;
 import software.amazon.awssdk.services.ses.model.GetTemplateResponse;
 import software.amazon.awssdk.services.ses.model.ListTemplatesRequest;
 import software.amazon.awssdk.services.ses.model.ListTemplatesResponse;
+import software.amazon.awssdk.services.ses.model.InvalidRenderingParameterException;
+import software.amazon.awssdk.services.ses.model.MissingRenderingAttributeException;
 import software.amazon.awssdk.services.ses.model.SendBulkTemplatedEmailRequest;
 import software.amazon.awssdk.services.ses.model.SendBulkTemplatedEmailResponse;
 import software.amazon.awssdk.services.ses.model.SendTemplatedEmailRequest;
 import software.amazon.awssdk.services.ses.model.SendTemplatedEmailResponse;
+import software.amazon.awssdk.services.ses.model.TemplateDoesNotExistException;
+import software.amazon.awssdk.services.ses.model.TestRenderTemplateRequest;
+import software.amazon.awssdk.services.ses.model.TestRenderTemplateResponse;
 import software.amazon.awssdk.services.ses.model.UpdateTemplateRequest;
 import software.amazon.awssdk.services.ses.model.VerifyEmailIdentityRequest;
 
@@ -39,11 +44,15 @@ import software.amazon.awssdk.services.sesv2.model.GetEmailTemplateRequest;
 import software.amazon.awssdk.services.sesv2.model.GetEmailTemplateResponse;
 import software.amazon.awssdk.services.sesv2.model.ListEmailTemplatesRequest;
 import software.amazon.awssdk.services.sesv2.model.ListEmailTemplatesResponse;
+import software.amazon.awssdk.services.sesv2.model.BadRequestException;
+import software.amazon.awssdk.services.sesv2.model.NotFoundException;
 import software.amazon.awssdk.services.sesv2.model.SendBulkEmailRequest;
 import software.amazon.awssdk.services.sesv2.model.SendBulkEmailResponse;
 import software.amazon.awssdk.services.sesv2.model.SendEmailRequest;
 import software.amazon.awssdk.services.sesv2.model.SendEmailResponse;
 import software.amazon.awssdk.services.sesv2.model.Template;
+import software.amazon.awssdk.services.sesv2.model.TestRenderEmailTemplateRequest;
+import software.amazon.awssdk.services.sesv2.model.TestRenderEmailTemplateResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -577,6 +586,248 @@ class SesTemplateTest {
                 .isInstanceOf(AwsServiceException.class)
                 .extracting(e -> ((AwsServiceException) e).statusCode())
                 .isEqualTo(400);
+    }
+
+    // ───────────────────── TestRender (V2 / V1) ─────────────────────
+
+    @Test
+    @Order(40)
+    void v2TestRenderEmailTemplateSubstitutesVariables() {
+        String name = "sdk-v2-render-" + TestFixtures.uniqueName();
+        try {
+            sesV2.createEmailTemplate(CreateEmailTemplateRequest.builder()
+                    .templateName(name)
+                    .templateContent(EmailTemplateContent.builder()
+                            .subject("Hello {{name}}")
+                            .text("Hi {{name}}, team {{team}}!")
+                            .html("<p>Hi <b>{{name}}</b></p>")
+                            .build())
+                    .build());
+
+            TestRenderEmailTemplateResponse response = sesV2.testRenderEmailTemplate(
+                    TestRenderEmailTemplateRequest.builder()
+                            .templateName(name)
+                            .templateData("{\"name\":\"Alice\",\"team\":\"floci\"}")
+                            .build());
+            assertThat(response.renderedTemplate())
+                    .contains("Subject: Hello Alice")
+                    .contains("Hi Alice, team floci!")
+                    .contains("multipart/alternative");
+        } finally {
+            safelyDeleteV2Template(name);
+        }
+    }
+
+    @Test
+    @Order(41)
+    void v2TestRenderEmailTemplateUnknownTemplateReturns404() {
+        assertThatThrownBy(() -> sesV2.testRenderEmailTemplate(
+                TestRenderEmailTemplateRequest.builder()
+                        .templateName("sdk-v2-render-missing-" + System.currentTimeMillis())
+                        .templateData("{}")
+                        .build()))
+                .isInstanceOf(NotFoundException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(404);
+    }
+
+    @Test
+    @Order(42)
+    void v2TestRenderEmailTemplateMissingVariableReturns400() {
+        String name = "sdk-v2-render-miss-" + TestFixtures.uniqueName();
+        try {
+            sesV2.createEmailTemplate(CreateEmailTemplateRequest.builder()
+                    .templateName(name)
+                    .templateContent(EmailTemplateContent.builder()
+                            .subject("Hello {{name}}")
+                            .text("Hi {{name}}, team {{team}}!")
+                            .build())
+                    .build());
+
+            assertThatThrownBy(() -> sesV2.testRenderEmailTemplate(
+                    TestRenderEmailTemplateRequest.builder()
+                            .templateName(name)
+                            .templateData("{\"name\":\"Alice\"}")
+                            .build()))
+                    .isInstanceOf(BadRequestException.class)
+                    .extracting(e -> ((AwsServiceException) e).statusCode())
+                    .isEqualTo(400);
+        } finally {
+            safelyDeleteV2Template(name);
+        }
+    }
+
+    @Test
+    @Order(43)
+    void v2TestRenderEmailTemplateInvalidJsonReturns400() {
+        String name = "sdk-v2-render-bad-" + TestFixtures.uniqueName();
+        try {
+            sesV2.createEmailTemplate(CreateEmailTemplateRequest.builder()
+                    .templateName(name)
+                    .templateContent(EmailTemplateContent.builder()
+                            .subject("Hello")
+                            .text("Hi")
+                            .build())
+                    .build());
+
+            assertThatThrownBy(() -> sesV2.testRenderEmailTemplate(
+                    TestRenderEmailTemplateRequest.builder()
+                            .templateName(name)
+                            .templateData("{not json")
+                            .build()))
+                    .isInstanceOf(BadRequestException.class)
+                    .extracting(e -> ((AwsServiceException) e).statusCode())
+                    .isEqualTo(400);
+        } finally {
+            safelyDeleteV2Template(name);
+        }
+    }
+
+    @Test
+    @Order(45)
+    void v1TestRenderTemplateSubstitutesVariables() {
+        String name = "sdk-v1-render-" + TestFixtures.uniqueName();
+        try {
+            sesV1.createTemplate(CreateTemplateRequest.builder()
+                    .template(software.amazon.awssdk.services.ses.model.Template.builder()
+                            .templateName(name)
+                            .subjectPart("Hello {{name}}")
+                            .textPart("Hi {{name}}, team {{team}}!")
+                            .htmlPart("<p>Hi <b>{{name}}</b></p>")
+                            .build())
+                    .build());
+
+            TestRenderTemplateResponse response = sesV1.testRenderTemplate(
+                    TestRenderTemplateRequest.builder()
+                            .templateName(name)
+                            .templateData("{\"name\":\"Alice\",\"team\":\"floci\"}")
+                            .build());
+            assertThat(response.renderedTemplate())
+                    .contains("Subject: Hello Alice")
+                    .contains("Hi Alice, team floci!")
+                    .contains("multipart/alternative");
+        } finally {
+            safelyDeleteV1Template(name);
+        }
+    }
+
+    @Test
+    @Order(46)
+    void v1TestRenderTemplateUnknownTemplateRaises() {
+        assertThatThrownBy(() -> sesV1.testRenderTemplate(
+                TestRenderTemplateRequest.builder()
+                        .templateName("sdk-v1-render-missing-" + System.currentTimeMillis())
+                        .templateData("{}")
+                        .build()))
+                .isInstanceOf(TemplateDoesNotExistException.class);
+    }
+
+    @Test
+    @Order(47)
+    void v1TestRenderTemplateMissingVariableRaises() {
+        String name = "sdk-v1-render-miss-" + TestFixtures.uniqueName();
+        try {
+            sesV1.createTemplate(CreateTemplateRequest.builder()
+                    .template(software.amazon.awssdk.services.ses.model.Template.builder()
+                            .templateName(name)
+                            .subjectPart("Hello {{name}}")
+                            .textPart("Hi {{name}}, team {{team}}!")
+                            .build())
+                    .build());
+
+            assertThatThrownBy(() -> sesV1.testRenderTemplate(
+                    TestRenderTemplateRequest.builder()
+                            .templateName(name)
+                            .templateData("{\"name\":\"Alice\"}")
+                            .build()))
+                    .isInstanceOf(MissingRenderingAttributeException.class);
+        } finally {
+            safelyDeleteV1Template(name);
+        }
+    }
+
+    @Test
+    @Order(48)
+    void v1TestRenderTemplateInvalidJsonRaises() {
+        String name = "sdk-v1-render-bad-" + TestFixtures.uniqueName();
+        try {
+            sesV1.createTemplate(CreateTemplateRequest.builder()
+                    .template(software.amazon.awssdk.services.ses.model.Template.builder()
+                            .templateName(name)
+                            .subjectPart("Hello")
+                            .textPart("Hi")
+                            .build())
+                    .build());
+
+            assertThatThrownBy(() -> sesV1.testRenderTemplate(
+                    TestRenderTemplateRequest.builder()
+                            .templateName(name)
+                            .templateData("{not json")
+                            .build()))
+                    .isInstanceOf(InvalidRenderingParameterException.class);
+        } finally {
+            safelyDeleteV1Template(name);
+        }
+    }
+
+    // ───── Strict missing-attribute on Send paths (regression coverage) ─────
+
+    @Test
+    @Order(50)
+    void v2SendEmailWithTemplateMissingVariableReturns400() {
+        String name = "sdk-v2-send-miss-" + TestFixtures.uniqueName();
+        try {
+            sesV2.createEmailTemplate(CreateEmailTemplateRequest.builder()
+                    .templateName(name)
+                    .templateContent(EmailTemplateContent.builder()
+                            .subject("Hello {{name}}")
+                            .text("Hi {{name}}, team {{team}}!")
+                            .build())
+                    .build());
+
+            assertThatThrownBy(() -> sesV2.sendEmail(SendEmailRequest.builder()
+                    .fromEmailAddress(v2Sender)
+                    .destination(Destination.builder()
+                            .toAddresses("recipient@example.com")
+                            .build())
+                    .content(EmailContent.builder()
+                            .template(Template.builder()
+                                    .templateName(name)
+                                    .templateData("{\"name\":\"Alice\"}")
+                                    .build())
+                            .build())
+                    .build()))
+                    .isInstanceOf(BadRequestException.class)
+                    .extracting(e -> ((AwsServiceException) e).statusCode())
+                    .isEqualTo(400);
+        } finally {
+            safelyDeleteV2Template(name);
+        }
+    }
+
+    @Test
+    @Order(51)
+    void v1SendTemplatedEmailMissingVariableRaises() {
+        String name = "sdk-v1-send-miss-" + TestFixtures.uniqueName();
+        try {
+            sesV1.createTemplate(CreateTemplateRequest.builder()
+                    .template(software.amazon.awssdk.services.ses.model.Template.builder()
+                            .templateName(name)
+                            .subjectPart("Hello {{name}}")
+                            .textPart("Hi {{name}}, team {{team}}!")
+                            .build())
+                    .build());
+
+            assertThatThrownBy(() -> sesV1.sendTemplatedEmail(SendTemplatedEmailRequest.builder()
+                    .source(v1Sender)
+                    .destination(d -> d.toAddresses("recipient@example.com"))
+                    .template(name)
+                    .templateData("{\"name\":\"Alice\"}")
+                    .build()))
+                    .isInstanceOf(MissingRenderingAttributeException.class);
+        } finally {
+            safelyDeleteV1Template(name);
+        }
     }
 
     // ─────────────────────────────── Helpers ───────────────────────────────

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -24,6 +24,7 @@ Floci exposes the classic Amazon SES Query API used by `aws ses ...` commands an
 | `UpdateTemplate`                    | Replace the content of a stored template                  |
 | `DeleteTemplate`                    | Remove a stored template                                  |
 | `ListTemplates`                     | List stored templates                                     |
+| `TestRenderTemplate`                | Render a stored template against supplied data, returning the MIME message |
 | `GetSendQuota`                      | Return local send quota counters                          |
 | `GetSendStatistics`                 | Return aggregate delivery stats for sent messages         |
 | `GetAccountSendingEnabled`          | Report whether sending is enabled                         |
@@ -184,6 +185,7 @@ Alongside the classic Query API, Floci implements a subset of the SES v2 REST JS
 | `GET` | `/v2/email/templates/{templateName}` | `GetEmailTemplate` |
 | `PUT` | `/v2/email/templates/{templateName}` | `UpdateEmailTemplate` |
 | `DELETE` | `/v2/email/templates/{templateName}` | `DeleteEmailTemplate` |
+| `POST` | `/v2/email/templates/{templateName}/render` | `TestRenderEmailTemplate` |
 | `POST` | `/v2/email/configuration-sets` | `CreateConfigurationSet` |
 | `GET` | `/v2/email/configuration-sets` | `ListConfigurationSets` |
 | `GET` | `/v2/email/configuration-sets/{name}` | `GetConfigurationSet` |

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -280,6 +280,7 @@ public class AwsQueryController {
             "GetIdentityDkimAttributes",
             "CreateTemplate", "UpdateTemplate", "GetTemplate", "DeleteTemplate",
             "ListTemplates", "SendTemplatedEmail", "SendBulkTemplatedEmail",
+            "TestRenderTemplate",
             "CreateConfigurationSet", "DescribeConfigurationSet",
             "ListConfigurationSets", "DeleteConfigurationSet"
     );

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -194,6 +194,7 @@ public class SesController {
             }
 
             JsonNode request = objectMapper.readTree(body);
+            requireJsonObject(request);
 
             String fromEmailAddress = request.path("FromEmailAddress").asText(null);
             if (fromEmailAddress == null || fromEmailAddress.isBlank()) {
@@ -201,7 +202,7 @@ public class SesController {
                         "FromEmailAddress is required.", 400);
             }
 
-            JsonNode destination = request.path("Destination");
+            JsonNode destination = requireObjectOrAbsent(request, "Destination");
             List<String> toAddresses = jsonArrayToList(destination.path("ToAddresses"));
             List<String> ccAddresses = jsonArrayToList(destination.path("CcAddresses"));
             List<String> bccAddresses = jsonArrayToList(destination.path("BccAddresses"));
@@ -246,7 +247,7 @@ public class SesController {
                     throw new AwsException("BadRequestException",
                             "Content.Template requires TemplateName, TemplateArn, or TemplateContent.", 400);
                 }
-                JsonNode templateData = parseTemplateData(template.path("TemplateData").asText(""));
+                JsonNode templateData = parseTemplateData(template, "TemplateData");
                 if (hasName || hasArn) {
                     String resolvedName = hasName
                             ? templateName
@@ -291,6 +292,7 @@ public class SesController {
             }
 
             JsonNode request = objectMapper.readTree(body);
+            requireJsonObject(request);
             String fromEmailAddress = request.path("FromEmailAddress").asText(null);
             if (fromEmailAddress == null || fromEmailAddress.isBlank()) {
                 throw new AwsException("BadRequestException",
@@ -337,7 +339,7 @@ public class SesController {
                 html = stored.getHtmlPart();
             }
 
-            JsonNode defaultTemplateData = parseTemplateData(template.path("TemplateData").asText(""));
+            JsonNode defaultTemplateData = parseTemplateData(template, "TemplateData");
 
             JsonNode bulkEntries = request.path("BulkEmailEntries");
             if (!bulkEntries.isArray() || bulkEntries.isEmpty()) {
@@ -347,15 +349,18 @@ public class SesController {
 
             List<BulkEmailEntry> entries = new ArrayList<>();
             for (JsonNode node : bulkEntries) {
-                JsonNode dest = node.path("Destination");
+                if (!node.isObject()) {
+                    throw new AwsException("BadRequestException",
+                            "BulkEmailEntries elements must be JSON objects.", 400);
+                }
+                JsonNode dest = requireObjectOrAbsent(node, "Destination");
                 List<String> to = jsonArrayToList(dest.path("ToAddresses"));
                 List<String> cc = jsonArrayToList(dest.path("CcAddresses"));
                 List<String> bcc = jsonArrayToList(dest.path("BccAddresses"));
-                String replacementRaw = node.path("ReplacementEmailContent")
-                        .path("ReplacementTemplate")
-                        .path("ReplacementTemplateData")
-                        .asText("");
-                entries.add(new BulkEmailEntry(to, cc, bcc, parseTemplateData(replacementRaw)));
+                JsonNode replacementContent = requireObjectOrAbsent(node, "ReplacementEmailContent");
+                JsonNode replacementTemplate = requireObjectOrAbsent(replacementContent, "ReplacementTemplate");
+                JsonNode replacementData = parseTemplateData(replacementTemplate, "ReplacementTemplateData");
+                entries.add(new BulkEmailEntry(to, cc, bcc, replacementData));
             }
 
             List<BulkEmailEntryResult> results = sesService.sendBulkTemplatedEmail(fromEmailAddress,
@@ -470,6 +475,36 @@ public class SesController {
             return Response.ok(objectMapper.createObjectNode()).build();
         } catch (AwsException e) {
             throw remapV1Exception(e);
+        }
+    }
+
+    @POST
+    @Path("/templates/{templateName}/render")
+    public Response testRenderEmailTemplate(@Context HttpHeaders headers,
+                                             @PathParam("templateName") String templateName,
+                                             String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            if (body == null || body.isBlank()) {
+                throw new AwsException("BadRequestException", "Request body is required.", 400);
+            }
+            JsonNode request = objectMapper.readTree(body);
+            requireJsonObject(request);
+            JsonNode templateDataNode = request.path("TemplateData");
+            if (!templateDataNode.isMissingNode() && !templateDataNode.isNull()
+                    && !templateDataNode.isTextual()) {
+                throw new AwsException("BadRequestException",
+                        "TemplateData must be a JSON-encoded string.", 400);
+            }
+            String templateDataRaw = templateDataNode.asText("");
+            String rendered = sesService.renderTestTemplate(templateName, templateDataRaw, region);
+            ObjectNode result = objectMapper.createObjectNode();
+            result.put("RenderedTemplate", rendered);
+            return Response.ok(result).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
         }
     }
 
@@ -688,21 +723,63 @@ public class SesController {
         return result;
     }
 
+    private JsonNode parseTemplateData(JsonNode parent, String fieldName) {
+        if (parent == null || parent.isMissingNode() || parent.isNull()) {
+            return objectMapper.createObjectNode();
+        }
+        if (!parent.isObject()) {
+            throw new AwsException("BadRequestException",
+                    "Parent of " + fieldName + " must be a JSON object.", 400);
+        }
+        JsonNode field = parent.path(fieldName);
+        if (field.isMissingNode() || field.isNull()) {
+            return objectMapper.createObjectNode();
+        }
+        if (!field.isTextual()) {
+            throw new AwsException("BadRequestException",
+                    fieldName + " must be a JSON-encoded string.", 400);
+        }
+        return parseTemplateData(field.asText(""));
+    }
+
     private JsonNode parseTemplateData(String raw) {
         if (raw == null || raw.isBlank()) {
             return objectMapper.createObjectNode();
         }
+        JsonNode node;
         try {
-            return objectMapper.readTree(raw);
+            node = objectMapper.readTree(raw);
         } catch (Exception e) {
             throw new AwsException("BadRequestException",
                     "Invalid TemplateData JSON: " + e.getMessage(), 400);
         }
+        if (!node.isObject()) {
+            throw new AwsException("BadRequestException",
+                    "TemplateData must be a JSON object.", 400);
+        }
+        return node;
+    }
+
+    private static void requireJsonObject(JsonNode root) {
+        if (root == null || !root.isObject()) {
+            throw new AwsException("BadRequestException",
+                    "Request body must be a JSON object.", 400);
+        }
+    }
+
+    private static JsonNode requireObjectOrAbsent(JsonNode parent, String fieldName) {
+        JsonNode child = parent.path(fieldName);
+        if (!child.isMissingNode() && !child.isNull() && !child.isObject()) {
+            throw new AwsException("BadRequestException",
+                    fieldName + " must be a JSON object.", 400);
+        }
+        return child;
     }
 
     private static AwsException remapV1Exception(AwsException e) {
         return switch (e.getErrorCode()) {
-            case "InvalidParameterValue", "InvalidTemplate" ->
+            case "InvalidParameterValue", "InvalidTemplate",
+                 "InvalidRenderingParameter", "MissingRenderingAttribute" ->
                     new AwsException("BadRequestException", e.getMessage(), 400);
             case "TemplateDoesNotExist", "ConfigurationSetDoesNotExist" ->
                     new AwsException("NotFoundException", e.getMessage(), 404);

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
@@ -66,6 +66,7 @@ public class SesQueryHandler {
                 case "ListTemplates" -> handleListTemplates(region);
                 case "SendTemplatedEmail" -> handleSendTemplatedEmail(params, region);
                 case "SendBulkTemplatedEmail" -> handleSendBulkTemplatedEmail(params, region);
+                case "TestRenderTemplate" -> handleTestRenderTemplate(params, region);
                 case "CreateConfigurationSet" -> handleCreateConfigurationSet(params, region);
                 case "DescribeConfigurationSet" -> handleDescribeConfigurationSet(params, region);
                 case "ListConfigurationSets" -> handleListConfigurationSets(region);
@@ -356,6 +357,20 @@ public class SesQueryHandler {
         return Response.ok(AwsQueryResponse.envelope("SendTemplatedEmail", AwsNamespaces.SES, result)).build();
     }
 
+    private Response handleTestRenderTemplate(MultivaluedMap<String, String> params, String region) {
+        String templateName = getParam(params, "TemplateName");
+        if (templateName == null || templateName.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "TemplateName is required.", 400);
+        }
+        String templateDataRaw = getParam(params, "TemplateData");
+        String rendered = sesService.renderTestTemplate(templateName, templateDataRaw, region);
+        // XML 1.0 character data forbids C0 controls except \t \n \r; strip them
+        // so SDK clients can parse the response when template data injects \x01 etc.
+        String xmlSafe = SesService.stripXml10InvalidChars(rendered);
+        String result = new XmlBuilder().elem("RenderedTemplate", xmlSafe).build();
+        return Response.ok(AwsQueryResponse.envelope("TestRenderTemplate", AwsNamespaces.SES, result)).build();
+    }
+
     private Response handleSendBulkTemplatedEmail(MultivaluedMap<String, String> params, String region) {
         if (!sesService.isAccountSendingEnabled(region)) {
             throw new AwsException("AccountSendingPausedException",
@@ -467,12 +482,18 @@ public class SesQueryHandler {
         if (raw == null || raw.isBlank()) {
             return objectMapper.createObjectNode();
         }
+        JsonNode node;
         try {
-            return objectMapper.readTree(raw);
+            node = objectMapper.readTree(raw);
         } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
             throw new AwsException("InvalidTemplate",
                     "Invalid TemplateData JSON: " + e.getMessage(), 400);
         }
+        if (!node.isObject()) {
+            throw new AwsException("InvalidParameterValue",
+                    "TemplateData must be a JSON object.", 400);
+        }
+        return node;
     }
 
     // --- Helpers ---

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -11,15 +11,21 @@ import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.SentEmail;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.security.SecureRandom;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -36,15 +42,18 @@ public class SesService {
     private static final int MAX_BULK_DESTINATIONS = 50;
     private static final int MAX_RECIPIENTS_PER_DESTINATION = 50;
 
+    private static final SecureRandom BOUNDARY_RANDOM = new SecureRandom();
+
     private final StorageBackend<String, Identity> identityStore;
     private final StorageBackend<String, SentEmail> emailStore;
     private final StorageBackend<String, Boolean> accountSettingsStore;
     private final StorageBackend<String, EmailTemplate> templateStore;
     private final StorageBackend<String, ConfigurationSet> configSetStore;
     private final SmtpRelay smtpRelay;
+    private final ObjectMapper objectMapper;
 
     @Inject
-    public SesService(StorageFactory storageFactory, SmtpRelay smtpRelay) {
+    public SesService(StorageFactory storageFactory, SmtpRelay smtpRelay, ObjectMapper objectMapper) {
         this.identityStore = storageFactory.create("ses", "ses-identities.json",
                 new TypeReference<Map<String, Identity>>() {});
         this.emailStore = storageFactory.create("ses", "ses-emails.json",
@@ -56,6 +65,7 @@ public class SesService {
         this.configSetStore = storageFactory.create("ses", "ses-config-sets.json",
                 new TypeReference<Map<String, ConfigurationSet>>() {});
         this.smtpRelay = smtpRelay;
+        this.objectMapper = objectMapper;
     }
 
     SesService(StorageBackend<String, Identity> identityStore,
@@ -63,13 +73,15 @@ public class SesService {
                StorageBackend<String, Boolean> accountSettingsStore,
                StorageBackend<String, EmailTemplate> templateStore,
                StorageBackend<String, ConfigurationSet> configSetStore,
-               SmtpRelay smtpRelay) {
+               SmtpRelay smtpRelay,
+               ObjectMapper objectMapper) {
         this.identityStore = identityStore;
         this.emailStore = emailStore;
         this.accountSettingsStore = accountSettingsStore;
         this.templateStore = templateStore;
         this.configSetStore = configSetStore;
         this.smtpRelay = smtpRelay;
+        this.objectMapper = objectMapper;
     }
 
     public Identity verifyEmailIdentity(String emailAddress, String region) {
@@ -416,6 +428,119 @@ public class SesService {
                 template.getHtmlPart(), templateData, region);
     }
 
+    public String renderTestTemplate(String templateName, String templateDataRaw, String region) {
+        EmailTemplate template = getTemplate(templateName, region);
+        JsonNode templateData = parseRenderingData(objectMapper, templateDataRaw);
+        String subject = applyTemplateData(template.getSubject(), templateData);
+        String text = applyTemplateData(template.getTextPart(), templateData);
+        String html = applyTemplateData(template.getHtmlPart(), templateData);
+        return buildTestRenderMime(subject, text, html, ZonedDateTime.now(ZoneOffset.UTC), nextBoundary());
+    }
+
+    static JsonNode parseRenderingData(ObjectMapper mapper, String raw) {
+        if (raw == null || raw.isBlank()) {
+            throw new AwsException("InvalidRenderingParameter",
+                    "Template rendering data is required.", 400);
+        }
+        JsonNode node;
+        try {
+            node = mapper.readTree(raw);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new AwsException("InvalidRenderingParameter",
+                    "Template rendering data is invalid: " + e.getOriginalMessage(), 400);
+        }
+        if (!node.isObject()) {
+            throw new AwsException("InvalidRenderingParameter",
+                    "Template rendering data must be a JSON object.", 400);
+        }
+        return node;
+    }
+
+    static String buildTestRenderMime(String subject, String text, String html,
+                                       ZonedDateTime date, String boundary) {
+        String safeSubject = sanitizeSubject(subject);
+        String safeText = text == null ? "" : text;
+        String safeHtml = html == null ? "" : html;
+        String dateHeader = DateTimeFormatter.RFC_1123_DATE_TIME.format(date);
+        StringBuilder out = new StringBuilder();
+        out.append("Date: ").append(dateHeader).append("\r\n");
+        out.append("Subject: ").append(safeSubject).append("\r\n");
+        out.append("MIME-Version: 1.0\r\n");
+        out.append("Content-Type: multipart/alternative; boundary=\"").append(boundary).append("\"\r\n");
+        out.append("\r\n");
+        appendMimePart(out, boundary, "text/plain", safeText);
+        appendMimePart(out, boundary, "text/html", safeHtml);
+        out.append("--").append(boundary).append("--\r\n");
+        return out.toString();
+    }
+
+    private static void appendMimePart(StringBuilder out, String boundary, String mimeType, String body) {
+        out.append("--").append(boundary).append("\r\n");
+        out.append("Content-Type: ").append(mimeType).append("; charset=UTF-8\r\n");
+        out.append("Content-Transfer-Encoding: ").append(pickTransferEncoding(body)).append("\r\n");
+        out.append("\r\n");
+        String normalized = normalizeToCrlf(body);
+        out.append(normalized);
+        if (!normalized.endsWith("\r\n")) {
+            out.append("\r\n");
+        }
+    }
+
+    static String normalizeToCrlf(String body) {
+        return body.replace("\r\n", "\n").replace("\r", "\n").replace("\n", "\r\n");
+    }
+
+    static String pickTransferEncoding(String body) {
+        return body.codePoints().allMatch(c -> c < 128) ? "7bit" : "8bit";
+    }
+
+    static String sanitizeSubject(String subject) {
+        if (subject == null) {
+            return "";
+        }
+        // Strip C0 control characters (U+0000-U+001F) and DEL (U+007F): RFC 5322
+        // forbids them in unstructured header field bodies. Replace with spaces so
+        // visible content is preserved when template data accidentally injects them.
+        StringBuilder out = new StringBuilder(subject.length());
+        for (int i = 0; i < subject.length(); i++) {
+            char c = subject.charAt(i);
+            out.append((c < 0x20 || c == 0x7F) ? ' ' : c);
+        }
+        return out.toString();
+    }
+
+    static String stripXml10InvalidChars(String s) {
+        if (s == null || s.isEmpty()) {
+            return s;
+        }
+        // XML 1.0 char production: \t \n \r, U+0020-U+D7FF, U+E000-U+FFFD,
+        // U+10000-U+10FFFF. Anything else (C0 controls, U+FFFE/U+FFFF, lone
+        // surrogates) makes the response unparseable by SDK XML parsers.
+        StringBuilder out = new StringBuilder(s.length());
+        int i = 0;
+        while (i < s.length()) {
+            int cp = s.codePointAt(i);
+            if (isXml10Char(cp)) {
+                out.appendCodePoint(cp);
+            }
+            i += Character.charCount(cp);
+        }
+        return out.toString();
+    }
+
+    private static boolean isXml10Char(int cp) {
+        return cp == 0x09 || cp == 0x0A || cp == 0x0D
+                || (cp >= 0x20 && cp <= 0xD7FF)
+                || (cp >= 0xE000 && cp <= 0xFFFD)
+                || (cp >= 0x10000 && cp <= 0x10FFFF);
+    }
+
+    private static String nextBoundary() {
+        byte[] bytes = new byte[6];
+        BOUNDARY_RANDOM.nextBytes(bytes);
+        return "===_floci_" + HexFormat.of().formatHex(bytes) + "_===";
+    }
+
     public String sendInlineTemplatedEmail(String source, List<String> toAddresses, List<String> ccAddresses,
                                             List<String> bccAddresses, List<String> replyToAddresses,
                                             String subject, String textPart, String htmlPart,
@@ -497,7 +622,9 @@ public class SesService {
     }
 
     static BulkEmailEntryResult.Status mapErrorCodeToBulkStatus(String errorCode) {
-        if ("InvalidParameterValue".equals(errorCode)) {
+        if ("InvalidParameterValue".equals(errorCode)
+                || "MissingRenderingAttribute".equals(errorCode)
+                || "InvalidRenderingParameter".equals(errorCode)) {
             return BulkEmailEntryResult.Status.INVALID_PARAMETER;
         }
         return BulkEmailEntryResult.Status.FAILED;
@@ -534,11 +661,12 @@ public class SesService {
         StringBuilder out = new StringBuilder();
         while (matcher.find()) {
             String key = matcher.group(1);
-            String replacement = "";
-            if (data != null && data.hasNonNull(key)) {
-                JsonNode value = data.get(key);
-                replacement = value.isValueNode() ? value.asText() : value.toString();
+            if (data == null || !data.hasNonNull(key)) {
+                throw new AwsException("MissingRenderingAttribute",
+                        "Attribute '" + key + "' is not present in the rendering data.", 400);
             }
+            JsonNode value = data.get(key);
+            String replacement = value.isValueNode() ? value.asText() : value.toString();
             matcher.appendReplacement(out, Matcher.quoteReplacement(replacement));
         }
         matcher.appendTail(out);

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesBulkV1IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesBulkV1IntegrationTest.java
@@ -5,11 +5,15 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
@@ -154,12 +158,14 @@ class SesBulkV1IntegrationTest {
         // An entry with only ReplacementTemplateData (no recipient) reaches sendEmail,
         // which throws AwsException("InvalidParameterValue", ...). Expected per-entry
         // Status string in v1 is "InvalidParameterValue", not "Failed" or "InvalidParameter".
+        // DefaultTemplateData supplies team so rendering succeeds before the recipient check.
         String body = given()
             .contentType("application/x-www-form-urlencoded")
             .header("Authorization", AUTH)
             .formParam("Action", "SendBulkTemplatedEmail")
             .formParam("Source", "bulk@example.com")
             .formParam("Template", "v1-bulk-welcome")
+            .formParam("DefaultTemplateData", "{\"team\":\"floci\"}")
             .formParam("Destinations.member.1.ReplacementTemplateData", "{\"name\":\"Ghost\"}")
         .when()
             .post("/")
@@ -228,6 +234,62 @@ class SesBulkV1IntegrationTest {
         .then()
             .statusCode(400)
             .body(containsString("<Code>MessageRejected</Code>"));
+    }
+
+    @Test
+    @Order(12)
+    void sendBulkTemplatedEmail_perEntryMissingVariable_mapsToInvalidParameterValue() {
+        // Per-entry rendering failure (missing {{name}}) surfaces as
+        // <Status>InvalidParameterValue</Status> in the bulk Query response,
+        // not as Failed.
+        String body = given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SendBulkTemplatedEmail")
+            .formParam("Source", "bulk@example.com")
+            .formParam("Template", "v1-bulk-welcome")
+            .formParam("DefaultTemplateData", "{\"team\":\"floci\"}")
+            .formParam("Destinations.member.1.Destination.ToAddresses.member.1", "alice@example.com")
+            .formParam("Destinations.member.1.ReplacementTemplateData", "{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().body().asString();
+
+        assertEquals(1L, body.split("<Status>InvalidParameterValue</Status>", -1).length - 1L,
+                "expected per-entry Status=InvalidParameterValue for missing rendering variable");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("nonObjectBulkTemplateDataPayloads")
+    @Order(10)
+    void sendBulkTemplatedEmail_nonObjectTemplateData_returnsInvalidParameterValue(
+            String label, String defaultTemplateData, String replacementTemplateData) {
+        var spec = given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SendBulkTemplatedEmail")
+            .formParam("Source", "bulk@example.com")
+            .formParam("Template", "v1-bulk-welcome")
+            .formParam("DefaultTemplateData", defaultTemplateData)
+            .formParam("Destinations.member.1.Destination.ToAddresses.member.1", "alice@example.com");
+        if (replacementTemplateData != null) {
+            spec = spec.formParam("Destinations.member.1.ReplacementTemplateData", replacementTemplateData);
+        }
+        spec
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>InvalidParameterValue</Code>"));
+    }
+
+    static Stream<Arguments> nonObjectBulkTemplateDataPayloads() {
+        return Stream.of(
+                Arguments.of("array DefaultTemplateData", "[1,2,3]", null),
+                Arguments.of("scalar ReplacementTemplateData", "{\"team\":\"floci\"}", "42")
+        );
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesBulkV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesBulkV2IntegrationTest.java
@@ -5,6 +5,11 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
@@ -280,6 +285,151 @@ class SesBulkV2IntegrationTest {
         .then()
             .statusCode(400)
             .body("__type", equalTo("MessageRejected"));
+    }
+
+    @Test
+    @Order(10)
+    void sendBulkEmail_perEntryMissingVariable_mapsToInvalidParameter() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "FromEmailAddress": "bulk@example.com",
+                  "DefaultContent": {
+                    "Template": {"TemplateName": "v2-bulk-welcome", "TemplateData": "{\\"team\\":\\"floci\\"}"}
+                  },
+                  "BulkEmailEntries": [
+                    {
+                      "Destination": {"ToAddresses": ["alice@example.com"]},
+                      "ReplacementEmailContent": {
+                        "ReplacementTemplate": {"ReplacementTemplateData": "{}"}
+                      }
+                    }
+                  ]
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-bulk-emails")
+        .then()
+            .statusCode(200)
+            .body("BulkEmailEntryResults[0].Status", equalTo("INVALID_PARAMETER"))
+            .body("BulkEmailEntryResults[0].Error", org.hamcrest.Matchers.containsString("name"));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("malformedSendBulkEmailBodies")
+    @Order(11)
+    void sendBulkEmail_malformedShape_returns400(String label, String body) {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body(body)
+        .when()
+            .post("/v2/email/outbound-bulk-emails")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    static Stream<Arguments> malformedSendBulkEmailBodies() {
+        String validDefaultTemplate = "\"DefaultContent\": {\"Template\": {\"TemplateName\": \"v2-bulk-welcome\", \"TemplateData\": \"{\\\"team\\\":\\\"floci\\\",\\\"name\\\":\\\"X\\\"}\"}}";
+        return Stream.of(
+                Arguments.of("body is array", "[1,2,3]"),
+                Arguments.of("body is JSON null literal", "null"),
+                Arguments.of("body is JSON string", "\"hello\""),
+                Arguments.of("BulkEmailEntries element is null", """
+                    {
+                      "FromEmailAddress": "bulk@example.com",
+                      %s,
+                      "BulkEmailEntries": [null]
+                    }
+                    """.formatted(validDefaultTemplate)),
+                Arguments.of("BulkEmailEntries element is string", """
+                    {
+                      "FromEmailAddress": "bulk@example.com",
+                      %s,
+                      "BulkEmailEntries": ["bad"]
+                    }
+                    """.formatted(validDefaultTemplate)),
+                Arguments.of("Destination as string", """
+                    {
+                      "FromEmailAddress": "bulk@example.com",
+                      %s,
+                      "BulkEmailEntries": [{"Destination": "bad"}]
+                    }
+                    """.formatted(validDefaultTemplate)),
+                Arguments.of("DefaultTemplateData as object", """
+                    {
+                      "FromEmailAddress": "bulk@example.com",
+                      "DefaultContent": {
+                        "Template": {"TemplateName": "v2-bulk-welcome", "TemplateData": {"team": "floci"}}
+                      },
+                      "BulkEmailEntries": [{"Destination": {"ToAddresses": ["alice@example.com"]}}]
+                    }
+                    """),
+                Arguments.of("DefaultTemplateData as invalid JSON string", """
+                    {
+                      "FromEmailAddress": "bulk@example.com",
+                      "DefaultContent": {
+                        "Template": {"TemplateName": "v2-bulk-welcome", "TemplateData": "{not json"}
+                      },
+                      "BulkEmailEntries": [{"Destination": {"ToAddresses": ["alice@example.com"]}}]
+                    }
+                    """),
+                Arguments.of("per-entry ReplacementTemplateData as object", """
+                    {
+                      "FromEmailAddress": "bulk@example.com",
+                      %s,
+                      "BulkEmailEntries": [
+                        {
+                          "Destination": {"ToAddresses": ["alice@example.com"]},
+                          "ReplacementEmailContent": {
+                            "ReplacementTemplate": {"ReplacementTemplateData": {"name": "Alice"}}
+                          }
+                        }
+                      ]
+                    }
+                    """.formatted(validDefaultTemplate)),
+                Arguments.of("ReplacementEmailContent as string", """
+                    {
+                      "FromEmailAddress": "bulk@example.com",
+                      %s,
+                      "BulkEmailEntries": [
+                        {
+                          "Destination": {"ToAddresses": ["alice@example.com"]},
+                          "ReplacementEmailContent": "not-an-object"
+                        }
+                      ]
+                    }
+                    """.formatted(validDefaultTemplate)),
+                Arguments.of("ReplacementEmailContent as array", """
+                    {
+                      "FromEmailAddress": "bulk@example.com",
+                      %s,
+                      "BulkEmailEntries": [
+                        {
+                          "Destination": {"ToAddresses": ["alice@example.com"]},
+                          "ReplacementEmailContent": [1,2,3]
+                        }
+                      ]
+                    }
+                    """.formatted(validDefaultTemplate)),
+                Arguments.of("ReplacementTemplate as array", """
+                    {
+                      "FromEmailAddress": "bulk@example.com",
+                      "DefaultContent": {
+                        "Template": {"TemplateName": "v2-bulk-welcome", "TemplateData": "{\\"team\\":\\"floci\\"}"}
+                      },
+                      "BulkEmailEntries": [
+                        {
+                          "Destination": {"ToAddresses": ["alice@example.com"]},
+                          "ReplacementEmailContent": {"ReplacementTemplate": [1,2,3]}
+                        }
+                      ]
+                    }
+                    """)
+        );
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSmtpTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSmtpTest.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.ses;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
@@ -33,7 +34,8 @@ class SesServiceSmtpTest {
                 new InMemoryStorage<String, Boolean>(),
                 new InMemoryStorage<String, EmailTemplate>(),
                 new InMemoryStorage<String, ConfigurationSet>(),
-                smtpRelay);
+                smtpRelay,
+                new ObjectMapper());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTemplateTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTemplateTest.java
@@ -3,10 +3,12 @@ package io.github.hectorvent.floci.services.ses;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Unit tests for {@link SesService#applyTemplateData} covering
@@ -17,10 +19,11 @@ class SesServiceTemplateTest {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     @Test
-    void undefinedVariable_replacedWithEmptyString() {
+    void undefinedVariable_throwsMissingRenderingAttribute() {
         JsonNode data = MAPPER.createObjectNode().put("name", "Alice");
-        String result = SesService.applyTemplateData("Hello {{name}}, team {{team}}", data);
-        assertEquals("Hello Alice, team ", result);
+        AwsException ex = assertThrows(AwsException.class,
+                () -> SesService.applyTemplateData("Hello {{name}}, team {{team}}", data));
+        assertEquals("MissingRenderingAttribute", ex.getErrorCode());
     }
 
     @Test
@@ -57,16 +60,18 @@ class SesServiceTemplateTest {
     }
 
     @Test
-    void emptyTemplateData_allVariablesCleared() {
+    void emptyTemplateData_throwsMissingRenderingAttribute() {
         JsonNode data = MAPPER.createObjectNode();
-        String result = SesService.applyTemplateData("Hello {{name}}, {{team}}", data);
-        assertEquals("Hello , ", result);
+        AwsException ex = assertThrows(AwsException.class,
+                () -> SesService.applyTemplateData("Hello {{name}}, {{team}}", data));
+        assertEquals("MissingRenderingAttribute", ex.getErrorCode());
     }
 
     @Test
-    void nullTemplateData_allVariablesCleared() {
-        String result = SesService.applyTemplateData("Hello {{name}}", null);
-        assertEquals("Hello ", result);
+    void nullTemplateData_throwsMissingRenderingAttribute() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> SesService.applyTemplateData("Hello {{name}}", null));
+        assertEquals("MissingRenderingAttribute", ex.getErrorCode());
     }
 
     @Test
@@ -100,15 +105,232 @@ class SesServiceTemplateTest {
     }
 
     @Test
-    void variableNameCaseSensitive() {
+    void variableNameCaseSensitive_matchesExact() {
         JsonNode data = MAPPER.createObjectNode().put("Name", "Alice");
-        String result = SesService.applyTemplateData("Hello {{name}} and {{Name}}", data);
-        assertEquals("Hello  and Alice", result);
+        assertEquals("Hello Alice", SesService.applyTemplateData("Hello {{Name}}", data));
+    }
+
+    @Test
+    void variableNameCaseSensitive_throwsForCaseMismatch() {
+        JsonNode data = MAPPER.createObjectNode().put("Name", "Alice");
+        AwsException ex = assertThrows(AwsException.class,
+                () -> SesService.applyTemplateData("Hello {{name}}", data));
+        assertEquals("MissingRenderingAttribute", ex.getErrorCode());
     }
 
     @Test
     void emptyStringValue() {
         JsonNode data = MAPPER.createObjectNode().put("name", "");
         assertEquals("Hello ", SesService.applyTemplateData("Hello {{name}}", data));
+    }
+
+    @Test
+    void buildTestRenderMime_asciiBody_uses7bit() {
+        java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
+        String mime = SesService.buildTestRenderMime("Hello", "Hi there", "<p>Hi</p>", date, "BOUND");
+        assertEquals(true, mime.contains("Subject: Hello\r\n"));
+        assertEquals(true, mime.contains("Content-Type: multipart/alternative; boundary=\"BOUND\""));
+        assertEquals(true, mime.contains("Content-Transfer-Encoding: 7bit"));
+        assertEquals(false, mime.contains("Content-Transfer-Encoding: 8bit"));
+        assertEquals(true, mime.endsWith("--BOUND--\r\n"));
+    }
+
+    @Test
+    void buildTestRenderMime_utf8Body_uses8bit() {
+        java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
+        String mime = SesService.buildTestRenderMime("件名", "こんにちは", "<p>こんにちは</p>", date, "BOUND");
+        assertEquals(true, mime.contains("Subject: 件名\r\n"));
+        assertEquals(true, mime.contains("Content-Transfer-Encoding: 8bit"));
+        assertEquals(true, mime.contains("こんにちは"));
+    }
+
+    @Test
+    void buildTestRenderMime_subjectStripsCRLF() {
+        java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
+        String mime = SesService.buildTestRenderMime("Multi\r\nLine", "x", "x", date, "BOUND");
+        // CR and LF are both C0 controls and are replaced with spaces.
+        assertEquals(true, mime.contains("Subject: Multi  Line\r\n"));
+    }
+
+    @Test
+    void pickTransferEncoding_asciiOnly() {
+        assertEquals("7bit", SesService.pickTransferEncoding("Hello world"));
+        assertEquals("7bit", SesService.pickTransferEncoding(""));
+    }
+
+    @Test
+    void pickTransferEncoding_nonAscii() {
+        assertEquals("8bit", SesService.pickTransferEncoding("こんにちは"));
+        assertEquals("8bit", SesService.pickTransferEncoding("café"));
+    }
+
+    @Test
+    void parseRenderingData_invalidJson_throwsInvalidRenderingParameter() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> SesService.parseRenderingData(MAPPER, "{not json"));
+        assertEquals("InvalidRenderingParameter", ex.getErrorCode());
+    }
+
+    @Test
+    void parseRenderingData_nonObject_throwsInvalidRenderingParameter() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> SesService.parseRenderingData(MAPPER, "[1,2,3]"));
+        assertEquals("InvalidRenderingParameter", ex.getErrorCode());
+    }
+
+    @Test
+    void parseRenderingData_blank_throwsInvalidRenderingParameter() {
+        // Matches moto's TestRenderTemplate behavior: blank input is not valid JSON.
+        assertEquals("InvalidRenderingParameter",
+                assertThrows(AwsException.class, () -> SesService.parseRenderingData(MAPPER, null)).getErrorCode());
+        assertEquals("InvalidRenderingParameter",
+                assertThrows(AwsException.class, () -> SesService.parseRenderingData(MAPPER, "")).getErrorCode());
+        assertEquals("InvalidRenderingParameter",
+                assertThrows(AwsException.class, () -> SesService.parseRenderingData(MAPPER, "   ")).getErrorCode());
+    }
+
+    @Test
+    void parseRenderingData_emptyObject_accepted() {
+        assertEquals(true, SesService.parseRenderingData(MAPPER, "{}").isObject());
+    }
+
+    @Test
+    void normalizeToCrlf_lfOnly_convertedToCrlf() {
+        assertEquals("a\r\nb\r\nc", SesService.normalizeToCrlf("a\nb\nc"));
+    }
+
+    @Test
+    void normalizeToCrlf_crOnly_convertedToCrlf() {
+        assertEquals("a\r\nb\r\nc", SesService.normalizeToCrlf("a\rb\rc"));
+    }
+
+    @Test
+    void normalizeToCrlf_alreadyCrlf_unchanged() {
+        assertEquals("a\r\nb\r\nc", SesService.normalizeToCrlf("a\r\nb\r\nc"));
+    }
+
+    @Test
+    void normalizeToCrlf_mixed_normalizesAll() {
+        assertEquals("a\r\nb\r\nc\r\nd", SesService.normalizeToCrlf("a\nb\rc\r\nd"));
+    }
+
+    @Test
+    void buildTestRenderMime_bodyWithBareLf_normalizedToCrlf() {
+        java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
+        String mime = SesService.buildTestRenderMime("S", "line1\nline2", "<p>x\ny</p>", date, "BOUND");
+        assertEquals(true, mime.contains("line1\r\nline2"));
+        assertEquals(true, mime.contains("x\r\ny"));
+        assertEquals(false, mime.contains("line1\nline2"));
+    }
+
+    @Test
+    void buildTestRenderMime_bodyEndingWithNewline_noExtraBlankLine() {
+        java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
+        String mime = SesService.buildTestRenderMime("S", "hello\n", "<p>hi</p>\n", date, "BOUND");
+        assertEquals(false, mime.contains("hello\r\n\r\n--BOUND"));
+        assertEquals(true, mime.contains("hello\r\n--BOUND"));
+        assertEquals(false, mime.contains("</p>\r\n\r\n--BOUND"));
+        assertEquals(true, mime.contains("</p>\r\n--BOUND"));
+    }
+
+    @Test
+    void buildTestRenderMime_bodyWithoutTrailingNewline_addsCrlfBeforeBoundary() {
+        java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
+        String mime = SesService.buildTestRenderMime("S", "hello", "<p>hi</p>", date, "BOUND");
+        assertEquals(true, mime.contains("hello\r\n--BOUND"));
+        assertEquals(true, mime.contains("</p>\r\n--BOUND"));
+    }
+
+    @Test
+    void mapErrorCodeToBulkStatus_invalidParameterValue() {
+        assertEquals(io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult.Status.INVALID_PARAMETER,
+                SesService.mapErrorCodeToBulkStatus("InvalidParameterValue"));
+    }
+
+    @Test
+    void mapErrorCodeToBulkStatus_missingRenderingAttribute() {
+        assertEquals(io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult.Status.INVALID_PARAMETER,
+                SesService.mapErrorCodeToBulkStatus("MissingRenderingAttribute"));
+    }
+
+    @Test
+    void mapErrorCodeToBulkStatus_invalidRenderingParameter() {
+        assertEquals(io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult.Status.INVALID_PARAMETER,
+                SesService.mapErrorCodeToBulkStatus("InvalidRenderingParameter"));
+    }
+
+    @Test
+    void mapErrorCodeToBulkStatus_unknownCode_failed() {
+        assertEquals(io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult.Status.FAILED,
+                SesService.mapErrorCodeToBulkStatus("SomethingElse"));
+    }
+
+    @Test
+    void sanitizeSubject_replacesC0ControlCharsWithSpace() {
+        assertEquals("a b c", SesService.sanitizeSubject("a\u0001b\u001fc"));
+        assertEquals("x y z", SesService.sanitizeSubject("x\ry\nz"));
+        assertEquals("a b", SesService.sanitizeSubject("a\u0007b"));
+    }
+
+    @Test
+    void sanitizeSubject_replacesDelWithSpace() {
+        assertEquals("a b", SesService.sanitizeSubject("a\u007fb"));
+    }
+
+    @Test
+    void sanitizeSubject_nullReturnsEmpty() {
+        assertEquals("", SesService.sanitizeSubject(null));
+    }
+
+    @Test
+    void sanitizeSubject_preservesPrintableAndUnicode() {
+        assertEquals("Hello 太郎", SesService.sanitizeSubject("Hello 太郎"));
+        assertEquals("Hello!", SesService.sanitizeSubject("Hello!"));
+    }
+
+    @Test
+    void stripXml10InvalidChars_keepsTabNewlineCarriageReturn() {
+        assertEquals("a\tb\nc\rd", SesService.stripXml10InvalidChars("a\tb\nc\rd"));
+    }
+
+    @Test
+    void stripXml10InvalidChars_removesC0ControlsExceptWhitespace() {
+        assertEquals("abc", SesService.stripXml10InvalidChars("a\u0001b\u001fc"));
+        assertEquals("ab", SesService.stripXml10InvalidChars("a\u0008b"));
+        assertEquals("ab", SesService.stripXml10InvalidChars("a\u000bb"));
+        assertEquals("ab", SesService.stripXml10InvalidChars("a\u000cb"));
+    }
+
+    @Test
+    void stripXml10InvalidChars_preservesUnicode() {
+        assertEquals("件名 太郎", SesService.stripXml10InvalidChars("件名 太郎"));
+    }
+
+    @Test
+    void stripXml10InvalidChars_removesNoncharacters() {
+        assertEquals("ab", SesService.stripXml10InvalidChars("a\ufffeb"));
+        assertEquals("ab", SesService.stripXml10InvalidChars("a\uffffb"));
+    }
+
+    @Test
+    void stripXml10InvalidChars_removesLoneSurrogates() {
+        assertEquals("ab", SesService.stripXml10InvalidChars("a\ud800b")); // lone high
+        assertEquals("ab", SesService.stripXml10InvalidChars("a\udc00b")); // lone low
+    }
+
+    @Test
+    void stripXml10InvalidChars_preservesPairedSupplementary() {
+        // U+1F600 GRINNING FACE encoded as surrogate pair D83D DE00
+        String emoji = "😀";
+        assertEquals("a" + emoji + "b", SesService.stripXml10InvalidChars("a" + emoji + "b"));
+    }
+
+    @Test
+    void buildTestRenderMime_subjectWithControlChars_replacedWithSpace() {
+        java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
+        String mime = SesService.buildTestRenderMime(
+                "Hello\u0001World", "x", "x", date, "BOUND");
+        assertEquals(true, mime.contains("Subject: Hello World\r\n"));
+        assertEquals(false, mime.contains("\u0001"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTemplateTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTemplateTest.java
@@ -4,11 +4,18 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link SesService#applyTemplateData} covering
@@ -152,41 +159,37 @@ class SesServiceTemplateTest {
         assertEquals(true, mime.contains("Subject: Multi  Line\r\n"));
     }
 
-    @Test
-    void pickTransferEncoding_asciiOnly() {
-        assertEquals("7bit", SesService.pickTransferEncoding("Hello world"));
-        assertEquals("7bit", SesService.pickTransferEncoding(""));
+    @ParameterizedTest(name = "{0} -> {1}")
+    @MethodSource("pickTransferEncodingCases")
+    void pickTransferEncoding_returnsExpected(String body, String expected) {
+        assertEquals(expected, SesService.pickTransferEncoding(body));
     }
 
-    @Test
-    void pickTransferEncoding_nonAscii() {
-        assertEquals("8bit", SesService.pickTransferEncoding("こんにちは"));
-        assertEquals("8bit", SesService.pickTransferEncoding("café"));
+    static Stream<Arguments> pickTransferEncodingCases() {
+        return Stream.of(
+                Arguments.of("ASCII text", "7bit"),
+                Arguments.of("", "7bit"),
+                Arguments.of("こんにちは", "8bit"),
+                Arguments.of("café", "8bit")
+        );
     }
 
-    @Test
-    void parseRenderingData_invalidJson_throwsInvalidRenderingParameter() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("parseRenderingDataInvalidCases")
+    void parseRenderingData_invalid_throwsInvalidRenderingParameter(String label, String raw) {
         AwsException ex = assertThrows(AwsException.class,
-                () -> SesService.parseRenderingData(MAPPER, "{not json"));
+                () -> SesService.parseRenderingData(MAPPER, raw));
         assertEquals("InvalidRenderingParameter", ex.getErrorCode());
     }
 
-    @Test
-    void parseRenderingData_nonObject_throwsInvalidRenderingParameter() {
-        AwsException ex = assertThrows(AwsException.class,
-                () -> SesService.parseRenderingData(MAPPER, "[1,2,3]"));
-        assertEquals("InvalidRenderingParameter", ex.getErrorCode());
-    }
-
-    @Test
-    void parseRenderingData_blank_throwsInvalidRenderingParameter() {
-        // Matches moto's TestRenderTemplate behavior: blank input is not valid JSON.
-        assertEquals("InvalidRenderingParameter",
-                assertThrows(AwsException.class, () -> SesService.parseRenderingData(MAPPER, null)).getErrorCode());
-        assertEquals("InvalidRenderingParameter",
-                assertThrows(AwsException.class, () -> SesService.parseRenderingData(MAPPER, "")).getErrorCode());
-        assertEquals("InvalidRenderingParameter",
-                assertThrows(AwsException.class, () -> SesService.parseRenderingData(MAPPER, "   ")).getErrorCode());
+    static Stream<Arguments> parseRenderingDataInvalidCases() {
+        return Stream.of(
+                Arguments.of("invalid JSON", "{not json"),
+                Arguments.of("non-object JSON (array)", "[1,2,3]"),
+                Arguments.of("null input", null),
+                Arguments.of("empty string", ""),
+                Arguments.of("whitespace-only", "   ")
+        );
     }
 
     @Test
@@ -194,24 +197,19 @@ class SesServiceTemplateTest {
         assertEquals(true, SesService.parseRenderingData(MAPPER, "{}").isObject());
     }
 
-    @Test
-    void normalizeToCrlf_lfOnly_convertedToCrlf() {
-        assertEquals("a\r\nb\r\nc", SesService.normalizeToCrlf("a\nb\nc"));
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("normalizeToCrlfCases")
+    void normalizeToCrlf_normalizesAllVariants(String label, String input, String expected) {
+        assertEquals(expected, SesService.normalizeToCrlf(input));
     }
 
-    @Test
-    void normalizeToCrlf_crOnly_convertedToCrlf() {
-        assertEquals("a\r\nb\r\nc", SesService.normalizeToCrlf("a\rb\rc"));
-    }
-
-    @Test
-    void normalizeToCrlf_alreadyCrlf_unchanged() {
-        assertEquals("a\r\nb\r\nc", SesService.normalizeToCrlf("a\r\nb\r\nc"));
-    }
-
-    @Test
-    void normalizeToCrlf_mixed_normalizesAll() {
-        assertEquals("a\r\nb\r\nc\r\nd", SesService.normalizeToCrlf("a\nb\rc\r\nd"));
+    static Stream<Arguments> normalizeToCrlfCases() {
+        return Stream.of(
+                Arguments.of("LF only",       "a\nb\nc",       "a\r\nb\r\nc"),
+                Arguments.of("CR only",       "a\rb\rc",       "a\r\nb\r\nc"),
+                Arguments.of("already CRLF",  "a\r\nb\r\nc",   "a\r\nb\r\nc"),
+                Arguments.of("mixed",         "a\nb\rc\r\nd",  "a\r\nb\r\nc\r\nd")
+        );
     }
 
     @Test
@@ -241,40 +239,19 @@ class SesServiceTemplateTest {
         assertEquals(true, mime.contains("</p>\r\n--BOUND"));
     }
 
-    @Test
-    void mapErrorCodeToBulkStatus_invalidParameterValue() {
-        assertEquals(io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult.Status.INVALID_PARAMETER,
-                SesService.mapErrorCodeToBulkStatus("InvalidParameterValue"));
+    @ParameterizedTest(name = "{0} -> {1}")
+    @MethodSource("mapErrorCodeToBulkStatusCases")
+    void mapErrorCodeToBulkStatus_returnsExpected(String errorCode, BulkEmailEntryResult.Status expected) {
+        assertEquals(expected, SesService.mapErrorCodeToBulkStatus(errorCode));
     }
 
-    @Test
-    void mapErrorCodeToBulkStatus_missingRenderingAttribute() {
-        assertEquals(io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult.Status.INVALID_PARAMETER,
-                SesService.mapErrorCodeToBulkStatus("MissingRenderingAttribute"));
-    }
-
-    @Test
-    void mapErrorCodeToBulkStatus_invalidRenderingParameter() {
-        assertEquals(io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult.Status.INVALID_PARAMETER,
-                SesService.mapErrorCodeToBulkStatus("InvalidRenderingParameter"));
-    }
-
-    @Test
-    void mapErrorCodeToBulkStatus_unknownCode_failed() {
-        assertEquals(io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult.Status.FAILED,
-                SesService.mapErrorCodeToBulkStatus("SomethingElse"));
-    }
-
-    @Test
-    void sanitizeSubject_replacesC0ControlCharsWithSpace() {
-        assertEquals("a b c", SesService.sanitizeSubject("a\u0001b\u001fc"));
-        assertEquals("x y z", SesService.sanitizeSubject("x\ry\nz"));
-        assertEquals("a b", SesService.sanitizeSubject("a\u0007b"));
-    }
-
-    @Test
-    void sanitizeSubject_replacesDelWithSpace() {
-        assertEquals("a b", SesService.sanitizeSubject("a\u007fb"));
+    static Stream<Arguments> mapErrorCodeToBulkStatusCases() {
+        return Stream.of(
+                Arguments.of("InvalidParameterValue",     BulkEmailEntryResult.Status.INVALID_PARAMETER),
+                Arguments.of("MissingRenderingAttribute", BulkEmailEntryResult.Status.INVALID_PARAMETER),
+                Arguments.of("InvalidRenderingParameter", BulkEmailEntryResult.Status.INVALID_PARAMETER),
+                Arguments.of("SomethingElse",             BulkEmailEntryResult.Status.FAILED)
+        );
     }
 
     @Test
@@ -282,47 +259,45 @@ class SesServiceTemplateTest {
         assertEquals("", SesService.sanitizeSubject(null));
     }
 
-    @Test
-    void sanitizeSubject_preservesPrintableAndUnicode() {
-        assertEquals("Hello 太郎", SesService.sanitizeSubject("Hello 太郎"));
-        assertEquals("Hello!", SesService.sanitizeSubject("Hello!"));
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("sanitizeSubjectCases")
+    void sanitizeSubject_returnsExpected(String label, String input, String expected) {
+        assertEquals(expected, SesService.sanitizeSubject(input));
     }
 
-    @Test
-    void stripXml10InvalidChars_keepsTabNewlineCarriageReturn() {
-        assertEquals("a\tb\nc\rd", SesService.stripXml10InvalidChars("a\tb\nc\rd"));
+    static Stream<Arguments> sanitizeSubjectCases() {
+        return Stream.of(
+                Arguments.of("C0 controls SOH/US",  "a\u0001b\u001fc", "a b c"),
+                Arguments.of("CR and LF",           "x\ry\nz",          "x y z"),
+                Arguments.of("BEL",                 "a\u0007b",          "a b"),
+                Arguments.of("DEL",                 "a\u007fb",          "a b"),
+                Arguments.of("Unicode preserved",   "Hello 太郎",          "Hello 太郎"),
+                Arguments.of("printable preserved", "Hello!",             "Hello!")
+        );
     }
 
-    @Test
-    void stripXml10InvalidChars_removesC0ControlsExceptWhitespace() {
-        assertEquals("abc", SesService.stripXml10InvalidChars("a\u0001b\u001fc"));
-        assertEquals("ab", SesService.stripXml10InvalidChars("a\u0008b"));
-        assertEquals("ab", SesService.stripXml10InvalidChars("a\u000bb"));
-        assertEquals("ab", SesService.stripXml10InvalidChars("a\u000cb"));
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("stripXml10InvalidCharsCases")
+    void stripXml10InvalidChars_returnsExpected(String label, String input, String expected) {
+        assertEquals(expected, SesService.stripXml10InvalidChars(input));
     }
 
-    @Test
-    void stripXml10InvalidChars_preservesUnicode() {
-        assertEquals("件名 太郎", SesService.stripXml10InvalidChars("件名 太郎"));
-    }
-
-    @Test
-    void stripXml10InvalidChars_removesNoncharacters() {
-        assertEquals("ab", SesService.stripXml10InvalidChars("a\ufffeb"));
-        assertEquals("ab", SesService.stripXml10InvalidChars("a\uffffb"));
-    }
-
-    @Test
-    void stripXml10InvalidChars_removesLoneSurrogates() {
-        assertEquals("ab", SesService.stripXml10InvalidChars("a\ud800b")); // lone high
-        assertEquals("ab", SesService.stripXml10InvalidChars("a\udc00b")); // lone low
-    }
-
-    @Test
-    void stripXml10InvalidChars_preservesPairedSupplementary() {
+    static Stream<Arguments> stripXml10InvalidCharsCases() {
         // U+1F600 GRINNING FACE encoded as surrogate pair D83D DE00
-        String emoji = "😀";
-        assertEquals("a" + emoji + "b", SesService.stripXml10InvalidChars("a" + emoji + "b"));
+        String emoji = "\uD83D\uDE00";
+        return Stream.of(
+                Arguments.of("keeps tab/LF/CR",          "a\tb\nc\rd",        "a\tb\nc\rd"),
+                Arguments.of("removes C0 SOH/US",        "a\u0001b\u001fc",   "abc"),
+                Arguments.of("removes BS",               "a\u0008b",            "ab"),
+                Arguments.of("removes VT",               "a\u000bb",            "ab"),
+                Arguments.of("removes FF",               "a\u000cb",            "ab"),
+                Arguments.of("preserves Unicode",        "件名 太郎",            "件名 太郎"),
+                Arguments.of("removes noncharacter FFFE","a\ufffeb",            "ab"),
+                Arguments.of("removes noncharacter FFFF","a\uffffb",            "ab"),
+                Arguments.of("removes lone high surrogate", "a\ud800b",         "ab"),
+                Arguments.of("removes lone low surrogate",  "a\udc00b",         "ab"),
+                Arguments.of("preserves paired surrogate (emoji)", "a" + emoji + "b", "a" + emoji + "b")
+        );
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTemplateTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTemplateTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -135,20 +136,20 @@ class SesServiceTemplateTest {
     void buildTestRenderMime_asciiBody_uses7bit() {
         java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
         String mime = SesService.buildTestRenderMime("Hello", "Hi there", "<p>Hi</p>", date, "BOUND");
-        assertEquals(true, mime.contains("Subject: Hello\r\n"));
-        assertEquals(true, mime.contains("Content-Type: multipart/alternative; boundary=\"BOUND\""));
-        assertEquals(true, mime.contains("Content-Transfer-Encoding: 7bit"));
-        assertEquals(false, mime.contains("Content-Transfer-Encoding: 8bit"));
-        assertEquals(true, mime.endsWith("--BOUND--\r\n"));
+        assertTrue(mime.contains("Subject: Hello\r\n"));
+        assertTrue(mime.contains("Content-Type: multipart/alternative; boundary=\"BOUND\""));
+        assertTrue(mime.contains("Content-Transfer-Encoding: 7bit"));
+        assertFalse(mime.contains("Content-Transfer-Encoding: 8bit"));
+        assertTrue(mime.endsWith("--BOUND--\r\n"));
     }
 
     @Test
     void buildTestRenderMime_utf8Body_uses8bit() {
         java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
         String mime = SesService.buildTestRenderMime("件名", "こんにちは", "<p>こんにちは</p>", date, "BOUND");
-        assertEquals(true, mime.contains("Subject: 件名\r\n"));
-        assertEquals(true, mime.contains("Content-Transfer-Encoding: 8bit"));
-        assertEquals(true, mime.contains("こんにちは"));
+        assertTrue(mime.contains("Subject: 件名\r\n"));
+        assertTrue(mime.contains("Content-Transfer-Encoding: 8bit"));
+        assertTrue(mime.contains("こんにちは"));
     }
 
     @Test
@@ -156,7 +157,7 @@ class SesServiceTemplateTest {
         java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
         String mime = SesService.buildTestRenderMime("Multi\r\nLine", "x", "x", date, "BOUND");
         // CR and LF are both C0 controls and are replaced with spaces.
-        assertEquals(true, mime.contains("Subject: Multi  Line\r\n"));
+        assertTrue(mime.contains("Subject: Multi  Line\r\n"));
     }
 
     @ParameterizedTest(name = "{0} -> {1}")
@@ -194,7 +195,7 @@ class SesServiceTemplateTest {
 
     @Test
     void parseRenderingData_emptyObject_accepted() {
-        assertEquals(true, SesService.parseRenderingData(MAPPER, "{}").isObject());
+        assertTrue(SesService.parseRenderingData(MAPPER, "{}").isObject());
     }
 
     @ParameterizedTest(name = "{0}")
@@ -216,27 +217,27 @@ class SesServiceTemplateTest {
     void buildTestRenderMime_bodyWithBareLf_normalizedToCrlf() {
         java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
         String mime = SesService.buildTestRenderMime("S", "line1\nline2", "<p>x\ny</p>", date, "BOUND");
-        assertEquals(true, mime.contains("line1\r\nline2"));
-        assertEquals(true, mime.contains("x\r\ny"));
-        assertEquals(false, mime.contains("line1\nline2"));
+        assertTrue(mime.contains("line1\r\nline2"));
+        assertTrue(mime.contains("x\r\ny"));
+        assertFalse(mime.contains("line1\nline2"));
     }
 
     @Test
     void buildTestRenderMime_bodyEndingWithNewline_noExtraBlankLine() {
         java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
         String mime = SesService.buildTestRenderMime("S", "hello\n", "<p>hi</p>\n", date, "BOUND");
-        assertEquals(false, mime.contains("hello\r\n\r\n--BOUND"));
-        assertEquals(true, mime.contains("hello\r\n--BOUND"));
-        assertEquals(false, mime.contains("</p>\r\n\r\n--BOUND"));
-        assertEquals(true, mime.contains("</p>\r\n--BOUND"));
+        assertFalse(mime.contains("hello\r\n\r\n--BOUND"));
+        assertTrue(mime.contains("hello\r\n--BOUND"));
+        assertFalse(mime.contains("</p>\r\n\r\n--BOUND"));
+        assertTrue(mime.contains("</p>\r\n--BOUND"));
     }
 
     @Test
     void buildTestRenderMime_bodyWithoutTrailingNewline_addsCrlfBeforeBoundary() {
         java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
         String mime = SesService.buildTestRenderMime("S", "hello", "<p>hi</p>", date, "BOUND");
-        assertEquals(true, mime.contains("hello\r\n--BOUND"));
-        assertEquals(true, mime.contains("</p>\r\n--BOUND"));
+        assertTrue(mime.contains("hello\r\n--BOUND"));
+        assertTrue(mime.contains("</p>\r\n--BOUND"));
     }
 
     @ParameterizedTest(name = "{0} -> {1}")
@@ -305,7 +306,7 @@ class SesServiceTemplateTest {
         java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
         String mime = SesService.buildTestRenderMime(
                 "Hello\u0001World", "x", "x", date, "BOUND");
-        assertEquals(true, mime.contains("Subject: Hello World\r\n"));
-        assertEquals(false, mime.contains("\u0001"));
+        assertTrue(mime.contains("Subject: Hello World\r\n"));
+        assertFalse(mime.contains("\u0001"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesTemplateV1IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesTemplateV1IntegrationTest.java
@@ -5,6 +5,11 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
@@ -187,6 +192,33 @@ class SesTemplateV1IntegrationTest {
         .then()
             .statusCode(400)
             .body(containsString("<Code>TemplateDoesNotExist</Code>"));
+    }
+
+    @ParameterizedTest(name = "TemplateData={0}")
+    @MethodSource("nonObjectTemplateDataPayloads")
+    @Order(50)
+    void sendTemplatedEmail_nonObjectTemplateData_returnsInvalidParameterValue(String templateData) {
+        // TemplateData is parsed before template lookup, so any template name suffices
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SendTemplatedEmail")
+            .formParam("Source", "v1-sender@example.com")
+            .formParam("Destination.ToAddresses.member.1", "to@example.com")
+            .formParam("Template", "any")
+            .formParam("TemplateData", templateData)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>InvalidParameterValue</Code>"));
+    }
+
+    static Stream<Arguments> nonObjectTemplateDataPayloads() {
+        return Stream.of(
+                Arguments.of("[1,2,3]"),
+                Arguments.of("42")
+        );
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesTemplateV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesTemplateV2IntegrationTest.java
@@ -5,6 +5,11 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
@@ -544,6 +549,63 @@ class SesTemplateV2IntegrationTest {
             .delete("/v2/email/templates/region-test")
         .then()
             .statusCode(200);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("malformedSendEmailBodies")
+    @Order(50)
+    void sendEmail_malformedShape_returnsBadRequest(String label, String body) {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body(body)
+        .when()
+            .post("/v2/email/outbound-emails")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    static Stream<Arguments> malformedSendEmailBodies() {
+        return Stream.of(
+                Arguments.of("body is array", "[1,2,3]"),
+                Arguments.of("body is JSON null literal", "null"),
+                Arguments.of("body is JSON string", "\"hello\""),
+                Arguments.of("Destination as string", """
+                    {
+                      "FromEmailAddress": "sender@example.com",
+                      "Destination": "bad",
+                      "Content": {"Simple": {"Subject": {"Data": "s"}, "Body": {"Text": {"Data": "t"}}}}
+                    }
+                    """),
+                Arguments.of("TemplateData as object", """
+                    {
+                      "FromEmailAddress": "sender@example.com",
+                      "Destination": {"ToAddresses": ["recipient@example.com"]},
+                      "Content": {
+                        "Template": {"TemplateName": "any", "TemplateData": {"name": "Alice"}}
+                      }
+                    }
+                    """),
+                Arguments.of("TemplateData as array", """
+                    {
+                      "FromEmailAddress": "sender@example.com",
+                      "Destination": {"ToAddresses": ["recipient@example.com"]},
+                      "Content": {
+                        "Template": {"TemplateName": "any", "TemplateData": [1,2,3]}
+                      }
+                    }
+                    """),
+                Arguments.of("TemplateData as invalid JSON string", """
+                    {
+                      "FromEmailAddress": "sender@example.com",
+                      "Destination": {"ToAddresses": ["recipient@example.com"]},
+                      "Content": {
+                        "Template": {"TemplateName": "any", "TemplateData": "{not json"}
+                      }
+                    }
+                    """)
+        );
     }
 
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesTestRenderV1IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesTestRenderV1IntegrationTest.java
@@ -1,0 +1,152 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesTestRenderV1IntegrationTest {
+
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/email/aws4_request";
+
+    @Test
+    @Order(1)
+    void createTemplate() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateTemplate")
+            .formParam("Template.TemplateName", "v1-render-welcome")
+            .formParam("Template.SubjectPart", "Hello {{name}}")
+            .formParam("Template.TextPart", "Hi {{name}}, team {{team}}!")
+            .formParam("Template.HtmlPart", "<p>Hi <b>{{name}}</b></p>")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void testRenderTemplate_substitutesVariables() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "TestRenderTemplate")
+            .formParam("TemplateName", "v1-render-welcome")
+            .formParam("TemplateData", "{\"name\":\"Alice\",\"team\":\"floci\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<TestRenderTemplateResponse"))
+            .body(containsString("<RenderedTemplate>"))
+            .body(containsString("Subject: Hello Alice"))
+            .body(containsString("Hi Alice, team floci!"))
+            .body(containsString("multipart/alternative"));
+    }
+
+    @Test
+    @Order(3)
+    void testRenderTemplate_unknownTemplate_returnsError() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "TestRenderTemplate")
+            .formParam("TemplateName", "ghost")
+            .formParam("TemplateData", "{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("TemplateDoesNotExist"));
+    }
+
+    @Test
+    @Order(4)
+    void testRenderTemplate_invalidJson_returnsInvalidRenderingParameter() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "TestRenderTemplate")
+            .formParam("TemplateName", "v1-render-welcome")
+            .formParam("TemplateData", "{not json")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidRenderingParameter"));
+    }
+
+    @Test
+    @Order(5)
+    void testRenderTemplate_missingVariable_returnsMissingRenderingAttribute() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "TestRenderTemplate")
+            .formParam("TemplateName", "v1-render-welcome")
+            .formParam("TemplateData", "{\"name\":\"Alice\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("MissingRenderingAttribute"));
+    }
+
+    @Test
+    @Order(7)
+    void testRenderTemplate_routedViaActionFallback_whenAuthHeaderAbsent() {
+        // Exercises AwsQueryController.inferServiceFromAction → SES_ACTIONS dispatch
+        // when no Authorization header is present (no service scope to resolve).
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "TestRenderTemplate")
+            .formParam("TemplateName", "v1-render-welcome")
+            .formParam("TemplateData", "{\"name\":\"Alice\",\"team\":\"floci\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<TestRenderTemplateResponse"))
+            .body(containsString("Subject: Hello Alice"));
+    }
+
+    @Test
+    @Order(8)
+    void testRenderTemplate_utf8Body_uses8bitEncoding() {
+        given()
+            .contentType("application/x-www-form-urlencoded; charset=UTF-8")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateTemplate")
+            .formParam("Template.TemplateName", "v1-render-jp")
+            .formParam("Template.SubjectPart", "件名 {{name}}")
+            .formParam("Template.TextPart", "こんにちは {{name}} さん")
+            .formParam("Template.HtmlPart", "<p>こんにちは {{name}} さん</p>")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded; charset=UTF-8")
+            .header("Authorization", AUTH)
+            .formParam("Action", "TestRenderTemplate")
+            .formParam("TemplateName", "v1-render-jp")
+            .formParam("TemplateData", "{\"name\":\"太郎\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("Subject: 件名 太郎"))
+            .body(containsString("Content-Transfer-Encoding: 8bit"))
+            .body(containsString("こんにちは 太郎 さん"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesTestRenderV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesTestRenderV2IntegrationTest.java
@@ -1,0 +1,199 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesTestRenderV2IntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/ses/aws4_request";
+
+    @Test
+    @Order(1)
+    void createTemplate() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "TemplateName": "v2-render-welcome",
+                  "TemplateContent": {
+                    "Subject": "Hello {{name}}",
+                    "Text": "Hi {{name}}, team {{team}}!",
+                    "Html": "<p>Hi <b>{{name}}</b></p>"
+                  }
+                }
+                """)
+        .when()
+            .post("/v2/email/templates")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void testRenderEmailTemplate_substitutesVariables() {
+        String rendered = given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"TemplateData": "{\\"name\\":\\"Alice\\",\\"team\\":\\"floci\\"}"}
+                """)
+        .when()
+            .post("/v2/email/templates/v2-render-welcome/render")
+        .then()
+            .statusCode(200)
+            .extract().path("RenderedTemplate");
+
+        org.junit.jupiter.api.Assertions.assertNotNull(rendered);
+        org.junit.jupiter.api.Assertions.assertTrue(rendered.contains("Subject: Hello Alice"));
+        org.junit.jupiter.api.Assertions.assertTrue(rendered.contains("Hi Alice, team floci!"));
+        org.junit.jupiter.api.Assertions.assertTrue(rendered.contains("multipart/alternative"));
+    }
+
+    @Test
+    @Order(3)
+    void testRenderEmailTemplate_unknownTemplate_returns404() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"TemplateData": "{}"}
+                """)
+        .when()
+            .post("/v2/email/templates/ghost/render")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"));
+    }
+
+    @Test
+    @Order(4)
+    void testRenderEmailTemplate_invalidJson_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"TemplateData": "{not json"}
+                """)
+        .when()
+            .post("/v2/email/templates/v2-render-welcome/render")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(5)
+    void testRenderEmailTemplate_missingVariable_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"TemplateData": "{\\"name\\":\\"Alice\\"}"}
+                """)
+        .when()
+            .post("/v2/email/templates/v2-render-welcome/render")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("malformedRenderBodies")
+    @Order(7)
+    void testRenderEmailTemplate_malformedBody_returns400(String label, String body) {
+        var spec = given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER);
+        if (body != null) {
+            spec = spec.body(body);
+        }
+        spec
+        .when()
+            .post("/v2/email/templates/v2-render-welcome/render")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    static Stream<Arguments> malformedRenderBodies() {
+        return Stream.of(
+                Arguments.of("null body", null),
+                Arguments.of("non-object body (array)", "[1,2,3]"),
+                Arguments.of("TemplateData as object", "{\"TemplateData\": {\"name\": \"Alice\"}}")
+        );
+    }
+
+    @Test
+    @Order(10)
+    void testRenderEmailTemplate_dateHeaderIsUtc() {
+        String rendered = given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"TemplateData": "{\\"name\\":\\"Alice\\",\\"team\\":\\"floci\\"}"}
+                """)
+        .when()
+            .post("/v2/email/templates/v2-render-welcome/render")
+        .then()
+            .statusCode(200)
+            .extract().path("RenderedTemplate");
+
+        // RFC 1123 with UTC ends with "GMT"; non-UTC zones would render numeric offsets
+        org.junit.jupiter.api.Assertions.assertTrue(
+                rendered.contains("Date: ") && rendered.split("\r\n", 2)[0].endsWith("GMT"),
+                "expected Date header in UTC/GMT form, got: " + rendered.split("\r\n", 2)[0]);
+    }
+
+    @Test
+    @Order(11)
+    void testRenderEmailTemplate_utf8Body_uses8bitEncoding() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "TemplateName": "v2-render-jp",
+                  "TemplateContent": {
+                    "Subject": "件名 {{name}}",
+                    "Text": "こんにちは {{name}} さん"
+                  }
+                }
+                """)
+        .when()
+            .post("/v2/email/templates")
+        .then()
+            .statusCode(200);
+
+        String rendered = given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"TemplateData": "{\\"name\\":\\"太郎\\"}"}
+                """)
+        .when()
+            .post("/v2/email/templates/v2-render-jp/render")
+        .then()
+            .statusCode(200)
+            .extract().path("RenderedTemplate");
+
+        org.junit.jupiter.api.Assertions.assertTrue(rendered.contains("Subject: 件名 太郎"));
+        org.junit.jupiter.api.Assertions.assertTrue(rendered.contains("Content-Transfer-Encoding: 8bit"));
+        org.junit.jupiter.api.Assertions.assertTrue(rendered.contains("こんにちは 太郎 さん"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesTestRenderV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesTestRenderV2IntegrationTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 @QuarkusTest


### PR DESCRIPTION
## Summary

Adds `TestRenderTemplate` to the SES v1 Query API and `TestRenderEmailTemplate` (`POST /v2/email/templates/{name}/render`) to the SES v2 REST JSON API.

The operation renders a stored template against caller-supplied data and returns a `multipart/alternative` MIME message (text/plain + text/html) with `Date` (UTC) and `Subject` headers. The MIME builder is hand-rolled (no new dependencies); transfer encoding is auto-selected — `7bit` for ASCII bodies, `8bit` for UTF-8 — matching moto's `encode_7or8bit`. Body line endings are normalized to CRLF; subject control characters and XML 1.0 invalid characters in the rendered output are stripped to keep the response parseable by SDK clients.

Template variable substitution is now strict across all rendering paths: a missing attribute raises `MissingRenderingAttribute` (mapped to `BadRequestException` on v2). This change also affects existing send paths (`SendTemplatedEmail`, `SendBulkTemplatedEmail`, v2 templated `SendEmail`), aligning them with AWS / moto / LocalStack semantics rather than silently substituting empty strings. Bulk per-entry rendering errors surface as `INVALID_PARAMETER` in `BulkEmailEntryResults`.

Non-object `TemplateData` is rejected upfront with operation-appropriate errors: `InvalidParameterValue` (v1), `BadRequestException` (v2), `InvalidRenderingParameter` (TestRender).

## Coverage gap closed

LocalStack OSS does not implement SES v2 at all, so this is the first open-source implementation of `TestRenderEmailTemplate`. The v1 path matches LocalStack/moto's `TestRenderTemplate` behavior (rendering format, error codes, output structure).

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against AWS Java SDK v2 `2.42.24` (declared in `compatibility-tests/sdk-test-java/pom.xml`):

- `software.amazon.awssdk.services.ses.SesClient.testRenderTemplate(...)` — v1 Query
- `software.amazon.awssdk.services.sesv2.SesV2Client.testRenderEmailTemplate(...)` — v2 REST JSON

Output format follows moto's reference implementation (used by LocalStack OSS): `Date: <RFC1123>\r\nSubject: <subject>\r\n` followed by a `multipart/alternative` MIME body. Error codes `TemplateDoesNotExist`, `InvalidRenderingParameter`, `MissingRenderingAttribute` match the v1 wire format documented in the AWS SES API reference; the v2 path remaps them to `BadRequestException` / `NotFoundException` per the SESv2 error model. SDK compatibility tests assert specific exception classes (`TemplateDoesNotExistException`, `MissingRenderingAttributeException`, `InvalidRenderingParameterException`, `NotFoundException`, `BadRequestException`) to lock in error identity.

## Checklist

- [x] `./mvnw test` passes locally (249 SES tests including 5 new integration test files)
- [x] New or updated integration test added — `SesTestRenderV1IntegrationTest`, `SesTestRenderV2IntegrationTest`, parameterized unit/integration test groups in `SesServiceTemplateTest`, `SesTemplateV1IntegrationTest`, `SesTemplateV2IntegrationTest`, `SesBulkV1IntegrationTest`, `SesBulkV2IntegrationTest`
- [x] AWS Java SDK compat tests in `compatibility-tests/sdk-test-java/SesTemplateTest` (34 cases passing)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)