### PR TITLE
feat(ses): extend tag endpoints to v2 EmailTemplate ARNs

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesTagResourceTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesTagResourceTest.java
@@ -10,7 +10,12 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import software.amazon.awssdk.services.sesv2.SesV2Client;
 import software.amazon.awssdk.services.sesv2.model.CreateConfigurationSetRequest;
+import software.amazon.awssdk.services.sesv2.model.CreateEmailTemplateRequest;
 import software.amazon.awssdk.services.sesv2.model.DeleteConfigurationSetRequest;
+import software.amazon.awssdk.services.sesv2.model.DeleteEmailTemplateRequest;
+import software.amazon.awssdk.services.sesv2.model.EmailTemplateContent;
+import software.amazon.awssdk.services.sesv2.model.GetEmailTemplateRequest;
+import software.amazon.awssdk.services.sesv2.model.GetEmailTemplateResponse;
 import software.amazon.awssdk.services.sesv2.model.ListTagsForResourceRequest;
 import software.amazon.awssdk.services.sesv2.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.sesv2.model.NotFoundException;
@@ -30,12 +35,17 @@ class SesTagResourceTest {
     private static SesV2Client sesV2;
     private static String configSetName;
     private static String configSetArn;
+    private static String templateName;
+    private static String templateArn;
 
     @BeforeAll
     static void setup() {
         sesV2 = TestFixtures.sesV2Client();
-        configSetName = "sdk-tag-cs-" + TestFixtures.uniqueName();
+        String suffix = TestFixtures.uniqueName();
+        configSetName = "sdk-tag-cs-" + suffix;
         configSetArn = "arn:aws:ses:us-east-1:000000000000:configuration-set/" + configSetName;
+        templateName = "sdk-tag-tpl-" + suffix;
+        templateArn = "arn:aws:ses:us-east-1:000000000000:template/" + templateName;
 
         sesV2.createConfigurationSet(CreateConfigurationSetRequest.builder()
                 .configurationSetName(configSetName)
@@ -48,6 +58,10 @@ class SesTagResourceTest {
             try {
                 sesV2.deleteConfigurationSet(DeleteConfigurationSetRequest.builder()
                         .configurationSetName(configSetName).build());
+            } catch (Exception ignored) {}
+            try {
+                sesV2.deleteEmailTemplate(DeleteEmailTemplateRequest.builder()
+                        .templateName(templateName).build());
             } catch (Exception ignored) {}
             sesV2.close();
         }
@@ -126,5 +140,53 @@ class SesTagResourceTest {
                 .tags(Tag.builder().key("k").value("v").build())
                 .build()))
                 .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @Order(10)
+    void emailTemplate_createWithTags_visibleViaListTagsAndGet() {
+        sesV2.createEmailTemplate(CreateEmailTemplateRequest.builder()
+                .templateName(templateName)
+                .templateContent(EmailTemplateContent.builder()
+                        .subject("S").text("T").build())
+                .tags(
+                        Tag.builder().key("env").value("dev").build(),
+                        Tag.builder().key("team").value("platform").build())
+                .build());
+
+        // ListTagsForResource sees the create-time tags
+        ListTagsForResourceResponse listed = sesV2.listTagsForResource(ListTagsForResourceRequest.builder()
+                .resourceArn(templateArn).build());
+        assertThat(listed.tags()).hasSize(2);
+
+        // GetEmailTemplate also surfaces them
+        GetEmailTemplateResponse got = sesV2.getEmailTemplate(GetEmailTemplateRequest.builder()
+                .templateName(templateName).build());
+        assertThat(got.tags())
+                .extracting(Tag::key)
+                .containsExactlyInAnyOrder("env", "team");
+    }
+
+    @Test
+    @Order(11)
+    void emailTemplate_tagAndUntag_lifecycle() {
+        sesV2.tagResource(TagResourceRequest.builder()
+                .resourceArn(templateArn)
+                .tags(Tag.builder().key("owner").value("alice").build())
+                .build());
+
+        ListTagsForResourceResponse afterTag = sesV2.listTagsForResource(ListTagsForResourceRequest.builder()
+                .resourceArn(templateArn).build());
+        assertThat(afterTag.tags()).hasSize(3);
+
+        sesV2.untagResource(UntagResourceRequest.builder()
+                .resourceArn(templateArn)
+                .tagKeys("env", "team")
+                .build());
+
+        ListTagsForResourceResponse afterUntag = sesV2.listTagsForResource(ListTagsForResourceRequest.builder()
+                .resourceArn(templateArn).build());
+        assertThat(afterUntag.tags()).hasSize(1);
+        assertThat(afterUntag.tags().get(0).key()).isEqualTo("owner");
     }
 }

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -200,6 +200,6 @@ Alongside the classic Query API, Floci implements a subset of the SES v2 REST JS
 | `DELETE` | `/v2/email/tags?ResourceArn=...&TagKeys=...` | `UntagResource` |
 | `GET` | `/v2/email/tags?ResourceArn=...` | `ListTagsForResource` |
 
-Tag operations currently support `arn:aws:ses:<region>:<account>:configuration-set/<name>` ARNs. Other resource types return `NotFoundException`.
+Tag operations currently support `arn:aws:ses:<region>:<account>:configuration-set/<name>` and `arn:aws:ses:<region>:<account>:template/<name>` ARNs. Tags supplied to `CreateConfigurationSet` and `CreateEmailTemplate` are reachable through `ListTagsForResource`; `UpdateEmailTemplate` does not modify tags. Other resource types return `NotFoundException`.
 
 Identity, template, configuration-set, and sent-message state is shared between the v1 Query API and the v2 REST JSON API, so a template created with `CreateTemplate` resolves through `SendEmail` on v2 (and vice versa), a configuration set created with `CreateConfigurationSet` is visible to both `DescribeConfigurationSet` (v1) and `GetConfigurationSet` (v2), and every send appears in the same `GET /_aws/ses` inspection mailbox.

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
+import io.github.hectorvent.floci.services.ses.model.Tag;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -459,6 +460,10 @@ public class SesController {
                 throw new AwsException("BadRequestException", "TemplateName is required.", 400);
             }
             EmailTemplate template = parseTemplateContent(templateName, request.path("TemplateContent"));
+            List<Tag> parsedTags = parseTagsArray(request.path("Tags"));
+            if (parsedTags != null) {
+                template.setTags(parsedTags);
+            }
             sesService.createTemplate(template, region);
             LOG.infov("SES V2 CreateEmailTemplate: {0}", templateName);
             return Response.ok(objectMapper.createObjectNode()).build();
@@ -576,19 +581,9 @@ public class SesController {
                 throw new AwsException("BadRequestException", "ConfigurationSetName is required.", 400);
             }
             ConfigurationSet cs = new ConfigurationSet(name);
-            JsonNode tags = request.get("Tags");
-            if (tags != null && !tags.isNull()) {
-                if (!tags.isArray()) {
-                    throw new AwsException("BadRequestException",
-                            "Tags must be an array.", 400);
-                }
-                List<ConfigurationSet.Tag> tagList = new ArrayList<>();
-                for (JsonNode t : tags) {
-                    tagList.add(new ConfigurationSet.Tag(
-                            t.path("Key").asText(null),
-                            t.path("Value").asText(null)));
-                }
-                cs.setTags(tagList);
+            List<Tag> parsedTags = parseTagsArray(request.path("Tags"));
+            if (parsedTags != null) {
+                cs.setTags(parsedTags);
             }
             sesService.createConfigurationSet(cs, region);
             LOG.infov("SES V2 CreateConfigurationSet: {0}", name);
@@ -623,7 +618,7 @@ public class SesController {
             ObjectNode result = objectMapper.createObjectNode();
             result.put("ConfigurationSetName", cs.getName());
             ArrayNode tags = result.putArray("Tags");
-            for (ConfigurationSet.Tag t : cs.getTags()) {
+            for (Tag t : cs.getTags()) {
                 ObjectNode tagNode = objectMapper.createObjectNode();
                 tagNode.put("Key", t.key());
                 tagNode.put("Value", t.value());
@@ -707,15 +702,9 @@ public class SesController {
             if (arn == null || arn.isBlank()) {
                 throw new AwsException("BadRequestException", "ResourceArn is required.", 400);
             }
-            JsonNode tagsNode = request.path("Tags");
-            if (!tagsNode.isArray()) {
+            List<Tag> tags = parseTagsArray(request.path("Tags"));
+            if (tags == null) {
                 throw new AwsException("BadRequestException", "Tags must be an array.", 400);
-            }
-            List<ConfigurationSet.Tag> tags = new ArrayList<>();
-            for (JsonNode t : tagsNode) {
-                String key = t.path("Key").asText(null);
-                String value = t.path("Value").asText(null);
-                tags.add(new ConfigurationSet.Tag(key, value));
             }
             sesService.tagResource(arn, region, tags);
             LOG.infov("SES V2 TagResource: {0}", arn);
@@ -729,10 +718,12 @@ public class SesController {
 
     @DELETE
     @Path("/tags")
-    public Response untagResource(@QueryParam("ResourceArn") String arn,
+    public Response untagResource(@Context HttpHeaders headers,
+                                   @QueryParam("ResourceArn") String arn,
                                    @QueryParam("TagKeys") List<String> tagKeys) {
+        String region = regionResolver.resolveRegion(headers);
         try {
-            sesService.untagResource(arn, tagKeys);
+            sesService.untagResource(arn, region, tagKeys);
             LOG.infov("SES V2 UntagResource: {0}", arn);
             return Response.ok(objectMapper.createObjectNode()).build();
         } catch (AwsException e) {
@@ -742,12 +733,14 @@ public class SesController {
 
     @GET
     @Path("/tags")
-    public Response listTagsForResource(@QueryParam("ResourceArn") String arn) {
+    public Response listTagsForResource(@Context HttpHeaders headers,
+                                         @QueryParam("ResourceArn") String arn) {
+        String region = regionResolver.resolveRegion(headers);
         try {
-            List<ConfigurationSet.Tag> tags = sesService.listResourceTags(arn);
+            List<Tag> tags = sesService.listResourceTags(arn, region);
             ObjectNode result = objectMapper.createObjectNode();
             ArrayNode arr = result.putArray("Tags");
-            for (ConfigurationSet.Tag t : tags) {
+            for (Tag t : tags) {
                 ObjectNode tagNode = objectMapper.createObjectNode();
                 tagNode.put("Key", t.key());
                 tagNode.put("Value", t.value());
@@ -867,6 +860,13 @@ public class SesController {
         if (template.getHtmlPart() != null) {
             content.put("Html", template.getHtmlPart());
         }
+        ArrayNode tags = result.putArray("Tags");
+        for (Tag t : template.getTags()) {
+            ObjectNode tagNode = objectMapper.createObjectNode();
+            tagNode.put("Key", t.key());
+            tagNode.put("Value", t.value());
+            tags.add(tagNode);
+        }
         return result;
     }
 
@@ -921,6 +921,28 @@ public class SesController {
                     fieldName + " must be a JSON object.", 400);
         }
         return child;
+    }
+
+    /**
+     * Parse a JSON {@code Tags} array node into a list of tag records. Returns {@code null}
+     * when the node is missing or null so callers can decide whether that is an error
+     * (TagResource) or a no-op (CreateConfigurationSet / CreateEmailTemplate). Throws
+     * {@code BadRequestException} when the node is present but not an array.
+     */
+    private List<Tag> parseTagsArray(JsonNode tagsNode) {
+        if (tagsNode.isMissingNode() || tagsNode.isNull()) {
+            return null;
+        }
+        if (!tagsNode.isArray()) {
+            throw new AwsException("BadRequestException", "Tags must be an array.", 400);
+        }
+        List<Tag> out = new ArrayList<>();
+        for (JsonNode t : tagsNode) {
+            out.add(new Tag(
+                    t.path("Key").asText(null),
+                    t.path("Value").asText(null)));
+        }
+        return out;
     }
 
     private static AwsException remapV1Exception(AwsException e) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -10,6 +10,7 @@ import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.SentEmail;
+import io.github.hectorvent.floci.services.ses.model.Tag;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -358,6 +359,11 @@ public class SesService {
 
     public EmailTemplate createTemplate(EmailTemplate template, String region) {
         validateTemplate(template);
+        if (template.getTags() != null) {
+            for (Tag tag : template.getTags()) {
+                validateTag(tag);
+            }
+        }
         String key = templateKey(region, template.getTemplateName());
         if (templateStore.get(key).isPresent()) {
             throw new AwsException("AlreadyExists",
@@ -385,6 +391,8 @@ public class SesService {
                         "Template " + template.getTemplateName() + " does not exist.", 400));
         template.setCreatedTimestamp(existing.getCreatedTimestamp());
         template.setLastUpdatedTimestamp(Instant.now());
+        // Tags are managed exclusively via Tag/UntagResource — preserve them on update.
+        template.setTags(existing.getTags());
         templateStore.put(key, template);
         LOG.infov("Updated SES template: {0} in region {1}", template.getTemplateName(), region);
         return template;
@@ -417,7 +425,7 @@ public class SesService {
         }
         String key = configSetKey(region, configSet.getName());
         if (configSet.getTags() != null) {
-            for (ConfigurationSet.Tag tag : configSet.getTags()) {
+            for (Tag tag : configSet.getTags()) {
                 validateTag(tag);
             }
         }
@@ -478,16 +486,20 @@ public class SesService {
         }
     }
 
-    public List<ConfigurationSet.Tag> listResourceTags(String arn) {
+    public List<Tag> listResourceTags(String arn, String region) {
         ResourceRef ref = parseSesArn(arn);
         return switch (ref.type()) {
             case "configuration-set" -> listConfigurationSetTags(ref.name(), ref.region());
+            // AWS ListTagsForResource on template ARNs uses the signing region for lookup
+            // (the ARN region is effectively ignored), unlike configuration-set which routes
+            // by the ARN's region.
+            case "template" -> listEmailTemplateTags(ref.name(), region);
             default -> throw new AwsException("NotFoundException",
                     "Resource " + arn + " was not found.", 404);
         };
     }
 
-    public void tagResource(String arn, String region, List<ConfigurationSet.Tag> newTags) {
+    public void tagResource(String arn, String region, List<Tag> newTags) {
         ResourceRef ref = parseSesArn(arn);
         if (!ref.region().equals(region)) {
             throw new AwsException("BadRequestException", "Failed to tag resource", 400);
@@ -497,17 +509,18 @@ public class SesService {
                     "1 validation error detected: Value at 'tags' failed to satisfy constraint: "
                             + "Member must have length greater than or equal to 1", 400);
         }
-        for (ConfigurationSet.Tag t : newTags) {
+        for (Tag t : newTags) {
             validateTag(t);
         }
         switch (ref.type()) {
             case "configuration-set" -> tagConfigurationSet(ref.name(), ref.region(), newTags);
+            case "template" -> tagEmailTemplate(ref.name(), ref.region(), newTags);
             default -> throw new AwsException("NotFoundException",
                     "Resource " + arn + " was not found.", 404);
         }
     }
 
-    public void untagResource(String arn, List<String> tagKeys) {
+    public void untagResource(String arn, String region, List<String> tagKeys) {
         ResourceRef ref = parseSesArn(arn);
         if (tagKeys == null || tagKeys.isEmpty()) {
             throw new AwsException("BadRequestException",
@@ -516,33 +529,33 @@ public class SesService {
         }
         switch (ref.type()) {
             case "configuration-set" -> untagConfigurationSet(ref.name(), ref.region(), tagKeys);
+            case "template" -> {
+                // AWS UntagResource on template ARNs strictly requires the ARN region to match
+                // the signing region (rejects mismatch with BadRequestException), unlike
+                // configuration-set which routes the lookup to the ARN's region.
+                if (!ref.region().equals(region)) {
+                    throw new AwsException("BadRequestException", "Failed to untag resource", 400);
+                }
+                untagEmailTemplate(ref.name(), region, tagKeys);
+            }
             default -> throw new AwsException("NotFoundException",
                     "Resource " + arn + " was not found.", 404);
         }
     }
 
-    private List<ConfigurationSet.Tag> listConfigurationSetTags(String name, String region) {
+    private List<Tag> listConfigurationSetTags(String name, String region) {
         ConfigurationSet cs = configSetStore.get(configSetKey(region, name))
                 .orElseThrow(() -> new AwsException("NotFoundException",
                         "No ConfigurationSet present with name: " + name, 404));
         return new ArrayList<>(cs.getTags());
     }
 
-    private void tagConfigurationSet(String name, String region, List<ConfigurationSet.Tag> newTags) {
+    private void tagConfigurationSet(String name, String region, List<Tag> newTags) {
         String key = configSetKey(region, name);
         ConfigurationSet cs = configSetStore.get(key)
                 .orElseThrow(() -> new AwsException("NotFoundException",
                         "No ConfigurationSet present with name: " + name, 404));
-        Map<String, String> merged = new LinkedHashMap<>();
-        for (ConfigurationSet.Tag t : cs.getTags()) {
-            merged.put(t.key(), t.value());
-        }
-        for (ConfigurationSet.Tag t : newTags) {
-            merged.put(t.key(), t.value());
-        }
-        List<ConfigurationSet.Tag> out = new ArrayList<>();
-        merged.forEach((k, v) -> out.add(new ConfigurationSet.Tag(k, v)));
-        cs.setTags(out);
+        cs.setTags(mergeTags(cs.getTags(), newTags));
         configSetStore.put(key, cs);
         LOG.infov("Tagged SES configuration set: {0} (region {1}, +{2} tags)", name, region, newTags.size());
     }
@@ -556,6 +569,48 @@ public class SesService {
         cs.getTags().removeIf(t -> toRemove.contains(t.key()));
         configSetStore.put(key, cs);
         LOG.infov("Untagged SES configuration set: {0} (region {1}, -{2} keys)", name, region, tagKeys.size());
+    }
+
+    private List<Tag> listEmailTemplateTags(String name, String region) {
+        EmailTemplate template = templateStore.get(templateKey(region, name))
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "No Template present with name: " + name, 404));
+        return new ArrayList<>(template.getTags());
+    }
+
+    private void tagEmailTemplate(String name, String region, List<Tag> newTags) {
+        String key = templateKey(region, name);
+        EmailTemplate template = templateStore.get(key)
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "No Template present with name: " + name, 404));
+        template.setTags(mergeTags(template.getTags(), newTags));
+        templateStore.put(key, template);
+        LOG.infov("Tagged SES template: {0} (region {1}, +{2} tags)", name, region, newTags.size());
+    }
+
+    private static List<Tag> mergeTags(List<Tag> existing,
+                                                         List<Tag> incoming) {
+        Map<String, String> merged = new LinkedHashMap<>();
+        for (Tag t : existing) {
+            merged.put(t.key(), t.value());
+        }
+        for (Tag t : incoming) {
+            merged.put(t.key(), t.value());
+        }
+        List<Tag> out = new ArrayList<>();
+        merged.forEach((k, v) -> out.add(new Tag(k, v)));
+        return out;
+    }
+
+    private void untagEmailTemplate(String name, String region, List<String> tagKeys) {
+        String key = templateKey(region, name);
+        EmailTemplate template = templateStore.get(key)
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "No Template present with name: " + name, 404));
+        Set<String> toRemove = new HashSet<>(tagKeys);
+        template.getTags().removeIf(t -> toRemove.contains(t.key()));
+        templateStore.put(key, template);
+        LOG.infov("Untagged SES template: {0} (region {1}, -{2} keys)", name, region, tagKeys.size());
     }
 
     private record ResourceRef(String region, String type, String name) {}
@@ -586,7 +641,7 @@ public class SesService {
         return new ResourceRef(parsed.region(), resource.substring(0, slash), resource.substring(slash + 1));
     }
 
-    static void validateTag(ConfigurationSet.Tag tag) {
+    static void validateTag(Tag tag) {
         if (tag == null) {
             throw new AwsException("InvalidParameterValue", "Tag must not be null.", 400);
         }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/ConfigurationSet.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/ConfigurationSet.java
@@ -36,10 +36,4 @@ public class ConfigurationSet {
 
     public List<Tag> getTags() { return tags; }
     public void setTags(List<Tag> tags) { this.tags = tags != null ? tags : new ArrayList<>(); }
-
-    @RegisterForReflection
-    public record Tag(
-            @JsonProperty("Key") String key,
-            @JsonProperty("Value") String value) {
-    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/EmailTemplate.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/EmailTemplate.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 @RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -27,6 +29,9 @@ public class EmailTemplate {
 
     @JsonProperty("LastUpdatedTimestamp")
     private Instant lastUpdatedTimestamp;
+
+    @JsonProperty("Tags")
+    private List<Tag> tags = new ArrayList<>();
 
     public EmailTemplate() {}
 
@@ -54,4 +59,7 @@ public class EmailTemplate {
 
     public Instant getLastUpdatedTimestamp() { return lastUpdatedTimestamp; }
     public void setLastUpdatedTimestamp(Instant lastUpdatedTimestamp) { this.lastUpdatedTimestamp = lastUpdatedTimestamp; }
+
+    public List<Tag> getTags() { return tags; }
+    public void setTags(List<Tag> tags) { this.tags = tags != null ? tags : new ArrayList<>(); }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/Tag.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/Tag.java
@@ -1,0 +1,10 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public record Tag(
+        @JsonProperty("Key") String key,
+        @JsonProperty("Value") String value) {
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesTagsV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesTagsV2IntegrationTest.java
@@ -120,6 +120,98 @@ class SesTagsV2IntegrationTest {
 
     @Test
     @Order(2)
+    void tags_lifecycle_onEmailTemplate() {
+        // Seed: create an email template we can tag against
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "TemplateName": "tag-tpl-1",
+                  "TemplateContent": {"Subject": "S", "Text": "T"}
+                }
+                """)
+        .when()
+            .post("/v2/email/templates")
+        .then()
+            .statusCode(200);
+
+        String arn = "arn:aws:ses:us-east-1:000000000000:template/tag-tpl-1";
+
+        // Initially empty
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+        .when()
+            .get("/v2/email/tags")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(0));
+
+        // Tag the template
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"ResourceArn": "%s", "Tags": [
+                  {"Key": "env", "Value": "stg"},
+                  {"Key": "owner", "Value": "alice"}
+                ]}
+                """.formatted(arn))
+        .when()
+            .post("/v2/email/tags")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+        .when()
+            .get("/v2/email/tags")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(2));
+
+        // Remove a key
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+            .queryParam("TagKeys", "env")
+        .when()
+            .delete("/v2/email/tags")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+        .when()
+            .get("/v2/email/tags")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(1))
+            .body("Tags[0].Key", equalTo("owner"));
+    }
+
+    @Test
+    @Order(3)
+    void tagResource_unknownEmailTemplate_returns404() {
+        String arn = "arn:aws:ses:us-east-1:000000000000:template/missing-tpl";
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"ResourceArn": "%s", "Tags": [{"Key": "env", "Value": "dev"}]}
+                """.formatted(arn))
+        .when()
+            .post("/v2/email/tags")
+        .then()
+            .statusCode(404)
+            .body(containsString("No Template present with name: missing-tpl"));
+    }
+
+    @Test
+    @Order(4)
     void tagResource_unknownConfigurationSet_returns404() {
         String arn = "arn:aws:ses:us-east-1:000000000000:configuration-set/missing-cs";
         given()
@@ -135,7 +227,7 @@ class SesTagsV2IntegrationTest {
     }
 
     @Test
-    @Order(3)
+    @Order(5)
     void listTagsForResource_unsupportedResourceType_returns404() {
         String arn = "arn:aws:ses:us-east-1:000000000000:identity/example.com";
         given()
@@ -148,7 +240,7 @@ class SesTagsV2IntegrationTest {
     }
 
     @Test
-    @Order(4)
+    @Order(6)
     void tagResource_invalidArn_returns400() {
         given()
             .contentType("application/json")
@@ -163,7 +255,7 @@ class SesTagsV2IntegrationTest {
     }
 
     @Test
-    @Order(5)
+    @Order(7)
     void tagResource_emptyTags_returns400() {
         String arn = "arn:aws:ses:us-east-1:000000000000:configuration-set/tag-cs-1";
         given()
@@ -179,7 +271,7 @@ class SesTagsV2IntegrationTest {
     }
 
     @Test
-    @Order(6)
+    @Order(8)
     void untagResource_missingTagKeys_returns400() {
         String arn = "arn:aws:ses:us-east-1:000000000000:configuration-set/tag-cs-1";
         given()
@@ -192,7 +284,7 @@ class SesTagsV2IntegrationTest {
     }
 
     @Test
-    @Order(7)
+    @Order(9)
     void tagResource_arnMissingRegion_returns400() {
         String arn = "arn:aws:ses::000000000000:configuration-set/tag-cs-1";
         given()
@@ -208,7 +300,7 @@ class SesTagsV2IntegrationTest {
     }
 
     @Test
-    @Order(8)
+    @Order(10)
     void tagResource_nonSesArn_returns400() {
         String arn = "arn:aws:s3:us-east-1:000000000000:bucket/my-bucket";
         given()
@@ -224,7 +316,7 @@ class SesTagsV2IntegrationTest {
     }
 
     @Test
-    @Order(9)
+    @Order(11)
     void tagResource_arnRegionMismatch_returns400() {
         // AWS rejects TagResource on ARN/signing region mismatch with BadRequestException
         // ("Failed to tag resource"). The behaviour differs from UntagResource, which
@@ -244,7 +336,7 @@ class SesTagsV2IntegrationTest {
     }
 
     @Test
-    @Order(10)
+    @Order(12)
     void untagResource_arnRegionMismatch_returns404() {
         // tag-cs-1 exists in us-east-1 but the ARN points to eu-west-1, so AWS
         // returns NotFoundException with the resource-specific message.
@@ -261,7 +353,7 @@ class SesTagsV2IntegrationTest {
     }
 
     @Test
-    @Order(11)
+    @Order(13)
     void tagResource_invalidConfigurationSetName_returns400() {
         // Whitespace in configuration-set name fails configSetKey validation,
         // which is remapped from InvalidParameterValue -> BadRequestException at the controller.
@@ -276,5 +368,43 @@ class SesTagsV2IntegrationTest {
             .post("/v2/email/tags")
         .then()
             .statusCode(400);
+    }
+
+    @Test
+    @Order(14)
+    void untagResource_template_arnRegionMismatch_returns400() {
+        // For template ARNs AWS rejects UntagResource on signing/ARN region mismatch with
+        // BadRequestException ("Failed to untag resource"), unlike ConfigurationSet which
+        // routes the lookup to the ARN's region and surfaces NotFound instead.
+        String arn = "arn:aws:ses:eu-west-1:000000000000:template/tag-tpl-1";
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+            .queryParam("TagKeys", "k")
+        .when()
+            .delete("/v2/email/tags")
+        .then()
+            .statusCode(400)
+            .body(containsString("Failed to untag resource"));
+    }
+
+    @Test
+    @Order(15)
+    void listTagsForResource_template_arnRegionIgnored_usesSigningRegion() {
+        // For template ARNs AWS ignores the ARN region for ListTagsForResource and
+        // resolves the template against the signing region instead. The seeded
+        // tag-tpl-1 lives in us-east-1 and was left with a single "owner=alice" tag
+        // by the lifecycle case at @Order(2); an eu-west-1 ARN must still surface it.
+        String arn = "arn:aws:ses:eu-west-1:000000000000:template/tag-tpl-1";
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+        .when()
+            .get("/v2/email/tags")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(1))
+            .body("Tags[0].Key", equalTo("owner"))
+            .body("Tags[0].Value", equalTo("alice"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesTemplateV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesTemplateV2IntegrationTest.java
@@ -551,6 +551,88 @@ class SesTemplateV2IntegrationTest {
             .statusCode(200);
     }
 
+    @Test
+    @Order(21)
+    void createEmailTemplate_withTags_visibleViaGet() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "TemplateName": "tpl-with-tags",
+                  "TemplateContent": {
+                    "Subject": "S",
+                    "Text": "T"
+                  },
+                  "Tags": [
+                    {"Key": "env", "Value": "stg"},
+                    {"Key": "team", "Value": "platform"}
+                  ]
+                }
+                """)
+        .when()
+            .post("/v2/email/templates")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/templates/tpl-with-tags")
+        .then()
+            .statusCode(200)
+            .body("TemplateName", equalTo("tpl-with-tags"))
+            .body("Tags.find { it.Key == 'env' }.Value", equalTo("stg"))
+            .body("Tags.find { it.Key == 'team' }.Value", equalTo("platform"));
+    }
+
+    @Test
+    @Order(22)
+    void createEmailTemplate_withTags_visibleViaListTagsForResource() {
+        // tpl-with-tags is created in @Order(21) above
+        String arn = "arn:aws:ses:us-east-1:000000000000:template/tpl-with-tags";
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+        .when()
+            .get("/v2/email/tags")
+        .then()
+            .statusCode(200)
+            .body("Tags.find { it.Key == 'env' }.Value", equalTo("stg"))
+            .body("Tags.find { it.Key == 'team' }.Value", equalTo("platform"));
+    }
+
+    @Test
+    @Order(23)
+    void updateEmailTemplate_preservesTags() {
+        // tpl-with-tags has 2 tags from @Order(21)
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "TemplateContent": {
+                    "Subject": "S2",
+                    "Text": "T2"
+                  }
+                }
+                """)
+        .when()
+            .put("/v2/email/templates/tpl-with-tags")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/templates/tpl-with-tags")
+        .then()
+            .statusCode(200)
+            .body("TemplateContent.Subject", equalTo("S2"))
+            .body("Tags.find { it.Key == 'env' }.Value", equalTo("stg"))
+            .body("Tags.find { it.Key == 'team' }.Value", equalTo("platform"));
+    }
+
     @ParameterizedTest(name = "{0}")
     @MethodSource("malformedSendEmailBodies")
     @Order(50)


### PR DESCRIPTION
## Summary

Extends the v2 SES tag endpoints (`/v2/email/tags`) to support `arn:aws:ses:<region>:<account>:template/<name>` ARNs, in addition to the previously-supported ConfigurationSet ARNs. Behaviour was verified against real AWS via `aws sesv2 ...` and aligned where it diverged.

- `EmailTemplate` gains a `tags` field; `CreateEmailTemplate` accepts an optional `Tags` array and validates entries via the existing `validateTag()` helper.
- `UpdateEmailTemplate` intentionally preserves the existing tags so that AWS-style "tags only mutated via Tag/UntagResource" semantics hold.
- `GetEmailTemplate` response surfaces stored tags.
- Missing templates return `NotFoundException` with the AWS-canonical `No Template present with name: <name>` message (AWS uses the bare "Template", not "EmailTemplate", for tag-endpoint lookups even though the SDK type is `EmailTemplate`).
- `UntagResource` on a template ARN strictly validates ARN/signing region match and rejects mismatches with `BadRequestException` ("Failed to untag resource"). ConfigurationSet's lenient ARN-region lookup is intentionally NOT applied here — AWS treats the two resource types asymmetrically for `UntagResource`.
- `ListTagsForResource` on a template ARN ignores the ARN region and resolves the template against the signing region (an eu-west-1 ARN surfaces tags of the us-east-1 template if signed in us-east-1).

Identity and other taggable resource types remain unsupported and return `NotFoundException`; follow-up PRs can extend coverage further.

The PR also includes three small refactors that fall out naturally from adding a second taggable resource:

- `Tag` is promoted from `ConfigurationSet.Tag` to a top-level `services/ses/model/Tag` so that EmailTemplate and the shared helpers no longer reference a Configuration-scoped name. JSON serialization is unchanged.
- A private `mergeTags(existing, incoming)` helper centralizes the LinkedHashMap merge previously duplicated between `tagConfigurationSet` and `tagEmailTemplate`.
- A private `parseTagsArray(JsonNode)` helper centralizes the JSON `Tags` array parse previously duplicated across `createConfigurationSet`, `createEmailTemplate`, and `tagResource`. The helper returns `null` for missing/null nodes; the required caller (`tagResource`) treats `null` as `BadRequestException`.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against AWS Java SDK v2 `2.42.24` (`software.amazon.awssdk:sesv2`) and AWS CLI v2 against real AWS. The compatibility test `SesTagResourceTest` is extended to cover:

- `CreateEmailTemplate` with `Tags` → both `GetEmailTemplate` and `ListTagsForResource` see the same tag set
- `TagResource` / `UntagResource` lifecycle against a template ARN

Region-mismatch asymmetry between Tag (strict) / Untag (strict for template, lenient for ConfigurationSet) / List (signing-region-based for template) is exercised in `SesTagsV2IntegrationTest`. `UpdateEmailTemplate`-preserves-tags is asserted in `SesTemplateV2IntegrationTest`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)