### PR TITLE
fix(s3): unblock .well-known/* object keys hijacked by Cognito routes

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoWellKnownController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoWellKnownController.java
@@ -16,10 +16,20 @@ import java.util.Base64;
  * Exposes Cognito well-known endpoints.
  * The JWKS endpoint allows downstream services to verify JWTs issued by Floci Cognito pools.
  * Path mirrors real AWS: /{userPoolId}/.well-known/jwks.json
+ *
+ * <p>The {@code poolId} path parameter is constrained to {@link #POOL_ID_PATTERN}
+ * so that S3 object keys like {@code /<bucket>/.well-known/jwks.json} do not
+ * collide with this route. Real Cognito UserPool IDs always contain an
+ * underscore (region prefix + {@code _} + random suffix, e.g.
+ * {@code us-east-1_AbC123XyZ}), while AWS S3 bucket names forbid underscores
+ * — using {@code _} as the discriminator routes S3 traffic correctly without
+ * needing a wider request filter.
  */
 @Path("/")
 @Produces(MediaType.APPLICATION_JSON)
 public class CognitoWellKnownController {
+
+    private static final String POOL_ID_PATTERN = "[^/_]+_[^/]+";
 
     private final CognitoService cognitoService;
 
@@ -29,7 +39,7 @@ public class CognitoWellKnownController {
     }
 
     @GET
-    @Path("/{poolId}/.well-known/jwks.json")
+    @Path("/{poolId:" + POOL_ID_PATTERN + "}/.well-known/jwks.json")
     public Response getJwks(@PathParam("poolId") String poolId) {
         UserPool pool = cognitoService.describeUserPool(poolId);
         String kid = cognitoService.getSigningKeyId(pool);
@@ -44,7 +54,7 @@ public class CognitoWellKnownController {
     }
 
     @GET
-    @Path("/{poolId}/.well-known/openid-configuration")
+    @Path("/{poolId:" + POOL_ID_PATTERN + "}/.well-known/openid-configuration")
     public Response getOpenIdConfiguration(@PathParam("poolId") String poolId) {
         UserPool pool = cognitoService.describeUserPool(poolId);
         String issuer = cognitoService.getIssuer(pool.getId());

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3WellKnownKeyIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3WellKnownKeyIntegrationTest.java
@@ -1,0 +1,119 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * S3 keys under <code>.well-known/</code> must NOT collide with the Cognito
+ * well-known OIDC endpoints (<code>/{poolId}/.well-known/jwks.json</code> and
+ * <code>/{poolId}/.well-known/openid-configuration</code>).
+ *
+ * <p>Discriminator: real Cognito UserPool IDs always contain an underscore
+ * (<code>&lt;region&gt;_&lt;random&gt;</code>, e.g. <code>us-east-1_xxx</code>),
+ * while AWS S3 bucket names forbid underscores. Any first path segment without
+ * an underscore therefore cannot be a Cognito pool id and must be routed to
+ * S3.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class S3WellKnownKeyIntegrationTest {
+
+    private static final String BUCKET = "test-bucket-jwks-967";
+    private static final String JWKS_KEY = ".well-known/jwks.json";
+    private static final String SIBLING_KEY = ".well-known/test.json";
+    private static final String JWKS_BODY = "{\"keys\":[{\"kty\":\"RSA\"}]}";
+    private static final String SIBLING_BODY = "{\"hello\":\"world\"}";
+
+    @Test
+    @Order(0)
+    void createBucket() {
+        given()
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(1)
+    void putAndGetSiblingWellKnownObject() {
+        given()
+            .header("Content-Type", "application/json")
+            .body(SIBLING_BODY)
+        .when()
+            .put("/" + BUCKET + "/" + SIBLING_KEY)
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "/" + SIBLING_KEY)
+        .then()
+            .statusCode(200)
+            .body(equalTo(SIBLING_BODY));
+    }
+
+    @Test
+    @Order(2)
+    void putAndGetJwksObject_mustNotBeRoutedToCognito() {
+        given()
+            .header("Content-Type", "application/json")
+            .body(JWKS_BODY)
+        .when()
+            .put("/" + BUCKET + "/" + JWKS_KEY)
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "/" + JWKS_KEY)
+        .then()
+            .statusCode(200)
+            .body(equalTo(JWKS_BODY));
+    }
+
+    @Test
+    @Order(3)
+    void getJwksObject_mustNotReturnCognitoErrorBody() {
+        String body = given()
+        .when()
+            .get("/" + BUCKET + "/" + JWKS_KEY)
+        .then()
+            .extract().asString();
+
+        if (body.contains("ResourceNotFoundException") || body.contains("User pool not found")) {
+            throw new AssertionError(
+                "GET /" + BUCKET + "/" + JWKS_KEY
+                + " was routed to Cognito instead of S3. Response: " + body);
+        }
+    }
+
+    @Test
+    @Order(4)
+    void getOpenIdConfigurationObject_mustNotBeRoutedToCognito() {
+        String openIdKey = ".well-known/openid-configuration";
+        String openIdBody = "{\"issuer\":\"custom\"}";
+
+        given()
+            .header("Content-Type", "application/json")
+            .body(openIdBody)
+        .when()
+            .put("/" + BUCKET + "/" + openIdKey)
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "/" + openIdKey)
+        .then()
+            .statusCode(200)
+            .body(containsString("custom"));
+    }
+}


### PR DESCRIPTION
## Summary

Fix 967

S3 object keys under `.well-known/` (e.g. `bucket/.well-known/jwks.json`) were being routed to `CognitoWellKnownController` instead of `S3Controller`. The controller threw `ResourceNotFoundException` ("User pool not found"), masking the S3 object even though `list-objects-v2` and `head-object` returned it. This broke applications that store JWKS under S3 (common pattern for local JWT verification setups).

Root cause: `CognitoWellKnownController` declared `Path("/{poolId}/.well-known/jwks.json")` (and the same for `openid-configuration`) without any constraint on `{poolId}`. Any first path segment matched, including S3 bucket names like `test-bucket`.

Fix: constrain the `{poolId}` path parameter to `[^/_]+_[^/]+`. Real Cognito UserPool IDs always contain an underscore (`<region>_<random>`, e.g. `us-east-1_xxx`); AWS S3 bucket names forbid underscores. Any first path segment without an underscore therefore cannot be a Cognito pool ID and now falls through to `S3Controller`. Existing Cognito tests use the canonical `us-east-1_*` format and continue to match.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Real S3 accepts arbitrary object keys including `.well-known/jwks.json`. AWS S3 bucket naming rules forbid underscores. Real Cognito UserPool IDs are always `<region>_<suffix>`. The discriminator therefore matches AWS reality exactly.

## Reproduces with

```bash
curl -i http://localhost:4566/test-bucket/.well-known/jwks.json
# HTTP/1.1 404 Not Found
# Content-Type: application/json
# {"__type":"ResourceNotFoundException","message":"User pool not found"}
```

After fix: the bytes of the stored S3 object are returned.

## TDD verification

- RED check (tests on `main` without fix): 3 of the 5 new tests failed (jwks PUT routing, jwks GET body, openid-configuration routing).
- GREEN check (tests with fix): 5/5 new tests pass; all existing Cognito and S3 tests pass (679 tests, 0 failures, 0 errors across the `s3.*` + `cognito.*` packages).

## Checklist

- [x] `./mvnw test` passes locally
- [x] New integration test added (`S3WellKnownKeyIntegrationTest`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
