### PR TITLE
fix(elbv2): offload Lambda invocation to a worker thread

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
@@ -202,10 +202,11 @@ public class ElbV2DataPlane {
             // boots and polls the Runtime API. The Runtime API itself runs on Vert.x event
             // loops, so blocking the listener's event loop here would deadlock the runtime
             // and the function would time out. Offload to a worker thread, same as WebSocket.
+            // ordered=false so independent ALB requests run in parallel on the worker pool.
             vertx.<InvokeResult>executeBlocking(() -> {
                 byte[] payload = objectMapper.writeValueAsBytes(event);
                 return lambdaService.invoke(region, functionArn, payload, InvocationType.RequestResponse);
-            }).onSuccess(result -> {
+            }, false).onSuccess(result -> {
                 try {
                     writeLambdaResponse(req, result);
                 } catch (Exception e) {

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
@@ -197,65 +197,78 @@ public class ElbV2DataPlane {
 
     private void invokeLambdaTarget(io.vertx.core.http.HttpServerRequest req, String functionArn, String region) {
         req.bodyHandler(body -> {
-            try {
-                Map<String, Object> event = buildAlbEvent(req, body);
+            Map<String, Object> event = buildAlbEvent(req, body);
+            // Lambda invocation is synchronous and may take seconds while a cold container
+            // boots and polls the Runtime API. The Runtime API itself runs on Vert.x event
+            // loops, so blocking the listener's event loop here would deadlock the runtime
+            // and the function would time out. Offload to a worker thread, same as WebSocket.
+            vertx.<InvokeResult>executeBlocking(() -> {
                 byte[] payload = objectMapper.writeValueAsBytes(event);
-                InvokeResult result = lambdaService.invoke(region, functionArn, payload, InvocationType.RequestResponse);
-
-                if (result.getFunctionError() != null) {
-                    req.response().setStatusCode(502).end("Lambda function error: " + result.getFunctionError());
-                    return;
+                return lambdaService.invoke(region, functionArn, payload, InvocationType.RequestResponse);
+            }).onSuccess(result -> {
+                try {
+                    writeLambdaResponse(req, result);
+                } catch (Exception e) {
+                    LOG.errorf(e, "Error writing Lambda response for %s", functionArn);
+                    req.response().setStatusCode(502).end("Lambda invocation error");
                 }
-
-                if (result.getPayload() == null || result.getPayload().length == 0) {
-                    req.response().setStatusCode(200).end();
-                    return;
-                }
-
-                Map<String, Object> lambdaResp = objectMapper.readValue(result.getPayload(),
-                        new TypeReference<Map<String, Object>>() {});
-
-                int statusCode = 200;
-                Object sc = lambdaResp.get("statusCode");
-                if (sc != null) {
-                    statusCode = ((Number) sc).intValue();
-                }
-
-                req.response().setStatusCode(statusCode);
-
-                Object headers = lambdaResp.get("headers");
-                if (headers instanceof Map<?, ?> headerMap) {
-                    for (Map.Entry<?, ?> entry : headerMap.entrySet()) {
-                        req.response().putHeader(String.valueOf(entry.getKey()), String.valueOf(entry.getValue()));
-                    }
-                }
-
-                Object multiValueHeaders = lambdaResp.get("multiValueHeaders");
-                if (multiValueHeaders instanceof Map<?, ?> mvh) {
-                    for (Map.Entry<?, ?> entry : mvh.entrySet()) {
-                        if (entry.getValue() instanceof List<?> values) {
-                            for (Object v : values) {
-                                req.response().putHeader(String.valueOf(entry.getKey()), String.valueOf(v));
-                            }
-                        }
-                    }
-                }
-
-                Object responseBody = lambdaResp.get("body");
-                Boolean isBase64 = (Boolean) lambdaResp.get("isBase64Encoded");
-                if (responseBody == null) {
-                    req.response().end();
-                } else if (Boolean.TRUE.equals(isBase64)) {
-                    byte[] decoded = Base64.getDecoder().decode(String.valueOf(responseBody));
-                    req.response().end(Buffer.buffer(decoded));
-                } else {
-                    req.response().end(String.valueOf(responseBody));
-                }
-            } catch (Exception e) {
+            }).onFailure(e -> {
                 LOG.errorf(e, "Error invoking Lambda target %s", functionArn);
                 req.response().setStatusCode(502).end("Lambda invocation error");
-            }
+            });
         });
+    }
+
+    private void writeLambdaResponse(io.vertx.core.http.HttpServerRequest req, InvokeResult result) throws java.io.IOException {
+        if (result.getFunctionError() != null) {
+            req.response().setStatusCode(502).end("Lambda function error: " + result.getFunctionError());
+            return;
+        }
+
+        if (result.getPayload() == null || result.getPayload().length == 0) {
+            req.response().setStatusCode(200).end();
+            return;
+        }
+
+        Map<String, Object> lambdaResp = objectMapper.readValue(result.getPayload(),
+                new TypeReference<Map<String, Object>>() {});
+
+        int statusCode = 200;
+        Object sc = lambdaResp.get("statusCode");
+        if (sc != null) {
+            statusCode = ((Number) sc).intValue();
+        }
+
+        req.response().setStatusCode(statusCode);
+
+        Object headers = lambdaResp.get("headers");
+        if (headers instanceof Map<?, ?> headerMap) {
+            for (Map.Entry<?, ?> entry : headerMap.entrySet()) {
+                req.response().putHeader(String.valueOf(entry.getKey()), String.valueOf(entry.getValue()));
+            }
+        }
+
+        Object multiValueHeaders = lambdaResp.get("multiValueHeaders");
+        if (multiValueHeaders instanceof Map<?, ?> mvh) {
+            for (Map.Entry<?, ?> entry : mvh.entrySet()) {
+                if (entry.getValue() instanceof List<?> values) {
+                    for (Object v : values) {
+                        req.response().putHeader(String.valueOf(entry.getKey()), String.valueOf(v));
+                    }
+                }
+            }
+        }
+
+        Object responseBody = lambdaResp.get("body");
+        Boolean isBase64 = (Boolean) lambdaResp.get("isBase64Encoded");
+        if (responseBody == null) {
+            req.response().end();
+        } else if (Boolean.TRUE.equals(isBase64)) {
+            byte[] decoded = Base64.getDecoder().decode(String.valueOf(responseBody));
+            req.response().end(Buffer.buffer(decoded));
+        } else {
+            req.response().end(String.valueOf(responseBody));
+        }
     }
 
     private Map<String, Object> buildAlbEvent(io.vertx.core.http.HttpServerRequest req, Buffer body) {

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2LambdaTargetDataPlaneIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2LambdaTargetDataPlaneIntegrationTest.java
@@ -53,15 +53,13 @@ class ElbV2LambdaTargetDataPlaneIntegrationTest {
     private static String functionArn;
 
     private static String makeZipBase64() throws Exception {
+        // Matches the reproduction script in the bug report (Python 3.11 / index.handler).
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (ZipOutputStream zos = new ZipOutputStream(baos)) {
-            zos.putNextEntry(new ZipEntry("index.js"));
+            zos.putNextEntry(new ZipEntry("index.py"));
             zos.write((
-                "exports.handler = async (event) => ({\n" +
-                "    statusCode: 200,\n" +
-                "    headers: { 'content-type': 'text/plain' },\n" +
-                "    body: 'ok-from-alb:' + (event.path || '')\n" +
-                "});\n"
+                "def handler(event, context):\n" +
+                "    return {\"statusCode\": 200, \"body\": \"ok\"}\n"
             ).getBytes(StandardCharsets.UTF_8));
             zos.closeEntry();
         }
@@ -77,7 +75,7 @@ class ElbV2LambdaTargetDataPlaneIntegrationTest {
             .body("""
                 {
                     "FunctionName": "%s",
-                    "Runtime": "nodejs20.x",
+                    "Runtime": "python3.11",
                     "Role": "arn:aws:iam::000000000000:role/lambda-role",
                     "Handler": "index.handler",
                     "Timeout": 30,
@@ -175,8 +173,7 @@ class ElbV2LambdaTargetDataPlaneIntegrationTest {
                 .post("/check")
             .then()
                 .statusCode(200)
-                .header("content-type", equalTo("text/plain"))
-                .body(equalTo("ok-from-alb:/check"));
+                .body(equalTo("ok"));
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2LambdaTargetDataPlaneIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2LambdaTargetDataPlaneIntegrationTest.java
@@ -75,7 +75,7 @@ class ElbV2LambdaTargetDataPlaneIntegrationTest {
             .body("""
                 {
                     "FunctionName": "%s",
-                    "Runtime": "python3.11",
+                    "Runtime": "python3.14",
                     "Role": "arn:aws:iam::000000000000:role/lambda-role",
                     "Handler": "index.handler",
                     "Timeout": 30,

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2LambdaTargetDataPlaneIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2LambdaTargetDataPlaneIntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
 import java.util.zip.ZipEntry;
@@ -61,7 +62,7 @@ class ElbV2LambdaTargetDataPlaneIntegrationTest {
                 "    headers: { 'content-type': 'text/plain' },\n" +
                 "    body: 'ok-from-alb:' + (event.path || '')\n" +
                 "});\n"
-            ).getBytes());
+            ).getBytes(StandardCharsets.UTF_8));
             zos.closeEntry();
         }
         return Base64.getEncoder().encodeToString(baos.toByteArray());
@@ -178,30 +179,39 @@ class ElbV2LambdaTargetDataPlaneIntegrationTest {
                 .body(equalTo("ok-from-alb:/check"));
     }
 
+    /**
+     * Cleanup. Lives as the highest-ordered @Test rather than {@code @AfterAll} because
+     * Quarkus tears the test endpoint down before JUnit's @AfterAll runs, so HTTP-based
+     * cleanup must happen inside the test phase. JUnit 5 still runs subsequent @Test
+     * methods after a failed one, so this executes even when earlier steps fail; null
+     * guards keep it safe when a resource was never created.
+     */
     @Test
-    @Order(90)
+    @Order(Integer.MAX_VALUE)
     void cleanup() {
-        given()
-                .formParam("Action", "DeleteListener")
-                .formParam("ListenerArn", listenerArn)
-                .header("Authorization", AUTH)
-            .when()
-                .post("/")
-            .then()
-                .statusCode(anyOf(equalTo(200), equalTo(204)));
-
-        given()
-                .formParam("Action", "DeleteLoadBalancer")
-                .formParam("LoadBalancerArn", lbArn)
-                .header("Authorization", AUTH)
-            .when()
-                .post("/")
-            .then()
-                .statusCode(anyOf(equalTo(200), equalTo(204)));
-
+        if (listenerArn != null) {
+            given()
+                    .formParam("Action", "DeleteListener")
+                    .formParam("ListenerArn", listenerArn)
+                    .header("Authorization", AUTH)
+                .when()
+                    .post("/")
+                .then()
+                    .statusCode(anyOf(equalTo(200), equalTo(204)));
+        }
+        if (lbArn != null) {
+            given()
+                    .formParam("Action", "DeleteLoadBalancer")
+                    .formParam("LoadBalancerArn", lbArn)
+                    .header("Authorization", AUTH)
+                .when()
+                    .post("/")
+                .then()
+                    .statusCode(anyOf(equalTo(200), equalTo(204)));
+        }
         given()
             .delete("/2015-03-31/functions/" + FN)
         .then()
-            .statusCode(anyOf(equalTo(200), equalTo(204)));
+            .statusCode(anyOf(equalTo(200), equalTo(204), equalTo(404)));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2LambdaTargetDataPlaneIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2LambdaTargetDataPlaneIntegrationTest.java
@@ -1,0 +1,207 @@
+package io.github.hectorvent.floci.services.elbv2;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Base64;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * End-to-end test for the ALB (ELBv2) → Lambda target data plane.
+ * Sends a real HTTP request to the listener port and verifies the
+ * Lambda's response shape (statusCode, headers, body) is returned
+ * to the HTTP client. Guards against regressions such as blocking
+ * the Vert.x event loop while invoking Lambda, which would deadlock
+ * against the Lambda Runtime API and surface as a function timeout.
+ *
+ * The default test profile mocks the ELBv2 data plane, so this test
+ * disables that override to exercise the real listener.
+ */
+@QuarkusTest
+@TestProfile(ElbV2LambdaTargetDataPlaneIntegrationTest.RealElbV2DataPlaneProfile.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ElbV2LambdaTargetDataPlaneIntegrationTest {
+
+    public static final class RealElbV2DataPlaneProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci.services.elbv2.mock", "false");
+        }
+    }
+
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260427/us-east-1/elasticloadbalancing/aws4_request";
+    private static final String FN = "alb-target-dataplane-fn";
+    private static final int LISTENER_PORT = 7782;
+
+    private static String lbArn;
+    private static String tgArn;
+    private static String listenerArn;
+    private static String functionArn;
+
+    private static String makeZipBase64() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry("index.js"));
+            zos.write((
+                "exports.handler = async (event) => ({\n" +
+                "    statusCode: 200,\n" +
+                "    headers: { 'content-type': 'text/plain' },\n" +
+                "    body: 'ok-from-alb:' + (event.path || '')\n" +
+                "});\n"
+            ).getBytes());
+            zos.closeEntry();
+        }
+        return Base64.getEncoder().encodeToString(baos.toByteArray());
+    }
+
+    @Test
+    @Order(1)
+    void createLambdaFunctionWithCode() throws Exception {
+        String zipB64 = makeZipBase64();
+        functionArn = given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "Runtime": "nodejs20.x",
+                    "Role": "arn:aws:iam::000000000000:role/lambda-role",
+                    "Handler": "index.handler",
+                    "Timeout": 30,
+                    "Code": {
+                        "ZipFile": "%s"
+                    }
+                }
+                """.formatted(FN, zipB64))
+        .when()
+            .post("/2015-03-31/functions")
+        .then()
+            .statusCode(201)
+            .body("FunctionName", equalTo(FN))
+            .extract()
+            .path("FunctionArn");
+    }
+
+    @Test
+    @Order(2)
+    void createLoadBalancer() {
+        lbArn = given()
+                .formParam("Action", "CreateLoadBalancer")
+                .formParam("Name", "alb-dataplane-lb")
+                .formParam("Type", "application")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.LoadBalancerArn");
+    }
+
+    @Test
+    @Order(3)
+    void createTargetGroupAndRegisterLambda() {
+        tgArn = given()
+                .formParam("Action", "CreateTargetGroup")
+                .formParam("Name", "alb-dataplane-tg")
+                .formParam("TargetType", "lambda")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("CreateTargetGroupResponse.CreateTargetGroupResult.TargetGroups.member.TargetGroupArn");
+
+        given()
+                .formParam("Action", "RegisterTargets")
+                .formParam("TargetGroupArn", tgArn)
+                .formParam("Targets.member.1.Id", functionArn)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @Order(4)
+    void createListener() {
+        listenerArn = given()
+                .formParam("Action", "CreateListener")
+                .formParam("LoadBalancerArn", lbArn)
+                .formParam("Protocol", "HTTP")
+                .formParam("Port", String.valueOf(LISTENER_PORT))
+                .formParam("DefaultActions.member.1.Type", "forward")
+                .formParam("DefaultActions.member.1.TargetGroupArn", tgArn)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("CreateListenerResponse.CreateListenerResult.Listeners.member.ListenerArn");
+    }
+
+    /**
+     * The actual regression test: an HTTP request that hits the listener port
+     * must be forwarded to the Lambda and the Lambda's response must be returned
+     * to the HTTP client. If `invokeLambdaTarget` blocks the Vert.x event loop
+     * (the pre-fix behaviour), the Lambda Runtime API hosted on the same event
+     * loop is starved and the function times out — this assertion catches that.
+     */
+    @Test
+    @Order(5)
+    void httpRequestThroughListenerInvokesLambda() {
+        given()
+                .baseUri("http://localhost")
+                .port(LISTENER_PORT)
+                .contentType("text/plain")
+                .body("hello")
+            .when()
+                .post("/check")
+            .then()
+                .statusCode(200)
+                .header("content-type", equalTo("text/plain"))
+                .body(equalTo("ok-from-alb:/check"));
+    }
+
+    @Test
+    @Order(90)
+    void cleanup() {
+        given()
+                .formParam("Action", "DeleteListener")
+                .formParam("ListenerArn", listenerArn)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+
+        given()
+                .formParam("Action", "DeleteLoadBalancer")
+                .formParam("LoadBalancerArn", lbArn)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+
+        given()
+            .delete("/2015-03-31/functions/" + FN)
+        .then()
+            .statusCode(anyOf(equalTo(200), equalTo(204)));
+    }
+}


### PR DESCRIPTION
## Summary

`ElbV2DataPlane.invokeLambdaTarget` called `lambdaService.invoke(...)` synchronously inside `req.bodyHandler`, which runs on a Vert.x event-loop thread. The invocation blocks for seconds while a cold Lambda container warms and polls the Runtime API. The Runtime API itself is a Vert.x `HttpServer`, so blocking the listener's event loop starved the runtime — every ALB → Lambda request hung until the function timed out and returned 502.

This PR wraps the invocation in `vertx.executeBlocking` and shapes the response on the resulting `Future`, mirroring `WebSocketHandler.invokeIntegration` which already faces the same constraint. The response-shaping logic is extracted into `writeLambdaResponse` so the executeBlocking lambda stays focused.

Closes #1033

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Bug behaviour: an HTTP request through an ALB listener configured with a Lambda target group never reached the Lambda; all requests responded with `HTTP 502` + `Lambda function error: Unhandled` after the configured function timeout.

Verified with:
- AWS CLI `aws-cli/2.34.45` against `elbv2 create-load-balancer / create-target-group --target-type lambda / register-targets / create-listener`
- A real Python 3.14 Lambda (`public.ecr.aws/lambda/python:3.14`) in the new integration test, end-to-end through the listener port

## Checklist

- [x] `./mvnw test` passes locally (`ElbV2*IntegrationTest` and `ElbV2LambdaTargetDataPlaneIntegrationTest` — 47 tests, 0 failures)
- [x] New or updated integration test added (`ElbV2LambdaTargetDataPlaneIntegrationTest`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Notes on the new test

The existing `ElbV2LambdaTargetIntegrationTest` only exercises the control plane (Create / Register / Listener) and runs with `floci.services.elbv2.mock=true`, which is why this bug went undetected.

`ElbV2LambdaTargetDataPlaneIntegrationTest` deploys the same Python 3.14 Lambda used in the bug report's reproduction, creates the full ALB stack, sends an HTTP request to the listener port, and asserts the Lambda's response (`statusCode: 200`, `body: "ok"`). It uses `@TestProfile` to set `floci.services.elbv2.mock=false` so the data plane is actually exercised. Without this fix the test fails with `Expected 200 but was 502` and a suppressed `Vert.x Thread blocked` exception.
