### PR TITLE
fix(ecs): Always expose ECS ports, even when running inside a container, to allow connection from host

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManager.java
@@ -84,16 +84,10 @@ public class EcsContainerManager {
                 specBuilder.withMemoryMb(def.getMemory());
             }
 
-            // Add port mappings. Publish to host only in native mode; in Docker
-            // mode ECS consumers reach containers via the docker network IP.
+            // Add port mappings
             if (def.getPortMappings() != null) {
-                boolean publishToHost = !containerDetector.isRunningInContainer();
                 for (PortMapping pm : def.getPortMappings()) {
-                    if (publishToHost) {
-                        specBuilder.withDynamicPort(pm.containerPort());
-                    } else {
-                        specBuilder.withExposedPort(pm.containerPort());
-                    }
+                    specBuilder.withDynamicPort(pm.containerPort());
                 }
             }
 
@@ -189,7 +183,7 @@ public class EcsContainerManager {
             int hostPort = pm.containerPort();
             String bindIp = "0.0.0.0";
 
-            if (!containerDetector.isRunningInContainer() && binding != null && binding.length > 0) {
+            if (binding != null && binding.length > 0) {
                 hostPort = Integer.parseInt(binding[0].getHostPortSpec());
                 if (binding[0].getHostIp() != null && !binding[0].getHostIp().isBlank()) {
                     bindIp = binding[0].getHostIp();


### PR DESCRIPTION
## Summary

Currently, ECS ports are not reachable from host when running inside a Docker container, but only within the Docker network. This PR changes that behavior and always exposes the ports to the host.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No AWS compatibitlity required

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
