### PR TITLE
fix(eventbridge): propagate region for correct SQS queue resolution

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeInvoker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeInvoker.java
@@ -61,7 +61,7 @@ public class EventBridgeInvoker {
                 String queueUrl = AwsArnUtils.arnToQueueUrl(arn, baseUrl);
                 String messageGroupId = target.getSqsParameters() != null
                         ? target.getSqsParameters().getMessageGroupId() : null;
-                sqsService.sendMessage(queueUrl, payload, 0, messageGroupId, null);
+                sqsService.sendMessage(queueUrl, payload, 0, messageGroupId, null, region);
                 LOG.debugv("EventBridge delivered to SQS: {0}", arn);
             } else if (arn.contains(":sns:")) {
                 String topicRegion = extractRegionFromArn(arn, region);

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeInvokerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeInvokerTest.java
@@ -2,27 +2,46 @@ package io.github.hectorvent.floci.services.eventbridge;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.services.eventbridge.model.InputTransformer;
+import io.github.hectorvent.floci.services.eventbridge.model.Target;
+import io.github.hectorvent.floci.services.lambda.LambdaService;
+import io.github.hectorvent.floci.services.sns.SnsService;
+import io.github.hectorvent.floci.services.sqs.SqsService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 class EventBridgeInvokerTest {
 
     private EventBridgeInvoker invoker;
+    private SqsService sqsService;
 
     @BeforeEach
     void setUp() {
+        LambdaService lambdaService = mock(LambdaService.class);
+        sqsService = mock(SqsService.class);
+        SnsService snsService = mock(SnsService.class);
         invoker = new EventBridgeInvoker(
-                mock(io.github.hectorvent.floci.services.lambda.LambdaService.class),
-                mock(io.github.hectorvent.floci.services.sqs.SqsService.class),
-                mock(io.github.hectorvent.floci.services.sns.SnsService.class),
+                lambdaService,
+                sqsService,
+                snsService,
                 new ObjectMapper(),
                 mock(io.github.hectorvent.floci.config.EmulatorConfig.class)
         );
+    }
+
+    @Test
+    void invokeTarget_sqsTarget_usesSuppliedRegion() {
+        Target target = new Target("id1", "arn:aws:sqs:eu-west-1:000000000000:my-queue", null, null);
+        String event = "{\"test\": \"data\"}";
+
+        invoker.invokeTarget(target, event, "eu-west-1");
+
+        verify(sqsService).sendMessage(anyString(), eq(event), anyInt(), isNull(), isNull(), eq("eu-west-1"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
Closes #839 
Ensure the EventBridge region is correctly passed through downstream processing so that SQS queue lookup uses the intended region instead of defaulting to the primary region.

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
