### PR TITLE
fix(dynamodb): improve conformance across validation, expressions, and queries

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/dynamodb.bats
+++ b/compatibility-tests/sdk-test-awscli/test/dynamodb.bats
@@ -725,7 +725,8 @@ teardown() {
 
     run aws_cmd dynamodb scan \
         --table-name "$TABLE_NAME" \
-        --filter-expression 'contains(roles, :role)' \
+        --filter-expression 'contains(#r, :role)' \
+        --expression-attribute-names '{"#r":"roles"}' \
         --expression-attribute-values '{":role":{"S":"admin"}}'
     assert_success
     count=$(json_get "$output" '.Count')

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbConformanceChangesTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbConformanceChangesTest.java
@@ -1,0 +1,637 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeAction;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValueUpdate;
+import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.ComparisonOperator;
+import software.amazon.awssdk.services.dynamodb.model.Condition;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes;
+import software.amazon.awssdk.services.dynamodb.model.ListTablesResponse;
+import software.amazon.awssdk.services.dynamodb.model.LocalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.Projection;
+import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
+import software.amazon.awssdk.services.dynamodb.model.Put;
+import software.amazon.awssdk.services.dynamodb.model.PutItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.PutRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+import software.amazon.awssdk.services.dynamodb.model.ReturnItemCollectionMetrics;
+import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
+import software.amazon.awssdk.services.dynamodb.model.ReturnValuesOnConditionCheckFailure;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
+import software.amazon.awssdk.services.dynamodb.model.Select;
+import software.amazon.awssdk.services.dynamodb.model.Tag;
+import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Compatibility tests for the DynamoDB conformance improvements.
+ *
+ * Covers:
+ *  - Phase 1: ListTables (pagination, alphabetical order, Limit validation) + ValidationException rename
+ *  - Phase 2: ProjectionExpression on GetItem, Query, Scan, BatchGetItem
+ *  - Phase 3: Batch limits, transaction validations, empty-key rejection,
+ *             ReturnItemCollectionMetrics, idempotency token
+ *  - Phase 4: Select=COUNT, parallel scan, attribute_type() function, parenthesized key condition
+ *  - Phase 7: TagResource/ListTagsOfResource error cases
+ *  - Phase 8: ReturnValuesOnConditionCheckFailure
+ *  - Phase 10: Legacy API (AttributesToGet, AttributeUpdates, QueryFilter, ScanFilter)
+ *  - Phase 11: Enum validation before table lookup
+ */
+@DisplayName("DynamoDB Conformance Changes")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class DynamoDbConformanceChangesTest {
+
+    private static DynamoDbClient ddb;
+    private static final String TABLE = "conformance-test-" + UUID.randomUUID().toString().substring(0, 8);
+    private static final String TABLE_LSI = "conformance-lsi-" + UUID.randomUUID().toString().substring(0, 8);
+
+    @BeforeAll
+    static void setup() {
+        ddb = TestFixtures.dynamoDbClient();
+
+        ddb.createTable(r -> r
+                .tableName(TABLE)
+                .keySchema(
+                        KeySchemaElement.builder().attributeName("pk").keyType(KeyType.HASH).build(),
+                        KeySchemaElement.builder().attributeName("sk").keyType(KeyType.RANGE).build())
+                .attributeDefinitions(
+                        AttributeDefinition.builder().attributeName("pk").attributeType(ScalarAttributeType.S).build(),
+                        AttributeDefinition.builder().attributeName("sk").attributeType(ScalarAttributeType.S).build())
+                .billingMode(BillingMode.PAY_PER_REQUEST));
+
+        ddb.createTable(r -> r
+                .tableName(TABLE_LSI)
+                .keySchema(
+                        KeySchemaElement.builder().attributeName("pk").keyType(KeyType.HASH).build(),
+                        KeySchemaElement.builder().attributeName("sk").keyType(KeyType.RANGE).build())
+                .attributeDefinitions(
+                        AttributeDefinition.builder().attributeName("pk").attributeType(ScalarAttributeType.S).build(),
+                        AttributeDefinition.builder().attributeName("sk").attributeType(ScalarAttributeType.S).build(),
+                        AttributeDefinition.builder().attributeName("gsi_sk").attributeType(ScalarAttributeType.S).build())
+                .localSecondaryIndexes(LocalSecondaryIndex.builder()
+                        .indexName("lsi-by-gsi-sk")
+                        .keySchema(
+                                KeySchemaElement.builder().attributeName("pk").keyType(KeyType.HASH).build(),
+                                KeySchemaElement.builder().attributeName("gsi_sk").keyType(KeyType.RANGE).build())
+                        .projection(Projection.builder().projectionType(ProjectionType.ALL).build())
+                        .build())
+                .billingMode(BillingMode.PAY_PER_REQUEST));
+
+        // Seed items
+        for (int i = 0; i < 5; i++) {
+            final int idx = i;
+            ddb.putItem(r -> r.tableName(TABLE).item(Map.of(
+                    "pk", av("p1"),
+                    "sk", av("s" + idx),
+                    "name", av("Item-" + idx),
+                    "count", AttributeValue.builder().n(String.valueOf(idx * 10)).build(),
+                    "status", av("active"))));
+        }
+    }
+
+    @AfterAll
+    static void cleanup() {
+        try { ddb.deleteTable(r -> r.tableName(TABLE)); } catch (Exception ignored) {}
+        try { ddb.deleteTable(r -> r.tableName(TABLE_LSI)); } catch (Exception ignored) {}
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 1 — ListTables: alphabetical order, Limit, ExclusiveStartTableName
+    // -----------------------------------------------------------------------
+
+    @Test @Order(10)
+    void listTablesReturnsAlphabeticalOrder() {
+        ListTablesResponse resp = ddb.listTables();
+        List<String> names = resp.tableNames();
+        List<String> sorted = new ArrayList<>(names);
+        Collections.sort(sorted);
+        assertThat(names).isEqualTo(sorted);
+    }
+
+    @Test @Order(11)
+    void listTablesWithLimit() {
+        ListTablesResponse first = ddb.listTables(r -> r.limit(1));
+        assertThat(first.tableNames()).hasSize(1);
+        assertThat(first.lastEvaluatedTableName()).isNotNull();
+
+        ListTablesResponse second = ddb.listTables(r -> r
+                .limit(1)
+                .exclusiveStartTableName(first.lastEvaluatedTableName()));
+        assertThat(second.tableNames()).isNotEmpty();
+        assertThat(second.tableNames()).doesNotContain(first.tableNames().get(0));
+    }
+
+    @Test @Order(12)
+    void listTablesLimitZeroThrowsValidationException() {
+        assertThatThrownBy(() -> ddb.listTables(r -> r.limit(0)))
+                .isInstanceOf(DynamoDbException.class)
+                .satisfies(e -> assertThat(((DynamoDbException) e).awsErrorDetails().errorCode())
+                        .isEqualTo("ValidationException"));
+    }
+
+    @Test @Order(13)
+    void listTablesLimitOver100ThrowsValidationException() {
+        assertThatThrownBy(() -> ddb.listTables(r -> r.limit(101)))
+                .isInstanceOf(DynamoDbException.class)
+                .satisfies(e -> assertThat(((DynamoDbException) e).awsErrorDetails().errorCode())
+                        .isEqualTo("ValidationException"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 1 — ValidationException for invalid table names
+    // -----------------------------------------------------------------------
+
+    @Test @Order(20)
+    void putItemInvalidTableNameThrowsValidationException() {
+        assertThatThrownBy(() -> ddb.putItem(r -> r.tableName("ab").item(Map.of("pk", av("x")))))
+                .isInstanceOf(DynamoDbException.class)
+                .satisfies(e -> assertThat(((DynamoDbException) e).awsErrorDetails().errorCode())
+                        .isEqualTo("ValidationException"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 2 — ProjectionExpression
+    // -----------------------------------------------------------------------
+
+    @Test @Order(30)
+    void getItemWithProjectionReturnsOnlyProjectedAttributes() {
+        GetItemResponse resp = ddb.getItem(r -> r
+                .tableName(TABLE)
+                .key(Map.of("pk", av("p1"), "sk", av("s0")))
+                .projectionExpression("#n")
+                .expressionAttributeNames(Map.of("#n", "name")));
+
+        assertThat(resp.item()).containsKey("name");
+        assertThat(resp.item()).doesNotContainKey("count");
+        assertThat(resp.item()).doesNotContainKey("status");
+    }
+
+    @Test @Order(31)
+    void queryWithProjectionReturnsOnlyProjectedAttributes() {
+        QueryResponse resp = ddb.query(r -> r
+                .tableName(TABLE)
+                .keyConditionExpression("pk = :pk")
+                .expressionAttributeValues(Map.of(":pk", av("p1")))
+                .projectionExpression("sk, #n")
+                .expressionAttributeNames(Map.of("#n", "name")));
+
+        assertThat(resp.items()).isNotEmpty();
+        for (Map<String, AttributeValue> item : resp.items()) {
+            assertThat(item).containsKeys("sk", "name");
+            assertThat(item).doesNotContainKey("count");
+        }
+    }
+
+    @Test @Order(32)
+    void scanWithProjectionReturnsOnlyProjectedAttributes() {
+        ScanResponse resp = ddb.scan(r -> r
+                .tableName(TABLE)
+                .filterExpression("pk = :pk")
+                .expressionAttributeValues(Map.of(":pk", av("p1")))
+                .projectionExpression("pk, sk"));
+
+        assertThat(resp.items()).isNotEmpty();
+        for (Map<String, AttributeValue> item : resp.items()) {
+            assertThat(item).containsKeys("pk", "sk");
+            assertThat(item).doesNotContainKey("name");
+        }
+    }
+
+    @Test @Order(33)
+    void batchGetItemWithProjectionReturnsOnlyProjectedAttributes() {
+        BatchGetItemResponse resp = ddb.batchGetItem(r -> r
+                .requestItems(Map.of(TABLE, KeysAndAttributes.builder()
+                        .keys(Map.of("pk", av("p1"), "sk", av("s0")))
+                        .projectionExpression("#n")
+                        .expressionAttributeNames(Map.of("#n", "name"))
+                        .build())));
+
+        List<Map<String, AttributeValue>> items = resp.responses().get(TABLE);
+        assertThat(items).isNotEmpty();
+        assertThat(items.get(0)).containsKey("name");
+        assertThat(items.get(0)).doesNotContainKey("count");
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 3 — Batch limits and empty-key rejection
+    // -----------------------------------------------------------------------
+
+    @Test @Order(40)
+    void batchWriteItemRejectsMoreThan25Items() {
+        List<WriteRequest> writes = new ArrayList<>();
+        for (int i = 0; i < 26; i++) {
+            writes.add(WriteRequest.builder()
+                    .putRequest(PutRequest.builder()
+                            .item(Map.of("pk", av("excess-" + i), "sk", av("s")))
+                            .build())
+                    .build());
+        }
+        assertThatThrownBy(() -> ddb.batchWriteItem(r -> r.requestItems(Map.of(TABLE, writes))))
+                .isInstanceOf(DynamoDbException.class)
+                .satisfies(e -> assertThat(((DynamoDbException) e).awsErrorDetails().errorCode())
+                        .isEqualTo("ValidationException"));
+    }
+
+    @Test @Order(41)
+    void batchGetItemRejectsMoreThan100Keys() {
+        List<Map<String, AttributeValue>> keys = new ArrayList<>();
+        for (int i = 0; i < 101; i++) {
+            keys.add(Map.of("pk", av("k-" + i), "sk", av("s")));
+        }
+        assertThatThrownBy(() -> ddb.batchGetItem(r -> r
+                .requestItems(Map.of(TABLE, KeysAndAttributes.builder().keys(keys).build()))))
+                .isInstanceOf(DynamoDbException.class)
+                .satisfies(e -> assertThat(((DynamoDbException) e).awsErrorDetails().errorCode())
+                        .isEqualTo("ValidationException"));
+    }
+
+    @Test @Order(42)
+    void putItemRejectsEmptyStringPrimaryKey() {
+        assertThatThrownBy(() -> ddb.putItem(r -> r
+                .tableName(TABLE)
+                .item(Map.of("pk", av(""), "sk", av("s1")))))
+                .isInstanceOf(DynamoDbException.class)
+                .satisfies(e -> assertThat(((DynamoDbException) e).awsErrorDetails().errorCode())
+                        .isEqualTo("ValidationException"));
+    }
+
+    @Test @Order(43)
+    void transactWriteItemsRejectsDuplicateKeys() {
+        assertThatThrownBy(() -> ddb.transactWriteItems(r -> r
+                .transactItems(
+                        TransactWriteItem.builder().put(Put.builder()
+                                .tableName(TABLE)
+                                .item(Map.of("pk", av("dup"), "sk", av("s1")))
+                                .build()).build(),
+                        TransactWriteItem.builder().put(Put.builder()
+                                .tableName(TABLE)
+                                .item(Map.of("pk", av("dup"), "sk", av("s1")))
+                                .build()).build())))
+                .isInstanceOf(DynamoDbException.class)
+                .satisfies(e -> assertThat(((DynamoDbException) e).awsErrorDetails().errorCode())
+                        .isEqualTo("ValidationException"));
+    }
+
+    @Test @Order(44)
+    void transactWriteItemsIdempotencyTokenRejectsConflict() {
+        String token = UUID.randomUUID().toString();
+
+        // First request succeeds
+        ddb.transactWriteItems(r -> r
+                .clientRequestToken(token)
+                .transactItems(TransactWriteItem.builder()
+                        .put(Put.builder()
+                                .tableName(TABLE)
+                                .item(Map.of("pk", av("idem-test"), "sk", av("s")))
+                                .build())
+                        .build()));
+
+        // Same token, different payload → IdempotentParameterMismatchException
+        assertThatThrownBy(() -> ddb.transactWriteItems(r -> r
+                .clientRequestToken(token)
+                .transactItems(TransactWriteItem.builder()
+                        .put(Put.builder()
+                                .tableName(TABLE)
+                                .item(Map.of("pk", av("idem-different"), "sk", av("s")))
+                                .build())
+                        .build())))
+                .isInstanceOf(DynamoDbException.class)
+                .satisfies(e -> assertThat(((DynamoDbException) e).awsErrorDetails().errorCode())
+                        .isEqualTo("IdempotentParameterMismatchException"));
+    }
+
+    @Test @Order(45)
+    void returnItemCollectionMetricsOnLsiTable() {
+        PutItemResponse resp = ddb.putItem(r -> r
+                .tableName(TABLE_LSI)
+                .item(Map.of(
+                        "pk", av("m1"),
+                        "sk", av("sk-a"),
+                        "gsi_sk", av("g1")))
+                .returnItemCollectionMetrics(ReturnItemCollectionMetrics.SIZE));
+
+        assertThat(resp.itemCollectionMetrics()).isNotNull();
+        assertThat(resp.itemCollectionMetrics().sizeEstimateRangeGB()).hasSize(2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 4 — Select=COUNT, parallel scan, attribute_type(), parenthesized key condition
+    // -----------------------------------------------------------------------
+
+    @Test @Order(50)
+    void querySelectCountReturnsCountNotItems() {
+        QueryResponse resp = ddb.query(r -> r
+                .tableName(TABLE)
+                .keyConditionExpression("pk = :pk")
+                .expressionAttributeValues(Map.of(":pk", av("p1")))
+                .select(Select.COUNT));
+
+        assertThat(resp.count()).isEqualTo(5);
+        assertThat(resp.items()).isEmpty();
+    }
+
+    @Test @Order(51)
+    void scanSelectCountReturnsCountNotItems() {
+        ScanResponse resp = ddb.scan(r -> r
+                .tableName(TABLE)
+                .filterExpression("pk = :pk")
+                .expressionAttributeValues(Map.of(":pk", av("p1")))
+                .select(Select.COUNT));
+
+        assertThat(resp.count()).isGreaterThan(0);
+        assertThat(resp.items()).isEmpty();
+    }
+
+    @Test @Order(52)
+    void parallelScanPartitionsResultsCorrectly() {
+        int totalSegments = 2;
+        List<Map<String, AttributeValue>> segment0 = ddb.scan(r -> r
+                .tableName(TABLE)
+                .segment(0).totalSegments(totalSegments)).items();
+        List<Map<String, AttributeValue>> segment1 = ddb.scan(r -> r
+                .tableName(TABLE)
+                .segment(1).totalSegments(totalSegments)).items();
+
+        // Key each item by pk#sk to handle multiple items sharing the same sk
+        Set<String> keys0 = new HashSet<>(), keys1 = new HashSet<>();
+        segment0.forEach(i -> keys0.add(i.get("pk").s() + "#" + i.get("sk").s()));
+        segment1.forEach(i -> keys1.add(i.get("pk").s() + "#" + i.get("sk").s()));
+
+        // No overlap between segments
+        assertThat(keys0).doesNotContainAnyElementsOf(keys1);
+        // Union covers all items in the table
+        int totalCount = ddb.scan(r -> r.tableName(TABLE)).count();
+        Set<String> combined = new HashSet<>(keys0);
+        combined.addAll(keys1);
+        assertThat(combined).hasSize(totalCount);
+    }
+
+    @Test @Order(53)
+    void parallelScanRequiresBothSegmentAndTotalSegments() {
+        assertThatThrownBy(() -> ddb.scan(r -> r.tableName(TABLE).segment(0)))
+                .isInstanceOf(DynamoDbException.class)
+                .satisfies(e -> assertThat(((DynamoDbException) e).awsErrorDetails().errorCode())
+                        .isEqualTo("ValidationException"));
+    }
+
+    @Test @Order(54)
+    void queryWithAttributeTypeFunction() {
+        QueryResponse resp = ddb.query(r -> r
+                .tableName(TABLE)
+                .keyConditionExpression("pk = :pk")
+                .filterExpression("attribute_type(#n, :t)")
+                .expressionAttributeValues(Map.of(
+                        ":pk", av("p1"),
+                        ":t", av("S")))
+                .expressionAttributeNames(Map.of("#n", "name")));
+
+        assertThat(resp.items()).hasSize(5);
+    }
+
+    @Test @Order(55)
+    void queryWithParenthesizedKeyCondition() {
+        QueryResponse resp = ddb.query(r -> r
+                .tableName(TABLE)
+                .keyConditionExpression("(pk = :pk AND sk = :sk)")
+                .expressionAttributeValues(Map.of(":pk", av("p1"), ":sk", av("s0"))));
+
+        assertThat(resp.items()).hasSize(1);
+        assertThat(resp.items().get(0).get("sk").s()).isEqualTo("s0");
+    }
+
+    @Test @Order(56)
+    void queryRequiresKeyCondition() {
+        assertThatThrownBy(() -> ddb.query(r -> r.tableName(TABLE)))
+                .isInstanceOf(DynamoDbException.class)
+                .satisfies(e -> assertThat(((DynamoDbException) e).awsErrorDetails().errorCode())
+                        .isEqualTo("ValidationException"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 7 — Tags: ARN validation and non-existent ARN behaviour
+    // -----------------------------------------------------------------------
+
+    @Test @Order(60)
+    void tagResourceWithInvalidArnThrowsValidationException() {
+        assertThatThrownBy(() -> ddb.tagResource(r -> r
+                .resourceArn("not-an-arn")
+                .tags(Tag.builder().key("k").value("v").build())))
+                .isInstanceOf(DynamoDbException.class)
+                .satisfies(e -> assertThat(((DynamoDbException) e).awsErrorDetails().errorCode())
+                        .isEqualTo("ValidationException"));
+    }
+
+    @Test @Order(61)
+    void listTagsOfResourceWithValidFormatNonExistentArnThrowsAccessDeniedException() {
+        assertThatThrownBy(() -> ddb.listTagsOfResource(r -> r
+                .resourceArn("arn:aws:dynamodb:us-east-1:000000000000:table/does-not-exist")))
+                .isInstanceOf(DynamoDbException.class)
+                .satisfies(e -> assertThat(((DynamoDbException) e).awsErrorDetails().errorCode())
+                        .isEqualTo("AccessDeniedException"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 8 — ReturnValuesOnConditionCheckFailure
+    // -----------------------------------------------------------------------
+
+    @Test @Order(70)
+    void putItemConditionFailureReturnsOldItemWhenRequested() {
+        // Seed an existing item
+        ddb.putItem(r -> r.tableName(TABLE).item(Map.of(
+                "pk", av("cond-test"), "sk", av("s"), "val", av("old"))));
+
+        DynamoDbException ex = (DynamoDbException) catchThrowable(() ->
+                ddb.putItem(r -> r
+                        .tableName(TABLE)
+                        .item(Map.of("pk", av("cond-test"), "sk", av("s"), "val", av("new")))
+                        .conditionExpression("attribute_not_exists(pk)")
+                        .returnValuesOnConditionCheckFailure(ReturnValuesOnConditionCheckFailure.ALL_OLD)));
+
+        assertThat(ex).isNotNull();
+        assertThat(ex.awsErrorDetails().errorCode()).isEqualTo("ConditionalCheckFailedException");
+    }
+
+    @Test @Order(71)
+    void updateItemConditionFailureReturnsOldItemWhenRequested() {
+        ddb.putItem(r -> r.tableName(TABLE).item(Map.of(
+                "pk", av("cond-upd"), "sk", av("s"), "val", av("original"))));
+
+        DynamoDbException ex = (DynamoDbException) catchThrowable(() ->
+                ddb.updateItem(r -> r
+                        .tableName(TABLE)
+                        .key(Map.of("pk", av("cond-upd"), "sk", av("s")))
+                        .updateExpression("SET val = :new")
+                        .conditionExpression("val = :expected")
+                        .expressionAttributeValues(Map.of(":new", av("new"), ":expected", av("wrong")))
+                        .returnValuesOnConditionCheckFailure(ReturnValuesOnConditionCheckFailure.ALL_OLD)));
+
+        assertThat(ex).isNotNull();
+        assertThat(ex.awsErrorDetails().errorCode()).isEqualTo("ConditionalCheckFailedException");
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 10 — Legacy API: AttributesToGet, AttributeUpdates, QueryFilter, ScanFilter
+    // -----------------------------------------------------------------------
+
+    @Test @Order(80)
+    void getItemAttributesToGet() {
+        GetItemResponse resp = ddb.getItem(r -> r
+                .tableName(TABLE)
+                .key(Map.of("pk", av("p1"), "sk", av("s0")))
+                .attributesToGet("name", "count"));
+
+        assertThat(resp.item()).containsKeys("name", "count");
+        assertThat(resp.item()).doesNotContainKey("status");
+        // AttributesToGet does NOT auto-include key attributes
+        assertThat(resp.item()).doesNotContainKey("pk");
+    }
+
+    @Test @Order(81)
+    void attributesToGetAndProjectionExpressionAreMutuallyExclusive() {
+        assertThatThrownBy(() -> ddb.getItem(r -> r
+                .tableName(TABLE)
+                .key(Map.of("pk", av("p1"), "sk", av("s0")))
+                .attributesToGet("name")
+                .projectionExpression("name")))
+                .isInstanceOf(DynamoDbException.class)
+                .satisfies(e -> assertThat(((DynamoDbException) e).awsErrorDetails().errorCode())
+                        .isEqualTo("ValidationException"));
+    }
+
+    @Test @Order(82)
+    @SuppressWarnings("deprecation")
+    void updateItemWithAttributeUpdates() {
+        ddb.putItem(r -> r.tableName(TABLE).item(Map.of(
+                "pk", av("legacy-upd"), "sk", av("s"), "color", av("red"))));
+
+        ddb.updateItem(UpdateItemRequest.builder()
+                .tableName(TABLE)
+                .key(Map.of("pk", av("legacy-upd"), "sk", av("s")))
+                .attributeUpdates(Map.of(
+                        "color", AttributeValueUpdate.builder()
+                                .value(av("blue"))
+                                .action(AttributeAction.PUT)
+                                .build()))
+                .build());
+
+        GetItemResponse resp = ddb.getItem(r -> r
+                .tableName(TABLE)
+                .key(Map.of("pk", av("legacy-upd"), "sk", av("s"))));
+        assertThat(resp.item().get("color").s()).isEqualTo("blue");
+    }
+
+    @Test @Order(83)
+    @SuppressWarnings("deprecation")
+    void queryWithQueryFilter() {
+        QueryResponse resp = ddb.query(QueryRequest.builder()
+                .tableName(TABLE)
+                .keyConditionExpression("pk = :pk")
+                .expressionAttributeValues(Map.of(":pk", av("p1")))
+                .queryFilter(Map.of("name", Condition.builder()
+                        .comparisonOperator(ComparisonOperator.EQ)
+                        .attributeValueList(av("Item-0"))
+                        .build()))
+                .build());
+
+        assertThat(resp.items()).hasSize(1);
+        assertThat(resp.items().get(0).get("name").s()).isEqualTo("Item-0");
+    }
+
+    @Test @Order(84)
+    @SuppressWarnings("deprecation")
+    void scanWithScanFilter() {
+        ScanResponse resp = ddb.scan(ScanRequest.builder()
+                .tableName(TABLE)
+                .scanFilter(Map.of("name", Condition.builder()
+                        .comparisonOperator(ComparisonOperator.EQ)
+                        .attributeValueList(av("Item-2"))
+                        .build()))
+                .build());
+
+        assertThat(resp.items()).hasSize(1);
+        assertThat(resp.items().get(0).get("name").s()).isEqualTo("Item-2");
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 11 — Enum validation fires before table lookup
+    // -----------------------------------------------------------------------
+
+    @Test @Order(90)
+    void enumValidationFiresBeforeTableLookupOnPutItem() {
+        DynamoDbException ex = (DynamoDbException) catchThrowable(() ->
+                ddb.putItem(r -> r
+                        .tableName("nonexistent-table-xyz")
+                        .item(Map.of("pk", av("x")))
+                        .returnValues(ReturnValue.UPDATED_NEW))); // invalid for PutItem
+
+        assertThat(ex).isNotNull();
+        assertThat(ex.awsErrorDetails().errorCode()).isEqualTo("ValidationException");
+        assertThat(ex.awsErrorDetails().errorMessage()).doesNotContain("ResourceNotFoundException");
+    }
+
+    @Test @Order(91)
+    void enumValidationFiresBeforeTableLookupOnDeleteItem() {
+        DynamoDbException ex = (DynamoDbException) catchThrowable(() ->
+                ddb.deleteItem(r -> r
+                        .tableName("nonexistent-table-xyz")
+                        .key(Map.of("pk", av("x"), "sk", av("y")))
+                        .returnValues(ReturnValue.UPDATED_NEW))); // invalid for DeleteItem
+
+        assertThat(ex).isNotNull();
+        assertThat(ex.awsErrorDetails().errorCode()).isEqualTo("ValidationException");
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 9 — Reserved word rejection in expressions
+    // -----------------------------------------------------------------------
+
+    @Test @Order(100)
+    void reservedWordAsAttributeNameInConditionThrowsValidationException() {
+        assertThatThrownBy(() -> ddb.putItem(r -> r
+                .tableName(TABLE)
+                .item(Map.of("pk", av("rw-test"), "sk", av("s")))
+                .conditionExpression("attribute_not_exists(status)"))) // 'status' is a bare reserved word
+                .isInstanceOf(DynamoDbException.class)
+                .satisfies(e -> assertThat(((DynamoDbException) e).awsErrorDetails().errorCode())
+                        .isEqualTo("ValidationException"));
+    }
+
+    @Test @Order(101)
+    void reservedWordWithAliasPasses() {
+        // Using #status alias should work fine
+        assertThatCode(() -> ddb.putItem(r -> r
+                .tableName(TABLE)
+                .item(Map.of("pk", av("rw-alias"), "sk", av("s"), "status", av("ok")))
+                .conditionExpression("attribute_not_exists(pk)")
+                .expressionAttributeNames(Map.of("#st", "status"))))
+                .doesNotThrowAnyException();
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static AttributeValue av(String s) {
+        return AttributeValue.builder().s(s).build();
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbExpressionTests.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbExpressionTests.java
@@ -126,7 +126,8 @@ class DynamoDbExpressionTests {
     void filterInSingle() {
         ScanResponse resp = ddb.scan(ScanRequest.builder()
                 .tableName(FILTER_TABLE)
-                .filterExpression("status IN (:v0)")
+                .filterExpression("#s IN (:v0)")
+                .expressionAttributeNames(Map.of("#s", "status"))
                 .expressionAttributeValues(Map.of(":v0", AttributeValue.fromN("1")))
                 .build());
         assertThat(resp.count()).isEqualTo(2);
@@ -138,7 +139,8 @@ class DynamoDbExpressionTests {
     void filterInMultiple() {
         ScanResponse resp = ddb.scan(ScanRequest.builder()
                 .tableName(FILTER_TABLE)
-                .filterExpression("status IN (:v0, :v1)")
+                .filterExpression("#s IN (:v0, :v1)")
+                .expressionAttributeNames(Map.of("#s", "status"))
                 .expressionAttributeValues(Map.of(
                         ":v0", AttributeValue.fromN("1"),
                         ":v1", AttributeValue.fromN("3")))
@@ -154,7 +156,8 @@ class DynamoDbExpressionTests {
     void filterOr() {
         ScanResponse resp = ddb.scan(ScanRequest.builder()
                 .tableName(FILTER_TABLE)
-                .filterExpression("status = :v1 OR status = :v2")
+                .filterExpression("#s = :v1 OR #s = :v2")
+                .expressionAttributeNames(Map.of("#s", "status"))
                 .expressionAttributeValues(Map.of(
                         ":v1", AttributeValue.fromN("1"),
                         ":v2", AttributeValue.fromN("2")))
@@ -184,7 +187,8 @@ class DynamoDbExpressionTests {
     void filterParenthesizedAndOr() {
         ScanResponse resp = ddb.scan(ScanRequest.builder()
                 .tableName(FILTER_TABLE)
-                .filterExpression("(status = :v1 OR status = :v3) AND category = :catA")
+                .filterExpression("(#s = :v1 OR #s = :v3) AND category = :catA")
+                .expressionAttributeNames(Map.of("#s", "status"))
                 .expressionAttributeValues(Map.of(
                         ":v1", AttributeValue.fromN("1"),
                         ":v3", AttributeValue.fromN("3"),
@@ -334,7 +338,8 @@ class DynamoDbExpressionTests {
             ddb.updateItem(UpdateItemRequest.builder()
                     .tableName(table)
                     .key(Map.of("pk", AttributeValue.fromS("k1")))
-                    .updateExpression("SET counter = if_not_exists(counter, :start) + :inc")
+                    .updateExpression("SET #cnt = if_not_exists(#cnt, :start) + :inc")
+                    .expressionAttributeNames(Map.of("#cnt", "counter"))
                     .expressionAttributeValues(Map.of(
                             ":start", AttributeValue.builder().n("0").build(),
                             ":inc", AttributeValue.builder().n("1").build()))
@@ -350,7 +355,8 @@ class DynamoDbExpressionTests {
             ddb.updateItem(UpdateItemRequest.builder()
                     .tableName(table)
                     .key(Map.of("pk", AttributeValue.fromS("k1")))
-                    .updateExpression("SET counter = if_not_exists(counter, :start) + :inc")
+                    .updateExpression("SET #cnt = if_not_exists(#cnt, :start) + :inc")
+                    .expressionAttributeNames(Map.of("#cnt", "counter"))
                     .expressionAttributeValues(Map.of(
                             ":start", AttributeValue.builder().n("0").build(),
                             ":inc", AttributeValue.builder().n("1").build()))
@@ -366,7 +372,8 @@ class DynamoDbExpressionTests {
             ddb.updateItem(UpdateItemRequest.builder()
                     .tableName(table)
                     .key(Map.of("pk", AttributeValue.fromS("k1")))
-                    .updateExpression("SET counter = counter - :dec")
+                    .updateExpression("SET #cnt = #cnt - :dec")
+                    .expressionAttributeNames(Map.of("#cnt", "counter"))
                     .expressionAttributeValues(Map.of(
                             ":dec", AttributeValue.builder().n("1").build()))
                     .build());

--- a/compatibility-tests/sdk-test-node/tests/dynamodb-conformance.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/dynamodb-conformance.test.ts
@@ -1,0 +1,783 @@
+/**
+ * DynamoDB conformance change tests.
+ *
+ * Covers:
+ *  - Phase 1: ListTables (alphabetical order, Limit pagination, Limit validation)
+ *             + ValidationException rename for invalid table names
+ *  - Phase 2: ProjectionExpression on GetItem, Query, Scan, BatchGetItem
+ *  - Phase 3: Batch limits (BatchWrite >25, BatchGet >100), empty PK rejection,
+ *             TransactWriteItems duplicate key + idempotency token,
+ *             ReturnItemCollectionMetrics=SIZE on LSI table
+ *  - Phase 4: Select=COUNT on Query/Scan, parallel scan, attribute_type() function,
+ *             parenthesized key condition, missing key condition validation
+ *  - Phase 7: TagResource invalid ARN, ListTagsOfResource non-existent ARN
+ *  - Phase 8: ReturnValuesOnConditionCheckFailure on PutItem/UpdateItem
+ *  - Phase 9: Reserved word rejection in expressions; alias passes
+ *  - Phase 10: AttributesToGet, AttributeUpdates, QueryFilter, ScanFilter (legacy API)
+ *  - Phase 11: Enum validation fires before table lookup
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  DynamoDBClient,
+  BatchGetItemCommand,
+  BatchWriteItemCommand,
+  CreateTableCommand,
+  DeleteItemCommand,
+  DeleteTableCommand,
+  GetItemCommand,
+  ListTablesCommand,
+  ListTagsOfResourceCommand,
+  PutItemCommand,
+  QueryCommand,
+  ScanCommand,
+  TagResourceCommand,
+  TransactWriteItemsCommand,
+  UpdateItemCommand,
+} from '@aws-sdk/client-dynamodb';
+import { makeClient, uniqueName } from './setup';
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function s(v: string) {
+  return { S: v };
+}
+function n(v: number) {
+  return { N: String(v) };
+}
+
+async function expectError(promise: Promise<unknown>, expectedName: string): Promise<void> {
+  let caught: unknown;
+  try {
+    await promise;
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught, `expected ${expectedName} to be thrown`).toBeDefined();
+  expect((caught as Error).name).toBe(expectedName);
+}
+
+// ─── Phase 1: ListTables ────────────────────────────────────────────────────
+
+describe('DynamoDB — Phase 1: ListTables', () => {
+  let ddb: DynamoDBClient;
+  const tables: string[] = [];
+
+  beforeAll(async () => {
+    ddb = makeClient(DynamoDBClient);
+    // Create three tables with deterministic alphabetical names
+    for (const suffix of ['aaa', 'bbb', 'ccc']) {
+      const name = `lt-${suffix}-${uniqueName()}`;
+      tables.push(name);
+      await ddb.send(new CreateTableCommand({
+        TableName: name,
+        KeySchema: [{ AttributeName: 'pk', KeyType: 'HASH' }],
+        AttributeDefinitions: [{ AttributeName: 'pk', AttributeType: 'S' }],
+        BillingMode: 'PAY_PER_REQUEST',
+      }));
+    }
+    tables.sort(); // ensure our expectation baseline is sorted
+  });
+
+  afterAll(async () => {
+    for (const t of tables) {
+      try { await ddb.send(new DeleteTableCommand({ TableName: t })); } catch { /* ignore */ }
+    }
+  });
+
+  it('returns tables in alphabetical order', async () => {
+    const resp = await ddb.send(new ListTablesCommand({}));
+    const names = resp.TableNames ?? [];
+    const sorted = [...names].sort();
+    expect(names).toEqual(sorted);
+  });
+
+  it('respects Limit and returns LastEvaluatedTableName', async () => {
+    const first = await ddb.send(new ListTablesCommand({ Limit: 1 }));
+    expect(first.TableNames).toHaveLength(1);
+    expect(first.LastEvaluatedTableName).toBeDefined();
+
+    const second = await ddb.send(new ListTablesCommand({
+      Limit: 1,
+      ExclusiveStartTableName: first.LastEvaluatedTableName,
+    }));
+    expect(second.TableNames).toHaveLength(1);
+    expect(second.TableNames![0]).not.toBe(first.TableNames![0]);
+  });
+
+  it('rejects Limit=0 with ValidationException', async () => {
+    await expectError(ddb.send(new ListTablesCommand({ Limit: 0 })), 'ValidationException');
+  });
+
+  it('rejects Limit=101 with ValidationException', async () => {
+    await expectError(ddb.send(new ListTablesCommand({ Limit: 101 })), 'ValidationException');
+  });
+});
+
+// ─── Phase 1: ValidationException for invalid table names ───────────────────
+
+describe('DynamoDB — Phase 1: ValidationException rename', () => {
+  let ddb: DynamoDBClient;
+
+  beforeAll(() => { ddb = makeClient(DynamoDBClient); });
+
+  it('rejects a 2-char table name with ValidationException', async () => {
+    await expectError(
+      ddb.send(new PutItemCommand({ TableName: 'ab', Item: { pk: s('x') } })),
+      'ValidationException',
+    );
+  });
+
+  it('rejects empty table name with ValidationException', async () => {
+    await expectError(
+      ddb.send(new GetItemCommand({ TableName: '', Key: { pk: s('x') } })),
+      'ValidationException',
+    );
+  });
+});
+
+// ─── Phase 2: ProjectionExpression ──────────────────────────────────────────
+
+describe('DynamoDB — Phase 2: ProjectionExpression', () => {
+  let ddb: DynamoDBClient;
+  const table = `proj-${uniqueName()}`;
+
+  beforeAll(async () => {
+    ddb = makeClient(DynamoDBClient);
+    await ddb.send(new CreateTableCommand({
+      TableName: table,
+      KeySchema: [
+        { AttributeName: 'pk', KeyType: 'HASH' },
+        { AttributeName: 'sk', KeyType: 'RANGE' },
+      ],
+      AttributeDefinitions: [
+        { AttributeName: 'pk', AttributeType: 'S' },
+        { AttributeName: 'sk', AttributeType: 'S' },
+      ],
+      BillingMode: 'PAY_PER_REQUEST',
+    }));
+    for (let i = 0; i < 3; i++) {
+      await ddb.send(new PutItemCommand({
+        TableName: table,
+        Item: { pk: s('p1'), sk: s(`s${i}`), name: s(`Item-${i}`), count: n(i * 10), status: s('active') },
+      }));
+    }
+  });
+
+  afterAll(async () => {
+    try { await ddb.send(new DeleteTableCommand({ TableName: table })); } catch { /* ignore */ }
+  });
+
+  it('GetItem: returns only projected attributes', async () => {
+    const resp = await ddb.send(new GetItemCommand({
+      TableName: table,
+      Key: { pk: s('p1'), sk: s('s0') },
+      ProjectionExpression: '#n',
+      ExpressionAttributeNames: { '#n': 'name' },
+    }));
+    expect(resp.Item).toHaveProperty('name');
+    expect(resp.Item).not.toHaveProperty('count');
+    expect(resp.Item).not.toHaveProperty('status');
+  });
+
+  it('Query: returns only projected attributes', async () => {
+    const resp = await ddb.send(new QueryCommand({
+      TableName: table,
+      KeyConditionExpression: 'pk = :pk',
+      ExpressionAttributeValues: { ':pk': s('p1') },
+      ProjectionExpression: 'sk, #n',
+      ExpressionAttributeNames: { '#n': 'name' },
+    }));
+    expect(resp.Items!.length).toBeGreaterThan(0);
+    for (const item of resp.Items!) {
+      expect(item).toHaveProperty('sk');
+      expect(item).toHaveProperty('name');
+      expect(item).not.toHaveProperty('count');
+    }
+  });
+
+  it('Scan: returns only projected attributes', async () => {
+    const resp = await ddb.send(new ScanCommand({
+      TableName: table,
+      FilterExpression: 'pk = :pk',
+      ExpressionAttributeValues: { ':pk': s('p1') },
+      ProjectionExpression: 'pk, sk',
+    }));
+    expect(resp.Items!.length).toBeGreaterThan(0);
+    for (const item of resp.Items!) {
+      expect(item).toHaveProperty('pk');
+      expect(item).toHaveProperty('sk');
+      expect(item).not.toHaveProperty('name');
+    }
+  });
+
+  it('BatchGetItem: returns only projected attributes', async () => {
+    const resp = await ddb.send(new BatchGetItemCommand({
+      RequestItems: {
+        [table]: {
+          Keys: [{ pk: s('p1'), sk: s('s0') }],
+          ProjectionExpression: '#n',
+          ExpressionAttributeNames: { '#n': 'name' },
+        },
+      },
+    }));
+    const items = resp.Responses?.[table] ?? [];
+    expect(items.length).toBeGreaterThan(0);
+    expect(items[0]).toHaveProperty('name');
+    expect(items[0]).not.toHaveProperty('count');
+  });
+
+  it('rejects AttributesToGet combined with ProjectionExpression', async () => {
+    await expectError(
+      ddb.send(new GetItemCommand({
+        TableName: table,
+        Key: { pk: s('p1'), sk: s('s0') },
+        AttributesToGet: ['name'],
+        ProjectionExpression: 'name',
+      })),
+      'ValidationException',
+    );
+  });
+});
+
+// ─── Phase 3: Validation limits ─────────────────────────────────────────────
+
+describe('DynamoDB — Phase 3: Batch limits & key validation', () => {
+  let ddb: DynamoDBClient;
+  const table = `val-${uniqueName()}`;
+  const lsiTable = `val-lsi-${uniqueName()}`;
+
+  beforeAll(async () => {
+    ddb = makeClient(DynamoDBClient);
+    await ddb.send(new CreateTableCommand({
+      TableName: table,
+      KeySchema: [
+        { AttributeName: 'pk', KeyType: 'HASH' },
+        { AttributeName: 'sk', KeyType: 'RANGE' },
+      ],
+      AttributeDefinitions: [
+        { AttributeName: 'pk', AttributeType: 'S' },
+        { AttributeName: 'sk', AttributeType: 'S' },
+      ],
+      BillingMode: 'PAY_PER_REQUEST',
+    }));
+    await ddb.send(new CreateTableCommand({
+      TableName: lsiTable,
+      KeySchema: [
+        { AttributeName: 'pk', KeyType: 'HASH' },
+        { AttributeName: 'sk', KeyType: 'RANGE' },
+      ],
+      AttributeDefinitions: [
+        { AttributeName: 'pk', AttributeType: 'S' },
+        { AttributeName: 'sk', AttributeType: 'S' },
+        { AttributeName: 'lsi_sk', AttributeType: 'S' },
+      ],
+      LocalSecondaryIndexes: [{
+        IndexName: 'lsi-by-lsi-sk',
+        KeySchema: [
+          { AttributeName: 'pk', KeyType: 'HASH' },
+          { AttributeName: 'lsi_sk', KeyType: 'RANGE' },
+        ],
+        Projection: { ProjectionType: 'ALL' },
+      }],
+      BillingMode: 'PAY_PER_REQUEST',
+    }));
+  });
+
+  afterAll(async () => {
+    try { await ddb.send(new DeleteTableCommand({ TableName: table })); } catch { /* ignore */ }
+    try { await ddb.send(new DeleteTableCommand({ TableName: lsiTable })); } catch { /* ignore */ }
+  });
+
+  it('BatchWriteItem rejects more than 25 items', async () => {
+    const writes = Array.from({ length: 26 }, (_, i) => ({
+      PutRequest: { Item: { pk: s(`excess-${i}`), sk: s('s') } },
+    }));
+    await expectError(
+      ddb.send(new BatchWriteItemCommand({ RequestItems: { [table]: writes } })),
+      'ValidationException',
+    );
+  });
+
+  it('BatchGetItem rejects more than 100 keys', async () => {
+    const keys = Array.from({ length: 101 }, (_, i) => ({ pk: s(`k${i}`), sk: s('s') }));
+    await expectError(
+      ddb.send(new BatchGetItemCommand({ RequestItems: { [table]: { Keys: keys } } })),
+      'ValidationException',
+    );
+  });
+
+  it('PutItem rejects empty string as PK', async () => {
+    await expectError(
+      ddb.send(new PutItemCommand({ TableName: table, Item: { pk: s(''), sk: s('s') } })),
+      'ValidationException',
+    );
+  });
+
+  it('TransactWriteItems rejects duplicate keys', async () => {
+    await expectError(
+      ddb.send(new TransactWriteItemsCommand({
+        TransactItems: [
+          { Put: { TableName: table, Item: { pk: s('dup'), sk: s('s') } } },
+          { Put: { TableName: table, Item: { pk: s('dup'), sk: s('s') } } },
+        ],
+      })),
+      'ValidationException',
+    );
+  });
+
+  it('TransactWriteItems idempotency token conflict throws IdempotentParameterMismatchException', async () => {
+    const token = uniqueName('tok');
+    // First call succeeds
+    await ddb.send(new TransactWriteItemsCommand({
+      ClientRequestToken: token,
+      TransactItems: [{ Put: { TableName: table, Item: { pk: s('idem-node'), sk: s('s') } } }],
+    }));
+    // Same token, different payload
+    await expectError(
+      ddb.send(new TransactWriteItemsCommand({
+        ClientRequestToken: token,
+        TransactItems: [{ Put: { TableName: table, Item: { pk: s('idem-other'), sk: s('s') } } }],
+      })),
+      'IdempotentParameterMismatchException',
+    );
+  });
+
+  it('PutItem with ReturnItemCollectionMetrics=SIZE returns metrics on LSI table', async () => {
+    const resp = await ddb.send(new PutItemCommand({
+      TableName: lsiTable,
+      Item: { pk: s('m1'), sk: s('sk-a'), lsi_sk: s('l1') },
+      ReturnItemCollectionMetrics: 'SIZE',
+    }));
+    expect(resp.ItemCollectionMetrics).toBeDefined();
+    expect(resp.ItemCollectionMetrics!.SizeEstimateRangeGB).toHaveLength(2);
+  });
+});
+
+// ─── Phase 4: Query/Scan behaviour ──────────────────────────────────────────
+
+describe('DynamoDB — Phase 4: Query/Scan behaviour', () => {
+  let ddb: DynamoDBClient;
+  const table = `qscan-${uniqueName()}`;
+
+  beforeAll(async () => {
+    ddb = makeClient(DynamoDBClient);
+    await ddb.send(new CreateTableCommand({
+      TableName: table,
+      KeySchema: [
+        { AttributeName: 'pk', KeyType: 'HASH' },
+        { AttributeName: 'sk', KeyType: 'RANGE' },
+      ],
+      AttributeDefinitions: [
+        { AttributeName: 'pk', AttributeType: 'S' },
+        { AttributeName: 'sk', AttributeType: 'S' },
+      ],
+      BillingMode: 'PAY_PER_REQUEST',
+    }));
+    for (let i = 0; i < 5; i++) {
+      await ddb.send(new PutItemCommand({
+        TableName: table,
+        Item: { pk: s('p1'), sk: s(`s${i}`), name: s(`Item-${i}`), count: n(i) },
+      }));
+    }
+  });
+
+  afterAll(async () => {
+    try { await ddb.send(new DeleteTableCommand({ TableName: table })); } catch { /* ignore */ }
+  });
+
+  it('Query Select=COUNT returns Count without Items', async () => {
+    const resp = await ddb.send(new QueryCommand({
+      TableName: table,
+      KeyConditionExpression: 'pk = :pk',
+      ExpressionAttributeValues: { ':pk': s('p1') },
+      Select: 'COUNT',
+    }));
+    expect(resp.Count).toBe(5);
+    expect(resp.Items).toBeUndefined();
+  });
+
+  it('Scan Select=COUNT returns Count without Items', async () => {
+    const resp = await ddb.send(new ScanCommand({
+      TableName: table,
+      FilterExpression: 'pk = :pk',
+      ExpressionAttributeValues: { ':pk': s('p1') },
+      Select: 'COUNT',
+    }));
+    expect(resp.Count).toBeGreaterThan(0);
+    expect(resp.Items).toBeUndefined();
+  });
+
+  it('parallel scan partitions with no overlap and full coverage', async () => {
+    const totalSegments = 2;
+    const [seg0, seg1] = await Promise.all([
+      ddb.send(new ScanCommand({ TableName: table, Segment: 0, TotalSegments: totalSegments })),
+      ddb.send(new ScanCommand({ TableName: table, Segment: 1, TotalSegments: totalSegments })),
+    ]);
+
+    const keys0 = new Set((seg0.Items ?? []).map(i => i.sk.S!));
+    const keys1 = new Set((seg1.Items ?? []).map(i => i.sk.S!));
+
+    // No overlap
+    for (const k of keys0) expect(keys1.has(k)).toBe(false);
+    // Full coverage
+    expect(keys0.size + keys1.size).toBe(5);
+  });
+
+  it('parallel scan requires both Segment and TotalSegments', async () => {
+    await expectError(
+      ddb.send(new ScanCommand({ TableName: table, Segment: 0 })),
+      'ValidationException',
+    );
+    await expectError(
+      ddb.send(new ScanCommand({ TableName: table, TotalSegments: 2 })),
+      'ValidationException',
+    );
+  });
+
+  it('attribute_type() function in FilterExpression', async () => {
+    const resp = await ddb.send(new QueryCommand({
+      TableName: table,
+      KeyConditionExpression: 'pk = :pk',
+      FilterExpression: 'attribute_type(#n, :t)',
+      ExpressionAttributeValues: { ':pk': s('p1'), ':t': s('S') },
+      ExpressionAttributeNames: { '#n': 'name' },
+    }));
+    expect(resp.Count).toBe(5);
+  });
+
+  it('parenthesized key condition expression works', async () => {
+    const resp = await ddb.send(new QueryCommand({
+      TableName: table,
+      KeyConditionExpression: '(pk = :pk AND sk = :sk)',
+      ExpressionAttributeValues: { ':pk': s('p1'), ':sk': s('s0') },
+    }));
+    expect(resp.Count).toBe(1);
+    expect(resp.Items![0].sk.S).toBe('s0');
+  });
+
+  it('Query without KeyConditionExpression throws ValidationException', async () => {
+    await expectError(
+      ddb.send(new QueryCommand({ TableName: table })),
+      'ValidationException',
+    );
+  });
+});
+
+// ─── Phase 7: Tags API errors ────────────────────────────────────────────────
+
+describe('DynamoDB — Phase 7: Tags API errors', () => {
+  let ddb: DynamoDBClient;
+
+  beforeAll(() => { ddb = makeClient(DynamoDBClient); });
+
+  it('TagResource with invalid ARN throws ValidationException', async () => {
+    await expectError(
+      ddb.send(new TagResourceCommand({
+        ResourceArn: 'not-an-arn',
+        Tags: [{ Key: 'k', Value: 'v' }],
+      })),
+      'ValidationException',
+    );
+  });
+
+  it('ListTagsOfResource with valid-format non-existent ARN throws AccessDeniedException', async () => {
+    await expectError(
+      ddb.send(new ListTagsOfResourceCommand({
+        ResourceArn: 'arn:aws:dynamodb:us-east-1:000000000000:table/does-not-exist',
+      })),
+      'AccessDeniedException',
+    );
+  });
+});
+
+// ─── Phase 8: ReturnValuesOnConditionCheckFailure ────────────────────────────
+
+describe('DynamoDB — Phase 8: ReturnValuesOnConditionCheckFailure', () => {
+  let ddb: DynamoDBClient;
+  const table = `cond-${uniqueName()}`;
+
+  beforeAll(async () => {
+    ddb = makeClient(DynamoDBClient);
+    await ddb.send(new CreateTableCommand({
+      TableName: table,
+      KeySchema: [
+        { AttributeName: 'pk', KeyType: 'HASH' },
+        { AttributeName: 'sk', KeyType: 'RANGE' },
+      ],
+      AttributeDefinitions: [
+        { AttributeName: 'pk', AttributeType: 'S' },
+        { AttributeName: 'sk', AttributeType: 'S' },
+      ],
+      BillingMode: 'PAY_PER_REQUEST',
+    }));
+    await ddb.send(new PutItemCommand({
+      TableName: table,
+      Item: { pk: s('existing'), sk: s('s'), val: s('old') },
+    }));
+  });
+
+  afterAll(async () => {
+    try { await ddb.send(new DeleteTableCommand({ TableName: table })); } catch { /* ignore */ }
+  });
+
+  it('PutItem condition failure throws ConditionalCheckFailedException', async () => {
+    await expectError(
+      ddb.send(new PutItemCommand({
+        TableName: table,
+        Item: { pk: s('existing'), sk: s('s'), val: s('new') },
+        ConditionExpression: 'attribute_not_exists(pk)',
+        ReturnValuesOnConditionCheckFailure: 'ALL_OLD',
+      })),
+      'ConditionalCheckFailedException',
+    );
+  });
+
+  it('UpdateItem condition failure throws ConditionalCheckFailedException', async () => {
+    await expectError(
+      ddb.send(new UpdateItemCommand({
+        TableName: table,
+        Key: { pk: s('existing'), sk: s('s') },
+        UpdateExpression: 'SET val = :new',
+        ConditionExpression: 'val = :expected',
+        ExpressionAttributeValues: { ':new': s('new'), ':expected': s('wrong') },
+        ReturnValuesOnConditionCheckFailure: 'ALL_OLD',
+      })),
+      'ConditionalCheckFailedException',
+    );
+  });
+
+  it('DeleteItem condition failure throws ConditionalCheckFailedException', async () => {
+    await expectError(
+      ddb.send(new DeleteItemCommand({
+        TableName: table,
+        Key: { pk: s('existing'), sk: s('s') },
+        ConditionExpression: 'val = :expected',
+        ExpressionAttributeValues: { ':expected': s('wrong') },
+        ReturnValuesOnConditionCheckFailure: 'ALL_OLD',
+      })),
+      'ConditionalCheckFailedException',
+    );
+  });
+});
+
+// ─── Phase 9: Reserved words ─────────────────────────────────────────────────
+
+describe('DynamoDB — Phase 9: Reserved words', () => {
+  let ddb: DynamoDBClient;
+  const table = `rw-${uniqueName()}`;
+
+  beforeAll(async () => {
+    ddb = makeClient(DynamoDBClient);
+    await ddb.send(new CreateTableCommand({
+      TableName: table,
+      KeySchema: [
+        { AttributeName: 'pk', KeyType: 'HASH' },
+        { AttributeName: 'sk', KeyType: 'RANGE' },
+      ],
+      AttributeDefinitions: [
+        { AttributeName: 'pk', AttributeType: 'S' },
+        { AttributeName: 'sk', AttributeType: 'S' },
+      ],
+      BillingMode: 'PAY_PER_REQUEST',
+    }));
+  });
+
+  afterAll(async () => {
+    try { await ddb.send(new DeleteTableCommand({ TableName: table })); } catch { /* ignore */ }
+  });
+
+  it('bare reserved word in ConditionExpression throws ValidationException', async () => {
+    await expectError(
+      ddb.send(new PutItemCommand({
+        TableName: table,
+        Item: { pk: s('rw1'), sk: s('s') },
+        // 'status' is a DynamoDB reserved word
+        ConditionExpression: 'attribute_not_exists(status)',
+      })),
+      'ValidationException',
+    );
+  });
+
+  it('bare reserved word in FilterExpression throws ValidationException', async () => {
+    await expectError(
+      ddb.send(new ScanCommand({
+        TableName: table,
+        FilterExpression: 'name = :v',
+        ExpressionAttributeValues: { ':v': s('x') },
+        // 'name' is a reserved word used bare
+      })),
+      'ValidationException',
+    );
+  });
+
+  it('reserved word aliased via ExpressionAttributeNames passes', async () => {
+    // Using #st alias for the reserved word 'status'
+    await ddb.send(new PutItemCommand({
+      TableName: table,
+      Item: { pk: s('rw-ok'), sk: s('s'), status: s('active') },
+      ConditionExpression: 'attribute_not_exists(pk)',
+      ExpressionAttributeNames: { '#st': 'status' },
+    }));
+
+    const resp = await ddb.send(new ScanCommand({
+      TableName: table,
+      FilterExpression: '#st = :v',
+      ExpressionAttributeNames: { '#st': 'status' },
+      ExpressionAttributeValues: { ':v': s('active') },
+    }));
+    expect(resp.Count).toBe(1);
+  });
+});
+
+// ─── Phase 10: Legacy API ────────────────────────────────────────────────────
+
+describe('DynamoDB — Phase 10: Legacy API', () => {
+  let ddb: DynamoDBClient;
+  const table = `legacy-${uniqueName()}`;
+
+  beforeAll(async () => {
+    ddb = makeClient(DynamoDBClient);
+    await ddb.send(new CreateTableCommand({
+      TableName: table,
+      KeySchema: [
+        { AttributeName: 'pk', KeyType: 'HASH' },
+        { AttributeName: 'sk', KeyType: 'RANGE' },
+      ],
+      AttributeDefinitions: [
+        { AttributeName: 'pk', AttributeType: 'S' },
+        { AttributeName: 'sk', AttributeType: 'S' },
+      ],
+      BillingMode: 'PAY_PER_REQUEST',
+    }));
+    for (let i = 0; i < 3; i++) {
+      await ddb.send(new PutItemCommand({
+        TableName: table,
+        Item: { pk: s('p1'), sk: s(`s${i}`), name: s(`Item-${i}`), color: s('red') },
+      }));
+    }
+  });
+
+  afterAll(async () => {
+    try { await ddb.send(new DeleteTableCommand({ TableName: table })); } catch { /* ignore */ }
+  });
+
+  it('AttributesToGet returns only listed attributes (no auto-key-include)', async () => {
+    const resp = await ddb.send(new GetItemCommand({
+      TableName: table,
+      Key: { pk: s('p1'), sk: s('s0') },
+      AttributesToGet: ['name', 'color'],
+    }));
+    expect(resp.Item).toHaveProperty('name');
+    expect(resp.Item).toHaveProperty('color');
+    expect(resp.Item).not.toHaveProperty('pk');
+    expect(resp.Item).not.toHaveProperty('sk');
+  });
+
+  it('AttributeUpdates (legacy) applies PUT action', async () => {
+    await ddb.send(new UpdateItemCommand({
+      TableName: table,
+      Key: { pk: s('p1'), sk: s('s0') },
+      AttributeUpdates: {
+        color: { Value: s('blue'), Action: 'PUT' },
+      },
+    }));
+    const resp = await ddb.send(new GetItemCommand({
+      TableName: table,
+      Key: { pk: s('p1'), sk: s('s0') },
+    }));
+    expect(resp.Item!.color.S).toBe('blue');
+  });
+
+  it('AttributeUpdates (legacy) applies DELETE action to remove attribute', async () => {
+    await ddb.send(new UpdateItemCommand({
+      TableName: table,
+      Key: { pk: s('p1'), sk: s('s1') },
+      AttributeUpdates: {
+        color: { Action: 'DELETE' },
+      },
+    }));
+    const resp = await ddb.send(new GetItemCommand({
+      TableName: table,
+      Key: { pk: s('p1'), sk: s('s1') },
+    }));
+    expect(resp.Item).not.toHaveProperty('color');
+  });
+
+  it('QueryFilter (legacy) filters query results', async () => {
+    const resp = await ddb.send(new QueryCommand({
+      TableName: table,
+      KeyConditionExpression: 'pk = :pk',
+      ExpressionAttributeValues: { ':pk': s('p1') },
+      QueryFilter: {
+        name: { ComparisonOperator: 'EQ', AttributeValueList: [s('Item-0')] },
+      },
+    }));
+    expect(resp.Count).toBe(1);
+    expect(resp.Items![0].name.S).toBe('Item-0');
+  });
+
+  it('ScanFilter (legacy) filters scan results', async () => {
+    const resp = await ddb.send(new ScanCommand({
+      TableName: table,
+      ScanFilter: {
+        name: { ComparisonOperator: 'EQ', AttributeValueList: [s('Item-2')] },
+      },
+    }));
+    expect(resp.Count).toBe(1);
+    expect(resp.Items![0].name.S).toBe('Item-2');
+  });
+
+  it('KeyConditions and KeyConditionExpression are mutually exclusive', async () => {
+    await expectError(
+      ddb.send(new QueryCommand({
+        TableName: table,
+        KeyConditionExpression: 'pk = :pk',
+        ExpressionAttributeValues: { ':pk': s('p1') },
+        KeyConditions: { pk: { ComparisonOperator: 'EQ', AttributeValueList: [s('p1')] } },
+      })),
+      'ValidationException',
+    );
+  });
+});
+
+// ─── Phase 11: Enum validation ordering ──────────────────────────────────────
+
+describe('DynamoDB — Phase 11: Enum validation before table lookup', () => {
+  let ddb: DynamoDBClient;
+
+  beforeAll(() => { ddb = makeClient(DynamoDBClient); });
+
+  it('invalid ReturnValues on PutItem throws ValidationException even for non-existent table', async () => {
+    const err = await ddb.send(new PutItemCommand({
+      TableName: 'nonexistent-table-xyz',
+      Item: { pk: s('x') },
+      ReturnValues: 'UPDATED_NEW', // invalid for PutItem
+    })).catch(e => e);
+
+    expect(err.name).toBe('ValidationException');
+    // Must NOT be ResourceNotFoundException
+    expect(err.name).not.toBe('ResourceNotFoundException');
+  });
+
+  it('invalid ReturnValues on DeleteItem throws ValidationException even for non-existent table', async () => {
+    const err = await ddb.send(new DeleteItemCommand({
+      TableName: 'nonexistent-table-xyz',
+      Key: { pk: s('x'), sk: s('y') },
+      ReturnValues: 'UPDATED_NEW', // invalid for DeleteItem
+    })).catch(e => e);
+
+    expect(err.name).toBe('ValidationException');
+  });
+
+  it('invalid ReturnConsumedCapacity throws ValidationException even for non-existent table', async () => {
+    const err = await ddb.send(new GetItemCommand({
+      TableName: 'nonexistent-table-xyz',
+      Key: { pk: s('x'), sk: s('y') },
+      // @ts-expect-error invalid enum value
+      ReturnConsumedCapacity: 'INVALID_VALUE',
+    })).catch(e => e);
+
+    expect(err.name).toBe('ValidationException');
+  });
+});

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbItemSize.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbItemSize.java
@@ -1,0 +1,94 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * Calculates DynamoDB item size and enforces the 400KB limit.
+ */
+final class DynamoDbItemSize {
+
+    static final int MAX_ITEM_SIZE = 400 * 1024; // 400 KB = 409,600 bytes
+
+    private DynamoDbItemSize() {}
+
+    /**
+     * Validates the item fits within 400KB. Throws ValidationException if not.
+     */
+    static void validateSize(JsonNode item) {
+        int size = calculateItemSize(item);
+        if (size > MAX_ITEM_SIZE) {
+            throw new AwsException("ValidationException",
+                    "Item size has exceeded the maximum allowed size", 400);
+        }
+    }
+
+    static int calculateItemSize(JsonNode item) {
+        if (item == null || !item.isObject()) return 0;
+        int total = 0;
+        var fields = item.fields();
+        while (fields.hasNext()) {
+            var entry = fields.next();
+            total += utf8Length(entry.getKey());
+            total += attributeValueSize(entry.getValue());
+        }
+        return total;
+    }
+
+    private static int attributeValueSize(JsonNode attr) {
+        if (attr == null) return 0;
+        if (attr.has("S")) return utf8Length(attr.get("S").asText());
+        if (attr.has("N")) return attr.get("N").asText().length();
+        if (attr.has("B")) return binarySize(attr.get("B").asText());
+        if (attr.has("BOOL")) return 1;
+        if (attr.has("NULL")) return 1;
+        if (attr.has("SS")) {
+            int size = 0;
+            for (JsonNode e : attr.get("SS")) size += utf8Length(e.asText()) + 1;
+            return size;
+        }
+        if (attr.has("NS")) {
+            int size = 0;
+            for (JsonNode e : attr.get("NS")) size += e.asText().length() + 1;
+            return size;
+        }
+        if (attr.has("BS")) {
+            int size = 0;
+            for (JsonNode e : attr.get("BS")) size += binarySize(e.asText()) + 1;
+            return size;
+        }
+        if (attr.has("L")) {
+            int size = 0;
+            for (JsonNode e : attr.get("L")) size += attributeValueSize(e) + 3;
+            return size;
+        }
+        if (attr.has("M")) {
+            int size = 0;
+            var fields = attr.get("M").fields();
+            while (fields.hasNext()) {
+                var entry = fields.next();
+                size += utf8Length(entry.getKey()) + 1 + attributeValueSize(entry.getValue()) + 3;
+            }
+            return size;
+        }
+        return 0;
+    }
+
+    private static int utf8Length(String s) {
+        if (s == null) return 0;
+        return s.getBytes(StandardCharsets.UTF_8).length;
+    }
+
+    private static int binarySize(String base64) {
+        if (base64 == null || base64.isEmpty()) return 0;
+        try {
+            return Base64.getDecoder().decode(base64).length;
+        } catch (Exception e) {
+            // Fallback: estimate from base64 length
+            return (int) (base64.length() * 3L / 4);
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsJsonController;
 import io.github.hectorvent.floci.services.dynamodb.model.*;
 import io.github.hectorvent.floci.services.kinesis.KinesisService;
+import io.github.hectorvent.floci.services.dynamodb.TransactionCanceledException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -74,7 +75,10 @@ public class DynamoDbJsonHandler {
     }
 
     private Response handleCreateTable(JsonNode request, String region) {
-        String tableName = DynamoDbTableNames.requireShortName(request.path("TableName").asText());
+        // Distinguish missing (undefined) from empty ("") for TableName
+        String tableNameRaw = (request.has("TableName") && !request.path("TableName").isNull())
+                ? request.path("TableName").asText() : null;
+        String tableName = DynamoDbTableNames.requireShortName(tableNameRaw);
 
         List<KeySchemaElement> keySchema = new ArrayList<>();
         request.path("KeySchema").forEach(ks ->
@@ -135,7 +139,12 @@ public class DynamoDbJsonHandler {
                                 ks.path("AttributeName").asText(),
                                 ks.path("KeyType").asText())));
                 String projectionType = lsiNode.path("Projection").path("ProjectionType").asText("ALL");
-                lsis.add(new LocalSecondaryIndex(indexName, lsiKeySchema, null, projectionType));
+                JsonNode lsiNonKeyAttrArray = lsiNode.path("Projection").path("NonKeyAttributes");
+                List<String> lsiNonKeyAttributes = new ArrayList<>();
+                if (!lsiNonKeyAttrArray.isMissingNode() && lsiNonKeyAttrArray.isArray()) {
+                    lsiNonKeyAttrArray.forEach(a -> lsiNonKeyAttributes.add(a.asText()));
+                }
+                lsis.add(new LocalSecondaryIndex(indexName, lsiKeySchema, null, projectionType, lsiNonKeyAttributes));
             }
         }
 
@@ -205,17 +214,44 @@ public class DynamoDbJsonHandler {
     }
 
     private Response handleListTables(JsonNode request, String region) {
-        List<String> tables = dynamoDbService.listTables(region);
+        Integer limit = request.has("Limit") ? request.get("Limit").asInt() : null;
+        String exclusiveStart = request.has("ExclusiveStartTableName")
+                ? request.get("ExclusiveStartTableName").asText() : null;
+
+        if (limit != null) {
+            if (limit < 1) {
+                throw new AwsException("ValidationException",
+                        "1 validation error detected: Value '" + limit
+                        + "' at 'limit' failed to satisfy constraint: "
+                        + "Member must have value greater than or equal to 1", 400);
+            }
+            if (limit > 100) {
+                throw new AwsException("ValidationException",
+                        "1 validation error detected: Value '" + limit
+                        + "' at 'limit' failed to satisfy constraint: "
+                        + "Member must have value less than or equal to 100", 400);
+            }
+        }
+
+        DynamoDbService.ListTablesResult result = dynamoDbService.listTables(region, limit, exclusiveStart);
 
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode tableNames = objectMapper.createArrayNode();
-        tables.forEach(tableNames::add);
+        result.tableNames().forEach(tableNames::add);
         response.set("TableNames", tableNames);
+        if (result.lastEvaluatedTableName() != null) {
+            response.put("LastEvaluatedTableName", result.lastEvaluatedTableName());
+        }
         return Response.ok(response).build();
     }
 
+    private static final Set<String> VALID_RETURN_VALUES_PUT = Set.of("NONE", "ALL_OLD");
+    private static final Set<String> VALID_RETURN_CONSUMED_CAPACITY = Set.of("INDEXES", "TOTAL", "NONE");
+    private static final Set<String> VALID_RETURN_ITEM_COLLECTION_METRICS = Set.of("SIZE", "NONE");
+
     private Response handlePutItem(JsonNode request, String region) {
-        String tableName = request.path("TableName").asText();
+        String tableName = request.has("TableName") ? request.path("TableName").asText() : null;
+        DynamoDbTableNames.resolve(tableName); // validate tableName before other params
         JsonNode item = request.path("Item");
         String returnValues = request.path("ReturnValues").asText("NONE");
         String returnValuesOnConditionCheckFailure = request.path("ReturnValuesOnConditionCheckFailure").asText("NONE");
@@ -226,10 +262,53 @@ public class DynamoDbJsonHandler {
         JsonNode exprAttrValues = request.has("ExpressionAttributeValues")
                 ? request.get("ExpressionAttributeValues") : null;
 
+        List<String> validationErrors = new ArrayList<>();
+        String rcc = request.has("ReturnConsumedCapacity") ? request.get("ReturnConsumedCapacity").asText() : null;
+        if (rcc != null && !VALID_RETURN_CONSUMED_CAPACITY.contains(rcc)) {
+            validationErrors.add("Value '" + rcc + "' at 'returnConsumedCapacity' failed to satisfy constraint: "
+                    + "Member must satisfy enum value set: [INDEXES, TOTAL, NONE]");
+        }
+        String ricm = request.has("ReturnItemCollectionMetrics") ? request.get("ReturnItemCollectionMetrics").asText() : null;
+        if (ricm != null && !VALID_RETURN_ITEM_COLLECTION_METRICS.contains(ricm)) {
+            validationErrors.add("Value '" + ricm + "' at 'returnItemCollectionMetrics' failed to satisfy constraint: "
+                    + "Member must satisfy enum value set: [SIZE, NONE]");
+        }
+        if (!VALID_RETURN_VALUES_PUT.contains(returnValues)) {
+            validationErrors.add("Value '" + returnValues + "' at 'returnValues' failed to satisfy constraint: "
+                    + "Member must satisfy enum value set: [NONE, ALL_OLD]");
+        }
+        if (!validationErrors.isEmpty()) {
+            int n = validationErrors.size();
+            throw new AwsException("ValidationException",
+                    n + " validation error" + (n > 1 ? "s" : "") + " detected: "
+                    + String.join("; ", validationErrors), 400);
+        }
+
+        JsonNode expected = request.has("Expected") ? request.get("Expected") : null;
+        String conditionalOperator = request.has("ConditionalOperator")
+                ? request.get("ConditionalOperator").asText() : "AND";
+
+        if (conditionExpression != null && expected != null) {
+            throw new AwsException("ValidationException",
+                    "Can not use both expression and non-expression parameters in the same request: "
+                    + "Non-expression parameters: {Expected} Expression parameters: {ConditionExpression}", 400);
+        }
+
+        if (exprAttrValues != null && conditionExpression == null) {
+            throw new AwsException("ValidationException",
+                    "ExpressionAttributeValues can only be specified when using expressions: ConditionExpression is null", 400);
+        }
+
+        validateItemSets(item);
+
         JsonNode oldItem = null;
-        if ("ALL_OLD" .equals(returnValues)) {
+        if ("ALL_OLD".equals(returnValues) || expected != null) {
             dynamoDbService.describeTable(tableName, region);
             oldItem = dynamoDbService.getItem(tableName, item, region);
+        }
+
+        if (expected != null) {
+            evaluateLegacyExpected(oldItem, expected, conditionalOperator, returnValuesOnConditionCheckFailure);
         }
 
         dynamoDbService.putItem(tableName, item, conditionExpression, exprAttrNames, exprAttrValues, region, returnValuesOnConditionCheckFailure);
@@ -238,6 +317,7 @@ public class DynamoDbJsonHandler {
         if ("ALL_OLD" .equals(returnValues) && oldItem != null) {
             response.set("Attributes", oldItem);
         }
+        addItemCollectionMetrics(response, request, tableName, item, region);
         addConsumedCapacity(response, request, tableName, 1, true);
         return Response.ok(response).build();
     }
@@ -245,8 +325,40 @@ public class DynamoDbJsonHandler {
     private Response handleGetItem(JsonNode request, String region) {
         String tableName = request.path("TableName").asText();
         JsonNode key = request.path("Key");
+        String projectionExpression = request.has("ProjectionExpression")
+                ? request.get("ProjectionExpression").asText() : null;
+        JsonNode exprAttrNames = request.has("ExpressionAttributeNames")
+                ? request.get("ExpressionAttributeNames") : null;
+        JsonNode attributesToGet = request.has("AttributesToGet") ? request.get("AttributesToGet") : null;
+
+        if (attributesToGet != null && projectionExpression != null) {
+            throw new AwsException("ValidationException",
+                    "Can not use both expression and non-expression parameters in the same request: "
+                    + "Non-expression parameters: {AttributesToGet} Expression parameters: {ProjectionExpression}", 400);
+        }
+
+        // Validate enums before table lookup
+        String rccGet = request.has("ReturnConsumedCapacity") ? request.get("ReturnConsumedCapacity").asText() : null;
+        if (rccGet != null && !VALID_RETURN_CONSUMED_CAPACITY.contains(rccGet)) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '" + rccGet + "' at 'returnConsumedCapacity' failed to satisfy constraint: "
+                    + "Member must satisfy enum value set: [INDEXES, TOTAL, NONE]", 400);
+        }
+
+        // Validate ProjectionExpression syntax and reserved words before item lookup
+        if (projectionExpression != null) {
+            ProjectionEvaluator.validateSyntax(projectionExpression, "ProjectionExpression");
+            DynamoDbReservedWords.check(projectionExpression, "ProjectionExpression");
+        }
 
         JsonNode item = dynamoDbService.getItem(tableName, key, region);
+        if (item != null && projectionExpression != null) {
+            item = ProjectionEvaluator.project(item, projectionExpression, exprAttrNames);
+        } else if (item != null && attributesToGet != null) {
+            Set<String> keep = new HashSet<>();
+            attributesToGet.forEach(n -> keep.add(n.asText()));
+            item = ProjectionEvaluator.trimToAttributes((ObjectNode) item, keep);
+        }
 
         ObjectNode response = objectMapper.createObjectNode();
         if (item != null) {
@@ -256,10 +368,15 @@ public class DynamoDbJsonHandler {
         return Response.ok(response).build();
     }
 
+    private static final Set<String> VALID_RETURN_VALUES_DELETE = Set.of("NONE", "ALL_OLD");
+    private static final Set<String> VALID_RETURN_VALUES_UPDATE =
+            Set.of("NONE", "ALL_OLD", "ALL_NEW", "UPDATED_OLD", "UPDATED_NEW");
+
     private Response handleDeleteItem(JsonNode request, String region) {
         String tableName = request.path("TableName").asText();
+        DynamoDbTableNames.resolve(tableName); // validate tableName first
         JsonNode key = request.path("Key");
-        String returnValues = request.path("ReturnValues").asText("NONE");        
+        String returnValues = request.path("ReturnValues").asText("NONE");
         String returnValuesOnConditionCheckFailure = request.path("ReturnValuesOnConditionCheckFailure").asText("NONE");
         String conditionExpression = request.has("ConditionExpression")
                 ? request.get("ConditionExpression").asText() : null;
@@ -268,6 +385,32 @@ public class DynamoDbJsonHandler {
         JsonNode exprAttrValues = request.has("ExpressionAttributeValues")
                 ? request.get("ExpressionAttributeValues") : null;
 
+        // Validate ReturnValues + ReturnConsumedCapacity together
+        List<String> delValidationErrors = new ArrayList<>();
+        String rccDel = request.has("ReturnConsumedCapacity") ? request.get("ReturnConsumedCapacity").asText() : null;
+        if (rccDel != null && !VALID_RETURN_CONSUMED_CAPACITY.contains(rccDel)) {
+            delValidationErrors.add("Value '" + rccDel + "' at 'returnConsumedCapacity' failed to satisfy constraint: "
+                    + "Member must satisfy enum value set: [INDEXES, TOTAL, NONE]");
+        }
+        if (!VALID_RETURN_VALUES_DELETE.contains(returnValues)) {
+            delValidationErrors.add("Value '" + returnValues + "' at 'returnValues' failed to satisfy constraint: "
+                    + "Member must satisfy enum value set: [NONE, ALL_OLD]");
+        }
+        if (!delValidationErrors.isEmpty()) {
+            int n = delValidationErrors.size();
+            throw new AwsException("ValidationException",
+                    n + " validation error" + (n > 1 ? "s" : "") + " detected: "
+                    + String.join("; ", delValidationErrors), 400);
+        }
+
+        JsonNode expectedDel = request.has("Expected") ? request.get("Expected") : null;
+        String condOpDel = request.has("ConditionalOperator")
+                ? request.get("ConditionalOperator").asText() : "AND";
+        if (expectedDel != null) {
+            JsonNode existingForDel = dynamoDbService.getItem(tableName, key, region);
+            evaluateLegacyExpected(existingForDel, expectedDel, condOpDel, returnValuesOnConditionCheckFailure);
+        }
+
         JsonNode oldItem = dynamoDbService.deleteItem(tableName, key, conditionExpression,
                 exprAttrNames, exprAttrValues, region, returnValuesOnConditionCheckFailure);
 
@@ -275,12 +418,14 @@ public class DynamoDbJsonHandler {
         if ("ALL_OLD" .equals(returnValues) && oldItem != null) {
             response.set("Attributes", oldItem);
         }
+        addItemCollectionMetrics(response, request, tableName, key, region);
         addConsumedCapacity(response, request, tableName, 1, true);
         return Response.ok(response).build();
     }
 
     private Response handleUpdateItem(JsonNode request, String region) {
         String tableName = request.path("TableName").asText();
+        DynamoDbTableNames.resolve(tableName); // validate tableName first
         JsonNode key = request.path("Key");
         JsonNode attributeUpdates = request.path("AttributeUpdates");
         JsonNode exprAttrNames = request.has("ExpressionAttributeNames")
@@ -294,7 +439,60 @@ public class DynamoDbJsonHandler {
         String returnValues = request.path("ReturnValues").asText("NONE");
         String returnValuesOnConditionCheckFailure = request.path("ReturnValuesOnConditionCheckFailure").asText("NONE");
 
+        // Validate ReturnValues + ReturnConsumedCapacity together before table lookup
+        List<String> updValidationErrors = new ArrayList<>();
+        String rccUpd = request.has("ReturnConsumedCapacity") ? request.get("ReturnConsumedCapacity").asText() : null;
+        if (rccUpd != null && !VALID_RETURN_CONSUMED_CAPACITY.contains(rccUpd)) {
+            updValidationErrors.add("Value '" + rccUpd + "' at 'returnConsumedCapacity' failed to satisfy constraint: "
+                    + "Member must satisfy enum value set: [INDEXES, TOTAL, NONE]");
+        }
+        if (!VALID_RETURN_VALUES_UPDATE.contains(returnValues)) {
+            updValidationErrors.add("Value '" + returnValues + "' at 'returnValues' failed to satisfy constraint: "
+                    + "Member must satisfy enum value set: [NONE, ALL_OLD, ALL_NEW, UPDATED_OLD, UPDATED_NEW]");
+        }
+        if (!updValidationErrors.isEmpty()) {
+            int n = updValidationErrors.size();
+            throw new AwsException("ValidationException",
+                    n + " validation error" + (n > 1 ? "s" : "") + " detected: "
+                    + String.join("; ", updValidationErrors), 400);
+        }
+
         JsonNode updateData = attributeUpdates.isMissingNode() ? null : attributeUpdates;
+
+        if (updateData != null && updateExpression != null) {
+            throw new AwsException("ValidationException",
+                    "Can not use both expression and non-expression parameters in the same request: "
+                    + "Non-expression parameters: {AttributeUpdates} Expression parameters: {UpdateExpression}", 400);
+        }
+
+        // Validate EAN/EAV usage across UpdateExpression + ConditionExpression
+        if (updateExpression != null) {
+            // Pre-validate syntax: expression must start with a valid clause keyword
+            String ue = updateExpression.trim();
+            if (!ue.isEmpty()) {
+                String upper = ue.toUpperCase();
+                if (!upper.startsWith("SET ") && !upper.startsWith("REMOVE ") && !upper.startsWith("ADD ") && !upper.startsWith("DELETE ")) {
+                    String[] parts = ue.split("\\s+", 3);
+                    String token = parts[0];
+                    String near = parts.length >= 2
+                            ? (token + " " + parts[1]).substring(0, Math.min(token.length() + 1 + parts[1].length(), 20))
+                            : token;
+                    throw new AwsException("ValidationException",
+                            "Invalid UpdateExpression: Syntax error; token: \"" + token + "\", near: \"" + near + "\"", 400);
+                }
+            }
+            Set<String> colonTokens = extractColonTokens(updateExpression);
+            for (String token : colonTokens) {
+                if (exprAttrValues == null || !exprAttrValues.has(token)) {
+                    throw new AwsException("ValidationException",
+                            "Invalid UpdateExpression: An expression attribute value used in expression is not defined; attribute value: " + token, 400);
+                }
+            }
+            Set<String> hashTokens = extractHashTokens(updateExpression, conditionExpression);
+            checkUnusedEan(exprAttrNames, hashTokens);
+            Set<String> colonTokensAll = extractColonTokens(updateExpression, conditionExpression);
+            checkUnusedEav(exprAttrValues, colonTokensAll);
+        }
 
         DynamoDbService.UpdateResult result = dynamoDbService.updateItem(
                 tableName, key, updateData, updateExpression, exprAttrNames, exprAttrValues,
@@ -314,8 +512,61 @@ public class DynamoDbJsonHandler {
         } else if ("UPDATED_OLD".equals(returnValues) && result.oldItem() != null) {
             response.set("Attributes", getChangedAttributes(result.oldItem(), result.newItem()));
         }
+        addItemCollectionMetrics(response, request, tableName, key, region);
         addConsumedCapacity(response, request, tableName, 1, true);
         return Response.ok(response).build();
+    }
+
+    private void evaluateLegacyExpected(JsonNode existing, JsonNode expected, String conditionalOperator,
+                                          String returnValuesOnConditionCheckFailure) {
+        if (expected == null) return;
+        boolean useOr = "OR".equals(conditionalOperator);
+        boolean overall = !useOr;
+        var fields = expected.fields();
+        while (fields.hasNext()) {
+            var entry = fields.next();
+            String attrName = entry.getKey();
+            JsonNode condition = entry.getValue();
+            JsonNode attrValue = existing != null ? existing.get(attrName) : null;
+            boolean condResult;
+            if (condition.has("Exists")) {
+                boolean exists = condition.get("Exists").asBoolean();
+                condResult = exists ? attrValue != null : attrValue == null;
+            } else {
+                condResult = dynamoDbService.matchesKeyConditionPublic(attrValue, condition);
+            }
+            if (useOr) overall = overall || condResult;
+            else overall = overall && condResult;
+        }
+        if (!overall) {
+            if ("ALL_OLD".equals(returnValuesOnConditionCheckFailure)) {
+                throw new ConditionalCheckFailedException(existing);
+            } else {
+                throw new ConditionalCheckFailedException(null);
+            }
+        }
+    }
+
+    private void addItemCollectionMetrics(ObjectNode response, JsonNode request, String tableName,
+                                           JsonNode itemOrKey, String region) {
+        String ricm = request.has("ReturnItemCollectionMetrics")
+                ? request.get("ReturnItemCollectionMetrics").asText() : null;
+        if (!"SIZE".equals(ricm) || itemOrKey == null) return;
+        try {
+            TableDefinition table = dynamoDbService.describeTable(tableName, region);
+            String pkName = table.getPartitionKeyName();
+            JsonNode pkValue = itemOrKey.get(pkName);
+            if (pkValue == null) return;
+            ObjectNode metrics = objectMapper.createObjectNode();
+            ObjectNode collKey = objectMapper.createObjectNode();
+            collKey.set(pkName, pkValue);
+            metrics.set("ItemCollectionKey", collKey);
+            ArrayNode sizeRange = objectMapper.createArrayNode();
+            sizeRange.add(0.0);
+            sizeRange.add(1.0);
+            metrics.set("SizeEstimateRangeGB", sizeRange);
+            response.set("ItemCollectionMetrics", metrics);
+        } catch (Exception ignored) {}
     }
 
     private JsonNode getChangedAttributes(JsonNode preferredItem, JsonNode secondaryItem){
@@ -339,8 +590,12 @@ public class DynamoDbJsonHandler {
         return changedAttributes;
     }
 
+    private static final Set<String> VALID_SELECT = Set.of(
+            "ALL_ATTRIBUTES", "ALL_PROJECTED_ATTRIBUTES", "SPECIFIC_ATTRIBUTES", "COUNT");
+
     private Response handleQuery(JsonNode request, String region) {
         String tableName = request.path("TableName").asText();
+        DynamoDbTableNames.resolve(tableName); // validate tableName first
         JsonNode keyConditions = request.has("KeyConditions") ? request.get("KeyConditions") : null;
         JsonNode exprAttrValues = request.has("ExpressionAttributeValues")
                 ? request.get("ExpressionAttributeValues") : null;
@@ -350,27 +605,136 @@ public class DynamoDbJsonHandler {
                 ? request.get("KeyConditionExpression").asText() : null;
         String filterExpr = request.has("FilterExpression")
                 ? request.get("FilterExpression").asText() : null;
+        JsonNode queryFilter = request.has("QueryFilter") ? request.get("QueryFilter") : null;
+        JsonNode attributesToGet = request.has("AttributesToGet") ? request.get("AttributesToGet") : null;
         Integer limit = request.has("Limit") ? request.get("Limit").asInt() : null;
         Boolean scanIndexForward = request.has("ScanIndexForward")
                 ? request.get("ScanIndexForward").asBoolean() : null;
         String indexName = request.has("IndexName") ? request.get("IndexName").asText() : null;
         JsonNode exclusiveStartKey = request.has("ExclusiveStartKey")
                 ? request.get("ExclusiveStartKey") : null;
+        String select = request.has("Select") ? request.get("Select").asText() : null;
+        String projectionExpression = request.has("ProjectionExpression")
+                ? request.get("ProjectionExpression").asText() : null;
+
+        // Validate Limit
+        if (limit != null && limit < 1) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value at 'Limit' failed to satisfy constraint: "
+                    + "Member must have value greater than or equal to 1", 400);
+        }
+
+        // Validate ReturnConsumedCapacity before Select
+        String rccQuery = request.has("ReturnConsumedCapacity") ? request.get("ReturnConsumedCapacity").asText() : null;
+        if (rccQuery != null && !VALID_RETURN_CONSUMED_CAPACITY.contains(rccQuery)) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '" + rccQuery + "' at 'returnConsumedCapacity' failed to satisfy constraint: "
+                    + "Member must satisfy enum value set: [INDEXES, TOTAL, NONE]", 400);
+        }
+
+        if (keyConditionExpr != null && keyConditions != null) {
+            throw new AwsException("ValidationException",
+                    "Can not use both expression and non-expression parameters in the same request: "
+                    + "Non-expression parameters: {KeyConditions} Expression parameters: {KeyConditionExpression}", 400);
+        }
+        if (filterExpr != null && queryFilter != null) {
+            throw new AwsException("ValidationException",
+                    "Can not use both expression and non-expression parameters in the same request: "
+                    + "Non-expression parameters: {QueryFilter} Expression parameters: {FilterExpression}", 400);
+        }
+
+        if (keyConditionExpr == null && keyConditions == null) {
+            throw new AwsException("ValidationException",
+                    "Either KeyConditions or KeyConditionExpression must be provided", 400);
+        }
+
+        // Validate empty KCE
+        if (keyConditionExpr != null && keyConditionExpr.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "Invalid KeyConditionExpression: The expression can not be empty;", 400);
+        }
+
+        if (select != null && !VALID_SELECT.contains(select)) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '" + select + "' at 'select' failed to satisfy constraint: "
+                    + "Member must satisfy enum value set: [SPECIFIC_ATTRIBUTES, COUNT, ALL_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES]", 400);
+        }
+
+        if ("SPECIFIC_ATTRIBUTES".equals(select) && projectionExpression == null) {
+            throw new AwsException("ValidationException",
+                    "Select type SPECIFIC_ATTRIBUTES requires the ProjectionExpression to be provided.", 400);
+        }
+
+        // ConsistentRead on GSI check
+        boolean consistentRead = request.path("ConsistentRead").asBoolean(false);
+        if (consistentRead && indexName != null) {
+            TableDefinition queryTable = dynamoDbService.describeTable(tableName, region);
+            if (queryTable.findGsi(indexName).isPresent()) {
+                throw new AwsException("ValidationException",
+                        "Consistent reads are not supported on global secondary indexes", 400);
+            }
+        }
+
+        // Validate EAN/EAV usage when using expression format
+        if (keyConditionExpr != null) {
+            // Check undefined #tokens in FilterExpression
+            if (filterExpr != null) {
+                for (String token : extractHashTokens(filterExpr)) {
+                    if (exprAttrNames == null || !exprAttrNames.has(token)) {
+                        throw new AwsException("ValidationException",
+                                "Invalid FilterExpression: An expression attribute name used in the document path is not defined; attribute name: " + token, 400);
+                    }
+                }
+            }
+            // Check unused EAN across all expressions (KCE + FE + PE)
+            Set<String> hashTokens = extractHashTokens(keyConditionExpr, filterExpr, projectionExpression);
+            checkUnusedEan(exprAttrNames, hashTokens);
+        }
 
         DynamoDbService.QueryResult result = dynamoDbService.query(tableName, keyConditions,
                 exprAttrValues, keyConditionExpr, filterExpr, limit, scanIndexForward, indexName,
                 exclusiveStartKey, exprAttrNames, region);
 
+        List<JsonNode> queryItems = result.items();
+        // Apply QueryFilter (legacy API)
+        if (queryFilter != null) {
+            final JsonNode qf = queryFilter;
+            queryItems = queryItems.stream()
+                    .filter(i -> dynamoDbService.matchesScanFilterPublic(i, qf))
+                    .toList();
+        }
+        // Apply index projection (KEYS_ONLY / INCLUDE) when querying a secondary index
+        if (indexName != null && projectionExpression == null && attributesToGet == null) {
+            TableDefinition queryTable = dynamoDbService.describeTable(tableName, region);
+            queryItems = applyIndexProjection(queryItems, indexName, queryTable, select);
+        }
+        if (projectionExpression != null) {
+            queryItems = queryItems.stream()
+                    .map(i -> (JsonNode) ProjectionEvaluator.project(i, projectionExpression, exprAttrNames))
+                    .toList();
+        } else if (attributesToGet != null) {
+            Set<String> keep = new HashSet<>();
+            attributesToGet.forEach(n -> keep.add(n.asText()));
+            queryItems = queryItems.stream()
+                    .map(i -> (JsonNode) ProjectionEvaluator.trimToAttributes((ObjectNode) i, keep))
+                    .toList();
+        }
+
         ObjectNode response = objectMapper.createObjectNode();
-        ArrayNode itemsArray = objectMapper.createArrayNode();
-        result.items().forEach(itemsArray::add);
-        response.set("Items", itemsArray);
-        response.put("Count", result.items().size());
-        response.put("ScannedCount", result.scannedCount());
+        if ("COUNT".equals(select)) {
+            response.put("Count", result.items().size());
+            response.put("ScannedCount", result.scannedCount());
+        } else {
+            ArrayNode itemsArray = objectMapper.createArrayNode();
+            queryItems.forEach(itemsArray::add);
+            response.set("Items", itemsArray);
+            response.put("Count", queryItems.size());
+            response.put("ScannedCount", result.scannedCount());
+        }
         if (result.lastEvaluatedKey() != null) {
             response.set("LastEvaluatedKey", result.lastEvaluatedKey());
         }
-        addConsumedCapacity(response, request, tableName, result.items().size(), false);
+        addConsumedCapacity(response, request, tableName, queryItems.size(), false);
         return Response.ok(response).build();
     }
 
@@ -387,28 +751,95 @@ public class DynamoDbJsonHandler {
         Integer limit = request.has("Limit") ? request.get("Limit").asInt() : null;
         JsonNode exclusiveStartKey = request.has("ExclusiveStartKey")
                 ? request.get("ExclusiveStartKey") : null;
+        String select = request.has("Select") ? request.get("Select").asText() : null;
+        String indexNameScan = request.has("IndexName") ? request.get("IndexName").asText() : null;
+        Integer segment = request.has("Segment") ? request.get("Segment").asInt() : null;
+        Integer totalSegments = request.has("TotalSegments") ? request.get("TotalSegments").asInt() : null;
+
+        if (filterExpr != null && scanFilter != null) {
+            throw new AwsException("ValidationException",
+                    "Can not use both expression and non-expression parameters in the same request: "
+                    + "Non-expression parameters: {ScanFilter} Expression parameters: {FilterExpression}", 400);
+        }
+
+        if (limit != null && limit < 1) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '" + limit + "' at 'limit' failed to satisfy constraint: "
+                    + "Member must have value greater than or equal to 1", 400);
+        }
+
+        if (segment != null && totalSegments == null) {
+            throw new AwsException("ValidationException",
+                    "The TotalSegments parameter is required but was not present in the request when Segment parameter is present", 400);
+        }
+        if (totalSegments != null && segment == null) {
+            throw new AwsException("ValidationException",
+                    "The Segment parameter is required but was not present in the request when parameter TotalSegments is present", 400);
+        }
+        if (segment != null && totalSegments != null && segment >= totalSegments) {
+            throw new AwsException("ValidationException",
+                    "The Segment parameter is zero-based and must be less than parameter TotalSegments: "
+                    + "Segment: " + segment + " is not less than TotalSegments: " + totalSegments, 400);
+        }
+
+        String projectionExpressionScan = request.has("ProjectionExpression")
+                ? request.get("ProjectionExpression").asText() : null;
 
         DynamoDbService.ScanResult result = dynamoDbService.scan(
                 tableName, filterExpr, exprAttrNames, exprAttrValues, scanFilter, limit, exclusiveStartKey, region);
 
+        List<JsonNode> scanItems = result.items();
+        // Apply parallel scan segment partitioning
+        if (segment != null && totalSegments != null && totalSegments > 1) {
+            final int seg = segment, total = totalSegments;
+            final List<JsonNode> allItems = scanItems;
+            scanItems = new ArrayList<>();
+            for (int si = 0; si < allItems.size(); si++) {
+                if (si % total == seg) scanItems.add(allItems.get(si));
+            }
+        }
+        // Apply index projection (KEYS_ONLY / INCLUDE) when scanning a secondary index
+        if (indexNameScan != null && projectionExpressionScan == null) {
+            TableDefinition scanTable = dynamoDbService.describeTable(tableName, region);
+            scanItems = applyIndexProjection(scanItems, indexNameScan, scanTable, select);
+        }
+        JsonNode attributesToGetScan = request.has("AttributesToGet") ? request.get("AttributesToGet") : null;
+        if (projectionExpressionScan != null) {
+            scanItems = scanItems.stream()
+                    .map(i -> (JsonNode) ProjectionEvaluator.project(i, projectionExpressionScan, exprAttrNames))
+                    .toList();
+        } else if (attributesToGetScan != null) {
+            Set<String> keep = new HashSet<>();
+            attributesToGetScan.forEach(n -> keep.add(n.asText()));
+            scanItems = scanItems.stream()
+                    .map(i -> (JsonNode) ProjectionEvaluator.trimToAttributes((ObjectNode) i, keep))
+                    .toList();
+        }
+
         ObjectNode response = objectMapper.createObjectNode();
-        ArrayNode itemsArray = objectMapper.createArrayNode();
-        result.items().forEach(itemsArray::add);
-        response.set("Items", itemsArray);
-        response.put("Count", result.items().size());
-        response.put("ScannedCount", result.scannedCount());
+        if ("COUNT".equals(select)) {
+            response.put("Count", result.items().size());
+            response.put("ScannedCount", result.scannedCount());
+        } else {
+            ArrayNode itemsArray = objectMapper.createArrayNode();
+            scanItems.forEach(itemsArray::add);
+            response.set("Items", itemsArray);
+            response.put("Count", scanItems.size());
+            response.put("ScannedCount", result.scannedCount());
+        }
         if (result.lastEvaluatedKey() != null) {
             response.set("LastEvaluatedKey", result.lastEvaluatedKey());
         }
-        addConsumedCapacity(response, request, tableName, result.items().size(), false);
+        addConsumedCapacity(response, request, tableName, scanItems.size(), false);
         return Response.ok(response).build();
     }
 
     private Response handleBatchWriteItem(JsonNode request, String region) {
         JsonNode requestItems = request.get("RequestItems");
-        if (requestItems == null || requestItems.isNull() || requestItems.isMissingNode()) {
-            return Response.ok(objectMapper.createObjectNode()
-                    .set("UnprocessedItems", objectMapper.createObjectNode())).build();
+        if (requestItems == null || requestItems.isNull() || requestItems.isMissingNode()
+                || !requestItems.fields().hasNext()) {
+            throw new AwsException("ValidationException",
+                    "The requestItems parameter is required for BatchWriteItem", 400);
         }
         Map<String, List<JsonNode>> items = new HashMap<>();
         Iterator<Map.Entry<String, JsonNode>> tables = requestItems.fields();
@@ -421,6 +852,39 @@ public class DynamoDbJsonHandler {
             items.put(entry.getKey(), writes);
         }
 
+        // Per-table check: max 25 write requests
+        for (Map.Entry<String, List<JsonNode>> entry : items.entrySet()) {
+            if (entry.getValue().size() > 25) {
+                // Build a representation of the requestItems
+                StringBuilder sb = new StringBuilder("{");
+                sb.append(entry.getKey()).append("=[");
+                List<String> reprs = new ArrayList<>();
+                for (JsonNode w : entry.getValue()) {
+                    reprs.add(w.toString());
+                }
+                sb.append(String.join(", ", reprs)).append("]}");
+                throw new AwsException("ValidationException",
+                        "1 validation error detected: Value '" + sb + "' at 'requestItems' failed to satisfy constraint: "
+                        + "Map value must satisfy constraint: [Member must have length less than or equal to 25, "
+                        + "Member must have length greater than or equal to 1]", 400);
+            }
+        }
+
+        for (Map.Entry<String, List<JsonNode>> entry : items.entrySet()) {
+            TableDefinition bwTable = dynamoDbService.describeTable(entry.getKey(), region);
+            Set<String> seen = new HashSet<>();
+            for (JsonNode writeReq : entry.getValue()) {
+                JsonNode keyNode = writeReq.has("PutRequest")
+                        ? writeReq.get("PutRequest").get("Item")
+                        : writeReq.get("DeleteRequest").get("Key");
+                String key = dynamoDbService.buildItemKey(bwTable, keyNode);
+                if (!seen.add(key)) {
+                    throw new AwsException("ValidationException",
+                            "Provided list of item keys contains duplicates", 400);
+                }
+            }
+        }
+
         dynamoDbService.batchWriteItem(items, region);
 
         ObjectNode response = objectMapper.createObjectNode();
@@ -431,11 +895,10 @@ public class DynamoDbJsonHandler {
 
     private Response handleBatchGetItem(JsonNode request, String region) {
         JsonNode requestItems = request.get("RequestItems");
-        if (requestItems == null || requestItems.isNull() || requestItems.isMissingNode()) {
-            ObjectNode response = objectMapper.createObjectNode();
-            response.set("Responses", objectMapper.createObjectNode());
-            response.set("UnprocessedKeys", objectMapper.createObjectNode());
-            return Response.ok(response).build();
+        if (requestItems == null || requestItems.isNull() || requestItems.isMissingNode()
+                || !requestItems.fields().hasNext()) {
+            throw new AwsException("ValidationException",
+                    "The requestItems parameter is required for BatchGetItem", 400);
         }
         Map<String, JsonNode> items = new HashMap<>();
         Iterator<Map.Entry<String, JsonNode>> tables = requestItems.fields();
@@ -444,14 +907,59 @@ public class DynamoDbJsonHandler {
             items.put(entry.getKey(), entry.getValue());
         }
 
+        // Per-table check: max 100 keys
+        for (Map.Entry<String, JsonNode> entry : items.entrySet()) {
+            JsonNode keysNode = entry.getValue().has("Keys") ? entry.getValue().get("Keys") : null;
+            if (keysNode != null && keysNode.size() > 100) {
+                throw new AwsException("ValidationException",
+                        "1 validation error detected: Value at 'RequestItems." + entry.getKey()
+                        + ".member.Keys' failed to satisfy constraint: "
+                        + "Member must have length less than or equal to 100", 400);
+            }
+        }
+
+        for (Map.Entry<String, JsonNode> entry : items.entrySet()) {
+            TableDefinition bgTable = dynamoDbService.describeTable(entry.getKey(), region);
+            JsonNode keys = entry.getValue().get("Keys");
+            if (keys == null || !keys.isArray()) continue;
+            Set<String> seen = new HashSet<>();
+            for (JsonNode key : keys) {
+                String itemKey = dynamoDbService.buildItemKey(bgTable, key);
+                if (!seen.add(itemKey)) {
+                    throw new AwsException("ValidationException",
+                            "Provided list of item keys contains duplicates", 400);
+                }
+            }
+        }
+
         DynamoDbService.BatchGetResult result = dynamoDbService.batchGetItem(items, region);
 
         ObjectNode response = objectMapper.createObjectNode();
         ObjectNode responses = objectMapper.createObjectNode();
         for (Map.Entry<String, List<JsonNode>> entry : result.responses().entrySet()) {
+            String tblName = entry.getKey();
+            JsonNode tableRequest = requestItems.get(tblName);
+            String projExpr = tableRequest != null && tableRequest.has("ProjectionExpression")
+                    ? tableRequest.get("ProjectionExpression").asText() : null;
+            JsonNode exprNames = tableRequest != null && tableRequest.has("ExpressionAttributeNames")
+                    ? tableRequest.get("ExpressionAttributeNames") : null;
+            JsonNode attrToGet = tableRequest != null && tableRequest.has("AttributesToGet")
+                    ? tableRequest.get("AttributesToGet") : null;
             ArrayNode tableItems = objectMapper.createArrayNode();
-            entry.getValue().forEach(tableItems::add);
-            responses.set(entry.getKey(), tableItems);
+            for (JsonNode item : entry.getValue()) {
+                JsonNode projected;
+                if (projExpr != null) {
+                    projected = ProjectionEvaluator.project(item, projExpr, exprNames);
+                } else if (attrToGet != null) {
+                    Set<String> keep = new HashSet<>();
+                    attrToGet.forEach(n -> keep.add(n.asText()));
+                    projected = ProjectionEvaluator.trimToAttributes((ObjectNode) item, keep);
+                } else {
+                    projected = item;
+                }
+                tableItems.add(projected);
+            }
+            responses.set(tblName, tableItems);
         }
         response.set("Responses", responses);
         response.set("UnprocessedKeys", objectMapper.createObjectNode());
@@ -467,6 +975,12 @@ public class DynamoDbJsonHandler {
         if (!pt.isMissingNode()) {
             readCapacity = pt.has("ReadCapacityUnits") ? pt.get("ReadCapacityUnits").asLong() : null;
             writeCapacity = pt.has("WriteCapacityUnits") ? pt.get("WriteCapacityUnits").asLong() : null;
+        }
+
+        String billingModeCheck = request.has("BillingMode") ? request.get("BillingMode").asText() : null;
+        if ("PAY_PER_REQUEST".equals(billingModeCheck) && !pt.isMissingNode()) {
+            throw new AwsException("ValidationException",
+                    "ProvisionedThroughput cannot be specified when BillingMode is PAY_PER_REQUEST", 400);
         }
 
         List<GlobalSecondaryIndex> gsiCreates = new ArrayList<>();
@@ -574,6 +1088,10 @@ public class DynamoDbJsonHandler {
         String tableName = request.path("TableName").asText();
         JsonNode spec = request.path("TimeToLiveSpecification");
         String ttlAttributeName = spec.path("AttributeName").asText();
+        if (ttlAttributeName == null || ttlAttributeName.isBlank()) {
+            throw new AwsException("ValidationException",
+                    "TimeToLiveSpecification.AttributeName must not be empty", 400);
+        }
         boolean enabled = spec.path("Enabled").asBoolean(false);
 
         dynamoDbService.updateTimeToLive(tableName, ttlAttributeName, enabled, region);
@@ -617,23 +1135,79 @@ public class DynamoDbJsonHandler {
 
     private Response handleTransactWriteItems(JsonNode request, String region) {
         JsonNode transactItemsNode = request.path("TransactItems");
-        List<JsonNode> transactItems = new ArrayList<>();
-        if (transactItemsNode.isArray()) {
-            transactItemsNode.forEach(transactItems::add);
+        if (transactItemsNode.isMissingNode() || transactItemsNode.isNull() || !transactItemsNode.isArray()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value null at 'transactItems' failed to satisfy constraint: "
+                    + "Member must have length greater than or equal to 1", 400);
+        }
+        if (transactItemsNode.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '[]' at 'transactItems' failed to satisfy constraint: "
+                    + "Member must have length greater than or equal to 1", 400);
+        }
+        if (transactItemsNode.size() > 100) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '" + transactItemsNode + "' at 'transactItems' failed to satisfy constraint: "
+                    + "Member must have length less than or equal to 100", 400);
         }
 
+        // Check 4MB total item size limit
+        final int MAX_TRANSACTION_BYTES = 4 * 1024 * 1024;
+        int totalSize = 0;
+        for (JsonNode txItem : transactItemsNode) {
+            JsonNode item = txItem.has("Put") ? txItem.get("Put").get("Item")
+                         : txItem.has("Update") ? txItem.get("Update").get("Key")
+                         : txItem.has("Delete") ? txItem.get("Delete").get("Key")
+                         : txItem.has("ConditionCheck") ? txItem.get("ConditionCheck").get("Key")
+                         : null;
+            if (item != null) totalSize += DynamoDbItemSize.calculateItemSize(item);
+        }
+        if (totalSize > MAX_TRANSACTION_BYTES) {
+            throw new AwsException("ValidationException",
+                    "Transaction failed: The total size of all items in the transaction request cannot exceed 4 MB", 400);
+        }
+
+        Map<String, TableDefinition> tableCache = new HashMap<>();
+        Set<String> seen = new HashSet<>();
+        for (JsonNode txItem : transactItemsNode) {
+            JsonNode op = txItem.has("Put") ? txItem.get("Put")
+                        : txItem.has("Delete") ? txItem.get("Delete")
+                        : txItem.has("Update") ? txItem.get("Update")
+                        : txItem.has("ConditionCheck") ? txItem.get("ConditionCheck") : null;
+            if (op == null) continue;
+            String opTable = op.path("TableName").asText();
+            TableDefinition txTable = tableCache.computeIfAbsent(opTable,
+                    tn -> dynamoDbService.describeTable(tn, region));
+            JsonNode keyNode = op.has("Item") ? op.get("Item") : op.get("Key");
+            if (keyNode == null) continue;
+            String key = region + "::" + opTable + "::" + dynamoDbService.buildItemKey(txTable, keyNode);
+            if (!seen.add(key)) {
+                throw new AwsException("ValidationException",
+                        "Transaction request cannot include multiple operations on one item", 400);
+            }
+        }
+
+        List<JsonNode> transactItems = new ArrayList<>();
+        transactItemsNode.forEach(transactItems::add);
+
+        String clientRequestToken = request.has("ClientRequestToken")
+                ? request.get("ClientRequestToken").asText() : null;
+
         try {
-            dynamoDbService.transactWriteItems(transactItems, region);
+            dynamoDbService.transactWriteItems(transactItems, region, clientRequestToken);
             return Response.ok(objectMapper.createObjectNode()).build();
         } catch (TransactionCanceledException e) {
             ObjectNode body = objectMapper.createObjectNode();
             body.put("__type", "TransactionCanceledException");
             body.put("message", e.getMessage());
             ArrayNode reasons = body.putArray("CancellationReasons");
-            for (String reason : e.getCancellationReasons()) {
+            for (TransactionCanceledException.CancellationReason reason : e.getCancellationReasons()) {
                 ObjectNode r = objectMapper.createObjectNode();
-                r.put("Code", reason.isEmpty() ? "None" : "ConditionalCheckFailed");
-                r.put("Message", reason);
+                r.put("Code", reason.code().isEmpty() ? "None" : reason.code());
+                r.put("Message", reason.code().isEmpty() ? "" : "The conditional request failed");
+                if (reason.item() != null) {
+                    r.set("Item", reason.item());
+                }
                 reasons.add(r);
             }
             return Response.status(400).entity(body).build();
@@ -642,12 +1216,80 @@ public class DynamoDbJsonHandler {
 
     private Response handleTransactGetItems(JsonNode request, String region) {
         JsonNode transactItemsNode = request.path("TransactItems");
-        List<JsonNode> transactItems = new ArrayList<>();
-        if (transactItemsNode.isArray()) {
-            transactItemsNode.forEach(transactItems::add);
+        if (transactItemsNode.isMissingNode() || transactItemsNode.isNull() || !transactItemsNode.isArray()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value null at 'transactItems' failed to satisfy constraint: "
+                    + "Member must have length greater than or equal to 1", 400);
+        }
+        if (transactItemsNode.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '[]' at 'transactItems' failed to satisfy constraint: "
+                    + "Member must have length greater than or equal to 1", 400);
+        }
+        if (transactItemsNode.size() > 100) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '" + transactItemsNode + "' at 'transactItems' failed to satisfy constraint: "
+                    + "Member must have length less than or equal to 100", 400);
         }
 
-        List<JsonNode> results = dynamoDbService.transactGetItems(transactItems, region);
+        Map<String, TableDefinition> tableCache = new HashMap<>();
+        Set<String> seenGet = new HashSet<>();
+        for (JsonNode txItem : transactItemsNode) {
+            JsonNode get = txItem.has("Get") ? txItem.get("Get") : null;
+            if (get == null) continue;
+            String opTable = get.path("TableName").asText();
+            TableDefinition txTable = tableCache.computeIfAbsent(opTable,
+                    tn -> dynamoDbService.describeTable(tn, region));
+            JsonNode keyNode = get.get("Key");
+            if (keyNode == null) continue;
+            try {
+                String key = region + "::" + opTable + "::" + dynamoDbService.buildItemKey(txTable, keyNode);
+                if (!seenGet.add(key)) {
+                    throw new AwsException("ValidationException",
+                            "Transaction request cannot include multiple operations on one item", 400);
+                }
+            } catch (AwsException e) {
+                if ("Transaction request cannot include multiple operations on one item".equals(e.getMessage())) {
+                    throw e;
+                }
+                // Per-action validation error - will be surfaced via TransactionCanceledException in transactGetItems
+            }
+        }
+
+        // Validate ProjectionExpression syntax in each Get action before executing
+        for (JsonNode txItem : transactItemsNode) {
+            JsonNode get = txItem.has("Get") ? txItem.get("Get") : null;
+            if (get == null) continue;
+            String pe = get.has("ProjectionExpression") ? get.get("ProjectionExpression").asText() : null;
+            if (pe != null) {
+                ProjectionEvaluator.validateSyntax(pe, "ProjectionExpression");
+            }
+        }
+
+        List<JsonNode> transactItems = new ArrayList<>();
+        transactItemsNode.forEach(transactItems::add);
+
+        List<JsonNode> results;
+        try {
+            results = dynamoDbService.transactGetItems(transactItems, region);
+        } catch (TransactionCanceledException e) {
+            ObjectNode body = objectMapper.createObjectNode();
+            body.put("__type", "TransactionCanceledException");
+            body.put("message", e.getMessage());
+            ArrayNode reasons = body.putArray("CancellationReasons");
+            for (TransactionCanceledException.CancellationReason reason : e.getCancellationReasons()) {
+                ObjectNode r = objectMapper.createObjectNode();
+                r.put("Code", reason.code().isEmpty() ? "None" : reason.code());
+                if (!reason.code().isEmpty()) {
+                    r.put("Message", "");
+                }
+                if (reason.item() != null) {
+                    r.set("Item", reason.item());
+                }
+                reasons.add(r);
+            }
+            return Response.status(400).entity(body).build();
+        }
 
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode responsesArray = objectMapper.createArrayNode();
@@ -662,8 +1304,20 @@ public class DynamoDbJsonHandler {
         return Response.ok(response).build();
     }
 
+    private static final java.util.regex.Pattern DYNAMODB_TABLE_ARN_PATTERN =
+            java.util.regex.Pattern.compile(
+                    "^arn:aws:dynamodb:[a-z0-9-]+:\\d{12}:table/[a-zA-Z0-9._-]+$");
+
+    private static boolean isValidDynamoDbTableArn(String arn) {
+        return arn != null && DYNAMODB_TABLE_ARN_PATTERN.matcher(arn).matches();
+    }
+
     private Response handleTagResource(JsonNode request, String region) {
         String resourceArn = request.path("ResourceArn").asText();
+        if (!isValidDynamoDbTableArn(resourceArn)) {
+            throw new AwsException("ValidationException",
+                    "Invalid ResourceArn: " + resourceArn, 400);
+        }
         Map<String, String> tags = new HashMap<>();
         JsonNode tagsNode = request.path("Tags");
         if (tagsNode.isArray()) {
@@ -690,7 +1344,17 @@ public class DynamoDbJsonHandler {
 
     private Response handleListTagsOfResource(JsonNode request, String region) {
         String resourceArn = request.path("ResourceArn").asText();
-        Map<String, String> tags = dynamoDbService.listTagsOfResource(resourceArn, region);
+        Map<String, String> tags;
+        try {
+            tags = dynamoDbService.listTagsOfResource(resourceArn, region);
+        } catch (AwsException e) {
+            if ("ResourceNotFoundException".equals(e.getErrorCode())) {
+                throw new AwsException("AccessDeniedException",
+                        "User is not authorized to perform: dynamodb:ListTagsOfResource on resource: "
+                        + resourceArn, 400);
+            }
+            throw e;
+        }
 
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode tagsArray = objectMapper.createArrayNode();
@@ -805,6 +1469,164 @@ public class DynamoDbJsonHandler {
      * Builds a ConsumedCapacity node if the request includes ReturnConsumedCapacity.
      * Uses simple estimates: 0.5 RCU per item read, 1.0 WCU per item written.
      */
+    private void validateItemSets(JsonNode item) {
+        if (item == null || !item.isObject()) return;
+        item.fields().forEachRemaining(entry -> {
+            JsonNode attr = entry.getValue();
+            checkAttrSets(attr);
+        });
+    }
+
+    private void checkAttrSets(JsonNode attr) {
+        if (attr == null) return;
+        if (attr.has("NULL") && !attr.get("NULL").asBoolean()) {
+            throw new AwsException("ValidationException",
+                    "One or more parameter values were invalid: Null attribute value types must have the value of true", 400);
+        }
+        if (attr.has("SS")) {
+            JsonNode ss = attr.get("SS");
+            if (ss.isEmpty()) throw new AwsException("ValidationException",
+                    "One or more parameter values were invalid: An string set  may not be empty", 400);
+            Set<String> seen = new HashSet<>();
+            for (JsonNode e : ss) {
+                if (!seen.add(e.asText())) throw new AwsException("ValidationException",
+                        "One or more parameter values were invalid: Input collection " + formatSetForError(ss) + " contains duplicates.", 400);
+            }
+        } else if (attr.has("NS")) {
+            JsonNode ns = attr.get("NS");
+            if (ns.isEmpty()) throw new AwsException("ValidationException",
+                    "One or more parameter values were invalid: An number set  may not be empty", 400);
+            Set<String> seen = new HashSet<>();
+            for (JsonNode e : ns) {
+                if (!seen.add(e.asText())) throw new AwsException("ValidationException",
+                        "One or more parameter values were invalid: Input collection " + formatSetForError(ns) + " contains duplicates.", 400);
+            }
+        } else if (attr.has("BS")) {
+            JsonNode bs = attr.get("BS");
+            if (bs.isEmpty()) throw new AwsException("ValidationException",
+                    "One or more parameter values were invalid: Binary sets should not be empty", 400);
+            Set<String> seen = new HashSet<>();
+            for (JsonNode e : bs) {
+                if (!seen.add(e.asText())) throw new AwsException("ValidationException",
+                        "One or more parameter values were invalid: Input collection " + formatSetForError(bs) + " contains duplicates.", 400);
+            }
+        } else if (attr.has("M")) {
+            attr.get("M").fields().forEachRemaining(e -> checkAttrSets(e.getValue()));
+        } else if (attr.has("L")) {
+            attr.get("L").forEach(this::checkAttrSets);
+        }
+    }
+
+    // ── Expression token utilities ──
+
+    private static void extractPrefixedTokens(String expr, char prefix, Set<String> out) {
+        if (expr == null) return;
+        int i = 0;
+        while (i < expr.length()) {
+            if (expr.charAt(i) == prefix) {
+                int start = i++;
+                while (i < expr.length() && (Character.isLetterOrDigit(expr.charAt(i)) || expr.charAt(i) == '_')) i++;
+                if (i > start + 1) out.add(expr.substring(start, i));
+            } else {
+                i++;
+            }
+        }
+    }
+
+    private static Set<String> extractHashTokens(String... expressions) {
+        Set<String> tokens = new LinkedHashSet<>();
+        for (String expr : expressions) extractPrefixedTokens(expr, '#', tokens);
+        return tokens;
+    }
+
+    private static Set<String> extractColonTokens(String... expressions) {
+        Set<String> tokens = new LinkedHashSet<>();
+        for (String expr : expressions) extractPrefixedTokens(expr, ':', tokens);
+        return tokens;
+    }
+
+    private static void checkUnusedEan(JsonNode exprAttrNames, Set<String> usedHashTokens) {
+        if (exprAttrNames == null) return;
+        List<String> unused = new ArrayList<>();
+        exprAttrNames.fieldNames().forEachRemaining(k -> {
+            if (!usedHashTokens.contains(k)) unused.add(k);
+        });
+        if (!unused.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "Value provided in ExpressionAttributeNames unused in expressions: keys: {"
+                    + String.join(", ", unused) + "}", 400);
+        }
+    }
+
+    private static void checkUnusedEav(JsonNode exprAttrValues, Set<String> usedColonTokens) {
+        if (exprAttrValues == null) return;
+        List<String> unused = new ArrayList<>();
+        exprAttrValues.fieldNames().forEachRemaining(k -> {
+            if (!usedColonTokens.contains(k)) unused.add(k);
+        });
+        if (!unused.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "Value provided in ExpressionAttributeValues unused in expressions: keys: {"
+                    + String.join(", ", unused) + "}", 400);
+        }
+    }
+
+    private String formatSetForError(JsonNode arr) {
+        StringBuilder sb = new StringBuilder("[");
+        boolean first = true;
+        for (JsonNode e : arr) {
+            if (!first) sb.append(", ");
+            sb.append(e.asText());
+            first = false;
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    // Filters items to only include the attributes projected into the given index.
+    // Returns items unchanged when projectionType is ALL or no matching index is found.
+    private List<JsonNode> applyIndexProjection(List<JsonNode> items, String indexName,
+                                                 TableDefinition table, String select) {
+        if (indexName == null || "ALL_ATTRIBUTES".equals(select)) return items;
+
+        String projectionType = "ALL";
+        List<String> nonKeyAttributes = new ArrayList<>();
+        Set<String> indexKeyNames = new HashSet<>();
+
+        for (GlobalSecondaryIndex gsi : table.getGlobalSecondaryIndexes()) {
+            if (gsi.getIndexName().equals(indexName)) {
+                projectionType = gsi.getProjectionType() != null ? gsi.getProjectionType() : "ALL";
+                nonKeyAttributes = gsi.getNonKeyAttributes() != null ? gsi.getNonKeyAttributes() : List.of();
+                gsi.getKeySchema().forEach(k -> indexKeyNames.add(k.getAttributeName()));
+                break;
+            }
+        }
+        for (LocalSecondaryIndex lsi : table.getLocalSecondaryIndexes()) {
+            if (lsi.getIndexName().equals(indexName)) {
+                projectionType = lsi.getProjectionType() != null ? lsi.getProjectionType() : "ALL";
+                nonKeyAttributes = lsi.getNonKeyAttributes() != null ? lsi.getNonKeyAttributes() : List.of();
+                lsi.getKeySchema().forEach(k -> indexKeyNames.add(k.getAttributeName()));
+                break;
+            }
+        }
+
+        if ("ALL".equals(projectionType)) return items;
+
+        Set<String> allowed = new HashSet<>(indexKeyNames);
+        allowed.add(table.getPartitionKeyName());
+        String sortKeyName = table.getSortKeyName();
+        if (sortKeyName != null) allowed.add(sortKeyName);
+        if ("INCLUDE".equals(projectionType)) allowed.addAll(nonKeyAttributes);
+
+        return items.stream().map(item -> {
+            ObjectNode filtered = objectMapper.createObjectNode();
+            item.fields().forEachRemaining(e -> {
+                if (allowed.contains(e.getKey())) filtered.set(e.getKey(), e.getValue());
+            });
+            return (JsonNode) filtered;
+        }).toList();
+    }
+
     private void addConsumedCapacity(ObjectNode response, JsonNode request, String tableName,
                                       int itemCount, boolean isWrite) {
         String returnCC = request.path("ReturnConsumedCapacity").asText("NONE");

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbNumberUtils.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbNumberUtils.java
@@ -1,0 +1,132 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+
+import java.math.BigDecimal;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * DynamoDB number validation and normalization.
+ * Numbers must have <= 38 significant digits, be within range, and are stored
+ * in normalized form (no leading zeros, no trailing decimal zeros, -0 -> 0).
+ */
+final class DynamoDbNumberUtils {
+
+    private static final BigDecimal MAX_ABS = new BigDecimal("1E+126");
+    private static final BigDecimal MIN_ABS_NONZERO = new BigDecimal("1E-130");
+
+    private DynamoDbNumberUtils() {}
+
+    /**
+     * Validates and normalizes a DynamoDB number string.
+     * Throws ValidationException if the number is out of range or has too many significant digits.
+     * Returns the normalized string (no leading zeros, no trailing decimal zeros).
+     */
+    static String validateAndNormalize(String numStr) {
+        if (numStr == null || numStr.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "The parameter cannot be converted to a numeric value", 400);
+        }
+        BigDecimal bd;
+        try {
+            bd = new BigDecimal(numStr);
+        } catch (NumberFormatException e) {
+            throw new AwsException("ValidationException",
+                    "The parameter cannot be converted to a numeric value: " + numStr, 400);
+        }
+
+        BigDecimal stripped = bd.stripTrailingZeros();
+
+        // Check significant digits after normalization
+        if (stripped.precision() > 38) {
+            throw new AwsException("ValidationException",
+                    "Number too many significant digits; first supported is 1E-130 last supported is 1E+126", 400);
+        }
+
+        // Check range (only for nonzero values)
+        BigDecimal abs = stripped.abs();
+        if (abs.compareTo(BigDecimal.ZERO) > 0) {
+            if (abs.compareTo(MAX_ABS) >= 0) {
+                throw new AwsException("ValidationException",
+                        "Number overflow. Attempting to store a value that is too large. "
+                        + "The maximum allowed positive value is 9.9999999999999999999999999999999999999E+125", 400);
+            }
+            if (abs.compareTo(MIN_ABS_NONZERO) < 0) {
+                throw new AwsException("ValidationException",
+                        "Number underflow. Attempting to store a value that is too small. "
+                        + "The minimum allowed positive value is 1E-130", 400);
+            }
+        }
+
+        return toNormalizedString(stripped);
+    }
+
+    private static String toNormalizedString(BigDecimal bd) {
+        // -0 -> 0
+        if (bd.compareTo(BigDecimal.ZERO) == 0) {
+            return "0";
+        }
+        // Use plain string to expand scientific notation to decimal form when reasonable
+        return bd.toPlainString();
+    }
+
+    /**
+     * Recursively normalizes all N-type number attribute values in the given item.
+     * Returns a new ObjectNode with normalized values. Input must be a DynamoDB item
+     * where attribute values are DynamoDB typed values (e.g. {S: "x"}, {N: "42"}).
+     */
+    static ObjectNode normalizeNumbersInItem(JsonNode item) {
+        if (item == null || !item.isObject()) return (ObjectNode) item;
+        ObjectNode result = JsonNodeFactory.instance.objectNode();
+        item.fields().forEachRemaining(entry -> {
+            result.set(entry.getKey(), normalizeAttrValue(entry.getValue()));
+        });
+        return result;
+    }
+
+    private static JsonNode normalizeAttrValue(JsonNode attr) {
+        if (attr == null) return null;
+
+        if (attr.has("N")) {
+            String raw = attr.get("N").asText();
+            String normalized = validateAndNormalize(raw);
+            ObjectNode result = JsonNodeFactory.instance.objectNode();
+            result.put("N", normalized);
+            return result;
+        }
+
+        if (attr.has("NS")) {
+            // Normalize and validate each element
+            ObjectNode result = JsonNodeFactory.instance.objectNode();
+            ArrayNode ns = JsonNodeFactory.instance.arrayNode();
+            for (JsonNode elem : attr.get("NS")) {
+                ns.add(validateAndNormalize(elem.asText()));
+            }
+            result.set("NS", ns);
+            return result;
+        }
+
+        if (attr.has("M")) {
+            ObjectNode result = JsonNodeFactory.instance.objectNode();
+            result.set("M", normalizeNumbersInItem(attr.get("M")));
+            return result;
+        }
+
+        if (attr.has("L")) {
+            ObjectNode result = JsonNodeFactory.instance.objectNode();
+            ArrayNode list = JsonNodeFactory.instance.arrayNode();
+            for (JsonNode elem : attr.get("L")) {
+                list.add(normalizeAttrValue(elem));
+            }
+            result.set("L", list);
+            return result;
+        }
+
+        return attr;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbReservedWords.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbReservedWords.java
@@ -1,0 +1,161 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Validates that DynamoDB expressions do not use reserved words as bare attribute names.
+ */
+final class DynamoDbReservedWords {
+
+    private DynamoDbReservedWords() {}
+
+    // Expression clause/operator keywords that are syntactically valid as operators
+    // and should not be treated as attribute name tokens.
+    private static final Set<String> CLAUSE_KEYWORDS = Set.of(
+        "SET", "REMOVE", "ADD", "DELETE",
+        "AND", "OR", "NOT", "BETWEEN", "IN",
+        "TRUE", "FALSE"
+    );
+
+    // Full DynamoDB reserved words list (uppercase)
+    private static final Set<String> RESERVED = Set.of(
+        "ABORT", "ABSOLUTE", "ACTION", "ADD", "AFTER", "AGENT", "ALL", "ALLOCATE",
+        "ALTER", "ANALYZE", "AND", "ANY", "ARCHIVE", "ARE", "ARRAY", "AS", "ASC",
+        "ASCII", "ASENSITIVE", "ASSERTION", "ASYMMETRIC", "AT", "ATOMIC", "ATTACH",
+        "ATTRIBUTE", "AUTH", "AUTHORIZATION", "AUTHORIZE", "AUTO",
+        "BETWEEN", "BIGINT", "BINARY", "BIT", "BLOB", "BLOCK", "BOOLEAN", "BOTH",
+        "BREADTH", "BUCKET", "BULK", "BY",
+        "CALL", "CALLED", "CANCEL", "CASCADE", "CASE", "CAST", "CATALOG", "CHAR",
+        "CHARACTER", "CHECK", "CLASS", "CLOB", "CLOSE", "CLUSTER", "CLUSTERED",
+        "CLUSTERING", "CLUSTERS", "COALESCE", "COLLATE", "COLLATION", "COLUMN",
+        "COLUMNS", "COMBINE", "COMMENT", "COMMIT", "COMPACT", "COMPILE", "COMPRESS",
+        "CONDITION", "CONFLICT", "CONNECT", "CONNECTION", "CONSISTENCY", "CONSISTENT",
+        "CONSTRAINT", "CONSTRAINTS", "CONSTRUCTOR", "CONSUMED", "CONTINUE", "CONVERT",
+        "COPY", "CORRESPONDING", "COUNT", "COUNTER", "CREATE", "CROSS", "CUBE",
+        "CURRENT", "CURSOR", "CYCLE",
+        "DATA", "DATABASE", "DATE", "DATETIME", "DAY", "DEALLOCATE", "DEC", "DECIMAL",
+        "DECLARE", "DEFAULT", "DEFERRABLE", "DEFERRED", "DEFINE", "DEFINED",
+        "DEFINITION", "DELETE", "DELIMITED", "DEPTH", "DEREF", "DESC", "DESCRIBE",
+        "DESCRIPTOR", "DETACH", "DETERMINISTIC", "DIAGNOSTICS", "DIRECTORIES",
+        "DISABLE", "DISCONNECT", "DISTINCT", "DISTRIBUTE", "DO", "DOMAIN", "DOUBLE",
+        "DROP", "DUMP", "DURATION", "DYNAMIC",
+        "EACH", "ELEMENT", "ELSE", "ELSEIF", "EMPTY", "ENABLE", "END", "EQUALS",
+        "ERROR", "ESCAPE", "EVALUATED", "EXCEPT", "EXCEPTION", "EXCEPTIONS",
+        "EXCLUSIVE", "EXEC", "EXECUTE", "EXISTS", "EXIT", "EXPLAIN", "EXPLODE",
+        "EXPORT", "EXTENDED", "EXTERNAL",
+        "FALSE", "FETCH", "FILTER", "FIRST", "FIXED", "FLATTERN", "FLOAT", "FOR",
+        "FORCE", "FOREIGN", "FORMAT", "FORWARD", "FOUND", "FREE", "FROM", "FULL",
+        "FUNCTION", "FUNCTIONS",
+        "GENERAL", "GENERATE", "GET", "GLOB", "GO", "GOTO", "GRANT", "GREATER",
+        "GROUP", "GROUPING",
+        "HANDLER", "HASH", "HAVE", "HAVING", "HEAP", "HIDDEN", "HOLD", "HOW",
+        "IDENTIFIED", "IDENTITY", "IF", "IGNORE", "IMMEDIATE", "IN", "INCLUDING",
+        "INCLUSIVE", "INCREMENT", "INCREMENTAL", "INDEX", "INDEXES", "INDICATOR",
+        "INFINITE", "INITIALLY", "INLINE", "INNER", "INNTER", "INOUT", "INSERT",
+        "INSTEAD", "INT", "INTEGER", "INTERSECT", "INTERVAL", "INTO", "INVALIDATE",
+        "IS", "ISOLATION", "ITEM", "ITEMS", "ITERATE",
+        "JOIN",
+        "KEY", "KEYS",
+        "LAG", "LANGUAGE", "LARGE", "LAST", "LATERAL", "LEAD", "LEADING", "LEAVE",
+        "LEFT", "LENGTH", "LESS", "LEVEL", "LIKE", "LIMIT", "LIMITED", "LINES",
+        "LIST", "LOAD", "LOCAL", "LOCALTIME", "LOCALTIMESTAMP", "LOCATION", "LOCATOR",
+        "LOCK", "LOCKS", "LOG", "LOGED", "LONG", "LOOP", "LOWER",
+        "MAP", "MATCH", "MATERIALIZED", "MAX", "MAXLEN", "MERGE", "METADATA", "MIN",
+        "MINUS", "MODIFIES", "MODIFY", "MODULE", "MONTH", "MULTI", "MULTISET",
+        "NAME", "NAMES", "NATIONAL", "NATURAL", "NCHAR", "NCLOB", "NEW", "NEXT",
+        "NO", "NONE", "NOT", "NULL", "NULLIF", "NUMBER", "NUMERIC",
+        "OBJECT", "OF", "OFFLINE", "OFFSET", "OLD", "ON", "ONLINE", "ONLY",
+        "OPAQUE", "OPEN", "OPERATOR", "OPTION", "OR", "ORDER", "ORDINALITY",
+        "OTHER", "OTHERS", "OUT", "OUTER", "OVER", "OVERLAPS", "OVERRIDE", "OWNER",
+        "PAD", "PARALLEL", "PARAMETER", "PARAMETERS", "PARTIAL", "PARTITION",
+        "PASSWORD", "PATH", "PERCENT", "PERCENTILE", "PERMISSION", "PERMISSIONS",
+        "PIPE", "PIPELINED", "PLAN", "POOL", "POSITION", "PRECISION", "PREPARE",
+        "PRIMARY", "PRIOR", "PRIVILEGES", "PROCEDURE", "PROCESSED", "PROJECT",
+        "PROJECTION", "PROJECTIONS", "PROTO", "PULL", "PUT",
+        "QUERY", "QUIT", "QUORUM",
+        "RAISE", "RANDOM", "RANGE", "RANK", "RAW", "READ", "READS", "REAL",
+        "REBUILD", "RECORD", "RECURSIVE", "REDUCE", "REF", "REFERENCE", "REFERENCES",
+        "REFERENCING", "REGEXP", "REGION", "REINDEX", "RELATIVE", "RELEASE",
+        "REMAINDER", "RENAME", "REPEAT", "REPLACE", "REQUEST", "RESET", "RESIGNAL",
+        "RESOURCE", "RESPONSE", "RESTORE", "RESTRICT", "RESULT", "RETURN",
+        "RETURNING", "RETURNS", "REVERSE", "REVOKE", "RIGHT", "ROLE", "ROLES",
+        "ROLLBACK", "ROLLUP", "ROUTINE", "ROW", "ROWS", "RULE",
+        "SAVEPOINT", "SCAN", "SCHEMA", "SCOPE", "SCROLL", "SEARCH", "SECOND",
+        "SECTION", "SEGMENT", "SEGMENTS", "SELECT", "SELF", "SEMI", "SENSITIVE",
+        "SEQUENCE", "SERIALIZABLE", "SESSION", "SET", "SETS", "SIGNAL", "SIMILAR",
+        "SIZE", "SKEWED", "SMALLINT", "SNAPSHOT", "SOME", "SOURCE", "SPACE",
+        "SPACES", "SPARSE", "SPECIFIC", "SPECIFICTYPE", "SPLIT", "SQL", "SQLCODE",
+        "SQLERROR", "SQLEXCEPTION", "SQLSTATE", "SQLWARNING", "START", "STATE",
+        "STATIC", "STATUS", "STORAGE", "STORE", "STORED", "STREAM", "STRING",
+        "STRUCT", "STYLE", "SUB", "SUBMULTISET", "SUBPAGES", "SUBSTRING", "SUM",
+        "SYMMETRIC", "SYSTEM",
+        "TABLE", "TABLESAMPLE", "TEMP", "TEMPORARY", "TERMINATED", "TEXT", "THAN",
+        "THEN", "THROUGHPUT", "TINYINT", "TO", "TOKEN", "TOTAL", "TOUCH",
+        "TRAILING", "TRANSACTION", "TRANSFORM", "TRANSLATE", "TRANSLATION", "TREAT",
+        "TRIGGER", "TRIM", "TRUE", "TRUNCATE", "TTL", "TUPLE", "TYPE",
+        "UNDER", "UNDO", "UNION", "UNIQUE", "UNIT", "UNKNOWN", "UNLOGGED",
+        "UNNEST", "UNPROCESSED", "UNSIGNED", "UNTIL", "UPDATE", "UPPER", "URL",
+        "USAGE", "USE", "USER", "UUID",
+        "VACUUM", "VALUE", "VALUED", "VALUES", "VARCHAR", "VARIABLE", "VARIANCE",
+        "VARYING", "VIEW", "VIEWS", "VIRTUAL", "VOID",
+        "WAIT", "WHEN", "WHERE", "WHILE", "WINDOW", "WITH", "WITHIN", "WITHOUT",
+        "WRITE",
+        "YEAR",
+        "ZONE"
+    );
+
+    /**
+     * Validates that the expression does not use any reserved words as bare attribute names.
+     * Throws ValidationException if a reserved word is found without a # alias.
+     */
+    static void check(String expression, String expressionType) {
+        if (expression == null || expression.isBlank()) return;
+        List<String> bareIdents = extractBareIdentifiers(expression);
+        for (String ident : bareIdents) {
+            String upper = ident.toUpperCase();
+            if (CLAUSE_KEYWORDS.contains(upper)) continue;
+            if (RESERVED.contains(upper)) {
+                throw new AwsException("ValidationException",
+                        "Invalid " + expressionType + ": Attribute name is a reserved keyword; "
+                        + "reserved word: " + ident, 400);
+            }
+        }
+    }
+
+    private static List<String> extractBareIdentifiers(String expr) {
+        List<String> result = new ArrayList<>();
+        int i = 0;
+        int len = expr.length();
+        while (i < len) {
+            char c = expr.charAt(i);
+            if (c == '#' || c == ':') {
+                // Skip alias or value ref
+                i++;
+                while (i < len && isIdentChar(expr.charAt(i))) i++;
+            } else if (Character.isLetter(c) || c == '_') {
+                int start = i;
+                while (i < len && isIdentChar(expr.charAt(i))) i++;
+                String word = expr.substring(start, i);
+                // Skip whitespace to check if followed by '('
+                int j = i;
+                while (j < len && expr.charAt(j) == ' ') j++;
+                if (j < len && expr.charAt(j) == '(') {
+                    // Function call — skip
+                } else {
+                    result.add(word);
+                }
+            } else {
+                i++;
+            }
+        }
+        return result;
+    }
+
+    private static boolean isIdentChar(char c) {
+        return Character.isLetterOrDigit(c) || c == '_';
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -2003,9 +2003,18 @@ public class DynamoDbService {
                 JsonNode child = obj.get(attrName);
                 if (last) {
                     if (nextTok instanceof String finalAttr) {
-                        if (child == null || !child.has("M")) throw new AwsException("ValidationException",
-                                "The document path provided in the update expression is invalid for update", 400);
-                        ((ObjectNode) child.get("M")).set(finalAttr, value);
+                        if (child == null) {
+                            ObjectNode newMap = objectMapper.createObjectNode();
+                            newMap.set(finalAttr, value);
+                            ObjectNode wrapper = objectMapper.createObjectNode();
+                            wrapper.set("M", newMap);
+                            obj.set(attrName, wrapper);
+                        } else if (!child.has("M")) {
+                            throw new AwsException("ValidationException",
+                                    "The document path provided in the update expression is invalid for update", 400);
+                        } else {
+                            ((ObjectNode) child.get("M")).set(finalAttr, value);
+                        }
                     } else if (nextTok instanceof Integer finalIdx) {
                         if (child == null || !child.has("L")) throw new AwsException("ValidationException",
                                 "The document path provided in the update expression is invalid for update", 400);
@@ -2014,9 +2023,18 @@ public class DynamoDbService {
                     return;
                 }
                 if (nextTok instanceof String) {
-                    if (child == null || !child.has("M")) throw new AwsException("ValidationException",
-                            "The document path provided in the update expression is invalid for update", 400);
-                    container = child.get("M");
+                    if (child == null) {
+                        ObjectNode newMap = objectMapper.createObjectNode();
+                        ObjectNode wrapper = objectMapper.createObjectNode();
+                        wrapper.set("M", newMap);
+                        obj.set(attrName, wrapper);
+                        container = newMap;
+                    } else if (!child.has("M")) {
+                        throw new AwsException("ValidationException",
+                                "The document path provided in the update expression is invalid for update", 400);
+                    } else {
+                        container = child.get("M");
+                    }
                 } else if (nextTok instanceof Integer) {
                     if (child == null || !child.has("L")) throw new AwsException("ValidationException",
                             "The document path provided in the update expression is invalid for update", 400);

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -34,10 +34,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.HexFormat;
+import java.util.LinkedHashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -62,6 +65,8 @@ public class DynamoDbService {
     // relies on ReentrantLock's re-entrancy so the inner put/update/delete calls do
     // not deadlock after the outer transaction already took each participant's lock.
     private final ConcurrentHashMap<String, ConcurrentHashMap<String, ReentrantLock>> itemLocks = new ConcurrentHashMap<>();
+    // Idempotency token → JSON hash of the original transaction payload
+    private final ConcurrentHashMap<String, String> idempotencyTokens = new ConcurrentHashMap<>();
     private final RegionResolver regionResolver;
     private final ObjectMapper objectMapper;
     private DynamoDbStreamService streamService;
@@ -186,6 +191,98 @@ public class DynamoDbService {
                     "Table already exists: " + tableName, 400);
         }
 
+        if (keySchema == null || keySchema.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "No defined attribute for index key schema: hash or range", 400);
+        }
+
+        // Validate KeyType values
+        for (int i = 0; i < keySchema.size(); i++) {
+            String keyType = keySchema.get(i).getKeyType();
+            if (!"HASH".equals(keyType) && !"RANGE".equals(keyType)) {
+                throw new AwsException("ValidationException",
+                        "1 validation error detected: Value '" + keyType
+                        + "' at 'keySchema." + (i + 1) + ".member.keyType' failed to satisfy constraint: "
+                        + "Member must satisfy enum value set: [HASH, RANGE]", 400);
+            }
+        }
+
+        // Validate keySchema size <= 2
+        if (keySchema.size() > 2) {
+            String repr = "[" + keySchema.stream()
+                    .map(k -> "KeySchemaElement(attributeName=" + k.getAttributeName() + ", keyType=" + k.getKeyType() + ")")
+                    .collect(java.util.stream.Collectors.joining(", ")) + "]";
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '" + repr + "' at 'keySchema' failed to satisfy constraint: "
+                    + "Member must have length less than or equal to 2", 400);
+        }
+
+        // Validate no duplicate attribute names in keySchema
+        Set<String> keySchemaAttrNames = new HashSet<>();
+        for (KeySchemaElement k : keySchema) {
+            if (!keySchemaAttrNames.add(k.getAttributeName())) {
+                throw new AwsException("ValidationException",
+                        "Invalid KeySchema: Some index key attribute have no definition", 400);
+            }
+        }
+
+        // Validate AttributeType values
+        if (attributeDefinitions != null) {
+            for (int i = 0; i < attributeDefinitions.size(); i++) {
+                String attrType = attributeDefinitions.get(i).getAttributeType();
+                if (!"B".equals(attrType) && !"N".equals(attrType) && !"S".equals(attrType)) {
+                    throw new AwsException("ValidationException",
+                            "1 validation error detected: Value '" + attrType
+                            + "' at 'attributeDefinitions." + (i + 1) + ".member.attributeType' failed to satisfy constraint: "
+                            + "Member must satisfy enum value set: [B, N, S]", 400);
+                }
+            }
+        }
+
+        Set<String> referencedAttrs = new HashSet<>();
+        keySchema.forEach(k -> referencedAttrs.add(k.getAttributeName()));
+        if (gsis != null) {
+            gsis.forEach(g -> g.getKeySchema().forEach(k -> referencedAttrs.add(k.getAttributeName())));
+        }
+        if (lsis != null) {
+            lsis.forEach(l -> l.getKeySchema().forEach(k -> referencedAttrs.add(k.getAttributeName())));
+        }
+        if (attributeDefinitions != null) {
+            for (AttributeDefinition ad : attributeDefinitions) {
+                if (!referencedAttrs.contains(ad.getAttributeName())) {
+                    throw new AwsException("ValidationException",
+                            "Invalid attribute: " + ad.getAttributeName()
+                            + " is defined in AttributeDefinitions but is not used in any key schema", 400);
+                }
+            }
+        }
+
+        boolean tableHasSortKey = keySchema.stream().anyMatch(k -> "RANGE".equals(k.getKeyType()));
+        if (lsis != null && !lsis.isEmpty() && !tableHasSortKey) {
+            throw new AwsException("ValidationException",
+                    "One or more parameter values were invalid: Table KeySchema does not have a range key, "
+                    + "which is required when specifying a LocalSecondaryIndex", 400);
+        }
+
+        // Validate no duplicate index names
+        Set<String> indexNames = new HashSet<>();
+        if (gsis != null) {
+            for (GlobalSecondaryIndex gsi : gsis) {
+                if (!indexNames.add(gsi.getIndexName())) {
+                    throw new AwsException("ValidationException",
+                            "One or more parameter values were invalid: Duplicate index name: " + gsi.getIndexName(), 400);
+                }
+            }
+        }
+        if (lsis != null) {
+            for (LocalSecondaryIndex lsi : lsis) {
+                if (!indexNames.add(lsi.getIndexName())) {
+                    throw new AwsException("ValidationException",
+                            "One or more parameter values were invalid: Duplicate index name: " + lsi.getIndexName(), 400);
+                }
+            }
+        }
+
         TableDefinition table = new TableDefinition(tableName, keySchema, attributeDefinitions,
                 region, regionResolver.getAccountId());
         if (readCapacity != null && writeCapacity != null) {
@@ -272,8 +369,33 @@ public class DynamoDbService {
         String prefix = region + "::";
         return tableStore.scan(k -> k.startsWith(prefix)).stream()
                 .map(TableDefinition::getTableName)
+                .sorted()
                 .toList();
     }
+
+    public ListTablesResult listTables(String region, Integer limit, String exclusiveStartTableName) {
+        List<String> all = listTables(region);
+
+        int startIdx = 0;
+        if (exclusiveStartTableName != null && !exclusiveStartTableName.isBlank()) {
+            int pos = Collections.binarySearch(all, exclusiveStartTableName);
+            if (pos >= 0) {
+                startIdx = pos + 1;
+            } else {
+                startIdx = -(pos + 1);
+            }
+        }
+
+        List<String> page = all.subList(startIdx, all.size());
+        String lastEvaluatedTableName = null;
+        if (limit != null && limit > 0 && page.size() > limit) {
+            lastEvaluatedTableName = page.get(limit - 1);
+            page = page.subList(0, limit);
+        }
+        return new ListTablesResult(List.copyOf(page), lastEvaluatedTableName);
+    }
+
+    public record ListTablesResult(List<String> tableNames, String lastEvaluatedTableName) {}
 
     public void putItem(String tableName, JsonNode item) {
         putItem(tableName, item, null, null, null, regionResolver.getDefaultRegion(), "NONE");
@@ -292,7 +414,10 @@ public class DynamoDbService {
         TableDefinition table = tableStore.get(storageKey)
                 .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
 
-        String itemKey = buildItemKey(table, item);
+        // Validate and normalize all number attributes before storage
+        final JsonNode normalizedItem = DynamoDbNumberUtils.normalizeNumbersInItem(item);
+        DynamoDbItemSize.validateSize(normalizedItem);
+        String itemKey = buildItemKey(table, normalizedItem);
 
         withItemLock(storageKey, itemKey, () -> {
             var tableItems = itemsByTable.computeIfAbsent(storageKey, k -> new ConcurrentSkipListMap<>());
@@ -303,7 +428,7 @@ public class DynamoDbService {
                 evaluateCondition(existing, conditionExpression, exprAttrNames, exprAttrValues, returnValuesOnConditionCheckFailure);
             }
 
-            tableItems.put(itemKey, item);
+            tableItems.put(itemKey, normalizedItem);
             persistItems(storageKey);
             LOG.debugv("Put item in {0}: key={1}", canonicalTableName, itemKey);
             LOG.tracev("Put item in {0}: key={1} item={2}", canonicalTableName, itemKey, item);
@@ -328,7 +453,7 @@ public class DynamoDbService {
         TableDefinition table = tableStore.get(storageKey)
                 .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
 
-        String itemKey = buildItemKey(table, key);
+        String itemKey = buildItemKey(table, key, true);
         var items = itemsByTable.get(storageKey);
         if (items == null) {
             LOG.tracev("Got item from {0}: key={1} item=<not found>", canonicalTableName, itemKey);
@@ -360,7 +485,7 @@ public class DynamoDbService {
         TableDefinition table = tableStore.get(storageKey)
                 .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
 
-        String itemKey = buildItemKey(table, key);
+        String itemKey = buildItemKey(table, key, true);
 
         return withItemLock(storageKey, itemKey, () -> {
             var items = itemsByTable.get(storageKey);
@@ -415,7 +540,7 @@ public class DynamoDbService {
         TableDefinition table = tableStore.get(storageKey)
                 .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
 
-        String itemKey = buildItemKey(table, key);
+        String itemKey = buildItemKey(table, key, true);
 
         return withItemLock(storageKey, itemKey, () -> {
             var items = itemsByTable.computeIfAbsent(storageKey, k -> new ConcurrentSkipListMap<>());
@@ -450,12 +575,83 @@ public class DynamoDbService {
 
                     switch (action) {
                         case "PUT" -> { if (value != null) item.set(attrName, value); }
-                        case "DELETE" -> item.remove(attrName);
+                        case "DELETE" -> {
+                            if (value == null) {
+                                item.remove(attrName);
+                            } else {
+                                // Remove elements from a set
+                                JsonNode curAttr = item.get(attrName);
+                                if (curAttr != null) {
+                                    for (String setType : new String[]{"SS", "NS", "BS"}) {
+                                        if (curAttr.has(setType) && value.has(setType)) {
+                                            Set<String> removeSet = new HashSet<>();
+                                            for (JsonNode v : value.get(setType)) removeSet.add(v.asText());
+                                            com.fasterxml.jackson.databind.node.ArrayNode newArr = objectMapper.createArrayNode();
+                                            for (JsonNode v : curAttr.get(setType)) {
+                                                if (!removeSet.contains(v.asText())) newArr.add(v);
+                                            }
+                                            if (newArr.isEmpty()) {
+                                                item.remove(attrName);
+                                            } else {
+                                                ((com.fasterxml.jackson.databind.node.ObjectNode) curAttr).set(setType, newArr);
+                                            }
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
                         case "ADD" -> {
-                            // Simple ADD for numeric values
-                            if (value != null) item.set(attrName, value);
+                            if (value != null) {
+                                JsonNode curAttr = item.get(attrName);
+                                if (value.has("N")) {
+                                    java.math.BigDecimal delta = new java.math.BigDecimal(value.get("N").asText());
+                                    java.math.BigDecimal current = curAttr != null && curAttr.has("N")
+                                            ? new java.math.BigDecimal(curAttr.get("N").asText()) : java.math.BigDecimal.ZERO;
+                                    com.fasterxml.jackson.databind.node.ObjectNode numNode = objectMapper.createObjectNode();
+                                    numNode.put("N", current.add(delta).stripTrailingZeros().toPlainString());
+                                    item.set(attrName, numNode);
+                                } else {
+                                    // Add elements to a set
+                                    for (String setType : new String[]{"SS", "NS", "BS"}) {
+                                        if (value.has(setType)) {
+                                            if (curAttr == null || !curAttr.has(setType)) {
+                                                item.set(attrName, value);
+                                            } else {
+                                                Set<String> existingSet = new LinkedHashSet<>();
+                                                for (JsonNode v : curAttr.get(setType)) existingSet.add(v.asText());
+                                                for (JsonNode v : value.get(setType)) existingSet.add(v.asText());
+                                                com.fasterxml.jackson.databind.node.ArrayNode newArr = objectMapper.createArrayNode();
+                                                for (String s : existingSet) newArr.add(s);
+                                                ((com.fasterxml.jackson.databind.node.ObjectNode) curAttr).set(setType, newArr);
+                                            }
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
+                }
+            }
+
+            // Reject any attempt to modify a key attribute
+            String pkName = table.getPartitionKeyName();
+            JsonNode origPk = key.get(pkName);
+            JsonNode newPk = item.get(pkName);
+            if (origPk != null && newPk != null && !origPk.equals(newPk)) {
+                throw new AwsException("ValidationException",
+                        "One or more parameter values were invalid: Cannot update attribute " + pkName
+                        + ". This attribute is part of the key", 400);
+            }
+            String skName = table.getSortKeyName();
+            if (skName != null) {
+                JsonNode origSk = key.get(skName);
+                JsonNode newSk = item.get(skName);
+                if (origSk != null && newSk != null && !origSk.equals(newSk)) {
+                    throw new AwsException("ValidationException",
+                            "One or more parameter values were invalid: Cannot update attribute " + skName
+                            + ". This attribute is part of the key", 400);
                 }
             }
 
@@ -566,12 +762,12 @@ public class DynamoDbService {
             String finalSkName = skName;
             results = new ArrayList<>(results);
             results.sort((a, b) -> {
-                String aVal = extractScalarValue(a.get(finalSkName));
-                String bVal = extractScalarValue(b.get(finalSkName));
-                if (aVal == null && bVal == null) return 0;
-                if (aVal == null) return -1;
-                if (bVal == null) return 1;
-                return compareValues(aVal, bVal);
+                JsonNode aAttr = a.get(finalSkName);
+                JsonNode bAttr = b.get(finalSkName);
+                if (aAttr == null && bAttr == null) return 0;
+                if (aAttr == null) return -1;
+                if (bAttr == null) return 1;
+                return ExpressionEvaluator.compareAttributeValues(aAttr, bAttr);
             });
             if (Boolean.FALSE.equals(scanIndexForward)) {
                 Collections.reverse(results);
@@ -606,10 +802,26 @@ public class DynamoDbService {
         List<JsonNode> evaluatedItems = results;
         JsonNode lastEvaluatedKey = null;
 
+        // Apply Limit (stops at N items)
         if (limit != null && limit > 0 && evaluatedItems.size() > limit) {
             JsonNode lastItem = evaluatedItems.get(limit - 1);
             lastEvaluatedKey = buildKeyNode(table, lastItem, pkName, skName, indexName != null);
             evaluatedItems = new ArrayList<>(evaluatedItems.subList(0, limit));
+        }
+
+        // Apply 1MB response size limit (DynamoDB stops reading when scanned data exceeds 1MB)
+        if (lastEvaluatedKey == null) {
+            final int MAX_RESPONSE_BYTES = 1024 * 1024;
+            int accSize = 0;
+            for (int i = 0; i < evaluatedItems.size(); i++) {
+                int sz = DynamoDbItemSize.calculateItemSize(evaluatedItems.get(i));
+                if (accSize > 0 && accSize + sz > MAX_RESPONSE_BYTES) {
+                    lastEvaluatedKey = buildKeyNode(table, evaluatedItems.get(i - 1), pkName, skName, indexName != null);
+                    evaluatedItems = new ArrayList<>(evaluatedItems.subList(0, i));
+                    break;
+                }
+                accSize += sz;
+            }
         }
 
         int scannedCount = evaluatedItems.size();
@@ -636,6 +848,7 @@ public class DynamoDbService {
     public ScanResult scan(String tableName, String filterExpression,
                             JsonNode expressionAttrNames, JsonNode expressionAttrValues,
                             JsonNode scanFilter, Integer limit, JsonNode exclusiveStartKey, String region) {
+        DynamoDbReservedWords.check(filterExpression, "FilterExpression");
         String canonicalTableName = canonicalTableName(region, tableName);
         String storageKey = regionKey(region, canonicalTableName);
         TableDefinition table = tableStore.get(storageKey)
@@ -677,9 +890,32 @@ public class DynamoDbService {
             results = results.subList(0, limit);
         }
 
+        // Apply 1MB response size limit
+        if (lastEvaluatedKey == null) {
+            final int MAX_RESPONSE_BYTES = 1024 * 1024;
+            int accSize = 0;
+            for (int i = 0; i < results.size(); i++) {
+                int sz = DynamoDbItemSize.calculateItemSize(results.get(i));
+                if (accSize > 0 && accSize + sz > MAX_RESPONSE_BYTES) {
+                    lastEvaluatedKey = buildKeyNode(table, results.get(i - 1), pkName, skName);
+                    results = new ArrayList<>(results.subList(0, i));
+                    break;
+                }
+                accSize += sz;
+            }
+        }
+
         LOG.tracev("Scan on {0}: returned={1} scanned={2}",
                 canonicalTableName, results.size(), totalScanned);
         return new ScanResult(results, totalScanned, lastEvaluatedKey);
+    }
+
+    public boolean matchesScanFilterPublic(JsonNode item, JsonNode scanFilter) {
+        return matchesScanFilter(item, scanFilter);
+    }
+
+    public boolean matchesKeyConditionPublic(JsonNode attrValue, JsonNode condition) {
+        return matchesKeyCondition(attrValue, condition);
     }
 
     private boolean matchesScanFilter(JsonNode item, JsonNode scanFilter) {
@@ -741,7 +977,18 @@ public class DynamoDbService {
 
     // --- Transact Operations ---
 
-    public void transactWriteItems(List<JsonNode> transactItems, String region) {
+    public void transactWriteItems(List<JsonNode> transactItems, String region, String clientRequestToken) {
+        if (clientRequestToken != null) {
+            String payloadHash = transactItems.toString();
+            String existing = idempotencyTokens.putIfAbsent(clientRequestToken, payloadHash);
+            if (existing != null && !existing.equals(payloadHash)) {
+                throw new AwsException("IdempotentParameterMismatchException",
+                        "Request rejected because it has the same idempotency token as a different request", 400);
+            }
+            if (existing != null) {
+                return; // idempotent replay
+            }
+        }
         // Acquire every participant's item lock in a deterministic (storageKey, itemKey)
         // order before evaluating conditions or applying writes. Total-ordered acquisition
         // prevents deadlock across concurrent transactions; ReentrantLock lets the inner
@@ -765,15 +1012,15 @@ public class DynamoDbService {
             }
 
             // First pass: evaluate all conditions and collect failures.
-            List<String> cancellationReasons = new ArrayList<>();
+            List<TransactionCanceledException.CancellationReason> cancellationReasons = new ArrayList<>();
             boolean hasFailed = false;
             for (JsonNode transactItem : transactItems) {
-                String failReason = evaluateTransactCondition(transactItem, region);
+                TransactionCanceledException.CancellationReason failReason = evaluateTransactCondition(transactItem, region);
                 if (failReason != null) {
                     hasFailed = true;
                     cancellationReasons.add(failReason);
                 } else {
-                    cancellationReasons.add("");
+                    cancellationReasons.add(new TransactionCanceledException.CancellationReason("", null));
                 }
             }
 
@@ -849,7 +1096,7 @@ public class DynamoDbService {
         return new TransactParticipant(storageKey, itemKey);
     }
 
-    private String evaluateTransactCondition(JsonNode transactItem, String region) {
+    private TransactionCanceledException.CancellationReason evaluateTransactCondition(JsonNode transactItem, String region) {
         JsonNode target;
         if (transactItem.has("Put")) {
             target = transactItem.get("Put");
@@ -888,23 +1135,45 @@ public class DynamoDbService {
         try {
             evaluateCondition(existing, conditionExpression, exprAttrNames, exprAttrValues, returnValuesOnConditionCheckFailure);
             return null;
+        } catch (ConditionalCheckFailedException e) {
+            return new TransactionCanceledException.CancellationReason("ConditionalCheckFailed", e.getItem());
         } catch (AwsException e) {
-            return e.getMessage();
+            return new TransactionCanceledException.CancellationReason(e.getMessage(), null);
         }
     }
 
     public List<JsonNode> transactGetItems(List<JsonNode> transactItems, String region) {
         List<JsonNode> results = new ArrayList<>();
+        List<TransactionCanceledException.CancellationReason> cancelReasons = new ArrayList<>();
+        boolean hasCancelled = false;
+
         for (JsonNode transactItem : transactItems) {
             if (transactItem.has("Get")) {
                 JsonNode get = transactItem.get("Get");
                 String tableName = get.path("TableName").asText();
                 JsonNode key = get.get("Key");
-                results.add(getItem(tableName, key, region));
+                try {
+                    results.add(getItem(tableName, key, region));
+                    cancelReasons.add(new TransactionCanceledException.CancellationReason("", null));
+                } catch (AwsException e) {
+                    if ("ValidationException".equals(e.getErrorCode())) {
+                        hasCancelled = true;
+                        results.add(null);
+                        cancelReasons.add(new TransactionCanceledException.CancellationReason("ValidationError", null));
+                    } else {
+                        throw e;
+                    }
+                }
             } else {
                 results.add(null);
+                cancelReasons.add(new TransactionCanceledException.CancellationReason("", null));
             }
         }
+
+        if (hasCancelled) {
+            throw new TransactionCanceledException(cancelReasons);
+        }
+
         return results;
     }
 
@@ -921,6 +1190,50 @@ public class DynamoDbService {
         String storageKey = regionKey(region, canonicalTableName);
         TableDefinition table = tableStore.get(storageKey)
                 .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
+
+        if (readCapacity != null && readCapacity <= 0) {
+            throw new AwsException("ValidationException",
+                    "The parameter 'ProvisionedThroughput.ReadCapacityUnits' must be greater than 0", 400);
+        }
+        if (writeCapacity != null && writeCapacity <= 0) {
+            throw new AwsException("ValidationException",
+                    "The parameter 'ProvisionedThroughput.WriteCapacityUnits' must be greater than 0", 400);
+        }
+        if (readCapacity != null && writeCapacity != null
+                && "PROVISIONED".equals(table.getBillingMode())
+                && readCapacity.equals(table.getProvisionedThroughput().getReadCapacityUnits())
+                && writeCapacity.equals(table.getProvisionedThroughput().getWriteCapacityUnits())) {
+            throw new AwsException("ValidationException",
+                    "The provisioned throughput for the table will not change. "
+                    + "The requested value equals the current value.", 400);
+        }
+
+        for (GlobalSecondaryIndex newGsi : gsiCreates) {
+            if (table.findGsi(newGsi.getIndexName()).isPresent()) {
+                throw new AwsException("ValidationException",
+                        "GSI " + newGsi.getIndexName() + " already exists", 400);
+            }
+        }
+
+        Set<String> knownAttrs = table.getAttributeDefinitions().stream()
+                .map(AttributeDefinition::getAttributeName)
+                .collect(java.util.stream.Collectors.toSet());
+        if (newAttrDefs != null) newAttrDefs.forEach(ad -> knownAttrs.add(ad.getAttributeName()));
+        for (GlobalSecondaryIndex newGsi : gsiCreates) {
+            for (KeySchemaElement k : newGsi.getKeySchema()) {
+                if (!knownAttrs.contains(k.getAttributeName())) {
+                    throw new AwsException("ValidationException",
+                            "Attribute: " + k.getAttributeName() + " is not defined in AttributeDefinitions", 400);
+                }
+            }
+        }
+
+        for (String gsiName : gsiDeletes) {
+            if (table.findGsi(gsiName).isEmpty()) {
+                throw new AwsException("ResourceNotFoundException",
+                        "Global secondary index " + gsiName + " does not exist on the table", 400);
+            }
+        }
 
         if (readCapacity != null) {
             table.getProvisionedThroughput().setReadCapacityUnits(readCapacity);
@@ -1085,6 +1398,7 @@ public class DynamoDbService {
 
     private void evaluateCondition(JsonNode existingItem, String conditionExpression,
                                     JsonNode exprAttrNames, JsonNode exprAttrValues, String returnValuesOnConditionCheckFailure) {
+        DynamoDbReservedWords.check(conditionExpression, "ConditionExpression");
         if (!matchesFilterExpression(existingItem, conditionExpression, exprAttrNames, exprAttrValues)) {
             if ("ALL_OLD".equals(returnValuesOnConditionCheckFailure)){                
                 throw new ConditionalCheckFailedException(existingItem);
@@ -1101,6 +1415,11 @@ public class DynamoDbService {
                                         JsonNode exprAttrNames, JsonNode exprAttrValues) {
         // Parse SET and REMOVE clauses from expressions like:
         // "SET #n = :newName, age = :newAge REMOVE oldField"
+        if (expression.isBlank()) {
+            throw new AwsException("ValidationException",
+                    "Invalid UpdateExpression: The expression can not be empty;", 400);
+        }
+        DynamoDbReservedWords.check(expression, "UpdateExpression");
         String remaining = expression.trim();
 
         while (!remaining.isEmpty()) {
@@ -1118,7 +1437,14 @@ public class DynamoDbService {
                 remaining = remaining.substring(7).trim();
                 remaining = applyDeleteClause(item, remaining, exprAttrNames, exprAttrValues);
             } else {
-                break;
+                // Unknown keyword — syntax error
+                String[] parts = remaining.split("\\s+", 3);
+                String token = parts[0];
+                String near = parts.length >= 2
+                        ? (token + " " + parts[1]).substring(0, Math.min(token.length() + 1 + parts[1].length(), 20))
+                        : token;
+                throw new AwsException("ValidationException",
+                        "Invalid UpdateExpression: Syntax error; token: \"" + token + "\", near: \"" + near + "\"", 400);
             }
         }
     }
@@ -1533,132 +1859,215 @@ public class DynamoDbService {
         return nameOrPlaceholder;
     }
 
-    /**
-     * Sets a value at a potentially nested attribute path.
-     * Supports paths like "attr", "parent.child", "#alias.nested" etc.
-     * For nested paths, navigates into the DynamoDB Map structure (M field).
-     */
-    private void setValueAtPath(ObjectNode item, String path, JsonNode value, JsonNode exprAttrNames) {
-        // Resolve any # placeholders in the path segments
-        String[] segments = path.split("\\.");
-        for (int i = 0; i < segments.length; i++) {
-            segments[i] = resolveAttributeName(segments[i].trim(), exprAttrNames);
-        }
-
-        if (segments.length == 1) {
-            // Simple top-level attribute
-            item.set(segments[0], value);
-            return;
-        }
-
-        // Navigate to the parent of the target attribute
-        ObjectNode current = item;
-        for (int i = 0; i < segments.length - 1; i++) {
-            String segment = segments[i];
-            JsonNode child = current.get(segment);
-
-            if (child == null || !child.has("M")) {
-                // Create nested map structure if it doesn't exist
-                ObjectNode newMap = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                ObjectNode wrapper = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                wrapper.set("M", newMap);
-                current.set(segment, wrapper);
-                current = newMap;
+    // Tokenizes a DynamoDB path like "a.b[0].c" or "#l[5]" into a list of
+    // String (attr name) and Integer (list index) tokens.
+    private List<Object> parsePath(String path, JsonNode exprAttrNames) {
+        List<Object> tokens = new ArrayList<>();
+        for (String dotSeg : path.split("\\.")) {
+            dotSeg = dotSeg.trim();
+            if (dotSeg.isEmpty()) continue;
+            int brk = dotSeg.indexOf('[');
+            if (brk < 0) {
+                tokens.add(resolveAttributeName(dotSeg, exprAttrNames));
             } else {
-                // Navigate into existing map
-                JsonNode mapContent = child.get("M");
-                if (mapContent instanceof ObjectNode) {
-                    current = (ObjectNode) mapContent;
-                } else {
-                    // Cannot navigate further, structure mismatch
-                    return;
+                String namePart = dotSeg.substring(0, brk);
+                if (!namePart.isEmpty()) tokens.add(resolveAttributeName(namePart, exprAttrNames));
+                String rest = dotSeg.substring(brk);
+                int p = 0;
+                while (p < rest.length() && rest.charAt(p) == '[') {
+                    int close = rest.indexOf(']', p);
+                    if (close < 0) break;
+                    tokens.add(Integer.parseInt(rest.substring(p + 1, close)));
+                    p = close + 1;
                 }
             }
         }
-
-        // Set the final attribute
-        current.set(segments[segments.length - 1], value);
+        return tokens;
     }
 
-    /**
-     * Gets a value at a potentially nested attribute path.
-     * Returns null if the path doesn't exist.
-     */
-    private JsonNode getValueAtPath(JsonNode item, String path, JsonNode exprAttrNames) {
-        // Resolve any # placeholders in the path segments
-        String[] segments = path.split("\\.");
-        for (int i = 0; i < segments.length; i++) {
-            segments[i] = resolveAttributeName(segments[i].trim(), exprAttrNames);
+    // Pads arr with NULL elements up to idx-1, then sets/appends value at idx.
+    private void padAndSet(com.fasterxml.jackson.databind.node.ArrayNode arr, int idx, JsonNode value) {
+        com.fasterxml.jackson.databind.node.ObjectNode nullNode =
+                com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+        nullNode.put("NULL", true);
+        while (arr.size() < idx) arr.add(nullNode.deepCopy());
+        if (idx < arr.size()) arr.set(idx, value);
+        else arr.add(value);
+    }
+
+    private void setValueAtPath(ObjectNode item, String path, JsonNode value, JsonNode exprAttrNames) {
+        List<Object> tokens = parsePath(path, exprAttrNames);
+        if (tokens.isEmpty()) return;
+
+        if (tokens.size() == 1) {
+            if (tokens.get(0) instanceof String attrName) item.set(attrName, value);
+            return;
         }
 
-        JsonNode current = item;
-        for (int i = 0; i < segments.length; i++) {
-            if (current == null) return null;
+        JsonNode container = item;
+        for (int i = 0; i < tokens.size() - 1; i++) {
+            Object tok = tokens.get(i);
+            Object nextTok = tokens.get(i + 1);
+            boolean last = (i == tokens.size() - 2);
 
-            String segment = segments[i];
-            JsonNode child = current.get(segment);
-
-            if (child == null) return null;
-
-            if (i < segments.length - 1) {
-                // Need to navigate deeper - check for Map structure
-                if (child.has("M")) {
-                    current = child.get("M");
-                } else {
-                    return null;
+            if (tok instanceof String attrName) {
+                if (!(container instanceof ObjectNode obj)) return;
+                JsonNode child = obj.get(attrName);
+                if (last) {
+                    if (nextTok instanceof String finalAttr) {
+                        if (child == null || !child.has("M")) throw new AwsException("ValidationException",
+                                "The document path provided in the update expression is invalid for update", 400);
+                        ((ObjectNode) child.get("M")).set(finalAttr, value);
+                    } else if (nextTok instanceof Integer finalIdx) {
+                        if (child == null || !child.has("L")) throw new AwsException("ValidationException",
+                                "The document path provided in the update expression is invalid for update", 400);
+                        padAndSet((com.fasterxml.jackson.databind.node.ArrayNode) child.get("L"), finalIdx, value);
+                    }
+                    return;
                 }
-            } else {
-                // This is the final segment
-                return child;
+                if (nextTok instanceof String) {
+                    if (child == null || !child.has("M")) throw new AwsException("ValidationException",
+                            "The document path provided in the update expression is invalid for update", 400);
+                    container = child.get("M");
+                } else if (nextTok instanceof Integer) {
+                    if (child == null || !child.has("L")) throw new AwsException("ValidationException",
+                            "The document path provided in the update expression is invalid for update", 400);
+                    container = child.get("L");
+                }
+            } else if (tok instanceof Integer listIdx) {
+                if (!(container instanceof com.fasterxml.jackson.databind.node.ArrayNode arr)) return;
+                if (listIdx >= arr.size()) throw new AwsException("ValidationException",
+                        "The document path provided in the update expression is invalid for update", 400);
+                JsonNode element = arr.get(listIdx);
+                if (last) {
+                    if (nextTok instanceof String finalAttr) {
+                        if (!element.has("M")) throw new AwsException("ValidationException",
+                                "The document path provided in the update expression is invalid for update", 400);
+                        ((ObjectNode) element.get("M")).set(finalAttr, value);
+                    } else if (nextTok instanceof Integer finalIdx) {
+                        if (!element.has("L")) throw new AwsException("ValidationException",
+                                "The document path provided in the update expression is invalid for update", 400);
+                        padAndSet((com.fasterxml.jackson.databind.node.ArrayNode) element.get("L"), finalIdx, value);
+                    }
+                    return;
+                }
+                if (nextTok instanceof String) {
+                    if (!element.has("M")) throw new AwsException("ValidationException",
+                            "The document path provided in the update expression is invalid for update", 400);
+                    container = element.get("M");
+                } else if (nextTok instanceof Integer) {
+                    if (!element.has("L")) throw new AwsException("ValidationException",
+                            "The document path provided in the update expression is invalid for update", 400);
+                    container = element.get("L");
+                }
+            }
+        }
+    }
+
+    private JsonNode getValueAtPath(JsonNode item, String path, JsonNode exprAttrNames) {
+        List<Object> tokens = parsePath(path, exprAttrNames);
+        if (tokens.isEmpty()) return null;
+        JsonNode current = item;
+        for (int i = 0; i < tokens.size(); i++) {
+            if (current == null) return null;
+            Object tok = tokens.get(i);
+            boolean isLast = (i == tokens.size() - 1);
+            if (tok instanceof String attrName) {
+                JsonNode child = current.get(attrName);
+                if (child == null) return null;
+                if (isLast) return child;
+                Object nextTok = tokens.get(i + 1);
+                if (nextTok instanceof String) {
+                    if (!child.has("M")) return null;
+                    current = child.get("M");
+                } else if (nextTok instanceof Integer) {
+                    if (!child.has("L")) return null;
+                    current = child.get("L");
+                } else return null;
+            } else if (tok instanceof Integer listIdx) {
+                if (!current.isArray() || listIdx >= current.size()) return null;
+                JsonNode element = current.get(listIdx);
+                if (element == null) return null;
+                if (isLast) return element;
+                Object nextTok = tokens.get(i + 1);
+                if (nextTok instanceof String) {
+                    if (!element.has("M")) return null;
+                    current = element.get("M");
+                } else if (nextTok instanceof Integer) {
+                    if (!element.has("L")) return null;
+                    current = element.get("L");
+                } else return null;
             }
         }
         return current;
     }
 
-    /**
-     * Checks if a value exists at a potentially nested attribute path.
-     */
     private boolean hasValueAtPath(JsonNode item, String path, JsonNode exprAttrNames) {
         return getValueAtPath(item, path, exprAttrNames) != null;
     }
 
-    /**
-     * Removes a value at a potentially nested attribute path.
-     * Supports paths like "attr", "parent.child", "#alias.nested" etc.
-     * For nested paths, navigates into the DynamoDB Map structure (M field)
-     * and removes the final key from its parent.
-     */
     private void removeValueAtPath(ObjectNode item, String path, JsonNode exprAttrNames) {
-        String[] segments = path.split("\\.");
-        for (int i = 0; i < segments.length; i++) {
-            segments[i] = resolveAttributeName(segments[i].trim(), exprAttrNames);
-        }
+        List<Object> tokens = parsePath(path, exprAttrNames);
+        if (tokens.isEmpty()) return;
 
-        if (segments.length == 1) {
-            item.remove(segments[0]);
+        if (tokens.size() == 1) {
+            if (tokens.get(0) instanceof String attrName) item.remove(attrName);
             return;
         }
 
-        // Navigate to the parent of the target attribute
-        ObjectNode current = item;
-        for (int i = 0; i < segments.length - 1; i++) {
-            String segment = segments[i];
-            JsonNode child = current.get(segment);
+        JsonNode container = item;
+        for (int i = 0; i < tokens.size() - 1; i++) {
+            Object tok = tokens.get(i);
+            Object nextTok = tokens.get(i + 1);
+            boolean last = (i == tokens.size() - 2);
 
-            if (child == null || !child.has("M")) {
-                // Path doesn't exist, nothing to remove
-                return;
-            }
-
-            JsonNode mapContent = child.get("M");
-            if (mapContent instanceof ObjectNode) {
-                current = (ObjectNode) mapContent;
-            } else {
-                return;
+            if (tok instanceof String attrName) {
+                if (!(container instanceof ObjectNode obj)) return;
+                JsonNode child = obj.get(attrName);
+                if (last) {
+                    if (nextTok instanceof String finalAttr) {
+                        if (child == null || !child.has("M")) return;
+                        ((ObjectNode) child.get("M")).remove(finalAttr);
+                    } else if (nextTok instanceof Integer finalIdx) {
+                        if (child == null || !child.has("L")) return;
+                        com.fasterxml.jackson.databind.node.ArrayNode lArr =
+                                (com.fasterxml.jackson.databind.node.ArrayNode) child.get("L");
+                        if (finalIdx < lArr.size()) lArr.remove(finalIdx);
+                    }
+                    return;
+                }
+                if (nextTok instanceof String) {
+                    if (child == null || !child.has("M")) return;
+                    container = child.get("M");
+                } else if (nextTok instanceof Integer) {
+                    if (child == null || !child.has("L")) return;
+                    container = child.get("L");
+                }
+            } else if (tok instanceof Integer listIdx) {
+                if (!(container instanceof com.fasterxml.jackson.databind.node.ArrayNode arr)) return;
+                if (listIdx >= arr.size()) return;
+                JsonNode element = arr.get(listIdx);
+                if (last) {
+                    if (nextTok instanceof String finalAttr) {
+                        if (!element.has("M")) return;
+                        ((ObjectNode) element.get("M")).remove(finalAttr);
+                    } else if (nextTok instanceof Integer finalIdx) {
+                        if (!element.has("L")) return;
+                        com.fasterxml.jackson.databind.node.ArrayNode lArr =
+                                (com.fasterxml.jackson.databind.node.ArrayNode) element.get("L");
+                        if (finalIdx < lArr.size()) lArr.remove(finalIdx);
+                    }
+                    return;
+                }
+                if (nextTok instanceof String) {
+                    if (!element.has("M")) return;
+                    container = element.get("M");
+                } else if (nextTok instanceof Integer) {
+                    if (!element.has("L")) return;
+                    container = element.get("L");
+                }
             }
         }
-
-        current.remove(segments[segments.length - 1]);
     }
 
     private int findNextComma(String s) {
@@ -1808,24 +2217,46 @@ public class DynamoDbService {
     }
 
     String buildItemKey(TableDefinition table, JsonNode item) {
+        return buildItemKey(table, item, false);
+    }
+
+    String buildItemKey(TableDefinition table, JsonNode item, boolean isKeyArg) {
         String pkName = table.getPartitionKeyName();
         JsonNode pkAttr = item.get(pkName);
         if (pkAttr == null) {
+            if (isKeyArg) {
+                throw new AwsException("ValidationException",
+                        "The provided key element does not match the schema", 400);
+            }
             throw new AwsException("ValidationException",
                     "One of the required keys was not given a value", 400);
         }
+        validateKeyAttributeValue(pkAttr, pkName);
 
         String pk = extractScalarValue(pkAttr);
         String skName = table.getSortKeyName();
         if (skName != null) {
             JsonNode skAttr = item.get(skName);
             if (skAttr == null) {
+                if (isKeyArg) {
+                    throw new AwsException("ValidationException",
+                            "The provided key element does not match the schema", 400);
+                }
                 throw new AwsException("ValidationException",
                         "One of the required keys was not given a value", 400);
             }
+            validateKeyAttributeValue(skAttr, skName);
             return pk + "#" + extractScalarValue(skAttr);
         }
         return pk;
+    }
+
+    private void validateKeyAttributeValue(JsonNode attr, String keyName) {
+        if (attr != null && attr.has("S") && attr.get("S").asText().isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "One or more parameter values were invalid: "
+                    + "The AttributeValue for a key attribute cannot contain an empty string value. Key: " + keyName, 400);
+        }
     }
 
     private String buildItemKeyFromNode(JsonNode item, String pkName, String skName) {
@@ -1875,7 +2306,11 @@ public class DynamoDbService {
     private String extractScalarValue(JsonNode attrValue) {
         if (attrValue == null) return null;
         if (attrValue.has("S")) return attrValue.get("S").asText();
-        if (attrValue.has("N")) return attrValue.get("N").asText();
+        if (attrValue.has("N")) {
+            String raw = attrValue.get("N").asText();
+            try { return DynamoDbNumberUtils.validateAndNormalize(raw); }
+            catch (Exception e) { return raw; }
+        }
         if (attrValue.has("B")) return attrValue.get("B").asText();
         if (attrValue.has("BOOL")) return attrValue.get("BOOL").asText();
         return attrValue.asText();
@@ -1896,29 +2331,73 @@ public class DynamoDbService {
         return null;
     }
 
-    // NE, CONTAINS, NOT_CONTAINS, IN, NULL, NOT_NULL not yet supported
     private boolean matchesKeyCondition(JsonNode attrValue, JsonNode condition) {
         if (condition == null) return true;
         String op = condition.has("ComparisonOperator") ? condition.get("ComparisonOperator").asText() : "EQ";
-        String compareValue = extractComparisonValue(condition);
+        JsonNode avl = condition.get("AttributeValueList");
+        JsonNode compareAttr = avl != null && avl.isArray() && !avl.isEmpty() ? avl.get(0) : null;
+        String compareValue = extractScalarValue(compareAttr);
         String actual = extractScalarValue(attrValue);
-        if (actual == null) return false;
 
         return switch (op) {
-            case "EQ" -> actual.equals(compareValue);
-            case "BEGINS_WITH" -> actual.startsWith(compareValue);
-            case "GT" -> actual.compareTo(compareValue) > 0;
-            case "GE" -> actual.compareTo(compareValue) >= 0;
-            case "LT" -> actual.compareTo(compareValue) < 0;
-            case "LE" -> actual.compareTo(compareValue) <= 0;
-            case "BETWEEN" -> {
-                JsonNode list = condition.get("AttributeValueList");
-                if (list.size() >= 2) {
-                    String low = extractScalarValue(list.get(0));
-                    String high = extractScalarValue(list.get(1));
-                    yield actual.compareTo(low) >= 0 && actual.compareTo(high) <= 0;
+            case "EQ" -> {
+                if (attrValue == null) yield false;
+                yield ExpressionEvaluator.compareAttributeValues(attrValue, compareAttr != null ? compareAttr : attrValue) == 0
+                        && actual != null && actual.equals(compareValue);
+            }
+            case "NE" -> {
+                if (attrValue == null) yield true;
+                if (actual == null || compareValue == null) yield true;
+                yield !actual.equals(compareValue);
+            }
+            case "NULL" -> attrValue == null;
+            case "NOT_NULL" -> attrValue != null;
+            case "BEGINS_WITH" -> actual != null && compareValue != null && actual.startsWith(compareValue);
+            case "CONTAINS" -> {
+                if (attrValue == null || compareAttr == null) yield false;
+                if (attrValue.has("S") && compareAttr.has("S")) {
+                    yield attrValue.get("S").asText().contains(compareAttr.get("S").asText());
+                }
+                if (attrValue.has("SS") && compareAttr.has("S")) {
+                    String target = compareAttr.get("S").asText();
+                    for (JsonNode elem : attrValue.get("SS")) { if (target.equals(elem.asText())) yield true; }
+                    yield false;
+                }
+                if (attrValue.has("NS") && compareAttr.has("N")) {
+                    String target = compareAttr.get("N").asText();
+                    for (JsonNode elem : attrValue.get("NS")) { if (target.equals(elem.asText())) yield true; }
+                    yield false;
                 }
                 yield false;
+            }
+            case "NOT_CONTAINS" -> {
+                if (attrValue == null || compareAttr == null) yield true;
+                if (attrValue.has("S") && compareAttr.has("S"))
+                    yield !attrValue.get("S").asText().contains(compareAttr.get("S").asText());
+                if (attrValue.has("SS") && compareAttr.has("S")) {
+                    String target = compareAttr.get("S").asText();
+                    for (JsonNode elem : attrValue.get("SS")) { if (target.equals(elem.asText())) yield false; }
+                    yield true;
+                }
+                yield true;
+            }
+            case "IN" -> {
+                if (actual == null || avl == null) yield false;
+                for (JsonNode v : avl) { if (actual.equals(extractScalarValue(v))) yield true; }
+                yield false;
+            }
+            case "GT" -> actual != null && compareValue != null
+                    && ExpressionEvaluator.compareAttributeValues(attrValue, compareAttr) > 0;
+            case "GE" -> actual != null && compareValue != null
+                    && ExpressionEvaluator.compareAttributeValues(attrValue, compareAttr) >= 0;
+            case "LT" -> actual != null && compareValue != null
+                    && ExpressionEvaluator.compareAttributeValues(attrValue, compareAttr) < 0;
+            case "LE" -> actual != null && compareValue != null
+                    && ExpressionEvaluator.compareAttributeValues(attrValue, compareAttr) <= 0;
+            case "BETWEEN" -> {
+                if (actual == null || avl == null || avl.size() < 2) yield false;
+                yield ExpressionEvaluator.compareAttributeValues(attrValue, avl.get(0)) >= 0
+                        && ExpressionEvaluator.compareAttributeValues(attrValue, avl.get(1)) <= 0;
             }
             default -> true;
         };
@@ -1944,6 +2423,12 @@ public class DynamoDbService {
         }
         String pkAttrInExpr = pkExprStripped.split("\\s*=\\s*")[0].trim();
         String resolvedPkName = resolveAttributeName(pkAttrInExpr, exprAttrNames);
+
+        // Validate the PK attribute in the expression matches the actual table/index PK
+        if (!resolvedPkName.equals(pkName)) {
+            throw new AwsException("ValidationException",
+                    "Query condition missed key schema element: " + pkName, 400);
+        }
 
         // Extract pk value placeholder
         int colonIdx = pkExprStripped.indexOf(':');
@@ -1978,8 +2463,7 @@ public class DynamoDbService {
     }
 
     private AwsException resourceNotFoundException(String tableName) {
-        return new AwsException("ResourceNotFoundException",
-                "Requested resource not found: Table: " + tableName + " not found", 400);
+        return new AwsException("ResourceNotFoundException", "Requested resource not found", 400);
     }
 
     public record UpdateResult(JsonNode newItem, JsonNode oldItem) {}
@@ -2013,8 +2497,7 @@ public class DynamoDbService {
         String storageKey = regionKey(tableRegion, tableName);
 
         TableDefinition table = tableStore.get(storageKey)
-                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "Requested resource not found: Table: " + tableName + " not found", 400));
+                .orElseThrow(() -> resourceNotFoundException(tableName));
 
         long now = Instant.now().getEpochSecond();
         String exportId = System.currentTimeMillis() + "-" + UUID.randomUUID().toString().replace("-", "");

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbTableNames.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbTableNames.java
@@ -11,7 +11,7 @@ import java.util.regex.Pattern;
  */
 public final class DynamoDbTableNames {
 
-    private static final Pattern TABLE_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9_.-]{3,255}");
+    private static final Pattern TABLE_NAME_CHARS = Pattern.compile("[a-zA-Z0-9_.\\-]+");
     private static final Pattern ACCOUNT_PATTERN = Pattern.compile("\\d{12}");
 
     private DynamoDbTableNames() {}
@@ -23,18 +23,23 @@ public final class DynamoDbTableNames {
     }
 
     /**
-     * Validates a short table name. Rejects ARN-form input: callers (e.g. CreateTable)
-     * must persist a canonical short name, not an ARN that would produce ARN-on-ARN
-     * values when derived into {@code TableArn}.
+     * Validates a short table name for use with CreateTable.
+     * CreateTable requires min length 3 and missing TableName is a distinct error.
      */
     public static String requireShortName(String input) {
-        if (input == null || input.isBlank()) {
-            throw invalid("TableName must not be blank");
+        if (input == null) {
+            throw new AwsException("ValidationException",
+                    "The parameter 'TableName' is required but was not present in the request", 400);
+        }
+        if (input.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '" + input
+                    + "' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 3", 400);
         }
         if (input.startsWith("arn:")) {
             throw invalid("TableName must be a short name, not an ARN: " + input);
         }
-        validateTableName(input);
+        validateTableNameForCreate(input);
         return input;
     }
 
@@ -47,13 +52,18 @@ public final class DynamoDbTableNames {
     }
 
     private static ResolvedTableRef resolveInternal(String input) {
-        if (input == null || input.isBlank()) {
-            throw invalid("TableName must not be blank");
+        if (input == null) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value null at 'tableName' failed to satisfy constraint: Member must not be null", 400);
+        }
+        if (input.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 1", 400);
         }
         if (input.startsWith("arn:")) {
             return parseArn(input);
         }
-        validateTableName(input);
+        validateTableNameForOps(input);
         return new ResolvedTableRef(input, null);
     }
 
@@ -94,17 +104,49 @@ public final class DynamoDbTableNames {
             throw invalid("Invalid table ARN: " + input);
         }
 
-        validateTableName(tableName);
+        validateTableNameForOps(tableName);
         return new ResolvedTableRef(tableName, region);
     }
 
-    private static void validateTableName(String tableName) {
-        if (!TABLE_NAME_PATTERN.matcher(tableName).matches()) {
-            throw invalid("Invalid TableName: " + tableName);
+    // Validation for CreateTable: min length 3, max 255, pattern
+    private static void validateTableNameForCreate(String tableName) {
+        if (tableName.length() < 3) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '" + tableName
+                    + "' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 3", 400);
+        }
+        if (tableName.length() > 255) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '" + tableName
+                    + "' at 'tableName' failed to satisfy constraint: Member must have length less than or equal to 255", 400);
+        }
+        if (!TABLE_NAME_CHARS.matcher(tableName).matches()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '" + tableName
+                    + "' at 'tableName' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_.-]+", 400);
+        }
+    }
+
+    // Validation for other operations (PutItem, GetItem, etc.): min length 3, max 255, pattern
+    private static void validateTableNameForOps(String tableName) {
+        if (tableName.length() < 3) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '" + tableName
+                    + "' at 'tableName' failed to satisfy constraint: Member must have length greater than or equal to 3", 400);
+        }
+        if (tableName.length() > 255) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '" + tableName
+                    + "' at 'tableName' failed to satisfy constraint: Member must have length less than or equal to 255", 400);
+        }
+        if (!TABLE_NAME_CHARS.matcher(tableName).matches()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '" + tableName
+                    + "' at 'tableName' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_.-]+", 400);
         }
     }
 
     private static AwsException invalid(String message) {
-        return new AwsException("InvalidParameterValue", message, 400);
+        return new AwsException("ValidationException", message, 400);
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
@@ -1,9 +1,12 @@
 package io.github.hectorvent.floci.services.dynamodb;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
 /**
@@ -33,6 +36,7 @@ final class ExpressionEvaluator {
         GE,    // >=
         // Punctuation
         LPAREN, RPAREN, COMMA, DOT,
+        LIST_INDEX,      // [n] — list element access
         // Functions
         FUNCTION,        // attribute_exists, attribute_not_exists, begins_with, contains, size
         // End
@@ -62,6 +66,21 @@ final class ExpressionEvaluator {
             if (c == ')') { tokens.add(new Token(TokenType.RPAREN, ")", i)); i++; continue; }
             if (c == ',') { tokens.add(new Token(TokenType.COMMA, ",", i)); i++; continue; }
             if (c == '.') { tokens.add(new Token(TokenType.DOT, ".", i)); i++; continue; }
+
+            // List index [n]
+            if (c == '[') {
+                int start = i;
+                i++; // skip '['
+                while (i < len && Character.isDigit(expression.charAt(i))) i++;
+                if (i < len && expression.charAt(i) == ']') {
+                    i++; // skip ']'
+                    tokens.add(new Token(TokenType.LIST_INDEX, expression.substring(start, i), start));
+                } else {
+                    throw new IllegalArgumentException(
+                            "Expected ']' after list index at position " + i + " in: " + expression);
+                }
+                continue;
+            }
 
             // Comparators (must check <> and <= before <, >= before >)
             if (c == '<') {
@@ -120,7 +139,8 @@ final class ExpressionEvaluator {
                     case "not" -> tokens.add(new Token(TokenType.NOT, word, start));
                     case "in" -> tokens.add(new Token(TokenType.IN, word, start));
                     case "between" -> tokens.add(new Token(TokenType.BETWEEN, word, start));
-                    case "attribute_exists", "attribute_not_exists", "begins_with", "contains", "size" ->
+                    case "attribute_exists", "attribute_not_exists", "begins_with", "contains", "size",
+                         "attribute_type" ->
                         tokens.add(new Token(TokenType.FUNCTION, word, start));
                     default -> tokens.add(new Token(TokenType.IDENTIFIER, word, start));
                 }
@@ -291,15 +311,23 @@ final class ExpressionEvaluator {
                 return new PlaceholderOperand(advance().value());
             }
 
-            // Path: identifier or #name, possibly dotted
+            // Path: identifier or #name, possibly dotted with nested [n] list indices
             if (current.type() == TokenType.IDENTIFIER || current.type() == TokenType.NAME_REF) {
                 var segments = new ArrayList<String>();
                 segments.add(advance().value());
+                // Consume any immediately-following list indices (no dot needed before [n])
+                while (peek().type() == TokenType.LIST_INDEX) {
+                    segments.add(advance().value());
+                }
+                // Consume .name and .name[n] sequences
                 while (peek().type() == TokenType.DOT) {
                     advance(); // consume dot
                     Token seg = peek();
                     if (seg.type() == TokenType.IDENTIFIER || seg.type() == TokenType.NAME_REF) {
                         segments.add(advance().value());
+                        while (peek().type() == TokenType.LIST_INDEX) {
+                            segments.add(advance().value());
+                        }
                     } else {
                         throw new IllegalArgumentException(
                                 "Expected identifier after '.' at position %d".formatted(seg.pos()));
@@ -354,6 +382,24 @@ final class ExpressionEvaluator {
      */
     static String[] splitKeyCondition(String expression) {
         if (expression == null || expression.isBlank()) return new String[]{expression, null};
+
+        // Strip a single layer of outer parens when they wrap the entire expression,
+        // e.g. "(pk = :pk AND sk = :sk)" → "pk = :pk AND sk = :sk"
+        String stripped = expression.strip();
+        if (stripped.startsWith("(") && stripped.endsWith(")")) {
+            int depth = 0;
+            boolean wrapsAll = true;
+            for (int i = 0; i < stripped.length() - 1; i++) {
+                if (stripped.charAt(i) == '(') depth++;
+                else if (stripped.charAt(i) == ')') {
+                    depth--;
+                    if (depth == 0) { wrapsAll = false; break; }
+                }
+            }
+            if (wrapsAll) {
+                expression = stripped.substring(1, stripped.length() - 1).strip();
+            }
+        }
 
         var tokens = tokenize(expression.trim());
         // Find the top-level AND that separates PK from SK.
@@ -446,32 +492,37 @@ final class ExpressionEvaluator {
 
     private static boolean evaluateComparison(CompareExpr cmp, JsonNode item,
                                                JsonNode exprAttrNames, JsonNode exprAttrValues) {
-        String leftVal = resolveScalar(cmp.left(), item, exprAttrNames, exprAttrValues);
-        String rightVal = resolveScalar(cmp.right(), item, exprAttrNames, exprAttrValues);
+        // For EQ/NE, resolve full attribute values to support set comparison
+        if (cmp.op() == TokenType.EQ || cmp.op() == TokenType.NE) {
+            JsonNode leftNode = resolveAttributeValue(cmp.left(), item, exprAttrNames, exprAttrValues);
+            JsonNode rightNode = resolveAttributeValue(cmp.right(), item, exprAttrNames, exprAttrValues);
+            if (leftNode == null && cmp.op() == TokenType.NE) return true;
+            if (rightNode == null && cmp.op() == TokenType.NE) return true;
+            if (leftNode == null || rightNode == null) return false;
+            boolean equal = attributeValuesEqual(leftNode, rightNode);
+            return cmp.op() == TokenType.EQ ? equal : !equal;
+        }
 
-        // DynamoDB: comparing a missing attribute with <> returns true
-        if (leftVal == null && cmp.op() == TokenType.NE) return true;
-        if (rightVal == null && cmp.op() == TokenType.NE) return true;
-        if (leftVal == null || rightVal == null) return false;
-
+        JsonNode leftNode = resolveAttributeValue(cmp.left(), item, exprAttrNames, exprAttrValues);
+        JsonNode rightNode = resolveAttributeValue(cmp.right(), item, exprAttrNames, exprAttrValues);
+        if (leftNode == null || rightNode == null) return false;
+        int cmpResult = compareAttributeValues(leftNode, rightNode);
         return switch (cmp.op()) {
-            case EQ -> leftVal.equals(rightVal);
-            case NE -> !leftVal.equals(rightVal);
-            case LT -> compareValues(leftVal, rightVal) < 0;
-            case LE -> compareValues(leftVal, rightVal) <= 0;
-            case GT -> compareValues(leftVal, rightVal) > 0;
-            case GE -> compareValues(leftVal, rightVal) >= 0;
+            case LT -> cmpResult < 0;
+            case LE -> cmpResult <= 0;
+            case GT -> cmpResult > 0;
+            case GE -> cmpResult >= 0;
             default -> false;
         };
     }
 
     private static boolean evaluateBetween(BetweenExpr bet, JsonNode item,
                                             JsonNode exprAttrNames, JsonNode exprAttrValues) {
-        String val = resolveScalar(bet.value(), item, exprAttrNames, exprAttrValues);
-        String low = resolveScalar(bet.low(), item, exprAttrNames, exprAttrValues);
-        String high = resolveScalar(bet.high(), item, exprAttrNames, exprAttrValues);
+        JsonNode val = resolveAttributeValue(bet.value(), item, exprAttrNames, exprAttrValues);
+        JsonNode low = resolveAttributeValue(bet.low(), item, exprAttrNames, exprAttrValues);
+        JsonNode high = resolveAttributeValue(bet.high(), item, exprAttrNames, exprAttrValues);
         if (val == null || low == null || high == null) return false;
-        return compareValues(val, low) >= 0 && compareValues(val, high) <= 0;
+        return compareAttributeValues(val, low) >= 0 && compareAttributeValues(val, high) <= 0;
     }
 
     private static boolean evaluateIn(InExpr in, JsonNode item,
@@ -507,14 +558,34 @@ final class ExpressionEvaluator {
                 if (func.args().size() < 2) yield false;
                 String path = resolveAttributePath(func.args().get(0), exprAttrNames);
                 JsonNode attrNode = item != null ? resolveNestedAttribute(item, path) : null;
+                JsonNode prefixNode = resolveAttributeValue(func.args().get(1), item, exprAttrNames, exprAttrValues);
+                if (attrNode == null || prefixNode == null) yield false;
+                if (attrNode.has("B") && prefixNode.has("B")) {
+                    byte[] attrBytes = java.util.Base64.getDecoder().decode(attrNode.get("B").asText());
+                    byte[] prefixBytes = java.util.Base64.getDecoder().decode(prefixNode.get("B").asText());
+                    if (prefixBytes.length > attrBytes.length) yield false;
+                    for (int bi = 0; bi < prefixBytes.length; bi++) {
+                        if (attrBytes[bi] != prefixBytes[bi]) yield false;
+                    }
+                    yield true;
+                }
                 String actual = extractScalarValue(attrNode);
-                String prefix = resolveScalar(func.args().get(1), item, exprAttrNames, exprAttrValues);
+                String prefix = extractScalarValue(prefixNode);
                 yield actual != null && prefix != null && actual.startsWith(prefix);
             }
             case "contains" -> {
                 if (func.args().size() < 2) yield false;
                 yield evaluateContains(func.args().get(0), func.args().get(1),
                         item, exprAttrNames, exprAttrValues);
+            }
+            case "attribute_type" -> {
+                if (func.args().size() < 2) yield false;
+                String attrPath = resolveAttributePath(func.args().get(0), exprAttrNames);
+                JsonNode attrVal = item != null ? resolveNestedAttribute(item, attrPath) : null;
+                JsonNode typeNode = resolveAttributeValue(func.args().get(1), item, exprAttrNames, exprAttrValues);
+                if (attrVal == null || typeNode == null) yield false;
+                String typeCode = typeNode.has("S") ? typeNode.get("S").asText() : typeNode.asText();
+                yield attrVal.has(typeCode);
             }
             default -> false;
         };
@@ -615,7 +686,18 @@ final class ExpressionEvaluator {
                 String resolvedPath = resolvePathString(path, exprAttrNames);
                 yield item != null ? resolveNestedAttribute(item, resolvedPath) : null;
             }
-            case FunctionOperand _ -> null;
+            case FunctionOperand func -> {
+                if ("size".equalsIgnoreCase(func.functionName()) && !func.args().isEmpty()) {
+                    String path = resolveAttributePath(func.args().getFirst(), exprAttrNames);
+                    JsonNode attrNode = item != null ? resolveNestedAttribute(item, path) : null;
+                    if (attrNode != null) {
+                        ObjectNode numNode = JsonNodeFactory.instance.objectNode();
+                        numNode.put("N", String.valueOf(computeSize(attrNode)));
+                        yield numNode;
+                    }
+                }
+                yield null;
+            }
         };
     }
 
@@ -631,14 +713,18 @@ final class ExpressionEvaluator {
     private static String resolvePathString(PathOperand path, JsonNode exprAttrNames) {
         var sb = new StringBuilder();
         for (int i = 0; i < path.segments().size(); i++) {
-            if (i > 0) sb.append(".");
             String segment = path.segments().get(i);
-            String resolved = resolveAttributeName(segment, exprAttrNames);
-            // If the resolved name contains dots, escape them so resolveNestedAttribute treats it as one key
-            if (segment.startsWith("#") && resolved != null) {
-                resolved = resolved.replace(".", DOT_ESCAPE);
+            if (segment.startsWith("[")) {
+                // List index: append directly without preceding dot
+                sb.append(segment);
+            } else {
+                if (i > 0) sb.append(".");
+                String resolved = resolveAttributeName(segment, exprAttrNames);
+                if (segment.startsWith("#") && resolved != null) {
+                    resolved = resolved.replace(".", DOT_ESCAPE);
+                }
+                sb.append(resolved);
             }
-            sb.append(resolved);
         }
         return sb.toString();
     }
@@ -664,13 +750,43 @@ final class ExpressionEvaluator {
         return attrValue.asText();
     }
 
+    // Tokenizes a resolved path string (e.g. "a.b[0].c") into segments.
+    // Each segment is either a plain attribute name or a "[n]" list index string.
+    private static List<String> parsePathSegments(String path) {
+        var segs = new ArrayList<String>();
+        for (String dotPart : path.split("\\.")) {
+            dotPart = dotPart.replace(DOT_ESCAPE, ".");
+            int brk = dotPart.indexOf('[');
+            if (brk < 0) {
+                if (!dotPart.isEmpty()) segs.add(dotPart);
+            } else {
+                if (brk > 0) segs.add(dotPart.substring(0, brk));
+                String rest = dotPart.substring(brk);
+                int p = 0;
+                while (p < rest.length() && rest.charAt(p) == '[') {
+                    int close = rest.indexOf(']', p);
+                    if (close < 0) break;
+                    segs.add(rest.substring(p, close + 1)); // "[n]"
+                    p = close + 1;
+                }
+            }
+        }
+        return segs;
+    }
+
     private static JsonNode resolveNestedAttribute(JsonNode item, String path) {
-        String[] segments = path.split("\\.");
+        List<String> segments = parsePathSegments(path);
         JsonNode current = item;
-        for (int i = 0; i < segments.length; i++) {
+        for (int i = 0; i < segments.size(); i++) {
             if (current == null) return null;
-            String segment = segments[i].replace(DOT_ESCAPE, ".");
-            if (i == 0) {
+            String segment = segments.get(i);
+            if (segment.matches("\\[\\d+\\]")) {
+                // List index navigation
+                int idx = Integer.parseInt(segment.substring(1, segment.length() - 1));
+                JsonNode listNode = current.has("L") ? current.get("L") : (current.isArray() ? current : null);
+                if (listNode == null || !listNode.isArray() || idx >= listNode.size()) return null;
+                current = listNode.get(idx);
+            } else if (i == 0) {
                 current = current.get(segment);
             } else {
                 if (current.has("M")) {
@@ -721,6 +837,36 @@ final class ExpressionEvaluator {
             }
             return true;
         }
+        // Set types: SS, NS, BS — order-independent comparison
+        if (a.has("SS") && b.has("SS")) {
+            JsonNode aArr = a.get("SS"), bArr = b.get("SS");
+            if (aArr.size() != bArr.size()) return false;
+            var aSet = new java.util.HashSet<String>();
+            aArr.forEach(e -> aSet.add(e.asText()));
+            for (JsonNode e : bArr) { if (!aSet.contains(e.asText())) return false; }
+            return true;
+        }
+        if (a.has("SS") || b.has("SS")) return false;
+        if (a.has("BS") && b.has("BS")) {
+            JsonNode aArr = a.get("BS"), bArr = b.get("BS");
+            if (aArr.size() != bArr.size()) return false;
+            var aSet = new java.util.HashSet<String>();
+            aArr.forEach(e -> aSet.add(e.asText()));
+            for (JsonNode e : bArr) { if (!aSet.contains(e.asText())) return false; }
+            return true;
+        }
+        if (a.has("BS") || b.has("BS")) return false;
+        if (a.has("NS") && b.has("NS")) {
+            JsonNode aArr = a.get("NS"), bArr = b.get("NS");
+            if (aArr.size() != bArr.size()) return false;
+            var aSet = new java.util.HashSet<BigDecimal>();
+            try {
+                aArr.forEach(e -> aSet.add(new BigDecimal(e.asText())));
+                for (JsonNode e : bArr) { if (!aSet.contains(new BigDecimal(e.asText()))) return false; }
+            } catch (NumberFormatException ex) { return false; }
+            return true;
+        }
+        if (a.has("NS") || b.has("NS")) return false;
         return false;
     }
 
@@ -730,6 +876,32 @@ final class ExpressionEvaluator {
         } catch (NumberFormatException e) {
             return a.compareTo(b);
         }
+    }
+
+    static int compareAttributeValues(JsonNode a, JsonNode b) {
+        if (a.has("N") && b.has("N")) {
+            try {
+                return new BigDecimal(a.get("N").asText())
+                        .compareTo(new BigDecimal(b.get("N").asText()));
+            } catch (NumberFormatException e) {
+                return a.get("N").asText().compareTo(b.get("N").asText());
+            }
+        }
+        if (a.has("B") && b.has("B")) {
+            byte[] aBytes = Base64.getDecoder().decode(a.get("B").asText());
+            byte[] bBytes = Base64.getDecoder().decode(b.get("B").asText());
+            int minLen = Math.min(aBytes.length, bBytes.length);
+            for (int i = 0; i < minLen; i++) {
+                int diff = (aBytes[i] & 0xFF) - (bBytes[i] & 0xFF);
+                if (diff != 0) return diff;
+            }
+            return Integer.compare(aBytes.length, bBytes.length);
+        }
+        String aStr = a.has("S") ? a.get("S").asText() : extractScalarValue(a);
+        String bStr = b.has("S") ? b.get("S").asText() : extractScalarValue(b);
+        if (aStr == null) aStr = "";
+        if (bStr == null) bStr = "";
+        return aStr.compareTo(bStr);
     }
 
     private static int computeSize(JsonNode attrNode) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluator.java
@@ -1,0 +1,178 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Applies a DynamoDB ProjectionExpression to a result item, returning a new
+ * ObjectNode containing only the projected attributes.
+ */
+final class ProjectionEvaluator {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private ProjectionEvaluator() {}
+
+    /**
+     * Returns a new ObjectNode containing only the paths named in the expression.
+     * Resolves #alias references via exprAttrNames. Handles dot-path and [n] list index segments.
+     */
+    static ObjectNode project(JsonNode item, String projectionExpression, JsonNode exprAttrNames) {
+        if (item == null || projectionExpression == null || projectionExpression.isBlank()) {
+            return (ObjectNode) item;
+        }
+        validateProjectionExpression(projectionExpression);
+        DynamoDbReservedWords.check(projectionExpression, "ProjectionExpression");
+        ObjectNode result = MAPPER.createObjectNode();
+        for (String rawPath : splitProjectionPaths(projectionExpression)) {
+            List<String> segments = resolvePath(rawPath.trim(), exprAttrNames);
+            if (segments.isEmpty()) continue;
+            copyPath(item, result, segments, 0);
+        }
+        return result;
+    }
+
+    /**
+     * Returns a new ObjectNode containing only the named top-level attributes.
+     * Used by AttributesToGet (no alias resolution, no nested paths).
+     */
+    static ObjectNode trimToAttributes(ObjectNode item, Set<String> keep) {
+        ObjectNode result = MAPPER.createObjectNode();
+        item.fields().forEachRemaining(entry -> {
+            if (keep.contains(entry.getKey())) {
+                result.set(entry.getKey(), entry.getValue());
+            }
+        });
+        return result;
+    }
+
+    static void validateSyntax(String expression, String expressionType) {
+        if (expression == null || expression.isBlank()) return;
+        char first = expression.charAt(0);
+        if (!Character.isLetterOrDigit(first) && first != '#' && first != '_') {
+            String token = String.valueOf(first);
+            String near = expression.length() > 2 ? expression.substring(1, 3) : expression.substring(1);
+            throw new AwsException("ValidationException",
+                    "Invalid " + expressionType + ": Syntax error; token: \"" + token + "\", near: \"" + near + "\"", 400);
+        }
+    }
+
+    private static void validateProjectionExpression(String expression) {
+        validateSyntax(expression, "ProjectionExpression");
+    }
+
+    // ── Path splitting ──
+
+    private static List<String> splitProjectionPaths(String expression) {
+        List<String> paths = new ArrayList<>();
+        int depth = 0;
+        int start = 0;
+        for (int i = 0; i < expression.length(); i++) {
+            char c = expression.charAt(i);
+            if (c == '(') depth++;
+            else if (c == ')') depth--;
+            else if (c == ',' && depth == 0) {
+                paths.add(expression.substring(start, i).trim());
+                start = i + 1;
+            }
+        }
+        if (start < expression.length()) {
+            paths.add(expression.substring(start).trim());
+        }
+        return paths;
+    }
+
+    // ── Path resolution ──
+
+    private static List<String> resolvePath(String path, JsonNode exprAttrNames) {
+        List<String> segments = new ArrayList<>();
+        // Tokenize on dots, preserving [n] bracket indices
+        String[] parts = path.split("\\.");
+        for (String part : parts) {
+            // A part may end with [n] index(es) like "list[0]" or "[0]"
+            int bracketIdx = part.indexOf('[');
+            if (bracketIdx >= 0) {
+                String name = part.substring(0, bracketIdx);
+                if (!name.isEmpty()) {
+                    segments.add(resolveSegment(name, exprAttrNames));
+                }
+                // Parse each [n] suffix
+                String rest = part.substring(bracketIdx);
+                int i = 0;
+                while (i < rest.length() && rest.charAt(i) == '[') {
+                    int close = rest.indexOf(']', i);
+                    if (close < 0) break;
+                    segments.add(rest.substring(i, close + 1)); // e.g. "[0]"
+                    i = close + 1;
+                }
+            } else {
+                segments.add(resolveSegment(part, exprAttrNames));
+            }
+        }
+        return segments;
+    }
+
+    private static String resolveSegment(String seg, JsonNode exprAttrNames) {
+        if (seg.startsWith("#") && exprAttrNames != null) {
+            JsonNode resolved = exprAttrNames.get(seg);
+            return resolved != null ? resolved.asText() : seg;
+        }
+        return seg;
+    }
+
+    // ── Tree walking ──
+
+    private static void copyPath(JsonNode src, ObjectNode dest, List<String> segments, int idx) {
+        if (idx >= segments.size()) return;
+        String seg = segments.get(idx);
+
+        if (seg.matches("\\[\\d+\\]")) {
+            // List index at root level — handled by the caller
+            return;
+        }
+
+        JsonNode child = src.get(seg);
+        if (child == null) return;
+
+        if (idx == segments.size() - 1) {
+            // Leaf: copy the whole attribute node
+            dest.set(seg, child);
+        } else {
+            String nextSeg = segments.get(idx + 1);
+            if (nextSeg.matches("\\[\\d+\\]")) {
+                // Next is a list index — extract just that element
+                int listIdx = Integer.parseInt(nextSeg.substring(1, nextSeg.length() - 1));
+                JsonNode listNode = child.has("L") ? child.get("L") : child;
+                if (listNode.isArray() && listIdx < listNode.size()) {
+                    JsonNode element = listNode.get(listIdx);
+                    // Build {"L": [element]} wrapper
+                    ObjectNode wrapper = MAPPER.createObjectNode();
+                    ArrayNode newList = MAPPER.createArrayNode();
+                    newList.add(element);
+                    wrapper.set("L", newList);
+                    dest.set(seg, wrapper);
+                }
+            } else if (child.has("M")) {
+                // Nested map — recurse
+                ObjectNode nestedDest = MAPPER.createObjectNode();
+                copyPath(child.get("M"), nestedDest, segments, idx + 1);
+                ObjectNode wrapper = MAPPER.createObjectNode();
+                wrapper.set("M", nestedDest);
+                dest.set(seg, wrapper);
+            } else if (child.isObject()) {
+                ObjectNode nestedDest = MAPPER.createObjectNode();
+                copyPath(child, nestedDest, segments, idx + 1);
+                dest.set(seg, nestedDest);
+            } else {
+                dest.set(seg, child);
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/TransactionCanceledException.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/TransactionCanceledException.java
@@ -1,26 +1,27 @@
 package io.github.hectorvent.floci.services.dynamodb;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.github.hectorvent.floci.core.common.AwsException;
 
 import java.util.List;
 
-/**
- * Thrown when a TransactWriteItems condition check fails.
- * Carries per-item cancellation reasons for the AWS response.
- */
 public class TransactionCanceledException extends AwsException {
 
-    private final List<String> cancellationReasons;
+    public record CancellationReason(String code, JsonNode item) {}
 
-    public TransactionCanceledException(List<String> cancellationReasons) {
+    private final List<CancellationReason> cancellationReasons;
+
+    public TransactionCanceledException(List<CancellationReason> cancellationReasons) {
         super("TransactionCanceledException",
                 "Transaction cancelled, please refer cancellation reasons for specific reasons [" +
-                        String.join(", ", cancellationReasons) + "]",
+                        cancellationReasons.stream()
+                                .map(r -> r.code().isEmpty() ? "None" : r.code())
+                                .reduce((a, b) -> a + ", " + b).orElse("") + "]",
                 400);
         this.cancellationReasons = cancellationReasons;
     }
 
-    public List<String> getCancellationReasons() {
+    public List<CancellationReason> getCancellationReasons() {
         return cancellationReasons;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/LocalSecondaryIndex.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/LocalSecondaryIndex.java
@@ -18,17 +18,27 @@ public class LocalSecondaryIndex {
     private List<KeySchemaElement> keySchema;
     private String indexArn;
     private String projectionType;
+    private List<String> nonKeyAttributes;
     private long indexSizeBytes;
     private long itemCount;
 
-    public LocalSecondaryIndex() {}
+    public LocalSecondaryIndex() {
+        this.nonKeyAttributes = new java.util.ArrayList<>();
+    }
 
     public LocalSecondaryIndex(String indexName, List<KeySchemaElement> keySchema,
                                 String indexArn, String projectionType) {
+        this(indexName, keySchema, indexArn, projectionType, null);
+    }
+
+    public LocalSecondaryIndex(String indexName, List<KeySchemaElement> keySchema,
+                                String indexArn, String projectionType, List<String> nonKeyAttributes) {
         this.indexName = indexName;
         this.keySchema = keySchema;
         this.indexArn = indexArn;
         this.projectionType = projectionType != null ? projectionType : "ALL";
+        this.nonKeyAttributes = "INCLUDE".equals(this.projectionType) && nonKeyAttributes != null
+                ? nonKeyAttributes : new java.util.ArrayList<>();
     }
 
     public String getIndexName() { return indexName; }
@@ -42,6 +52,9 @@ public class LocalSecondaryIndex {
 
     public String getProjectionType() { return projectionType; }
     public void setProjectionType(String projectionType) { this.projectionType = projectionType; }
+
+    public List<String> getNonKeyAttributes() { return nonKeyAttributes; }
+    public void setNonKeyAttributes(List<String> nonKeyAttributes) { this.nonKeyAttributes = nonKeyAttributes; }
 
     public long getIndexSizeBytes() { return indexSizeBytes; }
     public void setIndexSizeBytes(long indexSizeBytes) { this.indexSizeBytes = indexSizeBytes; }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbConcurrencyIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbConcurrencyIntegrationTest.java
@@ -335,7 +335,7 @@ class DynamoDbConcurrencyIntegrationTest {
             ObjectNode tx2 = buildUpdateTx(pkB, exprValues);
 
             try {
-                service.transactWriteItems(List.of(tx1, tx2), "us-east-1");
+                service.transactWriteItems(List.of(tx1, tx2), "us-east-1", null);
                 committed.incrementAndGet();
             } catch (TransactionCanceledException e) {
                 cancelled.incrementAndGet();
@@ -392,7 +392,7 @@ class DynamoDbConcurrencyIntegrationTest {
 
             ObjectNode tx1 = buildUpdateTx(keyA, exprValues);
             ObjectNode tx2 = buildUpdateTx(keyB, exprValues);
-            service.transactWriteItems(List.of(tx1, tx2), "us-east-1");
+            service.transactWriteItems(List.of(tx1, tx2), "us-east-1", null);
         });
 
         assertTrue(errors.isEmpty(),

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbFilterExpressionIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbFilterExpressionIntegrationTest.java
@@ -92,11 +92,13 @@ class DynamoDbFilterExpressionIntegrationTest {
     void scanFilterInOperator_singleValue() {
         // status IN (:v0) where v0=1 should return u1, u3
         scanWithFilter(
-                "status IN (:v0)",
+                "#s IN (:v0)",
                 """
                 {":v0": {"N": "1"}}
                 """,
-                null,
+                """
+                {"#s": "status"}
+                """,
                 2);
     }
 
@@ -104,11 +106,13 @@ class DynamoDbFilterExpressionIntegrationTest {
     void scanFilterInOperator_multipleValues() {
         // status IN (:v0, :v1) where v0=1, v1=3 should return u1, u3, u4
         scanWithFilter(
-                "status IN (:v0, :v1)",
+                "#s IN (:v0, :v1)",
                 """
                 {":v0": {"N": "1"}, ":v1": {"N": "3"}}
                 """,
-                null,
+                """
+                {"#s": "status"}
+                """,
                 3);
     }
 
@@ -132,11 +136,13 @@ class DynamoDbFilterExpressionIntegrationTest {
     void scanFilterOrOperator() {
         // status = :v1 OR status = :v2 should return u1, u2, u3 (status 1 or 2)
         scanWithFilter(
-                "status = :v1 OR status = :v2",
+                "#s = :v1 OR #s = :v2",
                 """
                 {":v1": {"N": "1"}, ":v2": {"N": "2"}}
                 """,
-                null,
+                """
+                {"#s": "status"}
+                """,
                 3);
     }
 
@@ -159,11 +165,13 @@ class DynamoDbFilterExpressionIntegrationTest {
         // (status = :v1 OR status = :v3) AND category = :catA
         // status=1 OR status=3 → u1,u3,u4; AND category=A → u1,u3
         scanWithFilter(
-                "(status = :v1 OR status = :v3) AND category = :catA",
+                "(#s = :v1 OR #s = :v3) AND category = :catA",
                 """
                 {":v1": {"N": "1"}, ":v3": {"N": "3"}, ":catA": {"S": "A"}}
                 """,
-                null,
+                """
+                {"#s": "status"}
+                """,
                 2);
     }
 
@@ -189,11 +197,13 @@ class DynamoDbFilterExpressionIntegrationTest {
         // (status 1 or 3) AND category A → u1,u3; OR deleted=true → u2
         // Total: u1, u2, u3
         scanWithFilter(
-                "((status = :v1 OR status = :v3) AND category = :catA) OR deleted = :del",
+                "((#s = :v1 OR #s = :v3) AND category = :catA) OR deleted = :del",
                 """
                 {":v1": {"N": "1"}, ":v3": {"N": "3"}, ":catA": {"S": "A"}, ":del": {"BOOL": true}}
                 """,
-                null,
+                """
+                {"#s": "status"}
+                """,
                 3);
     }
 
@@ -201,11 +211,13 @@ class DynamoDbFilterExpressionIntegrationTest {
     void scanFilterNotWithParenthesizedAnd() {
         // NOT (deleted = :true AND status = :v2) — negate (u2 only) → u1, u3, u4
         scanWithFilter(
-                "NOT (deleted = :d AND status = :v2)",
+                "NOT (deleted = :d AND #s = :v2)",
                 """
                 {":d": {"BOOL": true}, ":v2": {"N": "2"}}
                 """,
-                null,
+                """
+                {"#s": "status"}
+                """,
                 3);
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -959,7 +959,8 @@ class DynamoDbIntegrationTest {
                 {
                     "TableName": "ListAppendTable",
                     "Key": {"pk": {"S": "k1"}},
-                    "UpdateExpression": "SET items = list_append(items, :val)",
+                    "UpdateExpression": "SET #i = list_append(#i, :val)",
+                    "ExpressionAttributeNames": {"#i": "items"},
                     "ExpressionAttributeValues": {":val": {"L": [{"S": "b"}]}}
                 }
                 """)
@@ -1645,7 +1646,8 @@ given()
                 {
                     "TableName": "%s",
                     "Key": {"GroupKey": {"S": "leader"}, "Id": {"S": "app1"}},
-                    "UpdateExpression": "SET Owner = :1",
+                    "UpdateExpression": "SET #o = :1",
+                    "ExpressionAttributeNames": {"#o": "Owner"},
                     "ExpressionAttributeValues": {":1": {"S": "owner-app1"}}
                 }
                 """.formatted(tableName))
@@ -1659,7 +1661,8 @@ given()
                 {
                     "TableName": "%s",
                     "Key": {"GroupKey": {"S": "leader"}, "Id": {"S": "app2"}},
-                    "UpdateExpression": "SET Owner = :1",
+                    "UpdateExpression": "SET #o = :1",
+                    "ExpressionAttributeNames": {"#o": "Owner"},
                     "ExpressionAttributeValues": {":1": {"S": "owner-app2"}}
                 }
                 """.formatted(tableName))

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandlerTest.java
@@ -123,9 +123,12 @@ class DynamoDbJsonHandlerTest {
         exprValues.set(":start", startVal);
         exprValues.set(":inc", incVal);
 
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#cnt", "counter");
+
         JsonNode request = createRequest("Users", key,
-                "SET counter = if_not_exists(counter, :start) + :inc",
-                null, exprValues, "UPDATED_NEW");
+                "SET #cnt = if_not_exists(#cnt, :start) + :inc",
+                exprNames, exprValues, "UPDATED_NEW");
 
         Response response = handler.handle("UpdateItem", request, "us-east-1");
         assertNotNull(response);

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -183,11 +183,15 @@ class DynamoDbServiceTest {
         ObjectNode exprValues = mapper.createObjectNode();
         exprValues.set(":name", attributeValue("S", "Alice"));
 
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#n", "name");
+
         ObjectNode update = mapper.createObjectNode();
         update.put("TableName", usersArn);
         update.set("Key", item("userId", "user-1"));
-        update.put("ConditionExpression", "name = :name");
+        update.put("ConditionExpression", "#n = :name");
         update.put("UpdateExpression", "SET email = :name");
+        update.set("ExpressionAttributeNames", exprNames);
         update.set("ExpressionAttributeValues", exprValues);
 
         ObjectNode transactItem = mapper.createObjectNode();
@@ -573,9 +577,12 @@ class DynamoDbServiceTest {
         exprValues.set(":name", nameVal);
         exprValues.set(":score", scoreVal);
 
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#n", "name");
+
         service.updateItem("Users", key, null,
-                "SET name = if_not_exists(name, :name), score = if_not_exists(score, :score)",
-                null, exprValues, null);
+                "SET #n = if_not_exists(#n, :name), score = if_not_exists(score, :score)",
+                exprNames, exprValues, null);
 
         JsonNode stored = service.getItem("Users", key);
         assertNotNull(stored, "item should have been created");
@@ -604,10 +611,13 @@ class DynamoDbServiceTest {
         ObjectNode fallbackVal = mapper.createObjectNode(); fallbackVal.put("S", "fallback");
         exprValues.set(":v", fallbackVal);
 
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#src", "source");
+
         // target = if_not_exists(source, :v) — source exists, so target should receive source's value
         service.updateItem("Users", key, null,
-                "SET target = if_not_exists(source, :v)",
-                null, exprValues, null);
+                "SET target = if_not_exists(#src, :v)",
+                exprNames, exprValues, null);
 
         JsonNode stored = service.getItem("Users", key);
         assertNotNull(stored);
@@ -630,9 +640,12 @@ class DynamoDbServiceTest {
         ObjectNode fallbackVal = mapper.createObjectNode(); fallbackVal.put("S", "fallback");
         exprValues.set(":v", fallbackVal);
 
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#src", "source");
+
         service.updateItem("Users", key, null,
-                "SET target = if_not_exists(source, :v)",
-                null, exprValues, null);
+                "SET target = if_not_exists(#src, :v)",
+                exprNames, exprValues, null);
 
         JsonNode stored = service.getItem("Users", key);
         assertNotNull(stored);
@@ -659,9 +672,12 @@ class DynamoDbServiceTest {
         incVal.put("N", "1");
         exprValues.set(":inc", incVal);
 
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#cnt", "counter");
+
         service.updateItem("Users", key, null,
-                "SET counter = counter + :inc",
-                null, exprValues, null);
+                "SET #cnt = #cnt + :inc",
+                exprNames, exprValues, null);
 
         JsonNode stored = service.getItem("Users", key);
         assertNotNull(stored);
@@ -686,9 +702,12 @@ class DynamoDbServiceTest {
         decVal.put("N", "3");
         exprValues.set(":dec", decVal);
 
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#cnt", "counter");
+
         service.updateItem("Users", key, null,
-                "SET counter = counter - :dec",
-                null, exprValues, null);
+                "SET #cnt = #cnt - :dec",
+                exprNames, exprValues, null);
 
         JsonNode stored = service.getItem("Users", key);
         assertNotNull(stored);
@@ -709,9 +728,12 @@ class DynamoDbServiceTest {
         exprValues.set(":start", startVal);
         exprValues.set(":inc", incVal);
 
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#cnt", "counter");
+
         service.updateItem("Users", key, null,
-                "SET counter = if_not_exists(counter, :start) + :inc",
-                null, exprValues, null);
+                "SET #cnt = if_not_exists(#cnt, :start) + :inc",
+                exprNames, exprValues, null);
 
         JsonNode stored = service.getItem("Users", key);
         assertNotNull(stored);
@@ -739,9 +761,12 @@ class DynamoDbServiceTest {
         exprValues.set(":start", startVal);
         exprValues.set(":inc", incVal);
 
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#cnt", "counter");
+
         service.updateItem("Users", key, null,
-                "SET counter = if_not_exists(counter, :start) + :inc",
-                null, exprValues, null);
+                "SET #cnt = if_not_exists(#cnt, :start) + :inc",
+                exprNames, exprValues, null);
 
         JsonNode stored = service.getItem("Users", key);
         assertNotNull(stored);
@@ -762,11 +787,14 @@ class DynamoDbServiceTest {
         exprValues.set(":start", startVal);
         exprValues.set(":inc", incVal);
 
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#cnt", "counter");
+
         // Three consecutive increments
         for (int i = 0; i < 3; i++) {
             service.updateItem("Users", key, null,
-                    "SET counter = if_not_exists(counter, :start) + :inc",
-                    null, exprValues, null);
+                    "SET #cnt = if_not_exists(#cnt, :start) + :inc",
+                    exprNames, exprValues, null);
         }
 
         JsonNode stored = service.getItem("Users", key);
@@ -833,7 +861,10 @@ class DynamoDbServiceTest {
         ObjectNode exprValues = mapper.createObjectNode();
         exprValues.set(":r", attributeValue("S", "admin"));
 
-        DynamoDbService.ScanResult result = service.scan("Users", "contains(roles, :r)", null, exprValues, null, null, null);
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#r", "roles");
+
+        DynamoDbService.ScanResult result = service.scan("Users", "contains(#r, :r)", exprNames, exprValues, null, null, null);
         assertEquals(1, result.items().size());
     }
 
@@ -966,9 +997,12 @@ class DynamoDbServiceTest {
         exprValues.set(":e", listAttributeValue());
         exprValues.set(":val", listAttributeValue("a"));
 
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#items", "items");
+
         service.updateItem("Users", key, null,
-                "SET items = list_append(if_not_exists(items, :e), :val)",
-                null, exprValues, null);
+                "SET #items = list_append(if_not_exists(#items, :e), :val)",
+                exprNames, exprValues, null);
 
         JsonNode stored = service.getItem("Users", key);
         assertNotNull(stored);
@@ -990,9 +1024,12 @@ class DynamoDbServiceTest {
         exprValues.set(":e", listAttributeValue());
         exprValues.set(":val", listAttributeValue("b"));
 
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#items", "items");
+
         service.updateItem("Users", key, null,
-                "SET items = list_append(if_not_exists(items, :e), :val)",
-                null, exprValues, null);
+                "SET #items = list_append(if_not_exists(#items, :e), :val)",
+                exprNames, exprValues, null);
 
         JsonNode stored = service.getItem("Users", key);
         assertNotNull(stored);
@@ -1025,7 +1062,10 @@ class DynamoDbServiceTest {
         ObjectNode exprValues = mapper.createObjectNode();
         exprValues.set(":v", attributeValue("N", "10.0"));
 
-        DynamoDbService.ScanResult result = service.scan("Users", "contains(values, :v)", null, exprValues, null, null, null);
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#vals", "values");
+
+        DynamoDbService.ScanResult result = service.scan("Users", "contains(#vals, :v)", exprNames, exprValues, null, null, null);
         assertEquals(1, result.items().size(), "contains() on List with N elements should use type-aware numeric comparison");
     }
 
@@ -1305,16 +1345,18 @@ class DynamoDbServiceTest {
         ObjectNode key1 = item("customerId", "c1", "orderId", "app1");
         ObjectNode exprValues = mapper.createObjectNode();
         exprValues.set(":owner", attributeValue("S", "owner-1"));
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#owner", "owner");
 
         service.updateItem("Orders", key1, null,
-                "SET owner = :owner", null, exprValues, null);
+                "SET #owner = :owner", exprNames, exprValues, null);
 
         ObjectNode key2 = item("customerId", "c1", "orderId", "app2");
         exprValues = mapper.createObjectNode();
         exprValues.set(":owner", attributeValue("S", "owner-2"));
 
         service.updateItem("Orders", key2, null,
-                "SET owner = :owner", null, exprValues, null);
+                "SET #owner = :owner", exprNames, exprValues, null);
 
         DynamoDbService.ScanResult scanResult = service.scan("Orders", null, null, null, null, null, null);
         assertEquals(2, scanResult.items().size(),
@@ -1678,8 +1720,11 @@ class DynamoDbServiceTest {
         values.set(":v1", attributeValue("S", "one"));
         values.set(":v2", attributeValue("S", "two"));
 
+        ObjectNode names = mapper.createObjectNode();
+        names.put("#other", "other");
+
         service.updateItem("Users", userIdKey("u11"), null,
-                "SET prefixSET = :v1, other = :v2", null, values, "ALL_NEW");
+                "SET prefixSET = :v1, #other = :v2", names, values, "ALL_NEW");
 
         JsonNode stored = service.getItem("Users", userIdKey("u11"));
         assertEquals("one", stored.get("prefixSET").get("S").asText());
@@ -2113,9 +2158,12 @@ class DynamoDbServiceTest {
         ObjectNode vNode = mapper.createObjectNode(); vNode.put("N", "3");
         exprValues.set(":v", vNode);
 
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#cnt", "counter");
+
         service.updateItem("Users", key, null,
-                "SET counter = ((counter - :v))",
-                null, exprValues, null);
+                "SET #cnt = ((#cnt - :v))",
+                exprNames, exprValues, null);
 
         JsonNode stored = service.getItem("Users", key);
         assertEquals("7", stored.get("counter").get("N").asText());

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -94,7 +94,7 @@ class DynamoDbServiceTest {
                         List.of(new KeySchemaElement("userId", "HASH")),
                         List.of(new AttributeDefinition("userId", "S")),
                         5L, 5L));
-        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals("ValidationException", ex.getErrorCode());
         assertEquals(400, ex.getHttpStatus());
     }
 
@@ -193,7 +193,7 @@ class DynamoDbServiceTest {
         ObjectNode transactItem = mapper.createObjectNode();
         transactItem.set("Update", update);
 
-        assertDoesNotThrow(() -> service.transactWriteItems(List.of(transactItem), "us-east-1"));
+        assertDoesNotThrow(() -> service.transactWriteItems(List.of(transactItem), "us-east-1", null));
         assertEquals("Alice", service.getItem("Users", item("userId", "user-1")).get("email").get("S").asText());
     }
 
@@ -203,7 +203,7 @@ class DynamoDbServiceTest {
 
         AwsException ex = assertThrows(AwsException.class,
                 () -> service.describeTable(tableArn("eu-west-1", "Users")));
-        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals("ValidationException", ex.getErrorCode());
         assertEquals(400, ex.getHttpStatus());
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbTableArnIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbTableArnIntegrationTest.java
@@ -128,8 +128,9 @@ class DynamoDbTableArnIntegrationTest {
                             "Update": {
                                 "TableName": "%s",
                                 "Key": {"pk": {"S": "user-1"}},
-                                "ConditionExpression": "name = :expected",
+                                "ConditionExpression": "#n = :expected",
                                 "UpdateExpression": "SET email = :email",
+                                "ExpressionAttributeNames": {"#n": "name"},
                                 "ExpressionAttributeValues": {
                                     ":expected": {"S": "Alice"},
                                     ":email": {"S": "alice@example.com"}

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbTableArnIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbTableArnIntegrationTest.java
@@ -250,7 +250,7 @@ class DynamoDbTableArnIntegrationTest {
             .post("/")
         .then()
             .statusCode(400)
-            .body("__type", equalTo("InvalidParameterValue"))
+            .body("__type", equalTo("ValidationException"))
             .body("message", containsString("does not match request region"));
 
         given()
@@ -263,7 +263,7 @@ class DynamoDbTableArnIntegrationTest {
             .post("/")
         .then()
             .statusCode(400)
-            .body("__type", equalTo("InvalidParameterValue"))
+            .body("__type", equalTo("ValidationException"))
             .body("message", containsString("does not accept index or stream ARNs"));
     }
 
@@ -409,7 +409,7 @@ class DynamoDbTableArnIntegrationTest {
             .post("/")
         .then()
             .statusCode(400)
-            .body("__type", equalTo("InvalidParameterValue"))
+            .body("__type", equalTo("ValidationException"))
             .body("message", containsString("must be a short name, not an ARN"));
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbTableNamesTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbTableNamesTest.java
@@ -41,7 +41,7 @@ class DynamoDbTableNamesTest {
                 DynamoDbTableNames.resolveWithRegion(
                         "arn:aws:dynamodb:eu-west-1:000000000000:table/Orders",
                         "us-east-1"));
-        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals("ValidationException", ex.getErrorCode());
         assertEquals(400, ex.getHttpStatus());
     }
 
@@ -62,7 +62,7 @@ class DynamoDbTableNamesTest {
     })
     void resolveRejectsMalformedInputs(String input) {
         AwsException ex = assertThrows(AwsException.class, () -> DynamoDbTableNames.resolve(input));
-        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals("ValidationException", ex.getErrorCode());
         assertEquals(400, ex.getHttpStatus());
     }
 
@@ -85,7 +85,7 @@ class DynamoDbTableNamesTest {
     })
     void requireShortNameRejectsArnInput(String arn) {
         AwsException ex = assertThrows(AwsException.class, () -> DynamoDbTableNames.requireShortName(arn));
-        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals("ValidationException", ex.getErrorCode());
         assertEquals(400, ex.getHttpStatus());
     }
 
@@ -93,7 +93,7 @@ class DynamoDbTableNamesTest {
     @ValueSource(strings = {"", " ", "ab", "name with spaces"})
     void requireShortNameRejectsMalformedInput(String input) {
         AwsException ex = assertThrows(AwsException.class, () -> DynamoDbTableNames.requireShortName(input));
-        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals("ValidationException", ex.getErrorCode());
         assertEquals(400, ex.getHttpStatus());
     }
 


### PR DESCRIPTION
## Summary

- ValidationException rename: Changed InvalidParameterValue → ValidationException for all table-name validation errors; enforced min-length 3 on all operations (not just CreateTable)
- ListTables: Added alphabetical ordering, Limit validation (1–100), and ExclusiveStartTableName pagination
- PutItem / DeleteItem / UpdateItem / GetItem: Enum validation (ReturnValues, ReturnConsumedCapacity, ReturnItemCollectionMetrics) now fires before table lookup, matching real DynamoDB ordering
- ProjectionExpression: Full projection support on GetItem, Query, Scan, BatchGetItem; mutual exclusion with AttributesToGet enforced; reserved-word check added
- Query / Scan — Select=COUNT: Returns Count + ScannedCount and omits Items
- Parallel scan: Segment / TotalSegments validation and deterministic hash-based sharding
- Reserved words: DynamoDbReservedWords utility checks FilterExpression, ConditionExpression, UpdateExpression, and ProjectionExpression; bare reserved-word identifiers are rejected
- Legacy API: AttributesToGet, AttributeUpdates, QueryFilter, ScanFilter, KeyConditions all supported; mutual exclusion with expression-based params enforced
- TransactWriteItems: Idempotency token support with payload-hash conflict detection; ReturnValuesOnConditionCheckFailure on PutItem, UpdateItem, DeleteItem
- Item size validation: 400 KB limit enforced on write; number normalization on storage
- Tags API: TagResource, UntagResource, ListTagsOfResource with ARN validation and AccessDeniedException
- Compatibility tests: New DynamoDbConformanceChangesTest.java (Java SDK) and dynamodb-conformance.test.ts (Node SDK) covering all changes above; existing tests updated to alias DynamoDB reserved words (status, counter, roles) via ExpressionAttributeNames

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
