### PR TITLE
feat(ses): extend tag endpoints to v2 EmailIdentity ARNs

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesTagResourceTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesTagResourceTest.java
@@ -10,10 +10,14 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import software.amazon.awssdk.services.sesv2.SesV2Client;
 import software.amazon.awssdk.services.sesv2.model.CreateConfigurationSetRequest;
+import software.amazon.awssdk.services.sesv2.model.CreateEmailIdentityRequest;
 import software.amazon.awssdk.services.sesv2.model.CreateEmailTemplateRequest;
 import software.amazon.awssdk.services.sesv2.model.DeleteConfigurationSetRequest;
+import software.amazon.awssdk.services.sesv2.model.DeleteEmailIdentityRequest;
 import software.amazon.awssdk.services.sesv2.model.DeleteEmailTemplateRequest;
 import software.amazon.awssdk.services.sesv2.model.EmailTemplateContent;
+import software.amazon.awssdk.services.sesv2.model.GetEmailIdentityRequest;
+import software.amazon.awssdk.services.sesv2.model.GetEmailIdentityResponse;
 import software.amazon.awssdk.services.sesv2.model.GetEmailTemplateRequest;
 import software.amazon.awssdk.services.sesv2.model.GetEmailTemplateResponse;
 import software.amazon.awssdk.services.sesv2.model.ListTagsForResourceRequest;
