### PR TITLE
fix(apigatewayv2): include corsConfiguration on Api management responses

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
@@ -1649,6 +1649,32 @@ public class ApiGatewayController {
             api.getTags().forEach(tagsNode::put);
             node.set("tags", tagsNode);
         }
+        if (api.getCorsConfiguration() != null) {
+            node.set("corsConfiguration", toV2CorsNode(api.getCorsConfiguration()));
+        }
+        return node;
+    }
+
+    private ObjectNode toV2CorsNode(Api.Cors cors) {
+        ObjectNode node = objectMapper.createObjectNode();
+        if (cors.allowOrigins() != null) {
+            ArrayNode arr = node.putArray("allowOrigins");
+            cors.allowOrigins().forEach(arr::add);
+        }
+        if (cors.allowMethods() != null) {
+            ArrayNode arr = node.putArray("allowMethods");
+            cors.allowMethods().forEach(arr::add);
+        }
+        if (cors.allowHeaders() != null) {
+            ArrayNode arr = node.putArray("allowHeaders");
+            cors.allowHeaders().forEach(arr::add);
+        }
+        if (cors.exposeHeaders() != null) {
+            ArrayNode arr = node.putArray("exposeHeaders");
+            cors.exposeHeaders().forEach(arr::add);
+        }
+        if (cors.maxAge() != null) node.put("maxAge", cors.maxAge());
+        if (cors.allowCredentials() != null) node.put("allowCredentials", cors.allowCredentials());
         return node;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandler.java
@@ -508,6 +508,32 @@ public class ApiGatewayV2JsonHandler {
             ObjectNode tagsNode = node.putObject("Tags");
             api.getTags().forEach(tagsNode::put);
         }
+        if (api.getCorsConfiguration() != null) {
+            node.set("CorsConfiguration", toCorsNode(api.getCorsConfiguration()));
+        }
+        return node;
+    }
+
+    private ObjectNode toCorsNode(Api.Cors cors) {
+        ObjectNode node = objectMapper.createObjectNode();
+        if (cors.allowOrigins() != null) {
+            ArrayNode arr = node.putArray("AllowOrigins");
+            cors.allowOrigins().forEach(arr::add);
+        }
+        if (cors.allowMethods() != null) {
+            ArrayNode arr = node.putArray("AllowMethods");
+            cors.allowMethods().forEach(arr::add);
+        }
+        if (cors.allowHeaders() != null) {
+            ArrayNode arr = node.putArray("AllowHeaders");
+            cors.allowHeaders().forEach(arr::add);
+        }
+        if (cors.exposeHeaders() != null) {
+            ArrayNode arr = node.putArray("ExposeHeaders");
+            cors.exposeHeaders().forEach(arr::add);
+        }
+        if (cors.maxAge() != null) node.put("MaxAge", cors.maxAge());
+        if (cors.allowCredentials() != null) node.put("AllowCredentials", cors.allowCredentials());
         return node;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
@@ -98,6 +98,12 @@ public class ApiGatewayV2Service {
             api.setTags(tags);
         }
 
+        @SuppressWarnings("unchecked")
+        Map<String, Object> corsConfig = (Map<String, Object>) request.get("corsConfiguration");
+        if (corsConfig != null) {
+            api.setCorsConfiguration(toCors(corsConfig));
+        }
+
         apiStore.put(apiKey(region, api.getApiId()), api);
         LOG.infov("Created {0} API: {1} ({2}) in {3}", protocolType, api.getName(), api.getApiId(), region);
         return api;
@@ -138,9 +144,30 @@ public class ApiGatewayV2Service {
             Map<String, String> tags = (Map<String, String>) request.get("tags");
             api.setTags(tags);
         }
+        if (request.containsKey("corsConfiguration")) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> corsConfig = (Map<String, Object>) request.get("corsConfiguration");
+            api.setCorsConfiguration(corsConfig == null ? null : toCors(corsConfig));
+        }
 
         apiStore.put(apiKey(region, apiId), api);
         return api;
+    }
+
+    private static Api.Cors toCors(Map<String, Object> m) {
+        @SuppressWarnings("unchecked")
+        List<String> allowOrigins = (List<String>) m.get("allowOrigins");
+        @SuppressWarnings("unchecked")
+        List<String> allowMethods = (List<String>) m.get("allowMethods");
+        @SuppressWarnings("unchecked")
+        List<String> allowHeaders = (List<String>) m.get("allowHeaders");
+        @SuppressWarnings("unchecked")
+        List<String> exposeHeaders = (List<String>) m.get("exposeHeaders");
+        Integer maxAge = m.get("maxAge") == null ? null : ((Number) m.get("maxAge")).intValue();
+        Boolean allowCredentials = m.get("allowCredentials") == null
+                ? null
+                : Boolean.parseBoolean(String.valueOf(m.get("allowCredentials")));
+        return new Api.Cors(allowOrigins, allowMethods, allowHeaders, exposeHeaders, maxAge, allowCredentials);
     }
 
     // ──────────────────────────── Authorizer CRUD ────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/model/Api.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/model/Api.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RegisterForReflection
