### PR TITLE
fix(sqs): accept bare queue name in QueueUrl field

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -1253,12 +1253,29 @@ public class SqsService {
      * default account.
      */
     public String senderIdFor(String queueUrl) {
-        String fromUrl = accountFromQueueUrl(queueUrl);
+        String fromUrl = accountFromQueueUrl(normalizeQueueUrl(queueUrl));
         return fromUrl != null ? fromUrl : regionResolver.getAccountId();
     }
 
-    private static String regionKey(String region, String queueUrl) {
-        return region + "::" + extractQueuePath(queueUrl);
+    /**
+     * Accepts a full queue URL or a bare queue name and returns a canonical
+     * full URL.  AWS SQS allows clients to pass either form in the QueueUrl
+     * field; this mirrors that behavior so lookups succeed regardless of what
+     * the caller supplied.
+     */
+    private String normalizeQueueUrl(String queueUrl) {
+        if (queueUrl == null) {
+            return null;
+        }
+        if (queueUrl.contains("://")) {
+            return queueUrl;
+        }
+        // Bare queue name — construct the full URL the same way createQueue does.
+        return baseUrl + "/" + regionResolver.getAccountId() + "/" + queueUrl;
+    }
+
+    private String regionKey(String region, String queueUrl) {
+        return region + "::" + extractQueuePath(normalizeQueueUrl(queueUrl));
     }
 
     /**
@@ -1295,7 +1312,7 @@ public class SqsService {
      */
     private Optional<Queue> getQueueByUrl(String storageKey, String queueUrl) {
         if (queueStore instanceof AccountAwareStorageBackend<Queue> aware) {
-            String accountId = accountFromQueueUrl(queueUrl);
+            String accountId = accountFromQueueUrl(normalizeQueueUrl(queueUrl));
             if (accountId != null) {
                 return aware.getForAccount(accountId, storageKey);
             }

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -813,4 +813,30 @@ class SqsServiceTest {
         verify(sns).clearFifoDeduplicationCacheForSqsQueueSubscriptions(
                 queue.getQueueUrl(), "us-east-1");
     }
+
+    @Test
+    void sendAndReceiveMessage_bareQueueName() {
+        sqsService.createQueue("bare-name-queue", null);
+
+        Message sent = sqsService.sendMessage("bare-name-queue", "hello", 0);
+        assertNotNull(sent.getMessageId());
+
+        List<Message> received = sqsService.receiveMessage("bare-name-queue", 1, 30, 0);
+        assertEquals(1, received.size());
+        assertEquals("hello", received.get(0).getBody());
+    }
+
+    @Test
+    void deleteQueue_bareQueueName() {
+        sqsService.createQueue("delete-bare", null);
+        assertDoesNotThrow(() -> sqsService.deleteQueue("delete-bare"));
+        assertThrows(AwsException.class, () -> sqsService.deleteQueue("delete-bare"));
+    }
+
+    @Test
+    void getQueueAttributes_bareQueueName() {
+        sqsService.createQueue("attrs-bare", Map.of("VisibilityTimeout", "45"));
+        Map<String, String> attrs = sqsService.getQueueAttributes("attrs-bare", List.of("VisibilityTimeout"));
+        assertEquals("45", attrs.get("VisibilityTimeout"));
+    }
 }


### PR DESCRIPTION
AWS SQS resolves a plain queue name (e.g. "TestQueue") to the full queue URL transparently. Floci required the full URL, causing NonExistentQueue errors for clients that pass only the name — a pattern common in AWS SDK for Java v2 applications.

Add `normalizeQueueUrl()` which expands bare names to the canonical `{baseUrl}/{accountId}/{queueName}` form before storage-key computation, covering all SQS operations that accept a QueueUrl parameter.

## Summary

Bare queue names passed in the `QueueUrl` field (e.g. `TestQueue` instead of `http://localhost:4566/000000000000/TestQueue`) are now resolved to full URLs before any storage lookup, matching AWS SQS and LocalStack behavior.

Closes https://github.com/floci-io/floci/issues/979

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: all SQS operations (SendMessage, ReceiveMessage, DeleteMessage, GetQueueAttributes, etc.) returned `AWS.SimpleQueueService.NonExistentQueue` when `QueueUrl` contained a bare queue name instead of a full URL. AWS SQS accepts both forms.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
