### PR TITLE
fix(lambda): log actionable hint when concurrency pool is exhausted

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaConcurrencyLimiter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaConcurrencyLimiter.java
@@ -183,6 +183,11 @@ public class LambdaConcurrencyLimiter {
                 int otherReserved = regionTotal(region).get() - currentForThis;
                 int maxAllowed = regionLimit - unreservedMin - otherReserved;
                 if (target > maxAllowed) {
+                    LOG.warnv("Region {0} reservation pool exhausted: requested={1}, "
+                            + "alreadyReserved={2}, regionLimit={3}, unreservedMin={4}. "
+                            + "Raise FLOCI_SERVICES_LAMBDA_REGION_CONCURRENCY_LIMIT (e.g. 10000) "
+                            + "or lower the function's ReservedConcurrentExecutions.",
+                            region, target, otherReserved, regionLimit, unreservedMin);
                     throw new AwsException("LimitExceededException",
                             "Specified ReservedConcurrentExecutions for function decreases account's "
                             + "UnreservedConcurrentExecution below its minimum value of ["


### PR DESCRIPTION
When PutFunctionConcurrency hits the regional reservation cap, the LimitExceededException response is AWS-correct but the cause is invisible in floci logs. Operators see only terraform retrying for minutes (AWS SDK Go v2 plus the provider's MaxAttempts=25) while the underlying reason (total reservations exceed regionLimit minus unreservedMin) sits silently in the limiter.

Emit a WARN on every limit hit with the offending numbers and the env var to raise the cap. Error code, body and status remain identical to real AWS; this is observability only.

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
