### PR TITLE
fix(apigatewayv2): include connectionType and enableSimpleResponses on Integration/Authorizer responses

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
@@ -1665,6 +1665,7 @@ public class ApiGatewayController {
         ObjectNode node = objectMapper.createObjectNode();
         node.put("integrationId", i.getIntegrationId());
         node.put("integrationType", i.getIntegrationType());
+        if (i.getConnectionType() != null) node.put("connectionType", i.getConnectionType());
         node.put("payloadFormatVersion", i.getPayloadFormatVersion());
         if (i.getIntegrationUri() != null) node.put("integrationUri", i.getIntegrationUri());
         if (i.getRequestTemplates() != null) {
@@ -1741,6 +1742,9 @@ public class ApiGatewayController {
         }
         if (a.getAuthorizerResultTtlInSeconds() != null) {
             node.put("authorizerResultTtlInSeconds", a.getAuthorizerResultTtlInSeconds());
+        }
+        if (a.getEnableSimpleResponses() != null) {
+            node.put("enableSimpleResponses", a.getEnableSimpleResponses());
         }
         return node;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandler.java
@@ -539,6 +539,9 @@ public class ApiGatewayV2JsonHandler {
         if (auth.getAuthorizerResultTtlInSeconds() != null) {
             node.put("AuthorizerResultTtlInSeconds", auth.getAuthorizerResultTtlInSeconds());
         }
+        if (auth.getEnableSimpleResponses() != null) {
+            node.put("EnableSimpleResponses", auth.getEnableSimpleResponses());
+        }
         return node;
     }
 
@@ -559,6 +562,7 @@ public class ApiGatewayV2JsonHandler {
         ObjectNode node = objectMapper.createObjectNode();
         node.put("IntegrationId", i.getIntegrationId());
         node.put("IntegrationType", i.getIntegrationType());
+        if (i.getConnectionType() != null) node.put("ConnectionType", i.getConnectionType());
         node.put("PayloadFormatVersion", i.getPayloadFormatVersion());
         if (i.getIntegrationUri() != null) node.put("IntegrationUri", i.getIntegrationUri());
         if (i.getRequestTemplates() != null) {

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
@@ -175,6 +175,9 @@ public class ApiGatewayV2Service {
         if (request.get("authorizerResultTtlInSeconds") != null) {
             auth.setAuthorizerResultTtlInSeconds(((Number) request.get("authorizerResultTtlInSeconds")).intValue());
         }
+        if (request.get("enableSimpleResponses") != null) {
+            auth.setEnableSimpleResponses(Boolean.parseBoolean(String.valueOf(request.get("enableSimpleResponses"))));
+        }
 
         authorizerStore.put(authorizerKey(region, apiId, auth.getAuthorizerId()), auth);
         LOG.infov("Created authorizer: {0} ({1}) for API {2}", auth.getName(), auth.getAuthorizerId(), apiId);
@@ -232,6 +235,9 @@ public class ApiGatewayV2Service {
         }
         if (request.containsKey("authorizerResultTtlInSeconds") && request.get("authorizerResultTtlInSeconds") != null) {
             auth.setAuthorizerResultTtlInSeconds(((Number) request.get("authorizerResultTtlInSeconds")).intValue());
+        }
+        if (request.containsKey("enableSimpleResponses") && request.get("enableSimpleResponses") != null) {
+            auth.setEnableSimpleResponses(Boolean.parseBoolean(String.valueOf(request.get("enableSimpleResponses"))));
         }
 
         authorizerStore.put(authorizerKey(region, apiId, authorizerId), auth);
@@ -364,6 +370,7 @@ public class ApiGatewayV2Service {
         integration.setIntegrationId(shortId(8));
         integration.setIntegrationType((String) request.get("integrationType"));
         integration.setIntegrationUri((String) request.get("integrationUri"));
+        integration.setConnectionType((String) request.get("connectionType"));
         integration.setPayloadFormatVersion((String) request.getOrDefault("payloadFormatVersion", "2.0"));
         integration.setIntegrationMethod((String) request.get("integrationMethod"));
         integration.setTemplateSelectionExpression((String) request.get("templateSelectionExpression"));
@@ -412,6 +419,9 @@ public class ApiGatewayV2Service {
         }
         if (request.containsKey("integrationUri") && request.get("integrationUri") != null) {
             integration.setIntegrationUri((String) request.get("integrationUri"));
+        }
+        if (request.containsKey("connectionType") && request.get("connectionType") != null) {
+            integration.setConnectionType((String) request.get("connectionType"));
         }
         if (request.containsKey("payloadFormatVersion") && request.get("payloadFormatVersion") != null) {
             integration.setPayloadFormatVersion((String) request.get("payloadFormatVersion"));

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/model/Authorizer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/model/Authorizer.java
@@ -16,6 +16,7 @@ public class Authorizer {
     private String authorizerUri;
     private String authorizerPayloadFormatVersion;
     private Integer authorizerResultTtlInSeconds;
+    private Boolean enableSimpleResponses;
 
     public Authorizer() {}
 
@@ -42,6 +43,9 @@ public class Authorizer {
 
     public Integer getAuthorizerResultTtlInSeconds() { return authorizerResultTtlInSeconds; }
     public void setAuthorizerResultTtlInSeconds(Integer authorizerResultTtlInSeconds) { this.authorizerResultTtlInSeconds = authorizerResultTtlInSeconds; }
+
+    public Boolean getEnableSimpleResponses() { return enableSimpleResponses; }
+    public void setEnableSimpleResponses(Boolean enableSimpleResponses) { this.enableSimpleResponses = enableSimpleResponses; }
 
     @RegisterForReflection
     public record JwtConfiguration(List<String> audience, String issuer) {}

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/model/Integration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/model/Integration.java
@@ -10,6 +10,7 @@ import java.util.Map;
 public class Integration {
     private String integrationId;
     private String integrationType; // AWS_PROXY, HTTP_PROXY
+    private String connectionType; // INTERNET, VPC_LINK
     private String integrationUri;
     private String payloadFormatVersion; // 1.0, 2.0
     private String integrationMethod;
@@ -26,6 +27,9 @@ public class Integration {
 
     public String getIntegrationType() { return integrationType; }
     public void setIntegrationType(String integrationType) { this.integrationType = integrationType; }
+
+    public String getConnectionType() { return connectionType; }
+    public void setConnectionType(String connectionType) { this.connectionType = connectionType; }
 
     public String getIntegrationUri() { return integrationUri; }
     public void setIntegrationUri(String integrationUri) { this.integrationUri = integrationUri; }

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/IntegrationConnectionTypeAndAuthorizerSimpleResponsesTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/IntegrationConnectionTypeAndAuthorizerSimpleResponsesTest.java
@@ -1,0 +1,334 @@
+package io.github.hectorvent.floci.services.apigatewayv2;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * Regression coverage for the HTTP API v2 management API returning {@code connectionType}
+ * on Integration resources and {@code enableSimpleResponses} on Authorizer resources.
+ * Both values are accepted on create/update and are required by IaC tools like Terraform
+ * to avoid perceived drift on every plan.
+ */
+@QuarkusTest
+class IntegrationConnectionTypeAndAuthorizerSimpleResponsesTest {
+
+    private static final String AMZ_JSON = "application/x-amz-json-1.1";
+    private static final String TARGET_PREFIX = "AmazonApiGatewayV2.";
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260519/us-east-1/apigatewayv2/aws4_request";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    // ──────────────────────────── Integration.connectionType ────────────────────────────
+
+    @Test
+    void connectionTypeReturnedFromCreateGetAndList() {
+        String apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"conn-type-create","protocolType":"HTTP"}
+                        """)
+                .when().post("/v2/apis")
+                .then().statusCode(201)
+                .extract().path("apiId");
+
+        String integrationId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                          "integrationType":"HTTP_PROXY",
+                          "integrationUri":"https://example.com",
+                          "integrationMethod":"GET",
+                          "connectionType":"VPC_LINK",
+                          "payloadFormatVersion":"1.0"
+                        }
+                        """)
+                .when().post("/v2/apis/" + apiId + "/integrations")
+                .then().statusCode(201)
+                .body("connectionType", equalTo("VPC_LINK"))
+                .extract().path("integrationId");
+
+        given()
+                .when().get("/v2/apis/" + apiId + "/integrations/" + integrationId)
+                .then().statusCode(200)
+                .body("connectionType", equalTo("VPC_LINK"));
+
+        given()
+                .when().get("/v2/apis/" + apiId + "/integrations")
+                .then().statusCode(200)
+                .body("items.connectionType", hasItem("VPC_LINK"));
+    }
+
+    @Test
+    void connectionTypeReturnedAfterUpdate() {
+        String apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"conn-type-update","protocolType":"HTTP"}
+                        """)
+                .when().post("/v2/apis")
+                .then().statusCode(201)
+                .extract().path("apiId");
+
+        String integrationId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                          "integrationType":"HTTP_PROXY",
+                          "integrationUri":"https://example.com",
+                          "integrationMethod":"GET",
+                          "payloadFormatVersion":"1.0"
+                        }
+                        """)
+                .when().post("/v2/apis/" + apiId + "/integrations")
+                .then().statusCode(201)
+                .extract().path("integrationId");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"connectionType":"VPC_LINK"}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/integrations/" + integrationId)
+                .then().statusCode(200)
+                .body("connectionType", equalTo("VPC_LINK"));
+
+        given()
+                .when().get("/v2/apis/" + apiId + "/integrations/" + integrationId)
+                .then().statusCode(200)
+                .body("connectionType", equalTo("VPC_LINK"));
+    }
+
+    @Test
+    void connectionTypeOmittedWhenNull() {
+        String apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"conn-type-omit","protocolType":"HTTP"}
+                        """)
+                .when().post("/v2/apis")
+                .then().statusCode(201)
+                .extract().path("apiId");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                          "integrationType":"HTTP_PROXY",
+                          "integrationUri":"https://example.com",
+                          "integrationMethod":"GET",
+                          "payloadFormatVersion":"1.0"
+                        }
+                        """)
+                .when().post("/v2/apis/" + apiId + "/integrations")
+                .then().statusCode(201)
+                .body("$", not(hasKey("connectionType")))
+                .body("connectionType", nullValue());
+    }
+
+    // ──────────────────────────── Authorizer.enableSimpleResponses ────────────────────────────
+
+    @Test
+    void enableSimpleResponsesReturnedFromCreateGetAndList() {
+        String apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"simple-resp-create","protocolType":"HTTP"}
+                        """)
+                .when().post("/v2/apis")
+                .then().statusCode(201)
+                .extract().path("apiId");
+
+        String authorizerId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                          "authorizerType":"REQUEST",
+                          "name":"lambda-authz",
+                          "identitySource":["$request.header.Authorization"],
+                          "authorizerUri":"arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:authz/invocations",
+                          "authorizerPayloadFormatVersion":"2.0",
+                          "enableSimpleResponses":true
+                        }
+                        """)
+                .when().post("/v2/apis/" + apiId + "/authorizers")
+                .then().statusCode(201)
+                .body("enableSimpleResponses", equalTo(true))
+                .extract().path("authorizerId");
+
+        given()
+                .when().get("/v2/apis/" + apiId + "/authorizers/" + authorizerId)
+                .then().statusCode(200)
+                .body("enableSimpleResponses", equalTo(true));
+
+        given()
+                .when().get("/v2/apis/" + apiId + "/authorizers")
+                .then().statusCode(200)
+                .body("items.enableSimpleResponses", hasItem(true));
+    }
+
+    @Test
+    void enableSimpleResponsesReturnedAfterUpdate() {
+        String apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"simple-resp-update","protocolType":"HTTP"}
+                        """)
+                .when().post("/v2/apis")
+                .then().statusCode(201)
+                .extract().path("apiId");
+
+        String authorizerId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                          "authorizerType":"REQUEST",
+                          "name":"lambda-authz-2",
+                          "identitySource":["$request.header.Authorization"],
+                          "authorizerUri":"arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:authz/invocations",
+                          "authorizerPayloadFormatVersion":"2.0"
+                        }
+                        """)
+                .when().post("/v2/apis/" + apiId + "/authorizers")
+                .then().statusCode(201)
+                .extract().path("authorizerId");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"enableSimpleResponses":true}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/authorizers/" + authorizerId)
+                .then().statusCode(200)
+                .body("enableSimpleResponses", equalTo(true));
+
+        given()
+                .when().get("/v2/apis/" + apiId + "/authorizers/" + authorizerId)
+                .then().statusCode(200)
+                .body("enableSimpleResponses", equalTo(true));
+    }
+
+    @Test
+    void enableSimpleResponsesOmittedWhenNull() {
+        String apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"simple-resp-omit","protocolType":"HTTP"}
+                        """)
+                .when().post("/v2/apis")
+                .then().statusCode(201)
+                .extract().path("apiId");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                          "authorizerType":"JWT",
+                          "name":"jwt-authz",
+                          "identitySource":["$request.header.Authorization"],
+                          "jwtConfiguration":{"issuer":"https://example.com","audience":["api"]}
+                        }
+                        """)
+                .when().post("/v2/apis/" + apiId + "/authorizers")
+                .then().statusCode(201)
+                .body("$", not(hasKey("enableSimpleResponses")))
+                .body("enableSimpleResponses", nullValue());
+    }
+
+    // ──────────────────────────── JSON 1.1 dispatch ────────────────────────────
+
+    @Test
+    void connectionTypeReturnedViaJson11() {
+        String apiId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"Name":"conn-type-json11","ProtocolType":"HTTP"}
+                        """)
+                .when().post("/")
+                .then().statusCode(201)
+                .extract().path("ApiId");
+
+        String integrationId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateIntegration")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","IntegrationType":"HTTP_PROXY","IntegrationUri":"https://example.com","IntegrationMethod":"GET","ConnectionType":"VPC_LINK","PayloadFormatVersion":"1.0"}
+                        """.formatted(apiId))
+                .when().post("/")
+                .then().statusCode(201)
+                .body("ConnectionType", equalTo("VPC_LINK"))
+                .extract().path("IntegrationId");
+
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetIntegration")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","IntegrationId":"%s"}
+                        """.formatted(apiId, integrationId))
+                .when().post("/")
+                .then().statusCode(200)
+                .body("ConnectionType", equalTo("VPC_LINK"));
+    }
+
+    @Test
+    void enableSimpleResponsesReturnedViaJson11() {
+        String apiId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"Name":"simple-resp-json11","ProtocolType":"HTTP"}
+                        """)
+                .when().post("/")
+                .then().statusCode(201)
+                .extract().path("ApiId");
+
+        String authorizerId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateAuthorizer")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {
+                          "ApiId":"%s",
+                          "AuthorizerType":"REQUEST",
+                          "Name":"lambda-authz-json11",
+                          "IdentitySource":["$request.header.Authorization"],
+                          "AuthorizerUri":"arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:authz/invocations",
+                          "AuthorizerPayloadFormatVersion":"2.0",
+                          "EnableSimpleResponses":true
+                        }
+                        """.formatted(apiId))
+                .when().post("/")
+                .then().statusCode(201)
+                .body("EnableSimpleResponses", equalTo(true))
+                .extract().path("AuthorizerId");
+
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetAuthorizer")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","AuthorizerId":"%s"}
+                        """.formatted(apiId, authorizerId))
+                .when().post("/")
+                .then().statusCode(200)
+                .body("EnableSimpleResponses", equalTo(true));
+    }
+}


