### PR TITLE
fix(ses): allow SendRawEmail without Source when MIME From is present

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -183,9 +183,6 @@ public class SesService {
     }
 
     public String sendRawEmail(String source, List<String> destinations, String rawMessage, String region) {
-        if (source == null || source.isBlank()) {
-            throw new AwsException("InvalidParameterValue", "Source email is required.", 400);
-        }
         if (rawMessage == null || rawMessage.isBlank()) {
             throw new AwsException("InvalidParameterValue", "RawMessage.Data is required.", 400);
         }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesIntegrationTest.java
@@ -201,6 +201,26 @@ class SesIntegrationTest {
     }
 
     @Test
+    @Order(20)
+    void sendRawEmail_withoutSource_acceptedWhenMimeFromPresent() {
+        // Regression for https://github.com/floci-io/floci/issues/797
+        // AWS SES SendRawEmail allows omitting the Source parameter when the
+        // raw MIME message contains a From: header.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/email/aws4_request")
+            .formParam("Action", "SendRawEmail")
+            .formParam("Destinations.member.1", "recipient@example.com")
+            .formParam("RawMessage.Data",
+                "From: sender@example.com\r\nTo: recipient@example.com\r\nSubject: hello\r\n\r\nbody\r\n")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<MessageId>"));
+    }
+
+    @Test
     @Order(12)
     void getSendQuota() {
         given()

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesIntegrationTest.java
@@ -201,7 +201,7 @@ class SesIntegrationTest {
     }
 
     @Test
-    @Order(20)
+    @Order(29)
     void sendRawEmail_withoutSource_acceptedWhenMimeFromPresent() {
         // Regression for https://github.com/floci-io/floci/issues/797
         // AWS SES SendRawEmail allows omitting the Source parameter when the


### PR DESCRIPTION
## Summary

Closes #797.

AWS SES `SendRawEmail` treats the `Source` parameter as optional — when absent, the `From:` header in the raw MIME message acts as the source identity. Floci's `SesService.sendRawEmail` rejected such requests with `InvalidParameterValue: Source email is required`, diverging from real AWS and from LocalStack. Drop the null/blank check so the existing downstream MIME-From fallback (already implemented in `SmtpRelay.doRelayRaw`) takes effect.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** `SendRawEmail` returned HTTP 400 (`InvalidParameterValue`) whenever the `Source` parameter was omitted, regardless of whether the raw MIME body contained a `From:` header.

**Expected (AWS) behavior:** Per [the SES API reference](https://docs.aws.amazon.com/ses/latest/APIReference/API_SendRawEmail.html), `Source` is optional when the raw message includes a `From:` header. Real AWS SES and LocalStack both honor this fallback.

**Fixed behavior:** `sendRawEmail` no longer enforces a `Source` parameter. The downstream `SmtpRelay.doRelayRaw` already reads the MIME `From:` header when the explicit source argument is null, so removing the validation is sufficient — no MIME parsing change in `SesService` is needed.

Verified via a new regression test in `SesIntegrationTest` that posts a `SendRawEmail` request with no `Source` form param but a valid `From:` header in `RawMessage.Data`, asserting a 200 response.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)