### PR TITLE
fix Lambda container networking when Floci runs in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,6 @@ docker run -d --name floci \
   -p 4566:4566 \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -e FLOCI_DEFAULT_REGION=us-east-1 \
-  -e FLOCI_SERVICES_LAMBDA_DOCKER_NETWORK=bridge \
   -u root \
   floci/floci:latest
 ```

--- a/docs/configuration/docker-compose.md
+++ b/docs/configuration/docker-compose.md
@@ -103,7 +103,7 @@ services:
 
 With this setting Floci returns URLs like `http://floci:4566/000000000000/my-queue` that other containers can reach.
 
-This also ensures that Lambda containers Floci spawns into your Compose network receive a reachable endpoint, and that response fields such as SQS `QueueUrl` use the Docker service name instead of `localhost`.
+Floci automatically attaches Lambda containers it spawns to the same Compose network when no explicit Docker network is configured. Setting `FLOCI_HOSTNAME` ensures those containers receive a reachable endpoint, and that response fields such as SQS `QueueUrl` use the Docker service name instead of `localhost`.
 
 Fields affected:
 

--- a/docs/configuration/docker.md
+++ b/docs/configuration/docker.md
@@ -103,6 +103,8 @@ floci:
 
 Containers spawned by Floci (Lambda, RDS, ElastiCache, OpenSearch, MSK, ECS) need to be on the same Docker network to communicate with each other and with Floci itself.
 
