### PR TITLE
fix(s3): make us-east-1 bucket creation idempotent

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -157,6 +157,11 @@ public class S3Service {
     public Bucket createBucket(String bucketName, String region) {
         var existing = bucketStore.get(bucketName);
         if (existing.isPresent()) {
+            Bucket bucket = existing.get();
+            if (isDefaultS3Region(bucket.getRegion()) && isDefaultS3Region(region)) {
+                LOG.infov("Bucket already exists in default region, treating CreateBucket as idempotent: {0}", bucketName);
+                return bucket;
+            }
             throw new AwsException("BucketAlreadyOwnedByYou",
                     "Your previous request to create the named bucket succeeded and you already own it.", 409);
         }
@@ -166,6 +171,10 @@ public class S3Service {
         bucketStore.put(bucketName, bucket);
         LOG.infov("Created bucket: {0} in region: {1}", bucketName, region);
         return bucket;
+    }
+
+    private static boolean isDefaultS3Region(String region) {
+        return region == null || region.isBlank() || "us-east-1".equalsIgnoreCase(region);
     }
 
     public void deleteBucket(String bucketName) {

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -30,13 +30,13 @@ class S3IntegrationTest {
 
     @Test
     @Order(2)
-    void createDuplicateBucketFails() {
+    void createDuplicateBucketInUsEast1IsIdempotent() {
         given()
         .when()
             .put("/test-bucket")
         .then()
-            .statusCode(409)
-            .body(containsString("BucketAlreadyOwnedByYou"));
+            .statusCode(200)
+            .header("Location", equalTo("/test-bucket"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
@@ -58,9 +58,16 @@ class S3ServiceTest {
     }
 
     @Test
-    void createDuplicateBucketThrows() {
-        s3Service.createBucket("test-bucket", "us-east-1");
-        assertThrows(AwsException.class, () -> s3Service.createBucket("test-bucket", "us-east-1"));
+    void createDuplicateBucketInUsEast1IsIdempotent() {
+        Bucket first = s3Service.createBucket("test-bucket", "us-east-1");
+        Bucket duplicate = s3Service.createBucket("test-bucket", "us-east-1");
+        assertSame(first, duplicate);
+    }
+
+    @Test
+    void createDuplicateBucketOutsideUsEast1Throws() {
+        s3Service.createBucket("eu-bucket", "eu-central-1");
+        assertThrows(AwsException.class, () -> s3Service.createBucket("eu-bucket", "eu-central-1"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
Make us-east-1 bucket creation idempotent

Closes #828 

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [X] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [X] `./mvnw test` passes locally
- [X] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
