### PR TITLE
feat(ses): add v2 PutAccountSuppressionAttributes

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesAccountSuppressionTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesAccountSuppressionTest.java
@@ -1,0 +1,80 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Collections;
+import java.util.List;
+
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.GetAccountRequest;
+import software.amazon.awssdk.services.sesv2.model.GetAccountResponse;
+import software.amazon.awssdk.services.sesv2.model.PutAccountSuppressionAttributesRequest;
+import software.amazon.awssdk.services.sesv2.model.SuppressionListReason;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("SES V2 PutAccountSuppressionAttributes")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesAccountSuppressionTest {
+
+    private static SesV2Client sesV2;
+    private static List<SuppressionListReason> originalReasons;
+
+    @BeforeAll
+    static void setup() {
+        sesV2 = TestFixtures.sesV2Client();
+        // Capture the caller's existing account-level setting so cleanup can restore
+        // it — the suite can run against real AWS and must not leave auto-suppression
+        // disabled for the caller's account.
+        originalReasons = sesV2.getAccount(GetAccountRequest.builder().build())
+                .suppressionAttributes()
+                .suppressedReasons();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (sesV2 == null) {
+            return;
+        }
+        try {
+            // Let restore failures propagate — the test mutates account-level state,
+            // so a silent failure here would leave a real AWS caller's suppression
+            // setting disabled even though the suite reports green.
+            sesV2.putAccountSuppressionAttributes(PutAccountSuppressionAttributesRequest.builder()
+                    .suppressedReasons(originalReasons)
+                    .build());
+        } finally {
+            sesV2.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void putAndGet_suppressedReasonsRoundTrip() {
+        sesV2.putAccountSuppressionAttributes(PutAccountSuppressionAttributesRequest.builder()
+                .suppressedReasons(SuppressionListReason.BOUNCE, SuppressionListReason.COMPLAINT)
+                .build());
+
+        GetAccountResponse account = sesV2.getAccount(GetAccountRequest.builder().build());
+        assertThat(account.suppressionAttributes()).isNotNull();
+        assertThat(account.suppressionAttributes().suppressedReasons())
+                .containsExactlyInAnyOrder(SuppressionListReason.BOUNCE, SuppressionListReason.COMPLAINT);
+    }
+
+    @Test
+    @Order(2)
+    void put_explicitEmptyList_clearsReasons() {
+        sesV2.putAccountSuppressionAttributes(PutAccountSuppressionAttributesRequest.builder()
+                .suppressedReasons(Collections.emptyList())
+                .build());
+
+        GetAccountResponse account = sesV2.getAccount(GetAccountRequest.builder().build());
+        assertThat(account.suppressionAttributes().suppressedReasons()).isEmpty();
+    }
+}

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -42,7 +42,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [ACM](acm.md) | `POST /` + `X-Amz-Target: CertificateManager.*` | JSON 1.1 | 12 |
 | [ECR](ecr.md) | `POST /` + `X-Amz-Target: AmazonEC2ContainerRegistry_V20150921.*` (control plane) and `/v2/...` (data plane via `registry:2`) | JSON 1.1 + OCI Distribution | 17 |
 | [SES](ses.md) | `POST /` with `Action=` param | Query | 16 |
-| [SES v2](ses.md#v2) | `/v2/email/*` | REST JSON | 9 |
+| [SES v2](ses.md#v2) | `/v2/email/*` | REST JSON | 10 |
 | [OpenSearch](opensearch.md) | `/2021-01-01/opensearch/...` | REST JSON | 24 |
 | [AppConfig](appconfig.md) | `/applications/...`, `/deploymentstrategies/...` | REST JSON | 16 |
 | [AppConfigData](appconfig.md#data-plane) | `/configurationsessions`, `/configuration` | REST JSON | 2 |

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -172,6 +172,7 @@ Alongside the classic Query API, Floci implements a subset of the SES v2 REST JS
 | `POST` | `/v2/email/outbound-bulk-emails` | `SendBulkEmail` (templated, multiple destinations) |
 | `GET` | `/v2/email/account` | `GetAccount` |
 | `PUT` | `/v2/email/account/sending` | `PutAccountSendingAttributes` |
+| `PUT` | `/v2/email/account/suppression` | `PutAccountSuppressionAttributes` |
 | `POST` | `/v2/email/templates` | `CreateEmailTemplate` |
 | `GET` | `/v2/email/templates` | `ListEmailTemplates` |
 | `GET` | `/v2/email/templates/{templateName}` | `GetEmailTemplate` |

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.ses;
 
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntry;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
@@ -658,6 +659,7 @@ public class SesController {
         String region = regionResolver.resolveRegion(headers);
         long sentCount = sesService.getSentEmailCount(region);
         boolean sendingEnabled = sesService.isAccountSendingEnabled(region);
+        AccountSuppressionAttributes suppression = sesService.getAccountSuppressionAttributes(region);
 
         ObjectNode result = objectMapper.createObjectNode();
         result.put("DedicatedIpAutoWarmupEnabled", false);
@@ -670,7 +672,46 @@ public class SesController {
         sendQuota.put("MaxSendRate", 1.0);
         sendQuota.put("SentLast24Hours", (double) sentCount);
 
+        ObjectNode suppressionAttrs = result.putObject("SuppressionAttributes");
+        ArrayNode reasons = suppressionAttrs.putArray("SuppressedReasons");
+        for (String r : suppression.getSuppressedReasons()) {
+            reasons.add(r);
+        }
+
         return Response.ok(result).build();
+    }
+
+    @PUT
+    @Path("/account/suppression")
+    public Response putAccountSuppressionAttributes(@Context HttpHeaders headers, String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode request = (body == null || body.isBlank())
+                    ? objectMapper.createObjectNode()
+                    : objectMapper.readTree(body);
+            requireJsonObject(request);
+            JsonNode reasonsNode = request.path("SuppressedReasons");
+            List<String> reasons = new ArrayList<>();
+            if (!reasonsNode.isMissingNode() && !reasonsNode.isNull()) {
+                if (!reasonsNode.isArray()) {
+                    throw new AwsException("BadRequestException", "SuppressedReasons must be an array.", 400);
+                }
+                for (JsonNode r : reasonsNode) {
+                    if (r.isNull() || !r.isTextual()) {
+                        throw new AwsException("BadRequestException",
+                                "SuppressedReasons entries must be strings.", 400);
+                    }
+                    reasons.add(r.asText());
+                }
+            }
+            sesService.putAccountSuppressionAttributes(region, reasons);
+            LOG.infov("SES V2 PutAccountSuppressionAttributes: {0}", reasons);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
     }
 
     @PUT

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntry;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
@@ -56,6 +57,7 @@ public class SesService {
     private final StorageBackend<String, EmailTemplate> templateStore;
     private final StorageBackend<String, ConfigurationSet> configSetStore;
     private final StorageBackend<String, SuppressedDestination> suppressionStore;
+    private final StorageBackend<String, AccountSuppressionAttributes> accountSuppressionStore;
     private final SmtpRelay smtpRelay;
     private final ObjectMapper objectMapper;
 
@@ -73,6 +75,8 @@ public class SesService {
                 new TypeReference<Map<String, ConfigurationSet>>() {});
         this.suppressionStore = storageFactory.create("ses", "ses-suppression.json",
                 new TypeReference<Map<String, SuppressedDestination>>() {});
+        this.accountSuppressionStore = storageFactory.create("ses", "ses-account-suppression.json",
+                new TypeReference<Map<String, AccountSuppressionAttributes>>() {});
         this.smtpRelay = smtpRelay;
         this.objectMapper = objectMapper;
     }
@@ -83,6 +87,7 @@ public class SesService {
                StorageBackend<String, EmailTemplate> templateStore,
                StorageBackend<String, ConfigurationSet> configSetStore,
                StorageBackend<String, SuppressedDestination> suppressionStore,
+               StorageBackend<String, AccountSuppressionAttributes> accountSuppressionStore,
                SmtpRelay smtpRelay,
                ObjectMapper objectMapper) {
         this.identityStore = identityStore;
@@ -91,6 +96,7 @@ public class SesService {
         this.templateStore = templateStore;
         this.configSetStore = configSetStore;
         this.suppressionStore = suppressionStore;
+        this.accountSuppressionStore = accountSuppressionStore;
         this.smtpRelay = smtpRelay;
         this.objectMapper = objectMapper;
     }
@@ -693,6 +699,39 @@ public class SesService {
             throw new AwsException("BadRequestException", "Invalid ARN: " + arn, 400);
         }
         return new ResourceRef(parsed.region(), resource.substring(0, slash), resource.substring(slash + 1));
+    }
+
+    // ──────────────────── Account-level suppression attributes ────────────────────
+
+    public AccountSuppressionAttributes getAccountSuppressionAttributes(String region) {
+        return accountSuppressionStore.get(accountSuppressionKey(region))
+                .orElseGet(SesService::defaultAccountSuppressionAttributes);
+    }
+
+    private static AccountSuppressionAttributes defaultAccountSuppressionAttributes() {
+        // Fresh SES accounts default to auto-suppression on both BOUNCE and COMPLAINT;
+        // an explicit PUT (including an empty list) overrides this.
+        AccountSuppressionAttributes attrs = new AccountSuppressionAttributes();
+        attrs.setSuppressedReasons(new ArrayList<>(List.of("BOUNCE", "COMPLAINT")));
+        return attrs;
+    }
+
+    public void putAccountSuppressionAttributes(String region, List<String> suppressedReasons) {
+        List<String> sanitized = new ArrayList<>();
+        if (suppressedReasons != null) {
+            for (String r : suppressedReasons) {
+                validateSuppressionReason(r, "suppressedReasons", true);
+                sanitized.add(r);
+            }
+        }
+        AccountSuppressionAttributes attrs = new AccountSuppressionAttributes();
+        attrs.setSuppressedReasons(sanitized);
+        accountSuppressionStore.put(accountSuppressionKey(region), attrs);
+        LOG.infov("Updated account suppression attributes for region {0}: {1}", region, sanitized);
+    }
+
+    private static String accountSuppressionKey(String region) {
+        return "account-suppression::" + region;
     }
 
     // ──────────────────────────── Suppression list ────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/AccountSuppressionAttributes.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/AccountSuppressionAttributes.java
@@ -1,0 +1,23 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AccountSuppressionAttributes {
+
+    @JsonProperty("SuppressedReasons")
+    private List<String> suppressedReasons = new ArrayList<>();
+
+    public AccountSuppressionAttributes() {}
+
+    public List<String> getSuppressedReasons() { return suppressedReasons; }
+    public void setSuppressedReasons(List<String> suppressedReasons) {
+        this.suppressedReasons = suppressedReasons != null ? suppressedReasons : new ArrayList<>();
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSmtpTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSmtpTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.ses;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
@@ -36,6 +37,7 @@ class SesServiceSmtpTest {
                 new InMemoryStorage<String, EmailTemplate>(),
                 new InMemoryStorage<String, ConfigurationSet>(),
                 new InMemoryStorage<String, SuppressedDestination>(),
+                new InMemoryStorage<String, AccountSuppressionAttributes>(),
                 smtpRelay,
                 new ObjectMapper());
     }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
@@ -220,6 +220,9 @@ class SesV2IntegrationTest {
     @Test
     @Order(11)
     void getAccount() {
+        // SuppressionAttributes defaults to BOUNCE + COMPLAINT on a fresh region,
+        // matching real SES account behaviour. Later @Order(58+) tests overwrite
+        // the stored value, so this assertion only holds before those run.
         given()
             .contentType("application/json")
             .header("Authorization", AUTH_HEADER)
@@ -231,7 +234,9 @@ class SesV2IntegrationTest {
             .body("ProductionAccessEnabled", equalTo(true))
             .body("SendQuota.Max24HourSend", notNullValue())
             .body("SendQuota.MaxSendRate", notNullValue())
-            .body("SendQuota.SentLast24Hours", notNullValue());
+            .body("SendQuota.SentLast24Hours", notNullValue())
+            .body("SuppressionAttributes.SuppressedReasons",
+                  containsInAnyOrder("BOUNCE", "COMPLAINT"));
     }
 
     @Test
@@ -570,6 +575,175 @@ class SesV2IntegrationTest {
         .then()
             .statusCode(400)
             .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(58)
+    void putAccountSuppressionAttributes_storesReasons_visibleViaGetAccount() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"SuppressedReasons": ["BOUNCE", "COMPLAINT"]}
+                """)
+        .when()
+            .put("/v2/email/account/suppression")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/account")
+        .then()
+            .statusCode(200)
+            .body("SuppressionAttributes.SuppressedReasons", containsInAnyOrder("BOUNCE", "COMPLAINT"));
+    }
+
+    @Test
+    @Order(59)
+    void putAccountSuppressionAttributes_emptyArray_clearsReasons() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"SuppressedReasons": []}
+                """)
+        .when()
+            .put("/v2/email/account/suppression")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/account")
+        .then()
+            .statusCode(200)
+            .body("SuppressionAttributes.SuppressedReasons", hasSize(0));
+    }
+
+    @Test
+    @Order(61)
+    void putAccountSuppressionAttributes_missingField_succeedsWithEmptyList() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("{}")
+        .when()
+            .put("/v2/email/account/suppression")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/account")
+        .then()
+            .statusCode(200)
+            .body("SuppressionAttributes.SuppressedReasons", hasSize(0));
+    }
+
+    @Test
+    @Order(62)
+    void putAccountSuppressionAttributes_invalidReason_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"SuppressedReasons": ["BOUNCE", "OTHER"]}
+                """)
+        .when()
+            .put("/v2/email/account/suppression")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString(
+                    "1 validation error detected: Value at 'suppressedReasons' failed to satisfy constraint: "
+                            + "Member must satisfy constraint: [Member must satisfy enum value set: [BOUNCE, COMPLAINT]]"));
+    }
+
+    @Test
+    @Order(63)
+    void putAccountSuppressionAttributes_reasonsNotArray_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"SuppressedReasons": "BOUNCE"}
+                """)
+        .when()
+            .put("/v2/email/account/suppression")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(64)
+    void putAccountSuppressionAttributes_nullMember_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"SuppressedReasons": [null]}
+                """)
+        .when()
+            .put("/v2/email/account/suppression")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(65)
+    void putAccountSuppressionAttributes_numericMember_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"SuppressedReasons": [1, 2]}
+                """)
+        .when()
+            .put("/v2/email/account/suppression")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(66)
+    void putAccountSuppressionAttributes_acceptsValidationAttributes() {
+        // The optional ValidationAttributes object is accepted but not parsed —
+        // verifying the request shape does not regress to a 400.
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                    "SuppressedReasons": ["BOUNCE"],
+                    "ValidationAttributes": {
+                        "ConditionThreshold": {
+                            "ConditionThresholdEnabled": "ENABLED",
+                            "OverallConfidenceThreshold": {
+                                "ConfidenceVerdictThreshold": "HIGH"
+                            }
+                        }
+                    }
+                }
+                """)
+        .when()
+            .put("/v2/email/account/suppression")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/account")
+        .then()
+            .statusCode(200)
+            .body("SuppressionAttributes.SuppressedReasons", contains("BOUNCE"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Implements `PUT /v2/email/account/suppression` so callers can change the account-level suppression list reasons (`BOUNCE` / `COMPLAINT`). Entries are persisted per region in `ses-account-suppression.json` via a new `AccountSuppressionAttributes` model.

`GetAccount`'s response is extended with a `SuppressionAttributes` object that carries the stored `SuppressedReasons`. The setting itself is metadata-only — floci does not synthesise bounce / complaint events so no auto-suppression is actually triggered; the configuration round-trips for SDK users and tooling that introspects account-level settings.

Behaviour aligned with real-AWS verification:

- `SuppressedReasons` accepts `BOUNCE` / `COMPLAINT`, validated against the AWS-canonical nested `Member must satisfy constraint: [Member must satisfy enum value set: [BOUNCE, COMPLAINT]]` wording (verbatim match against real AWS).
- `SuppressedReasons` may be omitted (treated as empty list) or supplied as an empty array (clears the reasons) — both return 200.
- Non-textual array members (JSON null, numeric, etc.) are rejected with `BadRequestException`.
- Fresh regions report the AWS-default `[BOUNCE, COMPLAINT]` via `GetAccount`; an explicit PUT (including an empty list) overrides it.
- The optional `ValidationAttributes` body field is accepted but not parsed (Tier S scope).

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against AWS Java SDK v2 `2.42.24` (`software.amazon.awssdk:sesv2`) and AWS CLI v2 against real AWS. The compatibility test `SesAccountSuppressionTest` exercises `putAccountSuppressionAttributes` / `getAccount` and asserts the `SuppressionListReason` enum round-trips through the wire. `@BeforeAll` captures the caller's existing `SuppressedReasons` and `@AfterAll` restores them so the suite can run against real AWS without leaving the account with auto-suppression disabled. The `[BOUNCE, OTHER]` invalid-Reason error wording was reproduced against real AWS and matches floci verbatim.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)