### PR TITLE
fix(ecs): reconcile task lifecycle when Docker container exits

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.services.ecs.container.EcsTaskHandle;
 import io.github.hectorvent.floci.services.ecs.model.Attribute;
 import io.github.hectorvent.floci.services.ecs.model.CapacityProvider;
 import io.github.hectorvent.floci.services.ecs.model.ClusterSetting;
+import io.github.hectorvent.floci.services.ecs.model.Container;
 import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
 import io.github.hectorvent.floci.services.ecs.model.ContainerInstance;
 import io.github.hectorvent.floci.services.ecs.model.EcsCluster;
@@ -100,6 +101,7 @@ public class EcsService {
     @PostConstruct
     void init() {
         reconciler.scheduleAtFixedRate(this::reconcileServices, 5, 5, TimeUnit.SECONDS);
+        reconciler.scheduleAtFixedRate(this::reconcileTasks, 2, 2, TimeUnit.SECONDS);
     }
 
     @PreDestroy
@@ -328,14 +330,23 @@ public class EcsService {
 
         if (dockerMode) {
             EcsTaskHandle handle = taskHandles.remove(task.getTaskArn());
-            containerManager.stopTask(handle);
+            if (handle != null) {
+                containerManager.stopTask(handle);
+                for (Container container : task.getContainers()) {
+                    String dockerId = container.getDockerId();
+                    if (dockerId != null && container.getExitCode() == null) {
+                        var exitStatus = containerManager.checkContainerExitStatus(dockerId);
+                        if (exitStatus != null && exitStatus.exitCode() != null) {
+                            container.setExitCode(exitStatus.exitCode());
+                        }
+                    }
+                    container.setLastStatus("STOPPED");
+                }
+            }
         }
 
         task.setLastStatus(TaskStatus.STOPPED.name());
         task.setStoppedAt(Instant.now());
-        if (task.getContainers() != null) {
-            task.getContainers().forEach(c -> c.setLastStatus("STOPPED"));
-        }
 
         EcsCluster cluster = resolveClusterByArn(task.getClusterArn());
         if (cluster != null && cluster.getRunningTasksCount() > 0) {
@@ -1027,6 +1038,76 @@ public class EcsService {
                                     t.getTaskArn(), e.getMessage());
                         }
                     });
