### PR TITLE
feat: add required methods for VPC, subnet, instance, and fix syntax errors

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -190,10 +190,7 @@ public class Ec2Service {
         // Resolve subnet
         Subnet subnet = null;
         if (subnetId != null && !subnetId.isEmpty()) {
-            subnet = subnets.get(key(region, subnetId));
-            if (subnet == null) {
-                throw new AwsException("InvalidSubnetID.NotFound", "The subnet ID '" + subnetId + "' does not exist", 400);
-            }
+            subnet = getRequiredSubent(region, subnetId)
         } else {
             // Pick first default subnet
             subnet = subnets.values().stream()
@@ -289,7 +286,16 @@ public class Ec2Service {
 
         return reservation;
     }
+    
+    private Subent getRequiredSubent(String region, String subnetId) {
+        Subnet subnet = subnets.get(key(region, subnetId));
+        if (subnet == null) {
+            throw new AwsException("InvalidSubnetID.NotFound", "The subnet ID '" + subnetId + "' does not exist", 400);
+        }
 
+        return subnet;
+    }
+    
     private String assignPrivateIp(String region, String subnetId) {
         if (subnetId == null) {
             return "172.31.0." + (10 + new Random().nextInt(200));
@@ -345,9 +351,8 @@ public class Ec2Service {
         List<Map<String, String>> result = new ArrayList<>();
         for (String id : instanceIds) {
             Instance inst = instances.get(key(region, id));
-            if (inst == null) {
-                throw new AwsException("InvalidInstanceID.NotFound", "The instance ID '" + id + "' does not exist", 400);
-            }
+            Instance inst = getRequiredInstance(region, instanceId);
+            
             if (config.services().ec2().mock() && "pending".equals(inst.getState().getName())) {
                 inst.setState(InstanceState.running());
             }
@@ -373,10 +378,8 @@ public class Ec2Service {
         ensureDefaultResources(region);
         List<Map<String, String>> result = new ArrayList<>();
         for (String id : instanceIds) {
-            Instance inst = instances.get(key(region, id));
-            if (inst == null) {
-                throw new AwsException("InvalidInstanceID.NotFound", "The instance ID '" + id + "' does not exist", 400);
-            }
+            Instance inst = Instance inst = getRequiredInstance(region, instanceId);
+            
             if (config.services().ec2().mock() && "pending".equals(inst.getState().getName())) {
                 inst.setState(InstanceState.running());
             }
@@ -401,10 +404,8 @@ public class Ec2Service {
         ensureDefaultResources(region);
         List<Map<String, String>> result = new ArrayList<>();
         for (String id : instanceIds) {
-            Instance inst = instances.get(key(region, id));
-            if (inst == null) {
-                throw new AwsException("InvalidInstanceID.NotFound", "The instance ID '" + id + "' does not exist", 400);
-            }
+           Instance inst = getRequiredInstance(region, instanceId);
+
             if ("terminated".equals(inst.getState().getName())) {
                 throw new AwsException("IncorrectInstanceState",
                         "The instance '" + id + "' is not in a state from which it can be started.", 400);
@@ -429,10 +430,8 @@ public class Ec2Service {
     public void rebootInstances(String region, List<String> instanceIds) {
         ensureDefaultResources(region);
         for (String id : instanceIds) {
-            Instance inst = instances.get(key(region, id));
-            if (inst == null) {
-                throw new AwsException("InvalidInstanceID.NotFound", "The instance ID '" + id + "' does not exist", 400);
-            }
+            Instance inst = getRequiredInstance(region, instanceId);
+            
             if (!config.services().ec2().mock()) {
                 containerManager.reboot(inst);
             }
@@ -467,25 +466,30 @@ public class Ec2Service {
 
     public Instance describeInstanceAttribute(String region, String instanceId, String attribute) {
         ensureDefaultResources(region);
-        Instance inst = instances.get(key(region, instanceId));
-        if (inst == null) {
-            throw new AwsException("InvalidInstanceID.NotFound", "The instance ID '" + instanceId + "' does not exist", 400);
-        }
+        Instance inst = getRequiredInstance(region, instanceId);
+
         return inst;
     }
 
     public void modifyInstanceAttribute(String region, String instanceId, String attribute, String value) {
         ensureDefaultResources(region);
-        Instance inst = instances.get(key(region, instanceId));
-        if (inst == null) {
-            throw new AwsException("InvalidInstanceID.NotFound", "The instance ID '" + instanceId + "' does not exist", 400);
-        }
+        Instance inst = getRequiredInstance(region, instanceId);
+
         // basic attribute modifications
         switch (attribute) {
             case "instanceType" -> inst.setInstanceType(value);
             case "sourceDestCheck" -> inst.setSourceDestCheck(Boolean.parseBoolean(value));
             case "ebsOptimized" -> inst.setEbsOptimized(Boolean.parseBoolean(value));
         }
+    }
+
+    private Instance getRequiredInstance(String region, String instanceId) {
+        Instance inst = instances.get(key(region, instanceId));
+        if (inst == null) {
+            throw new AwsException("InvalidInstanceID.NotFound", "The instance ID '" + instanceId + "' does not exist", 400);
+        }
+
+        return inst;
     }
 
     // ─── VPCs ──────────────────────────────────────────────────────────────────
@@ -533,7 +537,7 @@ public class Ec2Service {
     public void modifyVpcAttribute(String region, String vpcId, String attribute, String value) {
         ensureDefaultResources(region);
         Vpc vpc = Vpc vpc = getRequiredVpc(region, vpcId);
-        
+
         switch (attribute) {
             case "enableDnsSupport"                    -> vpc.setEnableDnsSupport(Boolean.parseBoolean(value));
             case "enableDnsHostnames"                  -> vpc.setEnableDnsHostnames(Boolean.parseBoolean(value));
@@ -617,10 +621,8 @@ public class Ec2Service {
 
     public void modifySubnetAttribute(String region, String subnetId, String attribute, String value) {
         ensureDefaultResources(region);
-        Subnet subnet = subnets.get(key(region, subnetId));
-        if (subnet == null) {
-            throw new AwsException("InvalidSubnetID.NotFound", "The subnet ID '" + subnetId + "' does not exist", 400);
-        }
+        Subnet subnet = getRequiredSubent(region, subnetId)
+        
         if ("mapPublicIpOnLaunch".equals(attribute)) {
             subnet.setMapPublicIpOnLaunch(Boolean.parseBoolean(value));
         }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -190,7 +190,7 @@ public class Ec2Service {
         // Resolve subnet
         Subnet subnet = null;
         if (subnetId != null && !subnetId.isEmpty()) {
-            subnet = getRequiredSubent(region, subnetId);
+            subnet = getRequiredSubnet(region, subnetId);
         } else {
             // Pick first default subnet
             subnet = subnets.values().stream()
@@ -207,7 +207,7 @@ public class Ec2Service {
         List<GroupIdentifier> sgIdentifiers = new ArrayList<>();
         if (securityGroupIds != null && !securityGroupIds.isEmpty()) {
             for (String sgId : securityGroupIds) {
-                SecurityGroup sg = getRequiredSecurityGroup(region, groupId);
+                SecurityGroup sg = getRequiredSecurityGroup(region, sgId);
                 sgIdentifiers.add(new GroupIdentifier(sg.getGroupId(), sg.getGroupName()));
             }
         } else {
@@ -284,7 +284,7 @@ public class Ec2Service {
         return reservation;
     }
     
-    private Subent getRequiredSubent(String region, String subnetId) {
+    private Subnet getRequiredSubnet(String region, String subnetId) {
         Subnet subnet = subnets.get(key(region, subnetId));
         if (subnet == null) 
             throw new AwsException("InvalidSubnetID.NotFound", "The subnet ID '" + subnetId + "' does not exist", 400);
@@ -344,8 +344,7 @@ public class Ec2Service {
         ensureDefaultResources(region);
         List<Map<String, String>> result = new ArrayList<>();
         for (String id : instanceIds) {
-            Instance inst = instances.get(key(region, id));
-            Instance inst = getRequiredInstance(region, instanceId);
+            Instance inst = getRequiredInstance(region, id);
             
             if (config.services().ec2().mock() && "pending".equals(inst.getState().getName())) {
                 inst.setState(InstanceState.running());
@@ -372,7 +371,7 @@ public class Ec2Service {
         ensureDefaultResources(region);
         List<Map<String, String>> result = new ArrayList<>();
         for (String id : instanceIds) {
-            Instance inst = Instance inst = getRequiredInstance(region, instanceId);
+            Instance inst = getRequiredInstance(region, id);
             
             if (config.services().ec2().mock() && "pending".equals(inst.getState().getName())) {
                 inst.setState(InstanceState.running());
@@ -398,7 +397,7 @@ public class Ec2Service {
         ensureDefaultResources(region);
         List<Map<String, String>> result = new ArrayList<>();
         for (String id : instanceIds) {
-           Instance inst = getRequiredInstance(region, instanceId);
+           Instance inst = getRequiredInstance(region, id);
 
             if ("terminated".equals(inst.getState().getName())) {
                 throw new AwsException("IncorrectInstanceState",
@@ -424,7 +423,7 @@ public class Ec2Service {
     public void rebootInstances(String region, List<String> instanceIds) {
         ensureDefaultResources(region);
         for (String id : instanceIds) {
-            Instance inst = getRequiredInstance(region, instanceId);
+            Instance inst = getRequiredInstance(region, id);
 
             if (!config.services().ec2().mock()) {
                 containerManager.reboot(inst);
@@ -519,7 +518,7 @@ public class Ec2Service {
 
     public void deleteVpc(String region, String vpcId) {
         ensureDefaultResources(region);
-        Vpc vpc = getRequiredVpc(region, vpcId);
+        getRequiredVpc(region, vpcId);
 
         vpcs.remove(key(region, vpcId));
     }
@@ -575,7 +574,7 @@ public class Ec2Service {
 
     public Subnet createSubnet(String region, String vpcId, String cidrBlock, String availabilityZone) {
         ensureDefaultResources(region);
-        Vpc vpc = getRequiredVpc(region, vpcId);
+        getRequiredVpc(region, vpcId);
 
         String subnetId = "subnet-" + randomHex(8);
         Subnet subnet = new Subnet();
@@ -611,7 +610,7 @@ public class Ec2Service {
 
     public void modifySubnetAttribute(String region, String subnetId, String attribute, String value) {
         ensureDefaultResources(region);
-        Subnet subnet = getRequiredSubent(region, subnetId);
+        Subnet subnet = getRequiredSubnet(region, subnetId);
         
         if ("mapPublicIpOnLaunch".equals(attribute)) {
             subnet.setMapPublicIpOnLaunch(Boolean.parseBoolean(value));
@@ -1030,7 +1029,7 @@ public class Ec2Service {
 
     public void attachInternetGateway(String region, String igwId, String vpcId) {
         ensureDefaultResources(region);
-        InternetGateway igw = InternetGateway igw = getRequiredInternetGateway(region, igwId);
+        InternetGateway igw = getRequiredInternetGateway(region, igwId);
 
         igw.getAttachments().add(new InternetGatewayAttachment(vpcId, "available"));
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -190,7 +190,7 @@ public class Ec2Service {
         // Resolve subnet
         Subnet subnet = null;
         if (subnetId != null && !subnetId.isEmpty()) {
-            subnet = getRequiredSubent(region, subnetId)
+            subnet = getRequiredSubent(region, subnetId);
         } else {
             // Pick first default subnet
             subnet = subnets.values().stream()
@@ -286,9 +286,8 @@ public class Ec2Service {
     
     private Subent getRequiredSubent(String region, String subnetId) {
         Subnet subnet = subnets.get(key(region, subnetId));
-        if (subnet == null) {
+        if (subnet == null) 
             throw new AwsException("InvalidSubnetID.NotFound", "The subnet ID '" + subnetId + "' does not exist", 400);
-        }
 
         return subnet;
     }
@@ -480,10 +479,9 @@ public class Ec2Service {
 
     private Instance getRequiredInstance(String region, String instanceId) {
         Instance inst = instances.get(key(region, instanceId));
-        if (inst == null) {
+        if (inst == null) 
             throw new AwsException("InvalidInstanceID.NotFound", "The instance ID '" + instanceId + "' does not exist", 400);
-        }
-
+        
         return inst;
     }
 
@@ -521,14 +519,14 @@ public class Ec2Service {
 
     public void deleteVpc(String region, String vpcId) {
         ensureDefaultResources(region);
-        Vpc vpc = Vpc vpc = getRequiredVpc(region, vpcId);
+        Vpc vpc = getRequiredVpc(region, vpcId);
 
         vpcs.remove(key(region, vpcId));
     }
 
     public void modifyVpcAttribute(String region, String vpcId, String attribute, String value) {
         ensureDefaultResources(region);
-        Vpc vpc = Vpc vpc = getRequiredVpc(region, vpcId);
+        Vpc vpc = getRequiredVpc(region, vpcId);
 
         switch (attribute) {
             case "enableDnsSupport"                    -> vpc.setEnableDnsSupport(Boolean.parseBoolean(value));
@@ -540,7 +538,7 @@ public class Ec2Service {
 
     public Vpc describeVpcAttribute(String region, String vpcId, String attribute) {
         ensureDefaultResources(region);
-        Vpc vpc = Vpc vpc = getRequiredVpc(region, vpcId);
+        Vpc vpc = getRequiredVpc(region, vpcId);
 
         return vpc;
     }
@@ -556,7 +554,7 @@ public class Ec2Service {
 
     public VpcCidrBlockAssociation associateVpcCidrBlock(String region, String vpcId, String cidrBlock) {
         ensureDefaultResources(region);
-        Vpc vpc = Vpc vpc = getRequiredVpc(region, vpcId);
+        Vpc vpc = getRequiredVpc(region, vpcId);
 
         VpcCidrBlockAssociation assoc = new VpcCidrBlockAssociation(
                 "vpc-cidr-assoc-" + randomHex(8), cidrBlock);
@@ -577,7 +575,7 @@ public class Ec2Service {
 
     public Subnet createSubnet(String region, String vpcId, String cidrBlock, String availabilityZone) {
         ensureDefaultResources(region);
-        Vpc vpc = Vpc vpc = getRequiredVpc(region, vpcId);
+        Vpc vpc = getRequiredVpc(region, vpcId);
 
         String subnetId = "subnet-" + randomHex(8);
         Subnet subnet = new Subnet();
@@ -613,7 +611,7 @@ public class Ec2Service {
 
     public void modifySubnetAttribute(String region, String subnetId, String attribute, String value) {
         ensureDefaultResources(region);
-        Subnet subnet = getRequiredSubent(region, subnetId)
+        Subnet subnet = getRequiredSubent(region, subnetId);
         
         if ("mapPublicIpOnLaunch".equals(attribute)) {
             subnet.setMapPublicIpOnLaunch(Boolean.parseBoolean(value));
@@ -1033,7 +1031,7 @@ public class Ec2Service {
     public void attachInternetGateway(String region, String igwId, String vpcId) {
         ensureDefaultResources(region);
         InternetGateway igw = InternetGateway igw = getRequiredInternetGateway(region, igwId);
-        
+
         igw.getAttachments().add(new InternetGatewayAttachment(vpcId, "available"));
     }
 
@@ -1071,7 +1069,6 @@ public class Ec2Service {
 
     private Vpc getRequiredVpc(String region, String vpcId) {
         Vpc vpc = vpcs.get(key(region, vpcId));
-
         if (vpc == null)
             throw new AwsException("InvalidVpcID.NotFound", "The vpc ID '" + vpcId + "' does not exist", 400);
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -207,10 +207,7 @@ public class Ec2Service {
         List<GroupIdentifier> sgIdentifiers = new ArrayList<>();
         if (securityGroupIds != null && !securityGroupIds.isEmpty()) {
             for (String sgId : securityGroupIds) {
-                SecurityGroup sg = securityGroups.get(key(region, sgId));
-                if (sg == null) {
-                    throw new AwsException("InvalidGroup.NotFound", "The security group '" + sgId + "' does not exist", 400);
-                }
+                SecurityGroup sg = getRequiredSecurityGroup(region, groupId);
                 sgIdentifiers.add(new GroupIdentifier(sg.getGroupId(), sg.getGroupName()));
             }
         } else {
@@ -317,12 +314,10 @@ public class Ec2Service {
         ensureDefaultResources(region);
         if (!instanceIds.isEmpty()) {
             for (String id : instanceIds) {
-                if (instances.get(key(region, id)) == null) {
-                    throw new AwsException("InvalidInstanceID.NotFound",
-                            "The instance ID '" + id + "' does not exist", 400);
-                }
+                getRequiredInstance(region, id);
             }
         }
+
         if (config.services().ec2().mock()) {
             instances.values().stream()
                     .filter(i -> i.getRegion().equals(region) && "pending".equals(i.getState().getName()))
@@ -431,7 +426,7 @@ public class Ec2Service {
         ensureDefaultResources(region);
         for (String id : instanceIds) {
             Instance inst = getRequiredInstance(region, instanceId);
-            
+
             if (!config.services().ec2().mock()) {
                 containerManager.reboot(inst);
             }
@@ -514,10 +509,7 @@ public class Ec2Service {
         ensureDefaultResources(region);
         if (!vpcIds.isEmpty()) {
             for (String id : vpcIds) {
-                if (vpcs.get(key(region, id)) == null) {
-                    throw new AwsException("InvalidVpcID.NotFound",
-                            "The vpc ID '" + id + "' does not exist", 400);
-                }
+                getRequiredVpc(region, id);
             }
         }
         return vpcs.values().stream()
@@ -633,9 +625,7 @@ public class Ec2Service {
     public SecurityGroup createSecurityGroup(String region, String groupName, String description, String vpcId) {
         ensureDefaultResources(region);
         if (vpcId != null && !vpcId.isEmpty()) {
-            if (vpcs.get(key(region, vpcId)) == null) {
-                throw new AwsException("InvalidVpcID.NotFound", "The vpc ID '" + vpcId + "' does not exist", 400);
-            }
+            getVpcId(region, vpcId);
         } else {
             vpcId = "vpc-default";
         }
@@ -684,10 +674,8 @@ public class Ec2Service {
 
     public List<SecurityGroupRule> authorizeSecurityGroupIngress(String region, String groupId, List<IpPermission> permissions) {
         ensureDefaultResources(region);
-        SecurityGroup sg = securityGroups.get(key(region, groupId));
-        if (sg == null) {
-            throw new AwsException("InvalidGroup.NotFound", "The security group '" + groupId + "' does not exist", 400);
-        }
+        SecurityGroup sg = getRequiredSecurityGroup(region, groupId);
+
         List<SecurityGroupRule> rules = new ArrayList<>();
         for (IpPermission perm : permissions) {
             sg.getIpPermissions().add(perm);
@@ -698,10 +686,8 @@ public class Ec2Service {
 
     public List<SecurityGroupRule> authorizeSecurityGroupEgress(String region, String groupId, List<IpPermission> permissions) {
         ensureDefaultResources(region);
-        SecurityGroup sg = securityGroups.get(key(region, groupId));
-        if (sg == null) {
-            throw new AwsException("InvalidGroup.NotFound", "The security group '" + groupId + "' does not exist", 400);
-        }
+        SecurityGroup sg = getRequiredSecurityGroup(region, groupId);
+
         List<SecurityGroupRule> rules = new ArrayList<>();
         for (IpPermission perm : permissions) {
             sg.getIpPermissionsEgress().add(perm);
@@ -745,20 +731,24 @@ public class Ec2Service {
 
     public void revokeSecurityGroupIngress(String region, String groupId, List<IpPermission> permissions) {
         ensureDefaultResources(region);
-        SecurityGroup sg = securityGroups.get(key(region, groupId));
-        if (sg == null) {
-            throw new AwsException("InvalidGroup.NotFound", "The security group '" + groupId + "' does not exist", 400);
-        }
+        SecurityGroup sg = getRequiredSecurityGroup(region, groupId);
+
         sg.getIpPermissions().removeIf(p -> matchesAnyPermission(p, permissions));
     }
 
     public void revokeSecurityGroupEgress(String region, String groupId, List<IpPermission> permissions) {
         ensureDefaultResources(region);
-        SecurityGroup sg = securityGroups.get(key(region, groupId));
-        if (sg == null) {
-            throw new AwsException("InvalidGroup.NotFound", "The security group '" + groupId + "' does not exist", 400);
-        }
+        SecurityGroup sg = getRequiredSecurityGroup(region, groupId);
+
         sg.getIpPermissionsEgress().removeIf(p -> matchesAnyPermission(p, permissions));
+    }
+
+    private SecurityGroup getRequiredSecurityGroup(String region, String groupId) {
+        SecurityGroup sg = securityGroups.get(key(region, groupId));
+        if (sg == null)
+            throw new AwsException("InvalidGroup.NotFound", "The security group '" + groupId + "' does not exist", 400);
+        
+        return sg;
     }
 
     private boolean matchesAnyPermission(IpPermission existing, List<IpPermission> toRemove) {
@@ -1042,20 +1032,24 @@ public class Ec2Service {
 
     public void attachInternetGateway(String region, String igwId, String vpcId) {
         ensureDefaultResources(region);
-        InternetGateway igw = internetGateways.get(key(region, igwId));
-        if (igw == null) {
-            throw new AwsException("InvalidInternetGatewayID.NotFound", "The internet gateway '" + igwId + "' does not exist", 400);
-        }
+        InternetGateway igw = InternetGateway igw = getRequiredInternetGateway(region, igwId);
+        
         igw.getAttachments().add(new InternetGatewayAttachment(vpcId, "available"));
     }
 
     public void detachInternetGateway(String region, String igwId, String vpcId) {
         ensureDefaultResources(region);
-        InternetGateway igw = internetGateways.get(key(region, igwId));
-        if (igw == null) {
-            throw new AwsException("InvalidInternetGatewayID.NotFound", "The internet gateway '" + igwId + "' does not exist", 400);
-        }
+        InternetGateway igw = getRequiredInternetGateway(region, igwId);
+
         igw.getAttachments().removeIf(a -> a.getVpcId().equals(vpcId));
+    }
+
+    private InternetGateway getRequiredInternetGateway(String region, String igwId) {
+        InternetGateway igw = internetGateways.get(key(region, igwId));
+        if (igw == null) 
+            throw new AwsException("InvalidInternetGatewayID.NotFound", "The internet gateway '" + igwId + "' does not exist", 400);
+        
+        return igw; 
     }
 
     // ─── Route Tables ──────────────────────────────────────────────────────────
@@ -1102,10 +1096,8 @@ public class Ec2Service {
 
     public RouteTableAssociation associateRouteTable(String region, String routeTableId, String subnetId) {
         ensureDefaultResources(region);
-        RouteTable rt = routeTables.get(key(region, routeTableId));
-        if (rt == null) {
-            throw new AwsException("InvalidRouteTableID.NotFound", "The route table '" + routeTableId + "' does not exist", 400);
-        }
+        RouteTable rt = getRequiredRouteTable(region, routeTableId);
+
         String assocId = "rtbassoc-" + randomHex(8);
         RouteTableAssociation assoc = new RouteTableAssociation();
         assoc.setRouteTableAssociationId(assocId);
@@ -1128,20 +1120,24 @@ public class Ec2Service {
 
     public void createRoute(String region, String routeTableId, String destinationCidrBlock, String gatewayId) {
         ensureDefaultResources(region);
-        RouteTable rt = routeTables.get(key(region, routeTableId));
-        if (rt == null) {
-            throw new AwsException("InvalidRouteTableID.NotFound", "The route table '" + routeTableId + "' does not exist", 400);
-        }
+        RouteTable rt = getRequiredRouteTable(region, routeTableId);
+
         rt.getRoutes().add(new Route(destinationCidrBlock, gatewayId, "CreateRoute"));
     }
 
     public void deleteRoute(String region, String routeTableId, String destinationCidrBlock) {
         ensureDefaultResources(region);
-        RouteTable rt = routeTables.get(key(region, routeTableId));
-        if (rt == null) {
-            throw new AwsException("InvalidRouteTableID.NotFound", "The route table '" + routeTableId + "' does not exist", 400);
-        }
+        RouteTable rt = getRequiredRouteTable(region, routeTableId);
+
         rt.getRoutes().removeIf(r -> r.getDestinationCidrBlock().equals(destinationCidrBlock));
+    }
+
+    private RouteTable getRequiredRouteTable(String region, String routeTableId) {
+        RouteTable rt = routeTables.get(key(region, routeTableId));
+        if (rt == null) 
+            throw new AwsException("InvalidRouteTableID.NotFound", "The route table '" + routeTableId + "' does not exist", 400);
+        
+        return rt;
     }
 
     // ─── Elastic IPs ───────────────────────────────────────────────────────────
@@ -1160,12 +1156,18 @@ public class Ec2Service {
 
     public Address associateAddress(String region, String allocationId, String instanceId) {
         ensureDefaultResources(region);
-        Address addr = addresses.get(key(region, allocationId));
-        if (addr == null) {
-            throw new AwsException("InvalidAllocationID.NotFound", "The allocation ID '" + allocationId + "' does not exist", 400);
-        }
+        Address addr = getRequiredAddress(region, allocationId);
+
         addr.setInstanceId(instanceId);
         addr.setAssociationId("eipassoc-" + randomHex(17));
+        return addr;
+    }
+
+    private Address getRequiredAddress(String region, String allocationId) {
+        Address addr = addresses.get(key(region, allocationId));
+        if (addr == null) 
+            throw new AwsException("InvalidAllocationID.NotFound", "The allocation ID '" + allocationId + "' does not exist", 400);
+        
         return addr;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -525,19 +525,15 @@ public class Ec2Service {
 
     public void deleteVpc(String region, String vpcId) {
         ensureDefaultResources(region);
-        Vpc vpc = vpcs.get(key(region, vpcId));
-        if (vpc == null) {
-            throw new AwsException("InvalidVpcID.NotFound", "The vpc ID '" + vpcId + "' does not exist", 400);
-        }
+        Vpc vpc = Vpc vpc = getRequiredVpc(region, vpcId);
+
         vpcs.remove(key(region, vpcId));
     }
 
     public void modifyVpcAttribute(String region, String vpcId, String attribute, String value) {
         ensureDefaultResources(region);
-        Vpc vpc = vpcs.get(key(region, vpcId));
-        if (vpc == null) {
-            throw new AwsException("InvalidVpcID.NotFound", "The vpc ID '" + vpcId + "' does not exist", 400);
-        }
+        Vpc vpc = Vpc vpc = getRequiredVpc(region, vpcId);
+        
         switch (attribute) {
             case "enableDnsSupport"                    -> vpc.setEnableDnsSupport(Boolean.parseBoolean(value));
             case "enableDnsHostnames"                  -> vpc.setEnableDnsHostnames(Boolean.parseBoolean(value));
@@ -548,10 +544,8 @@ public class Ec2Service {
 
     public Vpc describeVpcAttribute(String region, String vpcId, String attribute) {
         ensureDefaultResources(region);
-        Vpc vpc = vpcs.get(key(region, vpcId));
-        if (vpc == null) {
-            throw new AwsException("InvalidVpcID.NotFound", "The vpc ID '" + vpcId + "' does not exist", 400);
-        }
+        Vpc vpc = Vpc vpc = getRequiredVpc(region, vpcId);
+
         return vpc;
     }
 
@@ -566,10 +560,8 @@ public class Ec2Service {
 
     public VpcCidrBlockAssociation associateVpcCidrBlock(String region, String vpcId, String cidrBlock) {
         ensureDefaultResources(region);
-        Vpc vpc = vpcs.get(key(region, vpcId));
-        if (vpc == null) {
-            throw new AwsException("InvalidVpcID.NotFound", "The vpc ID '" + vpcId + "' does not exist", 400);
-        }
+        Vpc vpc = Vpc vpc = getRequiredVpc(region, vpcId);
+
         VpcCidrBlockAssociation assoc = new VpcCidrBlockAssociation(
                 "vpc-cidr-assoc-" + randomHex(8), cidrBlock);
         vpc.getCidrBlockAssociationSet().add(assoc);
@@ -589,10 +581,8 @@ public class Ec2Service {
 
     public Subnet createSubnet(String region, String vpcId, String cidrBlock, String availabilityZone) {
         ensureDefaultResources(region);
-        Vpc vpc = vpcs.get(key(region, vpcId));
-        if (vpc == null) {
-            throw new AwsException("InvalidVpcID.NotFound", "The vpc ID '" + vpcId + "' does not exist", 400);
-        }
+        Vpc vpc = Vpc vpc = getRequiredVpc(region, vpcId);
+
         String subnetId = "subnet-" + randomHex(8);
         Subnet subnet = new Subnet();
         subnet.setSubnetId(subnetId);
@@ -1070,10 +1060,8 @@ public class Ec2Service {
 
     public RouteTable createRouteTable(String region, String vpcId) {
         ensureDefaultResources(region);
-        Vpc vpc = vpcs.get(key(region, vpcId));
-        if (vpc == null) {
-            throw new AwsException("InvalidVpcID.NotFound", "The vpc ID '" + vpcId + "' does not exist", 400);
-        }
+        Vpc vpc = getRequiredVpc(region, vpcId); 
+
         String rtId = "rtb-" + randomHex(8);
         RouteTable rt = new RouteTable();
         rt.setRouteTableId(rtId);
@@ -1084,6 +1072,15 @@ public class Ec2Service {
         routeTables.put(key(region, rtId), rt);
         return rt;
     }
+
+    private Vpc getRequiredVpc(String region, String vpcId) {
+        Vpc vpc = vpcs.get(key(region, vpcId));
+
+        if (vpc == null)
+            throw new AwsException("InvalidVpcID.NotFound", "The vpc ID '" + vpcId + "' does not exist", 400);
+
+        return vpc;
+    }       
 
     public List<RouteTable> describeRouteTables(String region, List<String> routeTableIds, Map<String, List<String>> filters) {
         ensureDefaultResources(region);

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -622,7 +622,7 @@ public class Ec2Service {
     public SecurityGroup createSecurityGroup(String region, String groupName, String description, String vpcId) {
         ensureDefaultResources(region);
         if (vpcId != null && !vpcId.isEmpty()) {
-            getVpcId(region, vpcId);
+            getRequiredVpc(region, vpcId);
         } else {
             vpcId = "vpc-default";
         }


### PR DESCRIPTION
## Summary

This PR refactors the `Ec2Service` to remove the **Duplicated Code** code smell by centralizing repeated AWS resource validation logic into reusable private helper methods.

Previously, several methods repeatedly performed:

- resource lookup from internal maps;
- null validation;
- exception throwing for missing resources.

These validations typically consisted of checking whether the resource was `null` and then throwing an `AwsException`.

Example of the repeated pattern:

```java
Vpc vpc = vpcs.get(key(region, vpcId));

if (vpc == null) {
    throw new AwsException(
        "InvalidVpcID.NotFound",
        "The vpc ID '" + vpcId + "' does not exist",
        400
    );
}

```
The refactoring introduces dedicated methods such as:

```java
getRequiredVpc(...)
getRequiredInstance(...)
getRequiredSecurityGroup(...)
getRequiredSubnet(...)
getRequiredSecurityGroup(...)
getRequiredInternetGateway(...)
getRequiredRouteTable(...)
getRequiredAddress(...)
```

These helpers centralize:

- resource retrieval;
- null validation;
- standardized exception handling.

This approach improves readability, reduces duplicated code, standardizes validation behavior, and simplifies future maintenance without changing the functional behavior of the service.

Example of the use:

```
Vpc vpc = getRequiredVpc(region, vpcId);

// and the logic encapsulation
    private Vpc getRequiredVpc(String region, String vpcId) {
        Vpc vpc = vpcs.get(key(region, vpcId));
        if (vpc == null)
            throw new AwsException("InvalidVpcID.NotFound", "The vpc ID '" + vpcId + "' does not exist", 400);

        return vpc;
    }

```

---

## Type of change

- [x] Docs / chore

---

## AWS Compatibility

This change does not modify the external AWS-compatible behavior or wire protocol implementation.

The refactoring only centralizes internal validation logic and preserves existing exception types/messages, including:

- `InvalidVpcID.NotFound`
- `InvalidSubnetID.NotFound`
- `InvalidInstanceID.NotFound`
- `InvalidGroup.NotFound`
- `InvalidInternetGateway.NotFound`
- `InvalidAddress.NotFound`
- `InvalidRouteTable.NotFound`

No API contract or compatibility behavior was changed.

---

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)