### PR TITLE
fix(s3): honor response-* query parameters on GetObject and HeadObject

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -508,6 +508,12 @@ public class S3Controller {
                               @QueryParam("uploadId") String uploadId,
                               @QueryParam("max-parts") Integer maxPartsQuery,
                               @QueryParam("part-number-marker") String partNumberMarkerQuery,
+                              @QueryParam("response-content-type") String responseContentType,
+                              @QueryParam("response-content-language") String responseContentLanguage,
+                              @QueryParam("response-expires") String responseExpires,
+                              @QueryParam("response-cache-control") String responseCacheControl,
+                              @QueryParam("response-content-disposition") String responseContentDisposition,
+                              @QueryParam("response-content-encoding") String responseContentEncoding,
                               @HeaderParam("x-amz-object-attributes") String objectAttributesHeader,
                               @HeaderParam("x-amz-max-parts") Integer maxParts,
                               @HeaderParam("x-amz-part-number-marker") Integer partNumberMarker,
@@ -552,13 +558,16 @@ public class S3Controller {
                 }
             }
             S3Object obj = s3Service.getObject(bucket, key, versionId);
+            ResponseHeaderOverrides overrides = new ResponseHeaderOverrides(
+                    responseContentType, responseContentLanguage, responseExpires,
+                    responseCacheControl, responseContentDisposition, responseContentEncoding);
 
             if (rangeHeader != null && rangeHeader.startsWith("bytes=")) {
-                return handleRangeRequest(obj, rangeHeader);
+                return handleRangeRequest(obj, rangeHeader, overrides);
             }
 
             var resp = Response.ok(obj.getData())
-                    .header("Content-Type", obj.getContentType())
+                    .header("Content-Type", overrides.contentType() != null ? overrides.contentType() : obj.getContentType())
                     .header("Content-Length", obj.getSize())
                     .header("ETag", obj.getETag())
                     .header("Last-Modified", RFC_822.format(obj.getLastModified()))
@@ -566,14 +575,14 @@ public class S3Controller {
             if (obj.getVersionId() != null) {
                 resp.header("x-amz-version-id", obj.getVersionId());
             }
-            appendObjectHeaders(resp, obj);
+            appendObjectHeaders(resp, obj, overrides);
             return resp.build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
         }
     }
 
