### PR TITLE
fix: init shows wrong status when tls is enabled and adding app config 

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -36,7 +36,7 @@ jobs:
           # References:
           #   https://www.conventionalcommits.org/en/v1.0.0/
 
-          PATTERN='^(feat|fix|perf|revert|docs|style|chore|refactor|test|build|ci)(\([a-zA-Z0-9_\-\.,]+\))?!?: .{1,}'
+          PATTERN='^(feat|fix|perf|revert|docs|style|chore|refactor|test|build|ci)(\([-a-zA-Z0-9_.,]+\))?!?: .{1,}'
           FAILED=0
 
           while IFS= read -r msg; do

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -5,16 +5,22 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
-  pull-requests: read
+  contents: read
 
 jobs:
-  lint-pr-title:
-    name: PR title follows Conventional Commits
+  lint-commits:
+    name: Commits follow Conventional Commits
     runs-on: ubuntu-latest
+
     steps:
-      - name: Validate PR title
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate commit messages
         env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # Conventional Commits pattern:
           #   <type>[optional scope]: <description>
@@ -25,27 +31,33 @@ jobs:
           # Breaking changes are signalled by appending ! before the colon:
           #   feat!: or feat(scope)!:
           #
+          # Merge commits are skipped automatically via --no-merges.
+          #
           # References:
           #   https://www.conventionalcommits.org/en/v1.0.0/
-          #   https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular
 
-          PATTERN='^(feat|fix|perf|revert|docs|style|chore|refactor|test|build|ci)(\([a-zA-Z0-9_\-\.]+\))?!?: .{1,}'
+          PATTERN='^(feat|fix|perf|revert|docs|style|chore|refactor|test|build|ci)(\([a-zA-Z0-9_\-\.,]+\))?!?: .{1,}'
+          FAILED=0
 
-          if echo "$PR_TITLE" | grep -qE "$PATTERN"; then
-            echo "PR title is valid: $PR_TITLE"
-          else
-            echo "::error::PR title does not follow Conventional Commits."
-            echo ""
-            echo "  Got: $PR_TITLE"
-            echo ""
-            echo "  Expected format: <type>[optional scope]: <description>"
-            echo "  Examples:"
-            echo "    feat(dynamodb): add PartiQL ExecuteStatement support"
-            echo "    fix(s3): make us-east-1 bucket creation idempotent"
-            echo "    chore: release 1.5.16"
-            echo "    feat!: remove legacy endpoint"
-            echo ""
-            echo "  Valid types: feat, fix, perf, revert, docs, style, chore, refactor, test, build, ci"
-            echo "  See: https://www.conventionalcommits.org/en/v1.0.0/"
-            exit 1
-          fi
+          while IFS= read -r msg; do
+            if echo "$msg" | grep -qE "$PATTERN"; then
+              echo "ok: $msg"
+            else
+              echo "::error::Commit does not follow Conventional Commits: $msg"
+              echo ""
+              echo "  Got: $msg"
+              echo ""
+              echo "  Expected format: <type>[optional scope]: <description>"
+              echo "  Examples:"
+              echo "    feat(dynamodb): add PartiQL ExecuteStatement support"
+              echo "    fix(s3): make us-east-1 bucket creation idempotent"
+              echo "    chore: release 1.5.16"
+              echo "    feat!: remove legacy endpoint"
+              echo ""
+              echo "  Valid types: feat, fix, perf, revert, docs, style, chore, refactor, test, build, ci"
+              echo "  See: https://www.conventionalcommits.org/en/v1.0.0/"
+              FAILED=1
+            fi
+          done < <(git log --no-merges --format="%s" "$BASE_SHA".."$HEAD_SHA")
+
+          exit $FAILED

