### PR TITLE
fix(apigatewayv2): raise Vert.x WebSocket frame size limit to 256 KB

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/config/HttpOptionsCustomizer.java
+++ b/src/main/java/io/github/hectorvent/floci/config/HttpOptionsCustomizer.java
@@ -5,30 +5,53 @@ import io.vertx.core.http.HttpServerOptions;
 import jakarta.enterprise.context.ApplicationScoped;
 
 /**
- * Removes the 8 KB per-attribute limit imposed by Vert.x's default
- * {@code HttpServerOptions.maxFormAttributeSize}.
+ * Customizes Vert.x HTTP server options for Floci's requirements.
  *
- * Without this, any request that arrives with
- * {@code Content-Type: application/x-www-form-urlencoded} and a single
- * attribute value larger than ~8 KB is rejected by Netty's form decoder
- * with "Size exceed allowed maximum capacity". This hits real AWS APIs
- * that use the Query Protocol: CloudFormation templates, EC2 UserData
- * (base64-encoded), large IAM policies, etc.
+ * <ul>
+ *   <li>Removes the 8 KB per-attribute limit imposed by Vert.x's default
+ *       {@code HttpServerOptions.maxFormAttributeSize}. Without this, any request
+ *       with {@code Content-Type: application/x-www-form-urlencoded} and a single
+ *       attribute value larger than ~8 KB is rejected by Netty's form decoder.
+ *       This hits real AWS APIs that use the Query Protocol: CloudFormation templates,
+ *       EC2 UserData (base64-encoded), large IAM policies, etc.</li>
+ *   <li>Raises the WebSocket frame and message size limits to accommodate payloads
+ *       up to 128 KB, matching the AWS API Gateway WebSocket payload limit. Vert.x
+ *       defaults to 64 KB per frame, which causes Netty to silently reject larger
+ *       frames before the application-level size check in
+ *       {@code WebSocketHandler} can fire.</li>
+ * </ul>
  *
  * The overall request body size is still bounded by
- * {@code quarkus.http.limits.max-body-size} (default 512 MB), so raising
- * the per-attribute limit to unlimited is safe.
+ * {@code quarkus.http.limits.max-body-size} (default 512 MB).
  */
 @ApplicationScoped
 public class HttpOptionsCustomizer implements HttpServerOptionsCustomizer {
 
+    /**
+     * Maximum WebSocket frame size: 256 KB.
+     * AWS API Gateway allows up to 128 KB payloads. We set the transport limit higher
+     * so that oversized frames (e.g. 128 KB + 1 byte) still reach the application-level
+     * handler in {@code WebSocketHandler}, which sends back a proper error response.
+     */
+    private static final int MAX_WS_FRAME_SIZE = 256 * 1024;
+
+    /**
+     * Maximum WebSocket message size (reassembled from multiple frames).
+     * Set to the same value as the frame limit.
+     */
+    private static final int MAX_WS_MESSAGE_SIZE = 256 * 1024;
+
     @Override
     public void customizeHttpServer(HttpServerOptions options) {
         options.setMaxFormAttributeSize(-1);
+        options.setMaxWebSocketFrameSize(MAX_WS_FRAME_SIZE);
+        options.setMaxWebSocketMessageSize(MAX_WS_MESSAGE_SIZE);
     }
 
     @Override
     public void customizeHttpsServer(HttpServerOptions options) {
         options.setMaxFormAttributeSize(-1);
+        options.setMaxWebSocketFrameSize(MAX_WS_FRAME_SIZE);
+        options.setMaxWebSocketMessageSize(MAX_WS_MESSAGE_SIZE);
     }
 }


### PR DESCRIPTION
## Summary

Fixes the 5 failing WebSocket payload size limit tests in the `sdk-test-node` compatibility suite.

## Problem

The Node.js `ws` library sends WebSocket messages as a **single frame** (no fragmentation). Vert.x defaults `maxWebSocketFrameSize` to 64 KB. When the compatibility tests send a 128 KB+ payload, Netty rejects the frame at the transport level before it reaches the application-level `textMessageHandler` in `WebSocketHandler`. The handler never gets a chance to send back the `{"message":"Message too long"}` error response, so the test times out.

Failing tests:
- `should reject messages exceeding 128 KB with error frame`
- `should accept messages at exactly 128 KB`
- `should reject binary frames exceeding 128 KB`
- `should reject messages exceeding 128 KB over WSS`
- `should accept messages at exactly 128 KB over WSS`

## Root Cause

The Java `@QuarkusTest` integration tests pass because the JDK `HttpClient` WebSocket implementation fragments large messages into ~16 KB frames, staying under Vert.x's 64 KB frame limit. The Node.js `ws` client does not fragment, exposing the mismatch.

## Fix

Raise `maxWebSocketFrameSize` and `maxWebSocketMessageSize` to 256 KB in `HttpOptionsCustomizer`. This allows oversized frames to reach the application handler, which enforces the AWS 128 KB limit and returns a proper error frame.

## Testing

- All 111 WebSocket Java integration tests pass
- `WebSocketProxyEventFormatTest#payloadSizeLimitEnforced` passes (verifies the 128 KB rejection still works at the application level)
- Local `sdk-test-node` compatibility tests pass (all 389 tests)