### PR TITLE
fix(lambda): make PortAllocator a checkout/release pool 

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/port/PortAllocator.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/port/PortAllocator.java
@@ -4,34 +4,43 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Thread-safe sequential port dispenser for Lambda Runtime API servers.
+ * Hands out ports from a configured range for Lambda Runtime API servers.
+ * Throws {@link IllegalStateException} when the range is exhausted; the
+ * caller releases a port back to the pool via {@link #release(int)}.
  */
 @ApplicationScoped
 public class PortAllocator {
 
-    private final AtomicInteger counter;
     private final int basePort;
-    private final int range;
+    private final int maxPort;
+    private final Set<Integer> inUse = ConcurrentHashMap.newKeySet();
 
     @Inject
     public PortAllocator(EmulatorConfig config) {
-        this.basePort = config.services().lambda().runtimeApiBasePort();
-        int maxPort = config.services().lambda().runtimeApiMaxPort();
-        this.range = maxPort - basePort + 1;
-        this.counter = new AtomicInteger(0);
+        this(config.services().lambda().runtimeApiBasePort(),
+                config.services().lambda().runtimeApiMaxPort());
     }
 
     PortAllocator(int basePort, int maxPort) {
         this.basePort = basePort;
-        this.range = maxPort - basePort + 1;
-        this.counter = new AtomicInteger(0);
+        this.maxPort = maxPort;
     }
 
     public int allocate() {
-        int offset = counter.getAndIncrement();
-        return basePort + (Math.abs(offset) % range);
+        for (int p = basePort; p <= maxPort; p++) {
+            if (inUse.add(p)) {
+                return p;
+            }
+        }
+        throw new IllegalStateException(
+                "No free ports in range " + basePort + "-" + maxPort);
+    }
+
+    public void release(int port) {
+        inUse.remove(port);
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -286,6 +286,8 @@ public class ContainerLauncher {
         } catch (ExecutionException | TimeoutException e) {
             LOG.warnv(e, "RuntimeApiServer did not close cleanly for container {0}",
                     handle.getContainerId());
+        } finally {
+            runtimeApiServerFactory.release(handle.getRuntimeApiServer());
         }
         lifecycleManager.stopAndRemove(handle.getContainerId(), handle.getLogStream());
     }

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServerFactory.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServerFactory.java
@@ -29,16 +29,22 @@ public class RuntimeApiServerFactory {
 
     public RuntimeApiServer create() {
         int port = portAllocator.allocate();
-        RuntimeApiServer server = new RuntimeApiServer(vertx, port);
         try {
+            RuntimeApiServer server = new RuntimeApiServer(vertx, port);
             server.start().get(10, TimeUnit.SECONDS);
             LOG.debugv("Created RuntimeApiServer on port {0}", port);
+            return server;
         } catch (InterruptedException e) {
+            portAllocator.release(port);
             Thread.currentThread().interrupt();
             throw new RuntimeException("Interrupted while starting RuntimeApiServer", e);
         } catch (ExecutionException | TimeoutException e) {
+            portAllocator.release(port);
             throw new RuntimeException("Failed to start RuntimeApiServer on port " + port, e);
         }
-        return server;
+    }
+
+    public void release(RuntimeApiServer server) {
+        portAllocator.release(server.getPort());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/core/common/port/PortAllocatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/port/PortAllocatorTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.core.common.port;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -38,5 +39,19 @@ class PortAllocatorTest {
         latch.await();
         executor.shutdown();
         assertEquals(threads, ports.size(), "All allocated ports must be unique");
+    }
+
+    @Test
+    void allocateNeverReturnsPortAlreadyHandedOut() {
+        PortAllocator allocator = new PortAllocator(9200, 9209);
+        Set<Integer> handed = new HashSet<>();
+        for (int i = 0; i < 11; i++) {
+            try {
+                int p = allocator.allocate();
+                assertTrue(handed.add(p), "allocate() returned port " + p + " already in use");
+            } catch (RuntimeException exhausted) {
+                return;
+            }
+        }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/core/common/port/PortAllocatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/port/PortAllocatorTest.java
@@ -45,13 +45,20 @@ class PortAllocatorTest {
     void allocateNeverReturnsPortAlreadyHandedOut() {
         PortAllocator allocator = new PortAllocator(9200, 9209);
         Set<Integer> handed = new HashSet<>();
-        for (int i = 0; i < 11; i++) {
-            try {
-                int p = allocator.allocate();
-                assertTrue(handed.add(p), "allocate() returned port " + p + " already in use");
-            } catch (RuntimeException exhausted) {
-                return;
-            }
+        for (int i = 0; i < 10; i++) {
+            assertTrue(handed.add(allocator.allocate()));
         }
+        assertThrows(IllegalStateException.class, allocator::allocate);
+    }
+
+    @Test
+    void releasedPortBecomesAvailableAgain() {
+        PortAllocator allocator = new PortAllocator(9200, 9201);
+        int first = allocator.allocate();
+        allocator.allocate();
+        assertThrows(IllegalStateException.class, allocator::allocate);
+
+        allocator.release(first);
+        assertEquals(first, allocator.allocate());
     }
 }


### PR DESCRIPTION
## Summary

The previous modular counter (basePort + offset % range) wrapped
silently when allocations exceeded the configured range, handing the
same port to two RuntimeApiServers. The second listen() either failed
with EADDRINUSE or bound on top of a draining socket (in both cases
producing a runtime API the Lambda bootstrap could not reach).

PortAllocator now tracks in-use ports in a Set and throws
IllegalStateException on exhaustion. RuntimeApiServerFactory releases
the port on start failure; ContainerLauncher releases it after the
server is stopped.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
