### PR TITLE
fix(ec2): add volumeId to BlockDeviceMapping and disableApiStop/disab…

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -411,6 +411,10 @@ public class Ec2QueryHandler {
             xml.start("sourceDestCheck").elem("value", String.valueOf(inst.isSourceDestCheck())).end("sourceDestCheck");
         } else if ("ebsOptimized".equals(attribute)) {
             xml.start("ebsOptimized").elem("value", String.valueOf(inst.isEbsOptimized())).end("ebsOptimized");
+        } else if ("disableApiStop".equals(attribute)) {
+            xml.start("disableApiStop").elem("value", String.valueOf(inst.isDisableApiStop())).end("disableApiStop");
+        } else if ("disableApiTermination".equals(attribute)) {
+            xml.start("disableApiTermination").elem("value", String.valueOf(inst.isDisableApiTermination())).end("disableApiTermination");
         }
         xml.end("DescribeInstanceAttributeResponse");
         return xmlResponse(xml.build());
@@ -1226,16 +1230,19 @@ public class Ec2QueryHandler {
                 .end("privateDnsNameOptions")
                 .start("capacityReservationSpecification")
                 .elem("capacityReservationPreference", "open")
-                .end("capacityReservationSpecification")
-                .start("blockDeviceMapping")
+                .end("capacityReservationSpecification");
+        if (inst.getRootVolumeId() != null) {
+            xml.start("blockDeviceMapping")
                 .start("item")
                 .elem("deviceName", inst.getRootDeviceName())
                 .start("ebs")
+                .elem("volumeId", inst.getRootVolumeId())
                 .elem("status", "attached")
                 .elem("deleteOnTermination", "true")
                 .end("ebs")
                 .end("item")
                 .end("blockDeviceMapping");
+        }
         xml.raw(tagSetXml(inst.getTags()));
         return xml.build();
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -39,6 +39,7 @@ import io.github.hectorvent.floci.services.ec2.model.SecurityGroupRule;
 import io.github.hectorvent.floci.services.ec2.model.Subnet;
 import io.github.hectorvent.floci.services.ec2.model.Tag;
 import io.github.hectorvent.floci.services.ec2.model.Volume;
+import io.github.hectorvent.floci.services.ec2.model.VolumeAttachment;
 import io.github.hectorvent.floci.services.ec2.model.Vpc;
 import io.github.hectorvent.floci.services.ec2.model.VpcCidrBlockAssociation;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -271,6 +272,27 @@ public class Ec2Service {
             eni.setDeviceIndex(0);
             inst.getNetworkInterfaces().add(eni);
 
+            // Root EBS volume
+            String rootVolId = "vol-" + randomHex(17);
+            inst.setRootVolumeId(rootVolId);
+            Volume rootVol = new Volume();
+            rootVol.setVolumeId(rootVolId);
+            rootVol.setAvailabilityZone(az);
+            rootVol.setVolumeType("gp3");
+            rootVol.setSize(8);
+            rootVol.setState("in-use");
+            rootVol.setRegion(region);
+            rootVol.setCreateTime(Instant.now());
+            VolumeAttachment att = new VolumeAttachment();
+            att.setVolumeId(rootVolId);
+            att.setInstanceId(instanceId);
+            att.setDevice(inst.getRootDeviceName());
+            att.setState("attached");
+            att.setDeleteOnTermination(true);
+            att.setAttachTime(Instant.now());
+            rootVol.getAttachments().add(att);
+            volumes.put(key(region, rootVolId), rootVol);
+
             instances.put(key(region, instanceId), inst);
             reservation.getInstances().add(inst);
 
@@ -357,6 +379,10 @@ public class Ec2Service {
                 inst.setTerminatedAt(System.currentTimeMillis());
             } else {
                 containerManager.terminate(inst);
+            }
+            // Delete root volume if deleteOnTermination (matches real AWS behavior)
+            if (inst.getRootVolumeId() != null) {
+                volumes.remove(key(region, inst.getRootVolumeId()));
             }
             Map<String, String> entry = new LinkedHashMap<>();
             entry.put("instanceId", id);

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/Instance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/Instance.java
@@ -42,6 +42,14 @@ public class Instance {
     private String region;
     private List<Tag> tags = new ArrayList<>();
 
+    private String rootVolumeId;
+
+    // NOTE: disableApiStop and disableApiTermination are stored but ModifyInstanceAttribute
+    // does not yet wire them through. Terraform reads these via DescribeInstanceAttribute;
+    // without model backing, a modify → plan cycle would show drift. Tracked as a known limitation.
+    private boolean disableApiStop = false;
+    private boolean disableApiTermination = false;
+
     // Docker backing fields (not serialised to AWS wire format)
     private String dockerContainerId;
     private String containerBridgeIp;
@@ -155,4 +163,13 @@ public class Instance {
 
     public String getContainerBridgeIp() { return containerBridgeIp; }
     public void setContainerBridgeIp(String containerBridgeIp) { this.containerBridgeIp = containerBridgeIp; }
+
+    public String getRootVolumeId() { return rootVolumeId; }
+    public void setRootVolumeId(String rootVolumeId) { this.rootVolumeId = rootVolumeId; }
+
+    public boolean isDisableApiStop() { return disableApiStop; }
+    public void setDisableApiStop(boolean disableApiStop) { this.disableApiStop = disableApiStop; }
+
+    public boolean isDisableApiTermination() { return disableApiTermination; }
+    public void setDisableApiTermination(boolean disableApiTermination) { this.disableApiTermination = disableApiTermination; }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -34,6 +34,7 @@ class Ec2IntegrationTest {
     private static String allocationId;
     private static String associationId;
     private static String volumeId;
+    private static String rootVolumeId;
 
     // =========================================================================
     // Default resources
@@ -643,6 +644,85 @@ class Ec2IntegrationTest {
 
     @Test
     @Order(82)
+    void describeInstancesBlockDeviceMappingHasVolumeId() {
+        given()
+            .formParam("Action", "DescribeInstances")
+            .formParam("InstanceId.1", instanceId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeInstancesResponse.reservationSet.item.instancesSet.item.blockDeviceMapping.item.deviceName",
+                    equalTo("/dev/xvda"))
+            .body("DescribeInstancesResponse.reservationSet.item.instancesSet.item.blockDeviceMapping.item.ebs.volumeId",
+                    startsWith("vol-"))
+            .body("DescribeInstancesResponse.reservationSet.item.instancesSet.item.blockDeviceMapping.item.ebs.status",
+                    equalTo("attached"))
+            .body("DescribeInstancesResponse.reservationSet.item.instancesSet.item.blockDeviceMapping.item.ebs.deleteOnTermination",
+                    equalTo("true"));
+    }
+
+    @Test
+    @Order(83)
+    void rootVolumeAppearsInDescribeVolumes() {
+        // Extract the root volume ID from DescribeInstances
+        String rootVolId = given()
+            .formParam("Action", "DescribeInstances")
+            .formParam("InstanceId.1", instanceId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .extract().path("DescribeInstancesResponse.reservationSet.item.instancesSet.item.blockDeviceMapping.item.ebs.volumeId");
+
+        // Verify it exists in DescribeVolumes with state=in-use
+        given()
+            .formParam("Action", "DescribeVolumes")
+            .formParam("VolumeId.1", rootVolId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVolumesResponse.volumeSet.item.volumeId", equalTo(rootVolId))
+            .body("DescribeVolumesResponse.volumeSet.item.status", equalTo("in-use"));
+    }
+
+    @Test
+    @Order(84)
+    void describeInstanceAttributeDisableApiStop() {
+        given()
+            .formParam("Action", "DescribeInstanceAttribute")
+            .formParam("InstanceId", instanceId)
+            .formParam("Attribute", "disableApiStop")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeInstanceAttributeResponse.instanceId", equalTo(instanceId))
+            .body("DescribeInstanceAttributeResponse.disableApiStop.value", equalTo("false"));
+    }
+
+    @Test
+    @Order(85)
+    void describeInstanceAttributeDisableApiTermination() {
+        given()
+            .formParam("Action", "DescribeInstanceAttribute")
+            .formParam("InstanceId", instanceId)
+            .formParam("Attribute", "disableApiTermination")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeInstanceAttributeResponse.instanceId", equalTo(instanceId))
+            .body("DescribeInstanceAttributeResponse.disableApiTermination.value", equalTo("false"));
+    }
+
+    @Test
+    @Order(86)
     void describeInstancesByFilter() {
         given()
             .formParam("Action", "DescribeInstances")
@@ -658,7 +738,7 @@ class Ec2IntegrationTest {
     }
 
     @Test
-    @Order(83)
+    @Order(87)
     void describeInstanceStatus() {
         given()
             .formParam("Action", "DescribeInstanceStatus")
@@ -673,7 +753,7 @@ class Ec2IntegrationTest {
     }
 
     @Test
-    @Order(84)
+    @Order(88)
     void associateAddressToInstance() {
         associationId = given()
             .formParam("Action", "AssociateAddress")
@@ -689,7 +769,7 @@ class Ec2IntegrationTest {
     }
 
     @Test
-    @Order(85)
+    @Order(89)
     void stopInstance() {
         given()
             .formParam("Action", "StopInstances")
@@ -704,7 +784,7 @@ class Ec2IntegrationTest {
     }
 
     @Test
-    @Order(86)
+    @Order(89)
     void startInstance() {
         given()
             .formParam("Action", "StartInstances")
@@ -719,7 +799,7 @@ class Ec2IntegrationTest {
     }
 
     @Test
-    @Order(87)
+    @Order(89)
     void rebootInstance() {
         given()
             .formParam("Action", "RebootInstances")
@@ -923,6 +1003,16 @@ class Ec2IntegrationTest {
     @Test
     @Order(100)
     void terminateInstance() {
+        // Capture root volume ID before termination
+        rootVolumeId = given()
+            .formParam("Action", "DescribeInstances")
+            .formParam("InstanceId.1", instanceId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .extract().path("DescribeInstancesResponse.reservationSet.item.instancesSet.item.blockDeviceMapping.item.ebs.volumeId");
+
         given()
             .formParam("Action", "TerminateInstances")
             .formParam("InstanceId.1", instanceId)
@@ -933,6 +1023,20 @@ class Ec2IntegrationTest {
             .statusCode(200)
             .body("TerminateInstancesResponse.instancesSet.item.instanceId", equalTo(instanceId))
             .body("TerminateInstancesResponse.instancesSet.item.currentState.name", equalTo("shutting-down"));
+    }
+
+    @Test
+    @Order(100)
+    void rootVolumeDeletedAfterTermination() {
+        given()
+            .formParam("Action", "DescribeVolumes")
+            .formParam("VolumeId.1", rootVolumeId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidVolume.NotFound"));
     }
 
     @Test


### PR DESCRIPTION
…leApiTermination to DescribeInstanceAttribute

Fixes Terraform provider crash when creating aws_instance against floci.
- Add rootVolumeId field to Instance model
- Create root EBS volume with VolumeAttachment on instance launch
- Include volumeId in blockDeviceMapping XML response
- Add disableApiStop and disableApiTermination to DescribeInstanceAttribute

Ref: floci-io/floci#871

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
