### PR TITLE
fix(s3): handle PutBucketRequestPayment instead of falling through to CreateBucket

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -194,6 +194,10 @@ public class S3Controller {
                 s3Service.putBucketOwnershipControls(bucket, new String(body, StandardCharsets.UTF_8));
                 return Response.ok().build();
             }
+            if (hasQueryParam(uriInfo, "requestPayment")) {
+                s3Service.putBucketRequestPayment(bucket, new String(body, StandardCharsets.UTF_8));
+                return Response.ok().build();
+            }
 
             String locationConstraint = null;
             if (body != null && body.length > 0) {
@@ -331,6 +335,9 @@ public class S3Controller {
             }
             if (hasQueryParam(uriInfo, "ownershipControls")) {
                 return Response.ok(s3Service.getBucketOwnershipControls(bucket)).build();
+            }
+            if (hasQueryParam(uriInfo, "requestPayment")) {
+                return Response.ok(s3Service.getBucketRequestPayment(bucket)).build();
             }
 
             // --- Website Hosting Redirection Logic ---

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.s3;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.AwsNamespaces;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.XmlBuilder;
 import io.github.hectorvent.floci.core.common.XmlParser;
@@ -1496,6 +1497,46 @@ public class S3Service {
                 .orElseThrow(() -> new AwsException("NoSuchBucket", "The specified bucket does not exist.", 404));
         bucket.setOwnershipControlsConfiguration(null);
         bucketStore.put(bucketName, bucket);
+    }
+
+    /**
+     * Stores the bucket Request Payment configuration. AWS only allows the values
+     * {@code BucketOwner} and {@code Requester}; we accept either and reject anything
+     * else with {@code MalformedXML} to match the real S3 behavior.
+     */
+    public void putBucketRequestPayment(String bucketName, String requestPaymentXml) {
+        Bucket bucket = bucketStore.get(bucketName)
+                .orElseThrow(() -> new AwsException("NoSuchBucket", "The specified bucket does not exist.", 404));
+        String payer = XmlParser.extractFirst(requestPaymentXml, "Payer", null);
+        if (payer == null) {
+            throw new AwsException("MalformedXML",
+                    "The XML you provided was not well-formed or did not validate against our published schema.",
+                    400);
+        }
+        payer = payer.trim();
+        if (!"BucketOwner".equals(payer) && !"Requester".equals(payer)) {
+            throw new AwsException("MalformedXML",
+                    "The XML you provided was not well-formed or did not validate against our published schema.",
+                    400);
+        }
+        bucket.setRequestPaymentPayer(payer);
+        bucketStore.put(bucketName, bucket);
+    }
+
+    /**
+     * Returns the bucket Request Payment configuration as XML. Buckets that have
+     * never been configured return the AWS default ({@code BucketOwner}); this matches
+     * real S3, which never returns 404 for {@code GetBucketRequestPayment}.
+     */
+    public String getBucketRequestPayment(String bucketName) {
+        Bucket bucket = bucketStore.get(bucketName)
+                .orElseThrow(() -> new AwsException("NoSuchBucket", "The specified bucket does not exist.", 404));
+        String payer = bucket.getRequestPaymentPayer() != null ? bucket.getRequestPaymentPayer() : "BucketOwner";
+        return new XmlBuilder()
+                .start("RequestPaymentConfiguration", AwsNamespaces.S3)
+                .elem("Payer", payer)
+                .end("RequestPaymentConfiguration")
+                .build();
     }
 
     public void restoreObject(String bucketName, String key, String versionId, String restoreXml) {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/Bucket.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/Bucket.java
@@ -26,6 +26,7 @@ public class Bucket {
     private String encryptionConfiguration; // XML string
     private String publicAccessBlockConfiguration; // XML string
     private String ownershipControlsConfiguration; // XML string
+    private String requestPaymentPayer; // "BucketOwner" (default) or "Requester"; null until first PUT
     private String region;
     private WebsiteConfiguration websiteConfiguration;
 
@@ -94,6 +95,9 @@ public class Bucket {
     public void setOwnershipControlsConfiguration(String ownershipControlsConfiguration) {
         this.ownershipControlsConfiguration = ownershipControlsConfiguration;
     }
+
+    public String getRequestPaymentPayer() { return requestPaymentPayer; }
+    public void setRequestPaymentPayer(String requestPaymentPayer) { this.requestPaymentPayer = requestPaymentPayer; }
 
     public String getRegion() { return region; }
     public void setRegion(String region) { this.region = region; }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3RequestPaymentIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3RequestPaymentIntegrationTest.java
@@ -1,0 +1,119 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class S3RequestPaymentIntegrationTest {
+
+    private static final String BUCKET = "request-payment-int-test";
+    private static final String REQUESTER_PAYS_XML = """
+            <RequestPaymentConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Payer>Requester</Payer>
+            </RequestPaymentConfiguration>
+            """;
+    private static final String BUCKET_OWNER_PAYS_XML = """
+            <RequestPaymentConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Payer>BucketOwner</Payer>
+            </RequestPaymentConfiguration>
+            """;
+
+    @Test
+    @Order(1)
+    void createBucket() {
+        given()
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void getRequestPaymentBeforePutReturnsBucketOwnerDefault() {
+        given()
+        .when()
+            .get("/" + BUCKET + "?requestPayment")
+        .then()
+            .statusCode(200)
+            .body(containsString("<RequestPaymentConfiguration"))
+            .body(containsString("<Payer>BucketOwner</Payer>"));
+    }
+
+    @Test
+    @Order(3)
+    void putRequestPaymentReturns200() {
+        given()
+            .body(REQUESTER_PAYS_XML)
+        .when()
+            .put("/" + BUCKET + "?requestPayment")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(4)
+    void getRequestPaymentReturnsStoredPayer() {
+        given()
+        .when()
+            .get("/" + BUCKET + "?requestPayment")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Payer>Requester</Payer>"));
+    }
+
+    /**
+     * Regression test for the Terraform-breaking bug where {@code PUT /{bucket}?requestPayment}
+     * fell through to the bucket-creation handler and returned {@code 409 BucketAlreadyOwnedByYou}.
+     * Real S3 allows {@code PutBucketRequestPayment} to be called repeatedly on an existing
+     * bucket — and Terraform's {@code aws_s3_bucket_request_payment_configuration} resource
+     * relies on this idempotency.
+     */
+    @Test
+    @Order(5)
+    void putRequestPaymentIsIdempotentOnExistingBucket() {
+        given()
+            .body(BUCKET_OWNER_PAYS_XML)
+        .when()
+            .put("/" + BUCKET + "?requestPayment")
+        .then()
+            .statusCode(200)
+            .body(not(containsString("BucketAlreadyOwnedByYou")));
+    }
+
+    @Test
+    @Order(6)
+    void putRequestPaymentRejectsInvalidPayer() {
+        given()
+            .body("""
+                    <RequestPaymentConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                        <Payer>SomeoneElse</Payer>
+                    </RequestPaymentConfiguration>
+                    """)
+        .when()
+            .put("/" + BUCKET + "?requestPayment")
+        .then()
+            .statusCode(400)
+            .body(containsString("MalformedXML"));
+    }
+
+    @Test
+    @Order(7)
+    void putRequestPaymentOnMissingBucketReturns404() {
+        given()
+            .body(BUCKET_OWNER_PAYS_XML)
+        .when()
+            .put("/this-bucket-does-not-exist-rp?requestPayment")
+        .then()
+            .statusCode(404)
+            .body(containsString("NoSuchBucket"));
+    }
+}


### PR DESCRIPTION
## Summary

`PUT /{bucket}?requestPayment` was not recognised as a sub-resource by `S3Controller`, so the request fell through to the bucket-creation handler. For any pre-existing bucket that returned `BucketAlreadyOwnedByYou` (HTTP 409), which broke real workloads such as Terraform's `aws_s3_bucket_request_payment_configuration` on every re-apply.

## Fix

Added explicit handling for the `requestPayment` sub-resource, mirroring the existing `OwnershipControls` / `Acl` flow:

- `Bucket` model gains a `requestPaymentPayer` field.
- `S3Service.putBucketRequestPayment` validates the bucket exists (`NoSuchBucket` / 404) and the payer value (`BucketOwner` | `Requester`); invalid payers return `MalformedXML` / 400 to match real S3.
- `S3Service.getBucketRequestPayment` returns the canonical `RequestPaymentConfiguration` XML, defaulting to `BucketOwner` when never set — real S3 never returns 404 for `GetBucketRequestPayment` (unlike `GetBucketOwnershipControls`).
- `S3Controller` dispatches `PUT` and `GET ?requestPayment` to the new methods.
- No `DELETE` handler is added; AWS does not expose one.

## Reproducer

The bug is deterministic — a single `PutBucketRequestPayment` call against an existing bucket triggers it:

```bash
aws --endpoint-url http://localhost:4566 s3api create-bucket --bucket demo
aws --endpoint-url http://localhost:4566 s3api put-bucket-request-payment \
  --bucket demo --request-payment-configuration Payer=BucketOwner
# Before: BucketAlreadyOwnedByYou (409)
# After:  empty 200 OK
```

The Terraform path that surfaced it in production:

```
Error: creating S3 Bucket (...) Request Payment Configuration:
operation error S3: PutBucketRequestPayment, https response error
StatusCode: 409, ... api error BucketAlreadyOwnedByYou: Your previous
request to create the named bucket succeeded and you already own it.
  with module.s3_data_platform_output.module.s3_bucket
       .aws_s3_bucket_request_payment_configuration.this[0],
  on .terraform/modules/s3_data_platform_output.s3_bucket/main.tf
  line 185, in resource "aws_s3_bucket_request_payment_configuration"
  "this":
  185: resource "aws_s3_bucket_request_payment_configuration" "this" {
```

## Tests

`S3RequestPaymentIntegrationTest` covers:

1. `GET ?requestPayment` before any `PUT` returns 200 with default `<Payer>BucketOwner</Payer>` (matches real S3 — no 404).
2. `PUT ?requestPayment` with `Payer=Requester` returns 200; subsequent `GET` reflects the stored payer.
3. **Regression for the original bug**: a second `PUT ?requestPayment` on an existing bucket returns 200 and the body does *not* contain `BucketAlreadyOwnedByYou`.
4. `PUT ?requestPayment` with an invalid `<Payer>` returns 400 `MalformedXML`.
5. `PUT ?requestPayment` on a non-existent bucket returns 404 `NoSuchBucket`.

## Notes

- AWS wire protocol preserved — no custom endpoint shapes; matches the public `PutBucketRequestPayment` / `GetBucketRequestPayment` actions exactly.
- Implementation pattern reused from the adjacent `ownershipControls` handler, so the change is narrow and keeps `S3Controller`'s sub-resource dispatch consistent.