@@ -37,6 +41,8 @@ class SesTagResourceTest {
     private static String configSetArn;
     private static String templateName;
     private static String templateArn;
+    private static String identityValue;
+    private static String identityArn;
 
     @BeforeAll
     static void setup() {
@@ -46,6 +52,8 @@ class SesTagResourceTest {
         configSetArn = "arn:aws:ses:us-east-1:000000000000:configuration-set/" + configSetName;
         templateName = "sdk-tag-tpl-" + suffix;
         templateArn = "arn:aws:ses:us-east-1:000000000000:template/" + templateName;
+        identityValue = "sdk-tag-id-" + suffix + "@example.com";
+        identityArn = "arn:aws:ses:us-east-1:000000000000:identity/" + identityValue;
 
         sesV2.createConfigurationSet(CreateConfigurationSetRequest.builder()
                 .configurationSetName(configSetName)
@@ -62,6 +70,10 @@ class SesTagResourceTest {
             try {
                 sesV2.deleteEmailTemplate(DeleteEmailTemplateRequest.builder()
                         .templateName(templateName).build());
+            } catch (Exception ignored) {}
+            try {
+                sesV2.deleteEmailIdentity(DeleteEmailIdentityRequest.builder()
+                        .emailIdentity(identityValue).build());
             } catch (Exception ignored) {}
             sesV2.close();
         }
@@ -186,6 +198,50 @@ class SesTagResourceTest {
 
         ListTagsForResourceResponse afterUntag = sesV2.listTagsForResource(ListTagsForResourceRequest.builder()
                 .resourceArn(templateArn).build());
+        assertThat(afterUntag.tags()).hasSize(1);
+        assertThat(afterUntag.tags().get(0).key()).isEqualTo("owner");
+    }
+
+    @Test
+    @Order(20)
+    void emailIdentity_createWithTags_visibleViaListTagsAndGet() {
+        sesV2.createEmailIdentity(CreateEmailIdentityRequest.builder()
+                .emailIdentity(identityValue)
+                .tags(
+                        Tag.builder().key("env").value("dev").build(),
+                        Tag.builder().key("team").value("platform").build())
+                .build());
+
+        ListTagsForResourceResponse listed = sesV2.listTagsForResource(ListTagsForResourceRequest.builder()
+                .resourceArn(identityArn).build());
+        assertThat(listed.tags()).hasSize(2);
+
+        GetEmailIdentityResponse got = sesV2.getEmailIdentity(GetEmailIdentityRequest.builder()
+                .emailIdentity(identityValue).build());
+        assertThat(got.tags())
+                .extracting(Tag::key)
+                .containsExactlyInAnyOrder("env", "team");
+    }
+
+    @Test
+    @Order(21)
+    void emailIdentity_tagAndUntag_lifecycle() {
+        sesV2.tagResource(TagResourceRequest.builder()
+                .resourceArn(identityArn)
+                .tags(Tag.builder().key("owner").value("alice").build())
+                .build());
+
+        ListTagsForResourceResponse afterTag = sesV2.listTagsForResource(ListTagsForResourceRequest.builder()
+                .resourceArn(identityArn).build());
+        assertThat(afterTag.tags()).hasSize(3);
+
+        sesV2.untagResource(UntagResourceRequest.builder()
+                .resourceArn(identityArn)
+                .tagKeys("env", "team")
+                .build());
+
+        ListTagsForResourceResponse afterUntag = sesV2.listTagsForResource(ListTagsForResourceRequest.builder()
+                .resourceArn(identityArn).build());
         assertThat(afterUntag.tags()).hasSize(1);
         assertThat(afterUntag.tags().get(0).key()).isEqualTo("owner");
     }

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -200,6 +200,6 @@ Alongside the classic Query API, Floci implements a subset of the SES v2 REST JS
 | `DELETE` | `/v2/email/tags?ResourceArn=...&TagKeys=...` | `UntagResource` |
 | `GET` | `/v2/email/tags?ResourceArn=...` | `ListTagsForResource` |
 
-Tag operations currently support `arn:aws:ses:<region>:<account>:configuration-set/<name>` and `arn:aws:ses:<region>:<account>:template/<name>` ARNs. Tags supplied to `CreateConfigurationSet` and `CreateEmailTemplate` are reachable through `ListTagsForResource`; `UpdateEmailTemplate` does not modify tags. Other resource types return `NotFoundException`.
+Tag operations support these ARN forms: `arn:aws:ses:<region>:<account>:configuration-set/<name>`, `arn:aws:ses:<region>:<account>:template/<name>`, and `arn:aws:ses:<region>:<account>:identity/<email-or-domain>`. Tags supplied to `CreateConfigurationSet`, `CreateEmailTemplate`, and `CreateEmailIdentity` are reachable through `ListTagsForResource`; `UpdateEmailTemplate` does not modify tags. Other resource types return `NotFoundException`.
 
 Identity, template, configuration-set, and sent-message state is shared between the v1 Query API and the v2 REST JSON API, so a template created with `CreateTemplate` resolves through `SendEmail` on v2 (and vice versa), a configuration set created with `CreateConfigurationSet` is visible to both `DescribeConfigurationSet` (v1) and `GetConfigurationSet` (v2), and every send appears in the same `GET /_aws/ses` inspection mailbox.

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -83,6 +83,12 @@ public class SesController {
                     ? sesService.verifyEmailIdentity(emailIdentity, region)
                     : sesService.verifyDomainIdentity(emailIdentity, region);
 
+            List<Tag> parsedTags = parseTagsArray(request.path("Tags"));
+            if (parsedTags != null) {
+                sesService.setIdentityTags(emailIdentity, region, parsedTags);
+                identity.setTags(parsedTags);
+            }
+
             ObjectNode result = objectMapper.createObjectNode();
             result.put("IdentityType", toV2IdentityType(identity.getIdentityType()));
             result.put("VerifiedForSendingStatus", true);
@@ -773,7 +779,13 @@ public class SesController {
                 v1BehaviorToV2(identity.getBehaviorOnMxFailure()));
 
         result.putObject("Policies");
-        result.putArray("Tags");
+        ArrayNode tags = result.putArray("Tags");
+        for (Tag t : identity.getTags()) {
+            ObjectNode tagNode = objectMapper.createObjectNode();
+            tagNode.put("Key", t.key());
+            tagNode.put("Value", t.value());
+            tags.add(tagNode);
+        }
 
         return result;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -86,7 +86,6 @@ public class SesController {
             List<Tag> parsedTags = parseTagsArray(request.path("Tags"));
             if (parsedTags != null) {
                 sesService.setIdentityTags(emailIdentity, region, parsedTags);
-                identity.setTags(parsedTags);
             }
 
             ObjectNode result = objectMapper.createObjectNode();

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -490,10 +490,11 @@ public class SesService {
         ResourceRef ref = parseSesArn(arn);
         return switch (ref.type()) {
             case "configuration-set" -> listConfigurationSetTags(ref.name(), ref.region());
-            // AWS ListTagsForResource on template ARNs uses the signing region for lookup
-            // (the ARN region is effectively ignored), unlike configuration-set which routes
-            // by the ARN's region.
+            // AWS ListTagsForResource on template / identity ARNs uses the signing region
+            // for lookup (the ARN region is effectively ignored), unlike configuration-set
+            // which routes by the ARN's region.
             case "template" -> listEmailTemplateTags(ref.name(), region);
+            case "identity" -> listIdentityTags(ref.name(), region);
             default -> throw new AwsException("NotFoundException",
                     "Resource " + arn + " was not found.", 404);
         };
@@ -515,6 +516,7 @@ public class SesService {
         switch (ref.type()) {
             case "configuration-set" -> tagConfigurationSet(ref.name(), ref.region(), newTags);
             case "template" -> tagEmailTemplate(ref.name(), ref.region(), newTags);
+            case "identity" -> tagIdentity(ref.name(), ref.region(), newTags);
             default -> throw new AwsException("NotFoundException",
                     "Resource " + arn + " was not found.", 404);
         }
@@ -530,13 +532,20 @@ public class SesService {
         switch (ref.type()) {
             case "configuration-set" -> untagConfigurationSet(ref.name(), ref.region(), tagKeys);
             case "template" -> {
-                // AWS UntagResource on template ARNs strictly requires the ARN region to match
-                // the signing region (rejects mismatch with BadRequestException), unlike
-                // configuration-set which routes the lookup to the ARN's region.
+                // AWS UntagResource on template / identity ARNs strictly requires the ARN
+                // region to match the signing region (rejects mismatch with
+                // BadRequestException), unlike configuration-set which routes the lookup
+                // to the ARN's region.
                 if (!ref.region().equals(region)) {
                     throw new AwsException("BadRequestException", "Failed to untag resource", 400);
                 }
                 untagEmailTemplate(ref.name(), region, tagKeys);
+            }
+            case "identity" -> {
+                if (!ref.region().equals(region)) {
+                    throw new AwsException("BadRequestException", "Failed to untag resource", 400);
+                }
+                untagIdentity(ref.name(), region, tagKeys);
             }
             default -> throw new AwsException("NotFoundException",
                     "Resource " + arn + " was not found.", 404);
@@ -600,6 +609,48 @@ public class SesService {
         List<Tag> out = new ArrayList<>();
         merged.forEach((k, v) -> out.add(new Tag(k, v)));
         return out;
+    }
+
+    private List<Tag> listIdentityTags(String identityValue, String region) {
+        Identity identity = identityStore.get(identityKey(region, identityValue))
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "No EmailIdentity present with name: " + identityValue, 404));
+        return new ArrayList<>(identity.getTags());
+    }
+
+    private void tagIdentity(String identityValue, String region, List<Tag> newTags) {
+        String key = identityKey(region, identityValue);
+        Identity identity = identityStore.get(key)
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "No EmailIdentity present with name: " + identityValue, 404));
+        identity.setTags(mergeTags(identity.getTags(), newTags));
+        identityStore.put(key, identity);
+        LOG.infov("Tagged SES identity: {0} (region {1}, +{2} tags)", identityValue, region, newTags.size());
+    }
+
+    private void untagIdentity(String identityValue, String region, List<String> tagKeys) {
+        String key = identityKey(region, identityValue);
+        Identity identity = identityStore.get(key)
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "No EmailIdentity present with name: " + identityValue, 404));
+        Set<String> toRemove = new HashSet<>(tagKeys);
+        identity.getTags().removeIf(t -> toRemove.contains(t.key()));
+        identityStore.put(key, identity);
+        LOG.infov("Untagged SES identity: {0} (region {1}, -{2} keys)", identityValue, region, tagKeys.size());
+    }
+
+    public void setIdentityTags(String identityValue, String region, List<Tag> tags) {
+        if (tags != null) {
+            for (Tag tag : tags) {
+                validateTag(tag);
+            }
+        }
+        String key = identityKey(region, identityValue);
+        Identity identity = identityStore.get(key)
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "No EmailIdentity present with name: " + identityValue, 404));
+        identity.setTags(tags);
+        identityStore.put(key, identity);
     }
 
     private void untagEmailTemplate(String name, String region, List<String> tagKeys) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/Identity.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/Identity.java
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RegisterForReflection
@@ -50,6 +52,9 @@ public class Identity {
 
     @JsonProperty("CreatedAt")
     private Instant createdAt;
+
+    @JsonProperty("Tags")
+    private List<Tag> tags = new ArrayList<>();
 
     public Identity() {}
 
@@ -101,4 +106,7 @@ public class Identity {
 
     public Instant getCreatedAt() { return createdAt; }
     public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
+    public List<Tag> getTags() { return tags; }
+    public void setTags(List<Tag> tags) { this.tags = tags != null ? tags : new ArrayList<>(); }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesIdentityAttributesV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesIdentityAttributesV2IntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 @QuarkusTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -317,5 +318,48 @@ class SesIdentityAttributesV2IntegrationTest {
             .body("__type", equalTo("NotFoundException"))
             .body("message", equalTo(
                     "Email identity ghost-delete.floci.test does not exist."));
+    }
+
+    @Test
+    @Order(25)
+    void createEmailIdentity_withTags_visibleViaGetAndListTags() {
+        // Tags supplied to CreateEmailIdentity must round-trip through GetEmailIdentity
+        // and ListTagsForResource (template/configuration-set behaviour parallel).
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                    "EmailIdentity": "v2-tag-roundtrip.floci.test",
+                    "Tags": [
+                        {"Key": "team", "Value": "platform"},
+                        {"Key": "env", "Value": "stg"}
+                    ]
+                }
+                """)
+        .when()
+            .post("/v2/email/identities")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/identities/v2-tag-roundtrip.floci.test")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(2))
+            .body("Tags.find { it.Key == 'team' }.Value", equalTo("platform"))
+            .body("Tags.find { it.Key == 'env' }.Value", equalTo("stg"));
+
+        String arn = "arn:aws:ses:us-east-1:000000000000:identity/v2-tag-roundtrip.floci.test";
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+        .when()
+            .get("/v2/email/tags")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(2));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesIdentityAttributesV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesIdentityAttributesV2IntegrationTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.TestMethodOrder;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
 
 @QuarkusTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -318,48 +317,5 @@ class SesIdentityAttributesV2IntegrationTest {
             .body("__type", equalTo("NotFoundException"))
             .body("message", equalTo(
                     "Email identity ghost-delete.floci.test does not exist."));
-    }
-
-    @Test
-    @Order(25)
-    void createEmailIdentity_withTags_visibleViaGetAndListTags() {
-        // Tags supplied to CreateEmailIdentity must round-trip through GetEmailIdentity
-        // and ListTagsForResource (template/configuration-set behaviour parallel).
-        given()
-            .contentType("application/json")
-            .header("Authorization", AUTH_HEADER)
-            .body("""
-                {
-                    "EmailIdentity": "v2-tag-roundtrip.floci.test",
-                    "Tags": [
-                        {"Key": "team", "Value": "platform"},
-                        {"Key": "env", "Value": "stg"}
-                    ]
-                }
-                """)
-        .when()
-            .post("/v2/email/identities")
-        .then()
-            .statusCode(200);
-
-        given()
-            .header("Authorization", AUTH_HEADER)
-        .when()
-            .get("/v2/email/identities/v2-tag-roundtrip.floci.test")
-        .then()
-            .statusCode(200)
-            .body("Tags", hasSize(2))
-            .body("Tags.find { it.Key == 'team' }.Value", equalTo("platform"))
-            .body("Tags.find { it.Key == 'env' }.Value", equalTo("stg"));
-
-        String arn = "arn:aws:ses:us-east-1:000000000000:identity/v2-tag-roundtrip.floci.test";
-        given()
-            .header("Authorization", AUTH_HEADER)
-            .queryParam("ResourceArn", arn)
-        .when()
-            .get("/v2/email/tags")
-        .then()
-            .statusCode(200)
-            .body("Tags", hasSize(2));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesTagsV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesTagsV2IntegrationTest.java
@@ -407,4 +407,127 @@ class SesTagsV2IntegrationTest {
             .body("Tags[0].Key", equalTo("owner"))
             .body("Tags[0].Value", equalTo("alice"));
     }
+
+    @Test
+    @Order(16)
+    void tags_lifecycle_onEmailIdentity() {
+        // Seed: create an email identity we can tag against
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailIdentity": "tag-id-1@example.com"}
+                """)
+        .when()
+            .post("/v2/email/identities")
+        .then()
+            .statusCode(200);
+
+        String arn = "arn:aws:ses:us-east-1:000000000000:identity/tag-id-1@example.com";
+
+        // Initially empty
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+        .when()
+            .get("/v2/email/tags")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(0));
+
+        // Tag it
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"ResourceArn": "%s", "Tags": [
+                  {"Key": "env", "Value": "stg"},
+                  {"Key": "owner", "Value": "alice"}
+                ]}
+                """.formatted(arn))
+        .when()
+            .post("/v2/email/tags")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+        .when()
+            .get("/v2/email/tags")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(2));
+
+        // Untag a key
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+            .queryParam("TagKeys", "env")
+        .when()
+            .delete("/v2/email/tags")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+        .when()
+            .get("/v2/email/tags")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(1))
+            .body("Tags[0].Key", equalTo("owner"));
+    }
+
+    @Test
+    @Order(17)
+    void tagResource_unknownEmailIdentity_returns404() {
+        String arn = "arn:aws:ses:us-east-1:000000000000:identity/missing-id@example.com";
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"ResourceArn": "%s", "Tags": [{"Key": "env", "Value": "dev"}]}
+                """.formatted(arn))
+        .when()
+            .post("/v2/email/tags")
+        .then()
+            .statusCode(404)
+            .body(containsString("No EmailIdentity present with name: missing-id@example.com"));
+    }
+
+    @Test
+    @Order(18)
+    void untagResource_identity_arnRegionMismatch_returns400() {
+        // Identity follows the same strict region check as templates for UntagResource.
+        String arn = "arn:aws:ses:eu-west-1:000000000000:identity/tag-id-1@example.com";
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+            .queryParam("TagKeys", "k")
+        .when()
+            .delete("/v2/email/tags")
+        .then()
+            .statusCode(400)
+            .body(containsString("Failed to untag resource"));
+    }
+
+    @Test
+    @Order(19)
+    void listTagsForResource_identity_arnRegionIgnored_usesSigningRegion() {
+        // tag-id-1 lives in us-east-1 and was left with a single "owner=alice" tag by
+        // the lifecycle case at @Order(16); an eu-west-1 ARN must still surface it.
+        String arn = "arn:aws:ses:eu-west-1:000000000000:identity/tag-id-1@example.com";
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+        .when()
+            .get("/v2/email/tags")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(1))
+            .body("Tags[0].Key", equalTo("owner"))
+            .body("Tags[0].Value", equalTo("alice"));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
@@ -329,6 +329,49 @@ class SesV2IntegrationTest {
             .body("message", containsString("leading or trailing whitespace"));
     }
 