@@ -18,6 +19,7 @@ public class Api {
     private String routeSelectionExpression;
     private String description;
     private String apiKeySelectionExpression;
+    private Cors corsConfiguration;
 
     public Api() {}
 
@@ -47,4 +49,16 @@ public class Api {
 
     public String getApiKeySelectionExpression() { return apiKeySelectionExpression; }
     public void setApiKeySelectionExpression(String apiKeySelectionExpression) { this.apiKeySelectionExpression = apiKeySelectionExpression; }
+
+    public Cors getCorsConfiguration() { return corsConfiguration; }
+    public void setCorsConfiguration(Cors corsConfiguration) { this.corsConfiguration = corsConfiguration; }
+
+    @RegisterForReflection
+    public record Cors(
+            List<String> allowOrigins,
+            List<String> allowMethods,
+            List<String> allowHeaders,
+            List<String> exposeHeaders,
+            Integer maxAge,
+            Boolean allowCredentials) {}
 }

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiCorsConfigurationResponseTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiCorsConfigurationResponseTest.java
@@ -1,0 +1,203 @@
+package io.github.hectorvent.floci.services.apigatewayv2;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * Regression coverage for the HTTP API v2 management API returning {@code corsConfiguration}
+ * on Api resources. The value is accepted on Create/Update but currently never emitted on
+ * Get/Create/Update responses, causing IaC tools like Terraform's
+ * {@code aws_apigatewayv2_api.cors_configuration} to perceive drift on every plan.
+ */
+@QuarkusTest
+class ApiCorsConfigurationResponseTest {
+
+    private static final String AMZ_JSON = "application/x-amz-json-1.1";
+    private static final String TARGET_PREFIX = "AmazonApiGatewayV2.";
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260519/us-east-1/apigatewayv2/aws4_request";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    // ──────────────────────────── REST path ────────────────────────────
+
+    @Test
+    void corsConfigurationReturnedFromCreateGetAndList() {
+        String apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                          "name":"cors-create",
+                          "protocolType":"HTTP",
+                          "corsConfiguration":{
+                            "allowOrigins":["https://example.com"],
+                            "allowMethods":["GET","POST"],
+                            "allowHeaders":["Content-Type","Authorization"],
+                            "exposeHeaders":["X-Request-Id"],
+                            "maxAge":600,
+                            "allowCredentials":true
+                          }
+                        }
+                        """)
+                .when().post("/v2/apis")
+                .then().statusCode(201)
+                .body("corsConfiguration.allowOrigins", contains("https://example.com"))
+                .body("corsConfiguration.allowMethods", contains("GET", "POST"))
+                .body("corsConfiguration.allowHeaders", contains("Content-Type", "Authorization"))
+                .body("corsConfiguration.exposeHeaders", contains("X-Request-Id"))
+                .body("corsConfiguration.maxAge", equalTo(600))
+                .body("corsConfiguration.allowCredentials", equalTo(true))
+                .extract().path("apiId");
+
+        given()
+                .when().get("/v2/apis/" + apiId)
+                .then().statusCode(200)
+                .body("corsConfiguration.allowOrigins", contains("https://example.com"))
+                .body("corsConfiguration.maxAge", equalTo(600))
+                .body("corsConfiguration.allowCredentials", equalTo(true));
+
+        given()
+                .when().get("/v2/apis")
+                .then().statusCode(200)
+                .body("items.find { it.apiId == '" + apiId + "' }.corsConfiguration.allowOrigins",
+                        contains("https://example.com"))
+                .body("items.find { it.apiId == '" + apiId + "' }.corsConfiguration.maxAge",
+                        equalTo(600));
+    }
+
+    @Test
+    void corsConfigurationReturnedAfterUpdate() {
+        String apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"cors-update","protocolType":"HTTP"}
+                        """)
+                .when().post("/v2/apis")
+                .then().statusCode(201)
+                .body("$", not(hasKey("corsConfiguration")))
+                .extract().path("apiId");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                          "corsConfiguration":{
+                            "allowOrigins":["*"],
+                            "allowMethods":["*"],
+                            "maxAge":300
+                          }
+                        }
+                        """)
+                .when().patch("/v2/apis/" + apiId)
+                .then().statusCode(200)
+                .body("corsConfiguration.allowOrigins", contains("*"))
+                .body("corsConfiguration.allowMethods", contains("*"))
+                .body("corsConfiguration.maxAge", equalTo(300));
+
+        given()
+                .when().get("/v2/apis/" + apiId)
+                .then().statusCode(200)
+                .body("corsConfiguration.allowOrigins", contains("*"))
+                .body("corsConfiguration.maxAge", equalTo(300));
+    }
+
+    @Test
+    void corsConfigurationPreservedWhenUpdatingOtherFields() {
+        String apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {
+                          "name":"cors-preserve",
+                          "protocolType":"HTTP",
+                          "corsConfiguration":{
+                            "allowOrigins":["https://example.com"],
+                            "maxAge":600
+                          }
+                        }
+                        """)
+                .when().post("/v2/apis")
+                .then().statusCode(201)
+                .extract().path("apiId");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"description":"updated description"}
+                        """)
+                .when().patch("/v2/apis/" + apiId)
+                .then().statusCode(200)
+                .body("description", equalTo("updated description"))
+                .body("corsConfiguration.allowOrigins", contains("https://example.com"))
+                .body("corsConfiguration.maxAge", equalTo(600));
+    }
+
+    @Test
+    void corsConfigurationOmittedWhenNull() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"cors-omit","protocolType":"HTTP"}
+                        """)
+                .when().post("/v2/apis")
+                .then().statusCode(201)
+                .body("$", not(hasKey("corsConfiguration")))
+                .body("corsConfiguration", nullValue());
+    }
+
+    // ──────────────────────────── JSON 1.1 path ────────────────────────────
+
+    @Test
+    void corsConfigurationReturnedViaJson11() {
+        String apiId = given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "CreateApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {
+                          "Name":"cors-json11",
+                          "ProtocolType":"HTTP",
+                          "CorsConfiguration":{
+                            "AllowOrigins":["https://example.com"],
+                            "AllowMethods":["GET"],
+                            "AllowHeaders":["Content-Type"],
+                            "ExposeHeaders":["X-Request-Id"],
+                            "MaxAge":600,
+                            "AllowCredentials":true
+                          }
+                        }
+                        """)
+                .when().post("/")
+                .then().statusCode(201)
+                .body("CorsConfiguration.AllowOrigins", contains("https://example.com"))
+                .body("CorsConfiguration.AllowMethods", contains("GET"))
+                .body("CorsConfiguration.MaxAge", equalTo(600))
+                .body("CorsConfiguration.AllowCredentials", equalTo(true))
+                .extract().path("ApiId");
+
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetApi")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s"}
+                        """.formatted(apiId))
+                .when().post("/")
+                .then().statusCode(200)
+                .body("CorsConfiguration.AllowOrigins", contains("https://example.com"))
+                .body("CorsConfiguration.MaxAge", equalTo(600));
+    }
+}


