### PR TITLE
fix(apigateway): accept any Content-Type on Put/ImportRestApi

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
@@ -222,6 +222,7 @@ public class ApiGatewayController {
 
     @POST
     @Path("/restapis")
+    @Consumes(MediaType.WILDCARD)
     public Response createRestApi(@Context HttpHeaders headers,
                                   @QueryParam("mode") String mode,
                                   String body) {
@@ -242,6 +243,7 @@ public class ApiGatewayController {
 
     @PUT
     @Path("/restapis/{apiId}")
+    @Consumes(MediaType.WILDCARD)
     public Response putRestApi(@Context HttpHeaders headers,
                                @PathParam("apiId") String apiId,
                                @QueryParam("mode") String mode,

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayOpenApiImportTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayOpenApiImportTest.java
@@ -1288,6 +1288,80 @@ class ApiGatewayOpenApiImportTest {
         given().delete("/restapis/" + apiId);
     }
 
+    // ──────────────────────────── Content-Type Tolerance ────────────────────────────
+
+    @Test
+    @Order(70)
+    void importRestApi_octetStreamContentType() throws Exception {
+        String spec = """
+                {"openapi": "3.0.1", "info": {"title": "OctetImport", "version": "1.0"}, "paths": {}}
+                """;
+        String body = given()
+                .contentType("application/octet-stream")
+                .queryParam("mode", "import")
+                .body(spec.getBytes())
+                .when()
+                .post("/restapis")
+                .then()
+                .statusCode(201)
+                .body("name", equalTo("OctetImport"))
+                .extract().body().asString();
+
+        String apiId = mapper.readTree(body).get("id").asText();
+        given().delete("/restapis/" + apiId);
+    }
+
+    @Test
+    @Order(71)
+    void putRestApi_noContentType() throws Exception {
+        String createBody = given()
+                .contentType(ContentType.JSON)
+                .body("{\"name\": \"NoCtype\"}")
+                .post("/restapis")
+                .then().statusCode(201).extract().body().asString();
+        String apiId = mapper.readTree(createBody).get("id").asText();
+
+        String spec = """
+                {"openapi": "3.0.1", "info": {"title": "NoCtypeOverwritten", "version": "1.0"}, "paths": {}}
+                """;
+        given()
+                .queryParam("mode", "overwrite")
+                .body(spec.getBytes())
+                .when()
+                .put("/restapis/" + apiId)
+                .then()
+                .statusCode(200)
+                .body("name", equalTo("NoCtypeOverwritten"));
+
+        given().delete("/restapis/" + apiId);
+    }
+
+    @Test
+    @Order(72)
+    void putRestApi_octetStreamContentType() throws Exception {
+        String createBody = given()
+                .contentType(ContentType.JSON)
+                .body("{\"name\": \"OctetOverwrite\"}")
+                .post("/restapis")
+                .then().statusCode(201).extract().body().asString();
+        String apiId = mapper.readTree(createBody).get("id").asText();
+
+        String spec = """
+                {"openapi": "3.0.1", "info": {"title": "OctetOverwritten", "version": "1.0"}, "paths": {}}
+                """;
+        given()
+                .contentType("application/octet-stream")
+                .queryParam("mode", "overwrite")
+                .body(spec.getBytes())
+                .when()
+                .put("/restapis/" + apiId)
+                .then()
+                .statusCode(200)
+                .body("name", equalTo("OctetOverwritten"));
+
+        given().delete("/restapis/" + apiId);
+    }
+
     // ──────────────────────────── Cleanup ────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

Closes #855.

The class-level `@Consumes` on `ApiGatewayController` restricted these endpoints to `application/json` and `application/json-patch+json`, so JAX-RS returned **415 Unsupported Media Type** for any other Content-Type. The Terraform AWS provider sends the OpenAPI body as `application/octet-stream`, which broke `aws_api_gateway_rest_api` resources that use an inline `body`.

Fix: add method-level `@Consumes(MediaType.WILDCARD)` on `createRestApi` (POST `/restapis`, handles ImportRestApi when `mode=import`) and `putRestApi` (PUT `/restapis/{apiId}`). Method-level annotations override the class-level default; the PATCH `updateRestApi` (which legitimately needs `application/json-patch+json`) is untouched.

This matches the existing Floci pattern for endpoints whose body is treated as an opaque blob:
- `BedrockRuntimeController` — `invokeModel`, `invokeModelWithResponseStream`, `converse` (lines 72, 86, 95)
- `S3ControlController` (line 88)
- `AppConfigController` (line 125)

The service-layer Swagger parser (`OpenAPIParser.readContents`) content-sniffs the body, so JSON and YAML payloads keep working regardless of the declared Content-Type.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** PUT `/restapis/{apiId}` and POST `/restapis?mode=import` returned `415` when called with `Content-Type: application/octet-stream`, the format sent by the AWS Go SDK v2 used by the Terraform AWS provider (`hashicorp/aws v6.45.0`). Real AWS accepts these requests.

**Reproduction (from #855):**
```bash
API_ID=$(aws --endpoint-url http://localhost:4566 apigateway create-rest-api \
  --name test-api --query 'id' --output text)
curl -v -X PUT "http://localhost:4566/restapis/$API_ID?mode=overwrite" \
  -H "Content-Type: application/octet-stream" \
  --data-binary '{"openapi":"3.0.1","info":{"title":"test","version":"1"},"paths":{}}'
# Before: 415
# After:  200
```

## Checklist

- [x] `./mvnw test` passes locally (all 339 API Gateway tests green; `ApiGatewayOpenApiImportTest` 25/25 including 3 new cases)
- [x] New or updated integration test added — `importRestApi_octetStreamContentType`, `putRestApi_octetStreamContentType`, `putRestApi_noContentType`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)