### PR TITLE
fix(s3): parse x-amz-tagging header in PutObject to persist object tags

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -494,6 +494,8 @@ public class S3Controller {
             String cacheControl = httpHeaders.getHeaderString("Cache-Control");
             String serverSideEncryption = httpHeaders.getHeaderString("x-amz-server-side-encryption");
             String cannedAcl = httpHeaders.getHeaderString("x-amz-acl");
+            String taggingHeader = httpHeaders.getHeaderString("x-amz-tagging");
+            Map<String, String> tagging = parseTaggingHeader(taggingHeader);
             S3Object obj = s3Service.putObject(bucket, key, data, contentType, extractUserMetadata(httpHeaders),
                     new PutObjectOptions()
                             .withStorageClass(httpHeaders.getHeaderString("x-amz-storage-class"))
@@ -506,7 +508,8 @@ public class S3Controller {
                             .withServerSideEncryption(serverSideEncryption)
                             .withAcl(cannedAcl)
                             .withChecksumAlgorithm(checksumAlgorithm)
-                            .withClientChecksum(extractChecksumFromHeaders(httpHeaders)));
+                            .withClientChecksum(extractChecksumFromHeaders(httpHeaders))
+                            .withTags(tagging));
             var resp = Response.ok().header("ETag", obj.getETag());
             if (obj.getVersionId() != null) {
                 resp.header("x-amz-version-id", obj.getVersionId());
@@ -2390,5 +2393,30 @@ public class S3Controller {
     }
 
     private record ParsedCopySource(String objectKey, String versionId) {
+    }
+
+    /**
+     * Parses the {@code x-amz-tagging} header value into a map of key-value pairs.
+     * The header value uses URL-encoded query-string format: {@code key1=value1&key2=value2}.
+     * Both keys and values must be URL-decoded per the AWS S3 PutObject API specification.
+     * Returns an empty map (not null) for a null or blank header to simplify callers.
+     */
+    private static Map<String, String> parseTaggingHeader(String taggingHeader) {
+        if (taggingHeader == null || taggingHeader.isBlank()) {
+            return Map.of();
+        }
+        Map<String, String> tags = new LinkedHashMap<>();
+        for (String pair : taggingHeader.split("&")) {
+            int eq = pair.indexOf('=');
+            if (eq <= 0) {
+                continue; // skip malformed pairs (no key or missing '=')
+            }
+            String key = URLDecoder.decode(pair.substring(0, eq), StandardCharsets.UTF_8);
+            String value = URLDecoder.decode(pair.substring(eq + 1), StandardCharsets.UTF_8);
+            if (!key.isBlank()) {
+                tags.put(key, value);
+            }
+        }
+        return tags;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -297,6 +297,9 @@ public class S3Service {
         object.setCacheControl(effectiveOptions.getCacheControl());
         object.setServerSideEncryption(normalizedServerSideEncryption);
         object.setAcl(cannedObjectAclXml(effectiveOptions.getAcl()));
+        if (effectiveOptions.getTags() != null) {
+            object.setTags(effectiveOptions.getTags());
+        }
 
         if (bucket.isVersioningEnabled()) {
             String versionId = UUID.randomUUID().toString();

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/PutObjectOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/PutObjectOptions.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.s3.model;
 
 import java.time.Instant;
+import java.util.Map;
 
 public class PutObjectOptions {
     private String storageClass;
@@ -13,6 +14,7 @@ public class PutObjectOptions {
     private String serverSideEncryption;
     private String acl;
     private String checksumAlgorithm;
+    private Map<String, String> tags;
 
     public String getStorageClass() { return storageClass; }
     public PutObjectOptions withStorageClass(String storageClass) { this.storageClass = storageClass; return this; }
@@ -47,4 +49,7 @@ public class PutObjectOptions {
     private S3Checksum clientChecksum;
     public S3Checksum getClientChecksum() { return clientChecksum; }
     public PutObjectOptions withClientChecksum(S3Checksum clientChecksum) { this.clientChecksum = clientChecksum; return this; }
+
+    public Map<String, String> getTags() { return tags; }
+    public PutObjectOptions withTags(Map<String, String> tags) { this.tags = tags; return this; }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
@@ -575,6 +575,28 @@ class S3ServiceTest {
     }
 
     @Test
+    void putObjectWithTags() {
+        s3Service.createBucket("test-bucket", "us-east-1");
+        Map<String, String> tags = Map.of("env", "test", "project", "floci");
+        S3Object put = s3Service.putObject("test-bucket", "tagged.txt", "data".getBytes(), "text/plain", null,
+                new PutObjectOptions().withTags(tags));
+
+        assertEquals(tags, put.getTags());
+
+        Map<String, String> retrieved = s3Service.getObjectTagging("test-bucket", "tagged.txt");
+        assertEquals(tags, retrieved);
+    }
+
+    @Test
+    void putObjectWithoutTagsHasEmptyTagSet() {
+        s3Service.createBucket("test-bucket", "us-east-1");
+        s3Service.putObject("test-bucket", "notags.txt", "data".getBytes(), "text/plain", null);
+
+        Map<String, String> retrieved = s3Service.getObjectTagging("test-bucket", "notags.txt");
+        assertTrue(retrieved.isEmpty());
+    }
+
+    @Test
     void putObjectWithInternalTraversalStaysWithinBucket() {
         s3Service.createBucket("test-bucket", "us-east-1");
         byte[] data = "safe-content".getBytes();


### PR DESCRIPTION
## Summary

Fixes #986: S3 PutObject silently drops tags from `x-amz-tagging` header.

## Problem

When calling PutObject with the `x-amz-tagging` header (either via the AWS SDK or the CLI `--tagging` flag), floci returned 200 OK but the tags were silently discarded. A subsequent GetObjectTagging call returned an empty `TagSet`.

## Root Cause

The `x-amz-tagging` header was never read or processed in `S3Controller.putObject()`.

## Changes

1. **PutObjectOptions.java** — Added `tags` field (Map<String, String>) with getter and fluent setter.
2. **S3Controller.java** — Read `x-amz-tagging` header in `putObject()`, parse the URL-encoded format (`key1=value1&key2=value2`) with `parseTaggingHeader()`, and pass it through `PutObjectOptions.withTags()`.
3. **S3Service.java** — In `storeObject()`, apply tags from `PutObjectOptions` to the `S3Object`.
4. **S3ServiceTest.java** — Added tests for putObject with tags and without tags.

## Verification

- The header parsing handles URL-decoding of keys and values per the AWS S3 PutObject API spec.
- Tags are persisted on the object and correctly returned by `GetObjectTagging`.
- Both versioned and unversioned buckets are supported (tags are set before the versioned/latest store split).