### PR TITLE
feat(sns): support FilterPolicyScope=MessageBody

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SnsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SnsTest.java
@@ -367,4 +367,122 @@ class SnsTest {
         sqs.deleteQueue(software.amazon.awssdk.services.sqs.model.DeleteQueueRequest.builder()
                 .queueUrl(cbdQueueUrl).build());
     }
+
+    @Test
+    @Order(14)
+    void filterPolicyScope_messageBody_topLevelMatch() throws InterruptedException {
+        long stamp = System.currentTimeMillis();
+        String mbQueueUrl = sqs.createQueue(software.amazon.awssdk.services.sqs.model.CreateQueueRequest.builder()
+                .queueName("sns-mb-filter-" + stamp).build()).queueUrl();
+        String mbQueueArn = sqs.getQueueAttributes(software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest.builder()
+                .queueUrl(mbQueueUrl)
+                .attributeNames(software.amazon.awssdk.services.sqs.model.QueueAttributeName.QUEUE_ARN)
+                .build())
+                .attributes().get(software.amazon.awssdk.services.sqs.model.QueueAttributeName.QUEUE_ARN);
+
+        String mbTopicArn = sns.createTopic(CreateTopicRequest.builder()
+                .name("sns-mb-filter-" + stamp).build()).topicArn();
+
+        String mbSubArn = sns.subscribe(SubscribeRequest.builder()
+                .topicArn(mbTopicArn)
+                .protocol("sqs")
+                .endpoint(mbQueueArn)
+                .build()).subscriptionArn();
+
+        sns.setSubscriptionAttributes(SetSubscriptionAttributesRequest.builder()
+                .subscriptionArn(mbSubArn)
+                .attributeName("FilterPolicyScope")
+                .attributeValue("MessageBody")
+                .build());
+        sns.setSubscriptionAttributes(SetSubscriptionAttributesRequest.builder()
+                .subscriptionArn(mbSubArn)
+                .attributeName("FilterPolicy")
+                .attributeValue("{\"event\":[\"order\"]}")
+                .build());
+
+        sns.publish(PublishRequest.builder()
+                .topicArn(mbTopicArn)
+                .message("{\"event\":\"refund\"}")
+                .build());
+        sns.publish(PublishRequest.builder()
+                .topicArn(mbTopicArn)
+                .message("{\"event\":\"order\"}")
+                .build());
+
+        Thread.sleep(500);
+
+        software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse recv = sqs.receiveMessage(
+                software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest.builder()
+                        .queueUrl(mbQueueUrl)
+                        .maxNumberOfMessages(10)
+                        .waitTimeSeconds(2)
+                        .build());
+
+        assertThat(recv.messages()).hasSize(1);
+        assertThat(recv.messages().get(0).body()).contains("order").doesNotContain("refund");
+
+        sns.unsubscribe(UnsubscribeRequest.builder().subscriptionArn(mbSubArn).build());
+        sns.deleteTopic(DeleteTopicRequest.builder().topicArn(mbTopicArn).build());
+        sqs.deleteQueue(software.amazon.awssdk.services.sqs.model.DeleteQueueRequest.builder()
+                .queueUrl(mbQueueUrl).build());
+    }
+
+    @Test
+    @Order(15)
+    void filterPolicyScope_messageBody_nestedKeyDescent() throws InterruptedException {
+        long stamp = System.currentTimeMillis();
+        String nestedQueueUrl = sqs.createQueue(software.amazon.awssdk.services.sqs.model.CreateQueueRequest.builder()
+                .queueName("sns-mb-nested-" + stamp).build()).queueUrl();
+        String nestedQueueArn = sqs.getQueueAttributes(software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest.builder()
+                .queueUrl(nestedQueueUrl)
+                .attributeNames(software.amazon.awssdk.services.sqs.model.QueueAttributeName.QUEUE_ARN)
+                .build())
+                .attributes().get(software.amazon.awssdk.services.sqs.model.QueueAttributeName.QUEUE_ARN);
+
+        String nestedTopicArn = sns.createTopic(CreateTopicRequest.builder()
+                .name("sns-mb-nested-" + stamp).build()).topicArn();
+
+        String nestedSubArn = sns.subscribe(SubscribeRequest.builder()
+                .topicArn(nestedTopicArn)
+                .protocol("sqs")
+                .endpoint(nestedQueueArn)
+                .build()).subscriptionArn();
+
+        sns.setSubscriptionAttributes(SetSubscriptionAttributesRequest.builder()
+                .subscriptionArn(nestedSubArn)
+                .attributeName("FilterPolicyScope")
+                .attributeValue("MessageBody")
+                .build());
+        sns.setSubscriptionAttributes(SetSubscriptionAttributesRequest.builder()
+                .subscriptionArn(nestedSubArn)
+                .attributeName("FilterPolicy")
+                .attributeValue("{\"store\":{\"city\":[\"seattle\"]}}")
+                .build());
+
+        sns.publish(PublishRequest.builder()
+                .topicArn(nestedTopicArn)
+                .message("{\"store\":{\"city\":\"boston\"}}")
+                .build());
+        sns.publish(PublishRequest.builder()
+                .topicArn(nestedTopicArn)
+                .message("{\"store\":{\"city\":\"seattle\"}}")
+                .build());
+
+        Thread.sleep(500);
+
+        software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse recv = sqs.receiveMessage(
+                software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest.builder()
+                        .queueUrl(nestedQueueUrl)
+                        .maxNumberOfMessages(10)
+                        .waitTimeSeconds(2)
+                        .build());
+
+        assertThat(recv.messages()).hasSize(1);
+        assertThat(recv.messages().get(0).body()).contains("seattle").doesNotContain("boston");
+
+        sns.unsubscribe(UnsubscribeRequest.builder().subscriptionArn(nestedSubArn).build());
+        sns.deleteTopic(DeleteTopicRequest.builder().topicArn(nestedTopicArn).build());
+        sqs.deleteQueue(software.amazon.awssdk.services.sqs.model.DeleteQueueRequest.builder()
+                .queueUrl(nestedQueueUrl).build());
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
@@ -314,12 +314,18 @@ public class SnsService {
         }
 
         String messageId = UUID.randomUUID().toString();
+        JsonNode parsedBody = null;
+        boolean bodyParseAttempted = false;
         for (Subscription sub : subscriptionsByTopic(effectiveArn, region)) {
             if ("true".equals(sub.getAttributes().get("PendingConfirmation"))) {
                 LOG.debugv("Skipping delivery to pending subscription {0}", sub.getSubscriptionArn());
                 continue;
             }
-            if (!matchesFilterPolicy(sub, messageAttributes)) {
+            if (!bodyParseAttempted && isMessageBodyScope(sub)) {
+                parsedBody = tryParseBody(message);
+                bodyParseAttempted = true;
+            }
+            if (!matchesFilterPolicy(sub, parsedBody, messageAttributes)) {
                 continue;
             }
             deliverMessage(sub, message, subject, messageAttributes, messageId, effectiveArn, messageGroupId, dedupId);
@@ -408,9 +414,15 @@ public class SnsService {
             String messageId = UUID.randomUUID().toString();
             @SuppressWarnings("unchecked")
             Map<String, MessageAttributeValue> attrs = (Map<String, MessageAttributeValue>) entry.get("MessageAttributes");
+            JsonNode parsedBody = null;
+            boolean bodyParseAttempted = false;
             for (Subscription sub : subscriptionsByTopic(topicArn, region)) {
                 if ("true".equals(sub.getAttributes().get("PendingConfirmation"))) continue;
-                if (!matchesFilterPolicy(sub, attrs)) continue;
+                if (!bodyParseAttempted && isMessageBodyScope(sub)) {
+                    parsedBody = tryParseBody(message);
+                    bodyParseAttempted = true;
+                }
+                if (!matchesFilterPolicy(sub, parsedBody, attrs)) continue;
                 deliverMessage(sub, message, subject, attrs, messageId, topicArn, messageGroupId, messageDeduplicationId);
             }
             LOG.debugv("Batch published message {0} (id={1}) to {2}", messageId, id, topicArn);
@@ -450,27 +462,68 @@ public class SnsService {
      * Returns {@code true} if no filter policy is set.
      * Returns {@code false} for malformed filter policies (fail closed).
      * <p>
-     * Only {@code FilterPolicyScope=MessageAttributes} is supported. When scope is
-     * {@code MessageBody}, filtering is skipped and the message is delivered (to avoid
-     * incorrectly dropping messages for an unsupported scope).
+     * {@code FilterPolicyScope=MessageAttributes} (default) evaluates the policy against
+     * the message attribute map. {@code FilterPolicyScope=MessageBody} parses the message
+     * body as JSON and evaluates the policy against the parsed tree (with nested-key
+     * descent and type-aware matching). A body that is not valid JSON fails closed.
      * <p>
      * All keys in the policy must match (AND logic). Within each key's rule array,
      * any matching element is sufficient (OR logic).
      */
-    private boolean matchesFilterPolicy(Subscription sub, Map<String, MessageAttributeValue> messageAttributes) {
+    private static boolean isMessageBodyScope(Subscription sub) {
+        return "MessageBody".equals(
+                sub.getAttributes().getOrDefault("FilterPolicyScope", "MessageAttributes"));
+    }
+
+    /**
+     * Per AWS SNS docs, {@code exists:true} requires the key to have a non-null and
+     * non-empty value. Empty strings, empty arrays, and empty objects do not count as
+     * "exists". Numbers and booleans are always considered non-empty.
+     */
+    private static boolean isNonEmptyValue(JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return false;
+        }
+        if (node.isTextual()) {
+            return !node.asText().isEmpty();
+        }
+        if (node.isContainerNode()) {
+            return !node.isEmpty();
+        }
+        return true;
+    }
+
+    private JsonNode tryParseBody(String message) {
+        if (message == null || message.isEmpty()) {
+            return null;
+        }
+        try {
+            return objectMapper.readTree(message);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    boolean matchesFilterPolicy(Subscription sub, JsonNode parsedBody,
+                                Map<String, MessageAttributeValue> messageAttributes) {
         String filterPolicyJson = sub.getAttributes().get("FilterPolicy");
         if (filterPolicyJson == null || filterPolicyJson.isBlank()) {
             return true;
         }
         String scope = sub.getAttributes().getOrDefault("FilterPolicyScope", "MessageAttributes");
-        if ("MessageBody".equals(scope)) {
-            return true;
-        }
         try {
             JsonNode filterPolicy = objectMapper.readTree(filterPolicyJson);
             if (!filterPolicy.isObject()) {
                 LOG.warnv("Invalid FilterPolicy (not a JSON object) for {0}", sub.getSubscriptionArn());
                 return false;
+            }
+            if ("MessageBody".equals(scope)) {
+                if (parsedBody == null) {
+                    LOG.debugv("FilterPolicyScope=MessageBody but body is not valid JSON for {0}; not delivering",
+                            sub.getSubscriptionArn());
+                    return false;
+                }
+                return matchesBodyPolicy(filterPolicy, parsedBody);
             }
             Map<String, MessageAttributeValue> attrs = messageAttributes != null ? messageAttributes : Map.of();
             var fields = filterPolicy.fields();
@@ -489,6 +542,137 @@ public class SnsService {
             LOG.warnv("Failed to parse filter policy for {0}: {1}", sub.getSubscriptionArn(), e.getMessage());
             return false;
         }
+    }
+
+    /**
+     * Evaluates a filter policy object against a parsed JSON body. Each policy key must
+     * match (AND); a key's value is either a rule array (terminal) or an object (nested
+     * descent into the body at the same key).
+     */
+    private boolean matchesBodyPolicy(JsonNode policy, JsonNode body) {
+        if (!policy.isObject()) {
+            return false;
+        }
+        var fields = policy.fields();
+        while (fields.hasNext()) {
+            var entry = fields.next();
+            String key = entry.getKey();
+            JsonNode ruleOrNested = entry.getValue();
+            JsonNode bodyValue = (body != null && body.isObject()) ? body.get(key) : null;
+            if (ruleOrNested.isArray()) {
+                if (!matchesBodyRules(bodyValue, ruleOrNested)) {
+                    return false;
+                }
+            } else if (ruleOrNested.isObject()) {
+                if (!matchesBodyPolicy(ruleOrNested, bodyValue)) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Evaluates a rule array against a body value. When the body value is itself an array,
+     * the rules are applied to each element (OR over elements), with {@code exists:true}
+     * additionally matching the array as a whole.
+     */
+    private boolean matchesBodyRules(JsonNode actual, JsonNode rules) {
+        if (!rules.isArray()) {
+            return false;
+        }
+        if (actual != null && actual.isArray()) {
+            boolean nonEmpty = !actual.isEmpty();
+            for (JsonNode rule : rules) {
+                if (rule.isObject() && rule.has("exists")) {
+                    if (rule.get("exists").asBoolean() == nonEmpty) {
+                        return true;
+                    }
+                } else {
+                    for (JsonNode element : actual) {
+                        if (matchesSingleBodyRule(element, rule)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+        for (JsonNode rule : rules) {
+            if (matchesSingleBodyRule(actual, rule)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean matchesSingleBodyRule(JsonNode actual, JsonNode rule) {
+        if (rule.isTextual()) {
+            return actual != null && actual.isTextual() && rule.asText().equals(actual.asText());
+        }
+        if (rule.isNumber()) {
+            if (actual == null || !actual.isNumber()) {
+                return false;
+            }
+            try {
+                return new BigDecimal(actual.asText()).compareTo(rule.decimalValue()) == 0;
+            } catch (NumberFormatException e) {
+                return false;
+            }
+        }
+        if (rule.isBoolean()) {
+            return actual != null && actual.isBoolean() && rule.booleanValue() == actual.booleanValue();
+        }
+        if (rule.isNull()) {
+            return actual != null && actual.isNull();
+        }
+        if (rule.isObject()) {
+            return matchesObjectRuleForNode(rule, actual);
+        }
+        return false;
+    }
+
+    private boolean matchesObjectRuleForNode(JsonNode rule, JsonNode actual) {
+        if (rule.has("exists")) {
+            return rule.get("exists").asBoolean() == isNonEmptyValue(actual);
+        }
+        boolean present = actual != null && !actual.isMissingNode() && !actual.isNull();
+        String stringValue = present && actual.isTextual() ? actual.asText() : null;
+        if (rule.has("prefix")) {
+            return stringValue != null && stringValue.startsWith(rule.get("prefix").asText());
+        }
+        if (rule.has("anything-but")) {
+            return matchesAnythingButForNode(rule.get("anything-but"), actual, stringValue, present);
+        }
+        if (rule.has("numeric") && present && actual.isNumber()) {
+            return evaluateNumericCondition(actual.decimalValue(), rule.get("numeric"));
+        }
+        return false;
+    }
+
+    private boolean matchesAnythingButForNode(JsonNode anythingBut, JsonNode actual,
+                                              String stringValue, boolean present) {
+        if (!present) {
+            return false;
+        }
+        if (anythingBut.isArray()) {
+            for (JsonNode v : anythingBut) {
+                if (v.isTextual() && stringValue != null && v.asText().equals(stringValue)) {
+                    return false;
+                }
+                if (v.isNumber() && actual.isNumber()
+                        && actual.decimalValue().compareTo(v.decimalValue()) == 0) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        if (anythingBut.isTextual()) {
+            return stringValue == null || !stringValue.equals(anythingBut.asText());
+        }
+        return false;
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsServiceTest.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.services.sns;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
@@ -262,5 +264,156 @@ class SnsServiceTest {
         snsService.subscribe(topic.getTopicArn(), "sqs", "http://queue2", REGION, Map.of());
         Map<String, String> attrs = snsService.getTopicAttributes(topic.getTopicArn(), REGION);
         assertEquals("2", attrs.get("SubscriptionsConfirmed"));
+    }
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private Subscription subscriptionWithPolicy(String filterPolicy, String scope) {
+        Subscription sub = new Subscription(
+                "arn:aws:sns:us-east-1:000000000000:t:sub", "arn:aws:sns:us-east-1:000000000000:t",
+                "sqs", "arn:aws:sqs:us-east-1:000000000000:q", ACCOUNT);
+        if (filterPolicy != null) {
+            sub.getAttributes().put("FilterPolicy", filterPolicy);
+        }
+        if (scope != null) {
+            sub.getAttributes().put("FilterPolicyScope", scope);
+        }
+        return sub;
+    }
+
+    private static JsonNode body(String json) {
+        try {
+            return MAPPER.readTree(json);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    @Test
+    void filterPolicy_messageBody_topLevelStringMatch() {
+        Subscription sub = subscriptionWithPolicy("{\"store\":[\"shoes\"]}", "MessageBody");
+        assertTrue(snsService.matchesFilterPolicy(sub, body("{\"store\":\"shoes\"}"), null));
+        assertFalse(snsService.matchesFilterPolicy(sub, body("{\"store\":\"books\"}"), null));
+    }
+
+    @Test
+    void filterPolicy_messageBody_nestedKeyDescent() {
+        Subscription sub = subscriptionWithPolicy(
+                "{\"store\":{\"city\":[\"seattle\",\"portland\"]}}", "MessageBody");
+        assertTrue(snsService.matchesFilterPolicy(sub,
+                body("{\"store\":{\"city\":\"seattle\"}}"), null));
+        assertFalse(snsService.matchesFilterPolicy(sub,
+                body("{\"store\":{\"city\":\"boston\"}}"), null));
+        assertFalse(snsService.matchesFilterPolicy(sub,
+                body("{\"store\":{\"region\":\"west\"}}"), null));
+    }
+
+    @Test
+    void filterPolicy_messageBody_numericRule() {
+        Subscription sub = subscriptionWithPolicy(
+                "{\"price\":[{\"numeric\":[\">=\",100,\"<\",200]}]}", "MessageBody");
+        assertTrue(snsService.matchesFilterPolicy(sub, body("{\"price\":150}"), null));
+        assertFalse(snsService.matchesFilterPolicy(sub, body("{\"price\":50}"), null));
+        assertFalse(snsService.matchesFilterPolicy(sub, body("{\"price\":\"150\"}"), null));
+    }
+
+    @Test
+    void filterPolicy_messageBody_arrayValueOr() {
+        Subscription sub = subscriptionWithPolicy("{\"tag\":[\"a\",\"b\"]}", "MessageBody");
+        assertTrue(snsService.matchesFilterPolicy(sub, body("{\"tag\":[\"x\",\"b\",\"y\"]}"), null));
+        assertFalse(snsService.matchesFilterPolicy(sub, body("{\"tag\":[\"x\",\"y\"]}"), null));
+    }
+
+    @Test
+    void filterPolicy_messageBody_existsTrueAndFalse() {
+        Subscription present = subscriptionWithPolicy("{\"k\":[{\"exists\":true}]}", "MessageBody");
+        assertTrue(snsService.matchesFilterPolicy(present, body("{\"k\":\"v\"}"), null));
+        assertFalse(snsService.matchesFilterPolicy(present, body("{\"other\":\"v\"}"), null));
+
+        Subscription absent = subscriptionWithPolicy("{\"k\":[{\"exists\":false}]}", "MessageBody");
+        assertTrue(snsService.matchesFilterPolicy(absent, body("{\"other\":\"v\"}"), null));
+        assertFalse(snsService.matchesFilterPolicy(absent, body("{\"k\":\"v\"}"), null));
+    }
+
+    @Test
+    void filterPolicy_messageBody_prefixAndAnythingBut() {
+        Subscription prefix = subscriptionWithPolicy(
+                "{\"name\":[{\"prefix\":\"foo\"}]}", "MessageBody");
+        assertTrue(snsService.matchesFilterPolicy(prefix, body("{\"name\":\"foobar\"}"), null));
+        assertFalse(snsService.matchesFilterPolicy(prefix, body("{\"name\":\"bar\"}"), null));
+
+        Subscription anythingBut = subscriptionWithPolicy(
+                "{\"name\":[{\"anything-but\":[\"foo\",\"bar\"]}]}", "MessageBody");
+        assertTrue(snsService.matchesFilterPolicy(anythingBut, body("{\"name\":\"baz\"}"), null));
+        assertFalse(snsService.matchesFilterPolicy(anythingBut, body("{\"name\":\"foo\"}"), null));
+    }
+
+    @Test
+    void filterPolicy_messageBody_prefixIsTextOnly() {
+        Subscription sub = subscriptionWithPolicy(
+                "{\"price\":[{\"prefix\":\"1\"}]}", "MessageBody");
+        assertFalse(snsService.matchesFilterPolicy(sub, body("{\"price\":100}"), null));
+        assertFalse(snsService.matchesFilterPolicy(sub, body("{\"price\":true}"), null));
+    }
+
+    @Test
+    void filterPolicy_messageBody_anythingButIsTypeAware() {
+        Subscription strRule = subscriptionWithPolicy(
+                "{\"x\":[{\"anything-but\":[\"foo\"]}]}", "MessageBody");
+        assertTrue(snsService.matchesFilterPolicy(strRule, body("{\"x\":100}"), null));
+
+        Subscription numRule = subscriptionWithPolicy(
+                "{\"x\":[{\"anything-but\":[100]}]}", "MessageBody");
+        assertFalse(snsService.matchesFilterPolicy(numRule, body("{\"x\":100}"), null));
+        assertTrue(snsService.matchesFilterPolicy(numRule, body("{\"x\":200}"), null));
+        assertTrue(snsService.matchesFilterPolicy(numRule, body("{\"x\":\"100\"}"), null));
+    }
+
+    @Test
+    void filterPolicy_messageBody_existsRequiresNonEmptyValue() {
+        Subscription existsTrue = subscriptionWithPolicy("{\"k\":[{\"exists\":true}]}", "MessageBody");
+        assertFalse(snsService.matchesFilterPolicy(existsTrue, body("{\"k\":\"\"}"), null));
+        assertFalse(snsService.matchesFilterPolicy(existsTrue, body("{\"k\":[]}"), null));
+        assertFalse(snsService.matchesFilterPolicy(existsTrue, body("{\"k\":{}}"), null));
+        assertTrue(snsService.matchesFilterPolicy(existsTrue, body("{\"k\":0}"), null));
+        assertTrue(snsService.matchesFilterPolicy(existsTrue, body("{\"k\":false}"), null));
+
+        Subscription existsFalse = subscriptionWithPolicy("{\"k\":[{\"exists\":false}]}", "MessageBody");
+        assertTrue(snsService.matchesFilterPolicy(existsFalse, body("{\"k\":\"\"}"), null));
+        assertTrue(snsService.matchesFilterPolicy(existsFalse, body("{\"k\":[]}"), null));
+        assertTrue(snsService.matchesFilterPolicy(existsFalse, body("{\"k\":{}}"), null));
+        assertFalse(snsService.matchesFilterPolicy(existsFalse, body("{\"k\":0}"), null));
+    }
+
+    @Test
+    void filterPolicy_messageBody_anythingButRequiresKeyPresent() {
+        Subscription sub = subscriptionWithPolicy(
+                "{\"x\":[{\"anything-but\":[\"foo\"]}]}", "MessageBody");
+        assertFalse(snsService.matchesFilterPolicy(sub, body("{}"), null));
+        assertFalse(snsService.matchesFilterPolicy(sub, body("{\"other\":\"v\"}"), null));
+    }
+
+    @Test
+    void filterPolicy_messageBody_invalidJson_doesNotDeliver() {
+        Subscription sub = subscriptionWithPolicy("{\"k\":[\"v\"]}", "MessageBody");
+        assertFalse(snsService.matchesFilterPolicy(sub, body("not json"), null));
+        assertFalse(snsService.matchesFilterPolicy(sub, body(""), null));
+    }
+
+    @Test
+    void filterPolicy_messageBody_noFilterPolicy_alwaysDelivers() {
+        Subscription sub = subscriptionWithPolicy(null, "MessageBody");
+        assertTrue(snsService.matchesFilterPolicy(sub, body("not json"), null));
+    }
+
+    @Test
+    void filterPolicy_messageAttributes_unchanged() {
+        Subscription sub = subscriptionWithPolicy("{\"event\":[\"order\"]}", null);
+        Map<String, io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue> matching = Map.of(
+                "event", new io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue("order", "String"));
+        Map<String, io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue> nonMatching = Map.of(
+                "event", new io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue("refund", "String"));
+        assertTrue(snsService.matchesFilterPolicy(sub, null, matching));
+        assertFalse(snsService.matchesFilterPolicy(sub, null, nonMatching));
     }
 }


### PR DESCRIPTION
## Summary

Implements `FilterPolicyScope=MessageBody` for SNS subscription filter policies. Previously the scope was accepted via `SetSubscriptionAttributes` but ignored at publish time, so all messages were delivered regardless of the policy. This is the MessageBody-scope half mentioned as expected behavior in #49 (`MessageAttributes` was already implemented).

When a subscription's scope is `MessageBody`, the published message is parsed as JSON and matched against the filter policy with:

- nested-key descent (`{"store":{"city":["seattle"]}}`)
- type-aware value matching (string, number, boolean, `null`)
- array-value fan-out (OR across elements)
- rule object operators (`exists`, `prefix`, `anything-but`, `numeric`)

Bodies that are not valid JSON fail closed and are not delivered to subscriptions using `MessageBody` scope. The body is parsed lazily once per publish, only when at least one subscription uses MessageBody scope, to avoid O(N-subscriptions) parses. The `MessageAttributes` scope evaluator is untouched.

Semantics validated against the AWS SNS docs:
- [`exists:true` requires a non-null, non-empty value](https://docs.aws.amazon.com/sns/latest/dg/attribute-key-matching.html)
- [`anything-but` does not match absent keys — it "can be combined with `exists: false`"](https://docs.aws.amazon.com/sns/latest/dg/string-value-matching.html)

Related: #49.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified end-to-end against the AWS Java SDK v2 (`software.amazon.awssdk.services.sns` 2.x) in `compatibility-tests/sdk-test-java`. Two new SDK tests exercise `SetSubscriptionAttributes(FilterPolicyScope=MessageBody)` + `SetSubscriptionAttributes(FilterPolicy=...)` followed by `Publish`, and assert that only the matching message reaches the SQS subscriber:

- top-level string match: `{"event":["order"]}`
- nested key descent: `{"store":{"city":["seattle"]}}`

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)