### PR TITLE
feat(scheduler): support TagResource, UntagResource, ListTagsForResource

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SchedulerTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SchedulerTest.java
@@ -3,6 +3,7 @@ package com.floci.test;
 import org.junit.jupiter.api.*;
 import software.amazon.awssdk.services.scheduler.SchedulerClient;
 import software.amazon.awssdk.services.scheduler.model.*;
+import software.amazon.awssdk.services.scheduler.model.Tag;
 
 import java.time.Instant;
 
@@ -453,5 +454,57 @@ class SchedulerTest {
                         .name(GROUP_NAME)
                         .build()))
                 .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    // ──────────────────────────── Tagging ────────────────────────────
+
+    @Test
+    @Order(30)
+    @DisplayName("TagResource / ListTagsForResource / UntagResource - schedule group")
+    void tagAndUntagScheduleGroup() {
+        String tagGroup = "tag-test-group";
+        try {
+            scheduler.createScheduleGroup(CreateScheduleGroupRequest.builder()
+                    .name(tagGroup)
+                    .tags(Tag.builder().key("env").value("dev").build())
+                    .build());
+
+            String arn = scheduler.getScheduleGroup(GetScheduleGroupRequest.builder()
+                    .name(tagGroup).build()).arn();
+
+            ListTagsForResourceResponse listed = scheduler.listTagsForResource(
+                    ListTagsForResourceRequest.builder().resourceArn(arn).build());
+            assertThat(listed.tags())
+                    .extracting(Tag::key, Tag::value)
+                    .containsExactlyInAnyOrder(tuple("env", "dev"));
+
+            scheduler.tagResource(TagResourceRequest.builder()
+                    .resourceArn(arn)
+                    .tags(
+                            Tag.builder().key("owner").value("Alice").build(),
+                            Tag.builder().key("env").value("staging").build())
+                    .build());
+
+            assertThat(scheduler.listTagsForResource(
+                    ListTagsForResourceRequest.builder().resourceArn(arn).build()).tags())
+                    .extracting(Tag::key, Tag::value)
+                    .containsExactlyInAnyOrder(
+                            tuple("env", "staging"),
+                            tuple("owner", "Alice"));
+
+            scheduler.untagResource(UntagResourceRequest.builder()
+                    .resourceArn(arn)
+                    .tagKeys("owner", "env")
+                    .build());
+
+            assertThat(scheduler.listTagsForResource(
+                    ListTagsForResourceRequest.builder().resourceArn(arn).build()).tags())
+                    .isEmpty();
+        } finally {
+            try {
+                scheduler.deleteScheduleGroup(DeleteScheduleGroupRequest.builder()
+                        .name(tagGroup).build());
+            } catch (Exception ignored) {}
+        }
     }
 }

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -28,7 +28,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [Step Functions](step-functions.md) | `POST /` + `X-Amz-Target: AmazonStatesService.*` | JSON 1.1 | 18 |
 | [CloudFormation](cloudformation.md) | `POST /` with `Action=` param | Query | 19 |
 | [EventBridge](eventbridge.md) | `POST /` + `X-Amz-Target: AmazonEventBridge.*` | JSON 1.1 | 16 |
