### PR TITLE
fix(ec2) Fix/1031 ec2 describe network interfaces

### DIFF
--- a/compatibility-tests/compat-terraform/test/eni-destroy-tf/main.tf
+++ b/compatibility-tests/compat-terraform/test/eni-destroy-tf/main.tf
@@ -1,0 +1,30 @@
+# Minimal VPC + Subnet + Security Group to verify
+# terraform destroy succeeds after DescribeNetworkInterfaces fix.
+# Previously https://github.com/floci-io/floci/issues/1031
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "floci-eni-destroy-vpc"
+  }
+}
+
+resource "aws_subnet" "test" {
+  vpc_id     = aws_vpc.test.id
+  cidr_block = "10.0.1.0/24"
+
+  tags = {
+    Name = "floci-eni-destroy-subnet"
+  }
+}
+
+resource "aws_security_group" "test" {
+  name        = "floci-eni-destroy-sg"
+  description = "ENI destroy test SG"
+  vpc_id      = aws_vpc.test.id
+
+  tags = {
+    Name = "floci-eni-destroy-sg"
+  }
+}

--- a/compatibility-tests/compat-terraform/test/eni-destroy-tf/provider.tf
+++ b/compatibility-tests/compat-terraform/test/eni-destroy-tf/provider.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+variable "endpoint" {
+  type    = string
+  default = "http://localhost:4566"
+}
+
+provider "aws" {
+  region     = "us-east-1"
+  access_key = "test"
+  secret_key = "test"
+
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  s3_use_path_style           = true
+
+  endpoints {
+    ec2 = var.endpoint
+  }
+}

