### PR TITLE
fix(sqs): scope FIFO dedup per MessageGroupId when DeduplicationScope=messageGroup

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
@@ -217,8 +217,15 @@ class GuardedMessageQueue {
     }
 
     Message findByDeduplicationId(String dedupId) {
+        return findByDeduplicationId(dedupId, null);
+    }
+
+    Message findByDeduplicationId(String dedupId, String messageGroupId) {
         try (var _ = hold()) {
-            return messages.stream().filter(msg -> dedupId.equals(msg.getMessageDeduplicationId()))
+            return messages.stream()
+                    .filter(msg -> dedupId.equals(msg.getMessageDeduplicationId()))
+                    .filter(msg -> messageGroupId == null
+                            || messageGroupId.equals(msg.getMessageGroupId()))
                     .findFirst().orElse(null);
         }
     }

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -406,7 +406,9 @@ public class SqsService {
             // are not duplicates and must both be accepted.
             boolean groupScoped = "messageGroup".equalsIgnoreCase(
                     queue.getAttributes().get("DeduplicationScope"));
-            String dedupCacheKey = groupScoped ? messageGroupId + "|" + dedupId : dedupId;
+            // Use NUL as the delimiter — it is outside the SQS-allowed character set for
+            // MessageGroupId/MessageDeduplicationId, so the composite key is unambiguous.
+            String dedupCacheKey = groupScoped ? messageGroupId + "\0" + dedupId : dedupId;
             cleanupDeduplicationCache(storageKey);
             var dedupMap = deduplicationCache.computeIfAbsent(storageKey, k -> new ConcurrentHashMap<>());
             Instant expiry = Instant.now().plusSeconds(DEDUP_WINDOW_SECONDS);

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -400,18 +400,25 @@ public class SqsService {
                 }
             }
 
-            // Check deduplication window — atomic putIfAbsent to avoid race condition
+            // Check deduplication window — atomic putIfAbsent to avoid race condition.
+            // When DeduplicationScope=messageGroup, dedup is scoped per MessageGroupId,
+            // so two messages with the same MessageDeduplicationId in different groups
+            // are not duplicates and must both be accepted.
+            boolean groupScoped = "messageGroup".equalsIgnoreCase(
+                    queue.getAttributes().get("DeduplicationScope"));
+            String dedupCacheKey = groupScoped ? messageGroupId + "|" + dedupId : dedupId;
             cleanupDeduplicationCache(storageKey);
             var dedupMap = deduplicationCache.computeIfAbsent(storageKey, k -> new ConcurrentHashMap<>());
             Instant expiry = Instant.now().plusSeconds(DEDUP_WINDOW_SECONDS);
