### PR TITLE
feat(sns,sqs): CloudFormation does not apply SQS ContentBasedDeduplication or create SNS SQS subscriptions correctly

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -133,6 +133,7 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::S3::Bucket" -> provisionS3Bucket(resource, properties, engine, region, accountId, stackName);
                 case "AWS::SQS::Queue" -> provisionSqsQueue(resource, properties, engine, region, accountId, stackName);
                 case "AWS::SNS::Topic" -> provisionSnsTopic(resource, properties, engine, region, accountId, stackName);
+                case "AWS::SNS::Subscription" -> provisionSnsSubscription(resource, properties, engine, region);
                 case "AWS::DynamoDB::Table", "AWS::DynamoDB::GlobalTable" ->
                         provisionDynamoTable(resource, properties, engine, region, accountId, stackName);
                 case "AWS::Lambda::Function" -> provisionLambda(resource, properties, engine, region, accountId, stackName);
@@ -189,6 +190,7 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::S3::Bucket" -> s3Service.deleteBucket(physicalId);
                 case "AWS::SQS::Queue" -> sqsService.deleteQueue(physicalId, region);
                 case "AWS::SNS::Topic" -> snsService.deleteTopic(physicalId, region);
+                case "AWS::SNS::Subscription" -> snsService.unsubscribe(physicalId, region);
                 case "AWS::DynamoDB::Table" -> dynamoDbService.deleteTable(physicalId, region);
                 case "AWS::Lambda::Function" -> lambdaService.deleteFunction(region, physicalId);
                 case "AWS::IAM::Role" -> deleteRoleSafe(physicalId);
@@ -240,8 +242,13 @@ public class CloudFormationResourceProvisioner {
             queueName = generatePhysicalName(stackName, r.getLogicalId(), 80, false);
         }
         Map<String, String> attrs = new HashMap<>();
