### PR TITLE
fix: DynamoDB DeleteTable status and PartiQL scan, add SecretsManager RestoreSecret

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -201,11 +201,9 @@ public class DynamoDbJsonHandler {
             throw new AwsException("ResourceInUseException",
                     "Table " + tableName + " can't be deleted while DeletionProtectionEnabled is set to true", 400);
         }
-        dynamoDbService.deleteTable(tableName, region);
-
-        table.setTableStatus("DELETING");
         ObjectNode response = objectMapper.createObjectNode();
         response.set("TableDescription", tableToNode(table));
+        dynamoDbService.deleteTable(tableName, region);
         return Response.ok(response).build();
     }
 
@@ -1922,7 +1920,10 @@ public class DynamoDbJsonHandler {
         String statement = request.path("Statement").asText();
         List<JsonNode> parameters = toPartiQLParams(request.path("Parameters"));
         DynamoDbPartiQLParser.Stmt stmt = DynamoDbPartiQLParser.parse(statement, parameters);
-        JsonNode result = partiQLHandler.execute(stmt, region);
+        PartiQLExecuteContext ctx = PartiQLExecuteContext.builder()
+                .limit(request.has("Limit") ? request.get("Limit").asInt() : null)
+                .nextToken(request.has("NextToken") ? request.get("NextToken").asText() : null);
+        JsonNode result = partiQLHandler.execute(stmt, ctx, region);
         return Response.ok(result).build();
     }
 