-            Instant previous = dedupMap.putIfAbsent(dedupId, expiry);
+            Instant previous = dedupMap.putIfAbsent(dedupCacheKey, expiry);
             persistDedup(storageKey);
             if (previous != null && Instant.now().isBefore(previous)) {
                 // Duplicate within window — keep the original messageId and
                 // sequenceNumber but compute response MD5s from this request's
                 // body and attributes, otherwise SDK clients (which validate
                 // MD5 against what they sent) reject the response.
-                Message existing = getOrCreateQueue(storageKey).findByDeduplicationId(dedupId);
+                Message existing = getOrCreateQueue(storageKey).findByDeduplicationId(
+                        dedupId, groupScoped ? messageGroupId : null);
                 if (existing != null) {
                     Message response = new Message(body);
                     response.setMessageId(existing.getMessageId());

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -609,6 +609,22 @@ class SqsServiceTest {
     }
 
     @Test
+    void fifoDedup_scopedToMessageGroup_dedupKeyHasNoCollisionFromDelimiterInIds() {
+        // AWS allows '|' (and other punctuation) in both MessageGroupId and
+        // MessageDeduplicationId, so a naive "group|dedup" cache key could collide:
+        // (group="a",   dedup="b|c") and (group="a|b", dedup="c") both yield "a|b|c".
+        // Both pairs must be treated as distinct messages.
+        Queue fifo = sqsService.createQueue("collision.fifo",
+                Map.of("FifoQueue", "true",
+                        "DeduplicationScope", "messageGroup",
+                        "FifoThroughputLimit", "perMessageGroupId"));
+        sqsService.sendMessage(fifo.getQueueUrl(), "A", 0, "a", "b|c");
+        sqsService.sendMessage(fifo.getQueueUrl(), "B", 0, "a|b", "c");
+        List<Message> received = sqsService.receiveMessage(fifo.getQueueUrl(), 10, 30, 0);
+        assertEquals(2, received.size());
+    }
+
+    @Test
     void fifoDedup_queueScope_rejectsSameDedupIdAcrossGroups() {
         Queue fifo = sqsService.createQueue("queue-scoped.fifo",
                 Map.of("FifoQueue", "true"));

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -597,6 +597,28 @@ class SqsServiceTest {
     }
 
     @Test
+    void fifoDedup_scopedToMessageGroup_acceptsSameDedupIdAcrossGroups() {
+        Queue fifo = sqsService.createQueue("fair.fifo",
+                Map.of("FifoQueue", "true",
+                        "DeduplicationScope", "messageGroup",
+                        "FifoThroughputLimit", "perMessageGroupId"));
+        sqsService.sendMessage(fifo.getQueueUrl(), "A", 0, "groupA", "sameDedup");
+        sqsService.sendMessage(fifo.getQueueUrl(), "B", 0, "groupB", "sameDedup");
+        List<Message> received = sqsService.receiveMessage(fifo.getQueueUrl(), 10, 30, 0);
+        assertEquals(2, received.size());
+    }
+
+    @Test
+    void fifoDedup_queueScope_rejectsSameDedupIdAcrossGroups() {
+        Queue fifo = sqsService.createQueue("queue-scoped.fifo",
+                Map.of("FifoQueue", "true"));
+        sqsService.sendMessage(fifo.getQueueUrl(), "A", 0, "groupA", "sameDedup");
+        sqsService.sendMessage(fifo.getQueueUrl(), "B", 0, "groupB", "sameDedup");
+        List<Message> received = sqsService.receiveMessage(fifo.getQueueUrl(), 10, 30, 0);
+        assertEquals(1, received.size());
+    }
+
+    @Test
     void purgeQueueWithClearFifoDelegatesToSnsForFifoDedupOnSubscribedTopics() {
         final var sns = mock(SnsService.class);
         final var service = new SqsService(


### PR DESCRIPTION
## Summary

Closes #901.

FIFO queues default to queue-wide deduplication, but the high-throughput configuration (`DeduplicationScope=messageGroup`, `FifoThroughputLimit=perMessageGroupId`) scopes dedup to each `MessageGroupId`. Floci was always keying the dedup cache by `MessageDeduplicationId` alone, so two `SendMessage` calls that shared a dedupId across different groups would have the second silently dropped.

Compose the dedup-cache key from `messageGroupId + ":" + dedupId` when the queue is configured with `DeduplicationScope=messageGroup`; fall back to the dedupId-only key otherwise.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Validated against real AWS SQS (eu-west-1):

```
$ aws sqs create-queue --queue-name fair.fifo \
    --attributes FifoQueue=true,DeduplicationScope=messageGroup,FifoThroughputLimit=perMessageGroupId
$ aws sqs send-message ... --message-group-id GroupA --message-deduplication-id SameDedup
  → MessageId: b2205a0a-...
$ aws sqs send-message ... --message-group-id GroupB --message-deduplication-id SameDedup
  → MessageId: 2b3ece43-...   (distinct — both messages accepted)
```

## Checklist

- [x] `./mvnw test` passes locally (`SqsServiceTest`: 49/49)
- [x] New or updated integration test added (`fifoDedup_scopedToMessageGroup_acceptsSameDedupIdAcrossGroups`, `fifoDedup_queueScope_rejectsSameDedupIdAcrossGroups`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)