--- a/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
@@ -35,6 +35,7 @@ public class EmulatorLifecycle {
 
     private static final Logger LOG = Logger.getLogger(EmulatorLifecycle.class);
     private static final int HTTP_PORT = 4566;
+    private static final int TLS_HTTP_BACKEND_PORT = 4510;
 
     @ConfigProperty(name = "quarkus.application.version", defaultValue = "")
     Optional<String> appVersion = Optional.empty();
@@ -130,7 +131,8 @@ public class EmulatorLifecycle {
     }
 
     void onHttpStart(@ObservesAsync HttpServerStart event) {
-        if (event.options().getPort() != HTTP_PORT) {
+        int expectedPort = config.tls().enabled() ? TLS_HTTP_BACKEND_PORT : HTTP_PORT;
+        if (event.options().getPort() != expectedPort) {
             return;
         }
         boolean hasStart = initializationHooksRunner.hasHooks(InitializationHook.START);

--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigController.java
@@ -120,6 +120,17 @@ public class AppConfigController {
 
     // ──────────────────────────── Hosted Configuration Version ────────────────────────────
 
+    @GET
+    @Path("/applications/{appId}/configurationprofiles/{profileId}/hostedconfigurationversions")
+    public Response listHostedConfigurationVersions(@PathParam("appId") String appId,
+                                                    @PathParam("profileId") String profileId) {
+        List<HostedConfigurationVersionSummary> items = service.listHostedConfigurationVersions(appId, profileId);
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode arr = root.putArray("Items");
+        items.forEach(arr::addPOJO);
+        return Response.ok(root).build();
+    }
+
     @POST
     @Path("/applications/{appId}/configurationprofiles/{profileId}/hostedconfigurationversions")
     @Consumes(MediaType.WILDCARD)

--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigService.java
@@ -136,6 +136,23 @@ public class AppConfigService {
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException", "Hosted configuration version not found", 404));
     }
 
+    public List<HostedConfigurationVersionSummary> listHostedConfigurationVersions(String appId, String profileId) {
+        String prefix = appId + "::" + profileId + "::";
+        return versionStore.scan(k -> k.startsWith(prefix))
+                .stream()
+                .sorted(Comparator.comparingInt(HostedConfigurationVersion::getVersionNumber))
+                .map(v -> {
+                    HostedConfigurationVersionSummary s = new HostedConfigurationVersionSummary();
+                    s.setApplicationId(v.getApplicationId());
+                    s.setConfigurationProfileId(v.getConfigurationProfileId());
+                    s.setVersionNumber(v.getVersionNumber());
+                    s.setDescription(v.getDescription());
+                    s.setContentType(v.getContentType());
+                    return s;
+                })
+                .toList();
+    }
+
     // ──────────────────────────── Deployment Strategy ────────────────────────────
 
     public DeploymentStrategy createDeploymentStrategy(Map<String, Object> request) {

--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/model/HostedConfigurationVersionSummary.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/model/HostedConfigurationVersionSummary.java
@@ -1,0 +1,36 @@
+package io.github.hectorvent.floci.services.appconfig.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class HostedConfigurationVersionSummary {
+
+    @JsonProperty("ApplicationId")
+    private String applicationId;
+    @JsonProperty("ConfigurationProfileId")
+    private String configurationProfileId;
+    @JsonProperty("VersionNumber")
+    private int versionNumber;
+    @JsonProperty("Description")
+    private String description;
+    @JsonProperty("ContentType")
+    private String contentType;
+
+    public HostedConfigurationVersionSummary() {}
+
+    public String getApplicationId() { return applicationId; }
+    public void setApplicationId(String applicationId) { this.applicationId = applicationId; }
+
+    public String getConfigurationProfileId() { return configurationProfileId; }
+    public void setConfigurationProfileId(String configurationProfileId) { this.configurationProfileId = configurationProfileId; }
+
+    public int getVersionNumber() { return versionNumber; }
+    public void setVersionNumber(int versionNumber) { this.versionNumber = versionNumber; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getContentType() { return contentType; }
+    public void setContentType(String contentType) { this.contentType = contentType; }
+}

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
@@ -19,6 +19,8 @@ import io.github.hectorvent.floci.services.rds.proxy.RdsProxyManager;
 import io.quarkus.runtime.ShutdownDelayInitiatedEvent;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
+import io.quarkus.vertx.http.HttpServerStart;
+import io.vertx.core.http.HttpServerOptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -122,6 +124,54 @@ class EmulatorLifecycleTest {
 
         verify(storageFactory).loadAll();
         // run() is NOT called synchronously from onStart — it will be called by onHttpStart
+        verify(initializationHooksRunner, never()).run(InitializationHook.START);
+        verify(initLifecycleState, never()).markStartCompleted();
+    }
+
+    @Test
+    @DisplayName("onHttpStart on port 4566 (non-TLS) triggers hook execution and marks lifecycle completed")
+    void onHttpStart_nonTls_triggersHooksOnPort4566() throws IOException, InterruptedException {
+        when(tlsConfig.enabled()).thenReturn(false);
+        when(initializationHooksRunner.hasHooks(InitializationHook.START)).thenReturn(true);
+        when(initializationHooksRunner.hasHooks(InitializationHook.READY)).thenReturn(false);
+
+        emulatorLifecycle.onHttpStart(new HttpServerStart(new HttpServerOptions().setPort(4566)));
+
+        verify(initializationHooksRunner).run(InitializationHook.START);
+        verify(initLifecycleState).markStartCompleted();
+    }
+
+    @Test
+    @DisplayName("onHttpStart on wrong port (non-TLS) is ignored")
+    void onHttpStart_nonTls_ignoresWrongPort() throws IOException, InterruptedException {
+        when(tlsConfig.enabled()).thenReturn(false);
+
+        emulatorLifecycle.onHttpStart(new HttpServerStart(new HttpServerOptions().setPort(4510)));
+
+        verify(initializationHooksRunner, never()).run(InitializationHook.START);
+        verify(initLifecycleState, never()).markStartCompleted();
+    }
+
+    @Test
+    @DisplayName("onHttpStart on port 4510 (TLS mode) triggers hook execution and marks lifecycle completed")
+    void onHttpStart_tls_triggersHooksOnBackendPort4510() throws IOException, InterruptedException {
+        when(tlsConfig.enabled()).thenReturn(true);
+        when(initializationHooksRunner.hasHooks(InitializationHook.START)).thenReturn(true);
+        when(initializationHooksRunner.hasHooks(InitializationHook.READY)).thenReturn(false);
+
+        emulatorLifecycle.onHttpStart(new HttpServerStart(new HttpServerOptions().setPort(4510)));
+
+        verify(initializationHooksRunner).run(InitializationHook.START);
+        verify(initLifecycleState).markStartCompleted();
+    }
+
+    @Test
+    @DisplayName("onHttpStart on port 4566 (TLS mode) is ignored — public port is not the backend port")
+    void onHttpStart_tls_ignoresPublicPort4566() throws IOException, InterruptedException {
+        when(tlsConfig.enabled()).thenReturn(true);
+
+        emulatorLifecycle.onHttpStart(new HttpServerStart(new HttpServerOptions().setPort(4566)));
+
         verify(initializationHooksRunner, never()).run(InitializationHook.START);
         verify(initLifecycleState, never()).markStartCompleted();
     }

--- a/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
@@ -210,9 +210,26 @@ class AppConfigIntegrationTest {
                 .header("Next-Poll-Configuration-Token", notNullValue());
     }
 
-    // ──────────────────────────── Builtin deployment strategies ────────────────────────────
+    // ──────────────────────────── Hosted Configuration Version list ────────────────────────────
 
     @Test @Order(13)
+    void listHostedConfigurationVersionsReturnsBothVersions() {
+        given()
+                .when().get("/applications/" + appId + "/configurationprofiles/" + profileId + "/hostedconfigurationversions")
+                .then()
+                .statusCode(200)
+                .body("Items.size()", equalTo(2))
+                .body("Items[0].VersionNumber", equalTo(1))
+                .body("Items[0].ContentType", startsWith("application/json"))
+                .body("Items[0].ApplicationId", equalTo(appId))
+                .body("Items[0].ConfigurationProfileId", equalTo(profileId))
+                .body("Items[1].VersionNumber", equalTo(2))
+                .body("Items.Content", everyItem(nullValue()));
+    }
+
+    // ──────────────────────────── Builtin deployment strategies ────────────────────────────
+
+    @Test @Order(14)
     void builtinStrategyAllAtOnceCanBeUsedWithoutCreating() {
         given()
                 .contentType(ContentType.JSON)
@@ -226,7 +243,7 @@ class AppConfigIntegrationTest {
 
     // ──────────────────────────── Application tagging ────────────────────────────
 
-    @Test @Order(14)
+    @Test @Order(15)
     void listTagsOnNewApplicationIsEmpty() {
         String arn = "arn:aws:appconfig:us-east-1:000000000000:application/" + appId;
         given()
@@ -236,7 +253,7 @@ class AppConfigIntegrationTest {
                 .body("Tags", anEmptyMap());
     }
 
-    @Test @Order(15)
+    @Test @Order(16)
     void tagApplication() {
         String arn = "arn:aws:appconfig:us-east-1:000000000000:application/" + appId;
         given()
@@ -247,7 +264,7 @@ class AppConfigIntegrationTest {
                 .statusCode(204);
     }
 
-    @Test @Order(16)
+    @Test @Order(17)
     void listTagsAfterTagging() {
         String arn = "arn:aws:appconfig:us-east-1:000000000000:application/" + appId;
         given()
@@ -258,7 +275,7 @@ class AppConfigIntegrationTest {
                 .body("Tags.team", equalTo("platform"));
     }
 
-    @Test @Order(17)
+    @Test @Order(18)
     void untagApplication() {
         String arn = "arn:aws:appconfig:us-east-1:000000000000:application/" + appId;
         given()
@@ -267,7 +284,7 @@ class AppConfigIntegrationTest {
                 .statusCode(204);
     }
 
-    @Test @Order(18)
+    @Test @Order(19)
     void listTagsAfterUntagging() {
         String arn = "arn:aws:appconfig:us-east-1:000000000000:application/" + appId;
         given()
@@ -280,7 +297,7 @@ class AppConfigIntegrationTest {
 
     // ──────────────────────────── Tags on non-application resources (no-op) ────────────────────────────
 
-    @Test @Order(19)
+    @Test @Order(20)
     void listTagsForEnvironmentArnReturnsEmpty() {
         String arn = "arn:aws:appconfig:us-east-1:000000000000:application/" + appId + "/environment/" + envId;
         given()
@@ -290,7 +307,7 @@ class AppConfigIntegrationTest {
                 .body("Tags", anEmptyMap());
     }
 
-    @Test @Order(20)
+    @Test @Order(21)
     void listTagsForDeploymentArnReturnsEmpty() {
         String arn = "arn:aws:appconfig:us-east-1:000000000000:application/" + appId + "/environment/" + envId + "/deployment/1";
         given()
@@ -300,7 +317,7 @@ class AppConfigIntegrationTest {
                 .body("Tags", anEmptyMap());
     }
 
-    @Test @Order(21)
+    @Test @Order(22)
     void emptyConfigurationReturnsEmptyPayload() {
         emptyAppId = given()
                 .contentType(ContentType.JSON)


### PR DESCRIPTION
## Summary

- **fix(lifecycle)** `EmulatorLifecycle.onHttpStart` now accepts port 4510 when `FLOCI_TLS_ENABLED=true`; previously `/_floci/init` never reported `completed.ready=true` under TLS, blocking any tooling that polls the init endpoint
- **fix(appconfig)** Added `GET .../hostedconfigurationversions` list endpoint, `HostedConfigurationVersionSummary` model (metadata only — no content bytes), and `listHostedConfigurationVersions` service method; previously requests fell

Closes #993 
Closes #996

## Type of change

- [x] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
