### PR TITLE
fix(ses): align V2 identity error responses with AWS

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -72,6 +72,11 @@ public class SesController {
                 throw new AwsException("BadRequestException", "EmailIdentity is required.", 400);
             }
 
+            if (sesService.getIdentityVerificationAttributes(emailIdentity, region) != null) {
+                throw new AwsException("AlreadyExistsException",
+                        "Email identity " + emailIdentity + " already exist.", 400);
+            }
+
             Identity identity = emailIdentity.contains("@")
                     ? sesService.verifyEmailIdentity(emailIdentity, region)
                     : sesService.verifyDomainIdentity(emailIdentity, region);
@@ -126,6 +131,10 @@ public class SesController {
     public Response deleteEmailIdentity(@Context HttpHeaders headers,
                                         @PathParam("emailIdentity") String emailIdentity) {
         String region = regionResolver.resolveRegion(headers);
+        if (sesService.getIdentityVerificationAttributes(emailIdentity, region) == null) {
+            throw new AwsException("NotFoundException",
+                    "Email identity " + emailIdentity + " does not exist.", 404);
+        }
         sesService.deleteIdentity(emailIdentity, region);
         LOG.infov("SES V2 DeleteEmailIdentity: {0}", emailIdentity);
         return Response.ok(objectMapper.createObjectNode()).build();

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -222,9 +222,20 @@ public class SesService {
 
     public void setDkimAttributes(String identityValue, boolean signingEnabled, String region) {
         String key = identityKey(region, identityValue);
-        Identity identity = identityStore.get(key)
-                .orElseThrow(() -> new AwsException("NotFoundException",
-                        "Identity does not exist: " + identityValue, 404));
+        Identity identity = identityStore.get(key).orElse(null);
+
+        if (identity == null) {
+            String domain = identityValue != null && identityValue.contains("@")
+                    ? identityValue.substring(identityValue.indexOf('@') + 1)
+                    : identityValue;
+            if (identityValue != null && identityValue.contains("@")
+                    && identityStore.get(identityKey(region, domain)).isPresent()) {
+                return;
+            }
+            throw new AwsException("BadRequestException",
+                    "Domain " + domain + " is not verified for DKIM signing.", 400);
+        }
+
         identity.setDkimEnabled(signingEnabled);
         if (signingEnabled) {
             identity.setDkimVerificationStatus("Success");

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesIdentityAttributesV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesIdentityAttributesV2IntegrationTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 @QuarkusTest
@@ -196,9 +197,125 @@ class SesIdentityAttributesV2IntegrationTest {
         .when()
             .put("/v2/email/identities/v2-attrs.floci.test/mail-from")
         .then()
-            .body("message", org.hamcrest.Matchers.containsString(
+            .body("message", containsString(
                     "Member must satisfy enum value set: [REJECT_MESSAGE, USE_DEFAULT_VALUE]"))
             .statusCode(400)
             .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(20)
+    void putEmailIdentityDkimAttributes_unknownIdentity_returnsBadRequest() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"SigningEnabled": true}
+                """)
+        .when()
+            .put("/v2/email/identities/ghost-dkim.floci.test/dkim")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo(
+                    "Domain ghost-dkim.floci.test is not verified for DKIM signing."));
+    }
+
+    @Test
+    @Order(21)
+    void putEmailIdentityDkimAttributes_emailFormatWithUnregisteredParent_returnsBadRequest() {
+        // Real SES v2 reports the parent domain (not the full email identity)
+        // in the error message even when the input is email-formatted.
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"SigningEnabled": true}
+                """)
+        .when()
+            .put("/v2/email/identities/orphan@no-such-parent.floci.test/dkim")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo(
+                    "Domain no-such-parent.floci.test is not verified for DKIM signing."));
+    }
+
+    @Test
+    @Order(22)
+    void putEmailIdentityDkimAttributes_emailWithRegisteredParentDomain_returnsNoOp() {
+        // Real SES v2 accepts the call (200 OK) for an email-format identity
+        // whose parent domain is registered, but persists nothing — DKIM is a
+        // domain-level concept. The parent domain's DkimAttributes must remain
+        // untouched, and no email identity is auto-created.
+        Object parentDkimBefore = given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/identities/v2-attrs.floci.test")
+        .then()
+            .statusCode(200)
+            .extract().path("DkimAttributes");
+
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"SigningEnabled": true}
+                """)
+        .when()
+            .put("/v2/email/identities/orphan@v2-attrs.floci.test/dkim")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/identities/v2-attrs.floci.test")
+        .then()
+            .statusCode(200)
+            .body("DkimAttributes", equalTo(parentDkimBefore));
+
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/identities/orphan@v2-attrs.floci.test")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(23)
+    void createEmailIdentity_duplicate_returnsAlreadyExists() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailIdentity": "v2-attrs.floci.test"}
+                """)
+        .when()
+            .post("/v2/email/identities")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("AlreadyExistsException"))
+            .body("message", equalTo(
+                    "Email identity v2-attrs.floci.test already exist."));
+    }
+
+    @Test
+    @Order(24)
+    void deleteEmailIdentity_unknownIdentity_returnsNotFound() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .delete("/v2/email/identities/ghost-delete.floci.test")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", equalTo(
+                    "Email identity ghost-delete.floci.test does not exist."));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
@@ -395,22 +395,6 @@ class SesV2IntegrationTest {
             .body("DkimAttributes.Status", equalTo("NOT_STARTED"));
     }
 
-    @Test
-    @Order(22)
-    void putDkimAttributes_notFound() {
-        given()
-            .contentType("application/json")
-            .header("Authorization", AUTH_HEADER)
-            .body("""
-                {"SigningEnabled": true}
-                """)
-        .when()
-            .put("/v2/email/identities/nonexistent@example.com/dkim")
-        .then()
-            .statusCode(404)
-            .body("__type", equalTo("NotFoundException"));
-    }
-
     // ──────────────── Feedback Attributes ────────────────
 
     @Test


### PR DESCRIPTION
## Summary

Align SES v2 identity error responses with real AWS SES v2 behavior.

- `PutEmailIdentityDkimAttributes` on an unknown identity now returns `400 BadRequestException` with the message `Domain X is not verified for DKIM signing.` instead of `404 NotFoundException`.
- `PutEmailIdentityDkimAttributes` on an email-format identity whose parent domain is registered now returns `200 OK` as a no-op (DKIM is a domain-level concept; the email identity is not auto-created and the parent domain's DkimAttributes are untouched).
- `CreateEmailIdentity` on a duplicate identity now returns `400 AlreadyExistsException` (was a silent 200 returning the existing identity).
- `DeleteEmailIdentity` on an unknown identity now returns `404 NotFoundException` (was a silent 200 no-op).

V1 idempotent semantics for `VerifyEmailIdentity` / `VerifyDomainIdentity` / `DeleteIdentity` are preserved -- strict checks are added at the V2 controller level only.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified empirically against real AWS SES v2 (`aws sesv2` CLI). Each error code, HTTP status, and message text was confirmed against live API responses:

- Unknown domain identity / put-dkim -> `BadRequestException: Domain X is not verified for DKIM signing.`
- Email-format identity with registered parent domain / put-dkim -> `200 OK` no-op (no side effect on parent domain DKIM attributes)
- Duplicate `CreateEmailIdentity` -> `AlreadyExistsException: Email identity X already exist.`
- Unknown identity `DeleteEmailIdentity` -> `NotFoundException: Email identity X does not exist.`

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)