@@ -1970,7 +1971,7 @@ public class DynamoDbJsonHandler {
             try {
                 DynamoDbPartiQLParser.Stmt stmt = DynamoDbPartiQLParser.parse(
                         s.path("Statement").asText(), toPartiQLParams(s.path("Parameters")));
-                JsonNode result = partiQLHandler.execute(stmt, region);
+                JsonNode result = partiQLHandler.execute(stmt, PartiQLExecuteContext.builder(), region);
                 ObjectNode slot = objectMapper.createObjectNode();
                 JsonNode firstItem = result.path("Items").path(0);
                 if (!firstItem.isMissingNode()) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbPartiQLHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbPartiQLHandler.java
@@ -10,6 +10,7 @@ import io.github.hectorvent.floci.services.dynamodb.model.ConditionalCheckFailed
 import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
 
 import java.util.*;
+import java.util.Base64;
 
 class DynamoDbPartiQLHandler {
 
@@ -21,9 +22,9 @@ class DynamoDbPartiQLHandler {
         this.mapper = mapper;
     }
 
-    JsonNode execute(Stmt stmt, String region) {
+    JsonNode execute(Stmt stmt, PartiQLExecuteContext ctx, String region) {
         return switch (stmt) {
-            case Stmt.Select s -> executeSelect(s, region);
+            case Stmt.Select s -> executeSelect(s, ctx, region);
             case Stmt.Insert s -> executeInsert(s, region);
             case Stmt.Update s -> executeUpdate(s, region);
             case Stmt.Delete s -> executeDelete(s, region);
@@ -32,7 +33,7 @@ class DynamoDbPartiQLHandler {
 
     // --- SELECT ---
 
-    private JsonNode executeSelect(Stmt.Select stmt, String region) {
+    private JsonNode executeSelect(Stmt.Select stmt, PartiQLExecuteContext ctx, String region) {
         TableDefinition table = service.describeTable(stmt.table(), region);
         String pkName = table.getPartitionKeyName();
         String skName = table.getSortKeyName();
@@ -57,9 +58,15 @@ class DynamoDbPartiQLHandler {
         }
 
         List<JsonNode> items;
-        // Only use GetItem when table has no sort key and we have a pk equality with no other conditions.
-        // When the table has a sort key, always use Query (GetItem requires both pk and sk).
-        if (pkEq != null && skName == null && skCond == null && filterConds.isEmpty()) {
+        JsonNode lastEvaluatedKey = null;
+
+        if (stmt.where().isEmpty()) {
+            JsonNode exclusiveStartKey = decodeNextToken(ctx.nextToken());
+            DynamoDbService.ScanResult result = service.scan(
+                    stmt.table(), null, null, null, null, ctx.limit(), exclusiveStartKey, region);
+            items = result.items();
+            lastEvaluatedKey = result.lastEvaluatedKey();
+        } else if (pkEq != null && skName == null && skCond == null && filterConds.isEmpty()) {
             ObjectNode key = mapper.createObjectNode();
             key.set(pkName, toTypedNode(pkEq.val()));
             JsonNode item = service.getItem(stmt.table(), key, region);
@@ -92,7 +99,27 @@ class DynamoDbPartiQLHandler {
         items.forEach(arr::add);
         ObjectNode resp = mapper.createObjectNode();
         resp.set("Items", arr);
+        if (lastEvaluatedKey != null) {
+            resp.put("NextToken", encodeNextToken(lastEvaluatedKey));
+        }
         return resp;
+    }
+
+    private String encodeNextToken(JsonNode lastEvaluatedKey) {
+        try {
+            return Base64.getEncoder().encodeToString(mapper.writeValueAsBytes(lastEvaluatedKey));
+        } catch (Exception e) {
+            throw new AwsException("InternalServerError", "Failed to encode NextToken", 500);
+        }
+    }
+
+    private JsonNode decodeNextToken(String nextToken) {
+        if (nextToken == null) return null;
+        try {
+            return mapper.readTree(Base64.getDecoder().decode(nextToken));
+        } catch (Exception e) {
+            throw new AwsException("ValidationException", "Invalid NextToken", 400);
+        }
     }
 
     private String buildKce(Cond.Eq pkEq, Cond skCond, String pkName, String skName,

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/PartiQLExecuteContext.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/PartiQLExecuteContext.java
@@ -1,0 +1,32 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+class PartiQLExecuteContext {
+
+    private Integer limit;
+    private String nextToken;
+
+    private PartiQLExecuteContext() {
+    }
+
+    static PartiQLExecuteContext builder() {
+        return new PartiQLExecuteContext();
+    }
+
+    PartiQLExecuteContext limit(Integer limit) {
+        this.limit = limit;
+        return this;
+    }
+
+    PartiQLExecuteContext nextToken(String nextToken) {
+        this.nextToken = nextToken;
+        return this;
+    }
+
+    Integer limit() {
+        return limit;
+    }
+
+    String nextToken() {
+        return nextToken;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
@@ -38,6 +38,7 @@ public class SecretsManagerJsonHandler {
             case "DescribeSecret" -> handleDescribeSecret(request, region);
             case "ListSecrets" -> handleListSecrets(request, region);
             case "DeleteSecret" -> handleDeleteSecret(request, region);
+            case "RestoreSecret" -> handleRestoreSecret(request, region);
             case "RotateSecret" -> handleRotateSecret(request, region);
             case "TagResource" -> handleTagResource(request, region);
             case "UntagResource" -> handleUntagResource(request, region);
@@ -295,6 +296,16 @@ public class SecretsManagerJsonHandler {
         if (secret.getDeletedDate() != null) {
             response.put("DeletionDate", secret.getDeletedDate().toEpochMilli() / 1000.0);
         }
+        return Response.ok(response).build();
+    }
+
+    private Response handleRestoreSecret(JsonNode request, String region) {
+        String secretId = request.path("SecretId").asText();
+        Secret secret = service.restoreSecret(secretId, region);
+
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("ARN", secret.getArn());
+        response.put("Name", secret.getName());
         return Response.ok(response).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
@@ -265,6 +265,21 @@ public class SecretsManagerService {
         return secret;
     }
 
+    public Secret restoreSecret(String secretId, String region) {
+        Secret secret = resolveSecret(secretId, region);
+        String storageKey = regionKey(region, secret.getName());
+
+        if (secret.getDeletedDate() == null) {
+            throw new AwsException("InvalidRequestException",
+                    "You can't perform this operation on the secret because it was not deleted.", 400);
+        }
+
+        secret.setDeletedDate(null);
+        store.put(storageKey, secret);
+        LOG.infov("Restored secret: {0}", secret.getName());
+        return secret;
+    }
+
     public Secret rotateSecret(String secretId, String rotationLambdaArn, Map<String, Integer> rotationRules,
                                boolean rotateImmediately, String region) {
         Secret secret = resolveSecret(secretId, region);

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbCborIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbCborIntegrationTest.java
@@ -171,6 +171,6 @@ class DynamoDbCborIntegrationTest {
             .extract().asByteArray();
 
         JsonNode response = CBOR_MAPPER.readTree(responseBytes);
-        assertThat(response.path("TableDescription").path("TableStatus").asText(), equalTo("DELETING"));
+        assertThat(response.path("TableDescription").path("TableStatus").asText(), equalTo("ACTIVE"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -777,6 +777,44 @@ class DynamoDbIntegrationTest {
             .body("Table.GlobalSecondaryIndexes", nullValue());
     }
 
+    /**
+     * AWS DynamoDB DeleteTable returns the table description with its current status (ACTIVE)
+     * at the time of the call. The transition to DELETING happens asynchronously after the response.
+     *
+     * @see <a href="https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DeleteTable.html">DeleteTable API Reference</a>
+     */
+    @Test
+    @Order(26)
+    void deleteTableReturnsActiveStatus() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "DeleteStatusTestTable",
+                    "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "id", "AttributeType": "S"}]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TableDescription.TableStatus", equalTo("ACTIVE"));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "DeleteStatusTestTable"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TableDescription.TableStatus", equalTo("ACTIVE"));
+    }
+
     // --- Cleanup ---
 
     @Test
@@ -792,7 +830,7 @@ class DynamoDbIntegrationTest {
             .post("/")
         .then()
             .statusCode(200)
-            .body("TableDescription.TableStatus", equalTo("DELETING"));
+            .body("TableDescription.TableStatus", equalTo("ACTIVE"));
 
         // Verify it's gone
         given()
@@ -2135,5 +2173,100 @@ given()
         assertEquals(5, allCollected.size(), "Expected 5 items total, got: " + allCollected);
         assertEquals(Set.of("ITEM_a", "ITEM_b", "ITEM_c", "ITEM_d", "ITEM_e"), new HashSet<>(allCollected));
         assertEquals(3, pages, "Expected ceil(5/2)=3 pages");
+    }
+
+    @Test
+    void partiqlSelectWithoutWhereClausePerformsScan() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        String tableName = "PartiqlScanTable";
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then().statusCode(200);
+
+        for (String pk : new String[]{"a", "b", "c"}) {
+            given()
+                .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+                .contentType(DYNAMODB_CONTENT_TYPE)
+                .body("""
+                    {
+                        "TableName": "%s",
+                        "Item": {"pk": {"S": "%s"}, "data": {"S": "val-%s"}}
+                    }
+                    """.formatted(tableName, pk, pk))
+            .when().post("/")
+            .then().statusCode(200);
+        }
+
+        // SELECT * without WHERE → full table scan, all 3 items
+        String selectAll = given()
+            .header("X-Amz-Target", "DynamoDB_20120810.ExecuteStatement")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"Statement": "SELECT * FROM \\"%s\\""}
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .extract().body().asString();
+
+        JsonNode selectAllResult = mapper.readTree(selectAll);
+        assertEquals(3, selectAllResult.path("Items").size(),
+                "SELECT * without WHERE should return all items");
+
+        // SELECT * with Limit=2 → 2 items + NextToken
+        String limitedSelect = given()
+            .header("X-Amz-Target", "DynamoDB_20120810.ExecuteStatement")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"Statement": "SELECT * FROM \\"%s\\"", "Limit": 2}
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .extract().body().asString();
+
+        JsonNode limitedResult = mapper.readTree(limitedSelect);
+        assertEquals(2, limitedResult.path("Items").size(),
+                "SELECT * with Limit=2 should return 2 items");
+        assertNotNull(limitedResult.get("NextToken"),
+                "Paginated response must include NextToken");
+
+        // Use NextToken to get the remaining item
+        String nextToken = limitedResult.get("NextToken").asText();
+        String nextPage = given()
+            .header("X-Amz-Target", "DynamoDB_20120810.ExecuteStatement")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"Statement": "SELECT * FROM \\"%s\\"", "NextToken": "%s"}
+                """.formatted(tableName, nextToken))
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .extract().body().asString();
+
+        JsonNode nextPageResult = mapper.readTree(nextPage);
+        assertEquals(1, nextPageResult.path("Items").size(),
+                "Second page should return the remaining 1 item");
+
+        // Cleanup
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "%s"}
+                """.formatted(tableName))
+        .when().post("/")
+        .then().statusCode(200);
     }
 }


### PR DESCRIPTION
## Summary

- DeleteTable now returns the table description with its current (ACTIVE) status before removing the table, matching AWS behavior where the DELETING transition is asynchronous
- PartiQL SELECT without a WHERE clause performs a full table scan, with Limit/NextToken pagination support via a new PartiQLExecuteContext carrier
- RestoreSecret operation implemented for SecretsManager — cancels a scheduled deletion by clearing deletedDate, throwing InvalidRequestException if the secret is not pending deletion

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

- Incorrect behavior: DeleteTable response included TableStatus: "DELETING". AWS returns the table's current status (ACTIVE) at call time; the transition to DELETING is asynchron
- ExecuteStatement with SELECT * FROM "table" (no WHERE clause) previously had no scan path. Now performs a full table scan with Limit/NextToken pagination, matching the ExecuteStatement API
- Implements RestoreSecret API (https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_RestoreSecret.html)

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
