### PR TITLE
fix: Create EBS root and attached volumes for EC2 instances

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
@@ -4,9 +4,9 @@ import io.github.hectorvent.floci.services.autoscaling.model.AsgInstance;
 import io.github.hectorvent.floci.services.autoscaling.model.AutoScalingGroup;
 import io.github.hectorvent.floci.services.autoscaling.model.LaunchConfiguration;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.model.BlockDevice;
 import io.github.hectorvent.floci.services.ec2.model.Instance;
 import io.github.hectorvent.floci.services.ec2.model.Reservation;
-import io.github.hectorvent.floci.services.ec2.model.Volume;
 import io.github.hectorvent.floci.services.elbv2.ElbV2Service;
 import io.github.hectorvent.floci.services.elbv2.model.TargetDescription;
 import jakarta.annotation.PostConstruct;
@@ -123,7 +123,7 @@ public class AutoScalingReconciler {
                     null,
                     lc.getUserData(),
                     lc.getIamInstanceProfile(),
-                    List.of(new Volume())
+                    List.of(new BlockDevice())
             );
 
             for (Instance ec2Inst : reservation.getInstances()) {

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.services.autoscaling.model.LaunchConfiguration
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.ec2.model.Instance;
 import io.github.hectorvent.floci.services.ec2.model.Reservation;
+import io.github.hectorvent.floci.services.ec2.model.Volume;
 import io.github.hectorvent.floci.services.elbv2.ElbV2Service;
 import io.github.hectorvent.floci.services.elbv2.model.TargetDescription;
 import jakarta.annotation.PostConstruct;
@@ -121,7 +122,9 @@ public class AutoScalingReconciler {
                     null,
                     null,
                     lc.getUserData(),
-                    lc.getIamInstanceProfile());
+                    lc.getIamInstanceProfile(),
+                    List.of(new Volume())
+            );
 
             for (Instance ec2Inst : reservation.getInstances()) {
                 AsgInstance asgInst = new AsgInstance();

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -208,9 +208,6 @@ public class Ec2QueryHandler {
     // ─── Instance handlers ────────────────────────────────────────────────────
 
     private Response handleRunInstances(MultivaluedMap<String, String> p, String region) {
-        for (final var e : p.entrySet()) {
-            System.out.printf("%s: [%s]\n", e.getKey(), String.join(", ", e.getValue()));
-        }
         String imageId = p.getFirst("ImageId");
         String instanceType = p.getFirst("InstanceType");
         int minCount = Integer.parseInt(p.getOrDefault("MinCount", List.of("1")).get(0));

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -12,7 +12,6 @@ import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -1281,10 +1280,10 @@ public class Ec2QueryHandler {
                 .start("item")
                 .elem("deviceName", inst.getRootDeviceName())
                 .start("ebs")
-                .elem("volumeId", inst.getRootDeviceEbsVolumeId())
+                .elem("volumeId", inst.getRootDeviceVolumeId())
                 .elem("attachTime", service.getVolumeAttachment(
                         inst.getRegion(),
-                        inst.getRootDeviceEbsVolumeId(),
+                        inst.getRootDeviceVolumeId(),
                         inst.getInstanceId()
                     ).map(VolumeAttachment::getAttachTime)
                     .map(ISO_FMT::format)

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -12,6 +12,7 @@ import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -1242,6 +1243,16 @@ public class Ec2QueryHandler {
                     .end("item");
         }
         xml.end("networkInterfaceSet");
+        final Optional<String> rootVolAttachTime = service.describeVolumes(
+            inst.getRegion(),
+            List.of(inst.getRootDeviceEbsVolumeId()),
+            Map.of("volume-id", List.of(inst.getRootDeviceEbsVolumeId()))
+        ).stream()
+            .flatMap((final Volume volume) -> volume.getAttachments().stream())
+            .filter((final VolumeAttachment att) -> att.getInstanceId().equals(inst.getInstanceId()))
+            .map(VolumeAttachment::getAttachTime)
+            .map(ISO_FMT::format)
+            .findFirst();
         xml.elem("clientToken", inst.getClientToken())
                 .start("stateReason")
                 .elem("code", "")
@@ -1281,6 +1292,7 @@ public class Ec2QueryHandler {
                 .elem("deviceName", inst.getRootDeviceName())
                 .start("ebs")
                 .elem("volumeId", inst.getRootDeviceEbsVolumeId())
+                .elem("attachTime", rootVolAttachTime.orElse(""))
                 .elem("status", "attached")
                 .elem("deleteOnTermination", "true")
                 .end("ebs")

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -2,13 +2,11 @@ package io.github.hectorvent.floci.services.ec2;
 
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.AwsNamespaces;
-import io.github.hectorvent.floci.core.common.AwsQueryResponse;
 import io.github.hectorvent.floci.core.common.XmlBuilder;
 import io.github.hectorvent.floci.services.ec2.model.*;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
@@ -17,8 +15,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @ApplicationScoped
 public class Ec2QueryHandler {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.services.ec2.model.*;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
@@ -16,7 +17,8 @@ import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-import java.util.Base64;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @ApplicationScoped
 public class Ec2QueryHandler {
@@ -209,7 +211,12 @@ public class Ec2QueryHandler {
 
     // ─── Instance handlers ────────────────────────────────────────────────────
 
+    private static final Pattern BLOCK_DEVICE_MAPPING_PATTERN = Pattern.compile("BlockDeviceMapping\\.(\\d+)(\\.\\w+){1,}");
+
     private Response handleRunInstances(MultivaluedMap<String, String> p, String region) {
+        for (final var e : p.entrySet()) {
+            System.out.printf("%s: [%s]\n", e.getKey(), String.join(", ", e.getValue()));
+        }
         String imageId = p.getFirst("ImageId");
         String instanceType = p.getFirst("InstanceType");
         int minCount = Integer.parseInt(p.getOrDefault("MinCount", List.of("1")).get(0));
@@ -244,8 +251,46 @@ public class Ec2QueryHandler {
             }
         }
 
+        // VoblockDeviceMappingslumes
+        List<Volume> volumes = new ArrayList<>();
+        final Queue<String> keyQueue = new ArrayDeque<>();
+        for (final Map.Entry<String, List<String>> entry : p.entrySet()) {
+            final String key = entry.getKey();
+            if (!key.startsWith("BlockDeviceMapping")) {
+                continue;
+            }
+            final List<String> values = entry.getValue();
+            if (values.size() != 1) {
+                continue;
+            }
+            keyQueue.clear();
+            Arrays.stream(key.split("\\.")).forEach(keyQueue::add);
+            keyQueue.poll(); // Remove BlockDeviceMapping at head
+            // TODO: Failed to parse index with NumberFormatException
+            final int index = Integer.parseInt(keyQueue.poll()) - 1;
+            final Volume volume = volumes.size() <= index ? new Volume() : volumes.get(index);
+            final String keySegment = keyQueue.poll();
+            if (!keySegment.equals("Ebs")) {
+                // TODO: Properties without "ebs" will be for VolumeAttachment instances
+                continue;
+            }
+            switch (keyQueue.poll()) {
+                case "VolumeType" -> volume.setVolumeType(values.get(0));
+                // TODO: Failed to parse size with NumberFormatException
+                case "VolumeSize" -> volume.setSize(Integer.parseInt(values.get(0)));
+                // TODO: Failed to parse iops with NumberFormatException
+                case "Iops" -> volume.setIops(Integer.parseInt(values.get(0)));
+                case "Encrypted" -> volume.setEncrypted(Boolean.parseBoolean(values.get(0)));
+            }
+        }
+        if (volumes.isEmpty()) {
+            // Ensure root volume always exists
+            volumes.add(new Volume());
+        }
+
         Reservation res = service.runInstances(region, imageId, instanceType, minCount, maxCount,
-                keyName, sgIds, subnetId, clientToken, instanceTags, userData, iamInstanceProfileArn);
+                keyName, sgIds, subnetId, clientToken, instanceTags, userData, iamInstanceProfileArn,
+                volumes);
 
         XmlBuilder xml = new XmlBuilder()
                 .start("RunInstancesResponse", AwsNamespaces.EC2)
@@ -1231,6 +1276,7 @@ public class Ec2QueryHandler {
                 .start("item")
                 .elem("deviceName", inst.getRootDeviceName())
                 .start("ebs")
+                .elem("volumeId", inst.getRootDeviceEbsVolumeId())
                 .elem("status", "attached")
                 .elem("deleteOnTermination", "true")
                 .end("ebs")

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -211,8 +211,6 @@ public class Ec2QueryHandler {
 
     // ─── Instance handlers ────────────────────────────────────────────────────
 
-    private static final Pattern BLOCK_DEVICE_MAPPING_PATTERN = Pattern.compile("BlockDeviceMapping\\.(\\d+)(\\.\\w+){1,}");
-
     private Response handleRunInstances(MultivaluedMap<String, String> p, String region) {
         for (final var e : p.entrySet()) {
             System.out.printf("%s: [%s]\n", e.getKey(), String.join(", ", e.getValue()));
@@ -252,7 +250,7 @@ public class Ec2QueryHandler {
         }
 
         // VoblockDeviceMappingslumes
-        List<Volume> volumes = new ArrayList<>();
+        List<BlockDevice> blockDevices = new ArrayList<>();
         final Queue<String> keyQueue = new ArrayDeque<>();
         for (final Map.Entry<String, List<String>> entry : p.entrySet()) {
             final String key = entry.getKey();
@@ -263,34 +261,45 @@ public class Ec2QueryHandler {
             if (values.size() != 1) {
                 continue;
             }
+            final String value = values.get(0);
             keyQueue.clear();
-            Arrays.stream(key.split("\\.")).forEach(keyQueue::add);
-            keyQueue.poll(); // Remove BlockDeviceMapping at head
+            Arrays.stream(key.split("\\.")).skip(1).forEach(keyQueue::add);
             // TODO: Failed to parse index with NumberFormatException
             final int index = Integer.parseInt(keyQueue.poll()) - 1;
-            final Volume volume = volumes.size() <= index ? new Volume() : volumes.get(index);
+            final BlockDevice blockDevice = blockDevices.size() <= index ? new BlockDevice() : blockDevices.get(index);
             final String keySegment = keyQueue.poll();
-            if (!keySegment.equals("Ebs")) {
-                // TODO: Properties without "ebs" will be for VolumeAttachment instances
-                continue;
+            switch (keySegment) {
+                case "DeviceName": blockDevice.setDeviceName(value); continue;
+                case "NoDevice": blockDevice.setNoDevice(""); continue;
+                case "VirtualName": blockDevice.setVirtualName(value);
+                case "Ebs": break;
+                default: continue;
             }
+            final Ebs ebs = new Ebs();
+            blockDevice.setEbs(ebs);
             switch (keyQueue.poll()) {
-                case "VolumeType" -> volume.setVolumeType(values.get(0));
-                // TODO: Failed to parse size with NumberFormatException
-                case "VolumeSize" -> volume.setSize(Integer.parseInt(values.get(0)));
-                // TODO: Failed to parse iops with NumberFormatException
-                case "Iops" -> volume.setIops(Integer.parseInt(values.get(0)));
-                case "Encrypted" -> volume.setEncrypted(Boolean.parseBoolean(values.get(0)));
+                case "AvailabilityZone" -> ebs.setAvailabilityZone(value);
+                case "AvailabilityZoneId" -> ebs.setAvailabilityZoneId(value);
+                case "EbsCardIndex" -> ebs.setEbsCardIndex(Integer.parseInt(value));
+                case "Encrypted" -> ebs.setEncrypted(Boolean.parseBoolean(value));
+                case "Iops" -> ebs.setIops(Integer.parseInt(value));
+                case "KmsKeyId" -> ebs.setKmsKeyId(value);
+                case "OutpostArn" -> ebs.setOutpostArn(value);
+                case "SnapshotId" -> ebs.setSnapshotId(value);
+                case "Throughput" -> ebs.setThroughput(Integer.parseInt(value));
+                case "VolumeInitializationRate" -> ebs.setVolumeInitializationRate(Integer.parseInt(value));
+                case "VolumeSize" -> ebs.setVolumeSize(Integer.parseInt(value));
+                case "VolumeType" -> ebs.setVolumeType(value);
             }
         }
-        if (volumes.isEmpty()) {
+        if (blockDevices.isEmpty()) {
             // Ensure root volume always exists
-            volumes.add(new Volume());
+            blockDevices.add(new BlockDevice());
         }
 
         Reservation res = service.runInstances(region, imageId, instanceType, minCount, maxCount,
                 keyName, sgIds, subnetId, clientToken, instanceTags, userData, iamInstanceProfileArn,
-                volumes);
+                blockDevices);
 
         XmlBuilder xml = new XmlBuilder()
                 .start("RunInstancesResponse", AwsNamespaces.EC2)
@@ -450,12 +459,12 @@ public class Ec2QueryHandler {
                 .start("DescribeInstanceAttributeResponse", AwsNamespaces.EC2)
                 .elem("requestId", UUID.randomUUID().toString())
                 .elem("instanceId", instanceId);
-        if ("instanceType".equals(attribute)) {
-            xml.start("instanceType").elem("value", inst.getInstanceType()).end("instanceType");
-        } else if ("sourceDestCheck".equals(attribute)) {
-            xml.start("sourceDestCheck").elem("value", String.valueOf(inst.isSourceDestCheck())).end("sourceDestCheck");
-        } else if ("ebsOptimized".equals(attribute)) {
-            xml.start("ebsOptimized").elem("value", String.valueOf(inst.isEbsOptimized())).end("ebsOptimized");
+        switch (attribute) {
+            case "instanceType" -> xml.start("instanceType").elem("value", inst.getInstanceType()).end("instanceType");
+            case "sourceDestCheck" -> xml.start("sourceDestCheck").elem("value", String.valueOf(inst.isSourceDestCheck())).end("sourceDestCheck");
+            case "ebsOptimized" -> xml.start("ebsOptimized").elem("value", String.valueOf(inst.isEbsOptimized())).end("ebsOptimized");
+            case "disableApiStop" -> xml.start("disableApiStop").elem("value", String.valueOf(inst.isDisableApiStop())).end("disableApiStop");
+            case "disableApiTermination" -> xml.start("disableApiTermination").elem("value", String.valueOf(inst.isDisableApiTermination())).end("disableApiTermination");
         }
         xml.end("DescribeInstanceAttributeResponse");
         return xmlResponse(xml.build());

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -1243,16 +1243,6 @@ public class Ec2QueryHandler {
                     .end("item");
         }
         xml.end("networkInterfaceSet");
-        final Optional<String> rootVolAttachTime = service.describeVolumes(
-            inst.getRegion(),
-            List.of(inst.getRootDeviceEbsVolumeId()),
-            Map.of("volume-id", List.of(inst.getRootDeviceEbsVolumeId()))
-        ).stream()
-            .flatMap((final Volume volume) -> volume.getAttachments().stream())
-            .filter((final VolumeAttachment att) -> att.getInstanceId().equals(inst.getInstanceId()))
-            .map(VolumeAttachment::getAttachTime)
-            .map(ISO_FMT::format)
-            .findFirst();
         xml.elem("clientToken", inst.getClientToken())
                 .start("stateReason")
                 .elem("code", "")
@@ -1292,8 +1282,14 @@ public class Ec2QueryHandler {
                 .elem("deviceName", inst.getRootDeviceName())
                 .start("ebs")
                 .elem("volumeId", inst.getRootDeviceEbsVolumeId())
-                .elem("attachTime", rootVolAttachTime.orElse(""))
-                .elem("status", "attached")
+                .elem("attachTime", service.getVolumeAttachment(
+                        inst.getRegion(),
+                        inst.getRootDeviceEbsVolumeId(),
+                        inst.getInstanceId()
+                    ).map(VolumeAttachment::getAttachTime)
+                    .map(ISO_FMT::format)
+                    .orElse("")
+                ).elem("status", "attached")
                 .elem("deleteOnTermination", "true")
                 .end("ebs")
                 .end("item")

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -260,14 +260,13 @@ public class Ec2QueryHandler {
             final String value = values.get(0);
             keyQueue.clear();
             Arrays.stream(key.split("\\.")).skip(1).forEach(keyQueue::add);
-            // TODO: Failed to parse index with NumberFormatException
             final int index = Integer.parseInt(keyQueue.poll()) - 1;
             final BlockDevice blockDevice = blockDevices.size() <= index ? new BlockDevice() : blockDevices.get(index);
             final String keySegment = keyQueue.poll();
             switch (keySegment) {
                 case "DeviceName": blockDevice.setDeviceName(value); continue;
-                case "NoDevice": blockDevice.setNoDevice(""); continue;
-                case "VirtualName": blockDevice.setVirtualName(value);
+                case "NoDevice": blockDevice.setNoDevice(value); continue;
+                case "VirtualName": blockDevice.setVirtualName(value); continue;
                 case "Ebs": break;
                 default: continue;
             }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -300,6 +300,7 @@ public class Ec2Service {
                 attachment.setAttachTime(Instant.now());
                 volume.getAttachments().add(attachment);
                 if (j == 0) {
+                    volume.setState("in-use");
                     inst.setRootDeviceVolumeId(volume.getVolumeId());
                     inst.setRootDeviceName(blockDevice.getDeviceName());
                 }
@@ -402,7 +403,6 @@ public class Ec2Service {
             entry.put("currentState", "shutting-down");
             entry.put("currentCode", "32");
             result.add(entry);
-            instances.remove(key(region, id));
         }
         return result;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -184,7 +184,8 @@ public class Ec2Service {
                                     int minCount, int maxCount, String keyName,
                                     List<String> securityGroupIds, String subnetId,
                                     String clientToken, List<Tag> instanceTags,
-                                    String userData, String iamInstanceProfileArn) {
+                                    String userData, String iamInstanceProfileArn,
+                                    final List<Volume> volumes) {
         ensureDefaultResources(region);
 
         // Resolve subnet
@@ -270,6 +271,24 @@ public class Ec2Service {
             eni.setAttachmentId("eni-attach-" + randomHex(17));
             eni.setDeviceIndex(0);
             inst.getNetworkInterfaces().add(eni);
+
+            // EBS volumes
+            for (int j = 0; j < volumes.size(); j++) {
+                final Volume volume = volumes.get(j);
+                final Volume ebsVolume = createVolume(
+                    region,
+                    az,
+                    volume.getVolumeType(),
+                    volume.getSize(),
+                    volume.isEncrypted(),
+                    volume.getIops(),
+                    null,
+                    null
+                );
+                if (j == 0) {
+                    inst.setRootDeviceEbsVolumeId(ebsVolume.getVolumeId());
+                }
+            }
 
             instances.put(key(region, instanceId), inst);
             reservation.getInstances().add(inst);

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -281,9 +281,9 @@ public class Ec2Service {
                 final BlockDevice blockDevice = blockDevices.get(j);
                 final Ebs ebs = Objects.requireNonNullElse(blockDevice.getEbs(), new Ebs());
                 final String ebsAz = ebs.getAvailabilityZone();
-                final Volume ebsVolume = createVolume(
+                final Volume volume = createVolume(
                     region,
-                    ebsAz != null ?  ebsAz : az,
+                    ebsAz != null ? ebsAz : az,
                     ebs.getVolumeType(),
                     ebs.getVolumeSize(),
                     ebs.isEncrypted(),
@@ -292,15 +292,15 @@ public class Ec2Service {
                     null
                 );
                 final VolumeAttachment attachment = new VolumeAttachment();
-                attachment.setVolumeId(ebsVolume.getVolumeId());
+                attachment.setVolumeId(volume.getVolumeId());
                 attachment.setInstanceId(inst.getInstanceId());
                 attachment.setDevice(blockDevice.getDeviceName());
                 attachment.setState("attached");
                 attachment.setDeleteOnTermination(true);
                 attachment.setAttachTime(Instant.now());
-                ebsVolume.getAttachments().add(attachment);
+                volume.getAttachments().add(attachment);
                 if (j == 0) {
-                    inst.setRootDeviceEbsVolumeId(ebsVolume.getVolumeId());
+                    inst.setRootDeviceVolumeId(volume.getVolumeId());
                     inst.setRootDeviceName(blockDevice.getDeviceName());
                 }
             }
@@ -382,8 +382,8 @@ public class Ec2Service {
             if (inst == null) {
                 throw new AwsException("InvalidInstanceID.NotFound", "The instance ID '" + id + "' does not exist", 400);
             }
-            if (inst.getRootDeviceEbsVolumeId() != null) {
-                volumes.remove(key(region, inst.getRootDeviceEbsVolumeId()));
+            if (inst.getRootDeviceVolumeId() != null) {
+                volumes.remove(key(region, inst.getRootDeviceVolumeId()));
             }
             if (config.services().ec2().mock() && "pending".equals(inst.getState().getName())) {
                 inst.setState(InstanceState.running());

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1511,6 +1511,9 @@ public class Ec2Service {
     }
 
     public Optional<VolumeAttachment> getVolumeAttachment(final String region, final String volumeId, final String instanceId) {
+        if (volumeId == null) {
+            return Optional.empty();
+        }
         return describeVolumes(
             region,
             List.of(volumeId),

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -7,6 +7,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -1507,5 +1508,16 @@ public class Ec2Service {
             throw new AwsException("InvalidVolume.NotFound",
                     "The volume '" + volumeId + "' does not exist.", 400);
         }
+    }
+
+    public Optional<VolumeAttachment> getVolumeAttachment(final String region, final String volumeId, final String instanceId) {
+        return describeVolumes(
+            region,
+            List.of(volumeId),
+            Map.of("volume-id", List.of(volumeId))
+        ).stream()
+            .flatMap((final Volume volume) -> volume.getAttachments().stream())
+            .filter((final VolumeAttachment att) -> att.getInstanceId().equals(instanceId))
+            .findFirst();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -41,6 +41,7 @@ import io.github.hectorvent.floci.services.ec2.model.SecurityGroupRule;
 import io.github.hectorvent.floci.services.ec2.model.Subnet;
 import io.github.hectorvent.floci.services.ec2.model.Tag;
 import io.github.hectorvent.floci.services.ec2.model.Volume;
+import io.github.hectorvent.floci.services.ec2.model.VolumeAttachment;
 import io.github.hectorvent.floci.services.ec2.model.Vpc;
 import io.github.hectorvent.floci.services.ec2.model.VpcCidrBlockAssociation;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -289,8 +290,17 @@ public class Ec2Service {
                     ebs.getSnapshotId(),
                     null
                 );
+                final VolumeAttachment attachment = new VolumeAttachment();
+                attachment.setVolumeId(ebsVolume.getVolumeId());
+                attachment.setInstanceId(inst.getInstanceId());
+                attachment.setDevice(blockDevice.getDeviceName());
+                attachment.setState("attached");
+                attachment.setDeleteOnTermination(true);
+                attachment.setAttachTime(Instant.now());
+                ebsVolume.getAttachments().add(attachment);
                 if (j == 0) {
                     inst.setRootDeviceEbsVolumeId(ebsVolume.getVolumeId());
+                    inst.setRootDeviceName(blockDevice.getDeviceName());
                 }
             }
 
@@ -371,6 +381,9 @@ public class Ec2Service {
             if (inst == null) {
                 throw new AwsException("InvalidInstanceID.NotFound", "The instance ID '" + id + "' does not exist", 400);
             }
+            if (inst.getRootDeviceEbsVolumeId() != null) {
+                volumes.remove(key(region, inst.getRootDeviceEbsVolumeId()));
+            }
             if (config.services().ec2().mock() && "pending".equals(inst.getState().getName())) {
                 inst.setState(InstanceState.running());
             }
@@ -388,6 +401,7 @@ public class Ec2Service {
             entry.put("currentState", "shutting-down");
             entry.put("currentCode", "32");
             result.add(entry);
+            instances.remove(key(region, id));
         }
         return result;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -278,9 +278,10 @@ public class Ec2Service {
             for (int j = 0; j < blockDevices.size(); j++) {
                 final BlockDevice blockDevice = blockDevices.get(j);
                 final Ebs ebs = Objects.requireNonNullElse(blockDevice.getEbs(), new Ebs());
+                final String ebsAz = ebs.getAvailabilityZone();
                 final Volume ebsVolume = createVolume(
                     region,
-                    ebs.getAvailabilityZone(),
+                    ebsAz != null ?  ebsAz : az,
                     ebs.getVolumeType(),
                     ebs.getVolumeSize(),
                     ebs.isEncrypted(),
@@ -1429,6 +1430,7 @@ public class Ec2Service {
                 default -> true;
             };
         }
+        // TODO: Do BlockDevice name & tags, and EBS tags need to be considered here?
         return true;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -19,6 +19,8 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.ec2.model.Address;
+import io.github.hectorvent.floci.services.ec2.model.BlockDevice;
+import io.github.hectorvent.floci.services.ec2.model.Ebs;
 import io.github.hectorvent.floci.services.ec2.model.GroupIdentifier;
 import io.github.hectorvent.floci.services.ec2.model.Image;
 import io.github.hectorvent.floci.services.ec2.model.Instance;
@@ -185,7 +187,7 @@ public class Ec2Service {
                                     List<String> securityGroupIds, String subnetId,
                                     String clientToken, List<Tag> instanceTags,
                                     String userData, String iamInstanceProfileArn,
-                                    final List<Volume> volumes) {
+                                    final List<BlockDevice> blockDevices) {
         ensureDefaultResources(region);
 
         // Resolve subnet
@@ -272,17 +274,18 @@ public class Ec2Service {
             eni.setDeviceIndex(0);
             inst.getNetworkInterfaces().add(eni);
 
-            // EBS volumes
-            for (int j = 0; j < volumes.size(); j++) {
-                final Volume volume = volumes.get(j);
+            // Block device EBS volumes 
+            for (int j = 0; j < blockDevices.size(); j++) {
+                final BlockDevice blockDevice = blockDevices.get(j);
+                final Ebs ebs = Objects.requireNonNullElse(blockDevice.getEbs(), new Ebs());
                 final Volume ebsVolume = createVolume(
                     region,
-                    az,
-                    volume.getVolumeType(),
-                    volume.getSize(),
-                    volume.isEncrypted(),
-                    volume.getIops(),
-                    null,
+                    ebs.getAvailabilityZone(),
+                    ebs.getVolumeType(),
+                    ebs.getVolumeSize(),
+                    ebs.isEncrypted(),
+                    ebs.getIops(),
+                    ebs.getSnapshotId(),
                     null
                 );
                 if (j == 0) {
@@ -504,6 +507,8 @@ public class Ec2Service {
             case "instanceType" -> inst.setInstanceType(value);
             case "sourceDestCheck" -> inst.setSourceDestCheck(Boolean.parseBoolean(value));
             case "ebsOptimized" -> inst.setEbsOptimized(Boolean.parseBoolean(value));
+            case "disableApiStop" -> inst.setDisableApiStop(Boolean.parseBoolean(value));
+            case "disableApiTermination" -> inst.setDisableApiTermination(Boolean.parseBoolean(value));
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/BlockDevice.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/BlockDevice.java
@@ -1,0 +1,30 @@
+package io.github.hectorvent.floci.services.ec2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BlockDevice {
+
+    private String deviceName;
+    private Ebs ebs = null;
+    private String noDevice = null;
+    private String virtualName = null;
+
+    public BlockDevice() {}
+
+	public String getDeviceName() { return deviceName; }
+	public void setDeviceName(String deviceName) { this.deviceName = deviceName; }
+
+	public Ebs getEbs() { return ebs; }
+	public void setEbs(Ebs ebs) { this.ebs = ebs; }
+
+	public String getNoDevice() { return noDevice; }
+	public void setNoDevice(String noDevice) { this.noDevice = noDevice; }
+
+	public String getVirtualName() { return virtualName; }
+
+	public void setVirtualName(String virtualName) { this.virtualName = virtualName; }
+
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/Ebs.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/Ebs.java
@@ -1,0 +1,65 @@
+package io.github.hectorvent.floci.services.ec2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Ebs {
+
+    private String availabilityZone = null;
+    private String availabilityZoneId = null;
+    private boolean deleteOnTermination = true;
+    private int ebsCardIndex = 0;
+    private boolean encrypted = false;
+    private int iops = 0;
+    private String kmsKeyId = null;
+    private String outpostArn = null;
+    private String snapshotId = null;
+    private int throughput = 0;
+    private int volumeInitializationRate = 0;
+    private int volumeSize = 0;
+    private String volumeType = null;
+
+    public Ebs() {}
+
+	public String getAvailabilityZone() { return availabilityZone; }
+	public void setAvailabilityZone(String availabilityZone) { this.availabilityZone = availabilityZone; }
+
+	public String getAvailabilityZoneId() { return availabilityZoneId; }
+	public void setAvailabilityZoneId(String availabilityZoneId) { this.availabilityZoneId = availabilityZoneId; }
+
+	public boolean isDeleteOnTermination() { return deleteOnTermination; }
+	public void setDeleteOnTermination(boolean deleteOnTermination) { this.deleteOnTermination = deleteOnTermination; }
+
+	public int getEbsCardIndex() { return ebsCardIndex; }
+	public void setEbsCardIndex(int ebsCardIndex) { this.ebsCardIndex = ebsCardIndex; }
+
+	public boolean isEncrypted() { return encrypted; }
+	public void setEncrypted(boolean encrypted) { this.encrypted = encrypted; }
+
+	public int getIops() { return iops; }
+	public void setIops(int iops) { this.iops = iops; }
+
+	public String getKmsKeyId() { return kmsKeyId; }
+	public void setKmsKeyId(String kmsKeyId) { this.kmsKeyId = kmsKeyId; }
+
+	public String getOutpostArn() { return outpostArn; }
+	public void setOutpostArn(String outpostArn) { this.outpostArn = outpostArn; }
+
+	public String getSnapshotId() { return snapshotId; }
+	public void setSnapshotId(String snapshotId) { this.snapshotId = snapshotId; }
+
+	public int getThroughput() { return throughput; }
+	public void setThroughput(int throughput) { this.throughput = throughput; }
+
+	public int getVolumeInitializationRate() { return volumeInitializationRate; }
+	public void setVolumeInitializationRate(int volumeInitializationRate) { this.volumeInitializationRate = volumeInitializationRate; }
+
+	public int getVolumeSize() { return volumeSize; }
+	public void setVolumeSize(int volumeSize) { this.volumeSize = volumeSize; }
+
+	public String getVolumeType() { return volumeType; }
+	public void setVolumeType(String volumeType) { this.volumeType = volumeType; }
+
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/Instance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/Instance.java
@@ -39,8 +39,8 @@ public class Instance {
     private boolean sourceDestCheck = true;
     private boolean ebsOptimized = false;
     private boolean enaSupport = true;
-    private boolean disableApiStop = true;
-    private boolean disableApiTermination = true;
+    private boolean disableApiStop = false;
+    private boolean disableApiTermination = false;
     private String iamInstanceProfileArn;
     private String region;
     private List<Tag> tags = new ArrayList<>();

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/Instance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/Instance.java
@@ -39,6 +39,8 @@ public class Instance {
     private boolean sourceDestCheck = true;
     private boolean ebsOptimized = false;
     private boolean enaSupport = true;
+    private boolean disableApiStop = true;
+    private boolean disableApiTermination = true;
     private String iamInstanceProfileArn;
     private String region;
     private List<Tag> tags = new ArrayList<>();
@@ -135,6 +137,12 @@ public class Instance {
 
     public boolean isEnaSupport() { return enaSupport; }
     public void setEnaSupport(boolean enaSupport) { this.enaSupport = enaSupport; }
+
+    public boolean isDisableApiStop() { return this.disableApiStop; }
+    public void setDisableApiStop(boolean disableApiStop) { this.disableApiStop = disableApiStop; }
+
+    public boolean isDisableApiTermination() { return this.disableApiTermination; }
+    public void setDisableApiTermination(boolean disableApiTermination) { this.disableApiTermination = disableApiTermination; }
 
     public String getIamInstanceProfileArn() { return iamInstanceProfileArn; }
     public void setIamInstanceProfileArn(String iamInstanceProfileArn) { this.iamInstanceProfileArn = iamInstanceProfileArn; }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/Instance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/Instance.java
@@ -31,7 +31,7 @@ public class Instance {
     private String virtualizationType = "hvm";
     private String rootDeviceName = "/dev/xvda";
     private String rootDeviceType = "ebs";
-    private String rootDeviceEbsVolumeId;
+    private String rootDeviceVolumeId;
     private Instant launchTime;
     private int amiLaunchIndex;
     private String clientToken;
@@ -114,8 +114,8 @@ public class Instance {
     public String getRootDeviceType() { return rootDeviceType; }
     public void setRootDeviceType(String rootDeviceType) { this.rootDeviceType = rootDeviceType; }
 
-    public String getRootDeviceEbsVolumeId() { return this.rootDeviceEbsVolumeId; }
-    public void setRootDeviceEbsVolumeId(final String rootDeviceEbsVolumeId) { this.rootDeviceEbsVolumeId = rootDeviceEbsVolumeId; }
+    public String getRootDeviceVolumeId() { return this.rootDeviceVolumeId; }
+    public void setRootDeviceVolumeId(final String rootDeviceVolumeId) { this.rootDeviceVolumeId = rootDeviceVolumeId; }
 
     public Instant getLaunchTime() { return launchTime; }
     public void setLaunchTime(Instant launchTime) { this.launchTime = launchTime; }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/Instance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/Instance.java
@@ -31,6 +31,7 @@ public class Instance {
     private String virtualizationType = "hvm";
     private String rootDeviceName = "/dev/xvda";
     private String rootDeviceType = "ebs";
+    private String rootDeviceEbsVolumeId;
     private Instant launchTime;
     private int amiLaunchIndex;
     private String clientToken;
@@ -110,6 +111,9 @@ public class Instance {
 
     public String getRootDeviceType() { return rootDeviceType; }
     public void setRootDeviceType(String rootDeviceType) { this.rootDeviceType = rootDeviceType; }
+
+    public String getRootDeviceEbsVolumeId() { return this.rootDeviceEbsVolumeId; }
+    public void setRootDeviceEbsVolumeId(final String rootDeviceEbsVolumeId) { this.rootDeviceEbsVolumeId = rootDeviceEbsVolumeId; }
 
     public Instant getLaunchTime() { return launchTime; }
     public void setLaunchTime(Instant launchTime) { this.launchTime = launchTime; }


### PR DESCRIPTION
## Summary

Creates root and attached EBS volumes for EC2 instances on creation.
Returns volume IDs for each attached EBS device on describe.

Addresses re-opened #871 

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
