### PR TITLE
feat(s3): virtual-hosted style addressing support

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -139,10 +139,15 @@ jobs:
             EXTRA_ARGS="$EXTRA_ARGS -v /tmp/floci-hot-reload:/tmp/floci-hot-reload -e HOT_RELOAD_BASE_DIR=/tmp/floci-hot-reload"
           fi
 
+          # --dns injects Floci's embedded DNS so *.floci wildcard subdomains
+          # (e.g. my-bucket.floci) resolve to Floci's IP inside the test container.
+          # FLOCI_S3_VHOST_ENDPOINT tells the S3 virtual-host client to use
+          # http://floci:4566 as the endpoint base instead of the public DNS fallback.
           docker run --rm --network compat-net \
+            --dns "${FLOCI_IP}" \
             -e FLOCI_ENDPOINT=http://floci:4566 \
+            -e FLOCI_S3_VHOST_ENDPOINT=http://floci:4566 \
             -v "$(pwd)/test-results:/results" \
-            --add-host "sdk-vhost-bucket.floci:${FLOCI_IP}" \
             $EXTRA_ARGS \
             compat-${{ matrix.test }}
 

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -241,6 +241,64 @@ public final class TestFixtures {
     }
 
     /**
+     * S3 client using virtual-hosted style addressing (no forcePathStyle).
+     *
+     * <p>The endpoint base is resolved in priority order:
+     * <ol>
+     *   <li>{@code FLOCI_S3_VHOST_ENDPOINT} env var — set this to {@code http://floci:4566}
+     *       in Docker test environments and point the test container's DNS at the Floci
+     *       container so that {@code <bucket>.floci} resolves via Floci's embedded DNS.</li>
+     *   <li>{@code s3.localhost.floci.io} — Floci's own public wildcard DNS, resolves to 127.0.0.1.</li>
+     *   <li>{@code s3.localhost.localstack.cloud} — LocalStack's public wildcard DNS, fallback.</li>
+     * </ol>
+     */
+    public static S3Client s3VirtualHostClient() {
+        URI virtualHostEndpoint;
+        String vhostEndpoint = System.getenv("FLOCI_S3_VHOST_ENDPOINT");
+        if (vhostEndpoint != null && !vhostEndpoint.trim().isEmpty()) {
+            virtualHostEndpoint = URI.create(vhostEndpoint);
+        } else {
+            int port = ENDPOINT.getPort() > 0 ? ENDPOINT.getPort() : 80;
+            String host = resolveVirtualHostBase(port);
+            virtualHostEndpoint = URI.create("http://" + host + ":" + port);
+        }
+        return S3Client.builder()
+                .endpointOverride(virtualHostEndpoint)
+                .region(REGION)
+                .credentialsProvider(CREDENTIALS)
+                .build();
+    }
+
+    /**
+     * Returns true when the S3 virtual-host endpoint is resolvable.
+     * When {@code FLOCI_S3_VHOST_ENDPOINT} is set the environment is
+     * assumed to have working DNS (e.g. --dns pointing at Floci).
+     */
+    public static boolean isS3VirtualHostResolvable() {
+        String vhostEndpoint = System.getenv("FLOCI_S3_VHOST_ENDPOINT");
+        if (vhostEndpoint != null && !vhostEndpoint.trim().isEmpty()) {
+            return true;
+        }
+        return isDnsResolvable("s3.localhost.floci.io") || isDnsResolvable("s3.localhost.localstack.cloud");
+    }
+
+    private static String resolveVirtualHostBase(int port) {
+        if (isDnsResolvable("s3.localhost.floci.io")) {
+            return "s3.localhost.floci.io";
+        }
+        return "s3.localhost.localstack.cloud";
+    }
+
+    private static boolean isDnsResolvable(String hostname) {
+        try {
+            java.net.InetAddress.getByName(hostname);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
      * S3 Control client for the S3 Control API (/v20180820/...).
      * Host prefix injection (account-ID prepended to host) is disabled so requests
      * go to the configured endpoint directly rather than 000000000000.localhost:4566.

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3VirtualHostStyleTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3VirtualHostStyleTest.java
@@ -1,0 +1,155 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Verifies S3 virtual-hosted style addressing via s3.localhost.localstack.cloud.
+ *
+ * The SDK sends requests to {@code <bucket>.s3.localhost.localstack.cloud:<port>},
+ * which resolves to 127.0.0.1 via LocalStack's public wildcard DNS. Floci's
+ * S3VirtualHostFilter extracts the bucket name from the Host header and rewrites
+ * the request to path-style internally.
+ *
+ * All tests are skipped when s3.localhost.localstack.cloud is not resolvable
+ * (e.g., no DNS / offline environment).
+ */
+@DisplayName("S3 Virtual-Hosted Style Addressing")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class S3VirtualHostStyleTest {
+
+    private static S3Client s3;
+    private static final String BUCKET = "vhost-test-bucket";
+    private static final String KEY = "test-object.txt";
+    private static final String COPIED_KEY = "copied-object.txt";
+    private static final String CONTENT = "Hello from virtual-hosted style!";
+
+    @BeforeAll
+    static void setup() {
+        assumeTrue(TestFixtures.isS3VirtualHostResolvable(),
+                "Skipping: S3 virtual-host DNS is not resolvable (set FLOCI_S3_VHOST_ENDPOINT or ensure s3.localhost.localstack.cloud resolves)");
+        s3 = TestFixtures.s3VirtualHostClient();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (s3 != null) {
+            try {
+                s3.deleteObject(DeleteObjectRequest.builder().bucket(BUCKET).key(KEY).build());
+            } catch (Exception ignored) {}
+            try {
+                s3.deleteObject(DeleteObjectRequest.builder().bucket(BUCKET).key(COPIED_KEY).build());
+            } catch (Exception ignored) {}
+            try {
+                s3.deleteBucket(DeleteBucketRequest.builder().bucket(BUCKET).build());
+            } catch (Exception ignored) {}
+            s3.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void createBucket() {
+        s3.createBucket(CreateBucketRequest.builder().bucket(BUCKET).build());
+    }
+
+    @Test
+    @Order(2)
+    void headBucket() {
+        HeadBucketResponse response = s3.headBucket(HeadBucketRequest.builder()
+                .bucket(BUCKET).build());
+
+        assertThat(response.sdkHttpResponse().isSuccessful()).isTrue();
+    }
+
+    @Test
+    @Order(3)
+    void headBucketNonExistent() {
+        assertThatThrownBy(() -> s3.headBucket(HeadBucketRequest.builder()
+                .bucket("vhost-nonexistent-xyz").build()))
+                .satisfiesAnyOf(
+                        e -> assertThat(e).isInstanceOf(NoSuchBucketException.class),
+                        e -> assertThat(((S3Exception) e).statusCode()).isEqualTo(404)
+                );
+    }
+
+    @Test
+    @Order(4)
+    void putObject() {
+        s3.putObject(PutObjectRequest.builder()
+                        .bucket(BUCKET).key(KEY).contentType("text/plain").build(),
+                RequestBody.fromString(CONTENT));
+    }
+
+    @Test
+    @Order(5)
+    void headObject() {
+        HeadObjectResponse response = s3.headObject(HeadObjectRequest.builder()
+                .bucket(BUCKET).key(KEY).build());
+
+        assertThat(response.contentLength()).isEqualTo(CONTENT.length());
+        assertThat(response.lastModified()).isNotNull();
+    }
+
+    @Test
+    @Order(6)
+    void getObject() throws Exception {
+        var response = s3.getObject(GetObjectRequest.builder()
+                .bucket(BUCKET).key(KEY).build());
+        String downloaded = new String(response.readAllBytes(), StandardCharsets.UTF_8);
+
+        assertThat(downloaded).isEqualTo(CONTENT);
+    }
+
+    @Test
+    @Order(7)
+    void listObjectsV2() {
+        ListObjectsV2Response response = s3.listObjectsV2(
+                ListObjectsV2Request.builder().bucket(BUCKET).build());
+
+        assertThat(response.contents())
+                .anyMatch(o -> KEY.equals(o.key()));
+    }
+
+    @Test
+    @Order(8)
+    void copyObject() throws Exception {
+        CopyObjectResponse response = s3.copyObject(CopyObjectRequest.builder()
+                .sourceBucket(BUCKET).sourceKey(KEY)
+                .destinationBucket(BUCKET).destinationKey(COPIED_KEY)
+                .build());
+
+        assertThat(response.copyObjectResult().eTag()).isNotNull();
+
+        var getResponse = s3.getObject(GetObjectRequest.builder()
+                .bucket(BUCKET).key(COPIED_KEY).build());
+        String downloaded = new String(getResponse.readAllBytes(), StandardCharsets.UTF_8);
+        assertThat(downloaded).isEqualTo(CONTENT);
+    }
+
+    @Test
+    @Order(9)
+    void deleteObject() {
+        s3.deleteObject(DeleteObjectRequest.builder().bucket(BUCKET).key(KEY).build());
+        s3.deleteObject(DeleteObjectRequest.builder().bucket(BUCKET).key(COPIED_KEY).build());
+
+        ListObjectsV2Response response = s3.listObjectsV2(
+                ListObjectsV2Request.builder().bucket(BUCKET).build());
+        assertThat(response.contents()).isEmpty();
+    }
+
+    @Test
+    @Order(10)
+    void deleteBucket() {
+        s3.deleteBucket(DeleteBucketRequest.builder().bucket(BUCKET).build());
+    }
+
+}

--- a/docker/run-docker-tests.sh
+++ b/docker/run-docker-tests.sh
@@ -25,6 +25,14 @@ echo " Floci is up!"
 NETWORK="floci_default"
 DOCKER_GID=$(stat -c '%g' /var/run/docker.sock 2>/dev/null || stat -f '%g' /var/run/docker.sock)
 
+# Floci's embedded DNS server resolves *.floci → Floci's IP.
+# Passing --dns <floci-ip> to test containers lets the S3 virtual-host client
+# send to <bucket>.floci:4566 which Floci DNS resolves correctly. Without this,
+# Docker's built-in DNS only resolves the exact service name "floci", not
+# wildcard subdomains like my-bucket.floci.
+FLOCI_CONTAINER=$(docker compose ps -q floci 2>/dev/null | head -1)
+FLOCI_IP=$(docker inspect -f "{{.NetworkSettings.Networks.${NETWORK}.IPAddress}}" "$FLOCI_CONTAINER" 2>/dev/null || true)
+
 # 3. Test suites
 SUITES=(
   "sdk-test-python"
@@ -48,9 +56,18 @@ for suite in "${SUITES[@]}"; do
   # Build
   docker build -q -t "$IMAGE_NAME" "compatibility-tests/$suite"
   
+  # Build DNS args: if we resolved Floci's IP, inject it as the DNS server so
+  # wildcard subdomains like <bucket>.floci resolve inside test containers.
+  DNS_ARGS=()
+  if [ -n "$FLOCI_IP" ]; then
+    DNS_ARGS=(--dns "$FLOCI_IP")
+  fi
+
   # Run
   docker run --rm --network "$NETWORK" \
+    "${DNS_ARGS[@]}" \
     -e FLOCI_ENDPOINT=http://floci:4566 \
+    -e FLOCI_S3_VHOST_ENDPOINT=http://floci:4566 \
     -v "$(pwd)/test-results:/results" \
     -v /var/run/docker.sock:/var/run/docker.sock \
     --group-add "$DOCKER_GID" \

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -88,9 +88,16 @@ Provide credentials for private registries (e.g. for Lambda base images). Use in
 
 ## DNS
 
+Floci's embedded DNS server always resolves the following wildcard suffixes to Floci's container IP — no configuration required:
+
+| Built-in suffix | Covers |
+|---|---|
+| `localhost.floci.io` | `localhost.floci.io` and `*.localhost.floci.io` (e.g. `my-bucket.s3.localhost.floci.io`) |
+| `localhost.localstack.cloud` | `localhost.localstack.cloud` and `*.localhost.localstack.cloud` (e.g. `my-bucket.s3.localhost.localstack.cloud`) |
+
 | Variable | Default | Description |
 |---|---|---|
-| `FLOCI_DNS_EXTRA_SUFFIXES` | _(none)_ | Comma-separated list of hostname suffixes that the embedded DNS server resolves to Floci's container IP. Useful when migrating from LocalStack: `FLOCI_DNS_EXTRA_SUFFIXES=localhost.localstack.cloud` |
+| `FLOCI_DNS_EXTRA_SUFFIXES` | _(none)_ | Comma-separated list of additional hostname suffixes to resolve to Floci's container IP. Use this for custom domains beyond the built-in ones above (e.g. a private internal suffix). |
 
 ---
 

--- a/docs/getting-started/migrate-from-localstack.md
+++ b/docs/getting-started/migrate-from-localstack.md
@@ -205,6 +205,33 @@ services:
 1. Switch to `latest-compat` if your init scripts use `aws` or `boto3`.
 2. LocalStack stores data in `/var/lib/localstack`; Floci uses `/app/data`.
 
+## S3 virtual-hosted style DNS
+
+If you use LocalStack's public wildcard DNS (`*.s3.localhost.localstack.cloud`) for S3 virtual-hosted style addressing, Floci supports it without any change:
+
+```java
+// This LocalStack endpoint works unchanged with Floci
+S3Client s3 = S3Client.builder()
+    .endpointOverride(URI.create("http://s3.localhost.localstack.cloud:4566"))
+    .build();
+// SDK sends to: my-bucket.s3.localhost.localstack.cloud:4566 → Floci
+```
+
+Floci also registers its own wildcard DNS domains for virtual-hosted style:
+
+| Domain | Usage |
+|---|---|
+| `*.s3.localhost.floci.io` | S3 virtual-hosted style (`bucket.s3.localhost.floci.io`) |
+| `*.localhost.floci.io` | Direct subdomain style (`bucket.localhost.floci.io`) |
+
+DNS resolution works differently depending on where the client runs:
+
+**From the host machine** — both `*.localhost.localstack.cloud` and `*.localhost.floci.io` are registered in public DNS and resolve to `127.0.0.1`. Requests reach Floci via the Docker port binding (`4566:4566`) with no extra configuration.
+
+**From inside a Docker container** — `127.0.0.1` is the container's own loopback, not Floci. Floci's embedded DNS server handles this: it resolves `*.localhost.floci.io` and `*.localhost.localstack.cloud` (and `*.localhost.localstack.cloud` subdomains) to Floci's container IP on the Docker network. Spawned containers (Lambda, RDS, ElastiCache) are automatically configured to use Floci as their DNS resolver, so virtual-hosted S3 URLs work inside them without any extra setup.
+
+See [S3 → Virtual-Hosted Style](../services/s3.md#virtual-hosted-style) for full details and SDK examples.
+
 ## What stays the same
 
 - Port `4566`

--- a/docs/services/s3.md
+++ b/docs/services/s3.md
@@ -88,24 +88,26 @@ aws s3 presign s3://my-bucket/report.pdf \
   --endpoint-url $AWS_ENDPOINT_URL
 ```
 
-## Path-Style URLs
+## Addressing Styles
 
-Floci uses path-style URLs:
+Floci supports both **path-style** and **virtual-hosted style** S3 addressing.
+
+### Path-Style (always works)
+
+Path-style embeds the bucket name in the URL path:
 
 ```
 http://localhost:4566/my-bucket/my-key
 ```
 
-When using the AWS SDK, enable path-style mode:
+Enable it in the SDK with `forcePathStyle` / `pathStyleAccessEnabled`:
 
 === "Java"
 
     ```java
     S3Client s3 = S3Client.builder()
         .endpointOverride(URI.create("http://localhost:4566"))
-        .serviceConfiguration(S3Configuration.builder()
-            .pathStyleAccessEnabled(true)
-            .build())
+        .forcePathStyle(true)
         .build();
     ```
 
@@ -125,6 +127,76 @@ When using the AWS SDK, enable path-style mode:
         endpoint_url="http://localhost:4566",
         config=Config(s3={"addressing_style": "path"}))
     ```
+
+### Virtual-Hosted Style
+
+Virtual-hosted style puts the bucket name in the hostname:
+
+```
+http://my-bucket.s3.localhost.floci.io:4566/my-key
+```
+
+Floci supports this natively — no `forcePathStyle` needed. The following wildcard DNS domains resolve to `127.0.0.1` via public DNS, so virtual-hosted requests reach Floci on the host machine automatically:
+
+| Domain pattern | Resolves to |
+|---|---|
+| `*.localhost.floci.io` | `127.0.0.1` |
+| `*.s3.localhost.floci.io` | `127.0.0.1` |
+| `*.localhost.localstack.cloud` | `127.0.0.1` |
+| `*.s3.localhost.localstack.cloud` | `127.0.0.1` |
+
+Plain `http://localhost:4566` also works without `forcePathStyle` — the SDK sends `Host: my-bucket.localhost:4566` and Floci's filter extracts the bucket name from that header.
+
+Configure the SDK endpoint to one of the base domains (no `forcePathStyle`):
+
+=== "Java"
+
+    ```java
+    S3Client s3 = S3Client.builder()
+        .endpointOverride(URI.create("http://s3.localhost.floci.io:4566"))
+        .region(Region.US_EAST_1)
+        .credentialsProvider(StaticCredentialsProvider.create(
+            AwsBasicCredentials.create("test", "test")))
+        .build();
+    // SDK sends requests to: my-bucket.s3.localhost.floci.io:4566
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    const s3 = new S3Client({
+      endpoint: "http://s3.localhost.floci.io:4566",
+      // no forcePathStyle — SDK uses virtual-hosted style by default
+    });
+    // SDK sends requests to: my-bucket.s3.localhost.floci.io:4566
+    ```
+
+=== "Python"
+
+    ```python
+    s3 = boto3.client("s3",
+        endpoint_url="http://s3.localhost.floci.io:4566")
+    # SDK sends requests to: my-bucket.s3.localhost.floci.io:4566
+    ```
+
+#### Virtual-Hosted Style Inside Docker
+
+Inside Docker containers, `127.0.0.1` resolves to the container itself — not Floci. Floci's **embedded DNS server** handles this automatically: it resolves `*.localhost.floci.io`, `*.s3.localhost.floci.io`, `*.localhost.localstack.cloud`, and `*.s3.localhost.localstack.cloud` to Floci's container IP on the Docker network.
+
+To use virtual-hosted style from a test container, point its DNS at Floci and set the endpoint to Floci's service hostname:
+
+```bash
+FLOCI_IP=$(docker inspect -f '{{.NetworkSettings.Networks.floci_default.IPAddress}}' floci)
+
+docker run --rm \
+  --network floci_default \
+  --dns "$FLOCI_IP" \
+  -e FLOCI_ENDPOINT=http://floci:4566 \
+  -e FLOCI_S3_VHOST_ENDPOINT=http://floci:4566 \
+  my-test-image
+```
+
+With `FLOCI_HOSTNAME=floci` set on the Floci container (default in the provided `docker-compose.yml`), the embedded DNS resolves `my-bucket.floci` to Floci's IP, and `S3VirtualHostFilter` extracts the bucket name from the Host header.
 
 ## Object Attribute Notes
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/dns/EmbeddedDnsServer.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/dns/EmbeddedDnsServer.java
@@ -43,12 +43,21 @@ public class EmbeddedDnsServer {
     private static final int TTL = 60;
     private static final String FALLBACK_UPSTREAM = "127.0.0.11";
     public static final String DEFAULT_SUFFIX = "localhost.floci.io";
+    public static final String LOCALSTACK_SUFFIX = "localhost.localstack.cloud";
+
+    // Well-known emulator wildcard DNS domains that always resolve to Floci's IP.
+    // The suffix "localhost.X" covers "localhost.X" itself and "*.localhost.X" — it does
+    // NOT cover "*.X" (e.g. "localhost.floci.io" does NOT resolve bare "*.floci.io").
+    //   localhost.localstack.cloud → localhost.localstack.cloud, *.localhost.localstack.cloud
+    //   localhost.floci.io         → localhost.floci.io, *.localhost.floci.io
+    static final List<String> BUILTIN_SUFFIXES = List.of(DEFAULT_SUFFIX, LOCALSTACK_SUFFIX);
 
     private volatile String serverIp;
     private final List<String> suffixes = new ArrayList<>();
     private String upstreamDns;
 
     EmbeddedDnsServer(List<String> suffixes) {
+        this.suffixes.addAll(BUILTIN_SUFFIXES);
         this.suffixes.addAll(suffixes);
     }
 
@@ -61,7 +70,8 @@ public class EmbeddedDnsServer {
             String myIp = InetAddress.getLocalHost().getHostAddress();
             upstreamDns = readUpstreamDns();
 
-            suffixes.add(config.hostname().orElse(DEFAULT_SUFFIX));
+            suffixes.addAll(BUILTIN_SUFFIXES);
+            config.hostname().ifPresent(suffixes::add);
             config.dns().extraSuffixes().ifPresent(suffixes::addAll);
 
             DatagramSocket socket = vertx.createDatagramSocket(new DatagramSocketOptions().setIpV6(false));

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
@@ -171,10 +171,19 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
         if (remainder.startsWith("s3.") && remainder.endsWith(".amazonaws.com")) {
             return true;
         }
-        // Support localstack.cloud subdomains (used by cdklocal and other tools)
-        // Example: bucket.s3.localhost.localstack.cloud
+        // localhost always resolves to 127.0.0.1 — accept regardless of FLOCI_HOSTNAME config.
+        // Fixes: SDK with endpointOverride("http://localhost:4566") without forcePathStyle sends
+        // Host: my-bucket.localhost:4566, which must be recognized even when baseHostname=floci.
+        if ("localhost".equals(remainder)) {
+            return true;
+        }
+        // LocalStack public wildcard DNS: bucket.s3.localhost.localstack.cloud and bucket.localhost.localstack.cloud
         if (remainder.endsWith(".localstack.cloud")) {
-            return remainder.startsWith("s3.");
+            return remainder.startsWith("s3.") || "localhost.localstack.cloud".equals(remainder);
+        }
+        // Floci public wildcard DNS: bucket.s3.localhost.floci.io and bucket.localhost.floci.io → 127.0.0.1
+        if (remainder.endsWith(".localhost.floci.io") || "localhost.floci.io".equals(remainder)) {
+            return remainder.startsWith("s3.") || "localhost.floci.io".equals(remainder);
         }
         return false;
     }

--- a/src/test/java/io/github/hectorvent/floci/core/common/dns/EmbeddedDnsServerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/dns/EmbeddedDnsServerTest.java
@@ -17,7 +17,7 @@ class EmbeddedDnsServerTest {
         dns = new EmbeddedDnsServer(List.of("localhost.floci.io"));
     }
 
-    // ── matchesSuffix ─────────────────────────────────────────────────────────
+    // ── matchesSuffix — configured suffix ────────────────────────────────────
 
     @Test
     void matchesSuffix_exactMatch() {
@@ -49,10 +49,74 @@ class EmbeddedDnsServerTest {
         assertFalse(dns.matchesSuffix("floci.io"));
     }
 
+    // bare *.floci.io (without localhost.) must NOT match — only *.localhost.floci.io is registered
+    @Test
+    void matchesSuffix_bareFlociIoSubdomainNoMatch() {
+        assertFalse(dns.matchesSuffix("my-bucket.floci.io"));
+    }
+
+    @Test
+    void matchesSuffix_bareS3FlociIoNoMatch() {
+        assertFalse(dns.matchesSuffix("s3.floci.io"));
+    }
+
+    // bare *.localstack.cloud (without localhost.) must NOT match either
+    @Test
+    void matchesSuffix_bareLocalstackCloudNoMatch() {
+        assertFalse(dns.matchesSuffix("my-bucket.localstack.cloud"));
+    }
+
     @Test
     void matchesSuffix_nullAndEmpty() {
         assertFalse(dns.matchesSuffix(null));
         assertFalse(dns.matchesSuffix(""));
+    }
+
+    // ── matchesSuffix — built-in emulator domains ─────────────────────────────
+
+    @Test
+    void matchesSuffix_localhostFlociIo_exact() {
+        assertTrue(dns.matchesSuffix("localhost.floci.io"));
+    }
+
+    @Test
+    void matchesSuffix_localhostFlociIo_subdomain() {
+        assertTrue(dns.matchesSuffix("my-bucket.localhost.floci.io"));
+    }
+
+    @Test
+    void matchesSuffix_s3LocalhostFlociIo() {
+        assertTrue(dns.matchesSuffix("s3.localhost.floci.io"));
+    }
+
+    @Test
+    void matchesSuffix_bucketS3LocalhostFlociIo() {
+        assertTrue(dns.matchesSuffix("my-bucket.s3.localhost.floci.io"));
+    }
+
+    @Test
+    void matchesSuffix_localhostLocalstackCloud_exact() {
+        assertTrue(dns.matchesSuffix("localhost.localstack.cloud"));
+    }
+
+    @Test
+    void matchesSuffix_localhostLocalstackCloud_subdomain() {
+        assertTrue(dns.matchesSuffix("my-bucket.localhost.localstack.cloud"));
+    }
+
+    @Test
+    void matchesSuffix_s3LocalhostLocalstackCloud() {
+        assertTrue(dns.matchesSuffix("s3.localhost.localstack.cloud"));
+    }
+
+    @Test
+    void matchesSuffix_bucketS3LocalhostLocalstackCloud() {
+        assertTrue(dns.matchesSuffix("my-bucket.s3.localhost.localstack.cloud"));
+    }
+
+    @Test
+    void matchesSuffix_bucketS3RegionLocalstackCloud() {
+        assertTrue(dns.matchesSuffix("my-bucket.s3.us-east-1.localhost.localstack.cloud"));
     }
 
     // ── readName ──────────────────────────────────────────────────────────────

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
@@ -24,11 +24,26 @@ class S3VirtualHostFilterTest {
             // K8s-style service hostname with FLOCI_HOSTNAME set
             "my-bucket.floci.default.svc.cluster.local, floci.default.svc.cluster.local, my-bucket",
             "my-bucket.floci-svc.namespace.svc, floci-svc.namespace.svc, my-bucket",
+            // localhost is always recognized regardless of baseHostname (fixes virtual-host when FLOCI_HOSTNAME=floci)
+            "my-bucket.localhost,      floci, my-bucket",
+            "my-bucket.localhost:4566, floci, my-bucket",
             // AWS S3 domains (fallback — independent of baseHostname)
             "my-bucket.s3.amazonaws.com,               localhost, my-bucket",
             "my-bucket.s3.amazonaws.com:443,            localhost, my-bucket",
             "my-bucket.s3.us-east-1.amazonaws.com,      localhost, my-bucket",
             "my-bucket.s3.eu-west-1.amazonaws.com:443,  localhost, my-bucket",
+            // LocalStack-compatible domains (*.localhost.localstack.cloud resolves to 127.0.0.1 via public DNS)
+            "my-bucket.s3.localhost.localstack.cloud,           localhost, my-bucket",
+            "my-bucket.s3.localhost.localstack.cloud:4566,      localhost, my-bucket",
+            "my-bucket.s3.us-east-1.localhost.localstack.cloud, localhost, my-bucket",
+            "my-bucket.localhost.localstack.cloud,              localhost, my-bucket",
+            "my-bucket.localhost.localstack.cloud:4566,         localhost, my-bucket",
+            // Floci public wildcard DNS (*.s3.localhost.floci.io and *.localhost.floci.io resolve to 127.0.0.1)
+            "my-bucket.s3.localhost.floci.io,       localhost, my-bucket",
+            "my-bucket.s3.localhost.floci.io:4566,  localhost, my-bucket",
+            "my-bucket.localhost.floci.io,          localhost, my-bucket",
+            "my-bucket.localhost.floci.io:4566,     localhost, my-bucket",
+            "my-bucket.s3.us-east-1.localhost.floci.io, localhost, my-bucket",
     })
     void extractsBucketFromVirtualHostedStyle(String host, String baseHostname, String expectedBucket) {
         assertEquals(expectedBucket, S3VirtualHostFilter.extractBucket(host, baseHostname));
@@ -73,9 +88,17 @@ class S3VirtualHostFilterTest {
 
     @Test
     void returnsNullForNullBaseHostname() {
-        // Without a baseHostname, only AWS S3 domains should match
-        assertNull(S3VirtualHostFilter.extractBucket("my-bucket.localhost:4566", null));
+        // path-style bare hostname (no subdomain) — must return null
+        assertNull(S3VirtualHostFilter.extractBucket("localhost:4566", null));
+        // well-known domains match regardless of baseHostname
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.localhost", null));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.localhost:4566", null));
         assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.amazonaws.com", null));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.localhost.localstack.cloud", null));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.localhost.localstack.cloud", null));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.localhost.floci.io", null));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.us-east-1.localhost.floci.io", null));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.localhost.floci.io", null));
     }
 
     // --- Hostname extraction from URL ---


### PR DESCRIPTION
## Summary

Adds first-class S3 virtual-hosted style addressing to Floci, fixing the 405
error users hit when the AWS SDK sends requests to `my-bucket.localhost:4566`
without `forcePathStyle` (#801).

### What changed

**`S3VirtualHostFilter`** `isAwsS3Domain()` now recognises as virtual-hosted:
- `*.localhost` — always, regardless of `FLOCI_HOSTNAME` (fixes #801)
- `*.localhost.floci.io` / `*.s3.localhost.floci.io` — Floci's own public wildcard DNS
- `*.localhost.localstack.cloud` / `*.s3.localhost.localstack.cloud` — LocalStack compat
- direct subdomain style (`bucket.localhost.localstack.cloud`) alongside the existing `s3.` prefix style

**`EmbeddedDnsServer`**: ships `localhost.localstack.cloud` and `localhost.floci.io`
as built-in suffixes so Lambda/RDS/ElastiCache containers resolve both emulator
DNS domains to Floci's IP without requiring `extraSuffixes` config.
The `orElse(DEFAULT_SUFFIX)` fallback is replaced with `ifPresent` now that
`localhost.floci.io` is always in the built-in list.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
