### PR TITLE
fix(sqs): reject SendMessageBatch when combined payload exceeds MaximumMessageSize

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
@@ -338,6 +338,11 @@ public class SqsJsonHandler {
         ArrayNode successful = objectMapper.createArrayNode();
         ArrayNode failed = objectMapper.createArrayNode();
 
+        record ParsedEntry(String id, String body, int delay, String groupId, String dedupId,
+                           Map<String, MessageAttributeValue> attributes) {}
+
+        List<ParsedEntry> parsedEntries = new ArrayList<>();
+        int totalSize = 0;
         if (entries.isArray()) {
             for (JsonNode entry : entries) {
                 String id = entry.path("Id").asText();
@@ -365,9 +370,19 @@ public class SqsJsonHandler {
                     });
                 }
 
+                totalSize += SqsService.computeMessageSize(messageBody, messageAttributes);
+                parsedEntries.add(new ParsedEntry(id, messageBody, delaySeconds,
+                        messageGroupId, messageDeduplicationId, messageAttributes));
+            }
+        }
+
+        sqsService.validateBatchPayloadSize(queueUrl, region, totalSize);
+
+        for (ParsedEntry parsed : parsedEntries) {
+                String id = parsed.id();
                 try {
-                    Message msg = sqsService.sendMessage(queueUrl, messageBody, delaySeconds,
-                            messageGroupId, messageDeduplicationId, messageAttributes, region);
+                    Message msg = sqsService.sendMessage(queueUrl, parsed.body(), parsed.delay(),
+                            parsed.groupId(), parsed.dedupId(), parsed.attributes(), region);
                     ObjectNode success = objectMapper.createObjectNode();
                     success.put("Id", id);
                     success.put("MessageId", msg.getMessageId());
@@ -387,7 +402,6 @@ public class SqsJsonHandler {
                     fail.put("SenderFault", true);
                     failed.add(fail);
                 }
-            }
         }
 
         ObjectNode response = objectMapper.createObjectNode();

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
@@ -313,6 +313,11 @@ public class SqsQueryHandler {
         String queueUrl = getParam(params, "QueueUrl");
         var xml = new XmlBuilder();
 
+        record ParsedEntry(String id, String body, int delay, String groupId, String dedupId,
+                           Map<String, MessageAttributeValue> attributes) {}
+
+        List<ParsedEntry> parsedEntries = new ArrayList<>();
+        int totalSize = 0;
         for (int i = 1; ; i++) {
             String id = getParam(params, "SendMessageBatchRequestEntry." + i + ".Id");
             if (id == null) break;
@@ -338,8 +343,18 @@ public class SqsQueryHandler {
                 }
             }
 
+            totalSize += SqsService.computeMessageSize(body, messageAttributes);
+            parsedEntries.add(new ParsedEntry(id, body, delaySeconds, messageGroupId,
+                    messageDeduplicationId, messageAttributes));
+        }
+
+        sqsService.validateBatchPayloadSize(queueUrl, region, totalSize);
+
+        for (ParsedEntry parsed : parsedEntries) {
+            String id = parsed.id();
             try {
-                var msg = sqsService.sendMessage(queueUrl, body, delaySeconds, messageGroupId, messageDeduplicationId, messageAttributes, region);
+                var msg = sqsService.sendMessage(queueUrl, parsed.body(), parsed.delay(),
+                        parsed.groupId(), parsed.dedupId(), parsed.attributes(), region);
                 xml.start("SendMessageBatchResultEntry")
                    .elem("Id", id)
                    .elem("MessageId", msg.getMessageId())

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -477,10 +477,29 @@ public class SqsService {
     }
 
     /**
+     * Validate that the combined payload of a {@code SendMessageBatch} call fits within
+     * the queue's {@code MaximumMessageSize}. AWS counts the batch limit as the sum of
+     * all entries (body + attributes) and returns {@code BatchRequestTooLong} as a
+     * top-level error -- not as per-entry failures -- when the total exceeds the limit.
+     */
+    public void validateBatchPayloadSize(String queueUrl, String region, int totalBytes) {
+        String storageKey = regionKey(region, queueUrl);
+        Queue queue = getQueueByUrl(storageKey, queueUrl)
+                .orElseThrow(() -> new AwsException("AWS.SimpleQueueService.NonExistentQueue",
+                        "The specified queue does not exist.", 400));
+        int max = parseMaxMessageSize(queue.getAttributes().get("MaximumMessageSize"));
+        if (totalBytes > max) {
+            throw new AwsException("BatchRequestTooLong",
+                    "Batch requests cannot be longer than " + max + " bytes. "
+                            + "You have sent " + totalBytes + " bytes.", 400);
+        }
+    }
+
+    /**
      * Total wire-level message size, in bytes, matching AWS SQS accounting:
      * UTF-8 body bytes + per-attribute (name UTF-8 + type UTF-8 + value bytes).
      */
-    private static int computeMessageSize(String body, Map<String, MessageAttributeValue> attributes) {
+    public static int computeMessageSize(String body, Map<String, MessageAttributeValue> attributes) {
         int total = body == null ? 0 : body.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
         if (attributes == null || attributes.isEmpty()) {
             return total;

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
@@ -384,6 +384,42 @@ class SqsIntegrationTest {
     }
 
     @Test
+    void sendMessageBatch_queryProtocol_oversizedBatchReturnsBatchRequestTooLong() {
+        String queueName = "batch-oversize-query-queue";
+        String queueUrl = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", queueName)
+        .when().post("/").then().statusCode(200)
+            .extract().xmlPath().getString("CreateQueueResponse.CreateQueueResult.QueueUrl");
+
+        try {
+            String bigBody = "x".repeat(100_000);
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "SendMessageBatch")
+                .formParam("QueueUrl", queueUrl)
+                .formParam("SendMessageBatchRequestEntry.1.Id", "a")
+                .formParam("SendMessageBatchRequestEntry.1.MessageBody", bigBody)
+                .formParam("SendMessageBatchRequestEntry.2.Id", "b")
+                .formParam("SendMessageBatchRequestEntry.2.MessageBody", bigBody)
+                .formParam("SendMessageBatchRequestEntry.3.Id", "c")
+                .formParam("SendMessageBatchRequestEntry.3.MessageBody", bigBody)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(400)
+                .body(containsString("BatchRequestTooLong"));
+        } finally {
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "DeleteQueue")
+                .formParam("QueueUrl", queueUrl)
+            .when().post("/");
+        }
+    }
+
+    @Test
     void createQueue_idempotent_sameAttributes() {
         String queueName = "idempotent-test-queue";
 

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
@@ -173,6 +173,30 @@ class SqsJsonProtocolTest {
     }
 
     @Test
+    @Order(6)
+    void sendMessageBatchExceedingQueueMaximumMessageSizeReturnsBatchRequestTooLong() {
+        // Default queue MaximumMessageSize is 262144 bytes. Each entry is well under the
+        // per-message limit; the sum is what trips the batch-level check.
+        String bigBody = "x".repeat(100_000);
+        String body = "{\"QueueUrl\":\"" + queueUrl + "\","
+                + "\"Entries\":["
+                + "{\"Id\":\"a\",\"MessageBody\":\"" + bigBody + "\"},"
+                + "{\"Id\":\"b\",\"MessageBody\":\"" + bigBody + "\"},"
+                + "{\"Id\":\"c\",\"MessageBody\":\"" + bigBody + "\"}"
+                + "]}";
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.SendMessageBatch")
+            .body(body)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("BatchRequestTooLong"));
+    }
+
+    @Test
     @Order(7)
     void receiveMessageOnEmptyQueueOmitsMessagesField() {
         // AWS omits the Messages field entirely when no messages are available.

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -597,6 +597,31 @@ class SqsServiceTest {
     }
 
     @Test
+    void validateBatchPayloadSize_underQueueLimit_succeeds() {
+        Queue queue = sqsService.createQueue("batch-q", null);
+        sqsService.validateBatchPayloadSize(queue.getQueueUrl(), "us-east-1", 100_000);
+    }
+
+    @Test
+    void validateBatchPayloadSize_overQueueLimit_throwsBatchRequestTooLong() {
+        Queue queue = sqsService.createQueue("batch-q", null);
+        AwsException ex = assertThrows(AwsException.class, () ->
+                sqsService.validateBatchPayloadSize(queue.getQueueUrl(), "us-east-1", 300_000));
+        assertEquals("BatchRequestTooLong", ex.getErrorCode());
+        assertTrue(ex.getMessage().contains("262144"));
+    }
+
+    @Test
+    void validateBatchPayloadSize_respectsCustomMaximumMessageSize() {
+        Queue queue = sqsService.createQueue("batch-q",
+                Map.of("MaximumMessageSize", "1048576"));
+        sqsService.validateBatchPayloadSize(queue.getQueueUrl(), "us-east-1", 1_000_000);
+        AwsException ex = assertThrows(AwsException.class, () ->
+                sqsService.validateBatchPayloadSize(queue.getQueueUrl(), "us-east-1", 1_048_577));
+        assertEquals("BatchRequestTooLong", ex.getErrorCode());
+    }
+
+    @Test
     void purgeQueueWithClearFifoDelegatesToSnsForFifoDedupOnSubscribedTopics() {
         final var sns = mock(SnsService.class);
         final var service = new SqsService(


### PR DESCRIPTION
## Summary

Closes #894.

`SendMessageBatch` was only catching per-entry size errors. A batch whose combined payload exceeded the queue's `MaximumMessageSize` would either succeed entirely (each entry individually under the per-message limit) or surface the offending entry under `Failed` with `InvalidParameterValue`. Real AWS rejects the entire call at the batch level with `AWS.SimpleQueueService.BatchRequestTooLong`.

Sum each entry's size up-front (body + attribute accounting, same as `SendMessage`) and call a new `SqsService.validateBatchPayloadSize` that throws `BatchRequestTooLong` when the total exceeds the queue's configured `MaximumMessageSize`. Per-entry processing is unchanged — individual entries that violate other rules still surface as `Failed`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Validated against real AWS SQS (eu-west-1):

```
$ aws sqs send-message-batch --queue-url ... --entries '[6 × 200KB entries]'
An error occurred (AWS.SimpleQueueService.BatchRequestTooLong) when calling
the SendMessageBatch operation: Batch requests cannot be longer than 1048576
bytes. You have sent 1200000 bytes.
```

Note: the default `MaximumMessageSize` for newly created queues in eu-west-1 is now **1 MiB** (1048576 bytes), not 256 KiB as in the original issue's reproduction. The fix uses the queue's configured `MaximumMessageSize` so this works regardless.

## Checklist

- [x] `./mvnw test` passes locally (`SqsServiceTest`: 50/50)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)