### PR TITLE
fix(apigatewayv2): include authorizerId on Route management API responses

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
@@ -1567,6 +1567,7 @@ public class ApiGatewayController {
         node.put("routeId", r.getRouteId());
         node.put("routeKey", r.getRouteKey());
         node.put("authorizationType", r.getAuthorizationType());
+        if (r.getAuthorizerId() != null) node.put("authorizerId", r.getAuthorizerId());
         if (r.getTarget() != null) node.put("target", r.getTarget());
         if (r.getRouteResponseSelectionExpression() != null) node.put("routeResponseSelectionExpression", r.getRouteResponseSelectionExpression());
         return node;

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/RouteAuthorizerIdResponseTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/RouteAuthorizerIdResponseTest.java
@@ -1,0 +1,122 @@
+package io.github.hectorvent.floci.services.apigatewayv2;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+/**
+ * Regression coverage for the HTTP API v2 management API returning {@code authorizerId}
+ * on Route resources. The value is persisted via {@code Route.setAuthorizerId} during
+ * create/update and used at runtime (e.g. WebSocketHandler, ApiGatewayExecuteController),
+ * so omitting it from the response causes IaC tools like Terraform to perceive drift on
+ * every plan.
+ */
+@QuarkusTest
+class RouteAuthorizerIdResponseTest {
+
+    @Test
+    void authorizerIdReturnedFromCreateGetAndList() {
+        String apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"authz-route-create","protocolType":"HTTP"}
+                        """)
+                .when().post("/v2/apis")
+                .then().statusCode(201)
+                .extract().path("apiId");
+
+        String authorizerId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                          "authorizerType":"JWT",
+                          "name":"jwt-authz",
+                          "identitySource":["$request.header.Authorization"],
+                          "jwtConfiguration":{"issuer":"https://example.com","audience":["api"]}
+                        }
+                        """)
+                .when().post("/v2/apis/" + apiId + "/authorizers")
+                .then().statusCode(201)
+                .extract().path("authorizerId");
+
+        String routeId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                          "routeKey":"GET /secured",
+                          "authorizationType":"JWT",
+                          "authorizerId":"%s"
+                        }
+                        """.formatted(authorizerId))
+                .when().post("/v2/apis/" + apiId + "/routes")
+                .then().statusCode(201)
+                .body("authorizationType", equalTo("JWT"))
+                .body("authorizerId", equalTo(authorizerId))
+                .extract().path("routeId");
+
+        given()
+                .when().get("/v2/apis/" + apiId + "/routes/" + routeId)
+                .then().statusCode(200)
+                .body("authorizationType", equalTo("JWT"))
+                .body("authorizerId", equalTo(authorizerId));
+
+        given()
+                .when().get("/v2/apis/" + apiId + "/routes")
+                .then().statusCode(200)
+                .body("items.authorizerId", hasItem(authorizerId));
+    }
+
+    @Test
+    void authorizerIdReturnedAfterUpdate() {
+        String apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"authz-route-update","protocolType":"HTTP"}
+                        """)
+                .when().post("/v2/apis")
+                .then().statusCode(201)
+                .extract().path("apiId");
+
+        String authorizerId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                          "authorizerType":"JWT",
+                          "name":"jwt-authz-2",
+                          "identitySource":["$request.header.Authorization"],
+                          "jwtConfiguration":{"issuer":"https://example.com","audience":["api"]}
+                        }
+                        """)
+                .when().post("/v2/apis/" + apiId + "/authorizers")
+                .then().statusCode(201)
+                .extract().path("authorizerId");
+
+        String routeId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"routeKey":"GET /open","authorizationType":"NONE"}
+                        """)
+                .when().post("/v2/apis/" + apiId + "/routes")
+                .then().statusCode(201)
+                .extract().path("routeId");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"authorizationType":"JWT","authorizerId":"%s"}
+                        """.formatted(authorizerId))
+                .when().patch("/v2/apis/" + apiId + "/routes/" + routeId)
+                .then().statusCode(200)
+                .body("authorizationType", equalTo("JWT"))
+                .body("authorizerId", equalTo(authorizerId));
+
+        given()
+                .when().get("/v2/apis/" + apiId + "/routes/" + routeId)
+                .then().statusCode(200)
+                .body("authorizerId", equalTo(authorizerId));
+    }
+}


### PR DESCRIPTION
## Summary

`Route` already persists `authorizerId` — `ApiGatewayV2Service.createRoute` / `updateRoute` call `setAuthorizerId(...)` from the request body — and the stored value is used at runtime by `WebSocketHandler` (WebSocket `$connect` authorizer) and `ApiGatewayExecuteController` (JWT routes on HTTP APIs, Lambda authorizer lookups).

But `ApiGatewayController.toV2RouteNode` never emits it, so `POST /v2/apis/{apiId}/routes`, `PATCH /v2/apis/{apiId}/routes/{routeId}`, and `GET /v2/apis/{apiId}/routes/{routeId}` all return a JSON body without `authorizerId`. From Terraform's perspective, `aws_apigatewayv2_route.authorizer_id` then shows drift on every plan even when the route is configured correctly.

This adds the missing emit alongside the other optional fields on the same method.

## Reproduction

Against `floci/floci:latest` (1.5.16):

```bash
docker run -d --rm --name floci -p 4566:4566 -e FLOCI_STORAGE_MODE=memory floci/floci:latest

API_ID=$(curl -sS -X POST http://localhost:4566/v2/apis \
  -H 'Content-Type: application/json' \
  -d '{"name":"demo","protocolType":"HTTP"}' | jq -r .apiId)

AUTH_ID=$(curl -sS -X POST http://localhost:4566/v2/apis/$API_ID/authorizers \
  -H 'Content-Type: application/json' \
  -d '{"authorizerType":"JWT","name":"a","identitySource":["$request.header.Authorization"],"jwtConfiguration":{"issuer":"https://example.com","audience":["api"]}}' \
  | jq -r .authorizerId)

ROUTE_ID=$(curl -sS -X POST http://localhost:4566/v2/apis/$API_ID/routes \
  -H 'Content-Type: application/json' \
  -d "{\"routeKey\":\"GET /x\",\"authorizationType\":\"JWT\",\"authorizerId\":\"$AUTH_ID\"}" \
  | jq -r .routeId)

curl -sS http://localhost:4566/v2/apis/$API_ID/routes/$ROUTE_ID
# before: {"routeId":"...","routeKey":"GET /x","authorizationType":"JWT"}   ← no authorizerId
# after:  {"routeId":"...","routeKey":"GET /x","authorizationType":"JWT","authorizerId":"..."}
```

## Tests

New `RouteAuthorizerIdResponseTest` (`src/test/java/io/github/hectorvent/floci/services/apigatewayv2/`):

- `authorizerIdReturnedFromCreateGetAndList` — create a route with `authorizationType=JWT` + `authorizerId`, then assert the create response, `GET /routes/{id}`, and `GET /routes` list item all contain `authorizerId`.
- `authorizerIdReturnedAfterUpdate` — create a route with `authorizationType=NONE`, then `PATCH` it to JWT with an authorizerId, and assert both the PATCH response and a subsequent `GET` include `authorizerId`.

Both tests fail without the change (`Expected: <id> / Actual: null`) and pass with it. Adjacent `ApiGatewayV2IntegrationTest` continues to pass (27 tests).