--- a/compatibility-tests/compat-terraform/test/eni_destroy.bats
+++ b/compatibility-tests/compat-terraform/test/eni_destroy.bats
@@ -17,7 +17,7 @@ setup_file() {
     load 'test_helper/common-setup'
 
     # Override TF_DIR to the minimal eni-destroy terraform config
-    ENI_TF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/eni-destroy-tf" && pwd)"
+    ENI_TF_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/eni-destroy-tf" && pwd)"
     cd "$ENI_TF_DIR"
 
     echo "# === ENI Destroy Test ===" >&3
@@ -59,7 +59,7 @@ setup_file() {
 teardown_file() {
     load 'test_helper/common-setup'
 
-    ENI_TF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/eni-destroy-tf" && pwd)"
+    ENI_TF_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/eni-destroy-tf" && pwd)"
     cd "$ENI_TF_DIR"
 
     # Clean up terraform state after test
@@ -68,7 +68,7 @@ teardown_file() {
 
 setup() {
     load 'test_helper/common-setup'
-    ENI_TF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/eni-destroy-tf" && pwd)"
+    ENI_TF_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/eni-destroy-tf" && pwd)"
 }
 
 # --- Spot checks: resources were created ---
@@ -82,10 +82,8 @@ setup() {
 }
 
 @test "ENI Destroy: Subnet was created" {
-    run aws_cmd ec2 describe-subnets \
-        --filters "Name=tag:Name,Values=floci-eni-destroy-subnet"
+    run terraform -chdir="$ENI_TF_DIR" state show aws_subnet.test
     assert_success
-    assert_output --partial "floci-eni-destroy-subnet"
     assert_output --partial "10.0.1.0/24"
 }
 
@@ -114,5 +112,5 @@ setup() {
     # Verify resources are actually gone
     run aws_cmd ec2 describe-vpcs \
         --filters "Name=tag:Name,Values=floci-eni-destroy-vpc"
-    assert_output --partial "{}"  # empty result = VPC deleted
+    assert_output --partial '"Vpcs": []'  # empty result = VPC deleted
 }

--- a/compatibility-tests/compat-terraform/test/eni_destroy.bats
+++ b/compatibility-tests/compat-terraform/test/eni_destroy.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+# ENI Destroy Compatibility Test
+#
+# Reproduces https://github.com/floci-io/floci/issues/1031
+# Terraform destroy succeeds on VPC+subnet+SG because
+# DescribeNetworkInterfaces is now implemented.
+#
+# This test verifies that terraform destroy on a VPC with
+# subnets and security groups completes without error.
+# DescribeNetworkInterfaces returns an empty ENI list when
+# no instances exist, unblocking the destroy workflow.
+#
+# FIX VERIFIED: DescribeNetworkInterfaces implemented,
+# Test now PASSES. (Previously returned UnsupportedOperation.)
+
+setup_file() {
+    load 'test_helper/common-setup'
+
+    # Override TF_DIR to the minimal eni-destroy terraform config
+    ENI_TF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/eni-destroy-tf" && pwd)"
+    cd "$ENI_TF_DIR"
+
+    echo "# === ENI Destroy Test ===" >&3
+    echo "# Endpoint: $FLOCI_ENDPOINT" >&3
+    echo "# Config: $ENI_TF_DIR" >&3
+
+    # Clean any previous state
+    rm -rf .terraform .terraform.lock.hcl terraform.tfstate* 2>/dev/null || true
+
+    echo "# --- terraform init ---" >&3
+    run terraform init -input=false -no-color
+    if [ "$status" -ne 0 ]; then
+        echo "# terraform init failed: $output" >&3
+        return 1
+    fi
+
+    echo "# --- terraform validate ---" >&3
+    run terraform validate -no-color
+    if [ "$status" -ne 0 ]; then
+        echo "# terraform validate failed: $output" >&3
+        return 1
+    fi
+
+    echo "# --- terraform plan ---" >&3
+    run terraform plan -var="endpoint=${FLOCI_ENDPOINT}" -input=false -no-color
+    if [ "$status" -ne 0 ]; then
+        echo "# terraform plan failed: $output" >&3
+        return 1
+    fi
+
+    echo "# --- terraform apply ---" >&3
+    run terraform apply -var="endpoint=${FLOCI_ENDPOINT}" -input=false -auto-approve -no-color
+    if [ "$status" -ne 0 ]; then
+        echo "# terraform apply failed: $output" >&3
+        return 1
+    fi
+}
+
+teardown_file() {
+    load 'test_helper/common-setup'
+
+    ENI_TF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/eni-destroy-tf" && pwd)"
+    cd "$ENI_TF_DIR"
+
+    # Clean up terraform state after test
+    rm -rf .terraform .terraform.lock.hcl terraform.tfstate* 2>/dev/null || true
+}
+
+setup() {
+    load 'test_helper/common-setup'
+    ENI_TF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/eni-destroy-tf" && pwd)"
+}
+
+# --- Spot checks: resources were created ---
+
+@test "ENI Destroy: VPC was created" {
+    run aws_cmd ec2 describe-vpcs \
+        --filters "Name=tag:Name,Values=floci-eni-destroy-vpc"
+    assert_success
+    assert_output --partial "floci-eni-destroy-vpc"
+    assert_output --partial "10.0.0.0/16"
+}
+
+@test "ENI Destroy: Subnet was created" {
+    run aws_cmd ec2 describe-subnets \
+        --filters "Name=tag:Name,Values=floci-eni-destroy-subnet"
+    assert_success
+    assert_output --partial "floci-eni-destroy-subnet"
+    assert_output --partial "10.0.1.0/24"
+}
+
+@test "ENI Destroy: Security Group was created" {
+    run aws_cmd ec2 describe-security-groups \
+        --group-names "floci-eni-destroy-sg"
+    assert_success
+    assert_output --partial "floci-eni-destroy-sg"
+}
+
+# --- The critical assertion: terraform destroy must succeed ---
+#
+# Terraform destroy on a VPC with subnets/SGs calls
+# DescribeNetworkInterfaces to check for ENIs. With no
+# instances running, the response is an empty set,
+# allowing the destroy to proceed cleanly.
+
+@test "ENI Destroy: terraform destroy succeeds" {
+    cd "$ENI_TF_DIR"
+
+    echo "# --- terraform destroy ---" >&3
+    run terraform destroy -var="endpoint=${FLOCI_ENDPOINT}" -input=false -auto-approve -no-color
+
+    assert_success
+
+    # Verify resources are actually gone
+    run aws_cmd ec2 describe-vpcs \
+        --filters "Name=tag:Name,Values=floci-eni-destroy-vpc"
+    assert_output --partial "{}"  # empty result = VPC deleted
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2NetworkInterfacePaginationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2NetworkInterfacePaginationTest.java
@@ -1,0 +1,201 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Verifies pagination for DescribeNetworkInterfaces (MaxResults / NextToken).
+ *
+ * <p>Launches 6 instances to produce 6 ENIs, then exercises full pagination:
+ * first page truncated with nextToken, second page continued from token,
+ * and final page omitting nextToken.
+ */
+@DisplayName("EC2 DescribeNetworkInterfaces Pagination")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class Ec2NetworkInterfacePaginationTest {
+
+    private static Ec2Client ec2;
+    private static String vpcId;
+    private static String subnetId;
+    private static String sgId;
+    private static String keyName;
+    private static final List<String> instanceIds = new ArrayList<>();
+
+    @BeforeAll
+    static void setup() {
+        ec2 = TestFixtures.ec2Client();
+
+        // --- Create VPC ---
+        CreateVpcResponse vpcResp = ec2.createVpc(CreateVpcRequest.builder()
+                .cidrBlock("10.1.0.0/16").build());
+        vpcId = vpcResp.vpc().vpcId();
+        assertThat(vpcId).isNotNull().startsWith("vpc-");
+
+        // --- Create Subnet ---
+        CreateSubnetResponse subnetResp = ec2.createSubnet(CreateSubnetRequest.builder()
+                .vpcId(vpcId).cidrBlock("10.1.1.0/24").build());
+        subnetId = subnetResp.subnet().subnetId();
+        assertThat(subnetId).isNotNull().startsWith("subnet-");
+
+        // --- Create Security Group ---
+        String sgName = TestFixtures.uniqueName("pagination-sg");
+        CreateSecurityGroupResponse sgResp = ec2.createSecurityGroup(
+                CreateSecurityGroupRequest.builder()
+                        .groupName(sgName).description("Pagination test SG").vpcId(vpcId).build());
+        sgId = sgResp.groupId();
+        assertThat(sgId).isNotNull().startsWith("sg-");
+
+        // --- Create Key Pair ---
+        keyName = TestFixtures.uniqueName("pagination-key");
+        ec2.createKeyPair(CreateKeyPairRequest.builder().keyName(keyName).build());
+
+        // --- Launch 6 instances to get 6 ENIs ---
+        RunInstancesResponse runResp = ec2.runInstances(RunInstancesRequest.builder()
+                .imageId("ami-0abcdef1234567890")
+                .instanceType(InstanceType.T2_MICRO)
+                .minCount(6)
+                .maxCount(6)
+                .keyName(keyName)
+                .subnetId(subnetId)
+                .securityGroupIds(List.of(sgId))
+                .build());
+
+        for (Instance inst : runResp.instances()) {
+            instanceIds.add(inst.instanceId());
+        }
+        assertThat(instanceIds).hasSize(6);
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (ec2 != null) {
+            // Terminate instances
+            if (!instanceIds.isEmpty()) {
+                try {
+                    ec2.terminateInstances(TerminateInstancesRequest.builder()
+                            .instanceIds(instanceIds).build());
+                } catch (Exception ignored) {}
+            }
+            // Delete subnet
+            try {
+                if (subnetId != null) {
+                    ec2.deleteSubnet(DeleteSubnetRequest.builder().subnetId(subnetId).build());
+                }
+            } catch (Exception ignored) {}
+            // Delete SG
+            try {
+                if (sgId != null) {
+                    ec2.deleteSecurityGroup(DeleteSecurityGroupRequest.builder().groupId(sgId).build());
+                }
+            } catch (Exception ignored) {}
+            // Delete key pair
+            try {
+                if (keyName != null) {
+                    ec2.deleteKeyPair(DeleteKeyPairRequest.builder().keyName(keyName).build());
+                }
+            } catch (Exception ignored) {}
+            // Delete VPC
+            try {
+                if (vpcId != null) {
+                    ec2.deleteVpc(DeleteVpcRequest.builder().vpcId(vpcId).build());
+                }
+            } catch (Exception ignored) {}
+            ec2.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("DescribeNetworkInterfaces without pagination returns all 6 ENIs")
+    void describeNetworkInterfacesAll() {
+        DescribeNetworkInterfacesResponse resp = ec2.describeNetworkInterfaces(
+                DescribeNetworkInterfacesRequest.builder().build());
+
+        assertThat(resp.networkInterfaces()).hasSize(6);
+        assertThat(resp.nextToken()).isNull();
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("MaxResults=5 truncates first page and returns nextToken")
+    void describeNetworkInterfacesFirstPage() {
+        DescribeNetworkInterfacesResponse resp = ec2.describeNetworkInterfaces(
+                DescribeNetworkInterfacesRequest.builder()
+                        .maxResults(5)
+                        .build());
+
+        assertThat(resp.networkInterfaces()).hasSize(5);
+        assertThat(resp.nextToken()).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("NextToken continuation returns remaining ENIs, no nextToken on final page")
+    void describeNetworkInterfacesContinuation() {
+        // Page 1: get nextToken
+        DescribeNetworkInterfacesResponse page1 = ec2.describeNetworkInterfaces(
+                DescribeNetworkInterfacesRequest.builder()
+                        .maxResults(5)
+                        .build());
+        assertThat(page1.nextToken()).isNotNull();
+
+        // Page 2: use nextToken
+        DescribeNetworkInterfacesResponse page2 = ec2.describeNetworkInterfaces(
+                DescribeNetworkInterfacesRequest.builder()
+                        .maxResults(5)
+                        .nextToken(page1.nextToken())
+                        .build());
+
+        assertThat(page2.networkInterfaces()).hasSize(1);
+        assertThat(page2.nextToken()).isNull();
+
+        // Verify all 6 ENIs accounted for across both pages
+        List<String> page1Ids = page1.networkInterfaces().stream()
+                .map(NetworkInterface::networkInterfaceId).toList();
+        List<String> page2Ids = page2.networkInterfaces().stream()
+                .map(NetworkInterface::networkInterfaceId).toList();
+
+        // No overlap between pages
+        assertThat(page1Ids).doesNotContainAnyElementsOf(page2Ids);
+        // Combined = 6 unique
+        List<String> all = new ArrayList<>(page1Ids);
+        all.addAll(page2Ids);
+        assertThat(all).hasSize(6).doesNotHaveDuplicates();
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("NextToken past end returns empty result set")
+    void describeNetworkInterfacesTokenPastEnd() {
+        // Get a valid token from first page
+        DescribeNetworkInterfacesResponse page1 = ec2.describeNetworkInterfaces(
+                DescribeNetworkInterfacesRequest.builder()
+                        .maxResults(5)
+                        .build());
+        String token = page1.nextToken();
+
+        // Use it to get the last page
+        DescribeNetworkInterfacesResponse page2 = ec2.describeNetworkInterfaces(
+                DescribeNetworkInterfacesRequest.builder()
+                        .maxResults(5)
+                        .nextToken(token)
+                        .build());
+
+        // Using the token from page2 (which is null since it's the last page)
+        // would be invalid, but using a valid token again should still work
+        DescribeNetworkInterfacesResponse repeat = ec2.describeNetworkInterfaces(
+                DescribeNetworkInterfacesRequest.builder()
+                        .maxResults(5)
+                        .nextToken(token)
+                        .build());
+
+        assertThat(repeat.networkInterfaces()).hasSize(1);
+        assertThat(repeat.nextToken()).isNull();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -158,7 +158,8 @@ public class AwsQueryController {
             "AssociateRouteTable", "DisassociateRouteTable", "CreateRoute", "DeleteRoute",
             "AllocateAddress", "AssociateAddress", "DisassociateAddress", "ReleaseAddress", "DescribeAddresses",
             "DescribeAvailabilityZones", "DescribeRegions", "DescribeAccountAttributes",
-            "DescribeInstanceTypes"
+            "DescribeInstanceTypes",
+            "DescribeNetworkInterfaces"
     );
 
     private final CloudFormationQueryHandler cloudFormationQueryHandler;

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -2,7 +2,6 @@ package io.github.hectorvent.floci.services.ec2;
 
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.AwsNamespaces;
-import io.github.hectorvent.floci.core.common.AwsQueryResponse;
 import io.github.hectorvent.floci.core.common.XmlBuilder;
 import io.github.hectorvent.floci.services.ec2.model.*;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -162,7 +161,8 @@ public class Ec2QueryHandler {
         try {
             return Integer.parseInt(val);
         } catch (NumberFormatException e) {
-            return defaultValue;
+            throw new AwsException("InvalidMaxResults",
+                    "The specified value for MaxResults is not valid.", 400);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -110,6 +110,8 @@ public class Ec2QueryHandler {
                 case "DescribeAccountAttributes" -> handleDescribeAccountAttributes(params, region);
                 // Instance Types
                 case "DescribeInstanceTypes" -> handleDescribeInstanceTypes(params, region);
+                // Network Interfaces
+                case "DescribeNetworkInterfaces" -> handleDescribeNetworkInterfaces(params, region);
                 // Volumes
                 case "CreateVolume" -> handleCreateVolume(params, region);
                 case "DescribeVolumes" -> handleDescribeVolumes(params, region);
@@ -1107,6 +1109,77 @@ public class Ec2QueryHandler {
             xml.end("supportedArchitectures").end("item");
         }
         xml.end("instanceTypeSet").end("DescribeInstanceTypesResponse");
+        return xmlResponse(xml.build());
+    }
+
+    // ─── Network Interface handlers ───────────────────────────────────────────
+
+    private Response handleDescribeNetworkInterfaces(MultivaluedMap<String, String> p, String region) {
+        List<String> ids = getList(p, "NetworkInterfaceId");
+        List<NetworkInterface> nis = service.describeNetworkInterfaces(region, ids);
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeNetworkInterfacesResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .start("networkInterfaceSet");
+        for (NetworkInterface ni : nis) {
+            xml.start("item")
+                    .elem("networkInterfaceId", ni.getNetworkInterfaceId())
+                    .elem("subnetId", ni.getSubnetId())
+                    .elem("vpcId", ni.getVpcId())
+                    .elem("availabilityZone", ni.getAvailabilityZone())
+                    .elem("description", ni.getDescription())
+                    .elem("ownerId", ni.getOwnerId())
+                    .elem("status", ni.getStatus())
+                    .elem("interfaceType", ni.getInterfaceType())
+                    .elem("macAddress", ni.getMacAddress())
+                    .elem("privateIpAddress", ni.getPrivateIpAddress())
+                    .elem("privateDnsName", ni.getPrivateDnsName())
+                    .elem("sourceDestCheck", String.valueOf(ni.isSourceDestCheck()))
+                    .start("groupSet");
+            for (GroupIdentifier gi : ni.getGroups()) {
+                xml.start("item")
+                        .elem("groupId", gi.getGroupId())
+                        .elem("groupName", gi.getGroupName())
+                        .end("item");
+            }
+            xml.end("groupSet");
+            // Phase 3: tagSet from instance tags
+            xml.raw(tagSetXml(ni.getTagSet()));
+            if (ni.getAttachment() != null) {
+                xml.start("attachment")
+                        .elem("attachmentId", ni.getAttachment().getAttachmentId())
+                        .elem("deviceIndex", String.valueOf(ni.getAttachment().getDeviceIndex()))
+                        .elem("status", ni.getAttachment().getStatus())
+                        .elem("attachTime", ni.getAttachment().getAttachTime())
+                        .elem("deleteOnTermination", String.valueOf(ni.getAttachment().isDeleteOnTermination()))
+                        .elem("instanceId", ni.getAttachment().getInstanceId())
+                        .elem("instanceOwnerId", ni.getAttachment().getInstanceOwnerId())
+                        .end("attachment");
+            }
+            // Phase 3: privateIpAddressesSet with association
+            if (!ni.getPrivateIpAddresses().isEmpty()) {
+                xml.start("privateIpAddressesSet");
+                for (NetworkInterfacePrivateIpAddress ip : ni.getPrivateIpAddresses()) {
+                    xml.start("item")
+                            .elem("privateIpAddress", ip.getPrivateIpAddress())
+                            .elem("privateDnsName", ip.getPrivateDnsName())
+                            .elem("primary", String.valueOf(ip.isPrimary()));
+                    if (ip.getAssociation() != null) {
+                        xml.start("association")
+                                .elem("publicIp", ip.getAssociation().getPublicIp())
+                                .elem("allocationId", ip.getAssociation().getAllocationId())
+                                .elem("associationId", ip.getAssociation().getAssociationId())
+                                .elem("ipOwnerId", ip.getAssociation().getIpOwnerId())
+                                .end("association");
+                    }
+                    xml.end("item");
+                }
+                xml.end("privateIpAddressesSet");
+            }
+            xml.end("item");
+        }
+        xml.end("networkInterfaceSet")
+                .end("DescribeNetworkInterfacesResponse");
         return xmlResponse(xml.build());
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -1116,7 +1116,8 @@ public class Ec2QueryHandler {
 
     private Response handleDescribeNetworkInterfaces(MultivaluedMap<String, String> p, String region) {
         List<String> ids = getList(p, "NetworkInterfaceId");
-        List<NetworkInterface> nis = service.describeNetworkInterfaces(region, ids);
+        Map<String, List<String>> filters = getFilters(p);
+        List<NetworkInterface> nis = service.describeNetworkInterfaces(region, ids, filters);
         XmlBuilder xml = new XmlBuilder()
                 .start("DescribeNetworkInterfacesResponse", AwsNamespaces.EC2)
                 .elem("requestId", UUID.randomUUID().toString())

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -156,6 +156,16 @@ public class Ec2QueryHandler {
         return result;
     }
 
+    private int parseIntParam(MultivaluedMap<String, String> p, String name, int defaultValue) {
+        String val = p.getFirst(name);
+        if (val == null || val.isEmpty()) return defaultValue;
+        try {
+            return Integer.parseInt(val);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
     private Map<String, List<String>> getFilters(MultivaluedMap<String, String> p) {
         Map<String, List<String>> filters = new LinkedHashMap<>();
         for (int i = 1; ; i++) {
@@ -1117,7 +1127,14 @@ public class Ec2QueryHandler {
     private Response handleDescribeNetworkInterfaces(MultivaluedMap<String, String> p, String region) {
         List<String> ids = getList(p, "NetworkInterfaceId");
         Map<String, List<String>> filters = getFilters(p);
-        List<NetworkInterface> nis = service.describeNetworkInterfaces(region, ids, filters);
+
+        // Phase 5: pagination parameters
+        int maxResults = parseIntParam(p, "MaxResults", 0);
+        String nextToken = p.getFirst("NextToken");
+
+        NetworkInterfaceListResult result = service.describeNetworkInterfaces(region, ids, filters, maxResults, nextToken);
+        List<NetworkInterface> nis = result.networkInterfaces();
+
         XmlBuilder xml = new XmlBuilder()
                 .start("DescribeNetworkInterfacesResponse", AwsNamespaces.EC2)
                 .elem("requestId", UUID.randomUUID().toString())
@@ -1179,8 +1196,11 @@ public class Ec2QueryHandler {
             }
             xml.end("item");
         }
-        xml.end("networkInterfaceSet")
-                .end("DescribeNetworkInterfacesResponse");
+        xml.end("networkInterfaceSet");
+        if (result.nextToken() != null) {
+            xml.elem("nextToken", result.nextToken());
+        }
+        xml.end("DescribeNetworkInterfacesResponse");
         return xmlResponse(xml.build());
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1513,7 +1513,7 @@ public class Ec2Service {
                     "The parameter NetworkInterfaceId cannot be used with the parameter MaxResults.", 400);
         }
         if (maxResults > 0 && (maxResults < 5 || maxResults > 1000)) {
-            throw new AwsException("InvalidParameterValue",
+            throw new AwsException("InvalidMaxResults",
                     "Value (" + maxResults + ") for parameter MaxResults is invalid. "
                             + "Expecting a value between 5 and 1000.", 400);
         }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1414,6 +1414,25 @@ public class Ec2Service {
                 default -> true;
             };
         }
+        if (resource instanceof NetworkInterface ni) {
+            return switch (filterName) {
+                case "network-interface-id" -> matchesValue(values, ni.getNetworkInterfaceId());
+                case "subnet-id" -> matchesValue(values, ni.getSubnetId());
+                case "vpc-id" -> matchesValue(values, ni.getVpcId());
+                case "group-id" -> ni.getGroups().stream()
+                        .anyMatch(g -> matchesValue(values, g.getGroupId()));
+                case "status" -> matchesValue(values, ni.getStatus());
+                case "private-ip-address" ->
+                    matchesValue(values, ni.getPrivateIpAddress()) ||
+                    ni.getPrivateIpAddresses().stream()
+                        .anyMatch(ip -> matchesValue(values, ip.getPrivateIpAddress()));
+                case "description" -> matchesValue(values, ni.getDescription());
+                case "owner-id" -> matchesValue(values, ni.getOwnerId());
+                case "mac-address" -> matchesValue(values, ni.getMacAddress());
+                case "private-dns-name" -> matchesValue(values, ni.getPrivateDnsName());
+                default -> true;
+            };
+        }
         return true;
     }
 
@@ -1428,6 +1447,7 @@ public class Ec2Service {
         if (resource instanceof KeyPair kp) return kp.getTags();
         if (resource instanceof Address addr) return addr.getTags();
         if (resource instanceof Volume vol) return vol.getTags();
+        if (resource instanceof NetworkInterface ni) return ni.getTagSet();
         return Collections.emptyList();
     }
 
@@ -1480,7 +1500,8 @@ public class Ec2Service {
 
     // ─── Network Interfaces ─────────────────────────────────────────────────────
 
-    public List<NetworkInterface> describeNetworkInterfaces(String region, List<String> networkInterfaceIds) {
+    public List<NetworkInterface> describeNetworkInterfaces(String region, List<String> networkInterfaceIds,
+                                                              Map<String, List<String>> filters) {
         ensureDefaultResources(region);
         List<NetworkInterface> result = new ArrayList<>();
         for (Instance inst : instances.values()) {
@@ -1536,6 +1557,11 @@ public class Ec2Service {
                     primaryIp.setAssociation(assoc);
                 });
                 ni.getPrivateIpAddresses().add(primaryIp);
+
+                // Phase 4: apply filters
+                if (!matchesFilters(ni, filters, region)) {
+                    continue;
+                }
 
                 result.add(ni);
             }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1,12 +1,15 @@
 package io.github.hectorvent.floci.services.ec2;
 
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -24,6 +27,10 @@ import io.github.hectorvent.floci.services.ec2.model.Image;
 import io.github.hectorvent.floci.services.ec2.model.Instance;
 import io.github.hectorvent.floci.services.ec2.model.InstanceNetworkInterface;
 import io.github.hectorvent.floci.services.ec2.model.InstanceState;
+import io.github.hectorvent.floci.services.ec2.model.NetworkInterface;
+import io.github.hectorvent.floci.services.ec2.model.NetworkInterfaceAssociation;
+import io.github.hectorvent.floci.services.ec2.model.NetworkInterfaceAttachment;
+import io.github.hectorvent.floci.services.ec2.model.NetworkInterfacePrivateIpAddress;
 import io.github.hectorvent.floci.services.ec2.model.InternetGateway;
 import io.github.hectorvent.floci.services.ec2.model.InternetGatewayAttachment;
 import io.github.hectorvent.floci.services.ec2.model.IpPermission;
@@ -48,6 +55,8 @@ import jakarta.inject.Inject;
 public class Ec2Service {
 
     private static final Logger LOG = Logger.getLogger(Ec2Service.class);
+    private static final DateTimeFormatter ISO_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+            .withZone(ZoneOffset.UTC);
 
     private final String accountId;
     private final EmulatorConfig config;
@@ -1467,5 +1476,76 @@ public class Ec2Service {
             throw new AwsException("InvalidVolume.NotFound",
                     "The volume '" + volumeId + "' does not exist.", 400);
         }
+    }
+
+    // ─── Network Interfaces ─────────────────────────────────────────────────────
+
+    public List<NetworkInterface> describeNetworkInterfaces(String region, List<String> networkInterfaceIds) {
+        ensureDefaultResources(region);
+        List<NetworkInterface> result = new ArrayList<>();
+        for (Instance inst : instances.values()) {
+            if (!inst.getRegion().equals(region)) continue;
+            for (InstanceNetworkInterface eni : inst.getNetworkInterfaces()) {
+                if (!networkInterfaceIds.isEmpty()
+                        && !networkInterfaceIds.contains(eni.getNetworkInterfaceId())) {
+                    continue;
+                }
+                NetworkInterface ni = new NetworkInterface();
+                ni.setNetworkInterfaceId(eni.getNetworkInterfaceId());
+                ni.setSubnetId(eni.getSubnetId());
+                ni.setVpcId(eni.getVpcId());
+                ni.setDescription(eni.getDescription());
+                ni.setOwnerId(eni.getOwnerId());
+                ni.setStatus(eni.getStatus());
+                ni.setMacAddress(eni.getMacAddress());
+                ni.setPrivateIpAddress(eni.getPrivateIpAddress());
+                ni.setPrivateDnsName(eni.getPrivateDnsName());
+                ni.setSourceDestCheck(eni.isSourceDestCheck());
+                ni.setGroups(new ArrayList<>(eni.getGroups()));
+                // Phase 3: availability zone, tags, interface type
+                if (inst.getPlacement() != null) {
+                    ni.setAvailabilityZone(inst.getPlacement().getAvailabilityZone());
+                }
+                ni.getTagSet().addAll(inst.getTags());
+
+                NetworkInterfaceAttachment att = new NetworkInterfaceAttachment();
+                att.setAttachmentId(eni.getAttachmentId());
+                att.setDeviceIndex(eni.getDeviceIndex());
+                att.setStatus("attached");
+                att.setInstanceId(inst.getInstanceId());
+                att.setInstanceOwnerId(eni.getOwnerId());
+                // Phase 3: attachTime from instance launchTime, deleteOnTermination
+                if (inst.getLaunchTime() != null) {
+                    att.setAttachTime(ISO_FMT.format(inst.getLaunchTime()));
+                }
+                att.setDeleteOnTermination(true);
+                ni.setAttachment(att);
+
+                // Phase 3: privateIpAddressesSet — primary IP
+                NetworkInterfacePrivateIpAddress primaryIp = new NetworkInterfacePrivateIpAddress();
+                primaryIp.setPrivateIpAddress(eni.getPrivateIpAddress());
+                primaryIp.setPrivateDnsName(eni.getPrivateDnsName());
+                primaryIp.setPrimary(true);
+                // Look up EIP association for this instance
+                addressForInstance(inst.getInstanceId()).ifPresent(addr -> {
+                    NetworkInterfaceAssociation assoc = new NetworkInterfaceAssociation();
+                    assoc.setPublicIp(addr.getPublicIp());
+                    assoc.setAllocationId(addr.getAllocationId());
+                    assoc.setAssociationId(addr.getAssociationId());
+                    assoc.setIpOwnerId(eni.getOwnerId());
+                    primaryIp.setAssociation(assoc);
+                });
+                ni.getPrivateIpAddresses().add(primaryIp);
+
+                result.add(ni);
+            }
+        }
+        return result;
+    }
+
+    private Optional<Address> addressForInstance(String instanceId) {
+        return addresses.values().stream()
+                .filter(a -> instanceId.equals(a.getInstanceId()) && a.getAssociationId() != null)
+                .findFirst();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1,10 +1,13 @@
 package io.github.hectorvent.floci.services.ec2;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +33,7 @@ import io.github.hectorvent.floci.services.ec2.model.InstanceState;
 import io.github.hectorvent.floci.services.ec2.model.NetworkInterface;
 import io.github.hectorvent.floci.services.ec2.model.NetworkInterfaceAssociation;
 import io.github.hectorvent.floci.services.ec2.model.NetworkInterfaceAttachment;
+import io.github.hectorvent.floci.services.ec2.model.NetworkInterfaceListResult;
 import io.github.hectorvent.floci.services.ec2.model.NetworkInterfacePrivateIpAddress;
 import io.github.hectorvent.floci.services.ec2.model.InternetGateway;
 import io.github.hectorvent.floci.services.ec2.model.InternetGatewayAttachment;
@@ -1500,10 +1504,32 @@ public class Ec2Service {
 
     // ─── Network Interfaces ─────────────────────────────────────────────────────
 
-    public List<NetworkInterface> describeNetworkInterfaces(String region, List<String> networkInterfaceIds,
-                                                              Map<String, List<String>> filters) {
+    public NetworkInterfaceListResult describeNetworkInterfaces(String region, List<String> networkInterfaceIds,
+                                                                   Map<String, List<String>> filters,
+                                                                   int maxResults, String nextToken) {
+        // Validate pagination parameters
+        if (maxResults > 0 && !networkInterfaceIds.isEmpty()) {
+            throw new AwsException("InvalidParameterCombination",
+                    "The parameter NetworkInterfaceId cannot be used with the parameter MaxResults.", 400);
+        }
+        if (maxResults > 0 && (maxResults < 5 || maxResults > 1000)) {
+            throw new AwsException("InvalidParameterValue",
+                    "Value (" + maxResults + ") for parameter MaxResults is invalid. "
+                            + "Expecting a value between 5 and 1000.", 400);
+        }
+        int offset = decodeToken(nextToken);
+
+        // Phase 6: validate NetworkInterfaceId format
+        for (String id : networkInterfaceIds) {
+            if (!id.startsWith("eni-")) {
+                throw new AwsException("InvalidNetworkInterfaceID.Malformed",
+                        "Invalid id: \"" + id + "\" (expecting \"eni-...\")", 400);
+            }
+        }
+
         ensureDefaultResources(region);
         List<NetworkInterface> result = new ArrayList<>();
+        Set<String> foundIds = new HashSet<>();
         for (Instance inst : instances.values()) {
             if (!inst.getRegion().equals(region)) continue;
             for (InstanceNetworkInterface eni : inst.getNetworkInterfaces()) {
@@ -1511,6 +1537,7 @@ public class Ec2Service {
                         && !networkInterfaceIds.contains(eni.getNetworkInterfaceId())) {
                     continue;
                 }
+                foundIds.add(eni.getNetworkInterfaceId());
                 NetworkInterface ni = new NetworkInterface();
                 ni.setNetworkInterfaceId(eni.getNetworkInterfaceId());
                 ni.setSubnetId(eni.getSubnetId());
@@ -1566,7 +1593,49 @@ public class Ec2Service {
                 result.add(ni);
             }
         }
-        return result;
+
+        // Phase 6: validate requested IDs exist
+        for (String id : networkInterfaceIds) {
+            if (!foundIds.contains(id)) {
+                throw new AwsException("InvalidNetworkInterfaceID.NotFound",
+                        "The network interface ID '" + id + "' does not exist", 400);
+            }
+        }
+
+        // Phase 5: pagination
+        if (maxResults > 0) {
+            int total = result.size();
+            int toIndex = Math.min(offset + maxResults, total);
+            List<NetworkInterface> page = (offset < total)
+                    ? result.subList(offset, toIndex)
+                    : Collections.emptyList();
+            String newNextToken = (toIndex < total)
+                    ? encodeToken(toIndex)
+                    : null;
+            return new NetworkInterfaceListResult(new ArrayList<>(page), newNextToken);
+        }
+
+        return new NetworkInterfaceListResult(result, null);
+    }
+
+    // ─── Pagination token encoding / decoding ──────────────────────────────────
+
+    private String encodeToken(int offset) {
+        String json = "{\"offset\":" + offset + "}";
+        return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private int decodeToken(String token) {
+        if (token == null || token.isEmpty()) return 0;
+        try {
+            String json = new String(Base64.getDecoder().decode(token), StandardCharsets.UTF_8);
+            int start = json.indexOf("\"offset\":") + 9;
+            int end = json.indexOf('}', start);
+            return Integer.parseInt(json.substring(start, end));
+        } catch (Exception e) {
+            throw new AwsException("InvalidParameterValue",
+                    "Invalid NextToken", 400);
+        }
     }
 
     private Optional<Address> addressForInstance(String instanceId) {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/NetworkInterface.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/NetworkInterface.java
@@ -1,0 +1,79 @@
+package io.github.hectorvent.floci.services.ec2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NetworkInterface {
+
+    private String networkInterfaceId;
+    private String subnetId;
+    private String vpcId;
+    private String description;
+    private String ownerId;
+    private String status = "in-use";
+    private String macAddress;
+    private String privateIpAddress;
+    private String privateDnsName;
+    private boolean sourceDestCheck = true;
+    private String availabilityZone;
+    private String interfaceType = "interface";
+    private List<GroupIdentifier> groups = new ArrayList<>();
+    private NetworkInterfaceAttachment attachment;
+    private List<Tag> tagSet = new ArrayList<>();
+    private List<NetworkInterfacePrivateIpAddress> privateIpAddresses = new ArrayList<>();
+
+    public NetworkInterface() {}
+
+    public String getNetworkInterfaceId() { return networkInterfaceId; }
+    public void setNetworkInterfaceId(String networkInterfaceId) { this.networkInterfaceId = networkInterfaceId; }
+
+    public String getSubnetId() { return subnetId; }
+    public void setSubnetId(String subnetId) { this.subnetId = subnetId; }
+
+    public String getVpcId() { return vpcId; }
+    public void setVpcId(String vpcId) { this.vpcId = vpcId; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getOwnerId() { return ownerId; }
+    public void setOwnerId(String ownerId) { this.ownerId = ownerId; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+
+    public String getMacAddress() { return macAddress; }
+    public void setMacAddress(String macAddress) { this.macAddress = macAddress; }
+
+    public String getPrivateIpAddress() { return privateIpAddress; }
+    public void setPrivateIpAddress(String privateIpAddress) { this.privateIpAddress = privateIpAddress; }
+
+    public String getPrivateDnsName() { return privateDnsName; }
+    public void setPrivateDnsName(String privateDnsName) { this.privateDnsName = privateDnsName; }
+
+    public boolean isSourceDestCheck() { return sourceDestCheck; }
+    public void setSourceDestCheck(boolean sourceDestCheck) { this.sourceDestCheck = sourceDestCheck; }
+
+    public List<GroupIdentifier> getGroups() { return groups; }
+    public void setGroups(List<GroupIdentifier> groups) { this.groups = groups; }
+
+    public String getAvailabilityZone() { return availabilityZone; }
+    public void setAvailabilityZone(String availabilityZone) { this.availabilityZone = availabilityZone; }
+
+    public String getInterfaceType() { return interfaceType; }
+    public void setInterfaceType(String interfaceType) { this.interfaceType = interfaceType; }
+
+    public NetworkInterfaceAttachment getAttachment() { return attachment; }
+    public void setAttachment(NetworkInterfaceAttachment attachment) { this.attachment = attachment; }
+
+    public List<Tag> getTagSet() { return tagSet; }
+    public void setTagSet(List<Tag> tagSet) { this.tagSet = tagSet; }
+
+    public List<NetworkInterfacePrivateIpAddress> getPrivateIpAddresses() { return privateIpAddresses; }
+    public void setPrivateIpAddresses(List<NetworkInterfacePrivateIpAddress> privateIpAddresses) { this.privateIpAddresses = privateIpAddresses; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/NetworkInterfaceAssociation.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/NetworkInterfaceAssociation.java
@@ -1,0 +1,36 @@
+package io.github.hectorvent.floci.services.ec2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NetworkInterfaceAssociation {
+
+    private String publicIp;
+    private String allocationId;
+    private String associationId;
+    private String ipOwnerId;
+    private String publicDnsName;
+    private String carrierIp;
+
+    public NetworkInterfaceAssociation() {}
+
+    public String getPublicIp() { return publicIp; }
+    public void setPublicIp(String publicIp) { this.publicIp = publicIp; }
+
+    public String getAllocationId() { return allocationId; }
+    public void setAllocationId(String allocationId) { this.allocationId = allocationId; }
+
+    public String getAssociationId() { return associationId; }
+    public void setAssociationId(String associationId) { this.associationId = associationId; }
+
+    public String getIpOwnerId() { return ipOwnerId; }
+    public void setIpOwnerId(String ipOwnerId) { this.ipOwnerId = ipOwnerId; }
+
+    public String getPublicDnsName() { return publicDnsName; }
+    public void setPublicDnsName(String publicDnsName) { this.publicDnsName = publicDnsName; }
+
+    public String getCarrierIp() { return carrierIp; }
+    public void setCarrierIp(String carrierIp) { this.carrierIp = carrierIp; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/NetworkInterfaceAttachment.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/NetworkInterfaceAttachment.java
@@ -1,0 +1,40 @@
+package io.github.hectorvent.floci.services.ec2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NetworkInterfaceAttachment {
+
+    private String attachmentId;
+    private int deviceIndex;
+    private String status = "attached";
+    private String instanceId;
+    private String instanceOwnerId;
+    private String attachTime;
+    private boolean deleteOnTermination = true;
+
+    public NetworkInterfaceAttachment() {}
+
+    public String getAttachmentId() { return attachmentId; }
+    public void setAttachmentId(String attachmentId) { this.attachmentId = attachmentId; }
+
+    public int getDeviceIndex() { return deviceIndex; }
+    public void setDeviceIndex(int deviceIndex) { this.deviceIndex = deviceIndex; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+
+    public String getInstanceId() { return instanceId; }
+    public void setInstanceId(String instanceId) { this.instanceId = instanceId; }
+
+    public String getInstanceOwnerId() { return instanceOwnerId; }
+    public void setInstanceOwnerId(String instanceOwnerId) { this.instanceOwnerId = instanceOwnerId; }
+
+    public String getAttachTime() { return attachTime; }
+    public void setAttachTime(String attachTime) { this.attachTime = attachTime; }
+
+    public boolean isDeleteOnTermination() { return deleteOnTermination; }
+    public void setDeleteOnTermination(boolean deleteOnTermination) { this.deleteOnTermination = deleteOnTermination; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/NetworkInterfaceListResult.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/NetworkInterfaceListResult.java
@@ -1,0 +1,18 @@
+package io.github.hectorvent.floci.services.ec2.model;
+
+import java.util.List;
+
+/**
+ * Result of paginated network interface listing.
+ *
+ * <p>Used by {@code DescribeNetworkInterfaces} to return a page of network interfaces
+ * along with a cursor token for fetching the next page.</p>
+ *
+ * @param networkInterfaces List of network interfaces for this page
+ * @param nextToken         Token for next page, or {@code null} if no more pages
+ * @see <a href="https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeNetworkInterfaces.html">AWS EC2 DescribeNetworkInterfaces</a>
+ */
+public record NetworkInterfaceListResult(
+    List<NetworkInterface> networkInterfaces,
+    String nextToken
+) {}

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/NetworkInterfacePrivateIpAddress.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/NetworkInterfacePrivateIpAddress.java
@@ -1,0 +1,28 @@
+package io.github.hectorvent.floci.services.ec2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NetworkInterfacePrivateIpAddress {
+
+    private String privateIpAddress;
+    private String privateDnsName;
+    private boolean primary;
+    private NetworkInterfaceAssociation association;
+
+    public NetworkInterfacePrivateIpAddress() {}
+
+    public String getPrivateIpAddress() { return privateIpAddress; }
+    public void setPrivateIpAddress(String privateIpAddress) { this.privateIpAddress = privateIpAddress; }
+
+    public String getPrivateDnsName() { return privateDnsName; }
+    public void setPrivateDnsName(String privateDnsName) { this.privateDnsName = privateDnsName; }
+
+    public boolean isPrimary() { return primary; }
+    public void setPrimary(boolean primary) { this.primary = primary; }
+
+    public NetworkInterfaceAssociation getAssociation() { return association; }
+    public void setAssociation(NetworkInterfaceAssociation association) { this.association = association; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -917,6 +917,112 @@ class Ec2IntegrationTest {
     }
 
     // =========================================================================
+    // Network Interfaces — Filter tests (Phase 4)
+    // =========================================================================
+
+    @Test
+    @Order(92)
+    void describeNetworkInterfacesFilterBySubnetId() {
+        given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("Filter.1.Name", "subnet-id")
+            .formParam("Filter.1.Value.1", subnetId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item.size()",
+                    greaterThanOrEqualTo(1))
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].subnetId",
+                    equalTo(subnetId));
+    }
+
+    @Test
+    @Order(92)
+    void describeNetworkInterfacesFilterByVpcId() {
+        given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("Filter.1.Name", "vpc-id")
+            .formParam("Filter.1.Value.1", vpcId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item.size()",
+                    greaterThanOrEqualTo(1))
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].vpcId",
+                    equalTo(vpcId));
+    }
+
+    @Test
+    @Order(92)
+    void describeNetworkInterfacesFilterByGroupId() {
+        given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("Filter.1.Name", "group-id")
+            .formParam("Filter.1.Value.1", securityGroupId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item.size()",
+                    greaterThanOrEqualTo(1));
+    }
+
+    @Test
+    @Order(92)
+    void describeNetworkInterfacesFilterByStatus() {
+        given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("Filter.1.Name", "status")
+            .formParam("Filter.1.Value.1", "in-use")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item.size()",
+                    greaterThanOrEqualTo(1))
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].status",
+                    equalTo("in-use"));
+    }
+
+    @Test
+    @Order(92)
+    void describeNetworkInterfacesFilterByTag() {
+        given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("Filter.1.Name", "tag:Name")
+            .formParam("Filter.1.Value.1", "test-instance")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item.size()",
+                    greaterThanOrEqualTo(1));
+    }
+
+    @Test
+    @Order(92)
+    void describeNetworkInterfacesFilterNoMatch() {
+        given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("Filter.1.Name", "status")
+            .formParam("Filter.1.Value.1", "available")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item.size()",
+                    equalTo(0));
+    }
+
+    // =========================================================================
     // Volumes
     // =========================================================================
 

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -34,6 +34,7 @@ class Ec2IntegrationTest {
     private static String allocationId;
     private static String associationId;
     private static String volumeId;
+    private static String networkInterfaceId;
 
     // =========================================================================
     // Default resources
@@ -733,6 +734,71 @@ class Ec2IntegrationTest {
     }
 
     // =========================================================================
+    // Network Interfaces
+    // =========================================================================
+
+    @Test
+    @Order(79)
+    void describeNetworkInterfacesBeforeRun() {
+        // Before any instances exist, the set should be empty
+        given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item.size()", equalTo(0));
+    }
+
+    @Test
+    @Order(88)
+    void describeNetworkInterfacesAfterRun() {
+        networkInterfaceId = given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item.size()", greaterThanOrEqualTo(1))
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].networkInterfaceId",
+                    startsWith("eni-"))
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].vpcId", notNullValue())
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].subnetId", notNullValue())
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].status", equalTo("in-use"))
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].privateIpAddress",
+                    notNullValue())
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].attachment.attachmentId",
+                    startsWith("eni-attach-"))
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].attachment.deviceIndex",
+                    equalTo("0"))
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].attachment.instanceId",
+                    notNullValue())
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].groupSet.item.size()",
+                    greaterThanOrEqualTo(1))
+            .extract().path("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].networkInterfaceId");
+    }
+
+    @Test
+    @Order(89)
+    void describeNetworkInterfacesByFilter() {
+        given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("NetworkInterfaceId.1", networkInterfaceId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item.size()", equalTo(1))
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].networkInterfaceId",
+                    equalTo(networkInterfaceId));
+    }
+
+    // =========================================================================
     // Tags
     // =========================================================================
 
@@ -810,6 +876,44 @@ class Ec2IntegrationTest {
         .then()
             .statusCode(200)
             .body("DescribeTagsResponse.tagSet.item.size()", equalTo(0));
+    }
+
+    @Test
+    @Order(92)
+    void describeNetworkInterfacesFullFields() {
+        // Phase 3: Full field coverage — privateIpAddressesSet, association, tagSet, enriched attachment
+        given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("NetworkInterfaceId.1", networkInterfaceId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            // availabilityZone from instance placement
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].availabilityZone",
+                    startsWith("us-east-1"))
+            // tagSet propagated from instance tags (created at Order 90)
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].tagSet.item[0].key",
+                    equalTo("Name"))
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].tagSet.item[0].value",
+                    equalTo("test-instance"))
+            // attachment: attachTime (from instance launchTime) and deleteOnTermination
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].attachment.attachTime",
+                    notNullValue())
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].attachment.deleteOnTermination",
+                    equalTo("true"))
+            // privateIpAddressesSet with primary IP and EIP association (from Order 84)
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0]." +
+                    "privateIpAddressesSet.item[0].privateIpAddress", notNullValue())
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0]." +
+                    "privateIpAddressesSet.item[0].primary", equalTo("true"))
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0]." +
+                    "privateIpAddressesSet.item[0].association.publicIp", notNullValue())
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0]." +
+                    "privateIpAddressesSet.item[0].association.allocationId",
+                    startsWith("eipalloc-"));
     }
 
     // =========================================================================

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -3,8 +3,12 @@ package io.github.hectorvent.floci.services.ec2;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.containsString;
+
+import java.util.List;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -1020,6 +1024,195 @@ class Ec2IntegrationTest {
             .statusCode(200)
             .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item.size()",
                     equalTo(0));
