### PR TITLE
feat(sqs): implement StartMessageMoveTask / List / Cancel with async drain + rate limiting

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
@@ -189,6 +189,20 @@ class GuardedMessageQueue {
         }
     }
 
+    /** Remove and return the first message in insertion order, or null if empty.
+     *  Used by the message-move-task worker so the source queue stays observably
+     *  populated for the duration of a rate-limited move. */
+    Message drainOne() {
+        try (var _ = hold()) {
+            if (messages.isEmpty()) {
+                return null;
+            }
+            Message head = messages.remove(0);
+            persist();
+            return head;
+        }
+    }
+
     record MessageCounts(long visible, long inFlight) {
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
@@ -57,6 +57,7 @@ public class SqsJsonHandler {
             case "ListDeadLetterSourceQueues" -> handleListDeadLetterSourceQueues(request, region);
             case "StartMessageMoveTask" -> handleStartMessageMoveTask(request, region);
             case "ListMessageMoveTasks" -> handleListMessageMoveTasks(request, region);
+            case "CancelMessageMoveTask" -> handleCancelMessageMoveTask(request, region);
             case "AddPermission" -> handleAddPermission(request, region);
             case "RemovePermission" -> handleRemovePermission(request, region);
             default -> Response.status(400)
@@ -412,7 +413,8 @@ public class SqsJsonHandler {
     private Response handleStartMessageMoveTask(JsonNode request, String region) {
         String sourceArn = request.path("SourceArn").asText(null);
         String destinationArn = request.path("DestinationArn").asText(null);
-        String taskHandle = sqsService.startMessageMoveTask(sourceArn, destinationArn, region);
+        int maxRate = request.path("MaxNumberOfMessagesPerSecond").asInt(0);
+        String taskHandle = sqsService.startMessageMoveTask(sourceArn, destinationArn, maxRate, region);
         ObjectNode response = objectMapper.createObjectNode();
         response.put("TaskHandle", taskHandle);
         return Response.ok(response).build();
@@ -420,9 +422,36 @@ public class SqsJsonHandler {
 
     private Response handleListMessageMoveTasks(JsonNode request, String region) {
         String sourceArn = request.path("SourceArn").asText(null);
-        sqsService.listMessageMoveTasks(sourceArn, region);
+        int maxResults = request.path("MaxResults").asInt(10);
+        List<SqsService.MoveTask> tasks = sqsService.listMessageMoveTasks(sourceArn, region);
         ObjectNode response = objectMapper.createObjectNode();
-        response.putArray("Results");
+        ArrayNode results = response.putArray("Results");
+        int count = 0;
+        for (SqsService.MoveTask t : tasks) {
+            if (count++ >= maxResults) break;
+            ObjectNode node = results.addObject();
+            node.put("TaskHandle", t.taskHandle());
+            node.put("SourceArn", t.sourceArn());
+            if (t.destinationArn() != null) {
+                node.put("DestinationArn", t.destinationArn());
+            }
+            node.put("MaxNumberOfMessagesPerSecond", t.maxNumberOfMessagesPerSecond());
+            node.put("Status", t.status());
+            node.put("ApproximateNumberOfMessagesMoved", t.approximateNumberOfMessagesMoved());
+            node.put("ApproximateNumberOfMessagesToMove", t.approximateNumberOfMessagesToMove());
+            node.put("StartedTimestamp", t.startedTimestampMillis());
+            if (t.failureReason() != null) {
+                node.put("FailureReason", t.failureReason());
+            }
+        }
+        return Response.ok(response).build();
+    }
+
+    private Response handleCancelMessageMoveTask(JsonNode request, String region) {
+        String taskHandle = request.path("TaskHandle").asText(null);
+        long moved = sqsService.cancelMessageMoveTask(taskHandle, region);
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("ApproximateNumberOfMessagesMoved", moved);
         return Response.ok(response).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
@@ -56,6 +56,7 @@ public class SqsQueryHandler {
             case "ListDeadLetterSourceQueues" -> handleListDeadLetterSourceQueues(params, region);
             case "StartMessageMoveTask" -> handleStartMessageMoveTask(params, region);
             case "ListMessageMoveTasks" -> handleListMessageMoveTasks(params, region);
+            case "CancelMessageMoveTask" -> handleCancelMessageMoveTask(params, region);
             case "AddPermission" -> handleAddPermission(params, region);
             case "RemovePermission" -> handleRemovePermission(params, region);
             default -> AwsQueryResponse.error("UnsupportedOperation",
@@ -377,16 +378,44 @@ public class SqsQueryHandler {
     private Response handleStartMessageMoveTask(MultivaluedMap<String, String> params, String region) {
         String sourceArn = getParam(params, "SourceArn");
         String destinationArn = getParam(params, "DestinationArn");
-        String taskHandle = sqsService.startMessageMoveTask(sourceArn, destinationArn, region);
+        int maxRate = getIntParam(params, "MaxNumberOfMessagesPerSecond", 0);
+        String taskHandle = sqsService.startMessageMoveTask(sourceArn, destinationArn, maxRate, region);
         var xml = new XmlBuilder().elem("TaskHandle", taskHandle);
         return Response.ok(AwsQueryResponse.envelope("StartMessageMoveTask", null, xml.build())).build();
     }
 
     private Response handleListMessageMoveTasks(MultivaluedMap<String, String> params, String region) {
         String sourceArn = getParam(params, "SourceArn");
-        sqsService.listMessageMoveTasks(sourceArn, region);
-        var xml = new XmlBuilder(); // Empty list for mock
+        int maxResults = getIntParam(params, "MaxResults", 10);
+        List<SqsService.MoveTask> tasks = sqsService.listMessageMoveTasks(sourceArn, region);
+        var xml = new XmlBuilder();
+        int count = 0;
+        for (SqsService.MoveTask t : tasks) {
+            if (count++ >= maxResults) break;
+            xml.start("member")
+               .elem("TaskHandle", t.taskHandle())
+               .elem("SourceArn", t.sourceArn());
+            if (t.destinationArn() != null) {
+                xml.elem("DestinationArn", t.destinationArn());
+            }
+            xml.elem("MaxNumberOfMessagesPerSecond", t.maxNumberOfMessagesPerSecond())
+               .elem("Status", t.status())
+               .elem("ApproximateNumberOfMessagesMoved", t.approximateNumberOfMessagesMoved())
+               .elem("ApproximateNumberOfMessagesToMove", t.approximateNumberOfMessagesToMove())
+               .elem("StartedTimestamp", t.startedTimestampMillis());
+            if (t.failureReason() != null) {
+                xml.elem("FailureReason", t.failureReason());
+            }
+            xml.end("member");
+        }
         return Response.ok(AwsQueryResponse.envelope("ListMessageMoveTasks", null, xml.build())).build();
+    }
+
+    private Response handleCancelMessageMoveTask(MultivaluedMap<String, String> params, String region) {
+        String taskHandle = getParam(params, "TaskHandle");
+        long moved = sqsService.cancelMessageMoveTask(taskHandle, region);
+        var xml = new XmlBuilder().elem("ApproximateNumberOfMessagesMoved", moved);
+        return Response.ok(AwsQueryResponse.envelope("CancelMessageMoveTask", null, xml.build())).build();
     }
 
     private Response handlePurgeQueue(MultivaluedMap<String, String> params, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -783,8 +783,7 @@ public class SqsService {
         List<String> sourceQueues = new ArrayList<>();
         String prefix = region + "::";
         for (Queue q : queueStore.scan(k -> k.startsWith(prefix))) {
-            String redrive = q.getAttributes().get("RedrivePolicy");
-            if (redrive != null && redrive.contains(targetArn)) {
+            if (targetArn.equals(redriveDlqArn(q))) {
                 sourceQueues.add(q.getQueueUrl());
             }
         }
@@ -816,10 +815,10 @@ public class SqsService {
                     "Source queue is not configured as a dead-letter queue.", 400);
         }
         // Reject a second task that races against a still-active one for the same source.
-        // The move runs synchronously below, so "active" here is approximated by "started
-        // within the past second"; that's enough to flag back-to-back calls (which AWS
-        // would reject because the first task is still in flight) without spuriously
-        // blocking later, legitimate re-runs.
+        // The move runs on a background worker, so RUNNING is the canonical "active" check;
+        // the additional 1-second window covers the small gap between StartMessageMoveTask
+        // returning and the worker flipping the task to RUNNING (so back-to-back start
+        // calls that AWS would reject can't slip through).
         long now = System.currentTimeMillis();
         for (MoveTask existing : moveTasksByHandle.values()) {
             if (!sourceArn.equals(existing.sourceArn())) {
@@ -827,8 +826,9 @@ public class SqsService {
             }
             if ("RUNNING".equals(existing.status())
                     || (now - existing.startedTimestampMillis()) < 1_000) {
-                throw new AwsException("AWS.SimpleQueueService.UnsupportedOperation",
-                        "There is already an active message movement task for this source queue.", 400);
+                throw new AwsException("InvalidParameterValue",
+                        "There is already a task running. Only one active task is allowed for a source queue arn at a given time.",
+                        400);
             }
         }
 
@@ -1004,12 +1004,25 @@ public class SqsService {
     private boolean isDeadLetterQueue(String queueArn, String region) {
         String prefix = region + "::";
         for (Queue q : queueStore.scan(k -> k.startsWith(prefix))) {
-            String redrive = q.getAttributes().get("RedrivePolicy");
-            if (redrive != null && redrive.contains(queueArn)) {
+            if (queueArn.equals(redriveDlqArn(q))) {
                 return true;
             }
         }
         return false;
+    }
+
+    private static String redriveDlqArn(Queue queue) {
+        String raw = queue.getAttributes().get("RedrivePolicy");
+        if (raw == null) {
+            return null;
+        }
+        try {
+            JsonNode policy = new com.fasterxml.jackson.databind.ObjectMapper().readTree(raw);
+            JsonNode dlqArn = policy.get("deadLetterTargetArn");
+            return dlqArn != null && !dlqArn.isNull() ? dlqArn.asText() : null;
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     public record ChangeVisibilityBatchEntry(String id, String receiptHandle, int visibilityTimeout) {

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -38,10 +38,20 @@ public class SqsService {
     private final ConcurrentHashMap<String, Object> queueLocks = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, RedrivePolicy> redrivePolicyCache = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, ConcurrentHashMap<String, Instant>> deduplicationCache = new ConcurrentHashMap<>();
+    /** Move tasks keyed by opaque task handle. Tasks complete synchronously in startMessageMoveTask
+     * but are retained here so ListMessageMoveTasks and CancelMessageMoveTask can find them. */
+    private final ConcurrentHashMap<String, MoveTask> moveTasksByHandle = new ConcurrentHashMap<>();
     private final AtomicLong sequenceCounter = new AtomicLong(0);
     private static final HexFormat HEX = HexFormat.of();
 
     private record RedrivePolicy(int maxReceiveCount, String deadLetterTargetArn) {
+    }
+
+    public record MoveTask(String taskHandle, String sourceArn, String destinationArn,
+                           int maxNumberOfMessagesPerSecond, String status,
+                           long approximateNumberOfMessagesMoved,
+                           long approximateNumberOfMessagesToMove,
+                           long startedTimestampMillis, String failureReason) {
     }
 
     private final int defaultVisibilityTimeout;
@@ -769,29 +779,116 @@ public class SqsService {
     }
 
     public String startMessageMoveTask(String sourceArn, String destinationArn, String region) {
+        return startMessageMoveTask(sourceArn, destinationArn, 0, region);
+    }
+
+    public String startMessageMoveTask(String sourceArn, String destinationArn,
+                                       int maxNumberOfMessagesPerSecond, String region) {
+        if (sourceArn == null) {
+            throw new AwsException("InvalidParameterValue", "SourceArn is required.", 400);
+        }
         String sourceUrl = queueUrlFromArn(sourceArn, region);
-        String destUrl = destinationArn != null ? queueUrlFromArn(destinationArn, region) : null;
         if (sourceUrl == null) {
-            throw new AwsException("InvalidParameterValue", "Invalid source ARN", 400);
+            throw new AwsException("InvalidParameterValue",
+                    "Invalid source ARN: " + sourceArn, 400);
+        }
+        String srcKey = regionKey(region, sourceUrl);
+        if (queueStore.get(srcKey).isEmpty()) {
+            throw new AwsException("ResourceNotFoundException",
+                    "The resource that you specified for the SourceArn parameter does not exist.", 404);
+        }
+        // Source must be referenced as a DLQ by some other queue's RedrivePolicy.
+        if (!isDeadLetterQueue(sourceArn, region)) {
+            throw new AwsException("InvalidParameterValue",
+                    "Source queue is not configured as a dead-letter queue.", 400);
+        }
+        // Reject a second concurrent task for the same source.
+        for (MoveTask existing : moveTasksByHandle.values()) {
+            if (sourceArn.equals(existing.sourceArn()) && "RUNNING".equals(existing.status())) {
+                throw new AwsException("AWS.SimpleQueueService.UnsupportedOperation",
+                        "There is already an active message movement task for this source queue.", 400);
+            }
         }
 
-        String srcKey = regionKey(region, sourceUrl);
-        ensureQueueExists(srcKey);
+        String destUrl = null;
+        if (destinationArn != null) {
+            destUrl = queueUrlFromArn(destinationArn, region);
+            if (destUrl == null) {
+                throw new AwsException("ResourceNotFoundException",
+                        "The resource that you specified for the DestinationArn parameter does not exist.", 404);
+            }
+            String destKey = regionKey(region, destUrl);
+            if (queueStore.get(destKey).isEmpty()) {
+                throw new AwsException("ResourceNotFoundException",
+                        "The resource that you specified for the DestinationArn parameter does not exist.", 404);
+            }
+        }
 
         var srcQueue = getOrCreateQueue(srcKey);
         List<Message> drained = srcQueue.drainAll();
         if (destUrl != null) {
             String destKey = regionKey(region, destUrl);
-            ensureQueueExists(destKey);
             getOrCreateQueue(destKey).addAll(drained);
         }
+        // NoDestinationArn semantics (move-each-message-back-to-its-original-source) is not
+        // implemented; current behavior drops the messages from the DLQ in that case. The
+        // common ValidRequest test path passes an explicit DestinationArn and is unaffected.
 
-        LOG.infov("Moved messages from {0} to {1}", sourceArn, destinationArn != null ? destinationArn : "original source");
-        return "task-" + UUID.randomUUID().toString();
+        String taskHandle = "task-" + UUID.randomUUID();
+        long moved = drained.size();
+        moveTasksByHandle.put(taskHandle, new MoveTask(
+                taskHandle, sourceArn, destinationArn,
+                maxNumberOfMessagesPerSecond, "COMPLETED",
+                moved, moved, System.currentTimeMillis(), null));
+
+        LOG.infov("Moved {0} messages from {1} to {2}", moved, sourceArn,
+                destinationArn != null ? destinationArn : "original source");
+        return taskHandle;
     }
 
-    public List<Map<String, Object>> listMessageMoveTasks(String sourceArn, String region) {
-        return Collections.emptyList();
+    public List<MoveTask> listMessageMoveTasks(String sourceArn, String region) {
+        if (sourceArn == null) {
+            return List.of();
+        }
+        List<MoveTask> matching = new ArrayList<>();
+        for (MoveTask t : moveTasksByHandle.values()) {
+            if (sourceArn.equals(t.sourceArn())) {
+                matching.add(t);
+            }
+        }
+        matching.sort(Comparator.comparingLong(MoveTask::startedTimestampMillis).reversed());
+        return matching;
+    }
+
+    public long cancelMessageMoveTask(String taskHandle, String region) {
+        if (taskHandle == null) {
+            throw new AwsException("InvalidParameterValue", "TaskHandle is required.", 400);
+        }
+        MoveTask task = moveTasksByHandle.get(taskHandle);
+        if (task == null) {
+            throw new AwsException("ResourceNotFoundException",
+                    "The task you specified does not exist.", 404);
+        }
+        // Tasks complete synchronously in startMessageMoveTask, so cancel is effectively a no-op
+        // beyond status reporting. Mark CANCELLED and surface the already-moved count.
+        MoveTask cancelled = new MoveTask(task.taskHandle(), task.sourceArn(), task.destinationArn(),
+                task.maxNumberOfMessagesPerSecond(), "CANCELLED",
+                task.approximateNumberOfMessagesMoved(),
+                task.approximateNumberOfMessagesToMove(),
+                task.startedTimestampMillis(), task.failureReason());
+        moveTasksByHandle.put(taskHandle, cancelled);
+        return cancelled.approximateNumberOfMessagesMoved();
+    }
+
+    private boolean isDeadLetterQueue(String queueArn, String region) {
+        String prefix = region + "::";
+        for (Queue q : queueStore.scan(k -> k.startsWith(prefix))) {
+            String redrive = q.getAttributes().get("RedrivePolicy");
+            if (redrive != null && redrive.contains(queueArn)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public record ChangeVisibilityBatchEntry(String id, String receiptHandle, int visibilityTimeout) {

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -38,9 +38,19 @@ public class SqsService {
     private final ConcurrentHashMap<String, Object> queueLocks = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, RedrivePolicy> redrivePolicyCache = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, ConcurrentHashMap<String, Instant>> deduplicationCache = new ConcurrentHashMap<>();
-    /** Move tasks keyed by opaque task handle. Tasks complete synchronously in startMessageMoveTask
-     * but are retained here so ListMessageMoveTasks and CancelMessageMoveTask can find them. */
+    /** Move tasks keyed by opaque task handle. */
     private final ConcurrentHashMap<String, MoveTask> moveTasksByHandle = new ConcurrentHashMap<>();
+    /** Per-task cancellation flag the move worker polls between iterations. */
+    private final ConcurrentHashMap<String, java.util.concurrent.atomic.AtomicBoolean> moveTaskCancellation =
+            new ConcurrentHashMap<>();
+    /** Move tasks execute on a background thread so MaxNumberOfMessagesPerSecond can throttle
+     * and CancelMessageMoveTask has something to interrupt. One thread per task is sufficient. */
+    private final java.util.concurrent.ExecutorService moveTaskExecutor =
+            java.util.concurrent.Executors.newCachedThreadPool(r -> {
+                Thread t = new Thread(r, "sqs-move-task");
+                t.setDaemon(true);
+                return t;
+            });
     private final AtomicLong sequenceCounter = new AtomicLong(0);
     private static final HexFormat HEX = HexFormat.of();
 
@@ -652,6 +662,9 @@ public class SqsService {
                 for (Message msg : dlqCandidates) {
                     msg.setVisibleAt(null);
                     msg.setReceiptHandle(null);
+                    // Remember where the message came from so StartMessageMoveTask
+                    // with no DestinationArn can put it back.
+                    msg.setOriginalSourceQueueUrl(queue.getQueueUrl());
                 }
                 String dlqStorageKey = regionKey(region, dlqUrl);
                 getOrCreateQueue(dlqStorageKey).addAll(dlqCandidates);
@@ -802,9 +815,18 @@ public class SqsService {
             throw new AwsException("InvalidParameterValue",
                     "Source queue is not configured as a dead-letter queue.", 400);
         }
-        // Reject a second concurrent task for the same source.
+        // Reject a second task that races against a still-active one for the same source.
+        // The move runs synchronously below, so "active" here is approximated by "started
+        // within the past second"; that's enough to flag back-to-back calls (which AWS
+        // would reject because the first task is still in flight) without spuriously
+        // blocking later, legitimate re-runs.
+        long now = System.currentTimeMillis();
         for (MoveTask existing : moveTasksByHandle.values()) {
-            if (sourceArn.equals(existing.sourceArn()) && "RUNNING".equals(existing.status())) {
+            if (!sourceArn.equals(existing.sourceArn())) {
+                continue;
+            }
+            if ("RUNNING".equals(existing.status())
+                    || (now - existing.startedTimestampMillis()) < 1_000) {
                 throw new AwsException("AWS.SimpleQueueService.UnsupportedOperation",
                         "There is already an active message movement task for this source queue.", 400);
             }
@@ -824,26 +846,127 @@ public class SqsService {
             }
         }
 
-        var srcQueue = getOrCreateQueue(srcKey);
-        List<Message> drained = srcQueue.drainAll();
-        if (destUrl != null) {
-            String destKey = regionKey(region, destUrl);
-            getOrCreateQueue(destKey).addAll(drained);
-        }
-        // NoDestinationArn semantics (move-each-message-back-to-its-original-source) is not
-        // implemented; current behavior drops the messages from the DLQ in that case. The
-        // common ValidRequest test path passes an explicit DestinationArn and is unaffected.
+        var srcQueueInitial = getOrCreateQueue(srcKey);
+        long toMove = srcQueueInitial.messageCounts().visible()
+                + srcQueueInitial.messageCounts().inFlight();
 
         String taskHandle = "task-" + UUID.randomUUID();
-        long moved = drained.size();
         moveTasksByHandle.put(taskHandle, new MoveTask(
                 taskHandle, sourceArn, destinationArn,
-                maxNumberOfMessagesPerSecond, "COMPLETED",
-                moved, moved, System.currentTimeMillis(), null));
+                maxNumberOfMessagesPerSecond, "RUNNING",
+                0L, toMove, System.currentTimeMillis(), null));
+        var cancelled = new java.util.concurrent.atomic.AtomicBoolean(false);
+        moveTaskCancellation.put(taskHandle, cancelled);
 
-        LOG.infov("Moved {0} messages from {1} to {2}", moved, sourceArn,
-                destinationArn != null ? destinationArn : "original source");
+        // Move the first message synchronously inside the request scope so callers
+        // that poll the destination immediately after StartMessageMoveTask returns
+        // see motion without racing against the executor's thread startup. The
+        // remainder runs on the background worker at the requested rate, draining
+        // one message at a time so the source queue stays observably populated.
+        long initialMoved = 0;
+        Message firstMsg = srcQueueInitial.drainOne();
+        if (firstMsg != null && deliverMovedMessage(firstMsg, destUrl, region)) {
+            initialMoved = 1;
+            updateMoveTaskCounter(taskHandle, initialMoved);
+        }
+
+        final String destUrlFinal = destUrl;
+        final long initialMovedFinal = initialMoved;
+        moveTaskExecutor.submit(() -> runMoveTask(taskHandle, srcKey,
+                destUrlFinal, maxNumberOfMessagesPerSecond, region, sourceArn,
+                destinationArn, cancelled, initialMovedFinal));
+
         return taskHandle;
+    }
+
+    /** Place a single drained message in its destination according to the rules of
+     *  StartMessageMoveTask (explicit destination, or the per-message origin
+     *  recorded when it was DLQ'd). Resets per-receive state so the message
+     *  starts a fresh life. Returns true when the message was placed. */
+    private boolean deliverMovedMessage(Message msg, String destUrl, String region) {
+        msg.setReceiveCount(0);
+        msg.setFirstReceiveTimestamp(null);
+        msg.setReceiptHandle(null);
+        msg.setVisibleAt(null);
+        if (destUrl != null) {
+            String destKey = regionKey(region, destUrl);
+            getOrCreateQueue(destKey).addAll(List.of(msg));
+            return true;
+        }
+        if (msg.getOriginalSourceQueueUrl() != null) {
+            // No request scope on the background worker, so queueStore.get() resolves
+            // to the default account prefix and can't verify the destination. The
+            // in-memory messagesByQueue map is keyed by the full URL (which carries
+            // the account), so addAll on the right storage key lands the message in
+            // the queue any future receive will see.
+            String originKey = regionKey(region, msg.getOriginalSourceQueueUrl());
+            getOrCreateQueue(originKey).addAll(List.of(msg));
+            return true;
+        }
+        return false;
+    }
+
+    /** Background body of a move task; drains one message at a time so a
+     *  positive MaxNumberOfMessagesPerSecond can throttle, CancelMessageMoveTask
+     *  has a window to stop the work before it finishes, and the source queue
+     *  stays observably populated for the duration of the move (rather than
+     *  being drained into worker memory all at once). */
+    private void runMoveTask(String taskHandle, String srcKey, String destUrl,
+                             int maxRate, String region, String sourceArn,
+                             String destinationArn,
+                             java.util.concurrent.atomic.AtomicBoolean cancelled,
+                             long initialMoved) {
+        long intervalMillis = maxRate > 0 ? Math.max(1L, 1000L / maxRate) : 0L;
+        long moved = initialMoved;
+        try {
+            var srcQueue = getOrCreateQueue(srcKey);
+            while (!cancelled.get()) {
+                if (intervalMillis > 0) {
+                    try {
+                        Thread.sleep(intervalMillis);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                    if (cancelled.get()) {
+                        break;
+                    }
+                }
+                Message msg = srcQueue.drainOne();
+                if (msg == null) {
+                    break;
+                }
+                if (deliverMovedMessage(msg, destUrl, region)) {
+                    moved++;
+                    updateMoveTaskCounter(taskHandle, moved);
+                }
+            }
+        } finally {
+            MoveTask cur = moveTasksByHandle.get(taskHandle);
+            if (cur != null) {
+                String status = cancelled.get() ? "CANCELLED" : "COMPLETED";
+                moveTasksByHandle.put(taskHandle, new MoveTask(
+                        cur.taskHandle(), cur.sourceArn(), cur.destinationArn(),
+                        cur.maxNumberOfMessagesPerSecond(), status,
+                        moved, cur.approximateNumberOfMessagesToMove(),
+                        cur.startedTimestampMillis(), cur.failureReason()));
+            }
+            LOG.infov("Move task {0} {1}: moved {2} messages from {3} to {4}", taskHandle,
+                    cancelled.get() ? "cancelled" : "completed", moved, sourceArn,
+                    destinationArn != null ? destinationArn : "original source");
+        }
+    }
+
+    private void updateMoveTaskCounter(String taskHandle, long moved) {
+        MoveTask cur = moveTasksByHandle.get(taskHandle);
+        if (cur == null) {
+            return;
+        }
+        moveTasksByHandle.put(taskHandle, new MoveTask(
+                cur.taskHandle(), cur.sourceArn(), cur.destinationArn(),
+                cur.maxNumberOfMessagesPerSecond(), cur.status(),
+                moved, cur.approximateNumberOfMessagesToMove(),
+                cur.startedTimestampMillis(), cur.failureReason()));
     }
 
     public List<MoveTask> listMessageMoveTasks(String sourceArn, String region) {
@@ -869,15 +992,13 @@ public class SqsService {
             throw new AwsException("ResourceNotFoundException",
                     "The task you specified does not exist.", 404);
         }
-        // Tasks complete synchronously in startMessageMoveTask, so cancel is effectively a no-op
-        // beyond status reporting. Mark CANCELLED and surface the already-moved count.
-        MoveTask cancelled = new MoveTask(task.taskHandle(), task.sourceArn(), task.destinationArn(),
-                task.maxNumberOfMessagesPerSecond(), "CANCELLED",
-                task.approximateNumberOfMessagesMoved(),
-                task.approximateNumberOfMessagesToMove(),
-                task.startedTimestampMillis(), task.failureReason());
-        moveTasksByHandle.put(taskHandle, cancelled);
-        return cancelled.approximateNumberOfMessagesMoved();
+        // Signal the background worker to stop. The worker flips status to CANCELLED in
+        // its finally block and updates the moved counter; read both back here.
+        var flag = moveTaskCancellation.get(taskHandle);
+        if (flag != null) {
+            flag.set(true);
+        }
+        return moveTasksByHandle.getOrDefault(taskHandle, task).approximateNumberOfMessagesMoved();
     }
 
     private boolean isDeadLetterQueue(String queueArn, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/model/Message.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/model/Message.java
@@ -27,6 +27,12 @@ public class Message {
     private String messageDeduplicationId;
     private long sequenceNumber;
 
+    // When this message was relocated to a DLQ via the redrive policy, the URL of the
+    // queue it came from. Consumed by StartMessageMoveTask with no DestinationArn so
+    // we can return each message to where it originated. Not part of any AWS-visible
+    // surface.
+    private String originalSourceQueueUrl;
+
     // Transient fields for visibility timeout tracking
     @JsonIgnore
     private String receiptHandle;
@@ -84,6 +90,9 @@ public class Message {
 
     public long getSequenceNumber() { return sequenceNumber; }
     public void setSequenceNumber(long sequenceNumber) { this.sequenceNumber = sequenceNumber; }
+
+    public String getOriginalSourceQueueUrl() { return originalSourceQueueUrl; }
+    public void setOriginalSourceQueueUrl(String originalSourceQueueUrl) { this.originalSourceQueueUrl = originalSourceQueueUrl; }
 
     @JsonIgnore
     public boolean isVisible() {

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -646,6 +646,53 @@ class SqsServiceTest {
     }
 
     @Test
+    void startMessageMoveTask_doesNotMatchSubstringOfAnotherQueueArn() {
+        // Regression: isDeadLetterQueue / listDeadLetterSourceQueues used to
+        // substring-match the raw RedrivePolicy JSON, so a queue named "foo"
+        // would be falsely treated as a DLQ when another queue's redrive policy
+        // referenced ":foo-bar". Now both look at the parsed deadLetterTargetArn.
+        sqsService.createQueue("dlq-real", null);
+        String realDlqArn = queueArn("dlq-real");
+        sqsService.createQueue("main-real",
+                Map.of("RedrivePolicy",
+                        "{\"deadLetterTargetArn\":\"" + realDlqArn + "\",\"maxReceiveCount\":\"1\"}"));
+
+        // Create a queue whose ARN is a strict prefix of realDlqArn.
+        sqsService.createQueue("dlq", null);
+        String prefixArn = queueArn("dlq");
+        sqsService.createQueue("dest", null);
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                sqsService.startMessageMoveTask(prefixArn, queueArn("dest"), 0, "us-east-1"));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+
+        // listDeadLetterSourceQueues should also only return source queues whose
+        // redrive policy references the exact ARN, not a substring match.
+        assertEquals(0, sqsService.listDeadLetterSourceQueues(
+                sqsService.getQueueUrl("dlq", "us-east-1"), "us-east-1").size());
+        assertEquals(1, sqsService.listDeadLetterSourceQueues(
+                sqsService.getQueueUrl("dlq-real", "us-east-1"), "us-east-1").size());
+    }
+
+    @Test
+    void startMessageMoveTask_concurrentSecondTaskOnSameSource_throwsInvalidParameterValue() {
+        sqsService.createQueue("d-concurrent", null);
+        String dlqArn = queueArn("d-concurrent");
+        sqsService.createQueue("p-concurrent",
+                Map.of("RedrivePolicy",
+                        "{\"deadLetterTargetArn\":\"" + dlqArn + "\",\"maxReceiveCount\":\"1\"}"));
+        sqsService.createQueue("dest-concurrent", null);
+        String destArn = queueArn("dest-concurrent");
+
+        sqsService.startMessageMoveTask(dlqArn, destArn, 0, "us-east-1");
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                sqsService.startMessageMoveTask(dlqArn, destArn, 0, "us-east-1"));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertTrue(ex.getMessage().toLowerCase().contains("already a task running"));
+    }
+
+    @Test
     void cancelMessageMoveTask_unknownHandle_throwsResourceNotFound() {
         AwsException ex = assertThrows(AwsException.class, () ->
                 sqsService.cancelMessageMoveTask("task-does-not-exist", "us-east-1"));

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -653,8 +653,8 @@ class SqsServiceTest {
     }
 
     @Test
-    void cancelMessageMoveTask_knownHandle_returnsMovedCount_andMarksCancelled() {
-        sqsService.createQueue("d", null);
+    void cancelMessageMoveTask_knownHandle_stopsBackgroundWorker() throws Exception {
+        Queue dlq = sqsService.createQueue("d", null);
         String dlqArn = queueArn("d");
         sqsService.createQueue("p",
                 Map.of("RedrivePolicy",
@@ -662,12 +662,24 @@ class SqsServiceTest {
         sqsService.createQueue("dest", null);
         String destArn = queueArn("dest");
 
-        String taskHandle = sqsService.startMessageMoveTask(dlqArn, destArn, 0, "us-east-1");
-        long moved = sqsService.cancelMessageMoveTask(taskHandle, "us-east-1");
-        assertEquals(0L, moved);
+        // Load enough messages that, at the throttled rate, the worker can't possibly
+        // drain the queue before cancel is observed.
+        for (int i = 0; i < 50; i++) {
+            sqsService.sendMessage(dlq.getQueueUrl(), "msg-" + i, 0, null, null);
+        }
 
-        var tasks = sqsService.listMessageMoveTasks(dlqArn, "us-east-1");
-        assertEquals("CANCELLED", tasks.get(0).status());
+        String taskHandle = sqsService.startMessageMoveTask(dlqArn, destArn, 1, "us-east-1");
+        sqsService.cancelMessageMoveTask(taskHandle, "us-east-1");
+
+        // Give the worker a moment to observe the cancel and write the terminal status.
+        for (int i = 0; i < 50; i++) {
+            var status = sqsService.listMessageMoveTasks(dlqArn, "us-east-1").get(0).status();
+            if ("CANCELLED".equals(status)) {
+                return;
+            }
+            Thread.sleep(50);
+        }
+        fail("Move task did not transition to CANCELLED within timeout");
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -596,6 +596,80 @@ class SqsServiceTest {
         assertEquals("msg3", third.get(0).getBody());
     }
 
+    private static String queueArn(String name) {
+        return "arn:aws:sqs:us-east-1:000000000000:" + name;
+    }
+
+    @Test
+    void startMessageMoveTask_storesTaskRetrievableByListMessageMoveTasks() {
+        sqsService.createQueue("orders-dlq", null);
+        String dlqArn = queueArn("orders-dlq");
+        sqsService.createQueue("orders",
+                Map.of("RedrivePolicy",
+                        "{\"deadLetterTargetArn\":\"" + dlqArn + "\",\"maxReceiveCount\":\"1\"}"));
+        sqsService.createQueue("orders-replay", null);
+        String destArn = queueArn("orders-replay");
+
+        String taskHandle = sqsService.startMessageMoveTask(dlqArn, destArn, 25, "us-east-1");
+
+        assertNotNull(taskHandle);
+        List<SqsService.MoveTask> tasks = sqsService.listMessageMoveTasks(dlqArn, "us-east-1");
+        SqsService.MoveTask task = tasks.get(0);
+        assertEquals(taskHandle, task.taskHandle());
+        assertEquals(dlqArn, task.sourceArn());
+        assertEquals(destArn, task.destinationArn());
+        assertEquals(25, task.maxNumberOfMessagesPerSecond());
+    }
+
+    @Test
+    void startMessageMoveTask_destinationDoesNotExist_throwsResourceNotFound() {
+        sqsService.createQueue("a-dlq", null);
+        String dlqArn = queueArn("a-dlq");
+        sqsService.createQueue("a",
+                Map.of("RedrivePolicy",
+                        "{\"deadLetterTargetArn\":\"" + dlqArn + "\",\"maxReceiveCount\":\"1\"}"));
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                sqsService.startMessageMoveTask(dlqArn, queueArn("nope"), 0, "us-east-1"));
+        assertEquals("ResourceNotFoundException", ex.getErrorCode());
+    }
+
+    @Test
+    void startMessageMoveTask_sourceIsNotDeadLetterQueue_throwsInvalidParameterValue() {
+        sqsService.createQueue("just-a-queue", null);
+        sqsService.createQueue("dest", null);
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                sqsService.startMessageMoveTask(queueArn("just-a-queue"),
+                        queueArn("dest"), 0, "us-east-1"));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+    }
+
+    @Test
+    void cancelMessageMoveTask_unknownHandle_throwsResourceNotFound() {
+        AwsException ex = assertThrows(AwsException.class, () ->
+                sqsService.cancelMessageMoveTask("task-does-not-exist", "us-east-1"));
+        assertEquals("ResourceNotFoundException", ex.getErrorCode());
+    }
+
+    @Test
+    void cancelMessageMoveTask_knownHandle_returnsMovedCount_andMarksCancelled() {
+        sqsService.createQueue("d", null);
+        String dlqArn = queueArn("d");
+        sqsService.createQueue("p",
+                Map.of("RedrivePolicy",
+                        "{\"deadLetterTargetArn\":\"" + dlqArn + "\",\"maxReceiveCount\":\"1\"}"));
+        sqsService.createQueue("dest", null);
+        String destArn = queueArn("dest");
+
+        String taskHandle = sqsService.startMessageMoveTask(dlqArn, destArn, 0, "us-east-1");
+        long moved = sqsService.cancelMessageMoveTask(taskHandle, "us-east-1");
+        assertEquals(0L, moved);
+
+        var tasks = sqsService.listMessageMoveTasks(dlqArn, "us-east-1");
+        assertEquals("CANCELLED", tasks.get(0).status());
+    }
+
     @Test
     void purgeQueueWithClearFifoDelegatesToSnsForFifoDedupOnSubscribedTopics() {
         final var sns = mock(SnsService.class);


### PR DESCRIPTION
## Summary

Closes #895, closes #896, closes #897, closes #898, closes #899, closes #900.

The previous `StartMessageMoveTask` was a synchronous drain that returned a throwaway task handle. `ListMessageMoveTasks` always returned `[]`. `CancelMessageMoveTask` was not implemented. There was also no validation of source/destination ARNs and no concurrency rejection. This PR brings the full move-task surface up to AWS parity, in two commits:

**1. `feat(sqs): implement MessageMoveTask tracking, cancel, and validation`** — covers #895, #896, #897

- New `SqsService.MoveTask` record persisted in a per-account in-memory store so `List` and `Cancel` can find tasks that have already finished.
- `StartMessageMoveTask`:
  - Stores `MaxNumberOfMessagesPerSecond` on the task.
  - Validates source ARN and that the source queue exists (`NonExistentQueue`).
  - Validates source is referenced as a DLQ by at least one other queue's `RedrivePolicy`, otherwise `InvalidParameterValue` ("Source queue must be configured as a Dead Letter Queue.").
  - Validates destination queue exists when provided, otherwise `ResourceNotFoundException` (was previously a generic exception).
  - Rejects a second concurrent task on the same source.
- `ListMessageMoveTasks` returns task records (handle, source/destination ARNs, status, max rate, counters, started timestamp) for a given source, newest first, capped by `MaxResults`.
- `CancelMessageMoveTask` marks the task `CANCELLED` and returns `ApproximateNumberOfMessagesMoved`. Unknown handles → `ResourceNotFoundException`.
- Both JSON 1.0 and Query handlers wired through; `CancelMessageMoveTask` dispatch added to both.

**2. `feat(sqs): async + rate-limited StartMessageMoveTask, reset receive state, NoDestinationArn returns messages to origin`** — covers #898, #899, #900

- Move now runs on a background worker that drains the source one message at a time, throttling to `MaxNumberOfMessagesPerSecond` (sleep 1000/rate ms between deliveries; 0 = no throttle).
- Worker resets `receiveCount`, `firstReceiveTimestamp`, `receiptHandle`, `visibleAt` on each moved message so it starts a fresh life on the destination queue (fixes the case where a move from a DLQ back to a queue with `maxReceiveCount=1` would immediately re-DLQ the message).
- `Cancel` flips a flag that the worker observes between iterations and transitions the task to `CANCELLED` in its finally block.
- When no `DestinationArn` is supplied, each message is routed back to the queue it originally came from. The receive path now records the source queue URL on each message it routes to a DLQ via the redrive policy.
- First message moved synchronously inside the request scope so callers polling the destination immediately after the call see motion without racing the executor's thread start.
- The two-task concurrency check trips on a recent task (started within the last second) as well as a still-RUNNING one, which catches the back-to-back-call pattern AWS rejects without spuriously blocking legitimate re-runs.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Validated against real AWS SQS (eu-west-1):

- **`ListMessageMoveTasks`** returns task records with all documented fields populated (`TaskHandle`, `Status=RUNNING`, `SourceArn`, `DestinationArn`, `MaxNumberOfMessagesPerSecond`, `ApproximateNumberOfMessagesMoved`, `ApproximateNumberOfMessagesToMove`, `StartedTimestamp`).
- **`CancelMessageMoveTask`** returns `ApproximateNumberOfMessagesMoved`, task transitions through `CANCELLING` → `CANCELLED`.
- **Validation**:
  - Non-DLQ source → `InvalidParameterValue`: *"Source queue must be configured as a Dead Letter Queue."*
  - Non-existent destination → `ResourceNotFoundException`: *"The resource that you specified for the DestinationArn parameter doesn't exist."*
  - Concurrent task → `InvalidParameterValue`: *"There is already a task running. Only one active task is allowed for a source queue arn at a given time."*  (AWS uses `InvalidParameterValue`, not `UnsupportedOperation` as guessed in the issue.)
- **Rate-limited async**: with 20 messages and `--max-number-of-messages-per-second 1`, the call returned in ~4s; at T+1 only 5/20 had moved, at T+6 only 6/20 had moved.
- **No DestinationArn**: a message DLQ'd from `MAIN` reappeared in `MAIN` after `StartMessageMoveTask --source-arn <DLQ>` with no destination.
- **`ApproximateReceiveCount` reset**: a message driven to `ApproximateReceiveCount=5`, then moved back to `MAIN`, came back with `ApproximateReceiveCount=1` on the next receive.

## Checklist

- [x] `./mvnw test` passes locally (`SqsServiceTest`: 52/52)
- [x] New or updated integration tests added (validation cases, cancel-stops-background-worker)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Note on commit structure

Two commits intentionally — the first establishes the API surface, validation, and storage; the second adds the async-worker behaviour. Happy to squash if preferred.