### PR TITLE
feat(ses): add v2 suppression list endpoints

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesSuppressionListTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesSuppressionListTest.java
@@ -1,0 +1,117 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.DeleteSuppressedDestinationRequest;
+import software.amazon.awssdk.services.sesv2.model.GetSuppressedDestinationRequest;
+import software.amazon.awssdk.services.sesv2.model.GetSuppressedDestinationResponse;
+import software.amazon.awssdk.services.sesv2.model.ListSuppressedDestinationsRequest;
+import software.amazon.awssdk.services.sesv2.model.ListSuppressedDestinationsResponse;
+import software.amazon.awssdk.services.sesv2.model.NotFoundException;
+import software.amazon.awssdk.services.sesv2.model.PutSuppressedDestinationRequest;
+import software.amazon.awssdk.services.sesv2.model.SuppressionListReason;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("SES V2 Suppression list")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesSuppressionListTest {
+
+    private static SesV2Client sesV2;
+    private static String bounceEmail;
+    private static String complaintEmail;
+
+    @BeforeAll
+    static void setup() {
+        sesV2 = TestFixtures.sesV2Client();
+        String suffix = TestFixtures.uniqueName();
+        bounceEmail = "sdk-bounce-" + suffix + "@example.com";
+        complaintEmail = "sdk-complaint-" + suffix + "@example.com";
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (sesV2 != null) {
+            try {
+                sesV2.deleteSuppressedDestination(DeleteSuppressedDestinationRequest.builder()
+                        .emailAddress(bounceEmail).build());
+            } catch (Exception ignored) {}
+            try {
+                sesV2.deleteSuppressedDestination(DeleteSuppressedDestinationRequest.builder()
+                        .emailAddress(complaintEmail).build());
+            } catch (Exception ignored) {}
+            sesV2.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void putAndGet_bounceRoundTrips() {
+        sesV2.putSuppressedDestination(PutSuppressedDestinationRequest.builder()
+                .emailAddress(bounceEmail)
+                .reason(SuppressionListReason.BOUNCE)
+                .build());
+
+        GetSuppressedDestinationResponse got = sesV2.getSuppressedDestination(
+                GetSuppressedDestinationRequest.builder()
+                        .emailAddress(bounceEmail).build());
+        assertThat(got.suppressedDestination().emailAddress()).isEqualTo(bounceEmail);
+        assertThat(got.suppressedDestination().reason()).isEqualTo(SuppressionListReason.BOUNCE);
+        assertThat(got.suppressedDestination().lastUpdateTime()).isNotNull();
+    }
+
+    @Test
+    @Order(2)
+    void putAndGet_complaintRoundTrips() {
+        sesV2.putSuppressedDestination(PutSuppressedDestinationRequest.builder()
+                .emailAddress(complaintEmail)
+                .reason(SuppressionListReason.COMPLAINT)
+                .build());
+
+        GetSuppressedDestinationResponse got = sesV2.getSuppressedDestination(
+                GetSuppressedDestinationRequest.builder()
+                        .emailAddress(complaintEmail).build());
+        assertThat(got.suppressedDestination().reason()).isEqualTo(SuppressionListReason.COMPLAINT);
+    }
+
+    @Test
+    @Order(3)
+    void list_includesBothEntries() {
+        ListSuppressedDestinationsResponse listed = sesV2.listSuppressedDestinations(
+                ListSuppressedDestinationsRequest.builder().build());
+        assertThat(listed.suppressedDestinationSummaries())
+                .extracting(s -> s.emailAddress())
+                .contains(bounceEmail, complaintEmail);
+    }
+
+    @Test
+    @Order(4)
+    void list_filteredByReason() {
+        ListSuppressedDestinationsResponse listed = sesV2.listSuppressedDestinations(
+                ListSuppressedDestinationsRequest.builder()
+                        .reasons(SuppressionListReason.BOUNCE)
+                        .build());
+        assertThat(listed.suppressedDestinationSummaries())
+                .allMatch(s -> s.reason() == SuppressionListReason.BOUNCE);
+    }
+
+    @Test
+    @Order(5)
+    void delete_removesEntry_subsequentGetThrowsNotFound() {
+        sesV2.deleteSuppressedDestination(DeleteSuppressedDestinationRequest.builder()
+                .emailAddress(bounceEmail).build());
+
+        assertThatThrownBy(() -> sesV2.getSuppressedDestination(
+                GetSuppressedDestinationRequest.builder()
+                        .emailAddress(bounceEmail).build()))
+                .isInstanceOf(NotFoundException.class);
+    }
+}

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -182,9 +182,15 @@ Alongside the classic Query API, Floci implements a subset of the SES v2 REST JS
 | `GET` | `/v2/email/configuration-sets` | `ListConfigurationSets` |
 | `GET` | `/v2/email/configuration-sets/{name}` | `GetConfigurationSet` |
 | `DELETE` | `/v2/email/configuration-sets/{name}` | `DeleteConfigurationSet` |
+| `PUT` | `/v2/email/suppression/addresses` | `PutSuppressedDestination` |
+| `GET` | `/v2/email/suppression/addresses/{EmailAddress}` | `GetSuppressedDestination` |
+| `DELETE` | `/v2/email/suppression/addresses/{EmailAddress}` | `DeleteSuppressedDestination` |
+| `GET` | `/v2/email/suppression/addresses` | `ListSuppressedDestinations` (optional `Reason` query filter) |
 | `POST` | `/v2/email/tags` | `TagResource` |
 | `DELETE` | `/v2/email/tags?ResourceArn=...&TagKeys=...` | `UntagResource` |
 | `GET` | `/v2/email/tags?ResourceArn=...` | `ListTagsForResource` |
+
+Suppression list entries are stored per region. `Reason` is `BOUNCE` or `COMPLAINT`. `SendEmail` is not yet integrated with the suppression list, so suppressed addresses are still delivered locally.
 
 Tag operations support these ARN forms: `arn:aws:ses:<region>:<account>:configuration-set/<name>`, `arn:aws:ses:<region>:<account>:template/<name>`, and `arn:aws:ses:<region>:<account>:identity/<email-or-domain>`. Tags supplied to `CreateConfigurationSet`, `CreateEmailTemplate`, and `CreateEmailIdentity` are reachable through `ListTagsForResource`; `UpdateEmailTemplate` does not modify tags. Other resource types return `NotFoundException`.
 

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
+import io.github.hectorvent.floci.services.ses.model.SuppressedDestination;
 import io.github.hectorvent.floci.services.ses.model.Tag;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -690,6 +691,88 @@ public class SesController {
         } catch (Exception e) {
             throw new AwsException("BadRequestException", e.getMessage(), 400);
         }
+    }
+
+    // ──────────────────── Suppression list ───────────────────────────
+
+    @PUT
+    @Path("/suppression/addresses")
+    public Response putSuppressedDestination(@Context HttpHeaders headers, String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            if (body == null || body.isBlank()) {
+                throw new AwsException("BadRequestException", "Request body is required.", 400);
+            }
+            JsonNode request = objectMapper.readTree(body);
+            String emailAddress = request.path("EmailAddress").asText(null);
+            String reason = request.path("Reason").asText(null);
+            sesService.putSuppressedDestination(region, emailAddress, reason);
+            LOG.infov("SES V2 PutSuppressedDestination: {0} ({1})", emailAddress, reason);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @GET
+    @Path("/suppression/addresses/{emailAddress}")
+    public Response getSuppressedDestination(@Context HttpHeaders headers,
+                                              @PathParam("emailAddress") String emailAddress) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            SuppressedDestination suppressed = sesService.getSuppressedDestination(region, emailAddress);
+            ObjectNode result = objectMapper.createObjectNode();
+            ObjectNode entry = result.putObject("SuppressedDestination");
+            entry.put("EmailAddress", suppressed.getEmailAddress());
+            entry.put("Reason", suppressed.getReason());
+            if (suppressed.getLastUpdateTime() != null) {
+                entry.put("LastUpdateTime", suppressed.getLastUpdateTime().getEpochSecond());
+            }
+            return Response.ok(result).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        }
+    }
+
+    @DELETE
+    @Path("/suppression/addresses/{emailAddress}")
+    public Response deleteSuppressedDestination(@Context HttpHeaders headers,
+                                                 @PathParam("emailAddress") String emailAddress) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            sesService.deleteSuppressedDestination(region, emailAddress);
+            LOG.infov("SES V2 DeleteSuppressedDestination: {0}", emailAddress);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        }
+    }
+
+    @GET
+    @Path("/suppression/addresses")
+    public Response listSuppressedDestinations(@Context HttpHeaders headers,
+                                                @QueryParam("Reason") List<String> reasons) {
+        String region = regionResolver.resolveRegion(headers);
+        List<SuppressedDestination> entries;
+        try {
+            entries = sesService.listSuppressedDestinations(region, reasons);
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        }
+        ObjectNode result = objectMapper.createObjectNode();
+        ArrayNode summaries = result.putArray("SuppressedDestinationSummaries");
+        for (SuppressedDestination s : entries) {
+            ObjectNode item = objectMapper.createObjectNode();
+            item.put("EmailAddress", s.getEmailAddress());
+            item.put("Reason", s.getReason());
+            if (s.getLastUpdateTime() != null) {
+                item.put("LastUpdateTime", s.getLastUpdateTime().getEpochSecond());
+            }
+            summaries.add(item);
+        }
+        return Response.ok(result).build();
     }
 
     // ──────────────────────────── Tags ───────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -704,8 +704,9 @@ public class SesController {
                 throw new AwsException("BadRequestException", "Request body is required.", 400);
             }
             JsonNode request = objectMapper.readTree(body);
