### PR TITLE
feat(sqs): persist and return AWSTraceHeader system attribute

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
@@ -348,7 +348,7 @@ public class SqsJsonHandler {
         ArrayNode failed = objectMapper.createArrayNode();
 
         record ParsedEntry(String id, String body, int delay, String groupId, String dedupId,
-                           Map<String, MessageAttributeValue> attributes) {}
+                           Map<String, MessageAttributeValue> attributes, String awsTraceHeader) {}
 
         List<ParsedEntry> parsedEntries = new ArrayList<>();
         int totalSize = 0;
@@ -379,9 +379,13 @@ public class SqsJsonHandler {
                     });
                 }
 
+                String entryAwsTraceHeader = entry.path("MessageSystemAttributes")
+                        .path("AWSTraceHeader").path("StringValue").asText(null);
+
                 totalSize += SqsService.computeMessageSize(messageBody, messageAttributes);
                 parsedEntries.add(new ParsedEntry(id, messageBody, delaySeconds,
-                        messageGroupId, messageDeduplicationId, messageAttributes));
+                        messageGroupId, messageDeduplicationId, messageAttributes,
+                        entryAwsTraceHeader));
             }
         }
 
@@ -391,7 +395,8 @@ public class SqsJsonHandler {
                 String id = parsed.id();
                 try {
                     Message msg = sqsService.sendMessage(queueUrl, parsed.body(), parsed.delay(),
-                            parsed.groupId(), parsed.dedupId(), parsed.attributes(), region);
+                            parsed.groupId(), parsed.dedupId(), parsed.attributes(),
+                            parsed.awsTraceHeader(), region);
                     ObjectNode success = objectMapper.createObjectNode();
                     success.put("Id", id);
                     success.put("MessageId", msg.getMessageId());

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
@@ -113,6 +113,9 @@ public class SqsJsonHandler {
                 && (all || requested.contains("MessageDeduplicationId"))) {
             attrs.put("MessageDeduplicationId", msg.getMessageDeduplicationId());
         }
+        if (msg.getAwsTraceHeader() != null && (all || requested.contains("AWSTraceHeader"))) {
+            attrs.put("AWSTraceHeader", msg.getAwsTraceHeader());
+        }
         if (!attrs.isEmpty()) {
             msgNode.set("Attributes", attrs);
         }
@@ -215,8 +218,13 @@ public class SqsJsonHandler {
             });
         }
 
+        // The AWS SDK only allows AWSTraceHeader to be set via MessageSystemAttributes;
+        // capture it (if present) so ReceiveMessage can return it as a system attribute.
+        String awsTraceHeader = request.path("MessageSystemAttributes")
+                .path("AWSTraceHeader").path("StringValue").asText(null);
+
         Message msg = sqsService.sendMessage(queueUrl, messageBody, delaySeconds,
-                messageGroupId, messageDeduplicationId, messageAttributes, region);
+                messageGroupId, messageDeduplicationId, messageAttributes, awsTraceHeader, region);
 
         ObjectNode response = objectMapper.createObjectNode();
         response.put("MessageId", msg.getMessageId());

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
@@ -332,7 +332,7 @@ public class SqsQueryHandler {
         var xml = new XmlBuilder();
 
         record ParsedEntry(String id, String body, int delay, String groupId, String dedupId,
-                           Map<String, MessageAttributeValue> attributes) {}
+                           Map<String, MessageAttributeValue> attributes, String awsTraceHeader) {}
 
         List<ParsedEntry> parsedEntries = new ArrayList<>();
         int totalSize = 0;
@@ -361,9 +361,20 @@ public class SqsQueryHandler {
                 }
             }
 
+            String entryAwsTraceHeader = null;
+            for (int k = 1; ; k++) {
+                String name = getParam(params, "SendMessageBatchRequestEntry." + i + ".MessageSystemAttribute." + k + ".Name");
+                if (name == null) break;
+                if ("AWSTraceHeader".equals(name)) {
+                    entryAwsTraceHeader = getParam(params,
+                            "SendMessageBatchRequestEntry." + i + ".MessageSystemAttribute." + k + ".Value.StringValue");
+                    break;
+                }
+            }
+
             totalSize += SqsService.computeMessageSize(body, messageAttributes);
             parsedEntries.add(new ParsedEntry(id, body, delaySeconds, messageGroupId,
-                    messageDeduplicationId, messageAttributes));
+                    messageDeduplicationId, messageAttributes, entryAwsTraceHeader));
         }
 
         sqsService.validateBatchPayloadSize(queueUrl, region, totalSize);
