### PR TITLE
feat(ses): add v2 TagResource / UntagResource / ListTagsForResource

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesTagResourceTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesTagResourceTest.java
@@ -1,0 +1,130 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.CreateConfigurationSetRequest;
+import software.amazon.awssdk.services.sesv2.model.DeleteConfigurationSetRequest;
+import software.amazon.awssdk.services.sesv2.model.ListTagsForResourceRequest;
+import software.amazon.awssdk.services.sesv2.model.ListTagsForResourceResponse;
+import software.amazon.awssdk.services.sesv2.model.NotFoundException;
+import software.amazon.awssdk.services.sesv2.model.Tag;
+import software.amazon.awssdk.services.sesv2.model.TagResourceRequest;
+import software.amazon.awssdk.services.sesv2.model.UntagResourceRequest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("SES V2 TagResource / UntagResource / ListTagsForResource")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesTagResourceTest {
+
+    private static SesV2Client sesV2;
+    private static String configSetName;
+    private static String configSetArn;
+
+    @BeforeAll
+    static void setup() {
+        sesV2 = TestFixtures.sesV2Client();
+        configSetName = "sdk-tag-cs-" + TestFixtures.uniqueName();
+        configSetArn = "arn:aws:ses:us-east-1:000000000000:configuration-set/" + configSetName;
+
+        sesV2.createConfigurationSet(CreateConfigurationSetRequest.builder()
+                .configurationSetName(configSetName)
+                .build());
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (sesV2 != null) {
+            try {
+                sesV2.deleteConfigurationSet(DeleteConfigurationSetRequest.builder()
+                        .configurationSetName(configSetName).build());
+            } catch (Exception ignored) {}
+            sesV2.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void listTagsForResource_initiallyEmpty() {
+        ListTagsForResourceResponse response = sesV2.listTagsForResource(ListTagsForResourceRequest.builder()
+                .resourceArn(configSetArn).build());
+        assertThat(response.tags()).isEmpty();
+    }
+
+    @Test
+    @Order(2)
+    void tagResource_addsTagsAndListReflectsThem() {
+        sesV2.tagResource(TagResourceRequest.builder()
+                .resourceArn(configSetArn)
+                .tags(
+                        Tag.builder().key("env").value("dev").build(),
+                        Tag.builder().key("owner").value("alice").build())
+                .build());
+
+        ListTagsForResourceResponse response = sesV2.listTagsForResource(ListTagsForResourceRequest.builder()
+                .resourceArn(configSetArn).build());
+
+        List<Tag> tags = response.tags();
+        assertThat(tags).hasSize(2);
+        assertThat(tags).anySatisfy(t -> {
+            assertThat(t.key()).isEqualTo("env");
+            assertThat(t.value()).isEqualTo("dev");
+        });
+        assertThat(tags).anySatisfy(t -> {
+            assertThat(t.key()).isEqualTo("owner");
+            assertThat(t.value()).isEqualTo("alice");
+        });
+    }
+
+    @Test
+    @Order(3)
+    void tagResource_existingKeyReplacesValue() {
+        sesV2.tagResource(TagResourceRequest.builder()
+                .resourceArn(configSetArn)
+                .tags(Tag.builder().key("env").value("prod").build())
+                .build());
+
+        ListTagsForResourceResponse response = sesV2.listTagsForResource(ListTagsForResourceRequest.builder()
+                .resourceArn(configSetArn).build());
+        assertThat(response.tags())
+                .filteredOn(t -> t.key().equals("env"))
+                .singleElement()
+                .extracting(Tag::value)
+                .isEqualTo("prod");
+    }
+
+    @Test
+    @Order(4)
+    void untagResource_removesSpecifiedKeys() {
+        sesV2.untagResource(UntagResourceRequest.builder()
+                .resourceArn(configSetArn)
+                .tagKeys("env")
+                .build());
+
+        ListTagsForResourceResponse response = sesV2.listTagsForResource(ListTagsForResourceRequest.builder()
+                .resourceArn(configSetArn).build());
+        assertThat(response.tags()).hasSize(1);
+        assertThat(response.tags().get(0).key()).isEqualTo("owner");
+    }
+
+    @Test
+    @Order(5)
+    void tagResource_unknownConfigurationSet_throwsNotFound() {
+        String missingArn = "arn:aws:ses:us-east-1:000000000000:configuration-set/missing-" + TestFixtures.uniqueName();
+        assertThatThrownBy(() -> sesV2.tagResource(TagResourceRequest.builder()
+                .resourceArn(missingArn)
+                .tags(Tag.builder().key("k").value("v").build())
+                .build()))
+                .isInstanceOf(NotFoundException.class);
+    }
+}

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -196,5 +196,10 @@ Alongside the classic Query API, Floci implements a subset of the SES v2 REST JS
 | `GET` | `/v2/email/configuration-sets` | `ListConfigurationSets` |
 | `GET` | `/v2/email/configuration-sets/{name}` | `GetConfigurationSet` |
 | `DELETE` | `/v2/email/configuration-sets/{name}` | `DeleteConfigurationSet` |
+| `POST` | `/v2/email/tags` | `TagResource` |
+| `DELETE` | `/v2/email/tags?ResourceArn=...&TagKeys=...` | `UntagResource` |
+| `GET` | `/v2/email/tags?ResourceArn=...` | `ListTagsForResource` |
+
+Tag operations currently support `arn:aws:ses:<region>:<account>:configuration-set/<name>` ARNs. Other resource types return `NotFoundException`.
 
 Identity, template, configuration-set, and sent-message state is shared between the v1 Query API and the v2 REST JSON API, so a template created with `CreateTemplate` resolves through `SendEmail` on v2 (and vice versa), a configuration set created with `CreateConfigurationSet` is visible to both `DescribeConfigurationSet` (v1) and `GetConfigurationSet` (v2), and every send appears in the same `GET /_aws/ses` inspection mailbox.

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
@@ -688,6 +689,77 @@ public class SesController {
             throw remapV1Exception(e);
         } catch (Exception e) {
             throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    // ──────────────────────────── Tags ───────────────────────────────
+
+    @POST
+    @Path("/tags")
+    public Response tagResource(@Context HttpHeaders headers, String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            if (body == null || body.isBlank()) {
+                throw new AwsException("BadRequestException", "Request body is required.", 400);
+            }
+            JsonNode request = objectMapper.readTree(body);
+            String arn = request.path("ResourceArn").asText(null);
+            if (arn == null || arn.isBlank()) {
+                throw new AwsException("BadRequestException", "ResourceArn is required.", 400);
+            }
+            JsonNode tagsNode = request.path("Tags");
+            if (!tagsNode.isArray()) {
+                throw new AwsException("BadRequestException", "Tags must be an array.", 400);
+            }
+            List<ConfigurationSet.Tag> tags = new ArrayList<>();
+            for (JsonNode t : tagsNode) {
+                String key = t.path("Key").asText(null);
+                String value = t.path("Value").asText(null);
+                tags.add(new ConfigurationSet.Tag(key, value));
+            }
+            sesService.tagResource(arn, region, tags);
+            LOG.infov("SES V2 TagResource: {0}", arn);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @DELETE
+    @Path("/tags")
+    public Response untagResource(@Context HttpHeaders headers,
+                                   @QueryParam("ResourceArn") String arn,
+                                   @QueryParam("TagKeys") List<String> tagKeys) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            sesService.untagResource(arn, region, tagKeys);
+            LOG.infov("SES V2 UntagResource: {0}", arn);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        }
+    }
+
+    @GET
+    @Path("/tags")
+    public Response listTagsForResource(@Context HttpHeaders headers,
+                                         @QueryParam("ResourceArn") String arn) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            List<ConfigurationSet.Tag> tags = sesService.listResourceTags(arn, region);
+            ObjectNode result = objectMapper.createObjectNode();
+            ArrayNode arr = result.putArray("Tags");
+            for (ConfigurationSet.Tag t : tags) {
+                ObjectNode tagNode = objectMapper.createObjectNode();
+                tagNode.put("Key", t.key());
+                tagNode.put("Value", t.value());
+                arr.add(tagNode);
+            }
+            return Response.ok(result).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -729,12 +729,10 @@ public class SesController {
 
     @DELETE
     @Path("/tags")
-    public Response untagResource(@Context HttpHeaders headers,
-                                   @QueryParam("ResourceArn") String arn,
+    public Response untagResource(@QueryParam("ResourceArn") String arn,
                                    @QueryParam("TagKeys") List<String> tagKeys) {
-        String region = regionResolver.resolveRegion(headers);
         try {
-            sesService.untagResource(arn, region, tagKeys);
+            sesService.untagResource(arn, tagKeys);
             LOG.infov("SES V2 UntagResource: {0}", arn);
             return Response.ok(objectMapper.createObjectNode()).build();
         } catch (AwsException e) {
@@ -744,11 +742,9 @@ public class SesController {
 
     @GET
     @Path("/tags")
-    public Response listTagsForResource(@Context HttpHeaders headers,
-                                         @QueryParam("ResourceArn") String arn) {
-        String region = regionResolver.resolveRegion(headers);
+    public Response listTagsForResource(@QueryParam("ResourceArn") String arn) {
         try {
-            List<ConfigurationSet.Tag> tags = sesService.listResourceTags(arn, region);
+            List<ConfigurationSet.Tag> tags = sesService.listResourceTags(arn);
             ObjectNode result = objectMapper.createObjectNode();
             ArrayNode arr = result.putArray("Tags");
             for (ConfigurationSet.Tag t : tags) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.ses;
 
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
@@ -26,8 +27,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HexFormat;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -472,6 +476,114 @@ public class SesService {
                     "ConfigurationSetName must be 1-64 characters and may only contain "
                             + "alphanumeric characters, underscores, and hyphens.", 400);
         }
+    }
+
+    public List<ConfigurationSet.Tag> listResourceTags(String arn, String region) {
+        ResourceRef ref = parseSesArn(arn);
+        return switch (ref.type()) {
+            case "configuration-set" -> listConfigurationSetTags(ref.name(), ref.region());
+            default -> throw new AwsException("NotFoundException",
+                    "Resource " + arn + " was not found.", 404);
+        };
+    }
+
+    public void tagResource(String arn, String region, List<ConfigurationSet.Tag> newTags) {
+        ResourceRef ref = parseSesArn(arn);
+        if (!ref.region().equals(region)) {
+            throw new AwsException("BadRequestException", "Failed to tag resource", 400);
+        }
+        if (newTags == null || newTags.isEmpty()) {
+            throw new AwsException("BadRequestException",
+                    "1 validation error detected: Value at 'tags' failed to satisfy constraint: "
+                            + "Member must have length greater than or equal to 1", 400);
+        }
+        for (ConfigurationSet.Tag t : newTags) {
+            validateTag(t);
+        }
+        switch (ref.type()) {
+            case "configuration-set" -> tagConfigurationSet(ref.name(), ref.region(), newTags);
+            default -> throw new AwsException("NotFoundException",
+                    "Resource " + arn + " was not found.", 404);
+        }
+    }
+
+    public void untagResource(String arn, String region, List<String> tagKeys) {
+        ResourceRef ref = parseSesArn(arn);
+        if (tagKeys == null || tagKeys.isEmpty()) {
+            throw new AwsException("BadRequestException",
+                    "1 validation error detected: Value at 'tagKeys' failed to satisfy constraint: "
+                            + "Member must have length greater than or equal to 1", 400);
+        }
+        switch (ref.type()) {
+            case "configuration-set" -> untagConfigurationSet(ref.name(), ref.region(), tagKeys);
+            default -> throw new AwsException("NotFoundException",
+                    "Resource " + arn + " was not found.", 404);
+        }
+    }
+
+    private List<ConfigurationSet.Tag> listConfigurationSetTags(String name, String region) {
+        ConfigurationSet cs = configSetStore.get(configSetKey(region, name))
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "No ConfigurationSet present with name: " + name, 404));
+        return new ArrayList<>(cs.getTags());
+    }
+
+    private void tagConfigurationSet(String name, String region, List<ConfigurationSet.Tag> newTags) {
+        String key = configSetKey(region, name);
+        ConfigurationSet cs = configSetStore.get(key)
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "No ConfigurationSet present with name: " + name, 404));
+        Map<String, String> merged = new LinkedHashMap<>();
+        for (ConfigurationSet.Tag t : cs.getTags()) {
+            merged.put(t.key(), t.value());
+        }
+        for (ConfigurationSet.Tag t : newTags) {
+            merged.put(t.key(), t.value());
+        }
+        List<ConfigurationSet.Tag> out = new ArrayList<>();
+        merged.forEach((k, v) -> out.add(new ConfigurationSet.Tag(k, v)));
+        cs.setTags(out);
+        configSetStore.put(key, cs);
+        LOG.infov("Tagged SES configuration set: {0} (region {1}, +{2} tags)", name, region, newTags.size());
+    }
+
+    private void untagConfigurationSet(String name, String region, List<String> tagKeys) {
+        String key = configSetKey(region, name);
+        ConfigurationSet cs = configSetStore.get(key)
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "No ConfigurationSet present with name: " + name, 404));
+        Set<String> toRemove = new HashSet<>(tagKeys);
+        cs.getTags().removeIf(t -> toRemove.contains(t.key()));
+        configSetStore.put(key, cs);
+        LOG.infov("Untagged SES configuration set: {0} (region {1}, -{2} keys)", name, region, tagKeys.size());
+    }
+
+    private record ResourceRef(String region, String type, String name) {}
+
+    private static ResourceRef parseSesArn(String arn) {
+        if (arn == null || arn.isBlank()) {
+            throw new AwsException("BadRequestException", "ResourceArn is required.", 400);
+        }
+        AwsArnUtils.Arn parsed;
+        try {
+            parsed = AwsArnUtils.parse(arn);
+        } catch (IllegalArgumentException e) {
+            throw new AwsException("BadRequestException", "Invalid ARN: " + arn, 400);
+        }
+        if (!"ses".equals(parsed.service())) {
+            throw new AwsException("BadRequestException",
+                    "ResourceArn must be a SES ARN: " + arn, 400);
+        }
+        if (parsed.region().isEmpty() || parsed.accountId().isEmpty()) {
+            throw new AwsException("BadRequestException",
+                    "ResourceArn must include region and account: " + arn, 400);
+        }
+        String resource = parsed.resource();
+        int slash = resource.indexOf('/');
+        if (slash <= 0 || slash == resource.length() - 1) {
+            throw new AwsException("BadRequestException", "Invalid ARN: " + arn, 400);
+        }
+        return new ResourceRef(parsed.region(), resource.substring(0, slash), resource.substring(slash + 1));
     }
 
     static void validateTag(ConfigurationSet.Tag tag) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -478,7 +478,7 @@ public class SesService {
         }
     }
 
-    public List<ConfigurationSet.Tag> listResourceTags(String arn, String region) {
+    public List<ConfigurationSet.Tag> listResourceTags(String arn) {
         ResourceRef ref = parseSesArn(arn);
         return switch (ref.type()) {
             case "configuration-set" -> listConfigurationSetTags(ref.name(), ref.region());
@@ -507,7 +507,7 @@ public class SesService {
         }
     }
 
-    public void untagResource(String arn, String region, List<String> tagKeys) {
+    public void untagResource(String arn, List<String> tagKeys) {
         ResourceRef ref = parseSesArn(arn);
         if (tagKeys == null || tagKeys.isEmpty()) {
             throw new AwsException("BadRequestException",

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV2IntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 
 /**
  * Integration tests for SES V2 ConfigurationSet endpoints under /v2/email/configuration-sets.
@@ -283,5 +284,40 @@ class SesConfigurationSetV2IntegrationTest {
         .then()
             .statusCode(400)
             .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(16)
+    void listTagsForResource_returnsTagsSetAtCreation() {
+        // Tags supplied to CreateConfigurationSet must also be reachable through
+        // the ListTagsForResource endpoint, not just GET configuration-sets/{name}.
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "ConfigurationSetName": "v2-cs-tag-roundtrip",
+                  "Tags": [
+                    {"Key": "team", "Value": "platform"},
+                    {"Key": "env", "Value": "stg"}
+                  ]
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(200);
+
+        String arn = "arn:aws:ses:us-east-1:000000000000:configuration-set/v2-cs-tag-roundtrip";
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+        .when()
+            .get("/v2/email/tags")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(2))
+            .body("Tags.find { it.Key == 'team' }.Value", equalTo("platform"))
+            .body("Tags.find { it.Key == 'env' }.Value", equalTo("stg"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesTagsV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesTagsV2IntegrationTest.java
@@ -1,0 +1,280 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Integration tests for the SES V2 tag endpoints
+ * (TagResource / UntagResource / ListTagsForResource at /v2/email/tags).
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesTagsV2IntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/ses/aws4_request";
+
+    @Test
+    @Order(1)
+    void tags_lifecycle_onConfigurationSet() {
+        // Seed: create a configuration set we can tag against
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"ConfigurationSetName": "tag-cs-1"}
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(200);
+
+        String arn = "arn:aws:ses:us-east-1:000000000000:configuration-set/tag-cs-1";
+
+        // Initially empty
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+        .when()
+            .get("/v2/email/tags")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(0));
+
+        // TagResource
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"ResourceArn": "%s", "Tags": [
+                  {"Key": "env", "Value": "dev"},
+                  {"Key": "owner", "Value": "alice"}
+                ]}
+                """.formatted(arn))
+        .when()
+            .post("/v2/email/tags")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+        .when()
+            .get("/v2/email/tags")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(2))
+            .body("Tags.find { it.Key == 'env' }.Value", equalTo("dev"))
+            .body("Tags.find { it.Key == 'owner' }.Value", equalTo("alice"));
+
+        // TagResource on existing key replaces value (merge semantics)
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"ResourceArn": "%s", "Tags": [
+                  {"Key": "env", "Value": "prod"}
+                ]}
+                """.formatted(arn))
+        .when()
+            .post("/v2/email/tags")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+        .when()
+            .get("/v2/email/tags")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(2))
+            .body("Tags.find { it.Key == 'env' }.Value", equalTo("prod"));
+
+        // UntagResource removes specific keys
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+            .queryParam("TagKeys", "env")
+        .when()
+            .delete("/v2/email/tags")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+        .when()
+            .get("/v2/email/tags")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(1))
+            .body("Tags[0].Key", equalTo("owner"));
+    }
+
+    @Test
+    @Order(2)
+    void tagResource_unknownConfigurationSet_returns404() {
+        String arn = "arn:aws:ses:us-east-1:000000000000:configuration-set/missing-cs";
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"ResourceArn": "%s", "Tags": [{"Key": "env", "Value": "dev"}]}
+                """.formatted(arn))
+        .when()
+            .post("/v2/email/tags")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(3)
+    void listTagsForResource_unsupportedResourceType_returns404() {
+        String arn = "arn:aws:ses:us-east-1:000000000000:identity/example.com";
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+        .when()
+            .get("/v2/email/tags")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(4)
+    void tagResource_invalidArn_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"ResourceArn": "not-an-arn", "Tags": [{"Key": "env", "Value": "dev"}]}
+                """)
+        .when()
+            .post("/v2/email/tags")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(5)
+    void tagResource_emptyTags_returns400() {
+        String arn = "arn:aws:ses:us-east-1:000000000000:configuration-set/tag-cs-1";
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"ResourceArn": "%s", "Tags": []}
+                """.formatted(arn))
+        .when()
+            .post("/v2/email/tags")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(6)
+    void untagResource_missingTagKeys_returns400() {
+        String arn = "arn:aws:ses:us-east-1:000000000000:configuration-set/tag-cs-1";
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+        .when()
+            .delete("/v2/email/tags")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(7)
+    void tagResource_arnMissingRegion_returns400() {
+        String arn = "arn:aws:ses::000000000000:configuration-set/tag-cs-1";
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"ResourceArn": "%s", "Tags": [{"Key": "k", "Value": "v"}]}
+                """.formatted(arn))
+        .when()
+            .post("/v2/email/tags")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(8)
+    void tagResource_nonSesArn_returns400() {
+        String arn = "arn:aws:s3:us-east-1:000000000000:bucket/my-bucket";
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"ResourceArn": "%s", "Tags": [{"Key": "k", "Value": "v"}]}
+                """.formatted(arn))
+        .when()
+            .post("/v2/email/tags")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(9)
+    void tagResource_arnRegionMismatch_returns400() {
+        // AWS rejects TagResource on ARN/signing region mismatch with BadRequestException
+        // ("Failed to tag resource"). The behaviour differs from UntagResource, which
+        // routes the lookup to the ARN's region and surfaces NotFoundException instead.
+        String arn = "arn:aws:ses:eu-west-1:000000000000:configuration-set/tag-cs-1";
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"ResourceArn": "%s", "Tags": [{"Key": "k", "Value": "v"}]}
+                """.formatted(arn))
+        .when()
+            .post("/v2/email/tags")
+        .then()
+            .statusCode(400)
+            .body(containsString("Failed to tag resource"));
+    }
+
+    @Test
+    @Order(10)
+    void untagResource_arnRegionMismatch_returns404() {
+        // tag-cs-1 exists in us-east-1 but the ARN points to eu-west-1, so AWS
+        // returns NotFoundException with the resource-specific message.
+        String arn = "arn:aws:ses:eu-west-1:000000000000:configuration-set/tag-cs-1";
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+            .queryParam("TagKeys", "k")
+        .when()
+            .delete("/v2/email/tags")
+        .then()
+            .statusCode(404)
+            .body(containsString("No ConfigurationSet present with name: tag-cs-1"));
+    }
+
+    @Test
+    @Order(11)
+    void tagResource_invalidConfigurationSetName_returns400() {
+        // Whitespace in configuration-set name fails configSetKey validation,
+        // which is remapped from InvalidParameterValue -> BadRequestException at the controller.
+        String arn = "arn:aws:ses:us-east-1:000000000000:configuration-set/has spaces";
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"ResourceArn": "%s", "Tags": [{"Key": "k", "Value": "v"}]}
+                """.formatted(arn))
+        .when()
+            .post("/v2/email/tags")
+        .then()
+            .statusCode(400);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the v2 SES tag endpoints at `/v2/email/tags`:

- `POST /v2/email/tags` — `TagResource`
- `DELETE /v2/email/tags?ResourceArn=...&TagKeys=...` — `UntagResource`
- `GET /v2/email/tags?ResourceArn=...` — `ListTagsForResource`

Initial scope covers ConfigurationSet ARNs only (`arn:aws:ses:<region>:<account>:configuration-set/<name>`). Identity / EmailTemplate / other taggable resource types return `NotFoundException`, leaving follow-up PRs to extend coverage. ARN parsing reuses `AwsArnUtils`.

Behaviour aligned with observed AWS responses: `TagResource` enforces ARN/signing region match and rejects mismatches with `BadRequestException` ("Failed to tag resource"); `UntagResource` / `ListTagsForResource` route lookups to the ARN's region so a mismatch surfaces as `NotFoundException` with the resource-specific message ("No ConfigurationSet present with name: ..."). Empty `Tags` / `TagKeys` lists return `BadRequestException`. TagResource merges by key (existing keys replaced); UntagResource silently skips keys not present.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against AWS Java SDK v2 `2.42.24` (`software.amazon.awssdk:sesv2`). New compatibility test `SesTagResourceTest` exercises:

- `SesV2Client.tagResource` / `untagResource` / `listTagsForResource` against a ConfigurationSet
- Merge-replace semantics, removal by key, and `NotFoundException` on unknown ARNs

Region asymmetry, validation errors, and AWS-canonical error messages were verified against real AWS via `aws sesv2 ...` CLI calls and reflected in `SesTagsV2IntegrationTest`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)