### PR TITLE
fix(sns): preserve binary message attributes through publish and fan-out

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsJsonHandler.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.sns;
 
 import io.github.hectorvent.floci.core.common.AwsErrorResponse;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.sns.model.Subscription;
 import io.github.hectorvent.floci.services.sns.model.Topic;
 import io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue;
@@ -156,21 +157,7 @@ public class SnsJsonHandler {
         String message = request.path("Message").asText(null);
         String subject = request.path("Subject").asText(null);
 
-        Map<String, MessageAttributeValue> attributes = new HashMap<>();
-        JsonNode attrsNode = request.path("MessageAttributes");
-        if (attrsNode.isObject()) {
-            attrsNode.fields().forEachRemaining(entry -> {
-                String dataType = entry.getValue().path("DataType").asText("String");
-                String binaryValueBase64 = entry.getValue().path("BinaryValue").asText(null);
-                if (binaryValueBase64 != null) {
-                    byte[] binaryValue = java.util.Base64.getDecoder().decode(binaryValueBase64);
-                    attributes.put(entry.getKey(), new MessageAttributeValue(binaryValue, dataType));
-                } else {
-                    String stringValue = entry.getValue().path("StringValue").asText();
-                    attributes.put(entry.getKey(), new MessageAttributeValue(stringValue, dataType));
-                }
-            });
-        }
+        Map<String, MessageAttributeValue> attributes = parseMessageAttributes(request.path("MessageAttributes"));
 
         String messageId = snsService.publish(topicArn, targetArn, phoneNumber, message, subject, attributes, region);
         ObjectNode response = objectMapper.createObjectNode();
@@ -234,19 +221,7 @@ public class SnsJsonHandler {
 
                 JsonNode attrsNode = entryNode.path("MessageAttributes");
                 if (attrsNode.isObject()) {
-                    Map<String, MessageAttributeValue> messageAttributes = new HashMap<>();
-                    attrsNode.fields().forEachRemaining(field -> {
-                        String dataType = field.getValue().path("DataType").asText("String");
-                        String binaryValueBase64 = field.getValue().path("BinaryValue").asText(null);
-                        if (binaryValueBase64 != null) {
-                            byte[] binaryValue = java.util.Base64.getDecoder().decode(binaryValueBase64);
-                            messageAttributes.put(field.getKey(), new MessageAttributeValue(binaryValue, dataType));
-                        } else {
-                            String stringValue = field.getValue().path("StringValue").asText();
-                            messageAttributes.put(field.getKey(), new MessageAttributeValue(stringValue, dataType));
-                        }
-                    });
-                    entry.put("MessageAttributes", messageAttributes);
+                    entry.put("MessageAttributes", parseMessageAttributes(attrsNode));
                 }
 
                 entries.add(entry);
@@ -312,6 +287,33 @@ public class SnsJsonHandler {
         node.put("Endpoint", s.getEndpoint() != null ? s.getEndpoint() : "");
         node.put("Owner", s.getOwner() != null ? s.getOwner() : "");
         return node;
+    }
+
+    private Map<String, MessageAttributeValue> parseMessageAttributes(JsonNode attrsNode) {
+        Map<String, MessageAttributeValue> attributes = new HashMap<>();
+        if (!attrsNode.isObject()) {
+            return attributes;
+        }
+        attrsNode.fields().forEachRemaining(entry -> {
+            JsonNode valueNode = entry.getValue();
+            String binaryValueBase64 = valueNode.path("BinaryValue").asText(null);
+            String defaultDataType = binaryValueBase64 != null ? "Binary" : "String";
+            String dataType = valueNode.path("DataType").asText(defaultDataType);
+            if (binaryValueBase64 != null) {
+                byte[] binaryValue;
+                try {
+                    binaryValue = java.util.Base64.getDecoder().decode(binaryValueBase64);
+                } catch (IllegalArgumentException e) {
+                    throw new AwsException("InvalidParameterValue",
+                            "Invalid binary value for message attribute '" + entry.getKey() + "': not valid base64.", 400);
+                }
+                attributes.put(entry.getKey(), new MessageAttributeValue(binaryValue, dataType));
+            } else {
+                String stringValue = valueNode.path("StringValue").asText();
+                attributes.put(entry.getKey(), new MessageAttributeValue(stringValue, dataType));
+            }
+        });
+        return attributes;
     }
 
     private Map<String, String> jsonNodeToMap(JsonNode node) {

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsJsonHandler.java
@@ -161,8 +161,14 @@ public class SnsJsonHandler {
         if (attrsNode.isObject()) {
             attrsNode.fields().forEachRemaining(entry -> {
                 String dataType = entry.getValue().path("DataType").asText("String");
-                String stringValue = entry.getValue().path("StringValue").asText();
-                attributes.put(entry.getKey(), new MessageAttributeValue(stringValue, dataType));
+                String binaryValueBase64 = entry.getValue().path("BinaryValue").asText(null);
+                if (binaryValueBase64 != null) {
+                    byte[] binaryValue = java.util.Base64.getDecoder().decode(binaryValueBase64);
+                    attributes.put(entry.getKey(), new MessageAttributeValue(binaryValue, dataType));
+                } else {
+                    String stringValue = entry.getValue().path("StringValue").asText();
+                    attributes.put(entry.getKey(), new MessageAttributeValue(stringValue, dataType));
+                }
             });
         }
 
@@ -231,8 +237,14 @@ public class SnsJsonHandler {
                     Map<String, MessageAttributeValue> messageAttributes = new HashMap<>();
                     attrsNode.fields().forEachRemaining(field -> {
                         String dataType = field.getValue().path("DataType").asText("String");
-                        String stringValue = field.getValue().path("StringValue").asText();
-                        messageAttributes.put(field.getKey(), new MessageAttributeValue(stringValue, dataType));
+                        String binaryValueBase64 = field.getValue().path("BinaryValue").asText(null);
+                        if (binaryValueBase64 != null) {
+                            byte[] binaryValue = java.util.Base64.getDecoder().decode(binaryValueBase64);
+                            messageAttributes.put(field.getKey(), new MessageAttributeValue(binaryValue, dataType));
+                        } else {
+                            String stringValue = field.getValue().path("StringValue").asText();
+                            messageAttributes.put(field.getKey(), new MessageAttributeValue(stringValue, dataType));
+                        }
                     });
                     entry.put("MessageAttributes", messageAttributes);
                 }

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsJsonHandler.java
@@ -14,6 +14,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -302,7 +303,7 @@ public class SnsJsonHandler {
             if (binaryValueBase64 != null) {
                 byte[] binaryValue;
                 try {
-                    binaryValue = java.util.Base64.getDecoder().decode(binaryValueBase64);
+                    binaryValue = Base64.getDecoder().decode(binaryValueBase64);
                 } catch (IllegalArgumentException e) {
                     throw new AwsException("InvalidParameterValue",
                             "Invalid binary value for message attribute '" + entry.getKey() + "': not valid base64.", 400);

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsQueryHandler.java
@@ -188,8 +188,14 @@ public class SnsQueryHandler {
             String name = params.getFirst("MessageAttributes.entry." + i + ".Name");
             if (name == null) break;
             String value = params.getFirst("MessageAttributes.entry." + i + ".Value.StringValue");
+            String binaryValueBase64 = params.getFirst("MessageAttributes.entry." + i + ".Value.BinaryValue");
             String dataType = params.getFirst("MessageAttributes.entry." + i + ".Value.DataType");
-            if (value != null) attributes.put(name, new MessageAttributeValue(value, dataType != null ? dataType : "String"));
+            if (binaryValueBase64 != null) {
+                byte[] binaryValue = java.util.Base64.getDecoder().decode(binaryValueBase64);
+                attributes.put(name, new MessageAttributeValue(binaryValue, dataType != null ? dataType : "Binary"));
+            } else if (value != null) {
+                attributes.put(name, new MessageAttributeValue(value, dataType != null ? dataType : "String"));
+            }
         }
 
         try {
@@ -223,8 +229,14 @@ public class SnsQueryHandler {
                 String name = params.getFirst(attrPrefix + ".Name");
                 if (name == null) break;
                 String value = params.getFirst(attrPrefix + ".Value.StringValue");
+                String binaryValueBase64 = params.getFirst(attrPrefix + ".Value.BinaryValue");
                 String dataType = params.getFirst(attrPrefix + ".Value.DataType");
-                if (value != null) attributes.put(name, new MessageAttributeValue(value, dataType != null ? dataType : "String"));
+                if (binaryValueBase64 != null) {
+                    byte[] binaryValue = java.util.Base64.getDecoder().decode(binaryValueBase64);
+                    attributes.put(name, new MessageAttributeValue(binaryValue, dataType != null ? dataType : "Binary"));
+                } else if (value != null) {
+                    attributes.put(name, new MessageAttributeValue(value, dataType != null ? dataType : "String"));
+                }
             }
             if (!attributes.isEmpty()) entry.put("MessageAttributes", attributes);
             entries.add(entry);

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsQueryHandler.java
@@ -183,19 +183,11 @@ public class SnsQueryHandler {
         String messageGroupId = getParam(params, "MessageGroupId");
         String messageDeduplicationId = getParam(params, "MessageDeduplicationId");
 
-        Map<String, MessageAttributeValue> attributes = new HashMap<>();
-        for (int i = 1; ; i++) {
-            String name = params.getFirst("MessageAttributes.entry." + i + ".Name");
-            if (name == null) break;
-            String value = params.getFirst("MessageAttributes.entry." + i + ".Value.StringValue");
-            String binaryValueBase64 = params.getFirst("MessageAttributes.entry." + i + ".Value.BinaryValue");
-            String dataType = params.getFirst("MessageAttributes.entry." + i + ".Value.DataType");
-            if (binaryValueBase64 != null) {
-                byte[] binaryValue = java.util.Base64.getDecoder().decode(binaryValueBase64);
-                attributes.put(name, new MessageAttributeValue(binaryValue, dataType != null ? dataType : "Binary"));
-            } else if (value != null) {
-                attributes.put(name, new MessageAttributeValue(value, dataType != null ? dataType : "String"));
-            }
+        Map<String, MessageAttributeValue> attributes;
+        try {
+            attributes = parseMessageAttributes(params, "MessageAttributes.entry.");
+        } catch (AwsException e) {
+            return xmlErrorResponse(e.getErrorCode(), e.getMessage(), e.getHttpStatus());
         }
 
         try {
@@ -223,20 +215,11 @@ public class SnsQueryHandler {
             entry.put("MessageGroupId", getParam(params, entryPrefix + ".MessageGroupId"));
             entry.put("MessageDeduplicationId", getParam(params, entryPrefix + ".MessageDeduplicationId"));
 
-            Map<String, MessageAttributeValue> attributes = new HashMap<>();
-            for (int j = 1; ; j++) {
-                String attrPrefix = entryPrefix + ".MessageAttributes.entry." + j;
-                String name = params.getFirst(attrPrefix + ".Name");
-                if (name == null) break;
-                String value = params.getFirst(attrPrefix + ".Value.StringValue");
-                String binaryValueBase64 = params.getFirst(attrPrefix + ".Value.BinaryValue");
-                String dataType = params.getFirst(attrPrefix + ".Value.DataType");
-                if (binaryValueBase64 != null) {
-                    byte[] binaryValue = java.util.Base64.getDecoder().decode(binaryValueBase64);
-                    attributes.put(name, new MessageAttributeValue(binaryValue, dataType != null ? dataType : "Binary"));
-                } else if (value != null) {
-                    attributes.put(name, new MessageAttributeValue(value, dataType != null ? dataType : "String"));
-                }
+            Map<String, MessageAttributeValue> attributes;
+            try {
+                attributes = parseMessageAttributes(params, entryPrefix + ".MessageAttributes.entry.");
+            } catch (AwsException e) {
+                return xmlErrorResponse(e.getErrorCode(), e.getMessage(), e.getHttpStatus());
             }
             if (!attributes.isEmpty()) entry.put("MessageAttributes", attributes);
             entries.add(entry);
@@ -371,6 +354,31 @@ public class SnsQueryHandler {
 
     private String getParam(MultivaluedMap<String, String> params, String name) {
         return params.getFirst(name);
+    }
+
+    private Map<String, MessageAttributeValue> parseMessageAttributes(
+            MultivaluedMap<String, String> params, String prefix) {
+        Map<String, MessageAttributeValue> attributes = new HashMap<>();
+        for (int i = 1; ; i++) {
+            String name = params.getFirst(prefix + i + ".Name");
+            if (name == null) break;
+            String value = params.getFirst(prefix + i + ".Value.StringValue");
+            String binaryValueBase64 = params.getFirst(prefix + i + ".Value.BinaryValue");
+            String dataType = params.getFirst(prefix + i + ".Value.DataType");
+            if (binaryValueBase64 != null) {
+                byte[] binaryValue;
+                try {
+                    binaryValue = java.util.Base64.getDecoder().decode(binaryValueBase64);
+                } catch (IllegalArgumentException e) {
+                    throw new AwsException("InvalidParameterValue",
+                            "Invalid binary value for message attribute '" + name + "': not valid base64.", 400);
+                }
+                attributes.put(name, new MessageAttributeValue(binaryValue, dataType != null ? dataType : "Binary"));
+            } else if (value != null) {
+                attributes.put(name, new MessageAttributeValue(value, dataType != null ? dataType : "String"));
+            }
+        }
+        return attributes;
     }
 
     Response xmlErrorResponse(String code, String message, int status) {

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsQueryHandler.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -368,7 +369,7 @@ public class SnsQueryHandler {
             if (binaryValueBase64 != null) {
                 byte[] binaryValue;
                 try {
-                    binaryValue = java.util.Base64.getDecoder().decode(binaryValueBase64);
+                    binaryValue = Base64.getDecoder().decode(binaryValueBase64);
                 } catch (IllegalArgumentException e) {
                     throw new AwsException("InvalidParameterValue",
                             "Invalid binary value for message attribute '" + name + "': not valid base64.", 400);

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
@@ -951,7 +951,12 @@ public class SnsService {
                 for (var entry : messageAttributes.entrySet()) {
                     ObjectNode attr = attrs.putObject(entry.getKey());
                     attr.put("Type", entry.getValue().getDataType());
-                    attr.put("Value", entry.getValue().getStringValue());
+                    if (entry.getValue().getBinaryValue() != null) {
+                        attr.put("Value", java.util.Base64.getEncoder()
+                                .encodeToString(entry.getValue().getBinaryValue()));
+                    } else {
+                        attr.put("Value", entry.getValue().getStringValue());
+                    }
                 }
             }
             ObjectNode record = objectMapper.createObjectNode();
@@ -1007,7 +1012,12 @@ public class SnsService {
                 for (var entry : messageAttributes.entrySet()) {
                     ObjectNode attr = attrs.putObject(entry.getKey());
                     attr.put("Type", entry.getValue().getDataType());
-                    attr.put("Value", entry.getValue().getStringValue());
+                    if (entry.getValue().getBinaryValue() != null) {
+                        attr.put("Value", java.util.Base64.getEncoder()
+                                .encodeToString(entry.getValue().getBinaryValue()));
+                    } else {
+                        attr.put("Value", entry.getValue().getStringValue());
+                    }
                 }
             }
             return objectMapper.writeValueAsString(node);

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
@@ -32,6 +32,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HexFormat;
 import java.util.List;
@@ -952,7 +953,7 @@ public class SnsService {
                     ObjectNode attr = attrs.putObject(entry.getKey());
                     attr.put("Type", entry.getValue().getDataType());
                     if (entry.getValue().getBinaryValue() != null) {
-                        attr.put("Value", java.util.Base64.getEncoder()
+                        attr.put("Value", Base64.getEncoder()
                                 .encodeToString(entry.getValue().getBinaryValue()));
                     } else {
                         attr.put("Value", entry.getValue().getStringValue());
@@ -1013,7 +1014,7 @@ public class SnsService {
                     ObjectNode attr = attrs.putObject(entry.getKey());
                     attr.put("Type", entry.getValue().getDataType());
                     if (entry.getValue().getBinaryValue() != null) {
-                        attr.put("Value", java.util.Base64.getEncoder()
+                        attr.put("Value", Base64.getEncoder()
                                 .encodeToString(entry.getValue().getBinaryValue()));
                     } else {
                         attr.put("Value", entry.getValue().getStringValue());
@@ -1050,7 +1051,7 @@ public class SnsService {
                     ObjectNode attr = attrs.putObject(entry.getKey());
                     attr.put("Type", entry.getValue().getDataType());
                     if (entry.getValue().getBinaryValue() != null) {
-                        attr.put("Value", java.util.Base64.getEncoder()
+                        attr.put("Value", Base64.getEncoder()
                                 .encodeToString(entry.getValue().getBinaryValue()));
                     } else {
                         attr.put("Value", entry.getValue().getStringValue());

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsIntegrationTest.java
@@ -212,7 +212,7 @@ class SnsIntegrationTest {
     }
 
     @Test
-    @Order(9)
+    @Order(18)
     void publish_fanOutPreservesBinaryMessageAttribute() {
         drainQueue(sqsQueueUrl);
 
@@ -256,7 +256,7 @@ class SnsIntegrationTest {
     }
 
     @Test
-    @Order(9)
+    @Order(19)
     void publish_invalidBinaryAttributeReturns400() {
         given()
             .contentType("application/x-www-form-urlencoded")

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsIntegrationTest.java
@@ -256,6 +256,24 @@ class SnsIntegrationTest {
     }
 
     @Test
+    @Order(9)
+    void publish_invalidBinaryAttributeReturns400() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "Publish")
+            .formParam("TopicArn", topicArn)
+            .formParam("Message", "hello")
+            .formParam("MessageAttributes.entry.1.Name", "binarycontent")
+            .formParam("MessageAttributes.entry.1.Value.DataType", "Binary")
+            .formParam("MessageAttributes.entry.1.Value.BinaryValue", "not valid base64!!!")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidParameterValue"));
+    }
+
+    @Test
     @Order(10)
     void publishBatch() {
         given()

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsIntegrationTest.java
@@ -212,6 +212,50 @@ class SnsIntegrationTest {
     }
 
     @Test
+    @Order(9)
+    void publish_fanOutPreservesBinaryMessageAttribute() {
+        drainQueue(sqsQueueUrl);
+
+        // "somebinarydata" base64-encoded -> c29tZWJpbmFyeWRhdGE=
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "Publish")
+            .formParam("TopicArn", topicArn)
+            .formParam("Message", "hello")
+            .formParam("MessageAttributes.entry.1.Name", "content")
+            .formParam("MessageAttributes.entry.1.Value.DataType", "String")
+            .formParam("MessageAttributes.entry.1.Value.StringValue", "somecontent")
+            .formParam("MessageAttributes.entry.2.Name", "binarycontent")
+            .formParam("MessageAttributes.entry.2.Value.DataType", "Binary")
+            .formParam("MessageAttributes.entry.2.Value.BinaryValue", "c29tZWJpbmFyeWRhdGE=")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<MessageId>"));
+
+        String jsonBodyInResponse = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ReceiveMessage")
+            .formParam("QueueUrl", sqsQueueUrl)
+            .formParam("MaxNumberOfMessages", "1")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("hello"))
+            .extract().xmlPath().getString(
+                    "ReceiveMessageResponse.ReceiveMessageResult.Message.Body");
+
+        assertTrue(jsonBodyInResponse.contains("\"binarycontent\""),
+                "Binary attribute should be present in delivered envelope: " + jsonBodyInResponse);
+        assertTrue(jsonBodyInResponse.contains("\"Binary\""),
+                "Binary attribute Type should be present: " + jsonBodyInResponse);
+        assertTrue(jsonBodyInResponse.contains("c29tZWJpbmFyeWRhdGE="),
+                "Binary attribute Value should be base64-encoded: " + jsonBodyInResponse);
+    }
+
+    @Test
     @Order(10)
     void publishBatch() {
         given()


### PR DESCRIPTION
## Summary

Binary SNS message attributes were silently dropped on publish and lost during fan-out. This change parses `BinaryValue` on `Publish`/`PublishBatch` in both the JSON and Query handlers, and base64-encodes binary attributes in the SNS-to-SQS and Lambda JSON envelopes (matching the existing handling already present in the HTTP notification builder).

Closes #988

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Previously, a `Publish` with a `Binary` `MessageAttribute` parsed only `StringValue`, so the attribute arrived at SQS/Lambda subscribers as a null/empty value (or was dropped entirely). AWS delivers binary attributes in the SNS-to-SQS JSON envelope as `{"Type":"Binary","Value":"<base64>"}`, which this PR now produces.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (`publish_fanOutPreservesBinaryMessageAttribute`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)