### PR TITLE
chore(docker): add OCI image metadata labels

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -155,6 +155,9 @@ jobs:
             org.opencontainers.image.version=nightly-${{ needs.prepare.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.created=${{ steps.created.outputs.created }}
+            version=nightly-${{ needs.prepare.outputs.version }}
+            build-date=${{ steps.created.outputs.created }}
+            vcs-ref=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -174,5 +177,8 @@ jobs:
             org.opencontainers.image.version=nightly-${{ needs.prepare.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.created=${{ steps.created.outputs.created }}
+            version=nightly-${{ needs.prepare.outputs.version }}
+            build-date=${{ steps.created.outputs.created }}
+            vcs-ref=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -130,6 +130,10 @@ jobs:
       - name: Make binaries executable
         run: chmod +x native/amd64/*-runner native/arm64/*-runner
 
+      - name: Set created timestamp
+        id: created
+        run: echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -147,6 +151,10 @@ jobs:
           tags: |
             floci/floci:nightly
             floci/floci:nightly-${{ needs.prepare.outputs.version }}
+          labels: |
+            org.opencontainers.image.version=nightly-${{ needs.prepare.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.created.outputs.created }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -162,5 +170,9 @@ jobs:
             floci/floci:nightly-${{ needs.prepare.outputs.version }}-compat
           build-args: |
             VERSION=nightly-${{ needs.prepare.outputs.version }}
+          labels: |
+            org.opencontainers.image.version=nightly-${{ needs.prepare.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.created.outputs.created }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,10 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
 
+      - name: Set created timestamp
+        id: created
+        run: echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
       - uses: actions/download-artifact@v8
         with:
           name: native-amd64
@@ -130,6 +134,10 @@ jobs:
             floci/floci:latest
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
+          labels: |
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.created.outputs.created }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -145,5 +153,9 @@ jobs:
             floci/floci:latest-compat
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
+          labels: |
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.created.outputs.created }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,9 @@ jobs:
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.created=${{ steps.created.outputs.created }}
+            version=${{ steps.version.outputs.version }}
+            build-date=${{ steps.created.outputs.created }}
+            vcs-ref=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -157,5 +160,8 @@ jobs:
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.created=${{ steps.created.outputs.created }}
+            version=${{ steps.version.outputs.version }}
+            build-date=${{ steps.created.outputs.created }}
+            vcs-ref=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/docker/Dockerfile.compat
+++ b/docker/Dockerfile.compat
@@ -1,6 +1,13 @@
 ARG VERSION=latest
 FROM floci/floci:${VERSION}
 
+LABEL org.opencontainers.image.title="Floci (compat)" \
+      org.opencontainers.image.description="Floci compatibility image with AWS CLI and boto3 pre-installed" \
+      org.opencontainers.image.url="https://floci.io" \
+      org.opencontainers.image.source="https://github.com/floci-io/floci" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.vendor="Floci"
+
 ENV AWS_DEFAULT_REGION=us-east-1
 ENV AWS_ACCESS_KEY_ID=test
 ENV AWS_SECRET_ACCESS_KEY=test

--- a/docker/Dockerfile.jvm-package
+++ b/docker/Dockerfile.jvm-package
@@ -40,6 +40,13 @@ COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY --chmod=755 docker/localstack-parity.sh /usr/local/bin/localstack-parity.sh
 COPY --chown=1001:root target/quarkus-app quarkus-app/
 
+LABEL org.opencontainers.image.title="Floci" \
+      org.opencontainers.image.description="Local AWS emulator — open-source alternative to LocalStack Community" \
+      org.opencontainers.image.url="https://floci.io" \
+      org.opencontainers.image.source="https://github.com/floci-io/floci" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.vendor="Floci"
+
 EXPOSE 4566 6379-6399
 
 HEALTHCHECK --interval=5s --timeout=3s --retries=5 \

--- a/docker/Dockerfile.jvm-package
+++ b/docker/Dockerfile.jvm-package
@@ -45,7 +45,17 @@ LABEL org.opencontainers.image.title="Floci" \
       org.opencontainers.image.url="https://floci.io" \
       org.opencontainers.image.source="https://github.com/floci-io/floci" \
       org.opencontainers.image.licenses="MIT" \
-      org.opencontainers.image.vendor="Floci"
+      org.opencontainers.image.vendor="Floci" \
+      description="Local AWS emulator — open-source alternative to LocalStack Community" \
+      io.k8s.description="Local AWS emulator — open-source alternative to LocalStack Community" \
+      io.k8s.display-name="Floci" \
+      io.openshift.expose-services="4566:tcp" \
+      io.openshift.tags="floci aws-emulator" \
+      maintainer="Floci <https://github.com/floci-io/floci>" \
+      name="floci/floci" \
+      summary="Local AWS emulator — open-source alternative to LocalStack Community" \
+      url="https://floci.io" \
+      vendor="Floci"
 
 EXPOSE 4566 6379-6399
 

--- a/docker/Dockerfile.native-package
+++ b/docker/Dockerfile.native-package
@@ -45,7 +45,17 @@ LABEL org.opencontainers.image.title="Floci" \
       org.opencontainers.image.url="https://floci.io" \
       org.opencontainers.image.source="https://github.com/floci-io/floci" \
       org.opencontainers.image.licenses="MIT" \
-      org.opencontainers.image.vendor="Floci"
+      org.opencontainers.image.vendor="Floci" \
+      description="Local AWS emulator — open-source alternative to LocalStack Community" \
+      io.k8s.description="Local AWS emulator — open-source alternative to LocalStack Community" \
+      io.k8s.display-name="Floci" \
+      io.openshift.expose-services="4566:tcp" \
+      io.openshift.tags="floci aws-emulator" \
+      maintainer="Floci <https://github.com/floci-io/floci>" \
+      name="floci/floci" \
+      summary="Local AWS emulator — open-source alternative to LocalStack Community" \
+      url="https://floci.io" \
+      vendor="Floci"
 
 EXPOSE 4566
 

--- a/docker/Dockerfile.native-package
+++ b/docker/Dockerfile.native-package
@@ -40,6 +40,13 @@ RUN mv /app/*-runner /app/application && chmod +x /app/application
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY --chmod=755 docker/localstack-parity.sh /usr/local/bin/localstack-parity.sh
 
+LABEL org.opencontainers.image.title="Floci" \
+      org.opencontainers.image.description="Local AWS emulator — open-source alternative to LocalStack Community" \
+      org.opencontainers.image.url="https://floci.io" \
+      org.opencontainers.image.source="https://github.com/floci-io/floci" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.vendor="Floci"
+
 EXPOSE 4566
 
 HEALTHCHECK --interval=5s --timeout=3s --retries=5 \


### PR DESCRIPTION
## Summary

Adds OCI image spec labels to all three published Dockerfiles and wires dynamic label injection into the release and nightly workflows.

  - `docker/Dockerfile.native-package` — static OCI labels (title, description, url, source, licenses, vendor)
  - `docker/Dockerfile.jvm-package` — same
  - `docker/Dockerfile.compat` — same (compat-specific description)
  - `.github/workflows/release.yml` — new `Set created timestamp` step; `version`, `revision`, `created` labels on both push steps
  - `.github/workflows/nightly.yml` — same

The key label for Renovate is `org.opencontainers.image.source`. Once this ships on the next release tag, Renovate PRs will automatically link back to the repository and include release notes from the changelog, matching the behaviour shown in the issue screenshots.

Closes #851

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
