### PR TITLE
fix(cbor): lowercase smithy-protocol response header casing

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsJsonCborController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsJsonCborController.java
@@ -154,12 +154,12 @@ public class AwsJsonCborController {
             byte[] cborBytes = nodeToSmithyCbor(responseNode);
             String responseContentType = responseContentType(httpHeaders);
             return Response.status(delegated.getStatus())
-                    .header("Smithy-Protocol", "rpc-v2-cbor")
+                    .header("smithy-protocol", "rpc-v2-cbor")
                     .type(responseContentType)
                     .entity(cborBytes)
                     .build();
         } catch (AwsException e) {
-            return cborErrorResponse(e, "Smithy-Protocol", responseContentType(httpHeaders));
+            return cborErrorResponse(e, "smithy-protocol", responseContentType(httpHeaders));
         } catch (Exception e) {
             LOG.error("Error processing Smithy CBOR request: " + serviceId + "." + operation, e);
             return Response.status(500).build();


### PR DESCRIPTION
## Summary

The Smithy RPC v2 CBOR protocol spec requires the response header to be sent as `smithy-protocol` (lowercase). The previous casing `Smithy-Protocol` caused SDK clients that perform a case-sensitive check on the response header to fail protocol negotiation.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