-    private Response handleRangeRequest(S3Object obj, String rangeHeader) {
+    private Response handleRangeRequest(S3Object obj, String rangeHeader, ResponseHeaderOverrides overrides) {
         byte[] data = obj.getData();
         int totalSize = data.length;
         String rangeSpec = rangeHeader.substring("bytes=".length()).trim();
@@ -609,15 +618,19 @@ public class S3Controller {
         }
 
         byte[] rangeData = java.util.Arrays.copyOfRange(data, start, end + 1);
-        return Response.status(206)
+        var resp = Response.status(206)
                 .entity(rangeData)
-                .header("Content-Type", obj.getContentType())
+                .header("Content-Type", overrides.contentType() != null ? overrides.contentType() : obj.getContentType())
                 .header("Content-Length", rangeData.length)
                 .header("Content-Range", "bytes " + start + "-" + end + "/" + totalSize)
                 .header("ETag", obj.getETag())
                 .header("Last-Modified", RFC_822.format(obj.getLastModified()))
-                .header("Accept-Ranges", "bytes")
-                .build();
+                .header("Accept-Ranges", "bytes");
+        if (obj.getVersionId() != null) {
+            resp.header("x-amz-version-id", obj.getVersionId());
+        }
+        appendObjectHeaders(resp, obj, overrides);
+        return resp.build();
     }
 
     private Response invalidRangeResponse(int totalSize) {
@@ -641,6 +654,12 @@ public class S3Controller {
     public Response headObject(@PathParam("bucket") String bucket,
                                @PathParam("key") String key,
                                @QueryParam("versionId") String versionId,
+                               @QueryParam("response-content-type") String responseContentType,
+                               @QueryParam("response-content-language") String responseContentLanguage,
+                               @QueryParam("response-expires") String responseExpires,
+                               @QueryParam("response-cache-control") String responseCacheControl,
+                               @QueryParam("response-content-disposition") String responseContentDisposition,
+                               @QueryParam("response-content-encoding") String responseContentEncoding,
                                @HeaderParam("If-Match") String ifMatch,
                                @HeaderParam("If-None-Match") String ifNoneMatch,
                                @HeaderParam("If-Modified-Since") String ifModifiedSince,
@@ -653,8 +672,11 @@ public class S3Controller {
             if (preconditionResponse != null) {
                 return preconditionResponse;
             }
+            ResponseHeaderOverrides overrides = new ResponseHeaderOverrides(
+                    responseContentType, responseContentLanguage, responseExpires,
+                    responseCacheControl, responseContentDisposition, responseContentEncoding);
             var resp = Response.ok()
-                    .header("Content-Type", obj.getContentType())
+                    .header("Content-Type", overrides.contentType() != null ? overrides.contentType() : obj.getContentType())
                     .header("Content-Length", obj.getSize())
                     .header("ETag", obj.getETag())
                     .header("Last-Modified", RFC_822.format(obj.getLastModified()))
@@ -662,7 +684,7 @@ public class S3Controller {
             if (obj.getVersionId() != null) {
                 resp.header("x-amz-version-id", obj.getVersionId());
             }
-            appendObjectHeaders(resp, obj);
+            appendObjectHeaders(resp, obj, overrides);
             return resp.build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
@@ -1457,21 +1479,58 @@ public class S3Controller {
         return Response.ok(xml).type(MediaType.APPLICATION_XML).build();
     }
 
+    private record ResponseHeaderOverrides(
+            String contentType,
+            String contentLanguage,
+            String expires,
+            String cacheControl,
+            String contentDisposition,
+            String contentEncoding) {
+        static final ResponseHeaderOverrides NONE = new ResponseHeaderOverrides(null, null, null, null, null, null);
+
+        ResponseHeaderOverrides {
+            // Real S3 ignores empty `response-*` values; @QueryParam binds "?foo=" as "" rather than null.
+            contentType = emptyToNull(contentType);
+            contentLanguage = emptyToNull(contentLanguage);
+            expires = emptyToNull(expires);
+            cacheControl = emptyToNull(cacheControl);
+            contentDisposition = emptyToNull(contentDisposition);
+            contentEncoding = emptyToNull(contentEncoding);
+        }
+
+        private static String emptyToNull(String s) {
+            return s == null || s.isEmpty() ? null : s;
+        }
+    }
+
     private void appendObjectHeaders(Response.ResponseBuilder resp, S3Object obj) {
+        appendObjectHeaders(resp, obj, ResponseHeaderOverrides.NONE);
+    }
+
+    private void appendObjectHeaders(Response.ResponseBuilder resp, S3Object obj, ResponseHeaderOverrides overrides) {
         if (obj.getStorageClass() != null) {
             resp.header("x-amz-storage-class", obj.getStorageClass());
         }
-        if (obj.getContentEncoding() != null) {
-            resp.header("Content-Encoding", obj.getContentEncoding());
+        String contentEncoding = overrides.contentEncoding() != null ? overrides.contentEncoding() : obj.getContentEncoding();
+        if (contentEncoding != null) {
+            resp.header("Content-Encoding", contentEncoding);
         }
-        if (obj.getContentDisposition() != null) {
-            resp.header("Content-Disposition", obj.getContentDisposition());
+        String contentDisposition = overrides.contentDisposition() != null ? overrides.contentDisposition() : obj.getContentDisposition();
+        if (contentDisposition != null) {
+            resp.header("Content-Disposition", contentDisposition);
         }
-        if (obj.getCacheControl() != null) {
-            resp.header("Cache-Control", obj.getCacheControl());
+        String cacheControl = overrides.cacheControl() != null ? overrides.cacheControl() : obj.getCacheControl();
+        if (cacheControl != null) {
+            resp.header("Cache-Control", cacheControl);
         }
         if (obj.getServerSideEncryption() != null) {
             resp.header("x-amz-server-side-encryption", obj.getServerSideEncryption());
+        }
+        if (overrides.contentLanguage() != null) {
+            resp.header("Content-Language", overrides.contentLanguage());
+        }
+        if (overrides.expires() != null) {
+            resp.header("Expires", overrides.expires());
         }
         if (obj.getMetadata() != null) {
             for (Map.Entry<String, String> entry : obj.getMetadata().entrySet()) {

--- a/src/test/java/io/github/hectorvent/floci/services/s3/PreSignedUrlIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/PreSignedUrlIntegrationTest.java
@@ -118,11 +118,127 @@ class PreSignedUrlIntegrationTest {
             .body(equalTo("uploaded via presigned PUT"));
     }
 
+    // --- response-* query parameter overrides on presigned GET/HEAD ---
+
     @Test
-    @Order(6)
+    @Order(10)
+    void uploadObjectWithStoredHeadersForOverrideTests() {
+        given()
+            .body("override-content")
+            .contentType("text/plain")
+            .header("Content-Disposition", "inline")
+            .header("Cache-Control", "max-age=60")
+        .when()
+            .put("/" + BUCKET + "/disposition-file.txt")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(11)
+    void getObjectAppliesResponseContentDispositionOverride() {
+        // Stored disposition is "inline"; override should win.
+        given()
+            .urlEncodingEnabled(false)
+        .when()
+            .get("/" + BUCKET + "/disposition-file.txt?response-content-disposition=attachment%3B%20filename%3D%22file.txt%22")
+        .then()
+            .statusCode(200)
+            .header("Content-Disposition", equalTo("attachment; filename=\"file.txt\""));
+    }
+
+    @Test
+    @Order(12)
+    void getObjectAppliesAllResponseOverrides() {
+        given()
+            .urlEncodingEnabled(false)
+        .when()
+            .get("/" + BUCKET + "/disposition-file.txt"
+                + "?response-content-type=application%2Fpdf"
+                + "&response-content-language=en-US"
+                + "&response-expires=Thu%2C%2001%20Dec%202099%2016%3A00%3A00%20GMT"
+                + "&response-cache-control=no-store"
+                + "&response-content-disposition=attachment"
+                + "&response-content-encoding=identity")
+        .then()
+            .statusCode(200)
+            .header("Content-Type", equalTo("application/pdf"))
+            .header("Content-Language", equalTo("en-US"))
+            .header("Expires", equalTo("Thu, 01 Dec 2099 16:00:00 GMT"))
+            .header("Cache-Control", equalTo("no-store"))
+            .header("Content-Disposition", equalTo("attachment"))
+            .header("Content-Encoding", equalTo("identity"));
+    }
+
+    @Test
+    @Order(13)
+    void getObjectWithoutOverridesReturnsStoredHeaders() {
+        given()
+        .when()
+            .get("/" + BUCKET + "/disposition-file.txt")
+        .then()
+            .statusCode(200)
+            .header("Content-Disposition", equalTo("inline"))
+            .header("Cache-Control", equalTo("max-age=60"));
+    }
+
+    @Test
+    @Order(14)
+    void headObjectAppliesResponseContentDispositionOverride() {
+        given()
+            .urlEncodingEnabled(false)
+        .when()
+            .head("/" + BUCKET + "/disposition-file.txt?response-content-disposition=attachment%3B%20filename%3D%22head.txt%22")
+        .then()
+            .statusCode(200)
+            .header("Content-Disposition", equalTo("attachment; filename=\"head.txt\""));
+    }
+
+    @Test
+    @Order(15)
+    void emptyResponseOverrideIsIgnoredAndFallsBackToStored() {
+        // `?response-content-disposition=` binds as "" in JAX-RS; real S3 treats it as absent.
+        given()
+            .urlEncodingEnabled(false)
+        .when()
+            .get("/" + BUCKET + "/disposition-file.txt?response-content-disposition=")
+        .then()
+            .statusCode(200)
+            .header("Content-Disposition", equalTo("inline"));
+    }
+
+    @Test
+    @Order(16)
+    void rangeRequestAppliesResponseContentDispositionOverride() {
+        given()
+            .urlEncodingEnabled(false)
+            .header("Range", "bytes=0-3")
+        .when()
+            .get("/" + BUCKET + "/disposition-file.txt?response-content-disposition=attachment%3B%20filename%3D%22range.txt%22")
+        .then()
+            .statusCode(206)
+            .header("Content-Disposition", equalTo("attachment; filename=\"range.txt\""));
+    }
+
+    @Test
+    @Order(17)
+    void rangeRequestWithoutOverrideFallsBackToStoredDisposition() {
+        given()
+            .header("Range", "bytes=0-3")
+        .when()
+            .get("/" + BUCKET + "/disposition-file.txt")
+        .then()
+            .statusCode(206)
+            .header("Content-Disposition", equalTo("inline"))
+            .header("Cache-Control", equalTo("max-age=60"));
+    }
+
+    @Test
+    @Order(99)
     void cleanUp() {
         given().when().delete("/" + BUCKET + "/secret-file.txt").then().statusCode(204);
         given().when().delete("/" + BUCKET + "/uploaded-via-presign.txt").then().statusCode(204);
+        given().when().delete("/" + BUCKET + "/disposition-file.txt").then().statusCode(204);
         given().when().delete("/" + BUCKET).then().statusCode(204);
     }
 }


### PR DESCRIPTION
## Summary

Closes #916.

Per the [S3 GetObject API reference](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html), six query parameters override response headers on `GetObject` and `HeadObject`:

- `response-content-type` → `Content-Type`
- `response-content-language` → `Content-Language`
- `response-expires` → `Expires`
- `response-cache-control` → `Cache-Control`
- `response-content-disposition` → `Content-Disposition`
- `response-content-encoding` → `Content-Encoding`

Floci previously ignored these and emitted only the values stored on the object at upload time. The canonical use case is generating multiple presigned URLs that serve the same object with different dispositions (e.g., one for inline rendering, another for `attachment` download) — that pattern was broken.

## Changes

- Add the six `@QueryParam` bindings on `getObject` and `headObject`.
- Bundle them in a private `ResponseHeaderOverrides` record. Compact constructor normalizes empty strings (`?response-content-disposition=`) to `null`, matching real S3 which ignores empty overrides — JAX-RS binds the empty value to `""`, not `null`.
- Refactor `appendObjectHeaders` with an override-aware overload; the no-arg overload (used by `putObject`) routes through the singleton `ResponseHeaderOverrides.NONE`.
- Route `handleRangeRequest` through `appendObjectHeaders` so 206 partial-content responses get the same override treatment — this also fixes a pre-existing gap where range responses dropped stored `Content-Disposition` / `Cache-Control` / `Content-Encoding` / `x-amz-version-id` headers.

## Test plan

New tests in `PreSignedUrlIntegrationTest` (@Order 10–17 + extended cleanup):

- [x] Single override applied (override wins over stored value)
- [x] All 6 overrides applied at once
- [x] No override → falls back to stored headers (regression guard)
- [x] HEAD request honors override
- [x] Empty `?response-*=` is ignored, falls back to stored
- [x] Range request + override → 206 with overridden header
- [x] Range request without override → 206 with stored header (closes pre-existing gap)
- [x] All 447 S3 tests pass locally

## Out of scope (follow-up)

- **#918** — Real S3 rejects `response-*` overrides on unsigned (anonymous) requests. Floci honors them on any request. Filed as a separate issue because (a) it's a different code path (auth classification, not response building), (b) Floci's auth model is intentionally permissive across the board, so the maintainers should decide whether to tighten this corner selectively.