### PR TITLE
fix(dynamodb): honor legacy Expected condition in UpdateItem

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbConformanceChangesTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbConformanceChangesTest.java
@@ -12,6 +12,7 @@ import software.amazon.awssdk.services.dynamodb.model.BillingMode;
 import software.amazon.awssdk.services.dynamodb.model.ComparisonOperator;
 import software.amazon.awssdk.services.dynamodb.model.Condition;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.ExpectedAttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
 import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
@@ -570,6 +571,83 @@ class DynamoDbConformanceChangesTest {
 
         assertThat(resp.items()).hasSize(1);
         assertThat(resp.items().get(0).get("name").s()).isEqualTo("Item-2");
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 10 — Legacy API: Expected (issue #848)
+    // -----------------------------------------------------------------------
+
+    @Test @Order(85)
+    @SuppressWarnings("deprecation")
+    void updateItemLegacyExpectedAttributeMissing() {
+        // Item does not exist; expecting a specific attribute value should fail
+        assertThatThrownBy(() -> ddb.updateItem(UpdateItemRequest.builder()
+                .tableName(TABLE)
+                .key(Map.of("pk", av("legacy-exp-missing"), "sk", av("s")))
+                .attributeUpdates(Map.of(
+                        "val", AttributeValueUpdate.builder().value(av("updated")).action(AttributeAction.PUT).build()))
+                .expected(Map.of("val", ExpectedAttributeValue.builder()
+                        .comparisonOperator(ComparisonOperator.EQ)
+                        .attributeValueList(av("original"))
+                        .build()))
+                .build()))
+                .isInstanceOf(ConditionalCheckFailedException.class);
+    }
+
+    @Test @Order(86)
+    @SuppressWarnings("deprecation")
+    void updateItemLegacyExpectedValueMismatch() {
+        ddb.putItem(r -> r.tableName(TABLE).item(Map.of(
+                "pk", av("legacy-exp-mismatch"), "sk", av("s"),
+                "count", AttributeValue.builder().n("2").build())));
+
+        assertThatThrownBy(() -> ddb.updateItem(UpdateItemRequest.builder()
+                .tableName(TABLE)
+                .key(Map.of("pk", av("legacy-exp-mismatch"), "sk", av("s")))
+                .attributeUpdates(Map.of(
+                        "count", AttributeValueUpdate.builder()
+                                .value(AttributeValue.builder().n("99").build())
+                                .action(AttributeAction.PUT)
+                                .build()))
+                .expected(Map.of("count", ExpectedAttributeValue.builder()
+                        .comparisonOperator(ComparisonOperator.EQ)
+                        .attributeValueList(AttributeValue.builder().n("1").build())
+                        .build()))
+                .build()))
+                .isInstanceOf(ConditionalCheckFailedException.class);
+
+        // Verify item was not updated
+        GetItemResponse resp = ddb.getItem(r -> r
+                .tableName(TABLE)
+                .key(Map.of("pk", av("legacy-exp-mismatch"), "sk", av("s"))));
+        assertThat(resp.item().get("count").n()).isEqualTo("2");
+    }
+
+    @Test @Order(87)
+    @SuppressWarnings("deprecation")
+    void updateItemLegacyExpectedMatchSucceeds() {
+        ddb.putItem(r -> r.tableName(TABLE).item(Map.of(
+                "pk", av("legacy-exp-match"), "sk", av("s"),
+                "count", AttributeValue.builder().n("1").build())));
+
+        ddb.updateItem(UpdateItemRequest.builder()
+                .tableName(TABLE)
+                .key(Map.of("pk", av("legacy-exp-match"), "sk", av("s")))
+                .attributeUpdates(Map.of(
+                        "count", AttributeValueUpdate.builder()
+                                .value(AttributeValue.builder().n("99").build())
+                                .action(AttributeAction.PUT)
+                                .build()))
+                .expected(Map.of("count", ExpectedAttributeValue.builder()
+                        .comparisonOperator(ComparisonOperator.EQ)
+                        .attributeValueList(AttributeValue.builder().n("1").build())
+                        .build()))
+                .build());
+
+        GetItemResponse resp = ddb.getItem(r -> r
+                .tableName(TABLE)
+                .key(Map.of("pk", av("legacy-exp-match"), "sk", av("s"))));
+        assertThat(resp.item().get("count").n()).isEqualTo("99");
     }
 
     // -----------------------------------------------------------------------

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -463,11 +463,20 @@ public class DynamoDbJsonHandler {
         }
 
         JsonNode updateData = attributeUpdates.isMissingNode() ? null : attributeUpdates;
+        JsonNode expectedUpd = request.has("Expected") ? request.get("Expected") : null;
+        String conditionalOperatorUpd = request.has("ConditionalOperator")
+                ? request.get("ConditionalOperator").asText() : "AND";
 
         if (updateData != null && updateExpression != null) {
             throw new AwsException("ValidationException",
                     "Can not use both expression and non-expression parameters in the same request: "
                     + "Non-expression parameters: {AttributeUpdates} Expression parameters: {UpdateExpression}", 400);
+        }
+
+        if (conditionExpression != null && expectedUpd != null) {
+            throw new AwsException("ValidationException",
+                    "Can not use both expression and non-expression parameters in the same request: "
+                    + "Non-expression parameters: {Expected} Expression parameters: {ConditionExpression}", 400);
         }
 
         // Validate EAN/EAV usage across UpdateExpression + ConditionExpression
@@ -497,6 +506,11 @@ public class DynamoDbJsonHandler {
             checkUnusedEan(exprAttrNames, hashTokens);
             Set<String> colonTokensAll = extractColonTokens(updateExpression, conditionExpression);
             checkUnusedEav(exprAttrValues, colonTokensAll);
+        }
+
+        if (expectedUpd != null) {
+            JsonNode existingForUpd = dynamoDbService.getItem(tableName, key, region);
+            evaluateLegacyExpected(existingForUpd, expectedUpd, conditionalOperatorUpd, returnValuesOnConditionCheckFailure);
         }
 
         DynamoDbService.UpdateResult result = dynamoDbService.updateItem(
@@ -538,7 +552,7 @@ public class DynamoDbJsonHandler {
                 boolean exists = condition.get("Exists").asBoolean();
                 condResult = exists ? attrValue != null : attrValue == null;
             } else {
-                condResult = dynamoDbService.matchesKeyConditionPublic(attrValue, condition);
+                condResult = dynamoDbService.matchesKeyConditionPublic(attrValue, normalizeLegacyCondition(condition));
             }
             if (useOr) overall = overall || condResult;
             else overall = overall && condResult;
@@ -550,6 +564,27 @@ public class DynamoDbJsonHandler {
                 throw new ConditionalCheckFailedException(null);
             }
         }
+    }
+
+    /**
+     * Converts a legacy Expected condition from the {"Value": {...}} form to the
+     * {"AttributeValueList": [{...}]} form expected by matchesKeyCondition.
+     * Operators that already use AttributeValueList (IN, BETWEEN) pass through unchanged.
+     */
+    private JsonNode normalizeLegacyCondition(JsonNode condition) {
+        if (!condition.has("Value") || condition.has("AttributeValueList")) {
+            return condition;
+        }
+        com.fasterxml.jackson.databind.node.ObjectNode normalized = objectMapper.createObjectNode();
+        condition.fields().forEachRemaining(e -> {
+            if (!"Value".equals(e.getKey())) {
+                normalized.set(e.getKey(), e.getValue());
+            }
+        });
+        com.fasterxml.jackson.databind.node.ArrayNode avl = objectMapper.createArrayNode();
+        avl.add(condition.get("Value"));
+        normalized.set("AttributeValueList", avl);
+        return normalized;
     }
 
     private void addItemCollectionMetrics(ObjectNode response, JsonNode request, String tableName,

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -1336,6 +1336,240 @@ given()
     }
 
     @Test
+    void updateItemLegacyExpectedAttributeMissing() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable1",
+                    "KeySchema": [
+                        {"AttributeName": "PK", "KeyType": "HASH"},
+                        {"AttributeName": "SK", "KeyType": "RANGE"}
+                    ],
+                    "AttributeDefinitions": [
+                        {"AttributeName": "PK", "AttributeType": "S"},
+                        {"AttributeName": "SK", "AttributeType": "S"}
+                    ],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // UpdateItem with Expected on a non-existent item → ConditionalCheckFailedException
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable1",
+                    "Key": {"PK": {"S": "k1"}, "SK": {"S": "s1"}},
+                    "Expected": {"MEM_NO": {"ComparisonOperator": "EQ", "Value": {"N": "1"}}},
+                    "AttributeUpdates": {
+                        "SESSION_DATA": {"Action": "PUT", "Value": {"S": "{}"}},
+                        "VERSION":      {"Action": "ADD", "Value": {"N": "1"}}
+                    }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ConditionalCheckFailedException"))
+            .body("message", equalTo("The conditional request failed"));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "LegacyExpectedTable1"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    void updateItemLegacyExpectedValueMismatch() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable2",
+                    "KeySchema": [
+                        {"AttributeName": "PK", "KeyType": "HASH"},
+                        {"AttributeName": "SK", "KeyType": "RANGE"}
+                    ],
+                    "AttributeDefinitions": [
+                        {"AttributeName": "PK", "AttributeType": "S"},
+                        {"AttributeName": "SK", "AttributeType": "S"}
+                    ],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Put an item with MEM_NO = 2
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable2",
+                    "Item": {"PK": {"S": "k2"}, "SK": {"S": "s1"}, "MEM_NO": {"N": "2"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // UpdateItem expecting MEM_NO == 1, but actual is 2 → ConditionalCheckFailedException
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable2",
+                    "Key": {"PK": {"S": "k2"}, "SK": {"S": "s1"}},
+                    "Expected": {"MEM_NO": {"ComparisonOperator": "EQ", "Value": {"N": "1"}}},
+                    "AttributeUpdates": {
+                        "SESSION_DATA": {"Action": "PUT", "Value": {"S": "{}"}},
+                        "VERSION":      {"Action": "ADD", "Value": {"N": "1"}}
+                    }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ConditionalCheckFailedException"))
+            .body("message", equalTo("The conditional request failed"));
+
+        // Item must be unmodified
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.GetItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable2",
+                    "Key": {"PK": {"S": "k2"}, "SK": {"S": "s1"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Item.MEM_NO.N", equalTo("2"))
+            .body("Item.SESSION_DATA", is(nullValue()));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "LegacyExpectedTable2"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    void updateItemLegacyExpectedMatchSucceeds() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable3",
+                    "KeySchema": [
+                        {"AttributeName": "PK", "KeyType": "HASH"},
+                        {"AttributeName": "SK", "KeyType": "RANGE"}
+                    ],
+                    "AttributeDefinitions": [
+                        {"AttributeName": "PK", "AttributeType": "S"},
+                        {"AttributeName": "SK", "AttributeType": "S"}
+                    ],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable3",
+                    "Item": {"PK": {"S": "k3"}, "SK": {"S": "s1"}, "MEM_NO": {"N": "1"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // UpdateItem with Expected MEM_NO == 1 (matches) → success
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable3",
+                    "Key": {"PK": {"S": "k3"}, "SK": {"S": "s1"}},
+                    "Expected": {"MEM_NO": {"ComparisonOperator": "EQ", "Value": {"N": "1"}}},
+                    "AttributeUpdates": {
+                        "SESSION_DATA": {"Action": "PUT", "Value": {"S": "{}"}}
+                    }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Verify the update was applied
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.GetItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable3",
+                    "Key": {"PK": {"S": "k3"}, "SK": {"S": "s1"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Item.SESSION_DATA.S", equalTo("{}"))
+            .body("Item.MEM_NO.N", equalTo("1"));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "LegacyExpectedTable3"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
     void updateAndDescribeContinuousBackups() {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")


### PR DESCRIPTION
## Summary

UpdateItem was silently ignoring the legacy `Expected` parameter sent by AWS SDK v1 clients, causing conditional writes to always succeed regardless of the condition.

Two bugs fixed:
- `handleUpdateItem` never read the `Expected` field from the request
- `evaluateLegacyExpected` passed conditions directly to `matchesKeyConditionPublic`, which reads `AttributeValueList`, but the legacy wire format uses the singular `Value` field instead

The fix reads `Expected` and `ConditionalOperator` in `handleUpdateItem`, validates mutual exclusion with `ConditionExpression`, fetches the existing item before the update, and normalizes `{"Value": x}` → `{"AttributeValueList": [x]}` before delegating to the condition evaluator.

Closes #848
## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
