### PR TITLE
fix(s3): remove shadowed hasQueryParam that misrouted presigned PUT with x-amz-tagging header

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -2275,13 +2275,6 @@ public class S3Controller {
         }
     }
 
-    private boolean hasQueryParam(UriInfo uriInfo, String param) {
-        if (uriInfo.getQueryParameters().containsKey(param)) return true;
-        String query = uriInfo.getRequestUri().getQuery();
-        if (query == null) return false;
-        return query.equals(param) || query.contains(param + "&") || query.contains("&" + param);
-    }
-
     private static final int MAX_INLINE_TAGS = 10;
     private static final int MAX_INLINE_TAGGING_HEADER_BYTES = 8 * 1024;
 


### PR DESCRIPTION
## Summary

S3Controller declared a private hasQueryParam(UriInfo, String) instance method that used String.contains() to check for sub-resource names. Because Java resolves instance methods before static imports, this method silently shadowed the correctly-implemented static import from S3RequestParser, which splits on & and compares parameter names exactly.

The result: a presigned PUT /{bucket}/{key} URL whose X-Amz-SignedHeaders value contained x-amz-tagging (e.g. host%3Bx-amz-tagging) caused query.contains("tagging&") to return true in the private method, misrouting the request to PutObjectTagging and returning 404 instead of uploading the object.

Fix: delete the private instance method. All call sites in S3Controller now use S3RequestParser.hasQueryParam, which was already correct.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