+    }
+
+    // =========================================================================
+    // Network Interfaces — Pagination (Phase 5)
+    // =========================================================================
+
+    @Test
+    @Order(92)
+    void describeNetworkInterfacesMaxResultsTooLow() {
+        given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("MaxResults", "4")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidParameterValue"));
+    }
+
+    @Test
+    @Order(92)
+    void describeNetworkInterfacesMaxResultsTooHigh() {
+        given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("MaxResults", "1001")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidParameterValue"));
+    }
+
+    @Test
+    @Order(92)
+    void describeNetworkInterfacesMaxResultsWithNetworkInterfaceId() {
+        given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("NetworkInterfaceId.1", networkInterfaceId)
+            .formParam("MaxResults", "5")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidParameterCombination"));
+    }
+
+    @Test
+    @Order(92)
+    void describeNetworkInterfacesInvalidNextToken() {
+        given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("NextToken", "invalid-token")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidParameterValue"));
+    }
+
+    @Test
+    @Order(92)
+    void describeNetworkInterfacesWithMaxResultsNoNextToken() {
+        // When MaxResults exceeds the number of available ENIs,
+        // all results are returned and nextToken is omitted.
+        // This test works regardless of how many instances exist
+        // (including zero, e.g. when run in isolation).
+        String body = given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("MaxResults", "5")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+        .extract().body().asString();
+
+        org.hamcrest.MatcherAssert.assertThat(body, not(containsString("<nextToken>")));
+    }
+
+    // =========================================================================
+    // Network Interfaces — Error Handling (Phase 6)
+    // =========================================================================
+
+    @Test
+    @Order(92)
+    void describeNetworkInterfacesNotFound() {
+        given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("NetworkInterfaceId.1", "eni-0000000000000dead")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidNetworkInterfaceID.NotFound"));
+    }
+
+    @Test
+    @Order(92)
+    void describeNetworkInterfacesMalformed() {
+        given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("NetworkInterfaceId.1", "not-an-eni-id")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidNetworkInterfaceID.Malformed"));
+    }
+
+    // =========================================================================
+    // Network Interfaces — Multipage Pagination (Phase 5 completion)
+    // =========================================================================
+    //
+    // Self-contained test: launches additional instances, tests full
+    // pagination cycle (MaxResults truncation + NextToken continuation),
+    // then terminates the extra instances. Does not affect other tests.
+
+    @Test
+    @Order(92)
+    void describeNetworkInterfacesMultipagePagination() {
+        // ── Launch 5 additional instances to have 6 total ENIs ──
+        List<String> batchIds = given()
+            .formParam("Action", "RunInstances")
+            .formParam("ImageId", "ami-0abcdef1234567890")
+            .formParam("InstanceType", "t2.micro")
+            .formParam("MinCount", "5")
+            .formParam("MaxCount", "5")
+            .formParam("KeyName", "test-key")
+            .formParam("SubnetId", subnetId)
+            .formParam("SecurityGroupId.1", securityGroupId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+        .extract().xmlPath().getList("RunInstancesResponse.instancesSet.item.instanceId", String.class);
+
+        assert batchIds.size() == 5 : "Expected 5 new instances, got " + batchIds.size();
+
+        // ── Page 1: MaxResults=5, expect 5 ENIs + nextToken ──
+        String nextToken = given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("MaxResults", "5")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item.size()", equalTo(5))
+            .body("DescribeNetworkInterfacesResponse.nextToken", notNullValue())
+        .extract().path("DescribeNetworkInterfacesResponse.nextToken");
+
+        assert nextToken != null && !nextToken.isEmpty() : "Expected non-empty nextToken on truncated page";
+
+        // ── Page 2: use NextToken, expect remaining ENIs, no nextToken ──
+        String body = given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("MaxResults", "5")
+            .formParam("NextToken", nextToken)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item.size()",
+                    org.hamcrest.Matchers.greaterThanOrEqualTo(1))
+        .extract().body().asString();
+
+        // Final page must NOT contain a nextToken element
+        org.hamcrest.MatcherAssert.assertThat(body,
+                not(containsString("<nextToken>")));
+
+        // ── Cleanup: terminate the 5 extra instances ──
+        for (String id : batchIds) {
+            given()
+                .formParam("Action", "TerminateInstances")
+                .formParam("InstanceId.1", id)
+                .header("Authorization", AUTH_HEADER)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+        }
     }
 
     // =========================================================================

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -1041,7 +1041,7 @@ class Ec2IntegrationTest {
             .post("/")
         .then()
             .statusCode(400)
-            .body("Response.Errors.Error.Code", equalTo("InvalidParameterValue"));
+            .body("Response.Errors.Error.Code", equalTo("InvalidMaxResults"));
     }
 
     @Test
