### PR TITLE
fix(s3): accept region-qualified virtual-host form bucket.s3.<region>.<host>

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
@@ -115,8 +115,9 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
         String firstLabel = hostname.substring(0, firstDot);
         String remainder  = hostname.substring(firstDot + 1);
 
-        // Primary: remainder must match the configured base hostname
-        if (baseHostname != null && remainder.equalsIgnoreCase(baseHostname)) {
+        // Primary: remainder must match the configured base hostname,
+        // either directly or in the AWS region-qualified s3.<region>.<host> form.
+        if (baseHostname != null && matchesEndpointHost(remainder, baseHostname)) {
             return firstLabel;
         }
 
@@ -126,6 +127,24 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
         }
 
         return null;
+    }
+
+    /**
+     * Matches a hostname directly or its region-qualified s3.&lt;region&gt;.&lt;hostname&gt; variant.
+     * Example: with hostname="localhost", both "localhost" and "s3.us-east-1.localhost" match.
+     */
+    private static boolean matchesEndpointHost(String remainder, String hostname) {
+        if (remainder.equalsIgnoreCase(hostname)) {
+            return true;
+        }
+        String lowerRem = remainder.toLowerCase();
+        String lowerHost = hostname.toLowerCase();
+        String suffix = "." + lowerHost;
+        if (lowerRem.startsWith("s3.") && lowerRem.endsWith(suffix)
+                && lowerRem.length() > "s3.".length() + suffix.length()) {
+            return true;
+        }
+        return false;
     }
 
     /** Extracts the hostname (without scheme or port) from a URL string. */
@@ -174,7 +193,8 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
         // localhost always resolves to 127.0.0.1 — accept regardless of FLOCI_HOSTNAME config.
         // Fixes: SDK with endpointOverride("http://localhost:4566") without forcePathStyle sends
         // Host: my-bucket.localhost:4566, which must be recognized even when baseHostname=floci.
-        if ("localhost".equals(remainder)) {
+        // Also accept the region-qualified s3.<region>.localhost form (e.g. bucket.s3.us-east-1.localhost).
+        if (matchesEndpointHost(remainder, "localhost")) {
             return true;
         }
         // LocalStack public wildcard DNS: bucket.s3.localhost.localstack.cloud and bucket.localhost.localstack.cloud

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
@@ -27,6 +27,14 @@ class S3VirtualHostFilterTest {
             // localhost is always recognized regardless of baseHostname (fixes virtual-host when FLOCI_HOSTNAME=floci)
             "my-bucket.localhost,      floci, my-bucket",
             "my-bucket.localhost:4566, floci, my-bucket",
+            // Region-qualified vhost form: bucket.s3.<region>.<baseHostname>
+            "my-bucket.s3.us-east-1.localhost,      localhost, my-bucket",
+            "my-bucket.s3.us-east-1.localhost:4566, localhost, my-bucket",
+            "my-bucket.s3.eu-west-2.localhost,      localhost, my-bucket",
+            // Region-qualified vhost against localhost fallback even when baseHostname differs
+            "my-bucket.s3.us-east-1.localhost,      floci, my-bucket",
+            // Region-qualified vhost against configured baseHostname
+            "my-bucket.s3.us-east-1.floci.internal, floci.internal, my-bucket",
             // AWS S3 domains (fallback — independent of baseHostname)
             "my-bucket.s3.amazonaws.com,               localhost, my-bucket",
             "my-bucket.s3.amazonaws.com:443,            localhost, my-bucket",
@@ -99,6 +107,9 @@ class S3VirtualHostFilterTest {
         assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.localhost.floci.io", null));
         assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.us-east-1.localhost.floci.io", null));
         assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.localhost.floci.io", null));
+        // Region-qualified vhost against localhost fallback works without baseHostname
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.us-east-1.localhost", null));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.us-east-1.localhost:4566", null));
     }
 
     // --- Hostname extraction from URL ---

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostIntegrationTest.java
@@ -20,6 +20,9 @@ class S3VirtualHostIntegrationTest {
     private static final String BUCKET = "vhost-bucket";
     private static final String HOST = BUCKET + ".localhost";
 
+    private static final String REGION_BUCKET = "vhost-region-bucket";
+    private static final String REGION_HOST = REGION_BUCKET + ".s3.us-east-1.localhost";
+
     @Test
     @Order(1)
     void createBucketViaVirtualHost() {
@@ -189,6 +192,62 @@ class S3VirtualHostIntegrationTest {
     }
 
     @Test
+    @Order(13)
+    void headBucketReturns404ForMissingRegionQualifiedHost() {
+        given()
+            .header("Host", REGION_HOST)
+        .when()
+            .head("/")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(14)
+    void createBucketViaRegionQualifiedVirtualHost() {
+        given()
+            .header("Host", REGION_HOST)
+        .when()
+            .put("/")
+        .then()
+            .statusCode(200)
+            .header("Location", equalTo("/" + REGION_BUCKET));
+    }
+
+    @Test
+    @Order(15)
+    void headBucketViaRegionQualifiedVirtualHost() {
+        given()
+            .header("Host", REGION_HOST)
+        .when()
+            .head("/")
+        .then()
+            .statusCode(200)
+            .header("x-amz-bucket-region", notNullValue());
+    }
+
+    @Test
+    @Order(16)
+    void putAndGetObjectViaRegionQualifiedVirtualHost() {
+        given()
+            .header("Host", REGION_HOST)
+            .contentType("text/plain")
+            .body("region-qualified content")
+        .when()
+            .put("/region.txt")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Host", REGION_HOST)
+        .when()
+            .get("/region.txt")
+        .then()
+            .statusCode(200)
+            .body(equalTo("region-qualified content"));
+    }
+
+    @Test
     @Order(20)
     void cleanupAndDeleteBucket() {
         given().header("Host", HOST).delete("/hello.txt");
@@ -196,6 +255,14 @@ class S3VirtualHostIntegrationTest {
 
         given()
             .header("Host", HOST)
+        .when()
+            .delete("/")
+        .then()
+            .statusCode(204);
+
+        given().header("Host", REGION_HOST).delete("/region.txt");
+        given()
+            .header("Host", REGION_HOST)
         .when()
             .delete("/")
         .then()


### PR DESCRIPTION
## Summary

AWS SDKs may send `Host: bucket.s3.<region>.<host>` for virtual-hosted style S3 requests. `S3VirtualHostFilter` previously only matched the bare base hostname, so the bucket was not extracted in this case. A small helper now accepts both the direct match and the region-qualified form against the configured base hostname and the localhost fallback. Closes #977.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: virtual-hosted requests with hostnames like `my-bucket.s3.us-east-1.localhost` (a form AWS SDKs may produce when a region is configured alongside an endpoint override) were not recognized as virtual-hosted, so the bucket label was not extracted and the path was not rewritten.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)