+When Floci itself runs inside Docker and no network is configured, it automatically detects the current container's Docker network and uses it for spawned containers. You only need to set this manually when you want to force a specific network.
+
 Set the shared network at the top level:
 
 ```yaml

--- a/docs/services/lambda.md
+++ b/docs/services/lambda.md
@@ -230,9 +230,10 @@ No extra configuration or `cap_add` is needed — Docker containers have
 non-root user) can bind UDP/53 without any changes to your Compose file.
 
 !!! tip "Docker Compose service names"
-    If Floci runs as a Docker Compose service and you attach Lambda containers
-    to that Compose network, set `FLOCI_HOSTNAME` to the service name, for
-    example `FLOCI_HOSTNAME=floci`. Floci then injects
+    If Floci runs as a Docker Compose service, set `FLOCI_HOSTNAME` to the
+    service name, for example `FLOCI_HOSTNAME=floci`. When no explicit Lambda
+    Docker network is configured, Floci automatically attaches Lambda
+    containers to the current Compose network. Floci then injects
     `AWS_ENDPOINT_URL=http://floci:4566` into Lambda containers and returns
     SQS `QueueUrl` values with the same reachable host.
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilder.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilder.java
@@ -38,13 +38,21 @@ public class ContainerBuilder {
     private final EmulatorConfig config;
     private final DockerHostResolver dockerHostResolver;
     private final EmbeddedDnsServer embeddedDnsServer;
+    private final CurrentContainerNetworkResolver currentContainerNetworkResolver;
 
     @Inject
     public ContainerBuilder(EmulatorConfig config, DockerHostResolver dockerHostResolver,
-                            EmbeddedDnsServer embeddedDnsServer) {
+                            EmbeddedDnsServer embeddedDnsServer,
+                            CurrentContainerNetworkResolver currentContainerNetworkResolver) {
         this.config = config;
         this.dockerHostResolver = dockerHostResolver;
         this.embeddedDnsServer = embeddedDnsServer;
+        this.currentContainerNetworkResolver = currentContainerNetworkResolver;
+    }
+
+    public ContainerBuilder(EmulatorConfig config, DockerHostResolver dockerHostResolver,
+                            EmbeddedDnsServer embeddedDnsServer) {
+        this(config, dockerHostResolver, embeddedDnsServer, null);
     }
 
     /**
@@ -54,7 +62,7 @@ public class ContainerBuilder {
      * @return a new Builder instance
      */
     public Builder newContainer(String image) {
-        return new Builder(image, config, dockerHostResolver, embeddedDnsServer);
+        return new Builder(image, config, dockerHostResolver, embeddedDnsServer, currentContainerNetworkResolver);
     }
 
     /**
@@ -65,6 +73,7 @@ public class ContainerBuilder {
         private final EmulatorConfig config;
         private final DockerHostResolver dockerHostResolver;
         private final EmbeddedDnsServer embeddedDnsServer;
+        private final CurrentContainerNetworkResolver currentContainerNetworkResolver;
 
         private String name;
         private final List<String> env = new ArrayList<>();
@@ -83,11 +92,13 @@ public class ContainerBuilder {
         private final List<String> dnsServers = new ArrayList<>();
 
         Builder(String image, EmulatorConfig config, DockerHostResolver dockerHostResolver,
-                EmbeddedDnsServer embeddedDnsServer) {
+                EmbeddedDnsServer embeddedDnsServer,
+                CurrentContainerNetworkResolver currentContainerNetworkResolver) {
             this.image = image;
             this.config = config;
             this.dockerHostResolver = dockerHostResolver;
             this.embeddedDnsServer = embeddedDnsServer;
+            this.currentContainerNetworkResolver = currentContainerNetworkResolver;
         }
 
         /**
@@ -202,10 +213,13 @@ public class ContainerBuilder {
          * This is the standard pattern for Floci container services.
          */
         public Builder withDockerNetwork(Optional<String> serviceNetwork) {
-            serviceNetwork
+            Optional<String> configuredNetwork = serviceNetwork
                     .or(() -> config.services().dockerNetwork())
                     .filter(n -> !n.isBlank())
-                    .ifPresent(n -> this.networkMode = n);
+                    .or(() -> currentContainerNetworkResolver != null
+                            ? currentContainerNetworkResolver.resolveNetworkName()
+                            : Optional.empty());
+            configuredNetwork.ifPresent(n -> this.networkMode = n);
             return this;
         }
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/CurrentContainerNetworkResolver.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/CurrentContainerNetworkResolver.java
@@ -1,0 +1,116 @@
+package io.github.hectorvent.floci.core.common.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.model.ContainerNetwork;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Resolves the Docker network used by the Floci container itself.
+ *
+ * <p>When Floci runs in Docker and launches sibling containers through the
+ * mounted Docker socket, those siblings must join the same Docker network to
+ * reach Floci's in-container Runtime API and service endpoints.
+ */
+@ApplicationScoped
+public class CurrentContainerNetworkResolver {
+
+    private static final Logger LOG = Logger.getLogger(CurrentContainerNetworkResolver.class);
+
+    private static final String HOSTNAME_FILE = "/etc/hostname";
+
+    private final DockerClient dockerClient;
+    private final ContainerDetector containerDetector;
+
+    private volatile Optional<CurrentContainerNetwork> cachedNetwork;
+
+    @Inject
+    public CurrentContainerNetworkResolver(DockerClient dockerClient, ContainerDetector containerDetector) {
+        this.dockerClient = dockerClient;
+        this.containerDetector = containerDetector;
+    }
+
+    public Optional<String> resolveNetworkName() {
+        return resolve().map(CurrentContainerNetwork::name);
+    }
+
+    public Optional<String> resolveContainerIp() {
+        return resolve().map(CurrentContainerNetwork::ipAddress);
+    }
+
+    Optional<CurrentContainerNetwork> resolve() {
+        Optional<CurrentContainerNetwork> cached = cachedNetwork;
+        if (cached != null) {
+            return cached;
+        }
+        cachedNetwork = detect();
+        return cachedNetwork;
+    }
+
+    private Optional<CurrentContainerNetwork> detect() {
+        if (!containerDetector.isRunningInContainer()) {
+            return Optional.empty();
+        }
+
+        String containerId = currentContainerId();
+        if (containerId.isBlank()) {
+            LOG.debug("Could not determine current Docker container id");
+            return Optional.empty();
+        }
+
+        try {
+            InspectContainerResponse inspect = dockerClient.inspectContainerCmd(containerId).exec();
+            Map<String, ContainerNetwork> networks = inspect.getNetworkSettings().getNetworks();
+            if (networks == null || networks.isEmpty()) {
+                return Optional.empty();
+            }
+
+            Optional<CurrentContainerNetwork> selected = selectNetwork(networks);
+            selected.ifPresent(network -> LOG.infov(
+                    "Detected current Docker network for spawned containers: {0} ({1})",
+                    network.name(), network.ipAddress()));
+            return selected;
+        } catch (Exception e) {
+            LOG.debugv("Could not inspect current Docker container {0}: {1}", containerId, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private Optional<CurrentContainerNetwork> selectNetwork(Map<String, ContainerNetwork> networks) {
+        return networks.entrySet().stream()
+                .filter(entry -> isUsable(entry.getValue()))
+                .filter(entry -> isUserDefinedNetwork(entry.getKey()))
+                .findFirst()
+                .or(() -> networks.entrySet().stream()
+                        .filter(entry -> isUsable(entry.getValue()))
+                        .findFirst())
+                .map(entry -> new CurrentContainerNetwork(entry.getKey(), entry.getValue().getIpAddress()));
+    }
+
+    private boolean isUsable(ContainerNetwork network) {
+        return network != null && network.getIpAddress() != null && !network.getIpAddress().isBlank();
+    }
+
+    private boolean isUserDefinedNetwork(String networkName) {
+        return !"bridge".equals(networkName) && !"host".equals(networkName) && !"none".equals(networkName);
+    }
+
+    String currentContainerId() {
+        try {
+            return Files.readString(Path.of(HOSTNAME_FILE)).trim();
+        } catch (Exception e) {
+            LOG.debugv("Could not read {0}: {1}", HOSTNAME_FILE, e.getMessage());
+            return "";
+        }
+    }
+
+    record CurrentContainerNetwork(String name, String ipAddress) {
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/DockerHostResolver.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/DockerHostResolver.java
@@ -24,11 +24,18 @@ public class DockerHostResolver {
     private final AtomicBoolean ufwHintLogged = new AtomicBoolean(false);
 
     private final ContainerDetector containerDetector;
+    private final CurrentContainerNetworkResolver currentContainerNetworkResolver;
 
     @Inject
-    public DockerHostResolver(EmulatorConfig config, ContainerDetector containerDetector) {
+    public DockerHostResolver(EmulatorConfig config, ContainerDetector containerDetector,
+                              CurrentContainerNetworkResolver currentContainerNetworkResolver) {
         this.config = config;
         this.containerDetector = containerDetector;
+        this.currentContainerNetworkResolver = currentContainerNetworkResolver;
+    }
+
+    public DockerHostResolver(EmulatorConfig config, ContainerDetector containerDetector) {
+        this(config, containerDetector, null);
     }
 
     public String resolve() {
@@ -39,6 +46,15 @@ public class DockerHostResolver {
         }
 
         if (containerDetector.isRunningInContainer()) {
+            if (currentContainerNetworkResolver != null) {
+                java.util.Optional<String> currentNetworkIp = currentContainerNetworkResolver.resolveContainerIp();
+                if (currentNetworkIp.isPresent()) {
+                    LOG.infov("Running in Docker — using current network IP for Runtime API: {0}",
+                            currentNetworkIp.get());
+                    return currentNetworkIp.get();
+                }
+            }
+
             // Use this container's own IP so Lambda containers on the same network
             // can reach the Runtime API server bound to all interfaces inside this container.
             try {

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilderTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilderTest.java
@@ -1,0 +1,72 @@
+package io.github.hectorvent.floci.core.common.docker;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.dns.EmbeddedDnsServer;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ContainerBuilderTest {
+
+    @Test
+    void withDockerNetwork_usesExplicitServiceNetworkFirst() {
+        TestFixture fixture = new TestFixture();
+        when(fixture.currentContainerNetworkResolver.resolveNetworkName()).thenReturn(Optional.of("compose_default"));
+
+        ContainerSpec spec = fixture.builder.newContainer("alpine")
+                .withDockerNetwork(Optional.of("lambda_network"))
+                .build();
+
+        assertEquals("lambda_network", spec.networkMode());
+    }
+
+    @Test
+    void withDockerNetwork_usesGlobalNetworkBeforeDetectedCurrentNetwork() {
+        TestFixture fixture = new TestFixture();
+        when(fixture.services.dockerNetwork()).thenReturn(Optional.of("global_network"));
+        when(fixture.currentContainerNetworkResolver.resolveNetworkName()).thenReturn(Optional.of("compose_default"));
+
+        ContainerSpec spec = fixture.builder.newContainer("alpine")
+                .withDockerNetwork(Optional.empty())
+                .build();
+
+        assertEquals("global_network", spec.networkMode());
+    }
+
+    @Test
+    void withDockerNetwork_inheritsCurrentContainerNetworkWhenNoConfigIsSet() {
+        TestFixture fixture = new TestFixture();
+        when(fixture.currentContainerNetworkResolver.resolveNetworkName()).thenReturn(Optional.of("avoxx-network"));
+
+        ContainerSpec spec = fixture.builder.newContainer("alpine")
+                .withDockerNetwork(Optional.empty())
+                .build();
+
+        assertEquals("avoxx-network", spec.networkMode());
+    }
+
+    private static class TestFixture {
+        final EmulatorConfig config = mock(EmulatorConfig.class);
+        final EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        final EmulatorConfig.DockerConfig docker = mock(EmulatorConfig.DockerConfig.class);
+        final DockerHostResolver dockerHostResolver = mock(DockerHostResolver.class);
+        final EmbeddedDnsServer embeddedDnsServer = mock(EmbeddedDnsServer.class);
+        final CurrentContainerNetworkResolver currentContainerNetworkResolver =
+                mock(CurrentContainerNetworkResolver.class);
+        final ContainerBuilder builder =
+                new ContainerBuilder(config, dockerHostResolver, embeddedDnsServer, currentContainerNetworkResolver);
+
+        TestFixture() {
+            when(config.services()).thenReturn(services);
+            when(services.dockerNetwork()).thenReturn(Optional.empty());
+            when(config.docker()).thenReturn(docker);
+            when(docker.logMaxSize()).thenReturn("10m");
+            when(docker.logMaxFile()).thenReturn("3");
+            when(embeddedDnsServer.getServerIp()).thenReturn(Optional.empty());
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/CurrentContainerNetworkResolverTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/CurrentContainerNetworkResolverTest.java
@@ -1,0 +1,82 @@
+package io.github.hectorvent.floci.core.common.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.InspectContainerCmd;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.model.ContainerNetwork;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CurrentContainerNetworkResolverTest {
+
+    @Test
+    void resolveNetworkName_prefersUserDefinedNetwork() {
+        DockerClient dockerClient = mock(DockerClient.class);
+        ContainerDetector containerDetector = mock(ContainerDetector.class);
+        when(containerDetector.isRunningInContainer()).thenReturn(true);
+
+        InspectContainerCmd inspectCmd = mock(InspectContainerCmd.class);
+        InspectContainerResponse inspect = mock(InspectContainerResponse.class, RETURNS_DEEP_STUBS);
+        Map<String, ContainerNetwork> networks = networks(
+                "bridge", "172.17.0.2",
+                "avoxx-network", "172.24.0.2");
+        when(dockerClient.inspectContainerCmd("floci-container")).thenReturn(inspectCmd);
+        when(inspectCmd.exec()).thenReturn(inspect);
+        when(inspect.getNetworkSettings().getNetworks()).thenReturn(networks);
+
+        CurrentContainerNetworkResolver resolver =
+                new TestResolver(dockerClient, containerDetector, "floci-container");
+
+        assertEquals(Optional.of("avoxx-network"), resolver.resolveNetworkName());
+        assertEquals(Optional.of("172.24.0.2"), resolver.resolveContainerIp());
+    }
+
+    @Test
+    void resolveNetworkName_returnsEmptyOutsideContainer() {
+        DockerClient dockerClient = mock(DockerClient.class);
+        ContainerDetector containerDetector = mock(ContainerDetector.class);
+        when(containerDetector.isRunningInContainer()).thenReturn(false);
+
+        CurrentContainerNetworkResolver resolver =
+                new TestResolver(dockerClient, containerDetector, "floci-container");
+
+        assertTrue(resolver.resolveNetworkName().isEmpty());
+    }
+
+    private static Map<String, ContainerNetwork> networks(String firstName, String firstIp,
+                                                          String secondName, String secondIp) {
+        Map<String, ContainerNetwork> networks = new LinkedHashMap<>();
+        networks.put(firstName, network(firstIp));
+        networks.put(secondName, network(secondIp));
+        return networks;
+    }
+
+    private static ContainerNetwork network(String ip) {
+        ContainerNetwork network = mock(ContainerNetwork.class);
+        when(network.getIpAddress()).thenReturn(ip);
+        return network;
+    }
+
+    private static class TestResolver extends CurrentContainerNetworkResolver {
+        private final String containerId;
+
+        TestResolver(DockerClient dockerClient, ContainerDetector containerDetector, String containerId) {
+            super(dockerClient, containerDetector);
+            this.containerId = containerId;
+        }
+
+        @Override
+        String currentContainerId() {
+            return containerId;
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/DockerHostResolverTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/DockerHostResolverTest.java
@@ -1,0 +1,34 @@
+package io.github.hectorvent.floci.core.common.docker;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DockerHostResolverTest {
+
+    @Test
+    void resolve_usesDetectedContainerNetworkIpWhenRunningInContainer() {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        ContainerDetector containerDetector = mock(ContainerDetector.class);
+        CurrentContainerNetworkResolver currentContainerNetworkResolver =
+                mock(CurrentContainerNetworkResolver.class);
+
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.LambdaServiceConfig lambda = mock(EmulatorConfig.LambdaServiceConfig.class);
+        when(config.services()).thenReturn(services);
+        when(services.lambda()).thenReturn(lambda);
+        when(lambda.dockerHostOverride()).thenReturn(Optional.empty());
+        when(containerDetector.isRunningInContainer()).thenReturn(true);
+        when(currentContainerNetworkResolver.resolveContainerIp()).thenReturn(Optional.of("172.24.0.2"));
+
+        DockerHostResolver resolver =
+                new DockerHostResolver(config, containerDetector, currentContainerNetworkResolver);
+
+        assertEquals("172.24.0.2", resolver.resolve());
+    }
+}


### PR DESCRIPTION
Automatically detect the Docker network of the running Floci container and use it for spawned containers when no explicit Docker network is configured. This lets Lambda containers reach Floci’s Runtime API in Docker Compose setups without requiring users to manually set FLOCI_SERVICES_LAMBDA_DOCKER_NETWORK.

Also update Lambda/Docker docs to clarify the automatic network inheritance behavior.

Tested with:

```bash
./mvnw -q -Dtest=ContainerBuilderTest,CurrentContainerNetworkResolverTest,DockerHostResolverTest,ContainerLauncherTest test
```

Fixes #756 
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [X] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [X] Breaking change (`feat!:` or `fix!:`)
- [X] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [X] `./mvnw test` passes locally
- [X] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
