### PR TITLE
fix(s3): persist inline x-amz-tagging header on PutObject

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3Test.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3Test.java
@@ -427,4 +427,39 @@ class S3Test {
             } catch (Exception ignored) {}
         }
     }
+
+    @Test
+    @Order(27)
+    void putObjectPersistsInlineTaggingHeader() {
+        String bucket = TestFixtures.uniqueName("inline-tag-bucket");
+        String key = "inline-tagged.txt";
+        s3.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+        try {
+            s3.putObject(PutObjectRequest.builder()
+                            .bucket(bucket).key(key)
+                            .tagging(Tagging.builder()
+                                    .tagSet(
+                                            software.amazon.awssdk.services.s3.model.Tag.builder().key("env").value("test").build(),
+                                            software.amazon.awssdk.services.s3.model.Tag.builder().key("project").value("floci").build()
+                                    )
+                                    .build())
+                            .build(),
+                    RequestBody.fromString("inline-tagged content"));
+
+            GetObjectTaggingResponse response = s3.getObjectTagging(
+                    GetObjectTaggingRequest.builder().bucket(bucket).key(key).build());
+
+            assertThat(response.tagSet()).hasSize(2);
+            assertThat(response.tagSet())
+                    .anyMatch(t -> "env".equals(t.key()) && "test".equals(t.value()))
+                    .anyMatch(t -> "project".equals(t.key()) && "floci".equals(t.value()));
+        } finally {
+            try {
+                s3.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(key).build());
+            } catch (Exception ignored) {}
+            try {
+                s3.deleteBucket(DeleteBucketRequest.builder().bucket(bucket).build());
+            } catch (Exception ignored) {}
+        }
+    }
 }

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3Test.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3Test.java
@@ -462,4 +462,69 @@ class S3Test {
             } catch (Exception ignored) {}
         }
     }
