### PR TITLE
fix(s3): omit body-description headers and user metadata from PutObject response

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3Test.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3Test.java
@@ -37,7 +37,10 @@ import software.amazon.awssdk.services.s3.model.PutObjectTaggingRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.model.Tagging;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPOutputStream;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -386,5 +389,42 @@ class S3Test {
     @Order(25)
     void deleteBucket() {
         s3.deleteBucket(DeleteBucketRequest.builder().bucket(BUCKET).build());
+    }
+
+    @Test
+    @Order(26)
+    void putObjectWithContentEncodingDoesNotBreakSdkDecompression() throws IOException {
+        String bucket = TestFixtures.uniqueName("gzip-bucket");
+        String key = "gzipped.json";
+        byte[] body;
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             GZIPOutputStream gz = new GZIPOutputStream(baos)) {
+            gz.write("{\"hello\":\"world\"}".getBytes(StandardCharsets.UTF_8));
+            gz.finish();
+            body = baos.toByteArray();
+        }
+        s3.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+        try {
+            var putResponse = s3.putObject(PutObjectRequest.builder()
+                            .bucket(bucket).key(key)
+                            .contentEncoding("gzip")
+                            .contentType("application/json")
+                            .build(),
+                    RequestBody.fromBytes(body));
+
+            assertThat(putResponse.eTag()).isNotBlank();
+
+            // HEAD response has a body, so Content-Encoding belongs there.
+            HeadObjectResponse head = s3.headObject(HeadObjectRequest.builder()
+                    .bucket(bucket).key(key).build());
+            assertThat(head.contentEncoding()).isEqualTo("gzip");
+        } finally {
+            try {
+                s3.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(key).build());
+            } catch (Exception ignored) {}
+            try {
+                s3.deleteBucket(DeleteBucketRequest.builder().bucket(bucket).build());
+            } catch (Exception ignored) {}
+        }
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -502,7 +502,7 @@ public class S3Controller {
             if (obj.getVersionId() != null) {
                 resp.header("x-amz-version-id", obj.getVersionId());
             }
-            appendObjectHeaders(resp, obj);
+            appendPutObjectResponseHeaders(resp, obj);
             return resp.build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
@@ -1514,6 +1514,19 @@ public class S3Controller {
 
     private void appendObjectHeaders(Response.ResponseBuilder resp, S3Object obj) {
         appendObjectHeaders(resp, obj, ResponseHeaderOverrides.NONE);
+    }
+
+    // PutObject's response body is empty — body-describing headers and x-amz-meta-*
+    // must not be emitted, or SDK clients will try to decompress and fail.
+    private void appendPutObjectResponseHeaders(Response.ResponseBuilder resp, S3Object obj) {
+        if (obj.getStorageClass() != null) {
+            resp.header("x-amz-storage-class", obj.getStorageClass());
+        }
+        if (obj.getServerSideEncryption() != null) {
+            resp.header("x-amz-server-side-encryption", obj.getServerSideEncryption());
+        }
+        appendChecksumHeaders(resp, obj.getChecksum());
+        appendLockHeaders(resp, obj);
     }
 
     private void appendObjectHeaders(Response.ResponseBuilder resp, S3Object obj, ResponseHeaderOverrides overrides) {

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -817,7 +817,10 @@ class S3IntegrationTest {
             .put("/encoding-test-bucket/encoded.txt")
         .then()
             .statusCode(200)
-            .header("ETag", notNullValue());
+            .header("ETag", notNullValue())
+            .header("Content-Encoding", nullValue())
+            .header("Content-Disposition", nullValue())
+            .header("Cache-Control", nullValue());
     }
 
     @Test


### PR DESCRIPTION
## Summary

S3 `PutObject` was echoing the object's `Content-Encoding` (and `Content-Disposition`, `Cache-Control`, `x-amz-meta-*`) onto a response whose body is always empty. Real AWS S3 omits all of those on PutObject — they only belong on `GetObject` / `HeadObject`, where there is a body to describe.

The user-visible symptom is `Content-Encoding: gzip` on the PutObject response: AWS SDK for Java v2's `Crc32Validation.decompressing` interceptor sees the header, wraps the empty stream in `GZIPInputStream`, and throws `EOFException` from `readHeader`. The object is stored correctly server-side, but every gzip-encoded `PutObject` through the SDK fails before returning — breaking, for example, Spring Cloud AWS's `S3Template.upload(...)` with gzip metadata.

`S3Controller#putObject` now calls a new `appendPutObjectResponseHeaders(resp, obj)` that emits only the headers AWS returns on PutObject (storage-class when set, SSE when set, checksum, object-lock) and intentionally omits `Content-Encoding`, `Content-Disposition`, `Cache-Control`, `Content-Language`, `Expires`, and `x-amz-meta-*`. The shared `appendObjectHeaders` is untouched, so GET / HEAD / CopyObject — including the persistence behavior added by #56 / PR #57 — are unchanged.

Closes #944

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: PutObject's response copied the object's persisted `Content-Encoding` / `Content-Disposition` / `Cache-Control` / `x-amz-meta-*` headers onto a response that has no body.

Verified against real AWS S3 (`us-west-2`) with AWS CLI v2 (`aws-cli/2.27.58`) and AWS SDK for Java v2 (`software.amazon.awssdk:s3:2.42.24`). Eight `PutObject` scenarios were captured from botocore's `--debug` response-headers log, each with one additional request header. For every header this PR changes Floci's behavior on, the post-PR response matches AWS:

| Request includes | Pre-PR Floci response | Real AWS response | Post-PR Floci response |
|---|---|---|---|
| `Content-Encoding: gzip` | emits `Content-Encoding: gzip` | omits | omits |
| `Cache-Control: max-age=…` | emits `Cache-Control` | omits | omits |
| `Content-Disposition: …` | emits `Content-Disposition` | omits | omits |
| `x-amz-meta-owner: team-a` | emits `x-amz-meta-owner` | omits | omits |

(`Content-Language` and `Expires` exist in the old `appendObjectHeaders` only via `ResponseHeaderOverrides`, and the PutObject path passes `ResponseHeaderOverrides.NONE`, so they were never actually emitted on PutObject responses.)

Regression coverage, both layers:

- New SDK-level test `compatibility-tests/sdk-test-java/S3Test#putObjectWithContentEncodingDoesNotBreakSdkDecompression` uses a real `S3Client` to `PutObject` a gzip-encoded object. Before the fix it throws the exact `EOFException → Crc32Validation.decompressing → DefaultS3Client.putObject` stack from #944; with the fix it passes.
- Existing in-process `S3IntegrationTest#putObjectWithContentEncoding` gains assertions that `Content-Encoding`, `Content-Disposition`, and `Cache-Control` are absent from the PutObject response. Adjacent tests (`getObjectReturnsContentEncoding`, `headObjectReturnsContentEncoding`, `copyObjectPreservesContentEncoding`, and the Cache-Control / Content-Disposition equivalents) continue to assert those headers ARE returned on GET / HEAD / CopyObject — protecting the behavior fixed by #56 / PR #57.

## Checklist

- [x] `./mvnw test` passes locally (4700 tests, 0 failures, 0 errors, 8 skipped)
- [x] New or updated integration test added (RestAssured regression assertions in `S3IntegrationTest#putObjectWithContentEncoding`, plus new SDK test `S3Test#putObjectWithContentEncodingDoesNotBreakSdkDecompression` in `compatibility-tests/sdk-test-java`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
