### PR TITLE
fix(apigateway): treat ANY method as wildcard for concrete HTTP methods (#710)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -242,6 +242,9 @@ public class ApiGatewayExecuteController {
 
         MethodConfig method = matched.getResourceMethods().get(httpMethod.toUpperCase());
         if (method == null) {
+            method = matched.getResourceMethods().get("ANY");
+        }
+        if (method == null) {
             return Response.status(405)
                     .entity(jsonMessage("Method Not Allowed"))
                     .type(MediaType.APPLICATION_JSON).build();

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayAnyMethodIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayAnyMethodIntegrationTest.java
@@ -1,0 +1,204 @@
+package io.github.hectorvent.floci.services.apigateway;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Verifies that a resource configured with HTTP method ANY matches concrete
+ * incoming HTTP methods (GET, POST, PUT, PATCH, DELETE).
+ *
+ * @see <a href="https://github.com/floci-io/floci/issues/710">Issue #710</a>
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayAnyMethodIntegrationTest {
+
+    private static String apiId;
+    private static String rootId;
+    private static String anyResourceId;
+    private static String getResourceId;
+    private static String deploymentId;
+
+    @Test @Order(1)
+    void createRestApi() {
+        apiId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"name\":\"any-method-test-api\"}")
+                .when().post("/restapis")
+                .then()
+                .statusCode(201)
+                .body("id", notNullValue())
+                .extract().path("id");
+    }
+
+    @Test @Order(2)
+    void setupAnyMethodMockIntegration() {
+        rootId = given()
+                .when().get("/restapis/" + apiId + "/resources")
+                .then()
+                .statusCode(200)
+                .extract().path("item[0].id");
+
+        anyResourceId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"pathPart\":\"any\"}")
+                .when().post("/restapis/" + apiId + "/resources/" + rootId)
+                .then()
+                .statusCode(201)
+                .extract().path("id");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"authorizationType\":\"NONE\"}")
+                .when().put("/restapis/" + apiId + "/resources/" + anyResourceId + "/methods/ANY")
+                .then()
+                .statusCode(201);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"responseParameters\":{}}")
+                .when().put("/restapis/" + apiId + "/resources/" + anyResourceId + "/methods/ANY/responses/200")
+                .then()
+                .statusCode(201);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"type\":\"MOCK\",\"requestTemplates\":{\"application/json\":\"{\\\"statusCode\\\": 200}\"}}")
+                .when().put("/restapis/" + apiId + "/resources/" + anyResourceId + "/methods/ANY/integration")
+                .then()
+                .statusCode(201);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"selectionPattern\":\"\",\"responseTemplates\":{\"application/json\":\"{\\\"matched\\\":\\\"any\\\"}\"}}")
+                .when().put("/restapis/" + apiId + "/resources/" + anyResourceId + "/methods/ANY/integration/responses/200")
+                .then()
+                .statusCode(201);
+    }
+
+    @Test @Order(3)
+    void setupConcreteGetResource() {
+        getResourceId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"pathPart\":\"get\"}")
+                .when().post("/restapis/" + apiId + "/resources/" + rootId)
+                .then()
+                .statusCode(201)
+                .extract().path("id");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"authorizationType\":\"NONE\"}")
+                .when().put("/restapis/" + apiId + "/resources/" + getResourceId + "/methods/GET")
+                .then()
+                .statusCode(201);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"responseParameters\":{}}")
+                .when().put("/restapis/" + apiId + "/resources/" + getResourceId + "/methods/GET/responses/200")
+                .then()
+                .statusCode(201);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"type\":\"MOCK\",\"requestTemplates\":{\"application/json\":\"{\\\"statusCode\\\": 200}\"}}")
+                .when().put("/restapis/" + apiId + "/resources/" + getResourceId + "/methods/GET/integration")
+                .then()
+                .statusCode(201);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"selectionPattern\":\"\",\"responseTemplates\":{\"application/json\":\"{\\\"matched\\\":\\\"get\\\"}\"}}")
+                .when().put("/restapis/" + apiId + "/resources/" + getResourceId + "/methods/GET/integration/responses/200")
+                .then()
+                .statusCode(201);
+    }
+
+    @Test @Order(4)
+    void createDeploymentAndStage() {
+        deploymentId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"description\":\"v1\"}")
+                .when().post("/restapis/" + apiId + "/deployments")
+                .then()
+                .statusCode(201)
+                .extract().path("id");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"stageName\":\"test\",\"deploymentId\":\"" + deploymentId + "\"}")
+                .when().post("/restapis/" + apiId + "/stages")
+                .then()
+                .statusCode(201);
+    }
+
+    @Test @Order(5)
+    void anyMethodMatchesGet() {
+        given()
+                .when().get("/execute-api/" + apiId + "/test/any")
+                .then()
+                .statusCode(200)
+                .body("matched", equalTo("any"));
+    }
+
+    @Test @Order(6)
+    void anyMethodMatchesPost() {
+        given()
+                .contentType(ContentType.JSON)
+                .when().post("/execute-api/" + apiId + "/test/any")
+                .then()
+                .statusCode(200)
+                .body("matched", equalTo("any"));
+    }
+
+    @Test @Order(7)
+    void anyMethodMatchesPut() {
+        given()
+                .contentType(ContentType.JSON)
+                .when().put("/execute-api/" + apiId + "/test/any")
+                .then()
+                .statusCode(200)
+                .body("matched", equalTo("any"));
+    }
+
+    @Test @Order(8)
+    void anyMethodMatchesPatch() {
+        given()
+                .contentType(ContentType.JSON)
+                .when().patch("/execute-api/" + apiId + "/test/any")
+                .then()
+                .statusCode(200)
+                .body("matched", equalTo("any"));
+    }
+
+    @Test @Order(9)
+    void anyMethodMatchesDelete() {
+        given()
+                .when().delete("/execute-api/" + apiId + "/test/any")
+                .then()
+                .statusCode(200)
+                .body("matched", equalTo("any"));
+    }
+
+    @Test @Order(10)
+    void concreteMethodStillWorks() {
+        given()
+                .when().get("/execute-api/" + apiId + "/test/get")
+                .then()
+                .statusCode(200)
+                .body("matched", equalTo("get"));
+    }
+
+    @Test @Order(11)
+    void cleanup() {
+        given().when().delete("/restapis/" + apiId).then().statusCode(202);
+    }
+}


### PR DESCRIPTION
## Summary

- ApiGatewayExecuteController looked up the incoming HTTP verb exactly against the resource's configured methods. A resource configured with ANY returned 405 Method Not Allowed for all concrete requests (GET, POST, PUT, PATCH, DELETE).
- Fixed by falling back to ANY before returning 405.
- Added ApiGatewayAnyMethodIntegrationTest covering all five HTTP methods against an ANY configured resource, plus a control case confirming concrete method routes are unaffected.

Closes #710

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore


## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
