### PR TITLE
feat(elbv2): add listener attribute and capacity reservation actions

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2QueryHandler.java
@@ -69,6 +69,7 @@ public class ElbV2QueryHandler {
                 case "DeleteLoadBalancer"            -> handleDeleteLoadBalancer(params, region);
                 case "ModifyLoadBalancerAttributes"  -> handleModifyLoadBalancerAttributes(params, region);
                 case "DescribeLoadBalancerAttributes"-> handleDescribeLoadBalancerAttributes(params, region);
+                case "DescribeCapacityReservation"   -> handleDescribeCapacityReservation(params, region);
                 case "SetSecurityGroups"             -> handleSetSecurityGroups(params, region);
                 case "SetSubnets"                    -> handleSetSubnets(params, region);
                 case "SetIpAddressType"              -> handleSetIpAddressType(params, region);
@@ -84,6 +85,8 @@ public class ElbV2QueryHandler {
                 case "DescribeListeners"             -> handleDescribeListeners(params, region);
                 case "DeleteListener"                -> handleDeleteListener(params, region);
                 case "ModifyListener"                -> handleModifyListener(params, region);
+                case "ModifyListenerAttributes"      -> handleModifyListenerAttributes(params, region);
+                case "DescribeListenerAttributes"    -> handleDescribeListenerAttributes(params, region);
                 // Rules
                 case "CreateRule"                    -> handleCreateRule(params, region);
                 case "DescribeRules"                 -> handleDescribeRules(params, region);
@@ -205,6 +208,31 @@ public class ElbV2QueryHandler {
            .end("DescribeLoadBalancerAttributesResult")
            .raw(AwsQueryResponse.responseMetadata())
            .end("DescribeLoadBalancerAttributesResponse");
+        return Response.ok(xml.build()).type(MediaType.APPLICATION_XML).build();
+    }
+
+    private Response handleDescribeCapacityReservation(MultivaluedMap<String, String> p, String region) {
+        String arn = p.getFirst("LoadBalancerArn");
+        ElbV2Service.CapacityReservation cr = service.describeCapacityReservation(region, arn);
+
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeCapacityReservationResponse", AwsNamespaces.ELB_V2)
+                .start("DescribeCapacityReservationResult");
+        if (cr.lastModifiedTime() != null) {
+            xml.elem("LastModifiedTime", ISO_FMT.format(cr.lastModifiedTime()));
+        }
+        if (cr.decreaseRequestsRemaining() != null) {
+            xml.elem("DecreaseRequestsRemaining", cr.decreaseRequestsRemaining());
+        }
+        if (cr.minimumCapacityUnits() != null) {
+            xml.start("MinimumLoadBalancerCapacity")
+                 .elem("CapacityUnits", cr.minimumCapacityUnits())
+               .end("MinimumLoadBalancerCapacity");
+        }
+        xml.start("CapacityReservationState").end("CapacityReservationState")
+           .end("DescribeCapacityReservationResult")
+           .raw(AwsQueryResponse.responseMetadata())
+           .end("DescribeCapacityReservationResponse");
         return Response.ok(xml.build()).type(MediaType.APPLICATION_XML).build();
     }
 
@@ -460,6 +488,43 @@ public class ElbV2QueryHandler {
                 .end("ModifyListenerResponse")
                 .build();
         return Response.ok(xml).type(MediaType.APPLICATION_XML).build();
+    }
+
+    private Response handleModifyListenerAttributes(MultivaluedMap<String, String> p, String region) {
+        String arn = p.getFirst("ListenerArn");
+        Map<String, String> attrs = parseAttributes(p, "Attributes");
+        service.modifyListenerAttributes(region, arn, attrs);
+
+        XmlBuilder xml = new XmlBuilder()
+                .start("ModifyListenerAttributesResponse", AwsNamespaces.ELB_V2)
+                .start("ModifyListenerAttributesResult")
+                  .start("Attributes");
+        for (Map.Entry<String, String> e : attrs.entrySet()) {
+            xml.start("member").elem("Key", e.getKey()).elem("Value", e.getValue()).end("member");
+        }
+        xml.end("Attributes")
+           .end("ModifyListenerAttributesResult")
+           .raw(AwsQueryResponse.responseMetadata())
+           .end("ModifyListenerAttributesResponse");
+        return Response.ok(xml.build()).type(MediaType.APPLICATION_XML).build();
+    }
+
+    private Response handleDescribeListenerAttributes(MultivaluedMap<String, String> p, String region) {
+        String arn = p.getFirst("ListenerArn");
+        Map<String, String> attrs = service.describeListenerAttributes(region, arn);
+
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeListenerAttributesResponse", AwsNamespaces.ELB_V2)
+                .start("DescribeListenerAttributesResult")
+                  .start("Attributes");
+        for (Map.Entry<String, String> e : attrs.entrySet()) {
+            xml.start("member").elem("Key", e.getKey()).elem("Value", e.getValue()).end("member");
+        }
+        xml.end("Attributes")
+           .end("DescribeListenerAttributesResult")
+           .raw(AwsQueryResponse.responseMetadata())
+           .end("DescribeListenerAttributesResponse");
+        return Response.ok(xml.build()).type(MediaType.APPLICATION_XML).build();
     }
 
     // ── Rules ─────────────────────────────────────────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
@@ -145,6 +145,18 @@ public class ElbV2Service {
         lb.getAttributes().putAll(newAttrs);
     }
 
+    /** Capacity reservation status for a load balancer. All fields are {@code null} when no
+     *  capacity is reserved, which is always the case in Floci (capacity cannot be reserved). */
+    public record CapacityReservation(Integer decreaseRequestsRemaining,
+                                      Integer minimumCapacityUnits,
+                                      Instant lastModifiedTime) {}
+
+    public CapacityReservation describeCapacityReservation(String region, String arn) {
+        requireLoadBalancer(region, arn);
+        // Floci does not reserve load balancer capacity, so there is never a reservation to report.
+        return new CapacityReservation(null, null, null);
+    }
+
     public void setSecurityGroups(String region, String arn, List<String> sgIds) {
         LoadBalancer lb = requireLoadBalancer(region, arn);
         lb.setSecurityGroups(new ArrayList<>(sgIds));
@@ -345,6 +357,16 @@ public class ElbV2Service {
             result = result.stream().filter(l -> arnSet.contains(l.getListenerArn())).collect(Collectors.toList());
         }
         return result;
+    }
+
+    public Map<String, String> describeListenerAttributes(String region, String arn) {
+        Listener listener = requireListener(region, arn);
+        return new LinkedHashMap<>(listener.getAttributes());
+    }
+
+    public void modifyListenerAttributes(String region, String arn, Map<String, String> newAttrs) {
+        Listener listener = requireListener(region, arn);
+        listener.getAttributes().putAll(newAttrs);
     }
 
     public void deleteListener(String region, String listenerArn) {

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
@@ -136,6 +136,37 @@ class ElbV2IntegrationTest {
                         equalTo("deletion_protection.enabled"));
     }
 
+    @Test
+    @Order(7)
+    void describeCapacityReservationReturnsEmptyForLbWithoutReservation() {
+        given()
+                .formParam("Action", "DescribeCapacityReservation")
+                .formParam("LoadBalancerArn", lbArn)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .contentType("application/xml")
+                .body("DescribeCapacityReservationResponse.ResponseMetadata.RequestId",
+                        not(emptyOrNullString()));
+    }
+
+    @Test
+    @Order(8)
+    void describeCapacityReservationUnknownLbThrows() {
+        given()
+                .formParam("Action", "DescribeCapacityReservation")
+                .formParam("LoadBalancerArn",
+                        "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/missing/0123456789abcdef")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(400)
+                .body("ErrorResponse.Error.Code", equalTo("LoadBalancerNotFound"));
+    }
+
     // ── Target Groups ─────────────────────────────────────────────────────────
 
     @Test
@@ -309,6 +340,55 @@ class ElbV2IntegrationTest {
             .then()
                 .statusCode(400)
                 .body("ErrorResponse.Error.Code", equalTo("DuplicateListener"));
+    }
+
+    @Test
+    @Order(33)
+    void modifyListenerAttributes() {
+        given()
+                .formParam("Action", "ModifyListenerAttributes")
+                .formParam("ListenerArn", listenerArn)
+                .formParam("Attributes.member.1.Key", "tcp.idle_timeout.seconds")
+                .formParam("Attributes.member.1.Value", "400")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body("ModifyListenerAttributesResponse.ModifyListenerAttributesResult.Attributes.member.Key",
+                        equalTo("tcp.idle_timeout.seconds"))
+                .body("ModifyListenerAttributesResponse.ModifyListenerAttributesResult.Attributes.member.Value",
+                        equalTo("400"));
+    }
+
+    @Test
+    @Order(34)
+    void describeListenerAttributes() {
+        given()
+                .formParam("Action", "DescribeListenerAttributes")
+                .formParam("ListenerArn", listenerArn)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body("DescribeListenerAttributesResponse.DescribeListenerAttributesResult.Attributes.member.Key",
+                        equalTo("tcp.idle_timeout.seconds"));
+    }
+
+    @Test
+    @Order(35)
+    void describeListenerAttributesUnknownListenerThrows() {
+        given()
+                .formParam("Action", "DescribeListenerAttributes")
+                .formParam("ListenerArn",
+                        "arn:aws:elasticloadbalancing:us-east-1:000000000000:listener/app/missing/0123456789abcdef/0123456789abcdef")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(400)
+                .body("ErrorResponse.Error.Code", equalTo("ListenerNotFound"));
     }
 
     // ── Rules ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`@pulumi/aws` 6.66.0+ (and recent Terraform AWS provider versions) call `DescribeListenerAttributes` and `DescribeCapacityReservation` when refreshing `Listener` and `LoadBalancer` resources. Floci returned `UnsupportedOperation` for both, which crashes the provider on refresh — the only workaround was pinning `@pulumi/aws` to `6.30.0`.

This PR implements the missing ELBv2 actions:

- **`DescribeListenerAttributes`** / **`ModifyListenerAttributes`** — mirror the existing `Describe/ModifyLoadBalancerAttributes` and `Describe/ModifyTargetGroupAttributes` handlers, backed by the `Listener.attributes` map that already exists on the model.
- **`DescribeCapacityReservation`** — returns an empty reservation (no `MinimumLoadBalancerCapacity`, empty `CapacityReservationState`), since Floci does not reserve load balancer capacity. Validates the load balancer exists and returns `LoadBalancerNotFound` otherwise.

Closes #1020

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Wire protocol verified against the AWS ELBv2 API reference (`2015-12-01`, Query protocol):

- `DescribeListenerAttributes` → request `ListenerArn`; response `Attributes` list of `Key`/`Value` members; error `ListenerNotFound`.
- `DescribeCapacityReservation` → request `LoadBalancerArn`; response `CapacityReservationState` (array), optional `DecreaseRequestsRemaining` / `LastModifiedTime` / `MinimumLoadBalancerCapacity`; error `LoadBalancerNotFound`.

## Checklist

- [x] `./mvnw test` passes locally (`ElbV2IntegrationTest`: 32 tests)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

### Tests added to `ElbV2IntegrationTest`

- `describeCapacityReservationReturnsEmptyForLbWithoutReservation`
- `describeCapacityReservationUnknownLbThrows` (→ `LoadBalancerNotFound`)
- `modifyListenerAttributes` / `describeListenerAttributes` (round-trip `tcp.idle_timeout.seconds`)
- `describeListenerAttributesUnknownListenerThrows` (→ `ListenerNotFound`)
