### PR TITLE
fix(eventbridge): keep persisted rules from disappearing on reload

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/Rule.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/Rule.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.services.eventbridge.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
@@ -8,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Rule {
 
     private String name;
@@ -57,6 +60,7 @@ public class Rule {
     public Instant getCreatedAt() { return createdAt; }
     public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
 
+    @JsonIgnore
     public String getRegion() {
         return AwsArnUtils.regionOrDefault(arn, null);
     }

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/RulePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/RulePersistenceTest.java
@@ -1,0 +1,84 @@
+package io.github.hectorvent.floci.services.eventbridge;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.core.storage.PersistentStorage;
+import io.github.hectorvent.floci.services.eventbridge.model.Rule;
+import io.github.hectorvent.floci.services.eventbridge.model.RuleState;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RulePersistenceTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void rulePersistsAcrossInstances() {
+        Path filePath = tempDir.resolve("eventbridge-rules.json");
+        String key = "000000000000/rule:us-east-1:default/my-rule";
+
+        Rule rule = new Rule();
+        rule.setName("my-rule");
+        rule.setArn("arn:aws:events:us-east-1:000000000000:rule/my-rule");
+        rule.setAccountId("000000000000");
+        rule.setEventBusName("default");
+        rule.setScheduleExpression("rate(5 minutes)");
+        rule.setState(RuleState.ENABLED);
+
+        var writer = new PersistentStorage<String, Rule>(
+                filePath, new TypeReference<Map<String, Rule>>() {});
+        writer.put(key, rule);
+
+        var reader = new PersistentStorage<String, Rule>(
+                filePath, new TypeReference<Map<String, Rule>>() {});
+        reader.load();
+
+        Optional<Rule> loaded = reader.get(key);
+        assertTrue(loaded.isPresent(),
+                "Rule should survive a fresh PersistentStorage instance + load()");
+        assertEquals("my-rule", loaded.get().getName());
+        assertEquals("arn:aws:events:us-east-1:000000000000:rule/my-rule", loaded.get().getArn());
+        assertEquals("rate(5 minutes)", loaded.get().getScheduleExpression());
+        assertEquals(RuleState.ENABLED, loaded.get().getState());
+    }
+
+    @Test
+    void ignoresUnknownPropertiesOnLoad() throws Exception {
+        // A persisted file may contain fields the current Rule class does not
+        // recognize: either a derived field written by an older Floci version
+        // (e.g. "region") or a brand new field from a future version. Loading
+        // must not fail in either case.
+        Path filePath = tempDir.resolve("eventbridge-rules.json");
+        String key = "000000000000/rule:us-east-1:default/legacy-rule";
+        String legacyJson = """
+                {
+                  "%s" : {
+                    "name" : "legacy-rule",
+                    "arn" : "arn:aws:events:us-east-1:000000000000:rule/legacy-rule",
+                    "accountId" : "000000000000",
+                    "eventBusName" : "default",
+                    "scheduleExpression" : "rate(5 minutes)",
+                    "state" : "ENABLED",
+                    "fieldFromFutureVersion" : "whatever"
+                  }
+                }
+                """.formatted(key);
+        Files.writeString(filePath, legacyJson);
+
+        var store = new PersistentStorage<String, Rule>(
+                filePath, new TypeReference<Map<String, Rule>>() {});
+        store.load();
+
+        Optional<Rule> loaded = store.get(key);
+        assertTrue(loaded.isPresent(),
+                "Rules with unknown extra fields should still load");
+        assertEquals("legacy-rule", loaded.get().getName());
+    }
+}


### PR DESCRIPTION
## Summary

`Rule.getRegion()` is a derived getter computed from the rule's ARN, but it has no matching setter. When `EventBridgeService` runs in any non-memory storage mode, `PersistentStorage`'s `ObjectMapper` writes `"region"` into `eventbridge-rules.json` on save, then throws `UnrecognizedPropertyException` on the next startup because `Rule` cannot deserialize it. The exception is swallowed by `PersistentStorage.load()`, so the rule store comes up empty and every `PutRule` made before the restart silently disappears.

Two changes on `Rule`:

- `@JsonIgnore` on `getRegion()` — the derived field shouldn't be written to disk in the first place.
- `@JsonIgnoreProperties(ignoreUnknown = true)` on the class — matches the convention used by `Target`, `InputTransformer`, `SqsParameters` and most other persisted models, and lets a file that includes `"region"` (written before this change) still load cleanly after upgrade.

## Reproduction

Against `floci/floci:latest` (1.5.16):

```bash
docker run -d --name floci -p 4566:4566 -v floci-data:/app/data \
  -e FLOCI_STORAGE_MODE=hybrid floci/floci:latest

aws --endpoint-url http://localhost:4566 events put-rule \
  --name my-rule --schedule-expression "rate(5 minutes)"

docker restart floci

aws --endpoint-url http://localhost:4566 events list-rules
# before: {"Rules": []}  (with UnrecognizedPropertyException in floci logs)
# after:  rule reappears
```

## Tests

New `RulePersistenceTest` (`src/test/java/io/github/hectorvent/floci/services/eventbridge/`):

- `rulePersistsAcrossInstances` — write a rule, instantiate a fresh `PersistentStorage` over the same file, assert the rule loads. Fails without `@JsonIgnore`.
- `ignoresUnknownPropertiesOnLoad` — load a JSON file containing a field the current `Rule` doesn't know. Fails without `@JsonIgnoreProperties`.

Also verified manually against the reproduction above.
