### PR TITLE
fix(sns): PublishBatch should fail individual entries instead of aborting whole batch

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsJsonHandler.java
@@ -209,12 +209,14 @@ public class SnsJsonHandler {
     private Response handlePublishBatch(JsonNode request, String region) {
         String topicArn = request.path("TopicArn").asText(null);
         List<Map<String, Object>> entries = new ArrayList<>();
+        List<String[]> entryAttributeFailures = new ArrayList<>();
 
         JsonNode entriesNode = request.path("PublishBatchRequestEntries");
         if (entriesNode.isArray()) {
             for (JsonNode entryNode : entriesNode) {
+                String id = entryNode.path("Id").asText(null);
                 Map<String, Object> entry = new HashMap<>();
-                entry.put("Id", entryNode.path("Id").asText(null));
+                entry.put("Id", id);
                 entry.put("Message", entryNode.path("Message").asText(null));
                 entry.put("Subject", entryNode.path("Subject").asText(null));
                 entry.put("MessageGroupId", entryNode.path("MessageGroupId").asText(null));
@@ -222,7 +224,14 @@ public class SnsJsonHandler {
 
                 JsonNode attrsNode = entryNode.path("MessageAttributes");
                 if (attrsNode.isObject()) {
-                    entry.put("MessageAttributes", parseMessageAttributes(attrsNode));
+                    try {
+                        entry.put("MessageAttributes", parseMessageAttributes(attrsNode));
+                    } catch (AwsException e) {
+                        // Real AWS SNS surfaces per-entry attribute errors as Failed entries
+                        // and keeps processing the rest of the batch, instead of aborting.
+                        entryAttributeFailures.add(new String[]{id, e.getErrorCode(), e.getMessage(), "true"});
+                        continue;
+                    }
                 }
 
                 entries.add(entry);
@@ -240,7 +249,9 @@ public class SnsJsonHandler {
             successful.add(item);
         }
         ArrayNode failed = response.putArray("Failed");
-        for (String[] f : result.failed()) {
+        List<String[]> allFailed = new ArrayList<>(result.failed());
+        allFailed.addAll(entryAttributeFailures);
+        for (String[] f : allFailed) {
             ObjectNode item = objectMapper.createObjectNode();
             item.put("Id", f[0]);
             item.put("Code", f[1]);

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsQueryHandler.java
@@ -205,6 +205,7 @@ public class SnsQueryHandler {
     private Response handlePublishBatch(MultivaluedMap<String, String> params, String region) {
         String topicArn = getParam(params, "TopicArn");
         List<Map<String, Object>> entries = new ArrayList<>();
+        List<String[]> entryAttributeFailures = new ArrayList<>();
         for (int i = 1; ; i++) {
             String entryPrefix = "PublishBatchRequestEntries.member." + i;
             String id = getParam(params, entryPrefix + ".Id");
@@ -220,7 +221,10 @@ public class SnsQueryHandler {
             try {
                 attributes = parseMessageAttributes(params, entryPrefix + ".MessageAttributes.entry.");
             } catch (AwsException e) {
-                return xmlErrorResponse(e.getErrorCode(), e.getMessage(), e.getHttpStatus());
+                // Real AWS SNS surfaces per-entry attribute errors as Failed entries
+                // and keeps processing the rest of the batch, instead of aborting.
+                entryAttributeFailures.add(new String[]{id, e.getErrorCode(), e.getMessage(), "true"});
+                continue;
             }
             if (!attributes.isEmpty()) entry.put("MessageAttributes", attributes);
             entries.add(entry);
@@ -233,7 +237,9 @@ public class SnsQueryHandler {
                 xml.start("member").elem("Id", s[0]).elem("MessageId", s[1]).end("member");
             }
             xml.end("Successful").start("Failed");
-            for (String[] f : result.failed()) {
+            List<String[]> allFailed = new ArrayList<>(result.failed());
+            allFailed.addAll(entryAttributeFailures);
+            for (String[] f : allFailed) {
                 xml.start("member").elem("Id", f[0]).elem("Code", f[1])
                    .elem("Message", f[2]).elem("SenderFault", f[3]).end("member");
             }

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsJsonHandlerPublishBatchTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsJsonHandlerPublishBatchTest.java
@@ -1,0 +1,103 @@
+package io.github.hectorvent.floci.services.sns;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.sqs.SqsService;
+import io.github.hectorvent.floci.services.sqs.SqsServiceFactory;
+import io.github.hectorvent.floci.services.sqs.model.Message;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that SnsJsonHandler.handle("PublishBatch", ...) returns AWS-compatible
+ * partial-failure responses: a malformed entry must land in the Failed list
+ * (with InvalidParameterValue + SenderFault=true) instead of aborting the
+ * whole batch with a top-level error.
+ */
+class SnsJsonHandlerPublishBatchTest {
+
+    private static final String REGION = "us-east-1";
+    private static final String ACCOUNT = "000000000000";
+    private static final String BASE_URL = "http://localhost:4566";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private SnsService snsService;
+    private SqsService sqsService;
+    private SnsJsonHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        RegionResolver regionResolver = new RegionResolver(REGION, ACCOUNT);
+        sqsService = SqsServiceFactory.createInMemory(BASE_URL, regionResolver);
+        snsService = new SnsService(new InMemoryStorage<>(), new InMemoryStorage<>(),
+                regionResolver, sqsService, null);
+        handler = new SnsJsonHandler(snsService, objectMapper);
+    }
+
+    @Test
+    void publishBatch_invalidBinaryAttribute_failsOnlyOffendingEntryAndProcessesRest() throws Exception {
+        // Arrange
+        sqsService.createQueue("json-partial-fail-queue", Map.of(), REGION);
+        String queueArn = "arn:aws:sqs:" + REGION + ":" + ACCOUNT + ":json-partial-fail-queue";
+
+        snsService.createTopic("json-partial-fail-topic", Map.of(), null, REGION);
+        String topicArn = "arn:aws:sns:" + REGION + ":" + ACCOUNT + ":json-partial-fail-topic";
+        snsService.subscribe(topicArn, "sqs", queueArn, REGION, Map.of("RawMessageDelivery", "true"));
+
+        ObjectNode request = objectMapper.createObjectNode();
+        request.put("TopicArn", topicArn);
+        ArrayNode entries = request.putArray("PublishBatchRequestEntries");
+
+        // Entry 1 — invalid base64 in BinaryValue; must NOT abort the batch
+        ObjectNode bad = entries.addObject();
+        bad.put("Id", "bad");
+        bad.put("Message", "ignored");
+        ObjectNode badAttrs = bad.putObject("MessageAttributes");
+        ObjectNode badBlob = badAttrs.putObject("blob");
+        badBlob.put("DataType", "Binary");
+        badBlob.put("BinaryValue", "@@@-not-base64-@@@");
+
+        // Entry 2 — valid; must be published
+        ObjectNode good = entries.addObject();
+        good.put("Id", "good");
+        good.put("Message", "valid-message");
+
+        // Act
+        JsonNode requestNode = objectMapper.readTree(objectMapper.writeValueAsString(request));
+        Response response = handler.handle("PublishBatch", requestNode, REGION);
+
+        // Assert — partial failure (matches real AWS SNS)
+        assertEquals(200, response.getStatus(),
+                "PublishBatch must return 200 with per-entry failures, not abort the whole batch");
+
+        JsonNode body = objectMapper.valueToTree(response.getEntity());
+        JsonNode failed = body.path("Failed");
+        JsonNode successful = body.path("Successful");
+
+        assertTrue(failed.isArray() && failed.size() == 1, "exactly one entry must be in Failed");
+        JsonNode failedEntry = failed.get(0);
+        assertEquals("bad", failedEntry.path("Id").asText());
+        assertEquals("InvalidParameterValue", failedEntry.path("Code").asText());
+        assertTrue(failedEntry.path("SenderFault").asBoolean(), "SenderFault must be true");
+
+        assertTrue(successful.isArray() && successful.size() == 1, "exactly one entry must be in Successful");
+        assertEquals("good", successful.get(0).path("Id").asText());
+
+        // Only the good entry should reach SQS
+        List<Message> messages = sqsService.receiveMessage(
+                BASE_URL + "/" + ACCOUNT + "/json-partial-fail-queue", 10, 30, 0, REGION);
+        assertEquals(1, messages.size(), "only the valid entry should be delivered");
+        assertEquals("valid-message", messages.get(0).getBody());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsQueryHandlerPublishBatchTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsQueryHandlerPublishBatchTest.java
@@ -89,6 +89,49 @@ class SnsQueryHandlerPublishBatchTest {
     }
 
     @Test
+    void publishBatch_invalidBinaryAttribute_failsOnlyOffendingEntryAndProcessesRest() {
+        // Arrange
+        sqsService.createQueue("partial-fail-queue", Map.of(), REGION);
+        String queueArn = "arn:aws:sqs:" + REGION + ":" + ACCOUNT + ":partial-fail-queue";
+
+        snsService.createTopic("partial-fail-topic", Map.of(), null, REGION);
+        String topicArn = "arn:aws:sns:" + REGION + ":" + ACCOUNT + ":partial-fail-topic";
+        snsService.subscribe(topicArn, "sqs", queueArn, REGION, Map.of("RawMessageDelivery", "true"));
+
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.add("TopicArn", topicArn);
+
+        // Entry 1: invalid base64 BinaryValue — must NOT abort the batch
+        params.add("PublishBatchRequestEntries.member.1.Id", "bad");
+        params.add("PublishBatchRequestEntries.member.1.Message", "ignored");
+        params.add("PublishBatchRequestEntries.member.1.MessageAttributes.entry.1.Name", "blob");
+        params.add("PublishBatchRequestEntries.member.1.MessageAttributes.entry.1.Value.DataType", "Binary");
+        params.add("PublishBatchRequestEntries.member.1.MessageAttributes.entry.1.Value.BinaryValue", "@@@-not-base64-@@@");
+
+        // Entry 2: valid — must be published
+        putBatchEntry(params, 2, "good", "valid-message", attr("kind", "String", "ok"));
+
+        // Act
+        Response response = handler.handle("PublishBatch", params, REGION);
+
+        // Assert — HTTP 200, partial-failure semantics (matches real AWS SNS)
+        assertEquals(200, response.getStatus(),
+                "PublishBatch must return 200 with per-entry failures, not abort the whole batch");
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<Failed>"), "response must contain Failed list");
+        assertTrue(body.contains("<Id>bad</Id>"), "bad entry must appear in Failed list");
+        assertTrue(body.contains("<Code>InvalidParameterValue</Code>"), "Failed entry must carry InvalidParameterValue code");
+        assertTrue(body.contains("<SenderFault>true</SenderFault>"), "Failed entry must carry SenderFault=true");
+        assertTrue(body.contains("<Id>good</Id>"), "good entry must appear in Successful list");
+
+        // Good entry must have been delivered to SQS; bad entry must NOT
+        List<Message> messages = sqsService.receiveMessage(
+                BASE_URL + "/" + ACCOUNT + "/partial-fail-queue", 10, 30, 0, REGION);
+        assertEquals(1, messages.size(), "only the valid entry should be delivered");
+        assertEquals("valid-message", messages.get(0).getBody());
+    }
+
+    @Test
     void publishBatch_entryWithoutMessageAttributes_doesNotPolluteOtherEntries() {
         // Arrange
         sqsService.createQueue("mixed-attrs-queue", Map.of(), REGION);


### PR DESCRIPTION
## Summary

Fix #992 — SNS `PublishBatch` aborted the entire batch when one entry had an invalid `BinaryValue` (or any other per-entry attribute error). Real AWS SNS surfaces the bad entry as a `Failed` member (`InvalidParameterValue` + `SenderFault=true`) and keeps publishing the rest. Both protocol handlers now do that.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Before**

- `SnsQueryHandler.handlePublishBatch` returned the per-entry `AwsException` as a top-level XML error (HTTP 400) — the whole batch was aborted.
- `SnsJsonHandler.handlePublishBatch` let the `AwsException` from `parseMessageAttributes` propagate out of the loop — same abort-the-whole-batch defect.

**After** (matches real AWS SNS)

- HTTP 200 with the offending entry in `Failed` (`Code=InvalidParameterValue`, `SenderFault=true`) and the remaining valid entries in `Successful`.
- Valid entries are delivered to subscribers; the failing entry is not.

## Reproduces with

```
[ERROR] SnsQueryHandlerPublishBatchTest.publishBatch_invalidBinaryAttribute_failsOnlyOffendingEntryAndProcessesRest
        PublishBatch must return 200 with per-entry failures, not abort the whole batch
        expected: <200> but was: <400>

[ERROR] SnsJsonHandlerPublishBatchTest.publishBatch_invalidBinaryAttribute_failsOnlyOffendingEntryAndProcessesRest
        AwsException: Invalid binary value for message attribute 'blob': not valid base64.
        (uncaught — bubbles out of the batch loop)
```

## TDD verification (main-thread)

- **RED** (`./mvnw -Dtest=...invalidBinaryAttribute...` on `main` without prod fix): 2/2 new tests fail with the symptoms above.
- **GREEN** (same command with prod fix applied): 2/2 new tests pass.
- Full SNS suite (`Sns*`): **93/93 pass** — no regression.

## Checklist

- [x] `./mvnw test` passes locally (SNS suite: 93/93)
- [x] New integration test added — one per protocol handler (Query + JSON)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