+        }
+    }
+
+    // ── Task Reconciliation ───────────────────────────────────────────────────
+
+    void reconcileTasks() {
+        if (!dockerMode) {
+            return;
+        }
+        for (EcsTask task : tasks.values()) {
+            if (TaskStatus.STOPPED.name().equals(task.getLastStatus())) {
+                continue;
+            }
+            try {
+                reconcileTask(task);
+            } catch (Exception e) {
+                LOG.debugv("Error reconciling ECS task {0}: {1}", task.getTaskArn(), e.getMessage());
+            }
+        }
+    }
+
+    private void reconcileTask(EcsTask task) {
+        EcsTaskHandle handle = taskHandles.get(task.getTaskArn());
+        if (handle == null) {
+            return;
+        }
+
+        List<Container> containers = task.getContainers();
+        if (containers == null || containers.isEmpty()) {
+            return;
+        }
+
+        boolean allStopped = true;
+        boolean hasChanges = false;
+
+        for (Container container : containers) {
+            String dockerId = container.getDockerId();
+            if (dockerId == null) {
+                continue;
+            }
+
+            var exitStatus = containerManager.checkContainerExitStatus(dockerId);
+            if (exitStatus == null) {
+                allStopped = false;
+                continue;
+            }
+
+            if (container.getExitCode() == null) {
+                container.setExitCode(exitStatus.exitCode());
+                container.setLastStatus("STOPPED");
+                hasChanges = true;
+                LOG.infov("Container {0} exited with code {1}", dockerId, exitStatus.exitCode());
+            }
+        }
+
+        if (allStopped && hasChanges) {
+            task.setLastStatus(TaskStatus.STOPPED.name());
+            task.setDesiredStatus(TaskStatus.STOPPED.name());
+            task.setStoppedAt(Instant.now());
+            if (task.getContainers() != null) {
+                for (Container c : task.getContainers()) {
+                    c.setLastStatus("STOPPED");
+                }
+            }
+            EcsCluster cluster = resolveClusterByArn(task.getClusterArn());
+            if (cluster != null && cluster.getRunningTasksCount() > 0) {
+                cluster.setRunningTasksCount(cluster.getRunningTasksCount() - 1);
+            }
+            taskHandles.remove(task.getTaskArn());
+            LOG.infov("Task {0} reconciled to STOPPED", task.getTaskArn());
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManager.java
@@ -202,7 +202,7 @@ public class EcsContainerManager {
     }
 
     private Container buildContainer(String taskArn, ContainerDefinition def, String dockerId,
-                                     List<NetworkBinding> networkBindings, String region) {
+                                      List<NetworkBinding> networkBindings, String region) {
         Container container = new Container();
         container.setTaskArn(taskArn);
         container.setName(def.getName());
@@ -213,6 +213,37 @@ public class EcsContainerManager {
         container.setContainerArn(regionResolver.buildArn("ecs", region,
                 "container/" + extractTaskId(taskArn) + "/" + def.getName()));
         return container;
+    }
+
+    /**
+     * Checks if a container has exited and returns its exit status.
+     *
+     * @param dockerId the Docker container ID
+     * @return an ExitStatus containing exitCode and exitTime, or null if container is still running
+     */
+    public ExitStatus checkContainerExitStatus(String dockerId) {
+        if (dockerId == null) {
+            return null;
+        }
+        try {
+            var inspect = lifecycleManager.getDockerClient().inspectContainerCmd(dockerId).exec();
+            var state = inspect.getState();
+            if (Boolean.TRUE.equals(state.getRunning())) {
+                return null;
+            }
+            Integer exitCode = state.getExitCode();
+            String finishedAt = state.getFinishedAt();
+            return new ExitStatus(exitCode, finishedAt);
+        } catch (Exception e) {
+            LOG.debugv("Error checking container {0} exit status: {1}", dockerId, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Exit status information for a container that has stopped.
+     */
+    public record ExitStatus(Integer exitCode, String finishedAt) {
     }
 
     private static String extractTaskId(String taskArn) {

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/EcsContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/EcsContainerManagerTest.java
@@ -1,0 +1,95 @@
+package io.github.hectorvent.floci.services.ecs;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
+import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
+import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.InspectContainerCmd;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.model.ContainerState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EcsContainerManagerTest {
+
+    @Mock ContainerBuilder containerBuilder;
+    @Mock ContainerLifecycleManager lifecycleManager;
+    @Mock ContainerLogStreamer logStreamer;
+    @Mock ContainerDetector containerDetector;
+    @Mock EmulatorConfig config;
+    @Mock RegionResolver regionResolver;
+    @Mock DockerClient dockerClient;
+    @Mock InspectContainerCmd inspectContainerCmd;
+
+    EcsContainerManager manager;
+
+    @BeforeEach
+    void setUp() {
+        when(config.services()).thenReturn(mock(EmulatorConfig.ServicesConfig.class));
+        when(config.services().ecs()).thenReturn(mock(EmulatorConfig.EcsConfig.class));
+        when(config.services().ecs().dockerNetwork()).thenReturn("bridge");
+
+        manager = new EcsContainerManager(
+                containerBuilder, lifecycleManager, logStreamer, containerDetector, config, regionResolver);
+    }
+
+    @Test
+    void checkContainerExitStatus_runningContainer_returnsNull() {
+        when(lifecycleManager.getDockerClient()).thenReturn(dockerClient);
+        when(dockerClient.inspectContainerCmd("abc123")).thenReturn(inspectContainerCmd);
+
+        ContainerState state = mock(ContainerState.class);
+        when(state.getRunning()).thenReturn(true);
+
+        InspectContainerResponse response = mock(InspectContainerResponse.class);
+        when(response.getState()).thenReturn(state);
+        when(inspectContainerCmd.exec()).thenReturn(response);
+
+        assertNull(manager.checkContainerExitStatus("abc123"));
+    }
+
+    @Test
+    void checkContainerExitStatus_exitedContainer_returnsExitStatus() {
+        when(lifecycleManager.getDockerClient()).thenReturn(dockerClient);
+        when(dockerClient.inspectContainerCmd("abc123")).thenReturn(inspectContainerCmd);
+
+        ContainerState state = mock(ContainerState.class);
+        when(state.getRunning()).thenReturn(false);
+        when(state.getExitCode()).thenReturn(0);
+        when(state.getFinishedAt()).thenReturn("2026-01-01T00:00:00Z");
+
+        InspectContainerResponse response = mock(InspectContainerResponse.class);
+        when(response.getState()).thenReturn(state);
+        when(inspectContainerCmd.exec()).thenReturn(response);
+
+        var exitStatus = manager.checkContainerExitStatus("abc123");
+
+        assertNotNull(exitStatus);
+        assertEquals(0, exitStatus.exitCode());
+        assertEquals("2026-01-01T00:00:00Z", exitStatus.finishedAt());
+    }
+
+    @Test
+    void checkContainerExitStatus_nonExistentContainer_returnsNull() {
+        when(lifecycleManager.getDockerClient()).thenReturn(dockerClient);
+        when(dockerClient.inspectContainerCmd("nonexistent")).thenReturn(inspectContainerCmd);
+        when(inspectContainerCmd.exec()).thenThrow(new RuntimeException("not found"));
+
+        assertNull(manager.checkContainerExitStatus("nonexistent"));
+    }
+
+    @Test
+    void checkContainerExitStatus_nullDockerId_returnsNull() {
+        assertNull(manager.checkContainerExitStatus(null));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #889 - Ensures ECS task state is correctly reconciled when a Floci-launched Docker container exits.

Previously, ECS tasks remained in `RUNNING` state even after the underlying Docker container had exited. This fix adds proper container exit detection and updates task state to `STOPPED` with correct `exitCode` and `stoppedAt` values.

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

- Fixes incorrect behavior where ECS task state did not transition to `STOPPED`
- Ensures compatibility with standard ECS workflows like:
  - `aws ecs run-task`
  - `aws ecs wait tasks-stopped`
- Verified behavior:
  - `lastStatus` transitions to `STOPPED`
  - `exitCode` is correctly populated from Docker container state
  - `stoppedAt` is set correctly

## Checklist

- [x] `./mvnw test` passes locally
- [ ] Added/updated integration test for `checkContainerExitStatus` (recommended)
- [x] Commit messages follow Conventional Commits