### PR TITLE
feat(ci): publish Docker images to ECR Public Gallery

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,7 @@ name: Nightly
 #   Native:  floci/floci:nightly   floci/floci:nightly-mmddyyyy
 #   Compat:  floci/floci:nightly-compat   floci/floci:nightly-mmddyyyy-compat
 #
-# Required secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN
+# Required secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN, AWS_ROLE_ARN
 
 on:
   schedule:
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -145,6 +146,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Build and push native nightly image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         env:
@@ -157,6 +169,8 @@ jobs:
           tags: |
             floci/floci:nightly
             floci/floci:nightly-${{ needs.prepare.outputs.version }}
+            public.ecr.aws/floci/floci:nightly
+            public.ecr.aws/floci/floci:nightly-${{ needs.prepare.outputs.version }}
           labels: |
             org.opencontainers.image.version=nightly-${{ needs.prepare.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -179,6 +193,8 @@ jobs:
           tags: |
             floci/floci:nightly-compat
             floci/floci:nightly-${{ needs.prepare.outputs.version }}-compat
+            public.ecr.aws/floci/floci:nightly-compat
+            public.ecr.aws/floci/floci:nightly-${{ needs.prepare.outputs.version }}-compat
           build-args: |
             VERSION=nightly-${{ needs.prepare.outputs.version }}
           labels: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,14 @@
 name: Release
 
 # Triggered when a version tag (e.g. 1.2.3) is pushed.
-# Builds native (amd64 + arm64) Docker images and pushes them to Docker Hub.
+# Builds native (amd64 + arm64) Docker images and pushes them to Docker Hub
+# and ECR Public Gallery (public.ecr.aws/floci/floci).
 #
 # Published tags:
 #   Native:  floci/floci:1.2.3        floci/floci:latest
 #   Compat:  floci/floci:1.2.3-compat floci/floci:latest-compat
 #
-# Required secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN
+# Required secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN, AWS_ROLE_ARN
 
 on:
   push:
@@ -16,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 # Per-tag concurrency. Back-to-back tag pushes (e.g. 1.5.3 and 1.6.0 landing
 # minutes apart) resolve to different ${{ github.ref }} values, so they run
@@ -126,6 +128,17 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Build and push native multi-arch image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         env:
@@ -138,6 +151,8 @@ jobs:
           tags: |
             floci/floci:${{ steps.version.outputs.version }}
             floci/floci:latest
+            public.ecr.aws/floci/floci:${{ steps.version.outputs.version }}
+            public.ecr.aws/floci/floci:latest
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
           labels: |
@@ -162,6 +177,8 @@ jobs:
           tags: |
             floci/floci:${{ steps.version.outputs.version }}-compat
             floci/floci:latest-compat
+            public.ecr.aws/floci/floci:${{ steps.version.outputs.version }}-compat
+            public.ecr.aws/floci/floci:latest-compat
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
           labels: |


### PR DESCRIPTION
## Summary

Add ECR Public Gallery (public.ecr.aws/floci/floci) as a second push target alongside Docker Hub in both the release and nightly workflows.

Uses GitHub OIDC (id-token: write) with the org-level AWS_ROLE_ARN secret and aws-actions/configure-aws-credentials to assume the ECR push role. ECR Public requires us-east-1 regardless of the primary deployment region.

Tags mirrored on each release: {version}, latest, {version}-compat, latest-compat. Tags mirrored on each nightly: nightly, nightly-{mmddyyyy}, nightly-compat, nightly-{mmddyyyy}-compat.

Closes #563

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