@@ -372,7 +383,8 @@ public class SqsQueryHandler {
             String id = parsed.id();
             try {
                 var msg = sqsService.sendMessage(queueUrl, parsed.body(), parsed.delay(),
-                        parsed.groupId(), parsed.dedupId(), parsed.attributes(), region);
+                        parsed.groupId(), parsed.dedupId(), parsed.attributes(),
+                        parsed.awsTraceHeader(), region);
                 xml.start("SendMessageBatchResultEntry")
                    .elem("Id", id)
                    .elem("MessageId", msg.getMessageId())

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
@@ -118,6 +118,10 @@ public class SqsQueryHandler {
             xml.start("Attribute").elem("Name", "MessageDeduplicationId")
                     .elem("Value", msg.getMessageDeduplicationId()).end("Attribute");
         }
+        if (msg.getAwsTraceHeader() != null && (all || requested.contains("AWSTraceHeader"))) {
+            xml.start("Attribute").elem("Name", "AWSTraceHeader")
+                    .elem("Value", msg.getAwsTraceHeader()).end("Attribute");
+        }
     }
 
     private List<String> collectIndexed(MultivaluedMap<String, String> params, String prefix) {
@@ -213,7 +217,20 @@ public class SqsQueryHandler {
             }
         }
 
-        Message msg = sqsService.sendMessage(queueUrl, body, delaySeconds, messageGroupId, messageDeduplicationId, messageAttributes, region);
+        // The AWS SDK only allows AWSTraceHeader to be set via MessageSystemAttributes;
+        // capture it (if present) so ReceiveMessage can return it as a system attribute.
+        String awsTraceHeader = null;
+        for (int i = 1; ; i++) {
+            String name = getParam(params, "MessageSystemAttribute." + i + ".Name");
+            if (name == null) break;
+            if ("AWSTraceHeader".equals(name)) {
+                awsTraceHeader = getParam(params, "MessageSystemAttribute." + i + ".Value.StringValue");
+                break;
+            }
+        }
+
+        Message msg = sqsService.sendMessage(queueUrl, body, delaySeconds, messageGroupId,
+                messageDeduplicationId, messageAttributes, awsTraceHeader, region);
 
         var xml = new XmlBuilder()
                 .elem("MessageId", msg.getMessageId())

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -374,6 +374,15 @@ public class SqsService {
                                String messageGroupId, String messageDeduplicationId,
                                Map<String, MessageAttributeValue> messageAttributes,
                                String region) {
+        return sendMessage(queueUrl, body, delaySeconds, messageGroupId, messageDeduplicationId,
+                messageAttributes, null, region);
+    }
+
+    public Message sendMessage(String queueUrl, String body, int delaySeconds,
+                               String messageGroupId, String messageDeduplicationId,
+                               Map<String, MessageAttributeValue> messageAttributes,
+                               String awsTraceHeader,
+                               String region) {
         String storageKey = regionKey(region, queueUrl);
         Queue queue = getQueueByUrl(storageKey, queueUrl)
                 .orElseThrow(() -> new AwsException("AWS.SimpleQueueService.NonExistentQueue",
@@ -459,6 +468,7 @@ public class SqsService {
             message.setMessageGroupId(messageGroupId);
             message.setMessageDeduplicationId(dedupId);
             message.setSequenceNumber(sequenceCounter.incrementAndGet());
+            message.setAwsTraceHeader(awsTraceHeader);
             if (effectiveDelaySeconds > 0) {
                 message.setVisibleAt(Instant.now().plusSeconds(effectiveDelaySeconds));
             }
@@ -478,6 +488,7 @@ public class SqsService {
 
         // Standard queue
         Message message = new Message(body);
+        message.setAwsTraceHeader(awsTraceHeader);
         if (effectiveDelaySeconds > 0) {
             message.setVisibleAt(Instant.now().plusSeconds(effectiveDelaySeconds));
         }

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/model/Message.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/model/Message.java
@@ -33,7 +33,9 @@ public class Message {
     // surface.
     private String originalSourceQueueUrl;
 
-    // Server-side system attribute callers may set via MessageSystemAttributes on SendMessage
+    // Caller-supplied system attribute (the only entry AWS allows under
+    // MessageSystemAttributes on SendMessage). Returned under Attributes.AWSTraceHeader
+    // on ReceiveMessage when requested.
     private String awsTraceHeader;
 
     // Transient fields for visibility timeout tracking

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/model/Message.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/model/Message.java
@@ -33,6 +33,9 @@ public class Message {
     // surface.
     private String originalSourceQueueUrl;
 
+    // Server-side system attribute callers may set via MessageSystemAttributes on SendMessage
+    private String awsTraceHeader;
+
     // Transient fields for visibility timeout tracking
     @JsonIgnore
     private String receiptHandle;
@@ -93,6 +96,9 @@ public class Message {
 
     public String getOriginalSourceQueueUrl() { return originalSourceQueueUrl; }
     public void setOriginalSourceQueueUrl(String originalSourceQueueUrl) { this.originalSourceQueueUrl = originalSourceQueueUrl; }
+
+    public String getAwsTraceHeader() { return awsTraceHeader; }
+    public void setAwsTraceHeader(String awsTraceHeader) { this.awsTraceHeader = awsTraceHeader; }
 
     @JsonIgnore
     public boolean isVisible() {

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
@@ -568,4 +568,90 @@ class SqsIntegrationTest {
             .when().post("/");
         }
     }
+
+    @Test
+    void sendMessage_queryProtocol_persistsAwsTraceHeader() {
+        String traceQueueName = "query-trace-queue";
+        String traceQueueUrl = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", traceQueueName)
+        .when().post("/").then().statusCode(200)
+            .extract().xmlPath().getString("CreateQueueResponse.CreateQueueResult.QueueUrl");
+
+        try {
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "SendMessage")
+                .formParam("QueueUrl", traceQueueUrl)
+                .formParam("MessageBody", "hi")
+                .formParam("MessageSystemAttribute.1.Name", "AWSTraceHeader")
+                .formParam("MessageSystemAttribute.1.Value.DataType", "String")
+                .formParam("MessageSystemAttribute.1.Value.StringValue", "Root=1-query-single")
+            .when().post("/").then().statusCode(200);
+
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "ReceiveMessage")
+                .formParam("QueueUrl", traceQueueUrl)
+                .formParam("MaxNumberOfMessages", "1")
+                .formParam("VisibilityTimeout", "0")
+                .formParam("MessageSystemAttributeName.1", "AWSTraceHeader")
+            .when().post("/").then().statusCode(200)
+                .body(containsString("<Name>AWSTraceHeader</Name>"))
+                .body(containsString("<Value>Root=1-query-single</Value>"));
+        } finally {
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "DeleteQueue")
+                .formParam("QueueUrl", traceQueueUrl)
+            .when().post("/");
+        }
+    }
+
+    @Test
+    void sendMessageBatch_queryProtocol_persistsAwsTraceHeaderPerEntry() {
+        String traceQueueName = "query-batch-trace-queue";
+        String traceQueueUrl = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", traceQueueName)
+        .when().post("/").then().statusCode(200)
+            .extract().xmlPath().getString("CreateQueueResponse.CreateQueueResult.QueueUrl");
+
+        try {
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "SendMessageBatch")
+                .formParam("QueueUrl", traceQueueUrl)
+                .formParam("SendMessageBatchRequestEntry.1.Id", "a")
+                .formParam("SendMessageBatchRequestEntry.1.MessageBody", "first")
+                .formParam("SendMessageBatchRequestEntry.1.MessageSystemAttribute.1.Name", "AWSTraceHeader")
+                .formParam("SendMessageBatchRequestEntry.1.MessageSystemAttribute.1.Value.DataType", "String")
+                .formParam("SendMessageBatchRequestEntry.1.MessageSystemAttribute.1.Value.StringValue", "Root=1-aaa")
+                .formParam("SendMessageBatchRequestEntry.2.Id", "b")
+                .formParam("SendMessageBatchRequestEntry.2.MessageBody", "second")
+                .formParam("SendMessageBatchRequestEntry.2.MessageSystemAttribute.1.Name", "AWSTraceHeader")
+                .formParam("SendMessageBatchRequestEntry.2.MessageSystemAttribute.1.Value.DataType", "String")
+                .formParam("SendMessageBatchRequestEntry.2.MessageSystemAttribute.1.Value.StringValue", "Root=1-bbb")
+            .when().post("/").then().statusCode(200);
+
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "ReceiveMessage")
+                .formParam("QueueUrl", traceQueueUrl)
+                .formParam("MaxNumberOfMessages", "10")
+                .formParam("VisibilityTimeout", "0")
+                .formParam("MessageSystemAttributeName.1", "AWSTraceHeader")
+            .when().post("/").then().statusCode(200)
+                .body(containsString("<Value>Root=1-aaa</Value>"))
+                .body(containsString("<Value>Root=1-bbb</Value>"));
+        } finally {
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "DeleteQueue")
+                .formParam("QueueUrl", traceQueueUrl)
+            .when().post("/");
+        }
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
@@ -197,6 +197,48 @@ class SqsJsonProtocolTest {
     }
 
     @Test
+    @Order(6)
+    void sendMessageBatchPersistsAwsTraceHeaderPerEntry() {
+        String traceQueueName = "json-batch-trace-queue";
+        String createBody = "{\"QueueName\":\"" + traceQueueName + "\"}";
+        String traceQueueUrl = given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+            .body(createBody)
+        .when().post("/").then().statusCode(200)
+            .extract().jsonPath().getString("QueueUrl");
+
+        String batchBody = "{\"QueueUrl\":\"" + traceQueueUrl + "\","
+                + "\"Entries\":["
+                + "{\"Id\":\"a\",\"MessageBody\":\"first\","
+                + "\"MessageSystemAttributes\":{"
+                + "\"AWSTraceHeader\":{\"DataType\":\"String\",\"StringValue\":\"Root=1-aaa\"}}},"
+                + "{\"Id\":\"b\",\"MessageBody\":\"second\","
+                + "\"MessageSystemAttributes\":{"
+                + "\"AWSTraceHeader\":{\"DataType\":\"String\",\"StringValue\":\"Root=1-bbb\"}}}"
+                + "]}";
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.SendMessageBatch")
+            .body(batchBody)
+        .when().post("/").then().statusCode(200)
+            .body("Successful", hasSize(2));
+
+        String receiveBody = "{\"QueueUrl\":\"" + traceQueueUrl + "\","
+                + "\"MaxNumberOfMessages\":10,"
+                + "\"MessageSystemAttributeNames\":[\"AWSTraceHeader\"]}";
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+            .body(receiveBody)
+        .when().post("/").then().statusCode(200)
+            .body("Messages", hasSize(2))
+            .body("Messages.Attributes.AWSTraceHeader", hasItems("Root=1-aaa", "Root=1-bbb"));
+    }
+
+    @Test
     @Order(7)
     void receiveMessageOnEmptyQueueOmitsMessagesField() {
         // AWS omits the Messages field entirely when no messages are available.

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -793,6 +793,16 @@ class SqsServiceTest {
     }
 
     @Test
+    void sendMessage_withAwsTraceHeader_isStoredAndReturnedOnReceive() {
+        Queue q = sqsService.createQueue("traced", null);
+        sqsService.sendMessage(q.getQueueUrl(), "hi", 0, null, null, null,
+                "Root=1-abc-def", "us-east-1");
+        var received = sqsService.receiveMessage(q.getQueueUrl(), 1, 30, 0);
+        assertEquals(1, received.size());
+        assertEquals("Root=1-abc-def", received.get(0).getAwsTraceHeader());
+    }
+
+    @Test
     void purgeQueueWithClearFifoDelegatesToSnsForFifoDedupOnSubscribedTopics() {
         final var sns = mock(SnsService.class);
         final var service = new SqsService(


### PR DESCRIPTION
## Summary

Closes #903.

`SendMessage`'s `MessageSystemAttributes` is restricted by AWS to a single key — `AWSTraceHeader` (the X-Ray trace context). Both the JSON and Query handlers were silently dropping it, so a subsequent `ReceiveMessage` with `MessageSystemAttributeNames=["All"]` returned only the four auto-derived attributes instead of the five AWS returns.

This change:

- Adds `awsTraceHeader` to the `Message` model.
- Parses it from `MessageSystemAttributes.AWSTraceHeader.StringValue` on both JSON 1.0 and Query wires.
- Threads a new `sendMessage` overload through `SqsService` (existing overloads remain so SNS delivery, ESM polling, etc. are unaffected).
- Surfaces it as a system attribute on receive when `All` or `AWSTraceHeader` is requested.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Validated against real AWS SQS (eu-west-1):

```
$ aws sqs send-message --queue-url ... --message-body hi \
    --message-system-attributes '{"AWSTraceHeader":{"StringValue":"Root=1-abc-def","DataType":"String"}}'
$ aws sqs receive-message --queue-url ... --message-system-attribute-names All
{ ..., "Attributes": { ..., "AWSTraceHeader": "Root=1-abc-def" } }
```

## Checklist

- [x] `./mvnw test` passes locally (`SqsServiceTest`: 48/48)
- [x] New or updated integration test added (`sendMessage_withAwsTraceHeader_isStoredAndReturnedOnReceive`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)