@@ -1055,7 +1055,21 @@ class Ec2IntegrationTest {
             .post("/")
         .then()
             .statusCode(400)
-            .body("Response.Errors.Error.Code", equalTo("InvalidParameterValue"));
+            .body("Response.Errors.Error.Code", equalTo("InvalidMaxResults"));
+    }
+
+    @Test
+    @Order(92)
+    void describeNetworkInterfacesMaxResultsNonNumeric() {
+        given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("MaxResults", "abc")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidMaxResults"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Implements EC2 `DescribeNetworkInterfaces` support to unblock Terraform destroy flows for VPC networking resources.

Closes #1031

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Before this change, `DescribeNetworkInterfaces` returned `UnsupportedOperation`, which caused Terraform AWS provider destroy operations to fail when deleting subnets, security groups, and VPCs. Terraform calls `DescribeNetworkInterfaces` as a safety check before deleting networking resources.

This PR adds `DescribeNetworkInterfaces` support with:

- empty `networkInterfaceSet` response when no ENIs exist
- ENI responses derived from launched EC2 instance network interfaces
- common filters including subnet, VPC, security group, status, private IP, and tags
- pagination with `MaxResults` / `NextToken`
- AWS-compatible validation for `MaxResults`, including `InvalidMaxResults`
- `InvalidParameterCombination` when `NetworkInterfaceId` is combined with `MaxResults`

Verified with:

- Java EC2 integration tests
- AWS SDK Java pagination compatibility test
- Terraform compatibility test covering VPC/subnet/security group create + destroy

## Checklist

- [X] `./mvnw test` passes locally (for related tests, there are other non-related failures)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
