### PR TITLE
fix(rds): register DbEndpoint for native reflection

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbEndpoint.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbEndpoint.java
@@ -1,3 +1,6 @@
 package io.github.hectorvent.floci.services.rds.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public record DbEndpoint(String address, int port) {}


### PR DESCRIPTION
## Summary

- Register `DbEndpoint` for reflection so Jackson can serialize persisted RDS metadata in GraalVM native images
- Fix native image RDS persistence failing before atomic rename, leaving only `rds-*.json.tmp`

Fixes #1013

## Verification

- `mvn test -Dtest=RdsServiceTest,RdsQueryHandlerTest`
- Built native Docker image with `docker/Dockerfile.native`
- Verified `FLOCI_STORAGE_MODE=hybrid` creates `rds-clusters.json` and `rds-instances.json` without `.tmp` leftovers
- Verified Floci container restart restores RDS cluster/instance metadata
- Verified inserted MySQL data survives restart via the reused RDS Docker volume