### PR TITLE
fix(s3): return ObjectLockConfigurationNotFoundError for non-lock buckets

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -949,6 +949,10 @@ public class S3Service {
         Bucket bucket = bucketStore.get(bucketName)
                 .orElseThrow(() -> new AwsException("NoSuchBucket",
                         "The specified bucket does not exist.", 404));
+        if (!bucket.isObjectLockEnabled()) {
+            throw new AwsException("ObjectLockConfigurationNotFoundError",
+                    "Object Lock configuration does not exist for this bucket", 404);
+        }
         return bucket.getDefaultRetention();
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ObjectLockIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ObjectLockIntegrationTest.java
@@ -1,0 +1,137 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class S3ObjectLockIntegrationTest {
+
+    private static final String PLAIN_BUCKET = "object-lock-plain";
+    private static final String NO_LOCK_BUCKET = "object-lock-disabled";
+    private static final String LOCK_BUCKET = "object-lock-enabled";
+
+    // --- plain bucket (no object-lock header) ---
+
+    @Test
+    @Order(1)
+    void createPlainBucket() {
+        given().when().put("/" + PLAIN_BUCKET).then().statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void plainBucketReturnsObjectLockConfigurationNotFoundError() {
+        given()
+        .when()
+            .get("/" + PLAIN_BUCKET + "?object-lock")
+        .then()
+            .statusCode(404)
+            .body(containsString("ObjectLockConfigurationNotFoundError"))
+            .body(containsString("Object Lock configuration does not exist for this bucket"));
+    }
+
+    // --- bucket created with x-amz-bucket-object-lock-enabled: false ---
+
+    @Test
+    @Order(3)
+    void createBucketWithObjectLockExplicitlyDisabled() {
+        given()
+            .header("x-amz-bucket-object-lock-enabled", "false")
+        .when()
+            .put("/" + NO_LOCK_BUCKET)
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(4)
+    void explicitlyDisabledBucketReturnsObjectLockConfigurationNotFoundError() {
+        given()
+        .when()
+            .get("/" + NO_LOCK_BUCKET + "?object-lock")
+        .then()
+            .statusCode(404)
+            .body(containsString("ObjectLockConfigurationNotFoundError"));
+    }
+
+    // --- bucket created with x-amz-bucket-object-lock-enabled: true ---
+
+    @Test
+    @Order(5)
+    void createBucketWithObjectLockEnabled() {
+        given()
+            .header("x-amz-bucket-object-lock-enabled", "true")
+        .when()
+            .put("/" + LOCK_BUCKET)
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(6)
+    void lockEnabledBucketReturnsConfigWithNoRule() {
+        given()
+        .when()
+            .get("/" + LOCK_BUCKET + "?object-lock")
+        .then()
+            .statusCode(200)
+            .body(containsString("<ObjectLockEnabled>Enabled</ObjectLockEnabled>"))
+            .body(not(containsString("<Rule>")));
+    }
+
+    @Test
+    @Order(7)
+    void putObjectLockConfigurationWithRetentionRule() {
+        String body = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <ObjectLockConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                  <ObjectLockEnabled>Enabled</ObjectLockEnabled>
+                  <Rule>
+                    <DefaultRetention>
+                      <Mode>COMPLIANCE</Mode>
+                      <Days>30</Days>
+                    </DefaultRetention>
+                  </Rule>
+                </ObjectLockConfiguration>
+                """;
+        given()
+            .body(body)
+        .when()
+            .put("/" + LOCK_BUCKET + "?object-lock")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(8)
+    void getObjectLockConfigurationReturnsRetentionRule() {
+        given()
+        .when()
+            .get("/" + LOCK_BUCKET + "?object-lock")
+        .then()
+            .statusCode(200)
+            .body(containsString("<ObjectLockEnabled>Enabled</ObjectLockEnabled>"))
+            .body(containsString("<Mode>COMPLIANCE</Mode>"))
+            .body(containsString("<Days>30</Days>"));
+    }
+
+    // --- non-existent bucket ---
+
+    @Test
+    @Order(9)
+    void nonExistentBucketReturnsNoSuchBucket() {
+        given()
+        .when()
+            .get("/does-not-exist-object-lock-test?object-lock")
+        .then()
+            .statusCode(404)
+            .body(containsString("NoSuchBucket"));
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes `GetObjectLockConfiguration` always returning `200 ObjectLockEnabled=Enabled` for every bucket, regardless of whether object lock was enabled at creation time
- Adds an `isObjectLockEnabled()` guard in `S3Service.getObjectLockConfiguration()` that throws `ObjectLockConfigurationNotFoundError` (HTTP 404) when the bucket was not created with `x-amz-bucket-object-lock-enabled: true`
- No controller changes needed — the existing try-catch in `S3Controller` already routes `AwsException` to the XML error response

Fixes #960

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
