### PR TITLE
fix(appconfig): use capital "Tags" body key matching AWS SDK wire format

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppConfigTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppConfigTest.java
@@ -266,4 +266,44 @@ class AppConfigTest {
         // The RestAssured internal test sees "" (raw HTTP header value).
         assertThat(response.versionLabel()).isNull();
     }
+
+    @Test
+    @Order(50)
+    @DisplayName("TagResource / ListTagsForResource - SDK round-trip")
+    void tagAndListViaSdk() {
+        // Reproducer for the wire-format mismatch that previously made AWS SDK callers
+        // silently get an empty tag set: SDK serializes as {"Tags": {...}} (capital),
+        // floci must accept and echo back that exact shape.
+        String tagAppId = appConfig.createApplication(CreateApplicationRequest.builder()
+                .name("tag-roundtrip-app")
+                .build()).id();
+        String arn = "arn:aws:appconfig:us-east-1:000000000000:application/" + tagAppId;
+        try {
+            appConfig.tagResource(TagResourceRequest.builder()
+                    .resourceArn(arn)
+                    .tags(java.util.Map.of("env", "prod", "owner", "Alice"))
+                    .build());
+
+            ListTagsForResourceResponse listed = appConfig.listTagsForResource(
+                    ListTagsForResourceRequest.builder().resourceArn(arn).build());
+            assertThat(listed.tags())
+                    .containsEntry("env", "prod")
+                    .containsEntry("owner", "Alice");
+
+            appConfig.untagResource(UntagResourceRequest.builder()
+                    .resourceArn(arn)
+                    .tagKeys("env")
+                    .build());
+
+            assertThat(appConfig.listTagsForResource(
+                    ListTagsForResourceRequest.builder().resourceArn(arn).build()).tags())
+                    .doesNotContainKey("env")
+                    .containsEntry("owner", "Alice");
+        } finally {
+            try {
+                appConfig.deleteApplication(DeleteApplicationRequest.builder()
+                        .applicationId(tagAppId).build());
+            } catch (Exception ignored) {}
+        }
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigTagHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigTagHandler.java
@@ -37,6 +37,11 @@ public class AppConfigTagHandler implements TagHandler {
     }
 
     @Override
+    public String tagsBodyKey() {
+        return "Tags";
+    }
+
+    @Override
     public Map<String, String> listTags(String region, String arn) {
         ResourceRef ref = parseArn(arn);
         return switch (ref.type()) {

--- a/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
@@ -233,7 +233,7 @@ class AppConfigIntegrationTest {
                 .when().get("/tags/" + arn)
                 .then()
                 .statusCode(200)
-                .body("tags", anEmptyMap());
+                .body("Tags", anEmptyMap());
     }
 
     @Test @Order(15)
@@ -241,7 +241,7 @@ class AppConfigIntegrationTest {
         String arn = "arn:aws:appconfig:us-east-1:000000000000:application/" + appId;
         given()
                 .contentType(ContentType.JSON)
-                .body("{\"tags\": {\"env\": \"local\", \"team\": \"platform\"}}")
+                .body("{\"Tags\": {\"env\": \"local\", \"team\": \"platform\"}}")
                 .when().post("/tags/" + arn)
                 .then()
                 .statusCode(204);
@@ -254,8 +254,8 @@ class AppConfigIntegrationTest {
                 .when().get("/tags/" + arn)
                 .then()
                 .statusCode(200)
-                .body("tags.env", equalTo("local"))
-                .body("tags.team", equalTo("platform"));
+                .body("Tags.env", equalTo("local"))
+                .body("Tags.team", equalTo("platform"));
     }
 
     @Test @Order(17)
@@ -274,8 +274,8 @@ class AppConfigIntegrationTest {
                 .when().get("/tags/" + arn)
                 .then()
                 .statusCode(200)
-                .body("tags", not(hasKey("env")))
-                .body("tags.team", equalTo("platform"));
+                .body("Tags", not(hasKey("env")))
+                .body("Tags.team", equalTo("platform"));
     }
 
     // ──────────────────────────── Tags on non-application resources (no-op) ────────────────────────────
@@ -287,7 +287,7 @@ class AppConfigIntegrationTest {
                 .when().get("/tags/" + arn)
                 .then()
                 .statusCode(200)
-                .body("tags", anEmptyMap());
+                .body("Tags", anEmptyMap());
     }
 
     @Test @Order(20)
@@ -297,7 +297,7 @@ class AppConfigIntegrationTest {
                 .when().get("/tags/" + arn)
                 .then()
                 .statusCode(200)
-                .body("tags", anEmptyMap());
+                .body("Tags", anEmptyMap());
     }
 
     @Test @Order(21)


### PR DESCRIPTION
## Summary

Closes #701.

`AppConfigTagHandler` inherits the default `tagsBodyKey() = "tags"` (lowercase), so `SharedTagsController` parses and serialises the AppConfig tag payload with the lowercase key. The AWS spec for AppConfig `TagResource` and `ListTagsForResource` is capital `"Tags"` with a map body — which is what AWS SDK clients send and expect — so SDK calls to `appConfig.tagResource(...)` silently dropped tags and listing came back empty.

This PR overrides `tagsBodyKey()` on `AppConfigTagHandler` to return `"Tags"`. The other axes (POST method, map body, lowercase `tagKeys` query) already match the defaults so no further override is needed.

The change set:

- `AppConfigTagHandler`: override `tagsBodyKey()` to return `"Tags"` (one-line override)
- `AppConfigIntegrationTest`: switch the REST-level tagging tests to send capital `"Tags"` bodies and assert capital `"Tags"` response keys, matching the AWS SDK wire format
- `compatibility-tests/sdk-test-java/AppConfigTest`: add a `tagResource` → `listTagsForResource` → `untagResource` SDK round-trip via `AppConfigClient` to lock in the wire format end-to-end

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Wire format verified against `botocore/data/appconfig/.../service-2.json`. The `TagResource` input shape is `{Tags: TagMap}` (capital `"Tags"`, map). The new SDK-level test in `compatibility-tests/sdk-test-java/AppConfigTest.java` exercises the full round-trip via AWS SDK for Java v2 `AppConfigClient` `2.42.41` (the version pinned in `pom.xml`), confirming the SDK's serialization is what floci now accepts and produces.

## Background

The orthogonal `TagHandler` default-method refactor that introduces `tagsBodyKey()` (and the rest of the per-axis hooks) landed in #700, so this fix is now a one-line override on top of `main`.

## Checklist

- [x] `./mvnw test` passes locally (94/94 across `AppConfigIntegrationTest`, `SchedulerIntegrationTest`, `ApiGatewayIntegrationTest`)
- [x] SDK-level compat test added (`AppConfigTest.tagAndListViaSdk`, 14/14 passes against a freshly-built floci docker image)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)