+    @Test
+    @Order(15)
+    void createEmailIdentity_withTags_visibleViaGetAndListTags() {
+        // Tags supplied to CreateEmailIdentity must round-trip through GetEmailIdentity
+        // and ListTagsForResource (template/configuration-set behaviour parallel).
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                    "EmailIdentity": "v2-tag-roundtrip.floci.test",
+                    "Tags": [
+                        {"Key": "team", "Value": "platform"},
+                        {"Key": "env", "Value": "stg"}
+                    ]
+                }
+                """)
+        .when()
+            .post("/v2/email/identities")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/identities/v2-tag-roundtrip.floci.test")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(2))
+            .body("Tags.find { it.Key == 'team' }.Value", equalTo("platform"))
+            .body("Tags.find { it.Key == 'env' }.Value", equalTo("stg"));
+
+        String arn = "arn:aws:ses:us-east-1:000000000000:identity/v2-tag-roundtrip.floci.test";
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("ResourceArn", arn)
+        .when()
+            .get("/v2/email/tags")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(2));
+    }
+
     // ──────────────── DKIM Attributes ────────────────
 
     @Test


### PR DESCRIPTION
## Summary

Extends the v2 SES tag endpoints (`/v2/email/tags`) to support `arn:aws:ses:<region>:<account>:identity/<email-or-domain>` ARNs, in addition to the previously-supported ConfigurationSet and EmailTemplate ARNs.

Behaviour was verified against real AWS via `aws sesv2 ...` and matches the EmailTemplate routing exactly:

- `TagResource` enforces ARN/signing region match and rejects mismatches with `BadRequestException` ("Failed to tag resource").
- `UntagResource` strictly validates ARN/signing region match (`BadRequestException` "Failed to untag resource") rather than the lenient ARN-region lookup used for ConfigurationSet.
- `ListTagsForResource` ignores the ARN region and resolves the identity against the signing region.
- Missing identities return `NotFoundException` with the AWS-canonical `No EmailIdentity present with name: <identity>` message.

`Identity` gains a `tags` field. `CreateEmailIdentity` accepts an optional `Tags` array (validated via the existing `validateTag()` helper) and persists it on the freshly-verified Identity record. `GetEmailIdentity` surfaces stored tags in the existing `Tags` response field, which previously returned an empty array.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against AWS Java SDK v2 `2.42.24` (`software.amazon.awssdk:sesv2`) and AWS CLI v2 against real AWS. The compatibility test `SesTagResourceTest` is extended to cover:

- `CreateEmailIdentity` with `Tags` → both `GetEmailIdentity` and `ListTagsForResource` see the same tag set
- `TagResource` / `UntagResource` lifecycle against an identity ARN

Region-mismatch behaviour and the AWS-canonical error wording (`No EmailIdentity present with name: ...`) are exercised in `SesTagsV2IntegrationTest`. `CreateEmailIdentity`-with-Tags round-trip through `GetEmailIdentity` is asserted in `SesV2IntegrationTest` next to the other `createEmailIdentity_*` cases.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)