### PR TITLE
fix(sns): preserve per-entry MessageAttributes in PublishBatch

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SnsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SnsTest.java
@@ -11,6 +11,9 @@ import software.amazon.awssdk.services.sns.model.ListSubscriptionsByTopicRequest
 import software.amazon.awssdk.services.sns.model.ListSubscriptionsByTopicResponse;
 import software.amazon.awssdk.services.sns.model.ListTopicsResponse;
 import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sns.model.PublishBatchRequest;
+import software.amazon.awssdk.services.sns.model.PublishBatchRequestEntry;
+import software.amazon.awssdk.services.sns.model.PublishBatchResponse;
 import software.amazon.awssdk.services.sns.model.PublishRequest;
 import software.amazon.awssdk.services.sns.model.PublishResponse;
 import software.amazon.awssdk.services.sns.model.SetSubscriptionAttributesRequest;
@@ -484,5 +487,93 @@ class SnsTest {
         sns.deleteTopic(DeleteTopicRequest.builder().topicArn(nestedTopicArn).build());
         sqs.deleteQueue(software.amazon.awssdk.services.sqs.model.DeleteQueueRequest.builder()
                 .queueUrl(nestedQueueUrl).build());
+    }
+
+    @Test
+    @Order(16)
+    void publishBatchPreservesPerEntryMessageAttributes() throws InterruptedException {
+        long stamp = System.currentTimeMillis();
+        String batchQueueUrl = sqs.createQueue(software.amazon.awssdk.services.sqs.model.CreateQueueRequest.builder()
+                .queueName("sns-batch-attrs-" + stamp).build()).queueUrl();
+        String batchQueueArn = sqs.getQueueAttributes(software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest.builder()
+                .queueUrl(batchQueueUrl)
+                .attributeNames(software.amazon.awssdk.services.sqs.model.QueueAttributeName.QUEUE_ARN)
+                .build())
+                .attributes().get(software.amazon.awssdk.services.sqs.model.QueueAttributeName.QUEUE_ARN);
+
+        String batchTopicArn = sns.createTopic(CreateTopicRequest.builder()
+                .name("sns-batch-attrs-" + stamp).build()).topicArn();
+
+        String batchSubArn = sns.subscribe(SubscribeRequest.builder()
+                .topicArn(batchTopicArn)
+                .protocol("sqs")
+                .endpoint(batchQueueArn)
+                .build()).subscriptionArn();
+
+        sns.setSubscriptionAttributes(SetSubscriptionAttributesRequest.builder()
+                .subscriptionArn(batchSubArn)
+                .attributeName("RawMessageDelivery")
+                .attributeValue("true")
+                .build());
+
+        PublishBatchResponse batchResponse = sns.publishBatch(PublishBatchRequest.builder()
+                .topicArn(batchTopicArn)
+                .publishBatchRequestEntries(
+                        PublishBatchRequestEntry.builder()
+                                .id("e1")
+                                .message("batch-msg-a")
+                                .messageAttributes(Map.of(
+                                        "ce-type", MessageAttributeValue.builder()
+                                                .dataType("String").stringValue("com.example.test").build(),
+                                        "ce-id", MessageAttributeValue.builder()
+                                                .dataType("String").stringValue("id-a").build()))
+                                .build(),
+                        PublishBatchRequestEntry.builder()
+                                .id("e2")
+                                .message("batch-msg-b")
+                                .messageAttributes(Map.of(
+                                        "ce-type", MessageAttributeValue.builder()
+                                                .dataType("String").stringValue("com.example.test").build(),
+                                        "ce-id", MessageAttributeValue.builder()
+                                                .dataType("String").stringValue("id-b").build(),
+                                        "count", MessageAttributeValue.builder()
+                                                .dataType("Number").stringValue("42").build()))
+                                .build())
+                .build());
+
+        assertThat(batchResponse.successful()).hasSize(2);
+        assertThat(batchResponse.failed()).isEmpty();
+
+        Thread.sleep(500);
+
+        software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse batchRecv = sqs.receiveMessage(
+                software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest.builder()
+                        .queueUrl(batchQueueUrl)
+                        .maxNumberOfMessages(10)
+                        .waitTimeSeconds(2)
+                        .messageAttributeNames("All")
+                        .build());
+
+        assertThat(batchRecv.messages()).hasSize(2);
+
+        var byBody = batchRecv.messages().stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        software.amazon.awssdk.services.sqs.model.Message::body, m -> m));
+
+        var attrsA = byBody.get("batch-msg-a").messageAttributes();
+        assertThat(attrsA).containsKeys("ce-type", "ce-id");
+        assertThat(attrsA.get("ce-id").stringValue()).isEqualTo("id-a");
+        assertThat(attrsA.get("ce-type").stringValue()).isEqualTo("com.example.test");
+
+        var attrsB = byBody.get("batch-msg-b").messageAttributes();
+        assertThat(attrsB).containsKeys("ce-type", "ce-id", "count");
+        assertThat(attrsB.get("ce-id").stringValue()).isEqualTo("id-b");
+        assertThat(attrsB.get("count").dataType()).isEqualTo("Number");
+        assertThat(attrsB.get("count").stringValue()).isEqualTo("42");
+
+        sns.unsubscribe(UnsubscribeRequest.builder().subscriptionArn(batchSubArn).build());
+        sns.deleteTopic(DeleteTopicRequest.builder().topicArn(batchTopicArn).build());
+        sqs.deleteQueue(software.amazon.awssdk.services.sqs.model.DeleteQueueRequest.builder()
+                .queueUrl(batchQueueUrl).build());
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsQueryHandler.java
@@ -207,14 +207,26 @@ public class SnsQueryHandler {
         String topicArn = getParam(params, "TopicArn");
         List<Map<String, Object>> entries = new ArrayList<>();
         for (int i = 1; ; i++) {
-            String id = getParam(params, "PublishBatchRequestEntries.member." + i + ".Id");
+            String entryPrefix = "PublishBatchRequestEntries.member." + i;
+            String id = getParam(params, entryPrefix + ".Id");
             if (id == null) break;
             Map<String, Object> entry = new java.util.HashMap<>();
             entry.put("Id", id);
-            entry.put("Message", getParam(params, "PublishBatchRequestEntries.member." + i + ".Message"));
-            entry.put("Subject", getParam(params, "PublishBatchRequestEntries.member." + i + ".Subject"));
-            entry.put("MessageGroupId", getParam(params, "PublishBatchRequestEntries.member." + i + ".MessageGroupId"));
-            entry.put("MessageDeduplicationId", getParam(params, "PublishBatchRequestEntries.member." + i + ".MessageDeduplicationId"));
+            entry.put("Message", getParam(params, entryPrefix + ".Message"));
+            entry.put("Subject", getParam(params, entryPrefix + ".Subject"));
+            entry.put("MessageGroupId", getParam(params, entryPrefix + ".MessageGroupId"));
+            entry.put("MessageDeduplicationId", getParam(params, entryPrefix + ".MessageDeduplicationId"));
+
+            Map<String, MessageAttributeValue> attributes = new HashMap<>();
+            for (int j = 1; ; j++) {
+                String attrPrefix = entryPrefix + ".MessageAttributes.entry." + j;
+                String name = params.getFirst(attrPrefix + ".Name");
+                if (name == null) break;
+                String value = params.getFirst(attrPrefix + ".Value.StringValue");
+                String dataType = params.getFirst(attrPrefix + ".Value.DataType");
+                if (value != null) attributes.put(name, new MessageAttributeValue(value, dataType != null ? dataType : "String"));
+            }
+            if (!attributes.isEmpty()) entry.put("MessageAttributes", attributes);
             entries.add(entry);
         }
         try {

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsQueryHandlerPublishBatchTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsQueryHandlerPublishBatchTest.java
@@ -1,0 +1,142 @@
+package io.github.hectorvent.floci.services.sns;
+
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.sqs.SqsService;
+import io.github.hectorvent.floci.services.sqs.SqsServiceFactory;
+import io.github.hectorvent.floci.services.sqs.model.Message;
+import io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests that SnsQueryHandler.handle("PublishBatch", ...) parses per-entry
+ * MessageAttributes from the Query-protocol form parameters and propagates
+ * them to subscribed SQS queues, matching the behavior of single-entry Publish.
+ */
+class SnsQueryHandlerPublishBatchTest {
+
+    private static final String REGION = "us-east-1";
+    private static final String ACCOUNT = "000000000000";
+    private static final String BASE_URL = "http://localhost:4566";
+
+    private SnsService snsService;
+    private SqsService sqsService;
+    private SnsQueryHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        RegionResolver regionResolver = new RegionResolver(REGION, ACCOUNT);
+        sqsService = SqsServiceFactory.createInMemory(BASE_URL, regionResolver);
+        snsService = new SnsService(new InMemoryStorage<>(), new InMemoryStorage<>(),
+                regionResolver, sqsService, null);
+        handler = new SnsQueryHandler(snsService);
+    }
+
+    @Test
+    void publishBatch_forwardsPerEntryMessageAttributesToSubscribedSqsQueue() {
+        // Arrange — raw delivery so SQS messages carry the SNS attributes directly
+        sqsService.createQueue("batch-attrs-queue", Map.of(), REGION);
+        String queueArn = "arn:aws:sqs:" + REGION + ":" + ACCOUNT + ":batch-attrs-queue";
+
+        snsService.createTopic("batch-attrs-topic", Map.of(), null, REGION);
+        String topicArn = "arn:aws:sns:" + REGION + ":" + ACCOUNT + ":batch-attrs-topic";
+        snsService.subscribe(topicArn, "sqs", queueArn, REGION, Map.of("RawMessageDelivery", "true"));
+
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.add("TopicArn", topicArn);
+        putBatchEntry(params, 1, "e1", "{\"id\":\"a\"}",
+                attr("kind", "String", "alpha"),
+                attr("id", "String", "id-a"),
+                attr("count", "Number", "42"));
+        putBatchEntry(params, 2, "e2", "{\"id\":\"b\"}",
+                attr("kind", "String", "alpha"),
+                attr("id", "String", "id-b"),
+                attr("count", "Number", "43"));
+
+        // Act
+        Response response = handler.handle("PublishBatch", params, REGION);
+
+        // Assert
+        assertEquals(200, response.getStatus());
+        assertTrue(((String) response.getEntity()).contains("<Successful>"));
+
+        List<Message> messages = sqsService.receiveMessage(
+                BASE_URL + "/" + ACCOUNT + "/batch-attrs-queue", 10, 30, 0, REGION);
+        assertEquals(2, messages.size());
+
+        for (Message m : messages) {
+            Map<String, MessageAttributeValue> attrs = m.getMessageAttributes();
+            assertNotNull(attrs);
+            assertEquals(3, attrs.size(), "all attributes should be forwarded, got " + attrs.keySet());
+
+            assertEquals("alpha", attrs.get("kind").getStringValue());
+            assertEquals("String", attrs.get("kind").getDataType());
+            assertEquals("Number", attrs.get("count").getDataType());
+
+            String id = attrs.get("id").getStringValue();
+            assertTrue("id-a".equals(id) || "id-b".equals(id));
+            assertTrue(m.getBody().contains(id.substring(id.length() - 1)));
+        }
+    }
+
+    @Test
+    void publishBatch_entryWithoutMessageAttributes_doesNotPolluteOtherEntries() {
+        // Arrange
+        sqsService.createQueue("mixed-attrs-queue", Map.of(), REGION);
+        String queueArn = "arn:aws:sqs:" + REGION + ":" + ACCOUNT + ":mixed-attrs-queue";
+
+        snsService.createTopic("mixed-attrs-topic", Map.of(), null, REGION);
+        String topicArn = "arn:aws:sns:" + REGION + ":" + ACCOUNT + ":mixed-attrs-topic";
+        snsService.subscribe(topicArn, "sqs", queueArn, REGION, Map.of("RawMessageDelivery", "true"));
+
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.add("TopicArn", topicArn);
+        putBatchEntry(params, 1, "with", "with-attrs", attr("marker", "String", "present"));
+        putBatchEntry(params, 2, "without", "no-attrs");
+
+        // Act
+        handler.handle("PublishBatch", params, REGION);
+
+        // Assert
+        List<Message> messages = sqsService.receiveMessage(
+                BASE_URL + "/" + ACCOUNT + "/mixed-attrs-queue", 10, 30, 0, REGION);
+        assertEquals(2, messages.size());
+
+        for (Message m : messages) {
+            if (m.getBody().contains("with-attrs")) {
+                assertEquals(1, m.getMessageAttributes().size());
+                assertEquals("present", m.getMessageAttributes().get("marker").getStringValue());
+            } else {
+                assertTrue(m.getMessageAttributes() == null || m.getMessageAttributes().isEmpty());
+            }
+        }
+    }
+
+    private static void putBatchEntry(MultivaluedMap<String, String> params, int idx,
+                                      String id, String message, Attr... attrs) {
+        String entryPrefix = "PublishBatchRequestEntries.member." + idx;
+        params.add(entryPrefix + ".Id", id);
+        params.add(entryPrefix + ".Message", message);
+        for (int j = 0; j < attrs.length; j++) {
+            String attrPrefix = entryPrefix + ".MessageAttributes.entry." + (j + 1);
+            params.add(attrPrefix + ".Name", attrs[j].name);
+            params.add(attrPrefix + ".Value.DataType", attrs[j].dataType);
+            params.add(attrPrefix + ".Value.StringValue", attrs[j].value);
+        }
+    }
+
+    private static Attr attr(String name, String dataType, String value) {
+        return new Attr(name, dataType, value);
+    }
+
+    private record Attr(String name, String dataType, String value) {}
+}


### PR DESCRIPTION
## Summary

The Query-protocol handler for `sns:PublishBatch` drops per-entry `MessageAttributes`, so any subscriber that relies on them (SQS, HTTP, Lambda) receives messages with an empty attribute map. Single-entry `sns:Publish` is unaffected.

Discovered while running a workload that uses [CloudEvents binary content mode](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/sns-protocol-binding.md) over SNS → SQS fan-out: every message published via `PublishBatch` was discarded by consumers because the `ce-type` / `ce-id` / `ce-source` routing headers were missing.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** `SnsQueryHandler.handlePublishBatch` parses `Id`, `Message`, `Subject`, `MessageGroupId`, and `MessageDeduplicationId` from each `PublishBatchRequestEntries.member.N.*`, but never reads `PublishBatchRequestEntries.member.N.MessageAttributes.entry.M.*`. The entry handed to `SnsService.publishBatch` therefore has no `MessageAttributes` key, so subscribers see an empty attribute map regardless of what the producer sent.

**Expected behavior** — `MessageAttributes` is a per-entry field on [`PublishBatchRequestEntry`](https://docs.aws.amazon.com/sns/latest/api/API_PublishBatchRequestEntry.html) (AWS API reference). All AWS SDKs serialize per-entry attributes using the same wire layout used by `Publish`, and both real AWS SNS and LocalStack forward them to subscribers unchanged. Floci's own `handlePublish` already does this — the batch handler is the only place in the codebase that diverges.

**Fix:** mirror the existing `handlePublish` attribute-parsing loop inside the per-entry loop of `handlePublishBatch`. Attach the attribute map only when non-empty, so the entry shape stays identical to the single-`Publish` path.

**Verified with:**
- AWS SDK for Java v2 (`software.amazon.awssdk:sns`) — see new compatibility test `SnsTest#publishBatchPreservesPerEntryMessageAttributes`. Asserts end-to-end fan-out into a `RawMessageDelivery=true` SQS subscriber with `String` and `Number` attribute types.
- Unit-level regression: `SnsQueryHandlerPublishBatchTest` (2 tests) — covers attribute forwarding and per-entry isolation (an entry without attributes must not inherit from siblings).

**Blast radius:** isolated to the Query-protocol `PublishBatch` path; the JSON-protocol handler (`SnsJsonHandler`), single `Publish`, and all other SNS actions are unchanged.

## Checklist

- [x] `./mvnw test` passes locally (all 80 SNS tests green: `SnsIntegrationTest`, `SnsServiceTest`, `SnsSqsFanoutFifoDeliveryTest`, `SnsLambdaIntegrationTest`, plus the new `SnsQueryHandlerPublishBatchTest`)
- [x] New or updated integration test added (handler unit test + SDK v2 compatibility test)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)