-            String emailAddress = request.path("EmailAddress").asText(null);
-            String reason = request.path("Reason").asText(null);
+            requireJsonObject(request);
+            String emailAddress = readRequiredStringField(request, "EmailAddress");
+            String reason = readRequiredStringField(request, "Reason");
             sesService.putSuppressedDestination(region, emailAddress, reason);
             LOG.infov("SES V2 PutSuppressedDestination: {0} ({1})", emailAddress, reason);
             return Response.ok(objectMapper.createObjectNode()).build();
@@ -714,6 +715,14 @@ public class SesController {
         } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
             throw new AwsException("BadRequestException", e.getMessage(), 400);
         }
+    }
+
+    private static String readRequiredStringField(JsonNode request, String fieldName) {
+        JsonNode node = request.path(fieldName);
+        if (node.isMissingNode() || node.isNull() || !node.isTextual()) {
+            throw new AwsException("BadRequestException", fieldName + " is required.", 400);
+        }
+        return node.asText();
     }
 
     @GET

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -10,6 +10,7 @@ import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.SentEmail;
+import io.github.hectorvent.floci.services.ses.model.SuppressedDestination;
 import io.github.hectorvent.floci.services.ses.model.Tag;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -54,6 +55,7 @@ public class SesService {
     private final StorageBackend<String, Boolean> accountSettingsStore;
     private final StorageBackend<String, EmailTemplate> templateStore;
     private final StorageBackend<String, ConfigurationSet> configSetStore;
+    private final StorageBackend<String, SuppressedDestination> suppressionStore;
     private final SmtpRelay smtpRelay;
     private final ObjectMapper objectMapper;
 
@@ -69,6 +71,8 @@ public class SesService {
                 new TypeReference<Map<String, EmailTemplate>>() {});
         this.configSetStore = storageFactory.create("ses", "ses-config-sets.json",
                 new TypeReference<Map<String, ConfigurationSet>>() {});
+        this.suppressionStore = storageFactory.create("ses", "ses-suppression.json",
+                new TypeReference<Map<String, SuppressedDestination>>() {});
         this.smtpRelay = smtpRelay;
         this.objectMapper = objectMapper;
     }
