### PR TITLE
fix(lambda): await HttpServer close in RuntimeApiServer.stop()

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -30,6 +30,9 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Starts and stops Docker containers for Lambda function execution.
@@ -276,7 +279,14 @@ public class ContainerLauncher {
         LOG.infov("Stopping container {0}", handle.getContainerId());
         handle.setState(ContainerState.STOPPED);
 
-        handle.getRuntimeApiServer().stop();
+        try {
+            handle.getRuntimeApiServer().stop().get(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException | TimeoutException e) {
+            LOG.warnv(e, "RuntimeApiServer did not close cleanly for container {0}",
+                    handle.getContainerId());
+        }
         lifecycleManager.stopAndRemove(handle.getContainerId(), handle.getLogStream());
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServer.java
@@ -49,6 +49,7 @@ public class RuntimeApiServer {
 
     private volatile HttpServer httpServer;
     private volatile boolean stopped;
+    private volatile CompletableFuture<Void> closeFuture;
 
     RuntimeApiServer(Vertx vertx, int port) {
         this.vertx = vertx;
@@ -136,9 +137,10 @@ public class RuntimeApiServer {
                 .setMaxFormAttributeSize(-1));
         httpServer.requestHandler(router).listen(port, "0.0.0.0", result -> {
             if (result.succeeded()) {
-                LOG.debugv("RuntimeApiServer started on port {0}", port);
+                LOG.infov("RuntimeApiServer started on port {0}", port);
                 started.complete(null);
             } else {
+                LOG.errorv(result.cause(), "RuntimeApiServer failed to bind on port {0}", port);
                 started.completeExceptionally(result.cause());
             }
         });
@@ -146,10 +148,25 @@ public class RuntimeApiServer {
         return started;
     }
 
-    public void stop() {
+    public synchronized CompletableFuture<Void> stop() {
+        if (closeFuture != null) {
+            return closeFuture;
+        }
         stopped = true;
+        CompletableFuture<Void> closed = new CompletableFuture<>();
+        closeFuture = closed;
         if (httpServer != null) {
-            httpServer.close();
+            httpServer.close(ar -> {
+                if (ar.succeeded()) {
+                    LOG.debugv("RuntimeApiServer on port {0} closed", port);
+                    closed.complete(null);
+                } else {
+                    LOG.warnv(ar.cause(), "RuntimeApiServer on port {0} failed to close cleanly", port);
+                    closed.completeExceptionally(ar.cause());
+                }
+            });
+        } else {
+            closed.complete(null);
         }
 
         // Wake any parked /next pollers with 204 (container shutting down — runtime will exit).
@@ -175,6 +192,8 @@ public class RuntimeApiServer {
                 inv.getResultFuture().complete(
                         new InvokeResult(200, "Unhandled", CONTAINER_STOPPED_PAYLOAD, null, inv.getRequestId())));
         inFlight.clear();
+
+        return closed;
     }
 
     public CompletableFuture<InvokeResult> enqueue(PendingInvocation invocation) {

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServerTest.java
@@ -223,6 +223,27 @@ class RuntimeApiServerTest {
         assertTrue(new String(result.getPayload()).contains("ContainerStopped"));
     }
 
+    @Test
+    @Timeout(10)
+    void stopReleasesPortSynchronously() throws Exception {
+        server.stop();
+        new ServerSocket(port).close();
+    }
+
+    @Test
+    @Timeout(10)
+    void newServerOnSamePortAcceptsTrafficAfterStop() throws Exception {
+        server.stop();
+
+        server = new RuntimeApiServer(vertx, port);
+        server.start();
+
+        HttpResponse<String> resp = httpClient.send(
+                HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/x")).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertEquals(404, resp.statusCode());
+    }
+
     private static int findFreePort() throws IOException {
         try (ServerSocket socket = new ServerSocket(0)) {
             return socket.getLocalPort();

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServerTest.java
@@ -45,8 +45,8 @@ class RuntimeApiServerTest {
     }
 
     @AfterEach
-    void tearDown() {
-        server.stop();
+    void tearDown() throws Exception {
+        server.stop().get(5, TimeUnit.SECONDS);
         scheduler.shutdownNow();
         vertx.close();
     }
@@ -226,17 +226,17 @@ class RuntimeApiServerTest {
     @Test
     @Timeout(10)
     void stopReleasesPortSynchronously() throws Exception {
-        server.stop();
+        server.stop().get(5, TimeUnit.SECONDS);
         new ServerSocket(port).close();
     }
 
     @Test
     @Timeout(10)
     void newServerOnSamePortAcceptsTrafficAfterStop() throws Exception {
-        server.stop();
+        server.stop().get(5, TimeUnit.SECONDS);
 
         server = new RuntimeApiServer(vertx, port);
-        server.start();
+        server.start().get(5, TimeUnit.SECONDS);
 
         HttpResponse<String> resp = httpClient.send(
                 HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/x")).GET().build(),


### PR DESCRIPTION
## Summary

No bug ticket, discovered and fixed bug.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

When testing terraform apply against floci on M3 Pro with OrbStack, the server turned out to have a race condition affecting the port re-use behavior. Not sure whether this is a MacOS / OrbStack specific bug, but could potentially affect other systems too with various degrees depending on socket-freeing behavior.

Ran pre-fix tests confirming the tests fail on old code:
https://github.com/askrella/floci/actions/runs/26061781952/job/76625059951#step:4:14494
<img width="825" height="75" alt="image" src="https://github.com/user-attachments/assets/c66c9345-d194-4b32-85c1-bce2c0620e1e" />

Post-fix tests run successfully for the proposed fix:
https://github.com/askrella/floci/actions/runs/26062702232/job/76626452694


