### PR TITLE
Fix crash when request Content-Type header is empty string

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/ServiceEnabledFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ServiceEnabledFilter.java
@@ -76,7 +76,9 @@ public class ServiceEnabledFilter implements ContainerRequestFilter {
     }
 
     private java.util.Optional<ServiceProtocol> inferProtocol(ContainerRequestContext ctx) {
-        String contentType = ctx.getMediaType() != null ? ctx.getMediaType().toString() : "";
+        // Use the raw header string to avoid IllegalArgumentException when Content-Type is empty.
+        String contentType = ctx.getHeaderString("Content-Type");
+        if (contentType == null) contentType = "";
         if (contentType.contains("cbor")) {
             return java.util.Optional.of(ServiceProtocol.CBOR);
         }


### PR DESCRIPTION
## Problem

Sending a PUT request with an empty `Content-Type: ""` header caused Floci to crash with a 500 error instead of handling the upload normally. Some S3 clients (e.g. the Ruby `paperclip` gem) send an empty string rather than omitting the header when the content type cannot be detected.

## Root cause

`ServiceEnabledFilter.inferProtocol` called `ctx.getMediaType()`, which asks JAX-RS to parse the `Content-Type` header value into a `MediaType` object. JAX-RS's parser throws `IllegalArgumentException` for an empty string (the null/absent case is handled separately). This exception propagated out of the filter and produced a 500.

## Fix

Replace `ctx.getMediaType()` with `ctx.getHeaderString("Content-Type")`, which returns the raw header value without parsing. An empty string and a null value are both treated the same way (defaulting to `""`), so the subsequent `contains(...)` checks work correctly with no behaviour change for well-formed content types.