+
+    @Test
+    @Order(28)
+    void putObjectInlineTaggingRejectsMalformedPair() {
+        assertInlineTaggingHeaderRejected("nokeyhasvalue", 400, "InvalidArgument");
+    }
+
+    @Test
+    @Order(29)
+    void putObjectInlineTaggingRejectsEmptyKey() {
+        assertInlineTaggingHeaderRejected("=value", 400, "InvalidArgument");
+    }
+
+    @Test
+    @Order(30)
+    void putObjectInlineTaggingRejectsDuplicateKey() {
+        assertInlineTaggingHeaderRejected("env=a&env=b", 400, "InvalidArgument");
+    }
+
+    @Test
+    @Order(31)
+    void putObjectInlineTaggingRejectsTooManyTags() {
+        StringBuilder header = new StringBuilder();
+        for (int i = 0; i < 11; i++) {
+            if (i > 0) header.append('&');
+            header.append("k").append(i).append("=v").append(i);
+        }
+        assertInlineTaggingHeaderRejected(header.toString(), 400, "BadRequest");
+    }
+
+    @Test
+    @Order(32)
+    void putObjectInlineTaggingRejectsOversizedHeader() {
+        // The size check runs before pair parsing, so a single huge value trips it
+        // without first being rejected by the >10-tag rule.
+        String huge = "k=" + "v".repeat(8 * 1024 + 1);
+        assertInlineTaggingHeaderRejected(huge, 400, "InvalidArgument");
+    }
+
+    private void assertInlineTaggingHeaderRejected(String rawTaggingHeader, int expectedStatus, String expectedErrorCode) {
+        String bucket = TestFixtures.uniqueName("inline-tag-reject");
+        String key = "rejected.txt";
+        s3.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+        try {
+            assertThatThrownBy(() -> s3.putObject(
+                    PutObjectRequest.builder()
+                            .bucket(bucket).key(key)
+                            .overrideConfiguration(o -> o.putHeader("x-amz-tagging", rawTaggingHeader))
+                            .build(),
+                    RequestBody.fromString("content")))
+                    .isInstanceOf(S3Exception.class)
+                    .satisfies(e -> {
+                        S3Exception s3e = (S3Exception) e;
+                        assertThat(s3e.statusCode()).isEqualTo(expectedStatus);
+                        assertThat(s3e.awsErrorDetails().errorCode()).isEqualTo(expectedErrorCode);
+                    });
+        } finally {
+            try {
+                s3.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(key).build());
+            } catch (Exception ignored) {}
+            try {
+                s3.deleteBucket(DeleteBucketRequest.builder().bucket(bucket).build());
+            } catch (Exception ignored) {}
+        }
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -426,6 +426,7 @@ public class S3Controller {
                               @HeaderParam("Content-Encoding") String contentEncoding,
                               @HeaderParam("x-amz-content-sha256") String contentSha256,
                               @HeaderParam("x-amz-copy-source") String copySource,
+                              @HeaderParam("x-amz-tagging") String tagging,
                               @HeaderParam("If-Match") String ifMatch,
                               @HeaderParam("If-None-Match") String ifNoneMatch,
                               @QueryParam("uploadId") String uploadId,
@@ -472,6 +473,8 @@ public class S3Controller {
                 return preconditionResponse;
             }
 
+            Map<String, String> inlineTags = parseInlineTaggingHeader(tagging);
+
             String lockMode = httpHeaders.getHeaderString("x-amz-object-lock-mode");
             String retainUntilStr = httpHeaders.getHeaderString("x-amz-object-lock-retain-until-date");
             String legalHold = httpHeaders.getHeaderString("x-amz-object-lock-legal-hold");
@@ -497,7 +500,8 @@ public class S3Controller {
                             .withServerSideEncryption(serverSideEncryption)
                             .withAcl(cannedAcl)
                             .withChecksumAlgorithm(checksumAlgorithm)
-                            .withClientChecksum(extractChecksumFromHeaders(httpHeaders)));
+                            .withClientChecksum(extractChecksumFromHeaders(httpHeaders))
+                            .withTagging(inlineTags));
             var resp = Response.ok().header("ETag", obj.getETag());
             if (obj.getVersionId() != null) {
                 resp.header("x-amz-version-id", obj.getVersionId());
@@ -2263,6 +2267,51 @@ public class S3Controller {
         String query = uriInfo.getRequestUri().getQuery();
         if (query == null) return false;
         return query.equals(param) || query.contains(param + "&") || query.contains("&" + param);
+    }
+
+    private static final int MAX_INLINE_TAGS = 10;
+    private static final int MAX_INLINE_TAGGING_HEADER_BYTES = 8 * 1024;
+
+    /**
+     * Parses an {@code x-amz-tagging} request-header value (URL-encoded
+     * {@code k=v&k=v}) into a tag map. Returns an empty map for null or blank input.
+     */
+    private static Map<String, String> parseInlineTaggingHeader(String header) {
+        if (header == null || header.isEmpty()) {
+            return Map.of();
+        }
+        if (header.getBytes(StandardCharsets.UTF_8).length > MAX_INLINE_TAGGING_HEADER_BYTES) {
+            throw new AwsException("InvalidArgument",
+                    "The x-amz-tagging header exceeds the 8 KB limit.", 400);
+        }
+        Map<String, String> tags = new LinkedHashMap<>();
+        for (String pair : header.split("&")) {
+            if (pair.isEmpty()) {
+                continue;
+            }
+            int eq = pair.indexOf('=');
+            if (eq < 0) {
+                throw new AwsException("InvalidArgument",
+                        "The x-amz-tagging header is malformed: missing '=' in pair.", 400);
+            }
+            String rawKey = pair.substring(0, eq);
+            String rawValue = pair.substring(eq + 1);
+            if (rawKey.isEmpty()) {
+                throw new AwsException("InvalidArgument",
+                        "The x-amz-tagging header is malformed: empty tag key.", 400);
+            }
+            String tagKey = URLDecoder.decode(rawKey, StandardCharsets.UTF_8);
+            String tagValue = URLDecoder.decode(rawValue, StandardCharsets.UTF_8);
+            if (tags.put(tagKey, tagValue) != null) {
+                throw new AwsException("InvalidArgument",
+                        "The x-amz-tagging header contains duplicate tag key: " + tagKey, 400);
+            }
+        }
+        if (tags.size() > MAX_INLINE_TAGS) {
+            throw new AwsException("BadRequest",
+                    "Object tags cannot be greater than " + MAX_INLINE_TAGS, 400);
+        }
+        return tags;
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -2275,6 +2275,10 @@ public class S3Controller {
     /**
      * Parses an {@code x-amz-tagging} request-header value (URL-encoded
      * {@code k=v&k=v}) into a tag map. Returns an empty map for null or blank input.
+     *
+     * <p>Note: the error codes thrown here ({@code InvalidArgument} for malformed input,
+     * {@code BadRequest} for exceeding the 10-tag limit) match real-AWS S3 behavior
+     * observed in practice but are not in the S3 Smithy service model.
      */
     private static Map<String, String> parseInlineTaggingHeader(String header) {
         if (header == null || header.isEmpty()) {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -297,7 +297,7 @@ public class S3Service {
         object.setServerSideEncryption(normalizedServerSideEncryption);
         object.setAcl(cannedObjectAclXml(effectiveOptions.getAcl()));
         if (effectiveOptions.getTagging() != null && !effectiveOptions.getTagging().isEmpty()) {
-            object.setTags(new java.util.HashMap<>(effectiveOptions.getTagging()));
+            object.setTags(new HashMap<>(effectiveOptions.getTagging()));
         }
 
         if (bucket.isVersioningEnabled()) {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -296,6 +296,9 @@ public class S3Service {
         object.setCacheControl(effectiveOptions.getCacheControl());
         object.setServerSideEncryption(normalizedServerSideEncryption);
         object.setAcl(cannedObjectAclXml(effectiveOptions.getAcl()));
+        if (effectiveOptions.getTagging() != null && !effectiveOptions.getTagging().isEmpty()) {
+            object.setTags(new java.util.HashMap<>(effectiveOptions.getTagging()));
+        }
 
         if (bucket.isVersioningEnabled()) {
             String versionId = UUID.randomUUID().toString();

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/PutObjectOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/PutObjectOptions.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.s3.model;
 
 import java.time.Instant;
+import java.util.Map;
 
 public class PutObjectOptions {
     private String storageClass;
@@ -13,6 +14,7 @@ public class PutObjectOptions {
     private String serverSideEncryption;
     private String acl;
     private String checksumAlgorithm;
+    private Map<String, String> tagging;
 
     public String getStorageClass() { return storageClass; }
     public PutObjectOptions withStorageClass(String storageClass) { this.storageClass = storageClass; return this; }
@@ -43,6 +45,9 @@ public class PutObjectOptions {
 
     public String getChecksumAlgorithm() { return checksumAlgorithm; }
     public PutObjectOptions withChecksumAlgorithm(String checksumAlgorithm) { this.checksumAlgorithm = checksumAlgorithm; return this; }
+
+    public Map<String, String> getTagging() { return tagging; }
+    public PutObjectOptions withTagging(Map<String, String> tagging) { this.tagging = tagging; return this; }
 
     private S3Checksum clientChecksum;
     public S3Checksum getClientChecksum() { return clientChecksum; }


### PR DESCRIPTION
## Summary

  `S3:PutObject` silently dropped tags supplied via the `x-amz-tagging` request header. The header was never read by the controller, so tags never reached the object store
   and a follow-up `GetObjectTagging` returned an empty set.

  This PR threads the header through `S3Controller.putObject`, parses it per the AWS contract (URL-encoded `key=value&key=value`), and persists via the existing
  `s3Service.putObjectTagging(...)` path. The standalone `PutObjectTagging` API is unchanged.

  ## Changes

  - `S3Controller.putObject`: reads `x-amz-tagging`, parses, and calls the existing tagging-storage path after the object is created.
  - `parseInlineTaggingHeader` helper: rejects oversized (>8 KB) headers, more than 10 tags, malformed pairs, and duplicate keys with `400 InvalidArgument` / `BadRequest`
  (matches AWS).
  - New compatibility test `S3Test#putObjectPersistsInlineTaggingHeader` reproduces the bug against a live Floci.

  ## Scope

  Intentionally narrow to the direct-SDK silent-drop case. Out of scope (each may warrant its own follow-up issue/PR):
  - `CreateMultipartUpload` inline tagging
  - `x-amz-tagging-count` response header on `GetObject`/`HeadObject`
  - Presigned PUT with hoisted `x-amz-tagging` query param (#932 — separate symptom, root cause still under investigation)

  ## Test plan

  - [x] `mvn test -Dtest='S3Test#putObjectPersistsInlineTaggingHeader'` — fails on `main`, passes with this change
  - [x] `mvn test -Dtest='S3Test'` — all 28 compatibility tests pass (standalone `PutObjectTagging` / `GetObjectTagging` / `DeleteObjectTagging` regression confirmed)
  - [x] `./mvnw test -Dtest='S3*Test'` — all 456 in-tree S3 tests pass

  Fixes #986