### PR TITLE
fix(s3): restore object on delete marker removal and add missing version headers

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -62,7 +62,9 @@ import org.jboss.logging.Logger;
 public class S3Controller {
 
     private static final Logger LOG = Logger.getLogger(S3Controller.class);
-    private static final DateTimeFormatter ISO_FORMAT = DateTimeFormatter.ISO_INSTANT;
+    private static final DateTimeFormatter ISO_FORMAT = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
+            .withZone(ZoneId.of("UTC"));
     private static final DateTimeFormatter RFC_822 = DateTimeFormatter
             .ofPattern("EEE, dd MMM yyyy HH:mm:ss z", Locale.US)
             .withZone(ZoneId.of("GMT"));

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -795,8 +795,10 @@ public class S3Controller {
                     httpHeaders.getHeaderString("x-amz-bypass-governance-retention"));
             S3Object result = s3Service.deleteObject(bucket, key, versionId, bypass);
             var resp = Response.noContent();
-            if (result != null && result.isDeleteMarker()) {
-                resp.header("x-amz-delete-marker", "true");
+            if (result != null) {
+                if (result.isDeleteMarker()) {
+                    resp.header("x-amz-delete-marker", "true");
+                }
                 resp.header("x-amz-version-id", result.getVersionId());
             }
             return resp.build();

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -517,16 +517,33 @@ public class S3Service {
             fireNotifications(bucketName, key, "ObjectRemoved:DeleteMarkerCreated", deleteMarker);
             return deleteMarker;
         } else if (versionId != null) {
-            // Check lock on the specific version before permanent deletion
-            objectStore.get(versionedKey(bucketName, key, versionId)).ifPresent(obj -> {
-                if (!obj.isDeleteMarker()) {
-                    checkLockProtection(obj, bypassGovernance);
-                }
-            });
+            // Get the specific version before permanent deletion
+            S3Object toDelete = objectStore.get(versionedKey(bucketName, key, versionId)).orElse(null);
+            if (toDelete != null && !toDelete.isDeleteMarker()) {
+                checkLockProtection(toDelete, bypassGovernance);
+            }
             // Permanently delete a specific version
             objectStore.delete(versionedKey(bucketName, key, versionId));
             LOG.debugv("Permanently deleted version: {0}/{1} v={2}", bucketName, key, versionId);
-            return null;
+            // Promote the next most-recent version when the deleted one was the latest
+            String latestKey = objectKey(bucketName, key);
+            objectStore.get(latestKey).ifPresent(latest -> {
+                if (versionId.equals(latest.getVersionId())) {
+                    String vPrefix = versionedKey(bucketName, key, "");
+                    List<S3Object> remaining = objectStore.scan(k -> k.startsWith(vPrefix));
+                    if (remaining.isEmpty()) {
+                        objectStore.delete(latestKey);
+                    } else {
+                        S3Object newLatest = remaining.stream()
+                                .max(Comparator.comparing(S3Object::getLastModified))
+                                .orElseThrow();
+                        newLatest.setLatest(true);
+                        objectStore.put(versionedKey(bucketName, key, newLatest.getVersionId()), newLatest);
+                        objectStore.put(latestKey, newLatest);
+                    }
+                }
+            });
+            return toDelete;
         } else {
             // Check lock on the non-versioned object before delete
             objectStore.get(objectKey(bucketName, key)).ifPresent(obj -> {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/S3Object.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/S3Object.java
@@ -55,7 +55,7 @@ public class S3Object {
         this.data = data;
         this.contentType = contentType != null ? contentType : "application/octet-stream";
         this.size = data.length;
-        this.lastModified = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        this.lastModified = Instant.now().truncatedTo(ChronoUnit.MILLIS);
         this.eTag = computeETag(data);
         this.metadata = new HashMap<>();
         this.storageClass = "STANDARD";

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
@@ -99,10 +99,10 @@ class S3ServiceTest {
     }
 
     @Test
-    void putObjectLastModifiedHasSecondPrecision() {
+    void putObjectLastModifiedHasMillisecondPrecision() {
         s3Service.createBucket("test-bucket", null);
         S3Object obj = s3Service.putObject("test-bucket", "file.txt", "data".getBytes(), null, null);
-        assertEquals(0, obj.getLastModified().getNano());
+        assertEquals(0, obj.getLastModified().getNano() % 1_000_000);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningIntegrationTest.java
@@ -17,6 +17,8 @@ class S3VersioningIntegrationTest {
     private static final String BUCKET = "versioning-int-test";
     private static String versionId1;
     private static String versionId2;
+    private static String headersTestVersionId;
+    private static String headersTestMarkerId;
 
     @Test
     @Order(1)
@@ -193,5 +195,54 @@ class S3VersioningIntegrationTest {
         // Delete specific versions permanently
         given().when().delete("/" + BUCKET + "/test.txt?versionId=" + versionId1).then().statusCode(204);
         given().when().delete("/" + BUCKET + "/test.txt?versionId=" + versionId2).then().statusCode(204);
+    }
+
+    @Test
+    @Order(16)
+    void deleteRegularVersionReturnsVersionIdHeaderOnly() {
+        headersTestVersionId = given()
+            .body("headers-test")
+            .contentType("text/plain")
+        .when()
+            .put("/" + BUCKET + "/headers.txt")
+        .then()
+            .statusCode(200)
+            .extract().header("x-amz-version-id");
+
+        given()
+        .when()
+            .delete("/" + BUCKET + "/headers.txt?versionId=" + headersTestVersionId)
+        .then()
+            .statusCode(204)
+            .header("x-amz-version-id", headersTestVersionId)
+            .header("x-amz-delete-marker", nullValue());
+    }
+
+    @Test
+    @Order(17)
+    void deleteMarkerByVersionIdReturnsBothHeaders() {
+        given()
+            .body("restore-test")
+            .contentType("text/plain")
+        .when()
+            .put("/" + BUCKET + "/restore.txt")
+        .then()
+            .statusCode(200);
+
+        headersTestMarkerId = given()
+        .when()
+            .delete("/" + BUCKET + "/restore.txt")
+        .then()
+            .statusCode(204)
+            .header("x-amz-delete-marker", "true")
+            .extract().header("x-amz-version-id");
+
+        given()
+        .when()
+            .delete("/" + BUCKET + "/restore.txt?versionId=" + headersTestMarkerId)
+        .then()
+            .statusCode(204)
+            .header("x-amz-version-id", headersTestMarkerId)
+            .header("x-amz-delete-marker", "true");
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
@@ -202,6 +202,47 @@ class S3VersioningServiceTest {
     }
 
     @Test
+    void deleteMarkerByVersionIdRestoresPreviousVersion() {
+        s3Service.putBucketVersioning("versioned-bucket", "Enabled");
+        S3Object v1 = s3Service.putObject("versioned-bucket", "file",
+                "original".getBytes(StandardCharsets.UTF_8), "text/plain", null);
+
+        S3Object marker = s3Service.deleteObject("versioned-bucket", "file");
+        assertThrows(AwsException.class, () -> s3Service.getObject("versioned-bucket", "file"));
+
+        s3Service.deleteObject("versioned-bucket", "file", marker.getVersionId());
+
+        S3Object restored = s3Service.getObject("versioned-bucket", "file");
+        assertEquals("original", new String(restored.getData()));
+        assertEquals(v1.getVersionId(), restored.getVersionId());
+    }
+
+    @Test
+    void deleteOnlyVersionByVersionIdClearsLatestPointer() {
+        s3Service.putBucketVersioning("versioned-bucket", "Enabled");
+        S3Object v1 = s3Service.putObject("versioned-bucket", "sole",
+                "data".getBytes(StandardCharsets.UTF_8), "text/plain", null);
+
+        s3Service.deleteObject("versioned-bucket", "sole", v1.getVersionId());
+
+        assertThrows(AwsException.class, () -> s3Service.getObject("versioned-bucket", "sole"));
+    }
+
+    @Test
+    void deleteNonLatestVersionByVersionIdLeavesLatestUnchanged() {
+        s3Service.putBucketVersioning("versioned-bucket", "Enabled");
+        S3Object v1 = s3Service.putObject("versioned-bucket", "multi",
+                "v1".getBytes(StandardCharsets.UTF_8), "text/plain", null);
+        s3Service.putObject("versioned-bucket", "multi",
+                "v2".getBytes(StandardCharsets.UTF_8), "text/plain", null);
+
+        s3Service.deleteObject("versioned-bucket", "multi", v1.getVersionId());
+
+        S3Object latest = s3Service.getObject("versioned-bucket", "multi");
+        assertEquals("v2", new String(latest.getData()));
+    }
+
+    @Test
     void listObjectsExcludesDeleteMarkers() {
         s3Service.putBucketVersioning("versioned-bucket", "Enabled");
         s3Service.putObject("versioned-bucket", "keep.txt",


### PR DESCRIPTION
## Summary

Fixes S3 versioning `DeleteObject` when specifying a `VersionId`.

Closes #917 


## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:**
1. Deleting a delete marker by `VersionId` did not restore the previous version.
2. Deleting the latest version by `VersionId` had no effect.
3. Response was missing `x-amz-version-id` and `x-amz-delete-marker` headers.

**Fix:** After permanently deleting a version, the latest pointer is updated to the next most-recent version (or removed if none remain). Response headers are now set correctly.

Verified against AWS CLI v2.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
