### PR TITLE
fix(pricing): bundle snapshot resources into native image

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/pricing/PricingService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pricing/PricingService.java
@@ -492,7 +492,14 @@ public class PricingService {
                 }
             }
             String resource = "pricing-snapshots/" + relativePath;
-            try (InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream(resource)) {
+            // Use the class's own loader rather than the thread's context loader.
+            // In a GraalVM native image the thread context loader can be the
+            // bootstrap loader, which sees no application resources, while the
+            // class's loader sees everything bundled into the image.
+            ClassLoader cl = PricingService.class.getClassLoader();
+            try (InputStream in = cl != null
+                    ? cl.getResourceAsStream(resource)
+                    : ClassLoader.getSystemResourceAsStream(resource)) {
                 if (in == null) {
                     return null;
                 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,12 @@ quarkus:
     # No 'delay' value is set - observers run synchronously, no artificial sleep is introduced.
     delay-enabled: true
   native:
+    resources:
+      # The Pricing service reads its bundled snapshot at runtime via
+      # ClassLoader#getResourceAsStream. Quarkus's static resource analysis
+      # cannot detect dynamically-built paths, so the tree is registered
+      # explicitly to ensure GraalVM includes every file in the native image.
+      includes: pricing-snapshots/**
     additional-build-args:
       - --report-unsupported-elements-at-runtime
       - --allow-incomplete-classpath


### PR DESCRIPTION
## Summary

Reported by @cfranzen on #821: when running Floci as a container, the Pricing service returns no service codes and `PricingService.load()` produces no log output at all — symptoms that point to the bundled snapshot files being absent rather than malformed.

Root cause: the standard Floci container ships the GraalVM native binary, and `pricing-snapshots/**` was never registered as a runtime resource in the native-image config, so GraalVM stripped every JSON file from the image. The classpath read in `SnapshotLoader.readJson` returned `null` for the `services.json` lookup, which short-circuits `load()` before it logs anything.

## Fix

Two small changes:

1. **Register the snapshot tree under `quarkus.native.resources.includes`.** Quarkus's static resource analysis can't detect paths assembled at call time (`"pricing-snapshots/" + relativePath`), so an explicit include is needed.
2. **Switch to `PricingService.class.getClassLoader()`** for the snapshot read. In a GraalVM native image the thread context classloader can be the bootstrap loader, which sees no application resources, while the class's own loader always sees what's bundled into the image.

## Test plan

- [x] `./mvnw test -Dtest=PricingIntegrationTest` — 26/26 green locally on JVM (Java 25)
- [ ] CI to run the native-image build + compatibility suite, which is what the original symptom required

I don't have a local GraalVM toolchain set up to validate the native build directly; CI will exercise the published image path that triggered the report.

Refs: https://github.com/floci-io/floci/pull/821#issuecomment-4445052790
