### PR TITLE
fix(sqs): drop uppercase "Tags" read from CreateQueue JSON handler

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
@@ -66,10 +66,7 @@ public class SqsJsonHandler {
     private Response handleCreateQueue(JsonNode request, String region) {
         String queueName = request.path("QueueName").asText(null);
         Map<String, String> attributes = jsonNodeToMap(request.path("Attributes"));
-        // Botocore sends "tags" (lowercase) for CreateQueue but "Tags" (uppercase) for TagQueue.
-        // Merge both to handle any client regardless of casing.
-        Map<String, String> tags = new HashMap<>(jsonNodeToMap(request.path("Tags")));
-        tags.putAll(jsonNodeToMap(request.path("tags")));
+        Map<String, String> tags = jsonNodeToMap(request.path("tags"));
         Queue queue = sqsService.createQueue(queueName, attributes, tags, region);
 
         ObjectNode response = objectMapper.createObjectNode();

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
@@ -297,6 +297,82 @@ class SqsIntegrationTest {
     }
 
     @Test
+    void createQueue_jsonProtocol_withLowercaseTags_tagsReturnedByListQueueTags() {
+        // SQS JSON 1.0 schema uses lowercase "tags" for CreateQueue (cf. uppercase "Tags" for TagQueue).
+        String taggedQueueName = "tagged-queue-json-integration-test";
+
+        String taggedQueueUrl = given()
+            .contentType("application/x-amz-json-1.0")
+            .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+            .body("{\"QueueName\": \"" + taggedQueueName + "\", \"tags\": {\"k1\": \"v1\", \"k2\": \"v2\"}}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().jsonPath().getString("QueueUrl");
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ListQueueTags")
+            .formParam("QueueUrl", taggedQueueUrl)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("k1"))
+            .body(containsString("v1"))
+            .body(containsString("k2"))
+            .body(containsString("v2"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DeleteQueue")
+            .formParam("QueueUrl", taggedQueueUrl)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    void createQueue_jsonProtocol_withUppercaseTags_tagsAreIgnored() {
+        // SQS JSON 1.0 only defines lowercase "tags" for CreateQueue; uppercase "Tags" belongs to
+        // TagQueue and must be treated as an unknown field here, matching real AWS.
+        String taggedQueueName = "ignored-uppercase-tags-queue";
+
+        String taggedQueueUrl = given()
+            .contentType("application/x-amz-json-1.0")
+            .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+            .body("{\"QueueName\": \"" + taggedQueueName + "\", \"Tags\": {\"k1\": \"v1\"}}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().jsonPath().getString("QueueUrl");
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ListQueueTags")
+            .formParam("QueueUrl", taggedQueueUrl)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(not(containsString("<Tag>")))
+            .body(not(containsString("k1")))
+            .body(not(containsString("v1")));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DeleteQueue")
+            .formParam("QueueUrl", taggedQueueUrl)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
     void unsupportedAction() {
         given()
             .contentType("application/x-www-form-urlencoded")

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
@@ -272,28 +272,27 @@ class SqsIntegrationTest {
             .body(containsString(taggedQueueName))
             .extract().xmlPath().getString("CreateQueueResponse.CreateQueueResult.QueueUrl");
 
-        given()
-            .contentType("application/x-www-form-urlencoded")
-            .formParam("Action", "ListQueueTags")
-            .formParam("QueueUrl", taggedQueueUrl)
-        .when()
-            .post("/")
-        .then()
-            .statusCode(200)
-            .body(containsString("k1"))
-            .body(containsString("v1"))
-            .body(containsString("k2"))
-            .body(containsString("v2"));
-
-        // cleanup
-        given()
-            .contentType("application/x-www-form-urlencoded")
-            .formParam("Action", "DeleteQueue")
-            .formParam("QueueUrl", taggedQueueUrl)
-        .when()
-            .post("/")
-        .then()
-            .statusCode(200);
+        try {
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "ListQueueTags")
+                .formParam("QueueUrl", taggedQueueUrl)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("k1"))
+                .body(containsString("v1"))
+                .body(containsString("k2"))
+                .body(containsString("v2"));
+        } finally {
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "DeleteQueue")
+                .formParam("QueueUrl", taggedQueueUrl)
+            .when()
+                .post("/");
+        }
     }
 
     @Test
@@ -311,27 +310,27 @@ class SqsIntegrationTest {
             .statusCode(200)
             .extract().jsonPath().getString("QueueUrl");
 
-        given()
-            .contentType("application/x-www-form-urlencoded")
-            .formParam("Action", "ListQueueTags")
-            .formParam("QueueUrl", taggedQueueUrl)
-        .when()
-            .post("/")
-        .then()
-            .statusCode(200)
-            .body(containsString("k1"))
-            .body(containsString("v1"))
-            .body(containsString("k2"))
-            .body(containsString("v2"));
-
-        given()
-            .contentType("application/x-www-form-urlencoded")
-            .formParam("Action", "DeleteQueue")
-            .formParam("QueueUrl", taggedQueueUrl)
-        .when()
-            .post("/")
-        .then()
-            .statusCode(200);
+        try {
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "ListQueueTags")
+                .formParam("QueueUrl", taggedQueueUrl)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("k1"))
+                .body(containsString("v1"))
+                .body(containsString("k2"))
+                .body(containsString("v2"));
+        } finally {
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "DeleteQueue")
+                .formParam("QueueUrl", taggedQueueUrl)
+            .when()
+                .post("/");
+        }
     }
 
     @Test
@@ -350,26 +349,26 @@ class SqsIntegrationTest {
             .statusCode(200)
             .extract().jsonPath().getString("QueueUrl");
 
-        given()
-            .contentType("application/x-www-form-urlencoded")
-            .formParam("Action", "ListQueueTags")
-            .formParam("QueueUrl", taggedQueueUrl)
-        .when()
-            .post("/")
-        .then()
-            .statusCode(200)
-            .body(not(containsString("<Tag>")))
-            .body(not(containsString("k1")))
-            .body(not(containsString("v1")));
-
-        given()
-            .contentType("application/x-www-form-urlencoded")
-            .formParam("Action", "DeleteQueue")
-            .formParam("QueueUrl", taggedQueueUrl)
-        .when()
-            .post("/")
-        .then()
-            .statusCode(200);
+        try {
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "ListQueueTags")
+                .formParam("QueueUrl", taggedQueueUrl)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(not(containsString("<Tag>")))
+                .body(not(containsString("k1")))
+                .body(not(containsString("v1")));
+        } finally {
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "DeleteQueue")
+                .formParam("QueueUrl", taggedQueueUrl)
+            .when()
+                .post("/");
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Follow-up to #747. The SQS JSON handler for `CreateQueue` was reading both `tags` (lowercase) and `Tags` (uppercase), merging the two. The SQS Smithy model only defines `tags` (lowercase) for `CreateQueueRequest` — uppercase `Tags` is the request shape for `TagQueueRequest`, a different action. Drop the defensive uppercase read so floci matches AWS field-name semantics.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** A client sending `{"QueueName": "...", "Tags": {...}}` (uppercase) to the JSON endpoint had its tags silently persisted by floci.

**Expected (AWS) behavior:** Real AWS treats unknown JSON fields as ignored, so the same uppercase `Tags` payload would result in no tags being attached. floci was more permissive than AWS, which masks client bugs only surfacing at migration time.

**Fixed behavior:** Only the canonical lowercase `tags` field is read for `CreateQueue`. Verified via two new JSON-protocol integration tests:
- `createQueue_jsonProtocol_withLowercaseTags_tagsReturnedByListQueueTags` — canonical lowercase path persists tags.
- `createQueue_jsonProtocol_withUppercaseTags_tagsAreIgnored` — uppercase `Tags` is treated as an unknown field.

No SDK clients are affected: botocore, aws-sdk-go, aws-sdk-java all send lowercase `tags` per the SQS Smithy model. The lowercase `tags` member name has existed in the SQS service model since the earliest commit in `aws-sdk-js-v3` (2021-10-19) — pre-dating JSON-1.0 protocol support — and has never changed. There was no historical era when uppercase `Tags` was the canonical wire name for `CreateQueue`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)