### PR TITLE
fix(iam): honour 12-digit access key in IAM resource ARNs

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.iam;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.iam.model.AccessKey;
@@ -44,10 +45,10 @@ public class IamService {
     private final StorageBackend<String, AccessKey> accessKeys;
     private final StorageBackend<String, InstanceProfile> instanceProfiles;
     private final StorageBackend<String, SessionCredential> sessions;
-    private final String accountId;
+    private final RegionResolver regionResolver;
 
     @Inject
-    public IamService(StorageFactory storageFactory, EmulatorConfig config) {
+    public IamService(StorageFactory storageFactory, EmulatorConfig config, RegionResolver regionResolver) {
         this(
             storageFactory.create("iam", "iam-users.json", new TypeReference<>() {}),
             storageFactory.create("iam", "iam-groups.json", new TypeReference<>() {}),
@@ -56,7 +57,7 @@ public class IamService {
             storageFactory.create("iam", "iam-access-keys.json", new TypeReference<>() {}),
             storageFactory.create("iam", "iam-instance-profiles.json", new TypeReference<>() {}),
             storageFactory.create("iam", "iam-sessions.json", new TypeReference<>() {}),
-            config.defaultAccountId()
+            regionResolver
         );
     }
 
@@ -67,7 +68,7 @@ public class IamService {
                StorageBackend<String, AccessKey> accessKeys,
                StorageBackend<String, InstanceProfile> instanceProfiles,
                StorageBackend<String, SessionCredential> sessions,
-               String accountId) {
+               RegionResolver regionResolver) {
         this.users = users;
         this.groups = groups;
         this.roles = roles;
@@ -75,7 +76,7 @@ public class IamService {
         this.accessKeys = accessKeys;
         this.instanceProfiles = instanceProfiles;
         this.sessions = sessions;
-        this.accountId = accountId;
+        this.regionResolver = regionResolver;
     }
 
     @PostConstruct
@@ -803,10 +804,6 @@ public class IamService {
     // Internal helpers
     // =========================================================================
 
-    public String getAccountId() {
-        return accountId;
-    }
-
     public Optional<String> findSecretKey(String accessKeyId) {
         return accessKeys.get(accessKeyId).map(AccessKey::getSecretAccessKey);
     }
@@ -996,7 +993,7 @@ public class IamService {
     }
 
     private String iamArn(String resourceType, String path, String name) {
-        return AwsArnUtils.Arn.of("iam", "", accountId, resourceType + path + name).toString();
+        return AwsArnUtils.Arn.of("iam", "", regionResolver.getAccountId(), resourceType + path + name).toString();
     }
 
     private static String normalizePath(String path) {

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
@@ -328,6 +328,42 @@ class IamIntegrationTest {
                     equalTo("TestRole"));
     }
 
+    @Test
+    @Order(23)
+    void iamCreateRoleHonoursTwelveDigitAccessKey() {
+        given()
+            .formParam("Action", "CreateRole")
+            .formParam("RoleName", "TenantRole")
+            .formParam("Path", "/")
+            .formParam("AssumeRolePolicyDocument", TRUST_POLICY)
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=123456789012/20260227/us-east-1/iam/aws4_request")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("CreateRoleResponse.CreateRoleResult.Role.RoleName", equalTo("TenantRole"))
+            .body("CreateRoleResponse.CreateRoleResult.Role.Arn",
+                    equalTo("arn:aws:iam::123456789012:role/TenantRole"));
+    }
+
+    @Test
+    @Order(24)
+    void iamGetRoleHonoursTwelveDigitAccessKey() {
+        given()
+            .formParam("Action", "GetRole")
+            .formParam("RoleName", "TenantRole")
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=123456789012/20260227/us-east-1/iam/aws4_request")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("GetRoleResponse.GetRoleResult.Role.RoleName", equalTo("TenantRole"))
+            .body("GetRoleResponse.GetRoleResult.Role.Arn",
+                    equalTo("arn:aws:iam::123456789012:role/TenantRole"));
+    }
+
     // =========================================================================
     // Managed Policies
     // =========================================================================

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.iam;
 
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.iam.model.AccessKey;
 import io.github.hectorvent.floci.services.iam.model.IamGroup;
@@ -31,7 +32,7 @@ class IamServiceTest {
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
-                "000000000000"
+                new RegionResolver("us-east-1", "000000000000")
         );
     }
 

--- a/src/test/java/io/github/hectorvent/floci/testutil/IamServiceTestHelper.java
+++ b/src/test/java/io/github/hectorvent/floci/testutil/IamServiceTestHelper.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.testutil;
 
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.services.iam.IamService;
@@ -23,7 +24,7 @@ public final class IamServiceTestHelper {
                     StorageBackend.class,
                     StorageBackend.class,
                     StorageBackend.class,
-                    String.class
+                    RegionResolver.class
             );
             constructor.setAccessible(true);
 
@@ -38,7 +39,7 @@ public final class IamServiceTestHelper {
                     accessKeys,
                     null,
                     null,
-                    "123456789012"
+                    new RegionResolver("us-east-1", "123456789012")
             );
         } catch (ReflectiveOperationException e) {
             throw new IllegalStateException("Failed to construct IamService test fixture", e);


### PR DESCRIPTION
## Summary

Closes #1018.

`IamService` stored the account ID as a field set once at construction time from `config.defaultAccountId()` (always `000000000000`). Every call to `CreateRole`, `CreateUser`, `CreateGroup`, `CreatePolicy`, and `CreateInstanceProfile` therefore returned an ARN with the wrong account regardless of which access key was used — the IAM equivalent of the STS bug fixed in #983.

Inject `RegionResolver` into `IamService` and call `regionResolver.getAccountId()` per request inside `iamArn()`, so ARNs reflect the caller's account when a 12-digit AKID is used.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** `CreateRole` called with `Credential=111111111111/…` returned `arn:aws:iam::000000000000:role/MyRole` instead of `arn:aws:iam::111111111111:role/MyRole`. Same for `GetRole`, `CreateUser`, `CreateGroup`, `CreatePolicy`, and `CreateInstanceProfile`.

**Correct behavior:** ARN account segment matches the 12-digit access key ID used in the `Authorization` header, consistent with how real AWS and the fixed STS handler behave.

## Architecture note

The STS fix in #983 injected `RegionResolver` into `StsQueryHandler` (the handler layer). This PR injects it into `IamService` (the service layer) instead, because `iamArn()` is called in 10+ places across the service and threading the account ID down through every handler call site felt like more noise than value.

Two options:
1. **Keep it in `IamService`** — the service already owns ARN construction, so resolving the account ID there is cohesive.
2. **Move to `IamQueryHandler`** — consistent with the STS pattern; the handler resolves the account ID per-request and passes it into service calls; would require adding an `accountId` parameter to `createRole`, `createUser`, etc.

Happy to refactor to option 2 if that is the preferred convention.

## Checklist

- [x] `./mvnw test` passes locally (full test suite green)
- [x] New or updated integration test added (`iamCreateRoleHonoursTwelveDigitAccessKey`, `iamGetRoleHonoursTwelveDigitAccessKey`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)