### PR TITLE
feat(kms): add RotateKeyOnDemand support

### DIFF
--- a/docs/services/kms.md
+++ b/docs/services/kms.md
@@ -30,6 +30,7 @@
 | `GetKeyRotationStatus` | Check if automatic key rotation is enabled |
 | `EnableKeyRotation` | Enable automatic key rotation (symmetric keys only) |
 | `DisableKeyRotation` | Disable automatic key rotation |
+| `RotateKeyOnDemand` | Rotate key material on demand (symmetric keys only) |
 
 ## Configuration
 

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
@@ -60,6 +60,7 @@ public class KmsJsonHandler {
             case "GetKeyRotationStatus" -> handleGetKeyRotationStatus(request, region);
             case "EnableKeyRotation" -> handleEnableKeyRotation(request, region);
             case "DisableKeyRotation" -> handleDisableKeyRotation(request, region);
+            case "RotateKeyOnDemand" -> handleRotateKeyOnDemand(request, region);
             default -> Response.status(400)
                     .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                     .build();
@@ -381,6 +382,13 @@ public class KmsJsonHandler {
     private Response handleDisableKeyRotation(JsonNode request, String region) {
         service.disableKeyRotation(request.path("KeyId").asText(), region);
         return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleRotateKeyOnDemand(JsonNode request, String region) {
+        String keyId = service.rotateKeyOnDemand(request.path("KeyId").asText(), region);
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("KeyId", keyId);
+        return Response.ok(response).build();
     }
 
     private ObjectNode keyToNode(KmsKey k) {

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -290,6 +290,16 @@ public class KmsService {
         LOG.infov("Disabled key rotation for KMS key: {0} in {1}", key.getKeyId(), region);
     }
 
+    public String rotateKeyOnDemand(String keyId, String region) {
+        KmsKey key = resolveKey(keyId, region);
+        if (!key.isEnabled()) {
+            throw new AwsException("DisabledException",
+                    "KMS key " + key.getKeyId() + " is disabled.", 400);
+        }
+        validateRotationSupported(key);
+        return key.getKeyId();
+    }
+
     private void validateRotationSupported(KmsKey key) {
         if (!"ENCRYPT_DECRYPT".equals(key.getKeyUsage())
                 || !"SYMMETRIC_DEFAULT".equals(key.getCustomerMasterKeySpec())) {

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
@@ -108,4 +108,28 @@ class KmsIntegrationTest {
             .statusCode(400)
             .body("__type", equalTo("KMSInvalidMacException"));
     }
+
+    @Test
+    void rotateKeyOnDemandReturnsKeyId() {
+        String keyId = given()
+                .header("X-Amz-Target", "TrentService.CreateKey")
+                .contentType("application/x-amz-json-1.1")
+                .body("{\"Description\":\"rotate-on-demand\"}")
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("KeyMetadata.KeyId");
+
+        given()
+                .header("X-Amz-Target", "TrentService.RotateKeyOnDemand")
+                .contentType("application/x-amz-json-1.1")
+                .body("{\"KeyId\":\"" + keyId + "\"}")
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .body("KeyId", equalTo(keyId));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -633,6 +633,36 @@ class KmsServiceTest {
         assertFalse(kmsService.getKeyRotationStatus(key.getKeyId(), REGION));
     }
 
+    // ── Issue #911 — RotateKeyOnDemand ──────────────────────────────────────
+
+    @Test
+    void rotateKeyOnDemandReturnsKeyId() {
+        KmsKey key = kmsService.createKey(null, REGION);
+        String keyId = kmsService.rotateKeyOnDemand(key.getKeyId(), REGION);
+        assertEquals(key.getKeyId(), keyId);
+    }
+
+    @Test
+    void rotateKeyOnDemandOnAsymmetricKeyThrows() {
+        KmsKey key = kmsService.createKey("rsa key", "SIGN_VERIFY", "RSA_2048", null, Map.of(), REGION);
+        AwsException ex = assertThrows(AwsException.class, () ->
+                kmsService.rotateKeyOnDemand(key.getKeyId(), REGION));
+
+        assertEquals("UnsupportedOperationException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+    }
+
+    @Test
+    void rotateKeyOnDemandOnDisabledKeyThrows() {
+        KmsKey key = kmsService.createKey(null, REGION);
+        key.setEnabled(false);
+        AwsException ex = assertThrows(AwsException.class, () ->
+                kmsService.rotateKeyOnDemand(key.getKeyId(), REGION));
+
+        assertEquals("DisabledException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+    }
+
     // ── Issue #497 — HMAC key specs ─────────────────────────────────────────
 
     @ParameterizedTest


### PR DESCRIPTION
## Summary

add KMS `RotateKeyOnDemand` support

Closes #911 
<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified with AWS CLI
- `aws kms rotate-key-on-demand --key-id <key-id>`

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
