### PR TITLE
fix(sts): honour 12-digit access key as account ID in STS responses

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/iam/StsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/StsQueryHandler.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsNamespaces;
 import io.github.hectorvent.floci.core.common.AwsQueryController;
 import io.github.hectorvent.floci.core.common.AwsQueryResponse;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.XmlBuilder;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -27,10 +28,12 @@ public class StsQueryHandler {
     private static final String CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
     private final IamService iamService;
+    private final RegionResolver regionResolver;
 
     @Inject
-    public StsQueryHandler(IamService iamService) {
+    public StsQueryHandler(IamService iamService, RegionResolver regionResolver) {
         this.iamService = iamService;
+        this.regionResolver = regionResolver;
     }
 
     public Response handle(String action, MultivaluedMap<String, String> params) {
@@ -66,7 +69,7 @@ public class StsQueryHandler {
         String roleName = roleArn != null && roleArn.contains("/")
                 ? roleArn.substring(roleArn.lastIndexOf('/') + 1)
                 : "UnknownRole";
-        String accountId = iamService.getAccountId();
+        String accountId = regionResolver.getAccountId();
         String assumedRoleArn = AwsArnUtils.Arn.of("sts", "", accountId, "assumed-role/" + roleName + "/" + sessionName).toString();
         String assumedRoleId = "AROA" + randomId(16) + ":" + sessionName;
 
@@ -86,7 +89,7 @@ public class StsQueryHandler {
     }
 
     private Response handleGetCallerIdentity(MultivaluedMap<String, String> params) {
-        String accountId = iamService.getAccountId();
+        String accountId = regionResolver.getAccountId();
         String result = new XmlBuilder()
                 .elem("UserId", accountId)
                 .elem("Account", accountId)
@@ -122,7 +125,7 @@ public class StsQueryHandler {
         Instant expiration = Instant.now().plusSeconds(durationSeconds);
 
         String roleName = roleArn.contains("/") ? roleArn.substring(roleArn.lastIndexOf('/') + 1) : "UnknownRole";
-        String accountId = iamService.getAccountId();
+        String accountId = regionResolver.getAccountId();
         String assumedRoleArn = AwsArnUtils.Arn.of("sts", "", accountId, "assumed-role/" + roleName + "/" + sessionName).toString();
         String assumedRoleId = "AROA" + randomId(16) + ":" + sessionName;
         String provider = providerId != null && !providerId.isBlank() ? providerId : "accounts.google.com";
@@ -159,7 +162,7 @@ public class StsQueryHandler {
         Instant expiration = Instant.now().plusSeconds(durationSeconds);
 
         String roleName = roleArn.contains("/") ? roleArn.substring(roleArn.lastIndexOf('/') + 1) : "UnknownRole";
-        String accountId = iamService.getAccountId();
+        String accountId = regionResolver.getAccountId();
         String assumedRoleArn = AwsArnUtils.Arn.of("sts", "", accountId, "assumed-role/" + roleName + "/" + sessionName).toString();
         String assumedRoleId = "AROA" + randomId(16) + ":" + sessionName;
 
@@ -193,7 +196,7 @@ public class StsQueryHandler {
         String secretKey = randomSecret(40);
         String sessionToken = randomSecret(200);
         Instant expiration = Instant.now().plusSeconds(durationSeconds);
-        String accountId = iamService.getAccountId();
+        String accountId = regionResolver.getAccountId();
         String federatedUserId = accountId + ":" + name;
         String federatedUserArn = AwsArnUtils.Arn.of("sts", "", accountId, "federated-user/" + name).toString();
 

--- a/src/main/java/io/github/hectorvent/floci/services/iam/StsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/StsQueryHandler.java
@@ -69,7 +69,7 @@ public class StsQueryHandler {
         String roleName = roleArn != null && roleArn.contains("/")
                 ? roleArn.substring(roleArn.lastIndexOf('/') + 1)
                 : "UnknownRole";
-        String accountId = regionResolver.getAccountId();
+        String accountId = AwsArnUtils.accountOrDefault(roleArn, regionResolver.getAccountId());
         String assumedRoleArn = AwsArnUtils.Arn.of("sts", "", accountId, "assumed-role/" + roleName + "/" + sessionName).toString();
         String assumedRoleId = "AROA" + randomId(16) + ":" + sessionName;
 
@@ -125,7 +125,7 @@ public class StsQueryHandler {
         Instant expiration = Instant.now().plusSeconds(durationSeconds);
 
         String roleName = roleArn.contains("/") ? roleArn.substring(roleArn.lastIndexOf('/') + 1) : "UnknownRole";
-        String accountId = regionResolver.getAccountId();
+        String accountId = AwsArnUtils.accountOrDefault(roleArn, regionResolver.getAccountId());
         String assumedRoleArn = AwsArnUtils.Arn.of("sts", "", accountId, "assumed-role/" + roleName + "/" + sessionName).toString();
         String assumedRoleId = "AROA" + randomId(16) + ":" + sessionName;
         String provider = providerId != null && !providerId.isBlank() ? providerId : "accounts.google.com";
@@ -162,7 +162,7 @@ public class StsQueryHandler {
         Instant expiration = Instant.now().plusSeconds(durationSeconds);
 
         String roleName = roleArn.contains("/") ? roleArn.substring(roleArn.lastIndexOf('/') + 1) : "UnknownRole";
-        String accountId = regionResolver.getAccountId();
+        String accountId = AwsArnUtils.accountOrDefault(roleArn, regionResolver.getAccountId());
         String assumedRoleArn = AwsArnUtils.Arn.of("sts", "", accountId, "assumed-role/" + roleName + "/" + sessionName).toString();
         String assumedRoleId = "AROA" + randomId(16) + ":" + sessionName;
 

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
@@ -52,6 +52,24 @@ class IamIntegrationTest {
 
     @Test
     @Order(2)
+    void stsGetCallerIdentityHonoursTwelveDigitAccessKey() {
+        given()
+            .formParam("Action", "GetCallerIdentity")
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=123456789012/20260227/us-east-1/sts/aws4_request")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("GetCallerIdentityResponse.GetCallerIdentityResult.UserId", equalTo("123456789012"))
+            .body("GetCallerIdentityResponse.GetCallerIdentityResult.Account", equalTo("123456789012"))
+            .body("GetCallerIdentityResponse.GetCallerIdentityResult.Arn",
+                    equalTo("arn:aws:iam::123456789012:root"));
+    }
+
+    @Test
+    @Order(3)
     void stsAssumeRole() {
         given()
             .formParam("Action", "AssumeRole")
@@ -71,6 +89,24 @@ class IamIntegrationTest {
             .body("AssumeRoleResponse.AssumeRoleResult.Credentials.Expiration", notNullValue())
             .body("AssumeRoleResponse.AssumeRoleResult.AssumedRoleUser.Arn",
                     containsString("assumed-role/TestRole/test-session"));
+    }
+
+    @Test
+    @Order(4)
+    void stsAssumeRoleHonoursTwelveDigitAccessKey() {
+        given()
+            .formParam("Action", "AssumeRole")
+            .formParam("RoleArn", "arn:aws:iam::123456789012:role/TestRole")
+            .formParam("RoleSessionName", "tenant-session")
+            .formParam("DurationSeconds", "3600")
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=123456789012/20260227/us-east-1/sts/aws4_request")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("AssumeRoleResponse.AssumeRoleResult.AssumedRoleUser.Arn",
+                    equalTo("arn:aws:sts::123456789012:assumed-role/TestRole/tenant-session"));
     }
 
     // =========================================================================

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
@@ -109,6 +109,24 @@ class IamIntegrationTest {
                     equalTo("arn:aws:sts::123456789012:assumed-role/TestRole/tenant-session"));
     }
 
+    @Test
+    @Order(6)
+    void stsAssumeRoleUsesAccountFromRoleArnForCrossAccount() {
+        given()
+            .formParam("Action", "AssumeRole")
+            .formParam("RoleArn", "arn:aws:iam::222222222222:role/CrossAccountRole")
+            .formParam("RoleSessionName", "cross-session")
+            .formParam("DurationSeconds", "3600")
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=123456789012/20260227/us-east-1/sts/aws4_request")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("AssumeRoleResponse.AssumeRoleResult.AssumedRoleUser.Arn",
+                    equalTo("arn:aws:sts::222222222222:assumed-role/CrossAccountRole/cross-session"));
+    }
+
     // =========================================================================
     // AWS Managed Policies (seeded at startup)
     // =========================================================================


### PR DESCRIPTION
## Summary

Closes #981. STS handlers were calling `iamService.getAccountId()`, which returns the static `floci.default-account-id` config value and ignores Floci's per-request 12-digit-AKID multi-account convention. As a result `GetCallerIdentity` always returned `000000000000` even when SNS/SQS/S3 had isolated resources under the caller's actual account. Switched `GetCallerIdentity`, `AssumeRole`, `AssumeRoleWithWebIdentity`, `AssumeRoleWithSAML`, and `GetFederationToken` to resolve the account ID via the request-scoped `RegionResolver`, matching the convention used elsewhere.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Previous behaviour returned a hard-coded `000000000000` UserId/Account/Arn regardless of the access key used. Expected AWS behaviour (and the convention Floci already follows for SNS/SQS/S3) is that the 12-digit access key ID maps to the account, so an ARN built from `sts:GetCallerIdentity` resolves to the same namespace as resources created by that caller.

## Checklist

- [x] `./mvnw test` passes locally (IamIntegrationTest: 24 passed; TlsIntegrationTest: 4 passed)
- [x] New or updated integration test added (`stsGetCallerIdentityHonoursTwelveDigitAccessKey`, `stsAssumeRoleHonoursTwelveDigitAccessKey`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)