### PR DESCRIPTION
## Summary

Two HTTP API v2 management-plane response fields are silently dropped on
serialization, causing Terraform to report drift on every plan against a
correctly-configured emulator:

- `aws_apigatewayv2_integration.connection_type` — the `connectionType`
  argument (`INTERNET` / `VPC_LINK`) is not accepted by the service and
  never emitted on Get/Create/Update.
- `aws_apigatewayv2_authorizer.enable_simple_responses` — the
  `enableSimpleResponses` argument (HTTP API Lambda authorizer payload
  v2.0) is not accepted by the service and never emitted on
  Get/Create/Update.

Both follow the exact same shape (missing model field → missing service
extraction → missing emit on both REST and JSON 1.1 response paths) and
both surface as the identical Terraform-drift symptom on `terraform plan`.
They were found together in the same audit pass against
`hashicorp/terraform-provider-aws` resource schemas, so they are landed
together. Happy to split into two PRs if preferred.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against the AWS API Gateway V2 documented schema:

- [`Integration.ConnectionType`](https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-integrations.html#apis-apiid-integrations-prop-integration-connectiontype) — `INTERNET | VPC_LINK`, optional, returned on every Integration response.
- [`Authorizer.EnableSimpleResponses`](https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid-authorizers-authorizerid.html#apis-apiid-authorizers-authorizerid-prop-authorizer-enablesimpleresponses) — `Boolean`, optional, returned on every Authorizer response when set.

Same Terraform-drift pattern as #887 (\`Route.authorizerId\`). Both fields
are documented as \`Computed = true\` on the Terraform provider side, so
the provider expects them to round-trip from the API.

## Implementation

For each field:

1. Add the field to the model POJO (\`Integration\` / \`Authorizer\`).
2. Read the field in \`ApiGatewayV2Service.create*\` / \`update*\` from the
   incoming request map. \`enableSimpleResponses\` uses the same defensive
   \`Boolean.parseBoolean(String.valueOf(...))\` pattern as \`Stage.autoDeploy\`.
3. Emit the field (when non-null) in both response paths:
   \`ApiGatewayController.toV2*Node\` (REST) and
   \`ApiGatewayV2JsonHandler.to*Node\` (JSON 1.1).

## Tests

New \`IntegrationConnectionTypeAndAuthorizerSimpleResponsesTest\` covers
both fields across create/get/list/update on the REST path, plus
omitted-when-null assertions, plus JSON 1.1 round-trip via
\`X-Amz-Target\` dispatch for both \`CreateIntegration\`/\`GetIntegration\`
and \`CreateAuthorizer\`/\`GetAuthorizer\`. 8 tests, all green.

## Checklist

- [x] \`./mvnw test -Dtest='ApiGatewayV2*Test,*Authorizer*,*Connection*'\` passes locally (203/203)
- [x] New regression test added
- [x] Commit messages follow Conventional Commits