### PR DESCRIPTION
## Summary

`Api.corsConfiguration` is silently dropped on serialization, causing
Terraform to report drift on every plan against a correctly-configured
emulator. `aws_apigatewayv2_api.cors_configuration` is documented as
`Computed = true` on the provider side, so the provider expects it to
round-trip from the API.

`Api` does not model `corsConfiguration` today, so neither
`ApiGatewayV2Service.createApi` / `updateApi` accept it from the inbound
request, nor do `ApiGatewayController.toV2ApiNode` (REST) /
`ApiGatewayV2JsonHandler.toApiNode` (JSON 1.1) emit it on Get / Create /
Update / List responses.

This is the third of three remaining apigatewayv2 drift cases in the same
class as #887 (`Route.authorizerId`) and #931 (`Integration.connectionType`,
`Authorizer.enableSimpleResponses`), kept separate from #931 because
`corsConfiguration` is a nested object rather than a single scalar.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against the AWS API Gateway V2 documented schema:

- [`Api.CorsConfiguration`](https://docs.aws.amazon.com/apigatewayv2/latest/api-reference/apis-apiid.html#apis-apiid-prop-api-corsconfiguration) — six optional sub-fields: `AllowOrigins`, `AllowMethods`, `AllowHeaders`, `ExposeHeaders`, `MaxAge`, `AllowCredentials`. Returned on every Api response when set.

## Implementation

1. New nested `Api.Cors` record mirroring the `Authorizer.JwtConfiguration`
   pattern (six AWS-documented sub-fields).
2. Shared `toCors(Map)` helper in `ApiGatewayV2Service` reads the field in
   `createApi` / `updateApi` from the inbound request. The boolean
   (`allowCredentials`) uses the same defensive
   `Boolean.parseBoolean(String.valueOf(...))` style as `Stage.autoDeploy`.
3. Emit the value (when non-null) from both response paths:
   `ApiGatewayController.toV2CorsNode` (REST) and
   `ApiGatewayV2JsonHandler.toCorsNode` (JSON 1.1).

## Tests

New `ApiCorsConfigurationResponseTest` covers:

- Create / Get / List round-trip on REST with all six sub-fields.
- PATCH `updateApi` replaces the existing `corsConfiguration`.
- Omitted-when-null assertions on responses with no CORS set.
- PATCH on an unrelated field preserves the existing `corsConfiguration`.
- JSON 1.1 `CreateApi` / `GetApi` round-trip via `X-Amz-Target` dispatch.

5 tests, all green.

## Out of scope

- WEBSOCKET-protocol APIs do not reject `corsConfiguration` in this PR.
  Validation can be added in a follow-up if desired.
- The `CorsConfiguration: {}` empty-object lifecycle (AWS uses this to
  disable CORS on `update-api`) is not verified against real AWS in this
  PR — only basic round-trip is covered.

## Checklist

- [x] `./mvnw test -Dtest='ApiCorsConfigurationResponseTest,ApiGatewayV2*Test,...'` passes locally (105/105 scoped run)
- [x] New regression test added
- [x] Commit message follows Conventional Commits