### PR TITLE
feat(ses): add UpdateAccountSendingEnabled (v1)

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesAccountSendingTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesAccountSendingTest.java
@@ -1,0 +1,83 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import software.amazon.awssdk.services.ses.SesClient;
+import software.amazon.awssdk.services.ses.model.GetAccountSendingEnabledResponse;
+import software.amazon.awssdk.services.ses.model.UpdateAccountSendingEnabledRequest;
+
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.GetAccountRequest;
+import software.amazon.awssdk.services.sesv2.model.GetAccountResponse;
+import software.amazon.awssdk.services.sesv2.model.PutAccountSendingAttributesRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("SES Account Sending Enabled (v1 + v2)")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesAccountSendingTest {
+
+    private static SesClient sesV1;
+    private static SesV2Client sesV2;
+
+    @BeforeAll
+    static void setup() {
+        sesV1 = TestFixtures.sesClient();
+        sesV2 = TestFixtures.sesV2Client();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        // Always restore the account-wide flag so it does not leak to other suites.
+        if (sesV1 != null) {
+            try {
+                sesV1.updateAccountSendingEnabled(UpdateAccountSendingEnabledRequest.builder()
+                        .enabled(true).build());
+            } catch (Exception ignored) {}
+            sesV1.close();
+        }
+        if (sesV2 != null) {
+            sesV2.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void v1UpdateAccountSendingEnabled_disablesAndReenables() {
+        sesV1.updateAccountSendingEnabled(UpdateAccountSendingEnabledRequest.builder()
+                .enabled(false).build());
+
+        GetAccountSendingEnabledResponse disabled = sesV1.getAccountSendingEnabled();
+        assertThat(disabled.enabled()).isFalse();
+
+        sesV1.updateAccountSendingEnabled(UpdateAccountSendingEnabledRequest.builder()
+                .enabled(true).build());
+
+        GetAccountSendingEnabledResponse enabled = sesV1.getAccountSendingEnabled();
+        assertThat(enabled.enabled()).isTrue();
+    }
+
+    @Test
+    @Order(2)
+    void v1AndV2_shareAccountSendingState() {
+        // Disable via v1, observe via v2 GetAccount
+        sesV1.updateAccountSendingEnabled(UpdateAccountSendingEnabledRequest.builder()
+                .enabled(false).build());
+
+        GetAccountResponse afterV1Disable = sesV2.getAccount(GetAccountRequest.builder().build());
+        assertThat(afterV1Disable.sendingEnabled()).isFalse();
+
+        // Re-enable via v2, observe via v1 GetAccountSendingEnabled
+        sesV2.putAccountSendingAttributes(PutAccountSendingAttributesRequest.builder()
+                .sendingEnabled(true).build());
+
+        GetAccountSendingEnabledResponse afterV2Enable = sesV1.getAccountSendingEnabled();
+        assertThat(afterV2Enable.enabled()).isTrue();
+    }
+}

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -28,6 +28,7 @@ Floci exposes the classic Amazon SES Query API used by `aws ses ...` commands an
 | `GetSendQuota`                      | Return local send quota counters                          |
 | `GetSendStatistics`                 | Return aggregate delivery stats for sent messages         |
 | `GetAccountSendingEnabled`          | Report whether sending is enabled                         |
+| `UpdateAccountSendingEnabled`       | Enable or disable account-wide sending                    |
 | `ListVerifiedEmailAddresses`        | List verified email identities                            |
 | `DeleteVerifiedEmailAddress`        | Delete a verified email identity                          |
 | `SetIdentityNotificationTopic`      | Store SNS notification topic ARNs for an identity         |

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
@@ -54,6 +54,7 @@ public class SesQueryHandler {
                 case "GetSendQuota" -> handleGetSendQuota(region);
                 case "GetSendStatistics" -> handleGetSendStatistics(region);
                 case "GetAccountSendingEnabled" -> handleGetAccountSendingEnabled(region);
+                case "UpdateAccountSendingEnabled" -> handleUpdateAccountSendingEnabled(params, region);
                 case "ListVerifiedEmailAddresses" -> handleListVerifiedEmailAddresses(region);
                 case "DeleteVerifiedEmailAddress" -> handleDeleteVerifiedEmailAddress(params, region);
                 case "SetIdentityNotificationTopic" -> handleSetIdentityNotificationTopic(params, region);
@@ -210,6 +211,12 @@ public class SesQueryHandler {
         return Response.ok(AwsQueryResponse.envelope("GetAccountSendingEnabled", AwsNamespaces.SES, result)).build();
     }
 
+    private Response handleUpdateAccountSendingEnabled(MultivaluedMap<String, String> params, String region) {
+        boolean enabled = parseOptionalBoolean(params, "Enabled", false);
+        sesService.setAccountSendingEnabled(region, enabled);
+        return Response.ok(AwsQueryResponse.envelopeEmptyResult("UpdateAccountSendingEnabled", AwsNamespaces.SES)).build();
+    }
+
     private Response handleListVerifiedEmailAddresses(String region) {
         List<String> emails = sesService.getVerifiedEmailAddresses(region);
         var xml = new XmlBuilder().start("VerifiedEmailAddresses");
@@ -312,6 +319,18 @@ public class SesQueryHandler {
         String raw = params.getFirst(name);
         if (raw == null) {
             throw new AwsException("InvalidParameterValue", name + " is required.", 400);
+        }
+        if (!"true".equalsIgnoreCase(raw) && !"false".equalsIgnoreCase(raw)) {
+            throw new AwsException("InvalidParameterValue",
+                    name + " must be \"true\" or \"false\".", 400);
+        }
+        return Boolean.parseBoolean(raw);
+    }
+
+    private static boolean parseOptionalBoolean(MultivaluedMap<String, String> params, String name, boolean defaultValue) {
+        String raw = params.getFirst(name);
+        if (raw == null || raw.isBlank()) {
+            return defaultValue;
         }
         if (!"true".equalsIgnoreCase(raw) && !"false".equalsIgnoreCase(raw)) {
             throw new AwsException("InvalidParameterValue",

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesIntegrationTest.java
@@ -17,7 +17,11 @@ import static org.hamcrest.Matchers.*;
 class SesIntegrationTest {
 
     private static String authorization(String service) {
-        return "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/" + service + "/aws4_request";
+        return authorization(service, "us-east-1");
+    }
+
+    private static String authorization(String service, String region) {
+        return "AWS4-HMAC-SHA256 Credential=AKID/20260101/" + region + "/" + service + "/aws4_request";
     }
 
     @Test
@@ -242,7 +246,7 @@ class SesIntegrationTest {
     }
 
     @Test
-    @Order(14)
+    @Order(15)
     void getAccountSendingEnabled_acceptsSesv2CredentialScopeAlias() {
         given()
             .contentType("application/x-www-form-urlencoded")
@@ -256,7 +260,7 @@ class SesIntegrationTest {
     }
 
     @Test
-    @Order(15)
+    @Order(16)
     void getIdentityDkimAttributes() {
         given()
             .contentType("application/x-www-form-urlencoded")
@@ -272,7 +276,7 @@ class SesIntegrationTest {
     }
 
     @Test
-    @Order(16)
+    @Order(17)
     void setIdentityNotificationTopic() {
         given()
             .contentType("application/x-www-form-urlencoded")
@@ -289,7 +293,7 @@ class SesIntegrationTest {
     }
 
     @Test
-    @Order(17)
+    @Order(18)
     void getIdentityNotificationAttributes() {
         given()
             .contentType("application/x-www-form-urlencoded")
@@ -305,7 +309,7 @@ class SesIntegrationTest {
     }
 
     @Test
-    @Order(18)
+    @Order(19)
     void deleteVerifiedEmailAddress() {
         given()
             .contentType("application/x-www-form-urlencoded")
@@ -330,7 +334,7 @@ class SesIntegrationTest {
     }
 
     @Test
-    @Order(19)
+    @Order(20)
     void deleteIdentity() {
         given()
             .contentType("application/x-www-form-urlencoded")
@@ -356,7 +360,7 @@ class SesIntegrationTest {
     }
 
     @Test
-    @Order(20)
+    @Order(21)
     void sendEmailV1_replyToAddressesStoredInInspection() {
         given().delete("/_aws/ses").then().statusCode(200);
 
@@ -384,7 +388,7 @@ class SesIntegrationTest {
     }
 
     @Test
-    @Order(21)
+    @Order(22)
     void deleteDomainIdentity() {
         given()
             .contentType("application/x-www-form-urlencoded")
@@ -409,7 +413,7 @@ class SesIntegrationTest {
     }
 
     @Test
-    @Order(22)
+    @Order(23)
     void verifyEmailIdentity_rejectsLeadingTrailingWhitespace() {
         given()
             .contentType("application/x-www-form-urlencoded")
@@ -425,7 +429,7 @@ class SesIntegrationTest {
     }
 
     @Test
-    @Order(23)
+    @Order(24)
     void verifyDomainIdentity_rejectsLeadingTrailingWhitespace() {
         given()
             .contentType("application/x-www-form-urlencoded")
@@ -441,7 +445,7 @@ class SesIntegrationTest {
     }
 
     @Test
-    @Order(24)
+    @Order(25)
     void unsupportedAction_returns400() {
         given()
             .contentType("application/x-www-form-urlencoded")
@@ -452,5 +456,146 @@ class SesIntegrationTest {
         .then()
             .statusCode(400)
             .body(containsString("UnsupportedOperation"));
+    }
+
+    @Test
+    @Order(26)
+    void updateAccountSendingEnabled_treatsMissingOrBlankEnabledAsFalse() {
+        // Missing Enabled parameter
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", authorization("email"))
+            .formParam("Action", "UpdateAccountSendingEnabled")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", authorization("email"))
+            .formParam("Action", "GetAccountSendingEnabled")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Enabled>false</Enabled>"));
+
+        // restore so the next assertion observes the blank-string default cleanly
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", authorization("email"))
+            .formParam("Action", "UpdateAccountSendingEnabled")
+            .formParam("Enabled", "true")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Blank Enabled parameter (e.g. AWS CLI passing --enabled "") behaves the same
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", authorization("email"))
+            .formParam("Action", "UpdateAccountSendingEnabled")
+            .formParam("Enabled", "")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", authorization("email"))
+            .formParam("Action", "GetAccountSendingEnabled")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Enabled>false</Enabled>"));
+
+        // restore default state for downstream tests
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", authorization("email"))
+            .formParam("Action", "UpdateAccountSendingEnabled")
+            .formParam("Enabled", "true")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(27)
+    void updateAccountSendingEnabled_isolatesPerRegion() {
+        // Disable sending in us-west-2 only; also exercises the response envelope shape
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", authorization("email", "us-west-2"))
+            .formParam("Action", "UpdateAccountSendingEnabled")
+            .formParam("Enabled", "false")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<UpdateAccountSendingEnabledResponse"));
+
+        // us-west-2 reflects the disable
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", authorization("email", "us-west-2"))
+            .formParam("Action", "GetAccountSendingEnabled")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Enabled>false</Enabled>"));
+
+        // us-east-1 is unaffected
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", authorization("email"))
+            .formParam("Action", "GetAccountSendingEnabled")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Enabled>true</Enabled>"));
+
+        // re-enable us-west-2 and confirm the toggle round-tripped
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", authorization("email", "us-west-2"))
+            .formParam("Action", "UpdateAccountSendingEnabled")
+            .formParam("Enabled", "true")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", authorization("email", "us-west-2"))
+            .formParam("Action", "GetAccountSendingEnabled")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Enabled>true</Enabled>"));
+    }
+
+    @Test
+    @Order(28)
+    void updateAccountSendingEnabled_invalidValue_returns400() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", authorization("email"))
+            .formParam("Action", "UpdateAccountSendingEnabled")
+            .formParam("Enabled", "yes")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidParameterValue"));
     }
 }


### PR DESCRIPTION
## Summary

Adds the v1 SES Query action `UpdateAccountSendingEnabled`, mirroring the existing v2 `PutAccountSendingAttributes` endpoint. Both paths share the same per-region account settings store, so toggling via either protocol is observed by the other. The `Enabled` parameter is optional per AWS docs; missing or empty is treated as `false`.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against AWS Java SDK v2 `2.42.24` (`software.amazon.awssdk:ses` and `:sesv2`). New compatibility test `SesAccountSendingTest` exercises:

- v1: `SesClient.updateAccountSendingEnabled` / `getAccountSendingEnabled`
- v2: `SesV2Client.putAccountSendingAttributes` / `getAccount`

and confirms the account-sending flag is shared across both protocols. Per-region isolation is covered in `SesIntegrationTest`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)