### PR TITLE
fix: ListObjects v1 marker pagination

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -280,6 +280,7 @@ public class S3Controller {
                                 @QueryParam("start-after") String startAfter,
                                 @QueryParam("encoding-type") String encodingType,
                                 @QueryParam("key-marker") String keyMarker,
+                                @QueryParam("marker") String marker,
                                 @Context UriInfo uriInfo) {
         validateRawUri();
         try {
@@ -355,8 +356,11 @@ public class S3Controller {
             }
 
             int max = (maxKeys != null && maxKeys > 0) ? maxKeys : 1000;
+            boolean v1 = !"2".equals(listType);
+            String effectiveStartAfter = v1 && marker != null ? marker : startAfter;
+            String effectiveContinuationToken = v1 ? null : continuationToken;
             S3Service.ListObjectsResult result = s3Service.listObjectsWithPrefixes(
-                    bucket, prefix, delimiter, max, continuationToken, startAfter);
+                    bucket, prefix, delimiter, max, effectiveContinuationToken, effectiveStartAfter);
             List<S3Object> objects = result.objects();
             List<String> commonPrefixes = result.commonPrefixes();
             boolean v2 = "2".equals(listType);
@@ -398,6 +402,11 @@ public class S3Controller {
                 }
                 if (startAfter != null) {
                     xml.elem("StartAfter", startAfter);
+                }
+            } else {
+                xml.elem("Marker", marker != null ? marker : "");
+                if (result.isTruncated() && result.nextContinuationToken() != null) {
+                    xml.elem("NextMarker", result.nextContinuationToken());
                 }
             }
             xml.end("ListBucketResult");


### PR DESCRIPTION
## Problem

When calling `ListObjects` (v1 API) with both a `prefix` and a `marker`, the marker was being ignored. The service always returned the first page of results with `IsTruncated: true`, causing any paginating client to loop forever.

## Root cause

`S3Controller.listObjects` captured `?marker=` as `@QueryParam("marker")` but never passed it to `s3Service.listObjectsWithPrefixes`. The method only passed `continuationToken` and `startAfter`, which are the ListObjectsV2 parameters.

## Fix

- Add `@QueryParam("marker") String marker` to the method signature.
- For v1 requests (`list-type` ≠ `"2"`), pass `marker` as the `startAfter` argument to `listObjectsWithPrefixes` (both serve the same "skip keys ≤ this value" purpose).
- For v1 requests, emit the required `<Marker>` and `<NextMarker>` XML elements in the response.

## Testing

Verified with the `aws-sdk-ruby` S3 client (`list_objects` with `max_keys: 1` and `prefix`) — pagination now advances correctly through all objects.