-| [EventBridge Scheduler](scheduler.md) | `/schedules/*`, `/schedule-groups/*` | REST JSON | 9 |
+| [EventBridge Scheduler](scheduler.md) | `/schedules/*`, `/schedule-groups/*`, `/tags/*` | REST JSON | 12 |
 | [CloudWatch Logs](cloudwatch.md) | `POST /` + `X-Amz-Target: Logs.*` | JSON 1.1 | 17 |
 | [CloudWatch Metrics](cloudwatch.md#metrics) | `POST /` with `Action=` or JSON 1.1 | Query / JSON | 11 |
 | [ElastiCache](elasticache.md) | `POST /` with `Action=` param + TCP proxy | Query + RESP | 8 |

--- a/docs/services/scheduler.md
+++ b/docs/services/scheduler.md
@@ -16,6 +16,9 @@
 | `UpdateSchedule` | `PUT` | `/schedules/{Name}` | Update a schedule |
 | `DeleteSchedule` | `DELETE` | `/schedules/{Name}` | Delete a schedule |
 | `ListSchedules` | `GET` | `/schedules` | List schedules |
+| `TagResource` | `POST` | `/tags/{ResourceArn}` | Add tags to a schedule group |
+| `UntagResource` | `DELETE` | `/tags/{ResourceArn}?TagKeys=...` | Remove tags from a schedule group |
+| `ListTagsForResource` | `GET` | `/tags/{ResourceArn}` | List tags on a schedule group |
 
 ## Schedule Invocation
 
@@ -36,7 +39,6 @@ Supported target types: SQS, Lambda, SNS, EventBridge `PutEvents`.
 
 ## Not Yet Supported
 
-- `TagResource` / `UntagResource` / `ListTagsForResource`
 - `RetryPolicy` and `DeadLetterConfig` on failed invocations (stored but not honored)
 - `FlexibleTimeWindow` jitter (fires deterministically at the scheduled time)
 - `NextToken`-based pagination for List operations
@@ -104,6 +106,23 @@ aws scheduler delete-schedule \
 # Delete a schedule group (cascades to all schedules in the group)
 aws scheduler delete-schedule-group \
   --name my-group \
+  --endpoint-url $AWS_ENDPOINT_URL
+
+# Add tags to a schedule group (tags apply to schedule groups only)
+aws scheduler tag-resource \
+  --resource-arn arn:aws:scheduler:us-east-1:000000000000:schedule-group/my-group \
+  --tags Key=env,Value=prod Key=owner,Value=Alice \
+  --endpoint-url $AWS_ENDPOINT_URL
+
+# List tags on a schedule group
+aws scheduler list-tags-for-resource \
+  --resource-arn arn:aws:scheduler:us-east-1:000000000000:schedule-group/my-group \
+  --endpoint-url $AWS_ENDPOINT_URL
+
+# Remove tags from a schedule group
+aws scheduler untag-resource \
+  --resource-arn arn:aws:scheduler:us-east-1:000000000000:schedule-group/my-group \
+  --tag-keys env owner \
   --endpoint-url $AWS_ENDPOINT_URL
 ```
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/SharedTagsController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/SharedTagsController.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.core.common;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -13,11 +14,11 @@ import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 
 import java.util.HashMap;
 import java.util.List;
@@ -25,7 +26,7 @@ import java.util.Map;
 
 /**
  * Dispatcher for AWS services that share the REST {@code /tags/{resourceArn}} path
- * (API Gateway, EventBridge Scheduler, EFS, ...).
+ * (API Gateway, EventBridge Scheduler, EKS, ...).
  *
  * <p>AWS distinguishes these services by hostname, but floci serves every service on a
  * single port, so the path alone is ambiguous. This controller resolves the owning
@@ -67,10 +68,7 @@ public class SharedTagsController {
         TagHandler handler = resolveHandler(arn);
         String region = regionResolver.resolveRegion(headers);
         Map<String, String> tags = handler.listTags(region, arn);
-        ObjectNode root = objectMapper.createObjectNode();
-        ObjectNode tagsNode = root.putObject("tags");
-        tags.forEach(tagsNode::put);
-        return Response.ok(root).build();
+        return Response.ok(buildListResponse(handler, tags)).build();
     }
 
     @POST
@@ -79,39 +77,124 @@ public class SharedTagsController {
     public Response tagResourcePost(@Context HttpHeaders headers,
                                     @PathParam("arn") String arn,
                                     String body) {
-        return tagResource(headers, arn, body);
+        TagHandler handler = resolveHandler(arn);
+        if (handler.tagResourceUsesPut()) {
+            throw new AwsException("MethodNotAllowedException",
+                    "POST is not supported for " + handler.serviceKey() + " tag resources; use PUT.", 405);
+        }
+        return doTagResource(headers, handler, arn, body);
     }
 
     @PUT
     @Path("/{arn: .*}")
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response tagResource(@Context HttpHeaders headers,
-                                @PathParam("arn") String arn,
-                                String body) {
+    public Response tagResourcePut(@Context HttpHeaders headers,
+                                   @PathParam("arn") String arn,
+                                   String body) {
         TagHandler handler = resolveHandler(arn);
+        if (!handler.tagResourceUsesPut()) {
+            throw new AwsException("MethodNotAllowedException",
+                    "PUT is not supported for " + handler.serviceKey() + " tag resources; use POST.", 405);
+        }
+        return doTagResource(headers, handler, arn, body);
+    }
+
+    private Response doTagResource(HttpHeaders headers, TagHandler handler, String arn, String body) {
         String region = regionResolver.resolveRegion(headers);
         try {
             JsonNode node = objectMapper.readTree(body);
-            Map<String, String> tags = new HashMap<>();
-            node.path("tags").fields().forEachRemaining(e -> tags.put(e.getKey(), e.getValue().asText()));
+            Map<String, String> tags = parseTags(handler, node);
             handler.tagResource(region, arn, tags);
             return Response.noContent().build();
         } catch (AwsException e) {
             throw e;
         } catch (Exception e) {
-            throw new AwsException("BadRequestException", e.getMessage(), 400);
+            String code = handler.strictTagValidation() ? "ValidationException" : "BadRequestException";
+            throw new AwsException(code, e.getMessage(), 400);
         }
     }
 
     @DELETE
     @Path("/{arn: .*}")
     public Response untagResource(@Context HttpHeaders headers,
-                                  @PathParam("arn") String arn,
-                                  @QueryParam("tagKeys") List<String> tagKeys) {
+                                  @Context UriInfo uriInfo,
+                                  @PathParam("arn") String arn) {
         TagHandler handler = resolveHandler(arn);
         String region = regionResolver.resolveRegion(headers);
+        List<String> tagKeys = readTagKeys(handler, uriInfo);
         handler.untagResource(region, arn, tagKeys);
         return Response.noContent().build();
+    }
+
+    private ObjectNode buildListResponse(TagHandler handler, Map<String, String> tags) {
+        ObjectNode root = objectMapper.createObjectNode();
+        String key = handler.tagsBodyKey();
+        if (handler.tagsBodyIsList()) {
+            ArrayNode arr = root.putArray(key);
+            tags.forEach((k, v) -> {
+                ObjectNode entry = arr.addObject();
+                entry.put("Key", k);
+                entry.put("Value", v);
+            });
+        } else {
+            ObjectNode tagsNode = root.putObject(key);
+            tags.forEach(tagsNode::put);
+        }
+        return root;
+    }
+
+    private Map<String, String> parseTags(TagHandler handler, JsonNode node) {
+        Map<String, String> tags = new HashMap<>();
+        String key = handler.tagsBodyKey();
+        JsonNode tagNode = node.get(key);
+        if (tagNode == null || tagNode.isNull()) {
+            if (handler.strictTagValidation()) {
+                throw new AwsException("ValidationException",
+                        "1 validation error detected: Value null at '" + key + "' failed to satisfy constraint: Member must not be null", 400);
+            }
+            return tags;
+        }
+        if (handler.tagsBodyIsList()) {
+            if (!tagNode.isArray()) {
+                if (handler.strictTagValidation()) {
+                    throw new AwsException("ValidationException",
+                            "1 validation error detected: Value at '" + key + "' failed to satisfy constraint: Member must be a list", 400);
+                }
+                return tags;
+            }
+            for (JsonNode entry : tagNode) {
+                JsonNode k = entry.get("Key");
+                JsonNode v = entry.get("Value");
+                if (k == null || k.isNull() || v == null || v.isNull()) {
+                    if (handler.strictTagValidation()) {
+                        throw new AwsException("ValidationException",
+                                "1 validation error detected: Tag entries at '" + key + "' must have non-null Key and Value", 400);
+                    }
+                    continue;
+                }
+                tags.put(k.asText(), v.asText());
+            }
+        } else {
+            if (!tagNode.isObject()) {
+                if (handler.strictTagValidation()) {
+                    throw new AwsException("ValidationException",
+                            "1 validation error detected: Value at '" + key + "' failed to satisfy constraint: Member must be a map", 400);
+                }
+                return tags;
+            }
+            tagNode.fields().forEachRemaining(e -> tags.put(e.getKey(), e.getValue().asText()));
+        }
+        return tags;
+    }
+
+    private List<String> readTagKeys(TagHandler handler, UriInfo uriInfo) {
+        String paramName = handler.tagKeysQueryName();
+        List<String> values = uriInfo.getQueryParameters().get(paramName);
+        if (handler.strictTagValidation() && (values == null || values.isEmpty())) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value null at '" + paramName + "' failed to satisfy constraint: Member must not be null", 400);
+        }
+        return (values == null) ? List.of() : List.copyOf(values);
     }
 
     private TagHandler resolveHandler(String arn) {

--- a/src/main/java/io/github/hectorvent/floci/core/common/SharedTagsController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/SharedTagsController.java
@@ -101,8 +101,9 @@ public class SharedTagsController {
 
     private Response doTagResource(HttpHeaders headers, TagHandler handler, String arn, String body) {
         String region = regionResolver.resolveRegion(headers);
+        String effectiveBody = (body == null || body.isBlank()) ? "{}" : body;
         try {
-            JsonNode node = objectMapper.readTree(body);
+            JsonNode node = objectMapper.readTree(effectiveBody);
             Map<String, String> tags = parseTags(handler, node);
             handler.tagResource(region, arn, tags);
             return Response.noContent().build();
@@ -146,6 +147,10 @@ public class SharedTagsController {
     private Map<String, String> parseTags(TagHandler handler, JsonNode node) {
         Map<String, String> tags = new HashMap<>();
         String key = handler.tagsBodyKey();
+        if (handler.strictTagValidation() && !node.isObject()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Request payload must be a JSON object", 400);
+        }
         JsonNode tagNode = node.get(key);
         if (tagNode == null || tagNode.isNull()) {
             if (handler.strictTagValidation()) {

--- a/src/main/java/io/github/hectorvent/floci/core/common/TagHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/TagHandler.java
@@ -5,11 +5,28 @@ import java.util.Map;
 
 /**
  * Per-service handler for the REST tag endpoints that share the {@code /tags/{resourceArn}}
- * path (API Gateway, EventBridge Scheduler, EFS, etc.).
+ * path (API Gateway, EventBridge Scheduler, EKS, etc.).
  *
  * <p>A single {@code SharedTagsController} routes all {@code /tags/{arn}} requests and
  * dispatches to the implementation whose {@link #serviceKey()} matches the {@code service}
  * segment of the request ARN ({@code arn:aws:<service>:<region>:<account>:<resource>}).
+ *
+ * <p>AWS services on this path are not internally consistent in their wire format. Three
+ * shape choices are independent:
+ * <ul>
+ *   <li>{@link #tagsBodyKey()} — the JSON key for the tag payload ({@code "tags"} or
+ *       {@code "Tags"}).
+ *   <li>{@link #tagsBodyIsList()} — whether the body holds a list of {@code {Key, Value}}
+ *       objects rather than a string-to-string map.
+ *   <li>{@link #tagKeysQueryName()} — the query parameter name for {@code UntagResource}
+ *       ({@code "tagKeys"} or {@code "TagKeys"}). Surprisingly, most services that use
+ *       capitalized {@code "Tags"} in the body still use lowercase {@code "tagKeys"} here.
+ * </ul>
+ * The defaults match the most common AWS shape (lowercase {@code "tags"} map +
+ * lowercase {@code "tagKeys"} + POST), which covers ~73 services. EKS and Pipes can use
+ * the defaults unmodified; API Gateway shares the same body shape but must override
+ * {@link #tagResourceUsesPut()} because AWS defines it with PUT. Handlers whose service
+ * deviates on any axis override the relevant method(s) only.
  *
  * <p>Implementations are responsible for parsing their own ARN resource format and raising
  * {@link io.github.hectorvent.floci.core.common.AwsException} on invalid input.
@@ -18,11 +35,68 @@ public interface TagHandler {
 
     /**
      * The ARN {@code service} segment this handler responds to (e.g. {@code "apigateway"},
-     * {@code "scheduler"}, {@code "elasticfilesystem"}). The {@code SharedTagsController}
-     * dispatcher extracts the third colon-separated component of the request ARN and looks
-     * up the handler whose {@code serviceKey()} equals that value.
+     * {@code "scheduler"}, {@code "eks"}). The {@code SharedTagsController} dispatcher
+     * extracts the third colon-separated component of the request ARN and looks up the
+     * handler whose {@code serviceKey()} equals that value.
      */
     String serviceKey();
+
+    /**
+     * JSON key for the tag payload on {@code TagResource} and {@code ListTagsForResource}.
+     * Defaults to lowercase {@code "tags"}. Override to {@code "Tags"} for services whose
+     * AWS spec capitalizes the key. EventBridge Scheduler is the only floci-registered
+     * handler that overrides today; ~40 other AWS services share the same AWS spec and
+     * would also need to override if they were added.
+     */
+    default String tagsBodyKey() {
+        return "tags";
+    }
+
+    /**
+     * Whether the {@code TagResource} body and {@code ListTagsForResource} response hold a
+     * list of {@code {Key, Value}} objects rather than a string-to-string map. Defaults to
+     * {@code false} (map). Override to {@code true} for services that use the list shape
+     * (EventBridge Scheduler, NetworkManager, Recycle Bin).
+     */
+    default boolean tagsBodyIsList() {
+        return false;
+    }
+
+    /**
+     * Whether the dispatcher should reject malformed {@code TagResource} and
+     * {@code UntagResource} payloads with {@code ValidationException} instead of silently
+     * coercing them to a no-op. Defaults to {@code false} for back-compat with the looser
+     * parsing that pre-existing handlers have always relied on. AWS-spec-strict services
+     * (notably EventBridge Scheduler) override to {@code true}.
+     *
+     * <p>This is independent of {@link #tagsBodyIsList()}: a future map-shaped handler
+     * that needs strict validation can opt in here without flipping the body shape.
+     */
+    default boolean strictTagValidation() {
+        return false;
+    }
+
+    /**
+     * Query parameter name for {@code UntagResource}. Defaults to lowercase
+     * {@code "tagKeys"}, which matches the great majority of AWS services — including
+     * most that use capitalized {@code "Tags"} in the body. Override to {@code "TagKeys"}
+     * only for services that capitalize the query parameter as well (EventBridge Scheduler
+     * is the lone such service in floci today).
+     */
+    default String tagKeysQueryName() {
+        return "tagKeys";
+    }
+
+    /**
+     * Whether {@code TagResource} uses {@code PUT /tags/{arn}}. Defaults to {@code false}
+     * (POST), matching the great majority of AWS services. Override to {@code true} for
+     * services that AWS defines with PUT (notably API Gateway, plus a handful of others).
+     * The dispatcher rejects the unused HTTP method with
+     * {@code 405 MethodNotAllowedException}.
+     */
+    default boolean tagResourceUsesPut() {
+        return false;
+    }
 
     Map<String, String> listTags(String region, String arn);
 

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayTagHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayTagHandler.java
@@ -31,6 +31,11 @@ public class ApiGatewayTagHandler implements TagHandler {
     }
 
     @Override
+    public boolean tagResourceUsesPut() {
+        return true;
+    }
+
+    @Override
     public Map<String, String> listTags(String region, String arn) {
         return service.getTags(region, apiIdFromArn(arn));
     }

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerService.java
@@ -128,6 +128,31 @@ public class SchedulerService {
         LOG.infov("Deleted schedule group: {0} (removed {1} schedules)", name, orphanKeys.size());
     }
 
+    public Map<String, String> getScheduleGroupTags(String name, String region) {
+        ScheduleGroup group = getScheduleGroup(name, region);
+        return Map.copyOf(group.getTags());
+    }
+
+    public void tagScheduleGroup(String name, String region, Map<String, String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return;
+        }
+        ScheduleGroup group = getScheduleGroup(name, region);
+        group.getTags().putAll(tags);
+        group.setLastModificationDate(Instant.now());
+        groupStore.put(groupKey(region, group.getName()), group);
+    }
+
+    public void untagScheduleGroup(String name, String region, List<String> tagKeys) {
+        if (tagKeys == null || tagKeys.isEmpty()) {
+            return;
+        }
+        ScheduleGroup group = getScheduleGroup(name, region);
+        tagKeys.forEach(group.getTags()::remove);
+        group.setLastModificationDate(Instant.now());
+        groupStore.put(groupKey(region, group.getName()), group);
+    }
+
     public List<ScheduleGroup> listScheduleGroups(String namePrefix, String region) {
         getOrCreateDefaultGroup(region);
         String storagePrefix = "group:" + region + ":";

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerTagHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerTagHandler.java
@@ -1,0 +1,86 @@
+package io.github.hectorvent.floci.services.scheduler;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.TagHandler;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@link TagHandler} implementation for EventBridge Scheduler.
+ *
+ * <p>ARN format: {@code arn:aws:scheduler:<region>:<account>:schedule-group/<name>}.
+ * AWS only permits tags on schedule groups; ARNs pointing at individual schedules
+ * ({@code schedule/<group>/<name>}) are rejected with {@code ValidationException} to
+ * mirror AWS behavior.
+ */
+@ApplicationScoped
+public class SchedulerTagHandler implements TagHandler {
+
+    private final SchedulerService service;
+
+    @Inject
+    public SchedulerTagHandler(SchedulerService service) {
+        this.service = service;
+    }
+
+    @Override
+    public String serviceKey() {
+        return "scheduler";
+    }
+
+    @Override
+    public String tagsBodyKey() {
+        return "Tags";
+    }
+
+    @Override
+    public boolean tagsBodyIsList() {
+        return true;
+    }
+
+    @Override
+    public String tagKeysQueryName() {
+        return "TagKeys";
+    }
+
+    @Override
+    public boolean strictTagValidation() {
+        return true;
+    }
+
+    @Override
+    public Map<String, String> listTags(String region, String arn) {
+        return service.getScheduleGroupTags(groupNameFromArn(arn), region);
+    }
+
+    @Override
+    public void tagResource(String region, String arn, Map<String, String> tags) {
+        service.tagScheduleGroup(groupNameFromArn(arn), region, tags);
+    }
+
+    @Override
+    public void untagResource(String region, String arn, List<String> tagKeys) {
+        service.untagScheduleGroup(groupNameFromArn(arn), region, tagKeys);
+    }
+
+    private static String groupNameFromArn(String arn) {
+        String[] parts = arn.split(":", 6);
+        if (parts.length < 6) {
+            throw new AwsException("ValidationException", "Invalid resource ARN: " + arn, 400);
+        }
+        String resource = parts[5];
+        String prefix = "schedule-group/";
+        if (!resource.startsWith(prefix)) {
+            throw new AwsException("ValidationException",
+                    "Tags are only supported on schedule groups: " + arn, 400);
+        }
+        String name = resource.substring(prefix.length());
+        if (name.isBlank() || name.contains("/")) {
+            throw new AwsException("ValidationException", "Invalid resource ARN: " + arn, 400);
+        }
+        return name;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayIntegrationTest.java
@@ -287,6 +287,18 @@ class ApiGatewayIntegrationTest {
                 .statusCode(204);
     }
 
+    @Test @Order(23)
+    void tagResourcePostReturns405() {
+        // AWS API Gateway only defines PUT for TagResource; POST is not in the spec.
+        String arn = "arn:aws:apigateway:us-east-1::/restapis/" + apiId;
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"tags\":{\"env\":\"test\"}}")
+                .when().post("/tags/" + arn)
+                .then()
+                .statusCode(405);
+    }
+
     @Test @Order(24)
     void getTags() {
         String arn = "arn:aws:apigateway:us-east-1::/restapis/" + apiId;

--- a/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
@@ -242,7 +242,7 @@ class AppConfigIntegrationTest {
         given()
                 .contentType(ContentType.JSON)
                 .body("{\"tags\": {\"env\": \"local\", \"team\": \"platform\"}}")
-                .when().put("/tags/" + arn)
+                .when().post("/tags/" + arn)
                 .then()
                 .statusCode(204);
     }

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerIntegrationTest.java
@@ -285,6 +285,33 @@ class SchedulerIntegrationTest {
     }
 
     @Test
+    @Order(16)
+    void tagResourceWithEmptyBodyReturns400() {
+        // Null/blank request body must surface as the structured AWS validation error
+        // ("Value null at 'Tags' ...") rather than leaking a Jackson parser message.
+        given()
+            .contentType("application/json")
+        .when()
+            .post("/tags/" + TAGGED_GROUP_ARN)
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(16)
+    void tagResourceWithNonObjectBodyReturns400() {
+        // A syntactically valid JSON array at the root must be rejected as a wire-shape
+        // error, not silently treated as "missing 'Tags'".
+        given()
+            .contentType("application/json")
+            .body("[1,2,3]")
+        .when()
+            .post("/tags/" + TAGGED_GROUP_ARN)
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
     @Order(17)
     void tagResourceOnScheduleArnReturns400() {
         // AWS only allows tagging schedule groups, not individual schedules.

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerIntegrationTest.java
@@ -6,7 +6,11 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 @QuarkusTest
@@ -170,6 +174,155 @@ class SchedulerIntegrationTest {
             .delete("/schedule-groups/already-gone")
         .then()
             .statusCode(404);
+    }
+
+    // ──────────────────────────── Tag tests ────────────────────────────
+
+    private static final String TAGGED_GROUP_ARN =
+            "arn:aws:scheduler:us-east-1:000000000000:schedule-group/tagged-group";
+
+    @Test
+    @Order(13)
+    void listTagsReturnsTagsFromCreate() {
+        // tagged-group was created at @Order(2) with env=test and team=platform.
+        given()
+        .when()
+            .get("/tags/" + TAGGED_GROUP_ARN)
+        .then()
+            .statusCode(200)
+            .body("Tags.find { it.Key == 'env' }.Value", equalTo("test"))
+            .body("Tags.find { it.Key == 'team' }.Value", equalTo("platform"));
+    }
+
+    @Test
+    @Order(14)
+    void tagResourceAddsTags() throws InterruptedException {
+        // createScheduleGroup uses one Instant.now() for both CreationDate and
+        // LastModificationDate (so they are byte-identical at creation). Sleep here so the
+        // tagScheduleGroup Instant.now() below is guaranteed to be strictly later, even on
+        // a system whose clock granularity collides with the test class's startup speed.
+        Thread.sleep(2);
+
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "Tags": [
+                        {"Key": "owner", "Value": "Alice"},
+                        {"Key": "env", "Value": "staging"}
+                    ]
+                }
+                """)
+        .when()
+            .post("/tags/" + TAGGED_GROUP_ARN)
+        .then()
+            .statusCode(204);
+
+        given()
+        .when()
+            .get("/tags/" + TAGGED_GROUP_ARN)
+        .then()
+            .statusCode(200)
+            .body("Tags.find { it.Key == 'owner' }.Value", equalTo("Alice"))
+            // overwrite of existing key
+            .body("Tags.find { it.Key == 'env' }.Value", equalTo("staging"))
+            .body("Tags.find { it.Key == 'team' }.Value", equalTo("platform"));
+
+        // Tag mutation must bump LastModificationDate above the initial CreationDate
+        // so a regression in this AWS-visible field is caught. Parse via Jackson directly
+        // because RestAssured coerces sub-second epoch doubles to Float and loses the
+        // sub-second delta the test relies on.
+        String body = given()
+        .when()
+            .get("/schedule-groups/tagged-group")
+        .then()
+            .statusCode(200)
+            .extract().asString();
+        try {
+            JsonNode tree = new ObjectMapper().readTree(body);
+            double creation = tree.get("CreationDate").asDouble();
+            double lastMod = tree.get("LastModificationDate").asDouble();
+            assertThat(lastMod, greaterThan(creation));
+        } catch (Exception e) {
+            throw new AssertionError("Failed to parse schedule-group response: " + body, e);
+        }
+    }
+
+    @Test
+    @Order(15)
+    void untagResourceRemovesKeys() {
+        given()
+            .queryParam("TagKeys", "owner")
+            .queryParam("TagKeys", "env")
+        .when()
+            .delete("/tags/" + TAGGED_GROUP_ARN)
+        .then()
+            .statusCode(204);
+
+        given()
+        .when()
+            .get("/tags/" + TAGGED_GROUP_ARN)
+        .then()
+            .statusCode(200)
+            .body("Tags.find { it.Key == 'owner' }", nullValue())
+            .body("Tags.find { it.Key == 'env' }", nullValue())
+            .body("Tags.find { it.Key == 'team' }.Value", equalTo("platform"));
+    }
+
+    @Test
+    @Order(16)
+    void tagResourceOnMissingGroupReturns404() {
+        String arn = "arn:aws:scheduler:us-east-1:000000000000:schedule-group/no-such-group";
+        given()
+            .contentType("application/json")
+            .body("""
+                {"Tags": [{"Key": "k", "Value": "v"}]}
+                """)
+        .when()
+            .post("/tags/" + arn)
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(17)
+    void tagResourceOnScheduleArnReturns400() {
+        // AWS only allows tagging schedule groups, not individual schedules.
+        String arn = "arn:aws:scheduler:us-east-1:000000000000:schedule/default/some-schedule";
+        given()
+            .contentType("application/json")
+            .body("""
+                {"Tags": [{"Key": "k", "Value": "v"}]}
+                """)
+        .when()
+            .post("/tags/" + arn)
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(18)
+    void tagResourceWithoutTagsReturns400() {
+        // AWS spec: Tags is required on TagResource. Empty body must surface as
+        // ValidationException rather than silently succeed.
+        given()
+            .contentType("application/json")
+            .body("{}")
+        .when()
+            .post("/tags/" + TAGGED_GROUP_ARN)
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(19)
+    void untagResourceWithoutTagKeysReturns400() {
+        // AWS spec: TagKeys is required on UntagResource.
+        given()
+        .when()
+            .delete("/tags/" + TAGGED_GROUP_ARN)
+        .then()
+            .statusCode(400);
     }
 
     // ──────────────────────────── Schedule tests ────────────────────────────
@@ -532,5 +685,55 @@ class SchedulerIntegrationTest {
             .get("/schedules/grouped-schedule")
         .then()
             .statusCode(404);
+    }
+
+    // ──────────────────────────── Tag validation tests ────────────────────────────
+
+    @Test
+    @Order(36)
+    void tagResourceEntryMissingKeyOrValueReturns400() {
+        // AWS Tag shape requires both Key and Value; entries with either missing
+        // must surface as ValidationException, not be silently dropped.
+        given()
+            .contentType("application/json")
+            .body("""
+                {"Tags": [{"Key": "k"}]}
+                """)
+        .when()
+            .post("/tags/" + TAGGED_GROUP_ARN)
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(37)
+    void tagResourceTagsWrongTypeReturns400() {
+        // Tags must be a list. An object or string in its place is a wire-format
+        // error, not a missing value, so the message should differ from "Value null".
+        given()
+            .contentType("application/json")
+            .body("""
+                {"Tags": "not-a-list"}
+                """)
+        .when()
+            .post("/tags/" + TAGGED_GROUP_ARN)
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(38)
+    void tagResourceWithPutMethodReturns405() {
+        // AWS Scheduler only defines POST for TagResource. PUT is not in the spec
+        // and must be rejected so floci does not expose a non-AWS mutation route.
+        given()
+            .contentType("application/json")
+            .body("""
+                {"Tags": [{"Key": "k", "Value": "v"}]}
+                """)
+        .when()
+            .put("/tags/" + TAGGED_GROUP_ARN)
+        .then()
+            .statusCode(405);
     }
 }


### PR DESCRIPTION
## Summary

Implements the three remaining EventBridge Scheduler APIs that were missing from floci's coverage: `TagResource`, `UntagResource`, and `ListTagsForResource`. Tags apply to schedule groups only, matching AWS behavior — tagging an individual schedule ARN returns `ValidationException`.

A survey of all ~75 AWS services that share the `/tags/{arn}` path shows three independent shape axes: body key (`Tags` capital vs `tags` lowercase), body structure (list of `{Key, Value}` objects vs string-to-string map), and untag query parameter name (`TagKeys` capital vs `tagKeys` lowercase). Most "capital `Tags`" services still use lowercase `tagKeys`, so these axes vary independently. `TagHandler` exposes them as five orthogonal default methods rather than a coarse-grained enum:

- `tagsBodyKey()` — defaults to `"tags"`; Scheduler overrides to `"Tags"`
- `tagsBodyIsList()` — defaults to `false` (map); Scheduler overrides to `true`
- `tagKeysQueryName()` — defaults to `"tagKeys"`; Scheduler overrides to `"TagKeys"`
- `tagResourceUsesPut()` — defaults to `false` (POST); API Gateway overrides to `true` (PUT)
- `strictTagValidation()` — defaults to `false` (lenient); Scheduler overrides to `true`

The defaults match the most common AWS shape (~73 services use lowercase `tags` map + POST + lowercase `tagKeys`) so handlers like EKS, Pipes, and AppConfig need no overrides. The dispatcher returns `405 MethodNotAllowedException` for the unused HTTP method per handler. Strict input validation (missing `Tags`, wrong-shaped `Tags`, missing `TagKeys`, entries missing `Key` or `Value`) is enforced when `strictTagValidation()` is true, mirroring the AWS Scheduler error shape; lenient handlers retain the looser parsing they had before. `strictTagValidation()` is decoupled from the body-shape axis so a future map-shaped handler that needs strict validation can opt in without flipping the body shape.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Wire format verified against `botocore/data/scheduler/2021-06-30/service-2.json` (AWS Python SDK data files). The new SDK-level test in `compatibility-tests/sdk-test-java/SchedulerTest.java` exercises `tagResource` / `listTagsForResource` / `untagResource` end-to-end via AWS SDK for Java v2 `SchedulerClient` `2.42.41` (the version pinned in this repository's `pom.xml`), validating that the SDK's serialization matches what floci accepts and produces.

## Out-of-scope notes

While preparing this PR, two preexisting test/coverage gaps were identified in adjacent areas and are intentionally **not** addressed here so they can be reviewed independently:

**1. AppConfig wire-format mismatch.** `AppConfigTagHandler` inherits the default `tagsBodyKey() = "tags"`, so the dispatcher reads the request body as `{"tags": {map}}` (lowercase). The AWS spec for AppConfig `TagResource` is `{"Tags": {map}}` (capital `Tags`, still a map). An AWS SDK call to `appConfig.tagResource(...)` would send `{"Tags": {...}}`, the dispatcher would parse it as an empty map, and return `204` with no tags applied. The existing `AppConfigIntegrationTest` uses raw HTTP with lowercase `tags`, so the mismatch is not caught, and `compatibility-tests/sdk-test-java/AppConfigTest.java` has no SDK-level coverage for AppConfig tags. With the orthogonal default methods introduced here, a fix is now a one-line override on `AppConfigTagHandler` (`tagsBodyKey() = "Tags"`) plus an SDK-level test; ~40 AWS services share this same shape so the change pays off beyond AppConfig alone. Best handled in a follow-up PR.

**2. EKS / Pipes lack `/tags/...` REST integration tests.** `EksService` and `PipesService` both implement `TagHandler`, but neither has integration tests that exercise the `/tags/{arn}` REST path. This gap predates this PR. The shared dispatcher's default code paths (POST / lowercase `tagKeys` / lowercase `tags` body) are exercised by `AppConfigIntegrationTest` (which uses the same defaults), so a regression in dispatcher behavior would be caught there. The untested surface is each handler's per-service ARN parsing, which this PR does not modify. Adding REST coverage for EKS and Pipes is a worthwhile follow-up but outside this PR's Scheduler scope.

## Checklist

- [x] `./mvnw test` passes locally (3458/3458)
- [x] New or updated integration test added (10 REST-level on Scheduler, 1 REST-level on API Gateway, 1 SDK-level)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)