-        if (props != null && props.has("VisibilityTimeout")) {
-            attrs.put("VisibilityTimeout", engine.resolve(props.get("VisibilityTimeout")));
+        if (props != null) {
+            if(props.has("VisibilityTimeout")) {
+                attrs.put("VisibilityTimeout", engine.resolve(props.get("VisibilityTimeout")));
+            }
+            if(props.has("ContentBasedDeduplication")) {
+                attrs.put("ContentBasedDeduplication", engine.resolve(props.get("ContentBasedDeduplication")));
+            }
         }
         var queue = sqsService.createQueue(queueName, attrs, region);
         // QueueArn is computed on demand in SqsService#getQueueAttributes and is not
@@ -259,13 +266,45 @@ public class CloudFormationResourceProvisioner {
     private void provisionSnsTopic(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
                                    String region, String accountId, String stackName) {
         String topicName = resolveOptional(props, "TopicName", engine);
+        String contentBasedDedupFlag = resolveOptional(props, "ContentBasedDeduplication", engine);
         if (topicName == null || topicName.isBlank()) {
             topicName = generatePhysicalName(stackName, r.getLogicalId(), 256, false);
         }
-        var topic = snsService.createTopic(topicName, Map.of(), Map.of(), region);
+
+        Map<String, String> attributes = new HashMap<>();
+
+        if (contentBasedDedupFlag != null && !contentBasedDedupFlag.isBlank()) {
+            attributes.put("ContentBasedDeduplication", contentBasedDedupFlag);
+        }
+
+        var topic = snsService.createTopic(topicName, attributes, Map.of(), region);
         r.setPhysicalId(topic.getTopicArn());
         r.getAttributes().put("Arn", topic.getTopicArn());
         r.getAttributes().put("TopicName", topicName);
+    }
+
+    private void provisionSnsSubscription(StackResource r, JsonNode props, CloudFormationTemplateEngine engine, String region) {
+        String topicArn = engine.resolve(props.path("TopicArn"));
+        String protocol = engine.resolve(props.path("Protocol"));
+        String endpoint = engine.resolve(props.path("Endpoint"));
+
+        Map<String, String> attributes = new HashMap<>();
+        if (props.has("FilterPolicy") && !props.path("FilterPolicy").isNull()) {
+            attributes.put("FilterPolicy", engine.resolveNode(props.path("FilterPolicy")).toString());
+        }
+        if (props.has("FilterPolicyScope")) {
+            attributes.put("FilterPolicyScope", engine.resolve(props.path("FilterPolicyScope")));
+        }
+        if (props.has("RawMessageDelivery")) {
+            attributes.put("RawMessageDelivery", engine.resolve(props.path("RawMessageDelivery")));
+        }
+        if (props.has("RedrivePolicy") && !props.path("RedrivePolicy").isNull()) {
+            attributes.put("RedrivePolicy", engine.resolveNode(props.path("RedrivePolicy")).toString());
+        }
+
+        var sub = snsService.subscribe(topicArn, protocol, endpoint, region, attributes);
+        r.setPhysicalId(sub.getSubscriptionArn());
+        r.getAttributes().put("Arn", sub.getSubscriptionArn());
     }
 
     // ── DynamoDB ──────────────────────────────────────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
@@ -127,7 +127,11 @@ public class SnsService {
 
         if (name.endsWith(".fifo")) {
             topic.getAttributes().put("FifoTopic", "true");
-            topic.getAttributes().putIfAbsent("ContentBasedDeduplication", "false");
+            if (attributes != null && attributes.containsKey("ContentBasedDeduplication") && "true".equals(attributes.get("ContentBasedDeduplication"))) {
+                topic.getAttributes().putIfAbsent("ContentBasedDeduplication", "true");
+            } else {
+                topic.getAttributes().putIfAbsent("ContentBasedDeduplication", "false");
+            }
         }
 
         topicStore.put(key, topic);

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -250,7 +250,11 @@ public class SqsService {
         queue.getAttributes().putIfAbsent("DelaySeconds", "0");
         queue.getAttributes().putIfAbsent("MessageRetentionPeriod", "345600");
         if (queue.isFifo()) {
-            queue.getAttributes().putIfAbsent("ContentBasedDeduplication", "false");
+            if (attributes != null && attributes.containsKey("ContentBasedDeduplication") && "true".equals(attributes.get("ContentBasedDeduplication"))) {
+                queue.getAttributes().putIfAbsent("ContentBasedDeduplication", "true");
+            } else {
+                queue.getAttributes().putIfAbsent("ContentBasedDeduplication", "false");
+            }
         }
 
         queueStore.put(storageKey, queue);

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -4127,4 +4127,180 @@ class CloudFormationIntegrationTest {
             .body("authorizerId", equalTo(secondAuth));
     }
 
+    @Test
+    void createStack_snsSqsFifoWithContentBasedDeduplicationAndSubscription() {
+        String stackName = "cfn-sns-sqs-fifo-stack";
+        String template = """
+            {
+              "Resources": {
+                "MyTopic": {
+                  "Type": "AWS::SNS::Topic",
+                  "Properties": {
+                    "TopicName": "cfn-test-topic.fifo",
+                    "ContentBasedDeduplication": true
+                  }
+                },
+                "MyQueue": {
+                  "Type": "AWS::SQS::Queue",
+                  "Properties": {
+                    "QueueName": "cfn-test-queue.fifo",
+                    "FifoQueue": true,
+                    "ContentBasedDeduplication": true
+                  }
+                },
+                "MySubscription": {
+                  "Type": "AWS::SNS::Subscription",
+                  "Properties": {
+                    "TopicArn": {"Ref": "MyTopic"},
+                    "Protocol": "sqs",
+                    "Endpoint": {"Fn::GetAtt": ["MyQueue", "Arn"]},
+                    "RawMessageDelivery": true
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // 1. Verify SNS Topic attributes
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "GetTopicAttributes")
+            .formParam("TopicArn", "arn:aws:sns:us-east-1:000000000000:cfn-test-topic.fifo")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("ContentBasedDeduplication"))
+            .body(containsString("<value>true</value>"))
+            .body(containsString("FifoTopic"));
+
+        // 2. Verify SQS Queue attributes
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "GetQueueAttributes")
+            .formParam("QueueUrl", "http://localhost:4566/000000000000/cfn-test-queue.fifo")
+            .formParam("AttributeName.1", "All")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("ContentBasedDeduplication"))
+            .body(containsString("<Value>true</Value>"))
+            .body(containsString("FifoQueue"));
+
+        // 3. Verify SNS Subscription attributes
+        String resourcesXml = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStackResources")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().asString();
+
+        String subArn = physicalIdByLogicalId(resourcesXml, "MySubscription");
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "GetSubscriptionAttributes")
+            .formParam("SubscriptionArn", subArn)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("RawMessageDelivery"))
+            .body(containsString("<value>true</value>"))
+            .body(containsString("sqs"));
+    }
+
+    @Test
+    void createStack_snsSubscriptionWithFilterPolicyAndRedrivePolicy() {
+        String stackName = "cfn-sns-sub-policies-stack";
+        String template = """
+            {
+              "Resources": {
+                "MyTopic": {
+                  "Type": "AWS::SNS::Topic",
+                  "Properties": {
+                    "TopicName": "cfn-sub-policies-topic"
+                  }
+                },
+                "MyQueue": {
+                  "Type": "AWS::SQS::Queue",
+                  "Properties": {
+                    "QueueName": "cfn-sub-policies-queue"
+                  }
+                },
+                "MyDLQ": {
+                  "Type": "AWS::SQS::Queue",
+                  "Properties": {
+                    "QueueName": "cfn-sub-policies-dlq"
+                  }
+                },
+                "MySubscription": {
+                  "Type": "AWS::SNS::Subscription",
+                  "Properties": {
+                    "TopicArn": {"Ref": "MyTopic"},
+                    "Protocol": "sqs",
+                    "Endpoint": {"Fn::GetAtt": ["MyQueue", "Arn"]},
+                    "FilterPolicy": {
+                      "price_usd": [{"numeric": [">=", 100]}]
+                    },
+                    "RedrivePolicy": {
+                      "deadLetterTargetArn": {"Fn::GetAtt": ["MyDLQ", "Arn"]}
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String resourcesXml = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStackResources")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().asString();
+
+        String subArn = physicalIdByLogicalId(resourcesXml, "MySubscription");
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "GetSubscriptionAttributes")
+            .formParam("SubscriptionArn", subArn)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("FilterPolicy"))
+            .body(containsString("price_usd"))
+            .body(containsString("RedrivePolicy"))
+            .body(containsString("deadLetterTargetArn"))
+            .body(containsString("cfn-sub-policies-dlq"));
+    }
+
 }

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsServiceTest.java
@@ -45,6 +45,14 @@ class SnsServiceTest {
     }
 
     @Test
+    void createTopic_fifoWithContentBasedDeduplication() {
+        Topic topic = snsService.createTopic("my-topic.fifo",
+                Map.of("ContentBasedDeduplication", "true"), null, REGION);
+        assertEquals("true", topic.getAttributes().get("ContentBasedDeduplication"));
+        assertEquals("true", topic.getAttributes().get("FifoTopic"));
+    }
+
+    @Test
     void createTopic_idempotent() {
         Topic first = snsService.createTopic("my-topic", null, null, REGION);
         Topic second = snsService.createTopic("my-topic", null, null, REGION);

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -233,6 +233,22 @@ class SqsServiceTest {
     }
 
     @Test
+    void createFifoQueueWithContentBasedDeduplicationFalse() {
+        Queue queue = sqsService.createQueue("test-queue.fifo",
+                Map.of("ContentBasedDeduplication", "false"));
+        assertTrue(queue.isFifo());
+        assertEquals("false", queue.getAttributes().get("ContentBasedDeduplication"));
+    }
+
+    @Test
+    void createFifoQueueWithoutContentBasedDeduplication() {
+        Queue queue = sqsService.createQueue("test-queue.fifo",
+                Map.of("VisibilityTimeout", "60"));
+        assertTrue(queue.isFifo());
+        assertEquals("false", queue.getAttributes().get("ContentBasedDeduplication"));
+    }
+
+    @Test
     void createFifoQueueWithoutSuffixFails() {
         assertThrows(AwsException.class, () ->
                 sqsService.createQueue("test-queue", Map.of("FifoQueue", "true")));


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Link any related issues with "Closes #N" -->
- ContentBasedDeduplication was always defaulting to false for both SQS queues and SNS topics. Added the logic to capture the value from payload if present and default to false if absent.
- Code to create SNS subscription via Cloud Formation was entirely missing. Added the code to both create and destroy the SNS subscription as part of the stack.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