@@ -78,6 +82,7 @@ public class SesService {
                StorageBackend<String, Boolean> accountSettingsStore,
                StorageBackend<String, EmailTemplate> templateStore,
                StorageBackend<String, ConfigurationSet> configSetStore,
+               StorageBackend<String, SuppressedDestination> suppressionStore,
                SmtpRelay smtpRelay,
                ObjectMapper objectMapper) {
         this.identityStore = identityStore;
@@ -85,6 +90,7 @@ public class SesService {
         this.accountSettingsStore = accountSettingsStore;
         this.templateStore = templateStore;
         this.configSetStore = configSetStore;
+        this.suppressionStore = suppressionStore;
         this.smtpRelay = smtpRelay;
         this.objectMapper = objectMapper;
     }
@@ -687,6 +693,87 @@ public class SesService {
             throw new AwsException("BadRequestException", "Invalid ARN: " + arn, 400);
         }
         return new ResourceRef(parsed.region(), resource.substring(0, slash), resource.substring(slash + 1));
+    }
+
+    // ──────────────────────────── Suppression list ────────────────────────────
+
+    public void putSuppressedDestination(String region, String emailAddress, String reason) {
+        String normalized = normalizeSuppressionEmail(emailAddress);
+        validateSuppressionReason(reason, "reason", false);
+        String key = suppressionKey(region, normalized);
+        SuppressedDestination existing = suppressionStore.get(key).orElse(null);
+        SuppressedDestination entry = existing != null ? existing : new SuppressedDestination(normalized, reason);
+        entry.setReason(reason);
+        entry.setLastUpdateTime(Instant.now());
+        suppressionStore.put(key, entry);
+        LOG.infov("Suppressed destination {0} in region {1} (reason={2})", normalized, region, reason);
+    }
+
+    public SuppressedDestination getSuppressedDestination(String region, String emailAddress) {
+        String normalized = normalizeSuppressionEmail(emailAddress);
+        return suppressionStore.get(suppressionKey(region, normalized))
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "Email address " + normalized + " does not exist on your suppression list.",
+                        404));
+    }
+
+    public void deleteSuppressedDestination(String region, String emailAddress) {
+        String normalized = normalizeSuppressionEmail(emailAddress);
+        String key = suppressionKey(region, normalized);
+        if (suppressionStore.get(key).isEmpty()) {
+            throw new AwsException("NotFoundException",
+                    "Email address " + normalized + " does not exist on your suppression list.",
+                    404);
+        }
+        suppressionStore.delete(key);
+        LOG.infov("Removed suppression entry for {0} in region {1}", normalized, region);
+    }
+
+    public List<SuppressedDestination> listSuppressedDestinations(String region, List<String> reasonFilters) {
+        Set<String> filters = new HashSet<>();
+        if (reasonFilters != null) {
+            for (String r : reasonFilters) {
+                if (r != null && !r.isBlank()) {
+                    validateSuppressionReason(r, "reasons", true);
+                    filters.add(r);
+                }
+            }
+        }
+        String prefix = "suppression::" + region + "::";
+        List<SuppressedDestination> all = new ArrayList<>(suppressionStore.scan(k -> k.startsWith(prefix)));
+        all.sort(Comparator.comparing(SuppressedDestination::getLastUpdateTime,
+                        Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(SuppressedDestination::getEmailAddress,
+                        Comparator.nullsLast(Comparator.naturalOrder())));
+        if (filters.isEmpty()) {
+            return all;
+        }
+        return all.stream()
+                .filter(s -> filters.contains(s.getReason()))
+                .toList();
+    }
+
+    private static String suppressionKey(String region, String emailAddress) {
+        return "suppression::" + region + "::" + emailAddress;
+    }
+
+    private static String normalizeSuppressionEmail(String emailAddress) {
+        if (emailAddress == null || emailAddress.isBlank()) {
+            throw new AwsException("BadRequestException", "EmailAddress is required.", 400);
+        }
+        // AWS trims leading/trailing whitespace from EmailAddress before storing.
+        return emailAddress.trim();
+    }
+
+    private static void validateSuppressionReason(String reason, String fieldName, boolean nested) {
+        if (reason == null || (!"BOUNCE".equals(reason) && !"COMPLAINT".equals(reason))) {
+            String constraint = nested
+                    ? "Member must satisfy constraint: [Member must satisfy enum value set: [BOUNCE, COMPLAINT]]"
+                    : "Member must satisfy enum value set: [BOUNCE, COMPLAINT]";
+            throw new AwsException("BadRequestException",
+                    "1 validation error detected: Value at '" + fieldName + "' failed to satisfy constraint: "
+                            + constraint, 400);
+        }
     }
 
     static void validateTag(Tag tag) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/SuppressedDestination.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/SuppressedDestination.java
@@ -1,0 +1,38 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SuppressedDestination {
+
+    @JsonProperty("EmailAddress")
+    private String emailAddress;
+
+    @JsonProperty("Reason")
+    private String reason;
+
+    @JsonProperty("LastUpdateTime")
+    private Instant lastUpdateTime;
+
+    public SuppressedDestination() {}
+
+    public SuppressedDestination(String emailAddress, String reason) {
+        this.emailAddress = emailAddress;
+        this.reason = reason;
+        this.lastUpdateTime = Instant.now();
+    }
+
+    public String getEmailAddress() { return emailAddress; }
+    public void setEmailAddress(String emailAddress) { this.emailAddress = emailAddress; }
+
+    public String getReason() { return reason; }
+    public void setReason(String reason) { this.reason = reason; }
+
+    public Instant getLastUpdateTime() { return lastUpdateTime; }
+    public void setLastUpdateTime(Instant lastUpdateTime) { this.lastUpdateTime = lastUpdateTime; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSmtpTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSmtpTest.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.SentEmail;
+import io.github.hectorvent.floci.services.ses.model.SuppressedDestination;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,6 +35,7 @@ class SesServiceSmtpTest {
                 new InMemoryStorage<String, Boolean>(),
                 new InMemoryStorage<String, EmailTemplate>(),
                 new InMemoryStorage<String, ConfigurationSet>(),
+                new InMemoryStorage<String, SuppressedDestination>(),
                 smtpRelay,
                 new ObjectMapper());
     }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesSuppressionV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesSuppressionV2IntegrationTest.java
@@ -227,6 +227,53 @@ class SesSuppressionV2IntegrationTest {
     }
 
     @Test
+    @Order(16)
+    void putSuppressedDestination_nullEmailAddress_returns400() {
+        // JSON null for EmailAddress must not coerce into the literal string "null".
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailAddress": null, "Reason": "BOUNCE"}
+                """)
+        .when()
+            .put("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(17)
+    void putSuppressedDestination_nullReason_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailAddress": "null-reason@example.com", "Reason": null}
+                """)
+        .when()
+            .put("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(18)
+    void putSuppressedDestination_nonObjectBody_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("[\"not\", \"an\", \"object\"]")
+        .when()
+            .put("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
     @Order(13)
     void putSuppressedDestination_trimsWhitespaceFromEmailAddress() {
         // AWS silently trims leading/trailing whitespace from EmailAddress on Put.

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesSuppressionV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesSuppressionV2IntegrationTest.java
@@ -1,0 +1,292 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Integration tests for SES v2 suppression list endpoints at /v2/email/suppression/addresses.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesSuppressionV2IntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/ses/aws4_request";
+
+    @Test
+    @Order(1)
+    void putSuppressedDestination_bounce() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailAddress": "bounce-1@example.com", "Reason": "BOUNCE"}
+                """)
+        .when()
+            .put("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void putSuppressedDestination_complaint() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailAddress": "complaint-1@example.com", "Reason": "COMPLAINT"}
+                """)
+        .when()
+            .put("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(3)
+    void getSuppressedDestination_returnsStoredEntry() {
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/suppression/addresses/bounce-1@example.com")
+        .then()
+            .statusCode(200)
+            .body("SuppressedDestination.EmailAddress", equalTo("bounce-1@example.com"))
+            .body("SuppressedDestination.Reason", equalTo("BOUNCE"))
+            .body("SuppressedDestination.LastUpdateTime", notNullValue());
+    }
+
+    @Test
+    @Order(4)
+    void getSuppressedDestination_unknown_returns404() {
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/suppression/addresses/missing@example.com")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"));
+    }
+
+    @Test
+    @Order(5)
+    void putSuppressedDestination_updatesExistingReason() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailAddress": "bounce-1@example.com", "Reason": "COMPLAINT"}
+                """)
+        .when()
+            .put("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/suppression/addresses/bounce-1@example.com")
+        .then()
+            .statusCode(200)
+            .body("SuppressedDestination.Reason", equalTo("COMPLAINT"));
+    }
+
+    @Test
+    @Order(6)
+    void listSuppressedDestinations_returnsAll() {
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(200)
+            .body("SuppressedDestinationSummaries", hasSize(greaterThanOrEqualTo(2)))
+            .body("SuppressedDestinationSummaries.EmailAddress",
+                  hasItems("bounce-1@example.com", "complaint-1@example.com"));
+    }
+
+    @Test
+    @Order(7)
+    void listSuppressedDestinations_filteredByReason() {
+        // Seed a BOUNCE entry so the filter has something to exclude — without it
+        // every existing entry is already COMPLAINT (bounce-1 was flipped at @Order(5))
+        // and the assertion would pass even if the server ignored the filter.
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailAddress": "filter-bounce@example.com", "Reason": "BOUNCE"}
+                """)
+        .when()
+            .put("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("Reason", "COMPLAINT")
+        .when()
+            .get("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(200)
+            .body("SuppressedDestinationSummaries.Reason.unique()", contains("COMPLAINT"))
+            .body("SuppressedDestinationSummaries.EmailAddress",
+                  not(hasItem("filter-bounce@example.com")));
+
+        // Clean up so the BOUNCE seed does not leak into later assertions
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .delete("/v2/email/suppression/addresses/filter-bounce@example.com")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(8)
+    void deleteSuppressedDestination_removesEntry() {
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .delete("/v2/email/suppression/addresses/bounce-1@example.com")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/suppression/addresses/bounce-1@example.com")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(9)
+    void deleteSuppressedDestination_unknown_returns404() {
+        // AWS DeleteSuppressedDestination is not idempotent — an unknown email
+        // surfaces as NotFoundException with the same wording as GetSuppressedDestination.
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .delete("/v2/email/suppression/addresses/already-gone@example.com")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("does not exist on your suppression list"));
+    }
+
+    @Test
+    @Order(10)
+    void putSuppressedDestination_invalidReason_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailAddress": "bad@example.com", "Reason": "OTHER"}
+                """)
+        .when()
+            .put("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(11)
+    void putSuppressedDestination_missingEmailAddress_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"Reason": "BOUNCE"}
+                """)
+        .when()
+            .put("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(12)
+    void putSuppressedDestination_missingBody_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .put("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(13)
+    void putSuppressedDestination_trimsWhitespaceFromEmailAddress() {
+        // AWS silently trims leading/trailing whitespace from EmailAddress on Put.
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailAddress": "  padded@example.com  ", "Reason": "BOUNCE"}
+                """)
+        .when()
+            .put("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/suppression/addresses/padded@example.com")
+        .then()
+            .statusCode(200)
+            .body("SuppressedDestination.EmailAddress", equalTo("padded@example.com"));
+    }
+
+    @Test
+    @Order(14)
+    void listSuppressedDestinations_unknownReasonFilter_returns400() {
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("Reason", "OTHER")
+        .when()
+            .get("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(15)
+    void listSuppressedDestinations_multipleReasonFilters_appliesOrSemantics() {
+        // Seed a BOUNCE entry alongside the surviving complaint-1 COMPLAINT entry
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailAddress": "multi-bounce@example.com", "Reason": "BOUNCE"}
+                """)
+        .when()
+            .put("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("Reason", "BOUNCE")
+            .queryParam("Reason", "COMPLAINT")
+        .when()
+            .get("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(200)
+            .body("SuppressedDestinationSummaries.EmailAddress",
+                  hasItems("multi-bounce@example.com", "complaint-1@example.com"));
+    }
+}


### PR DESCRIPTION
## Summary

Implements the v2 SES suppression list management plane at `/v2/email/suppression/addresses`:

- `PUT /v2/email/suppression/addresses` — `PutSuppressedDestination`
- `GET /v2/email/suppression/addresses/{EmailAddress}` — `GetSuppressedDestination`
- `DELETE /v2/email/suppression/addresses/{EmailAddress}` — `DeleteSuppressedDestination`
- `GET /v2/email/suppression/addresses` — `ListSuppressedDestinations` (repeated `Reason` query param applies OR-semantics across BOUNCE / COMPLAINT)

Entries are persisted per region in `ses-suppression.json`. A repeat `Put` for the same `EmailAddress` updates the existing entry's `Reason` and `LastUpdateTime`. `List` responses are sorted by `LastUpdateTime` then `EmailAddress` for stable output.

Behaviour aligned with real-AWS verification:

- `EmailAddress` is silently trimmed of leading/trailing whitespace on `Put` / `Get` / `Delete` (matching AWS); whitespace-only is rejected with `BadRequestException`.
- `Reason` validation errors use the AWS-canonical `1 validation error detected: Value at '<field>' failed to satisfy constraint: Member must satisfy enum value set: [BOUNCE, COMPLAINT]` wording, with the nested `Member must satisfy constraint: [...]` wrapping AWS emits for the list-typed `reasons` filter.
- `GetSuppressedDestination` and `DeleteSuppressedDestination` return `NotFoundException` with `Email address <X> does not exist on your suppression list.` for unknown addresses. AWS `DeleteSuppressedDestination` is not idempotent — an unknown EmailAddress surfaces as 404, so floci matches.

SendEmail integration is intentionally out of scope: suppressed addresses are still delivered locally so that existing send tests remain unaffected. A follow-up PR can wire suppression checks into the send path along with the `PutAccount/ConfigurationSetSuppressionOptions` configuration endpoints.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against AWS Java SDK v2 \`2.42.24\` (\`software.amazon.awssdk:sesv2\`) and AWS CLI v2 against real AWS. Error wordings (\`Email address <X> does not exist on your suppression list.\`), 404-on-unknown-Delete, AWS-canonical enum-validation strings (flat for \`reason\`, nested for \`reasons\`), and silent whitespace-trim on Put were all reproduced against real AWS before being mirrored here. The compatibility test \`SesSuppressionListTest\` exercises \`putSuppressedDestination\` / \`getSuppressedDestination\` / \`deleteSuppressedDestination\` / \`listSuppressedDestinations\` (including the \`Reason\` filter) and asserts the \`SuppressionListReason\` enum round-trips through the wire.

## Checklist

- [x] \`./mvnw test\` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)