### PR TITLE
fix(apigateway): resolve _user_request_ APIs created outside default region

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -240,6 +240,12 @@ public class ApiGatewayExecuteController {
             return dispatchV2(httpMethod, apiId, stageName, proxy, headers, uriInfo, body, region);
         }
 
+        // Resolve region for unsigned data-plane requests
+        String auth = headers.getHeaderString("Authorization");
+        if (auth == null || auth.isBlank()) {
+            region = apiGatewayService.resolveRestApiRegion(region, apiId);
+        }
+
         // Verify API and stage exist
         Stage stage;
         try {

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
@@ -191,6 +191,18 @@ public class ApiGatewayService {
                 .orElseThrow(() -> new AwsException("NotFoundException", "Invalid API id specified", 404));
     }
 
+    public String resolveRestApiRegion(String preferredRegion, String apiId) {
+        if (apiStore.get(apiKey(preferredRegion, apiId)).isPresent()) {
+            return preferredRegion;
+        }
+
+        return apiStore.keys().stream()
+                .filter(k -> k.endsWith("::" + apiId))
+                .map(k -> k.substring(0, k.indexOf("::")))
+                .findFirst()
+                .orElse(preferredRegion);
+    }
+
     public List<RestApi> getRestApis(String region) {
         String prefix = region + "::";
         return apiStore.scan(k -> k.startsWith(prefix));

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayUserRequestIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayUserRequestIntegrationTest.java
@@ -123,4 +123,201 @@ class ApiGatewayUserRequestIntegrationTest {
     void cleanup() {
         given().when().delete("/restapis/" + apiId).then().statusCode(202);
     }
+
+    @Test @Order(7)
+    void executeViaUserRequestPathFindsRestApiCreatedInNonDefaultRegionWithoutAuthHeader() {
+        String euWest2Auth = "AWS4-HMAC-SHA256 Credential=test/20260525/eu-west-2/apigateway/aws4_request, SignedHeaders=host, Signature=test";
+        String localApiId = null;
+
+        try {
+            localApiId = given()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", euWest2Auth)
+                    .body("{\"name\":\"user-request-region-fallback-test\"}")
+                    .when().post("/restapis")
+                    .then()
+                    .statusCode(201)
+                    .body("id", notNullValue())
+                    .extract().path("id");
+
+            String localRootId = given()
+                    .header("Authorization", euWest2Auth)
+                    .when().get("/restapis/" + localApiId + "/resources")
+                    .then()
+                    .statusCode(200)
+                    .extract().path("item[0].id");
+
+            String localResourceId = given()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", euWest2Auth)
+                    .body("{\"pathPart\":\"hello\"}")
+                    .when().post("/restapis/" + localApiId + "/resources/" + localRootId)
+                    .then()
+                    .statusCode(201)
+                    .extract().path("id");
+
+            given()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", euWest2Auth)
+                    .body("{\"authorizationType\":\"NONE\"}")
+                    .when().put("/restapis/" + localApiId + "/resources/" + localResourceId + "/methods/GET")
+                    .then()
+                    .statusCode(201);
+
+            given()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", euWest2Auth)
+                    .body("{\"responseParameters\":{}}")
+                    .when().put("/restapis/" + localApiId + "/resources/" + localResourceId + "/methods/GET/responses/200")
+                    .then()
+                    .statusCode(201);
+
+            given()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", euWest2Auth)
+                    .body("{\"type\":\"MOCK\",\"requestTemplates\":{\"application/json\":\"{\\\"statusCode\\\": 200}\"}}")
+                    .when().put("/restapis/" + localApiId + "/resources/" + localResourceId + "/methods/GET/integration")
+                    .then()
+                    .statusCode(201);
+
+            given()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", euWest2Auth)
+                    .body("{\"selectionPattern\":\"\",\"responseTemplates\":{\"application/json\":\"{\\\"message\\\":\\\"ok\\\"}\"}}")
+                    .when().put("/restapis/" + localApiId + "/resources/" + localResourceId + "/methods/GET/integration/responses/200")
+                    .then()
+                    .statusCode(201);
+
+            String localDeploymentId = given()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", euWest2Auth)
+                    .body("{\"description\":\"region fallback\"}")
+                    .when().post("/restapis/" + localApiId + "/deployments")
+                    .then()
+                    .statusCode(201)
+                    .extract().path("id");
+
+            given()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", euWest2Auth)
+                    .body("{\"stageName\":\"dev\",\"deploymentId\":\"" + localDeploymentId + "\"}")
+                    .when().post("/restapis/" + localApiId + "/stages")
+                    .then()
+                    .statusCode(201);
+
+            given()
+                    .when().get("/restapis/" + localApiId + "/dev/_user_request_/hello")
+                    .then()
+                    .statusCode(200)
+                    .body("message", equalTo("ok"));
+        } finally {
+            if (localApiId != null) {
+                given()
+                        .header("Authorization", euWest2Auth)
+                        .when().delete("/restapis/" + localApiId)
+                        .then()
+                        .statusCode(anyOf(equalTo(202), equalTo(404)));
+            }
+
+        }
+    }
+
+    @Test @Order(8)
+    void executeViaUserRequestPathDoesNotFallbackWhenSigV4RegionIsExplicit() {
+        String euWest2Auth = "AWS4-HMAC-SHA256 Credential=test/20260525/eu-west-2/apigateway/aws4_request, SignedHeaders=host, Signature=test";
+        String usEast1Auth = "AWS4-HMAC-SHA256 Credential=test/20260525/us-east-1/apigateway/aws4_request, SignedHeaders=host, Signature=test";
+        String localApiId = null;
+
+        try {
+            localApiId = given()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", euWest2Auth)
+                    .body("{\"name\":\"user-request-explicit-region-test\"}")
+                    .when().post("/restapis")
+                    .then()
+                    .statusCode(201)
+                    .body("id", notNullValue())
+                    .extract().path("id");
+
+            String localRootId = given()
+                    .header("Authorization", euWest2Auth)
+                    .when().get("/restapis/" + localApiId + "/resources")
+                    .then()
+                    .statusCode(200)
+                    .extract().path("item[0].id");
+
+            String localResourceId = given()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", euWest2Auth)
+                    .body("{\"pathPart\":\"hello\"}")
+                    .when().post("/restapis/" + localApiId + "/resources/" + localRootId)
+                    .then()
+                    .statusCode(201)
+                    .extract().path("id");
+
+            given()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", euWest2Auth)
+                    .body("{\"authorizationType\":\"NONE\"}")
+                    .when().put("/restapis/" + localApiId + "/resources/" + localResourceId + "/methods/GET")
+                    .then()
+                    .statusCode(201);
+
+            given()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", euWest2Auth)
+                    .body("{\"responseParameters\":{}}")
+                    .when().put("/restapis/" + localApiId + "/resources/" + localResourceId + "/methods/GET/responses/200")
+                    .then()
+                    .statusCode(201);
+
+            given()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", euWest2Auth)
+                    .body("{\"type\":\"MOCK\",\"requestTemplates\":{\"application/json\":\"{\\\"statusCode\\\": 200}\"}}")
+                    .when().put("/restapis/" + localApiId + "/resources/" + localResourceId + "/methods/GET/integration")
+                    .then()
+                    .statusCode(201);
+
+            given()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", euWest2Auth)
+                    .body("{\"selectionPattern\":\"\",\"responseTemplates\":{\"application/json\":\"{\\\"message\\\":\\\"ok\\\"}\"}}")
+                    .when().put("/restapis/" + localApiId + "/resources/" + localResourceId + "/methods/GET/integration/responses/200")
+                    .then()
+                    .statusCode(201);
+
+            String localDeploymentId = given()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", euWest2Auth)
+                    .body("{\"description\":\"explicit region\"}")
+                    .when().post("/restapis/" + localApiId + "/deployments")
+                    .then()
+                    .statusCode(201)
+                    .extract().path("id");
+
+            given()
+                    .contentType(ContentType.JSON)
+                    .header("Authorization", euWest2Auth)
+                    .body("{\"stageName\":\"dev\",\"deploymentId\":\"" + localDeploymentId + "\"}")
+                    .when().post("/restapis/" + localApiId + "/stages")
+                    .then()
+                    .statusCode(201);
+
+            given()
+                    .header("Authorization", usEast1Auth)
+                    .when().get("/restapis/" + localApiId + "/dev/_user_request_/hello")
+                    .then()
+                    .statusCode(404)
+                    .body("message", equalTo("Invalid API id specified"));
+        } finally {
+            if (localApiId != null) {
+                given()
+                        .header("Authorization", euWest2Auth)
+                        .when().delete("/restapis/" + localApiId)
+                        .then()
+                        .statusCode(anyOf(equalTo(202), equalTo(404)));
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`_user_request_` calls do not include SigV4 headers, so REST APIs were always looked up in the default region. APIs created in another region failed with `Invalid API id specified`.

This fixes the REST data-plane path by falling back to an API-id lookup when the API is not found in the resolved region.

Closes #874

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified with AWS CLI by creating a REST API in `eu-west-2`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)