### PR TITLE
fix(ecr): release registry port when container start fails

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManager.java
@@ -142,28 +142,28 @@ public class EcrRegistryManager {
                 config.services().ecr().registryBasePort(),
                 config.services().ecr().registryMaxPort());
 
-        String image = config.services().ecr().registryImage();
-
-        // Build environment variables
-        List<String> env = new ArrayList<>(List.of(
-                "REGISTRY_STORAGE_DELETE_ENABLED=true",
-                "REGISTRY_HTTP_ADDR=0.0.0.0:" + CONTAINER_INTERNAL_PORT
-        ));
-
-        // Build container spec
-        ContainerBuilder.Builder specBuilder = containerBuilder.newContainer(image)
-                .withName(name)
-                .withEnv(env)
-                .withPortBinding(CONTAINER_INTERNAL_PORT, chosenPort)
-                .withDockerNetwork(config.services().ecr().dockerNetwork())
-                .withLogRotation();
-
-        // Handle persistence mounting based on storage configuration
-        addPersistenceMounts(specBuilder, env);
-
-        ContainerSpec spec = specBuilder.build();
-
         try {
+            String image = config.services().ecr().registryImage();
+
+            // Build environment variables
+            List<String> env = new ArrayList<>(List.of(
+                    "REGISTRY_STORAGE_DELETE_ENABLED=true",
+                    "REGISTRY_HTTP_ADDR=0.0.0.0:" + CONTAINER_INTERNAL_PORT
+            ));
+
+            // Build container spec
+            ContainerBuilder.Builder specBuilder = containerBuilder.newContainer(image)
+                    .withName(name)
+                    .withEnv(env)
+                    .withPortBinding(CONTAINER_INTERNAL_PORT, chosenPort)
+                    .withDockerNetwork(config.services().ecr().dockerNetwork())
+                    .withLogRotation();
+
+            // Handle persistence mounting based on storage configuration
+            addPersistenceMounts(specBuilder, env);
+
+            ContainerSpec spec = specBuilder.build();
+
             ContainerInfo info = lifecycleManager.createAndStart(spec);
             this.containerId = info.containerId();
             this.hostPort = chosenPort;
@@ -173,6 +173,12 @@ public class EcrRegistryManager {
             // Attach log streaming (new feature)
             attachLogStream();
         } catch (Exception e) {
+            // Release the reserved port unless the container actually started, so a
+            // failed start (e.g. Docker unreachable) does not permanently exhaust the
+            // registry port pool across retries.
+            if (!started) {
+                portAllocator.release(chosenPort);
+            }
             throw new RuntimeException("Failed to start ECR backing registry container: " + e.getMessage(), e);
         }
         runReconcileOnce();

--- a/src/test/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManagerTest.java
@@ -1,0 +1,90 @@
+package io.github.hectorvent.floci.services.ecr.registry;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
+import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
+import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
+import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
+import io.github.hectorvent.floci.core.common.docker.PortAllocator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link EcrRegistryManager} startup behavior. Uses a real
+ * {@link PortAllocator} and a mocked Docker layer so the failure path can be
+ * exercised without a Docker daemon.
+ */
+class EcrRegistryManagerTest {
+
+    private static final int BASE_PORT = 6100;
+    private static final int MAX_PORT = 6101; // pool of exactly two ports
+
+    private PortAllocator portAllocator;
+    private ContainerLifecycleManager lifecycleManager;
+    private EcrRegistryManager manager;
+
+    @BeforeEach
+    void setUp() {
+        portAllocator = new PortAllocator();
+
+        ContainerBuilder containerBuilder = Mockito.mock(ContainerBuilder.class);
+        ContainerBuilder.Builder builder =
+                Mockito.mock(ContainerBuilder.Builder.class, Mockito.RETURNS_SELF);
+        when(containerBuilder.newContainer(anyString())).thenReturn(builder);
+        when(builder.build()).thenReturn(Mockito.mock(ContainerSpec.class));
+
+        lifecycleManager = Mockito.mock(ContainerLifecycleManager.class);
+        when(lifecycleManager.findByName(anyString())).thenReturn(Optional.empty());
+
+        ContainerLogStreamer logStreamer = Mockito.mock(ContainerLogStreamer.class);
+        ContainerDetector containerDetector = Mockito.mock(ContainerDetector.class);
+        RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
+
+        EmulatorConfig config = Mockito.mock(EmulatorConfig.class);
+        EmulatorConfig.EcrServiceConfig ecr = Mockito.mock(EmulatorConfig.EcrServiceConfig.class);
+        EmulatorConfig.StorageConfig storage = Mockito.mock(EmulatorConfig.StorageConfig.class);
+        when(config.services()).thenReturn(Mockito.mock(EmulatorConfig.ServicesConfig.class));
+        when(config.services().ecr()).thenReturn(ecr);
+        when(config.storage()).thenReturn(storage);
+        // Empty host-persistent-path selects named-volume mode (no host bind-mount logic).
+        when(storage.hostPersistentPath()).thenReturn("");
+        when(ecr.registryContainerName()).thenReturn("floci-test-ecr-registry");
+        when(ecr.registryImage()).thenReturn("registry:2");
+        when(ecr.registryBasePort()).thenReturn(BASE_PORT);
+        when(ecr.registryMaxPort()).thenReturn(MAX_PORT);
+        when(ecr.dockerNetwork()).thenReturn(Optional.empty());
+
+        manager = new EcrRegistryManager(containerBuilder, lifecycleManager, logStreamer,
+                containerDetector, portAllocator, config, regionResolver);
+    }
+
+    @Test
+    void ensureStarted_releasesPortWhenDockerStartFails_soPoolIsNotExhausted() {
+        when(lifecycleManager.createAndStart(any()))
+                .thenThrow(new RuntimeException("Cannot connect to the Docker daemon"));
+
+        // Far more attempts than the two-port pool. Every attempt must surface the
+        // real Docker failure. If the reserved port were leaked on failure, the pool
+        // would exhaust after two attempts and later calls would instead fail with
+        // "No free port available" — the symptom this test guards against.
+        for (int attempt = 0; attempt < 6; attempt++) {
+            RuntimeException ex = assertThrows(RuntimeException.class, manager::ensureStarted);
+            assertTrue(ex.getMessage().contains("Failed to start ECR backing registry container"),
+                    "attempt " + attempt + " should surface the Docker failure, got: " + ex.getMessage());
+            assertFalse(ex.getMessage().contains("No free port available"),
+                    "port pool leaked on attempt " + attempt + ": " + ex.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`EcrRegistryManager.ensureStarted()` reserved a host port from the ECR registry pool (`5100-5199`) and never released it when container start-up failed. Since `PortAllocator` is `@ApplicationScoped`, every failed start leaked a port permanently, and after enough retries all 100 ports were exhausted — producing a misleading `No free port available in range 5100-5199` that masked the real failure (e.g. Docker daemon unreachable from the Floci container).

This change widens the `try` to cover all post-allocation work (including `addPersistenceMounts() → ensureVolume()`, the first Docker call in the default named-volume mode) and releases the reserved port on failure, unless the container actually started. This mirrors the existing release-on-failure pattern in `RuntimeApiServerFactory` (Lambda) and `Ec2ContainerManager` (EC2).

Closes #1009

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

For bug fixes: the incorrect behavior was that repeated `CreateRepository` calls leaked registry ports and eventually failed with `No free port available` instead of a stable error. After the fix, repeated failed start-ups reuse the same port and consistently surface the real start-up error (`Failed to start ECR backing registry container`).

## Checklist

- [x] `./mvnw test` passes locally (ECR suite: 23 tests)
- [x] New or updated integration test added — `EcrRegistryManagerTest`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

### Test note

`EcrRegistryManagerTest` uses a real `PortAllocator` with a two-port range and a mocked Docker layer whose `createAndStart` always throws. It calls `ensureStarted()` six times and asserts every attempt surfaces the real Docker failure. Without this fix the test fails on the third attempt with `No free port available in range 6100-6101`; with the fix the port is released after each failure and the pool never exhausts.
