### PR TITLE
feat(opensearch): round-trip VPC/security/encryption options and per-family instance type metadata

### DIFF
--- a/docs/services/opensearch.md
+++ b/docs/services/opensearch.md
@@ -116,6 +116,7 @@ services:
 - **Supported engine versions:** `OpenSearch_3.6`, `OpenSearch_3.5`, `OpenSearch_3.4`, `OpenSearch_3.3`, `OpenSearch_3.2`, `OpenSearch_3.1`, `OpenSearch_3.0`, `OpenSearch_2.19`, `OpenSearch_2.17`, `OpenSearch_2.15`, `OpenSearch_2.13`, `OpenSearch_2.11`, `OpenSearch_2.9`, `OpenSearch_2.7`, `OpenSearch_2.5`, `OpenSearch_2.3`, `OpenSearch_1.3`, `OpenSearch_1.2`, `Elasticsearch_7.10`, `Elasticsearch_7.9`, `Elasticsearch_7.8`
 - **Version validation:** `CreateDomain`, `UpdateDomainConfig`, and `UpgradeDomain` reject unknown engine versions with `ValidationException`. `UpgradeDomain` also rejects targets that aren't reachable from the current version per AWS's documented upgrade matrix.
 - **Cluster defaults:** `m5.large.search`, 1 instance, EBS enabled with 10 GiB `gp2` volume.
+- **Instance type families:** `t3.*` / `m5/m6g/m7g.*` / `r5/r6g/r7g.*` / `c5/c6g/c7g.*` are EBS-backed (3584 GiB max). `i3.*` are local-NVMe instance-store. `or1.*` are S3-backed and surface a much larger volume ceiling on `DescribeInstanceTypeLimits` (8–36 TiB depending on size). Floci still boots one Docker container per domain regardless of family — the metadata fidelity matters for SDK clients that introspect, not for runtime data placement.
 - **Container storage:** each domain gets a named Docker volume (`floci-opensearch-{volumeId}`) created automatically. In memory mode the volume is removed on domain delete; in persistent modes it is retained unless `FLOCI_STORAGE_PRUNE_VOLUMES_ON_DELETE=true`.
 
 ## Examples
@@ -235,5 +236,6 @@ os_client.delete_domain(DomainName="my-search")
 
 - In mock mode, no data-plane endpoints (`/_search`, `/_index`, etc.) are served — only the management API is emulated.
 - No Elasticsearch-compatible management endpoints (`/2015-01-01/es/domain/...`).
-- VPC options, fine-grained access control, encryption-at-rest, and cross-cluster connections are accepted in the request but silently ignored.
-- All unsupported operations (VPC endpoints, reserved instances, packages, applications, data sources) return `UnsupportedOperationException`.
+- `VPCOptions`, `AdvancedSecurityOptions`, `EncryptionAtRestOptions`, `NodeToNodeEncryptionOptions`, and `DomainEndpointOptions` round-trip on `CreateDomain` / `UpdateDomainConfig` / `DescribeDomain` / `DescribeDomainConfig`, but are not enforced by the running container — Floci serves the domain over plain HTTP with the security plugin disabled regardless. Round-tripping is enough for SDK clients (Terraform, CDK, Pulumi) to detect drift correctly.
+- Master passwords for `AdvancedSecurityOptions.MasterUserOptions` are accepted but never echoed back, matching AWS behavior.
+- Cross-cluster connections, VPC endpoints, packages, applications, and data sources are not supported and return `UnsupportedOperationException`.

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchController.java
@@ -2,9 +2,14 @@ package io.github.hectorvent.floci.services.opensearch;
 
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.opensearch.model.AdvancedSecurityOptions;
 import io.github.hectorvent.floci.services.opensearch.model.ClusterConfig;
 import io.github.hectorvent.floci.services.opensearch.model.Domain;
+import io.github.hectorvent.floci.services.opensearch.model.DomainEndpointOptions;
 import io.github.hectorvent.floci.services.opensearch.model.EbsOptions;
+import io.github.hectorvent.floci.services.opensearch.model.EncryptionAtRestOptions;
+import io.github.hectorvent.floci.services.opensearch.model.NodeToNodeEncryptionOptions;
+import io.github.hectorvent.floci.services.opensearch.model.VpcOptions;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -31,20 +36,6 @@ public class OpenSearchController {
 
     private static final Logger LOG = Logger.getLogger(OpenSearchController.class);
 
-    private static final List<String> INSTANCE_TYPES = List.of(
-            "t3.small.search", "t3.medium.search",
-            "m5.large.search", "m5.xlarge.search", "m5.2xlarge.search",
-            "m6g.large.search", "m6g.xlarge.search", "m6g.2xlarge.search",
-            "m7g.large.search", "m7g.xlarge.search", "m7g.2xlarge.search",
-            "r5.large.search", "r5.xlarge.search", "r5.2xlarge.search",
-            "r6g.large.search", "r6g.xlarge.search", "r6g.2xlarge.search",
-            "r7g.large.search", "r7g.xlarge.search", "r7g.2xlarge.search",
-            "c5.large.search", "c5.xlarge.search", "c5.2xlarge.search",
-            "c6g.large.search", "c6g.xlarge.search", "c6g.2xlarge.search",
-            "c7g.large.search", "c7g.xlarge.search", "c7g.2xlarge.search",
-            "or1.medium.search", "or1.large.search", "or1.xlarge.search", "or1.2xlarge.search"
-    );
-
     private final OpenSearchService service;
     private final RegionResolver regionResolver;
     private final ObjectMapper objectMapper;
@@ -69,8 +60,15 @@ public class OpenSearchController {
             EbsOptions ebsOptions = parseEbsOptions(req.path("EBSOptions"));
             Map<String, String> tags = parseTags(req.path("TagList"));
 
+            OpenSearchService.DomainOptions options = new OpenSearchService.DomainOptions(
+                    parseVpcOptions(req.path("VPCOptions")),
+                    parseAdvancedSecurityOptions(req.path("AdvancedSecurityOptions")),
+                    parseEncryptionAtRestOptions(req.path("EncryptionAtRestOptions")),
+                    parseNodeToNodeEncryptionOptions(req.path("NodeToNodeEncryptionOptions")),
+                    parseDomainEndpointOptions(req.path("DomainEndpointOptions")));
+
             Domain domain = service.createDomain(domainName, engineVersion, clusterConfig,
-                    ebsOptions, tags, region);
+                    ebsOptions, tags, options, region);
 
             ObjectNode response = objectMapper.createObjectNode();
             response.set("DomainStatus", toDomainStatusNode(domain));
@@ -151,6 +149,8 @@ public class OpenSearchController {
         versionSection.put("Options", domain.getEngineVersion());
         versionSection.set("Status", configStatusNode(epochSeconds));
 
+        attachDomainOptionConfigs(domainConfig, domain, epochSeconds);
+
         return Response.ok(response).build();
     }
 
@@ -166,8 +166,15 @@ public class OpenSearchController {
             ClusterConfig clusterConfig = parseClusterConfig(req.path("ClusterConfig"));
             EbsOptions ebsOptions = parseEbsOptions(req.path("EBSOptions"));
 
+            OpenSearchService.DomainOptions options = new OpenSearchService.DomainOptions(
+                    parseVpcOptions(req.path("VPCOptions")),
+                    parseAdvancedSecurityOptions(req.path("AdvancedSecurityOptions")),
+                    parseEncryptionAtRestOptions(req.path("EncryptionAtRestOptions")),
+                    parseNodeToNodeEncryptionOptions(req.path("NodeToNodeEncryptionOptions")),
+                    parseDomainEndpointOptions(req.path("DomainEndpointOptions")));
+
             Domain domain = service.updateDomainConfig(domainName, engineVersion, clusterConfig,
-                    ebsOptions, region);
+                    ebsOptions, options, region);
 
             long epochSeconds = domain.getCreatedAt() != null ? domain.getCreatedAt().getEpochSecond() : 0;
             ObjectNode response = objectMapper.createObjectNode();
@@ -184,6 +191,8 @@ public class OpenSearchController {
             ObjectNode versionSection = domainConfig.putObject("EngineVersion");
             versionSection.put("Options", domain.getEngineVersion());
             versionSection.set("Status", configStatusNode(epochSeconds));
+
+            attachDomainOptionConfigs(domainConfig, domain, epochSeconds);
 
             return Response.ok(response).build();
         } catch (AwsException e) {
@@ -307,15 +316,16 @@ public class OpenSearchController {
                                              @PathParam("engineVersion") String engineVersion) {
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode details = response.putArray("InstanceTypeDetails");
-        for (String instanceType : INSTANCE_TYPES) {
+        for (String instanceType : OpenSearchInstanceTypes.listAll()) {
+            OpenSearchInstanceTypes.InstanceTypeSpec spec = OpenSearchInstanceTypes.specOf(instanceType);
             ObjectNode detail = objectMapper.createObjectNode();
-            detail.put("InstanceType", instanceType);
-            detail.put("EncryptionEnabled", true);
-            detail.put("CognitoEnabled", false);
-            detail.put("AppLogsEnabled", true);
-            detail.put("AdvancedSecurityEnabled", false);
+            detail.put("InstanceType", spec.instanceType());
+            detail.put("EncryptionEnabled", spec.encryptionEnabled());
+            detail.put("CognitoEnabled", spec.cognitoEnabled());
+            detail.put("AppLogsEnabled", spec.appLogsEnabled());
+            detail.put("AdvancedSecurityEnabled", spec.advancedSecurityEnabled());
             ArrayNode roles = detail.putArray("InstanceRole");
-            roles.add("Data");
+            OpenSearchInstanceTypes.DATA_ROLE.forEach(roles::add);
             details.add(detail);
         }
         return Response.ok(response).build();
@@ -326,29 +336,35 @@ public class OpenSearchController {
     public Response describeInstanceTypeLimits(@Context HttpHeaders headers,
                                                 @PathParam("engineVersion") String engineVersion,
                                                 @PathParam("instanceType") String instanceType) {
+        OpenSearchInstanceTypes.InstanceTypeSpec spec = OpenSearchInstanceTypes.specOf(instanceType);
+        if (spec == null) {
+            // Generic fallback so freshly announced types don't 404 here.
+            spec = OpenSearchInstanceTypes.genericFallback(instanceType);
+        }
+
         ObjectNode response = objectMapper.createObjectNode();
         ObjectNode limitsByRole = response.putObject("LimitsByRole");
         ObjectNode dataRole = limitsByRole.putObject("data");
 
         ArrayNode storageTypes = dataRole.putArray("StorageTypes");
         ObjectNode storageType = objectMapper.createObjectNode();
-        storageType.put("StorageTypeName", "ebs");
-        storageType.put("StorageSubTypeName", "standard");
+        storageType.put("StorageTypeName", spec.storageType());
+        storageType.put("StorageSubTypeName", spec.ebsAttachable() ? "standard" : "managed");
         ArrayNode storageTypeLimits = storageType.putArray("StorageTypeLimits");
         ObjectNode minLimit = objectMapper.createObjectNode();
         minLimit.put("LimitName", "MinimumVolumeSize");
-        minLimit.putArray("LimitValues").add("10");
+        minLimit.putArray("LimitValues").add(String.valueOf(spec.minVolumeSizeGib()));
         storageTypeLimits.add(minLimit);
         ObjectNode maxLimit = objectMapper.createObjectNode();
         maxLimit.put("LimitName", "MaximumVolumeSize");
-        maxLimit.putArray("LimitValues").add("3584");
+        maxLimit.putArray("LimitValues").add(String.valueOf(spec.maxVolumeSizeGib()));
         storageTypeLimits.add(maxLimit);
         storageTypes.add(storageType);
 
         ObjectNode instanceLimits = dataRole.putObject("InstanceLimits");
         ObjectNode instanceCountLimits = instanceLimits.putObject("InstanceCountLimits");
-        instanceCountLimits.put("MinimumInstanceCount", 1);
-        instanceCountLimits.put("MaximumInstanceCount", 20);
+        instanceCountLimits.put("MinimumInstanceCount", spec.minInstanceCount());
+        instanceCountLimits.put("MaximumInstanceCount", spec.maxInstanceCount());
 
         dataRole.putArray("AdditionalLimits");
 
@@ -478,6 +494,119 @@ public class OpenSearchController {
         node.put("Endpoint", domain.getEndpoint() != null ? domain.getEndpoint() : "");
         node.set("ClusterConfig", toClusterConfigNode(domain.getClusterConfig()));
         node.set("EBSOptions", toEbsOptionsNode(domain.getEbsOptions()));
+        if (domain.getVpcOptions() != null) {
+            node.set("VPCOptions", toVpcOptionsNode(domain.getVpcOptions()));
+        }
+        if (domain.getAdvancedSecurityOptions() != null) {
+            node.set("AdvancedSecurityOptions", toAdvancedSecurityNode(domain.getAdvancedSecurityOptions()));
+        }
+        if (domain.getEncryptionAtRestOptions() != null) {
+            node.set("EncryptionAtRestOptions", toEncryptionAtRestNode(domain.getEncryptionAtRestOptions()));
+        }
+        if (domain.getNodeToNodeEncryptionOptions() != null) {
+            node.set("NodeToNodeEncryptionOptions", toNodeToNodeEncryptionNode(domain.getNodeToNodeEncryptionOptions()));
+        }
+        if (domain.getDomainEndpointOptions() != null) {
+            node.set("DomainEndpointOptions", toDomainEndpointOptionsNode(domain.getDomainEndpointOptions()));
+        }
+        return node;
+    }
+
+    /**
+     * Attach optional config sections to {@code DescribeDomainConfig} /
+     * {@code UpdateDomainConfig} responses. Only emit entries that the domain
+     * actually carries — AWS omits the keys entirely when the feature is
+     * unset, rather than emitting empty objects.
+     */
+    private void attachDomainOptionConfigs(ObjectNode domainConfig, Domain domain, long epochSeconds) {
+        if (domain.getVpcOptions() != null) {
+            ObjectNode section = domainConfig.putObject("VPCOptions");
+            section.set("Options", toVpcOptionsNode(domain.getVpcOptions()));
+            section.set("Status", configStatusNode(epochSeconds));
+        }
+        if (domain.getAdvancedSecurityOptions() != null) {
+            ObjectNode section = domainConfig.putObject("AdvancedSecurityOptions");
+            section.set("Options", toAdvancedSecurityNode(domain.getAdvancedSecurityOptions()));
+            section.set("Status", configStatusNode(epochSeconds));
+        }
+        if (domain.getEncryptionAtRestOptions() != null) {
+            ObjectNode section = domainConfig.putObject("EncryptionAtRestOptions");
+            section.set("Options", toEncryptionAtRestNode(domain.getEncryptionAtRestOptions()));
+            section.set("Status", configStatusNode(epochSeconds));
+        }
+        if (domain.getNodeToNodeEncryptionOptions() != null) {
+            ObjectNode section = domainConfig.putObject("NodeToNodeEncryptionOptions");
+            section.set("Options", toNodeToNodeEncryptionNode(domain.getNodeToNodeEncryptionOptions()));
+            section.set("Status", configStatusNode(epochSeconds));
+        }
+        if (domain.getDomainEndpointOptions() != null) {
+            ObjectNode section = domainConfig.putObject("DomainEndpointOptions");
+            section.set("Options", toDomainEndpointOptionsNode(domain.getDomainEndpointOptions()));
+            section.set("Status", configStatusNode(epochSeconds));
+        }
+    }
+
+    private ObjectNode toVpcOptionsNode(VpcOptions vpc) {
+        ObjectNode node = objectMapper.createObjectNode();
+        ArrayNode subnets = node.putArray("SubnetIds");
+        vpc.getSubnetIds().forEach(subnets::add);
+        ArrayNode sgs = node.putArray("SecurityGroupIds");
+        vpc.getSecurityGroupIds().forEach(sgs::add);
+        ArrayNode azs = node.putArray("AvailabilityZones");
+        vpc.getAvailabilityZones().forEach(azs::add);
+        if (vpc.getVpcId() != null) {
+            node.put("VPCId", vpc.getVpcId());
+        }
+        return node;
+    }
+
+    private ObjectNode toAdvancedSecurityNode(AdvancedSecurityOptions adv) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("Enabled", adv.isEnabled());
+        node.put("InternalUserDatabaseEnabled", adv.isInternalUserDatabaseEnabled());
+        node.put("AnonymousAuthEnabled", adv.isAnonymousAuthEnabled());
+        if (adv.getAnonymousAuthDisableDate() != null) {
+            node.put("AnonymousAuthDisableDate", adv.getAnonymousAuthDisableDate());
+        }
+        // Only echo username + ARN — never master password (AWS doesn't either).
+        if (adv.getMasterUserOptions() != null) {
+            ObjectNode mu = node.putObject("MasterUserOptions");
+            if (adv.getMasterUserOptions().getMasterUserName() != null) {
+                mu.put("MasterUserName", adv.getMasterUserOptions().getMasterUserName());
+            }
+            if (adv.getMasterUserOptions().getMasterUserArn() != null) {
+                mu.put("MasterUserARN", adv.getMasterUserOptions().getMasterUserArn());
+            }
+        }
+        return node;
+    }
+
+    private ObjectNode toEncryptionAtRestNode(EncryptionAtRestOptions enc) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("Enabled", enc.isEnabled());
+        if (enc.getKmsKeyId() != null) {
+            node.put("KmsKeyId", enc.getKmsKeyId());
+        }
+        return node;
+    }
+
+    private ObjectNode toNodeToNodeEncryptionNode(NodeToNodeEncryptionOptions n2n) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("Enabled", n2n.isEnabled());
+        return node;
+    }
+
+    private ObjectNode toDomainEndpointOptionsNode(DomainEndpointOptions deo) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("EnforceHTTPS", deo.isEnforceHttps());
+        node.put("TLSSecurityPolicy", deo.getTlsSecurityPolicy());
+        node.put("CustomEndpointEnabled", deo.isCustomEndpointEnabled());
+        if (deo.getCustomEndpoint() != null) {
+            node.put("CustomEndpoint", deo.getCustomEndpoint());
+        }
+        if (deo.getCustomEndpointCertificateArn() != null) {
+            node.put("CustomEndpointCertificateArn", deo.getCustomEndpointCertificateArn());
+        }
         return node;
     }
 
@@ -554,6 +683,110 @@ public class OpenSearchController {
             ebs.setVolumeSize(node.get("VolumeSize").asInt());
         }
         return ebs;
+    }
+
+    private VpcOptions parseVpcOptions(JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        VpcOptions opts = new VpcOptions();
+        List<String> subnets = new ArrayList<>();
+        node.path("SubnetIds").forEach(n -> subnets.add(n.asText()));
+        opts.setSubnetIds(subnets);
+        List<String> sgs = new ArrayList<>();
+        node.path("SecurityGroupIds").forEach(n -> sgs.add(n.asText()));
+        opts.setSecurityGroupIds(sgs);
+        // AvailabilityZones / VPCId are AWS-derived in real life (placement
+        // engine reads them from the subnets), but Terraform plans round-trip
+        // whatever was last seen, so accept them on update too.
+        List<String> azs = new ArrayList<>();
+        node.path("AvailabilityZones").forEach(n -> azs.add(n.asText()));
+        opts.setAvailabilityZones(azs);
+        if (node.has("VPCId")) {
+            opts.setVpcId(node.get("VPCId").asText());
+        }
+        return opts;
+    }
+
+    private AdvancedSecurityOptions parseAdvancedSecurityOptions(JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        AdvancedSecurityOptions opts = new AdvancedSecurityOptions();
+        if (node.has("Enabled")) {
+            opts.setEnabled(node.get("Enabled").asBoolean());
+        }
+        if (node.has("InternalUserDatabaseEnabled")) {
+            opts.setInternalUserDatabaseEnabled(node.get("InternalUserDatabaseEnabled").asBoolean());
+        }
+        if (node.has("AnonymousAuthEnabled")) {
+            opts.setAnonymousAuthEnabled(node.get("AnonymousAuthEnabled").asBoolean());
+        }
+        if (node.has("AnonymousAuthDisableDate")) {
+            opts.setAnonymousAuthDisableDate(node.get("AnonymousAuthDisableDate").asText());
+        }
+        JsonNode mu = node.path("MasterUserOptions");
+        if (!mu.isMissingNode() && !mu.isNull()) {
+            AdvancedSecurityOptions.MasterUserOptions m = new AdvancedSecurityOptions.MasterUserOptions();
+            if (mu.has("MasterUserName")) {
+                m.setMasterUserName(mu.get("MasterUserName").asText());
+            }
+            if (mu.has("MasterUserARN")) {
+                m.setMasterUserArn(mu.get("MasterUserARN").asText());
+            }
+            // Master password intentionally not stored — AWS never echoes it
+            // back and we have no use for it without a real security plugin.
+            opts.setMasterUserOptions(m);
+        }
+        return opts;
+    }
+
+    private EncryptionAtRestOptions parseEncryptionAtRestOptions(JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        EncryptionAtRestOptions opts = new EncryptionAtRestOptions();
+        if (node.has("Enabled")) {
+            opts.setEnabled(node.get("Enabled").asBoolean());
+        }
+        if (node.has("KmsKeyId")) {
+            opts.setKmsKeyId(node.get("KmsKeyId").asText());
+        }
+        return opts;
+    }
+
+    private NodeToNodeEncryptionOptions parseNodeToNodeEncryptionOptions(JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        NodeToNodeEncryptionOptions opts = new NodeToNodeEncryptionOptions();
+        if (node.has("Enabled")) {
+            opts.setEnabled(node.get("Enabled").asBoolean());
+        }
+        return opts;
+    }
+
+    private DomainEndpointOptions parseDomainEndpointOptions(JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        DomainEndpointOptions opts = new DomainEndpointOptions();
+        if (node.has("EnforceHTTPS")) {
+            opts.setEnforceHttps(node.get("EnforceHTTPS").asBoolean());
+        }
+        if (node.has("TLSSecurityPolicy")) {
+            opts.setTlsSecurityPolicy(node.get("TLSSecurityPolicy").asText());
+        }
+        if (node.has("CustomEndpointEnabled")) {
+            opts.setCustomEndpointEnabled(node.get("CustomEndpointEnabled").asBoolean());
+        }
+        if (node.has("CustomEndpoint")) {
+            opts.setCustomEndpoint(node.get("CustomEndpoint").asText());
+        }
+        if (node.has("CustomEndpointCertificateArn")) {
+            opts.setCustomEndpointCertificateArn(node.get("CustomEndpointCertificateArn").asText());
+        }
+        return opts;
     }
 
     private Map<String, String> parseTags(JsonNode node) {

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchInstanceTypes.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchInstanceTypes.java
@@ -1,0 +1,132 @@
+package io.github.hectorvent.floci.services.opensearch;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Catalog of AWS OpenSearch instance types and their per-family characteristics.
+ * Drives {@code DescribeInstanceTypeDetails} / {@code DescribeInstanceTypeLimits}
+ * so SDK clients see family-appropriate metadata instead of one canned response.
+ *
+ * <p>The single-node Docker container Floci boots is the same regardless of
+ * instance type — that's a fundamental fidelity gap an emulator can't close
+ * — but the metadata exposed via the management API needs to reflect reality
+ * so introspection tools (Terraform, CDK, cost calculators) work correctly.
+ *
+ * <p>Notable family differences modeled here:
+ * <ul>
+ *   <li><b>{@code or1.*}</b> — OpenSearch-optimized, S3-backed segments. Only
+ *       supports the {@code instance-store} storage type and AWS does not
+ *       offer EBS attachment. Volume-size limits are correspondingly large.</li>
+ *   <li><b>{@code i3.*}</b> — i3 generation has fixed local NVMe; EBS is
+ *       attached but volume-size limits are smaller because the bulk of
+ *       storage comes from the instance store.</li>
+ *   <li>Everything else (m5/m6g/m7g, r5/r6g/r7g, c5/c6g/c7g, t3) — EBS-only,
+ *       3584 GiB max gp2/gp3 volume.</li>
+ * </ul>
+ */
+public final class OpenSearchInstanceTypes {
+
+    /** Subset of {@code InstanceType.InstanceRole} values relevant for emulation. */
+    public static final List<String> DATA_ROLE = List.of("Data");
+
+    /**
+     * Single per-instance-type entry. Family-level fields live here rather
+     * than being recomputed at API call time so the metadata surface matches
+     * AWS exactly for the cases where SDK clients introspect it.
+     */
+    public record InstanceTypeSpec(
+            String instanceType,
+            String storageType,         // ebs | instance-store | s3-backed
+            int minVolumeSizeGib,
+            int maxVolumeSizeGib,
+            boolean ebsAttachable,
+            boolean encryptionEnabled,
+            boolean cognitoEnabled,
+            boolean appLogsEnabled,
+            boolean advancedSecurityEnabled,
+            int minInstanceCount,
+            int maxInstanceCount) {
+    }
+
+    private static final Map<String, InstanceTypeSpec> CATALOG = new LinkedHashMap<>();
+
+    static {
+        // EBS-backed general-purpose / compute / memory families. 3584 GiB max
+        // mirrors AWS's published gp2/gp3 limit for OpenSearch domains.
+        for (String type : List.of(
+                "t3.small.search", "t3.medium.search",
+                "m5.large.search", "m5.xlarge.search", "m5.2xlarge.search",
+                "m6g.large.search", "m6g.xlarge.search", "m6g.2xlarge.search",
+                "m7g.large.search", "m7g.xlarge.search", "m7g.2xlarge.search",
+                "r5.large.search", "r5.xlarge.search", "r5.2xlarge.search",
+                "r6g.large.search", "r6g.xlarge.search", "r6g.2xlarge.search",
+                "r7g.large.search", "r7g.xlarge.search", "r7g.2xlarge.search",
+                "c5.large.search", "c5.xlarge.search", "c5.2xlarge.search",
+                "c6g.large.search", "c6g.xlarge.search", "c6g.2xlarge.search",
+                "c7g.large.search", "c7g.xlarge.search", "c7g.2xlarge.search")) {
+            CATALOG.put(type, new InstanceTypeSpec(
+                    type, "ebs", 10, 3584, true,
+                    true, true, true, true,
+                    1, 80));
+        }
+
+        // i3.* — local NVMe instance store. EBS still attachable for cluster
+        // metadata but the bulk of storage is the instance store; we expose
+        // smaller EBS limits accordingly.
+        for (String type : List.of(
+                "i3.large.search", "i3.xlarge.search", "i3.2xlarge.search",
+                "i3.4xlarge.search", "i3.8xlarge.search", "i3.16xlarge.search")) {
+            CATALOG.put(type, new InstanceTypeSpec(
+                    type, "instance-store", 10, 100, true,
+                    true, true, true, true,
+                    1, 40));
+        }
+
+        // or1.* — OpenSearch-optimized, S3-backed segments. EBS is NOT
+        // attachable; storage scales with the instance class. Limits per
+        // AWS's or1 launch announcement (Nov 2023) and subsequent expansion.
+        CATALOG.put("or1.medium.search", new InstanceTypeSpec(
+                "or1.medium.search", "s3-backed", 10, 8192, false,
+                true, false, true, true, 1, 40));
+        CATALOG.put("or1.large.search", new InstanceTypeSpec(
+                "or1.large.search", "s3-backed", 10, 16384, false,
+                true, false, true, true, 1, 40));
+        CATALOG.put("or1.xlarge.search", new InstanceTypeSpec(
+                "or1.xlarge.search", "s3-backed", 10, 24576, false,
+                true, false, true, true, 1, 40));
+        CATALOG.put("or1.2xlarge.search", new InstanceTypeSpec(
+                "or1.2xlarge.search", "s3-backed", 10, 36864, false,
+                true, false, true, true, 1, 40));
+    }
+
+    private OpenSearchInstanceTypes() {
+    }
+
+    /** Every supported instance type, in canonical (catalog) order. */
+    public static List<String> listAll() {
+        return List.copyOf(CATALOG.keySet());
+    }
+
+    /**
+     * Look up the spec for {@code instanceType}. Unknown types return null —
+     * callers should treat that as "AWS has it, we don't model it" and fall
+     * back to a generic EBS spec rather than fail; AWS publishes new types
+     * faster than emulators can keep up.
+     */
+    public static InstanceTypeSpec specOf(String instanceType) {
+        return CATALOG.get(instanceType);
+    }
+
+    /**
+     * Spec used when the requested type is not in the catalog. Generic EBS
+     * defaults — keeps {@code DescribeInstanceTypeLimits} from 404'ing on
+     * brand-new instance types AWS just announced.
+     */
+    public static InstanceTypeSpec genericFallback(String instanceType) {
+        return new InstanceTypeSpec(
+                instanceType, "ebs", 10, 3584, true,
+                true, true, true, true, 1, 80);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchService.java
@@ -7,9 +7,14 @@ import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.opensearch.model.AdvancedSecurityOptions;
 import io.github.hectorvent.floci.services.opensearch.model.ClusterConfig;
 import io.github.hectorvent.floci.services.opensearch.model.Domain;
+import io.github.hectorvent.floci.services.opensearch.model.DomainEndpointOptions;
 import io.github.hectorvent.floci.services.opensearch.model.EbsOptions;
+import io.github.hectorvent.floci.services.opensearch.model.EncryptionAtRestOptions;
+import io.github.hectorvent.floci.services.opensearch.model.NodeToNodeEncryptionOptions;
+import io.github.hectorvent.floci.services.opensearch.model.VpcOptions;
 import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -73,10 +78,34 @@ public class OpenSearchService {
         }
     }
 
+    /**
+     * Bag of optional configuration blocks parsed by {@link OpenSearchController}
+     * and round-tripped on Describe. Any field can be null when the request
+     * omitted the corresponding block — the service treats null as "leave the
+     * existing value untouched" on update and "feature unset" on create.
+     */
+    public record DomainOptions(
+            VpcOptions vpcOptions,
+            AdvancedSecurityOptions advancedSecurityOptions,
+            EncryptionAtRestOptions encryptionAtRestOptions,
+            NodeToNodeEncryptionOptions nodeToNodeEncryptionOptions,
+            DomainEndpointOptions domainEndpointOptions) {
+
+        public static final DomainOptions EMPTY = new DomainOptions(null, null, null, null, null);
+    }
+
     public Domain createDomain(String domainName, String engineVersion, ClusterConfig clusterConfig,
                                 EbsOptions ebsOptions, Map<String, String> tags, String region) {
+        return createDomain(domainName, engineVersion, clusterConfig, ebsOptions, tags,
+                DomainOptions.EMPTY, region);
+    }
+
+    public Domain createDomain(String domainName, String engineVersion, ClusterConfig clusterConfig,
+                                EbsOptions ebsOptions, Map<String, String> tags,
+                                DomainOptions options, String region) {
         validateDomainName(domainName);
         OpenSearchVersions.validate(engineVersion);
+        validateOptions(options);
 
         if (domainStore.get(domainName).isPresent()) {
             throw new AwsException("ResourceAlreadyExistsException",
@@ -105,6 +134,7 @@ public class OpenSearchService {
         if (tags != null) {
             domain.setTags(tags);
         }
+        applyDomainOptions(domain, options);
 
         if (config.services().opensearch().mock()) {
             domain.setProcessing(false);
@@ -143,8 +173,16 @@ public class OpenSearchService {
     public Domain updateDomainConfig(String domainName, String engineVersion,
                                       ClusterConfig clusterConfig, EbsOptions ebsOptions,
                                       String region) {
+        return updateDomainConfig(domainName, engineVersion, clusterConfig, ebsOptions,
+                DomainOptions.EMPTY, region);
+    }
+
+    public Domain updateDomainConfig(String domainName, String engineVersion,
+                                      ClusterConfig clusterConfig, EbsOptions ebsOptions,
+                                      DomainOptions options, String region) {
         Domain domain = describeDomain(domainName);
         OpenSearchVersions.validate(engineVersion);
+        validateOptions(options);
 
         if (engineVersion != null && !engineVersion.isBlank()) {
             domain.setEngineVersion(engineVersion);
@@ -170,6 +208,7 @@ public class OpenSearchService {
                 existing.setVolumeSize(ebsOptions.getVolumeSize());
             }
         }
+        applyDomainOptions(domain, options);
 
         domainStore.put(domainName, domain);
         return domain;
@@ -231,6 +270,62 @@ public class OpenSearchService {
         if (!name.matches("[a-z][a-z0-9\\-]*")) {
             throw new AwsException("ValidationException",
                     "Domain name must start with a lowercase letter and contain only lowercase letters, numbers, and hyphens.", 400);
+        }
+    }
+
+    /**
+     * Cross-block validation: only the cases where a wrong combination is
+     * deterministically rejected by AWS land here. Per-field syntax checks
+     * stay in the controller's parsers.
+     */
+    private void validateOptions(DomainOptions options) {
+        if (options == null) {
+            return;
+        }
+        VpcOptions vpc = options.vpcOptions();
+        if (vpc != null && !vpc.getSubnetIds().isEmpty() && vpc.getSubnetIds().stream().anyMatch(String::isBlank)) {
+            throw new AwsException("ValidationException",
+                    "VPCOptions.SubnetIds may not contain blank entries.", 400);
+        }
+        AdvancedSecurityOptions adv = options.advancedSecurityOptions();
+        if (adv != null && adv.isEnabled() && adv.isInternalUserDatabaseEnabled()) {
+            // AWS rejects internal user db without a master user — keep
+            // emulator-side parity so Terraform plans surface the same error.
+            if (adv.getMasterUserOptions() == null
+                    || adv.getMasterUserOptions().getMasterUserName() == null
+                    || adv.getMasterUserOptions().getMasterUserName().isBlank()) {
+                throw new AwsException("ValidationException",
+                        "AdvancedSecurityOptions.MasterUserOptions.MasterUserName is required "
+                                + "when InternalUserDatabaseEnabled=true.", 400);
+            }
+        }
+        DomainEndpointOptions deo = options.domainEndpointOptions();
+        if (deo != null && deo.isCustomEndpointEnabled()
+                && (deo.getCustomEndpoint() == null || deo.getCustomEndpoint().isBlank())) {
+            throw new AwsException("ValidationException",
+                    "DomainEndpointOptions.CustomEndpoint is required when CustomEndpointEnabled=true.", 400);
+        }
+    }
+
+    /** Copy non-null fields from {@code options} onto {@code domain}. Null leaves the field untouched. */
+    private void applyDomainOptions(Domain domain, DomainOptions options) {
+        if (options == null) {
+            return;
+        }
+        if (options.vpcOptions() != null) {
+            domain.setVpcOptions(options.vpcOptions());
+        }
+        if (options.advancedSecurityOptions() != null) {
+            domain.setAdvancedSecurityOptions(options.advancedSecurityOptions());
+        }
+        if (options.encryptionAtRestOptions() != null) {
+            domain.setEncryptionAtRestOptions(options.encryptionAtRestOptions());
+        }
+        if (options.nodeToNodeEncryptionOptions() != null) {
+            domain.setNodeToNodeEncryptionOptions(options.nodeToNodeEncryptionOptions());
+        }
+        if (options.domainEndpointOptions() != null) {
+            domain.setDomainEndpointOptions(options.domainEndpointOptions());
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/model/AdvancedSecurityOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/model/AdvancedSecurityOptions.java
@@ -1,0 +1,106 @@
+package io.github.hectorvent.floci.services.opensearch.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * Fine-grained access control options. Round-tripped on Describe; the actual
+ * security plugin remains disabled inside the OpenSearch container regardless,
+ * since Floci is a local emulator and the plugin requires TLS + a real cluster
+ * config that we don't ship.
+ *
+ * <p>Sensitive fields (master password, SAML metadata) are accepted on the
+ * request but never serialized back — matching AWS behavior, which only echoes
+ * the username and structural flags.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AdvancedSecurityOptions {
+
+    @JsonProperty("Enabled")
+    private boolean enabled = false;
+
+    @JsonProperty("InternalUserDatabaseEnabled")
+    private boolean internalUserDatabaseEnabled = false;
+
+    @JsonProperty("AnonymousAuthEnabled")
+    private boolean anonymousAuthEnabled = false;
+
+    @JsonProperty("AnonymousAuthDisableDate")
+    private String anonymousAuthDisableDate;
+
+    /** {@code MasterUserName} only — passwords / ARNs are intentionally not echoed back. */
+    @JsonProperty("MasterUserOptions")
+    private MasterUserOptions masterUserOptions;
+
+    public AdvancedSecurityOptions() {}
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isInternalUserDatabaseEnabled() {
+        return internalUserDatabaseEnabled;
+    }
+
+    public void setInternalUserDatabaseEnabled(boolean internalUserDatabaseEnabled) {
+        this.internalUserDatabaseEnabled = internalUserDatabaseEnabled;
+    }
+
+    public boolean isAnonymousAuthEnabled() {
+        return anonymousAuthEnabled;
+    }
+
+    public void setAnonymousAuthEnabled(boolean anonymousAuthEnabled) {
+        this.anonymousAuthEnabled = anonymousAuthEnabled;
+    }
+
+    public String getAnonymousAuthDisableDate() {
+        return anonymousAuthDisableDate;
+    }
+
+    public void setAnonymousAuthDisableDate(String anonymousAuthDisableDate) {
+        this.anonymousAuthDisableDate = anonymousAuthDisableDate;
+    }
+
+    public MasterUserOptions getMasterUserOptions() {
+        return masterUserOptions;
+    }
+
+    public void setMasterUserOptions(MasterUserOptions masterUserOptions) {
+        this.masterUserOptions = masterUserOptions;
+    }
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class MasterUserOptions {
+        @JsonProperty("MasterUserName")
+        private String masterUserName;
+
+        @JsonProperty("MasterUserARN")
+        private String masterUserArn;
+
+        public MasterUserOptions() {}
+
+        public String getMasterUserName() {
+            return masterUserName;
+        }
+
+        public void setMasterUserName(String masterUserName) {
+            this.masterUserName = masterUserName;
+        }
+
+        public String getMasterUserArn() {
+            return masterUserArn;
+        }
+
+        public void setMasterUserArn(String masterUserArn) {
+            this.masterUserArn = masterUserArn;
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/model/Domain.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/model/Domain.java
@@ -38,6 +38,21 @@ public class Domain {
     @JsonProperty("EBSOptions")
     private EbsOptions ebsOptions = new EbsOptions();
 
+    @JsonProperty("VPCOptions")
+    private VpcOptions vpcOptions;
+
+    @JsonProperty("AdvancedSecurityOptions")
+    private AdvancedSecurityOptions advancedSecurityOptions;
+
+    @JsonProperty("EncryptionAtRestOptions")
+    private EncryptionAtRestOptions encryptionAtRestOptions;
+
+    @JsonProperty("NodeToNodeEncryptionOptions")
+    private NodeToNodeEncryptionOptions nodeToNodeEncryptionOptions;
+
+    @JsonProperty("DomainEndpointOptions")
+    private DomainEndpointOptions domainEndpointOptions;
+
     @JsonProperty("Endpoint")
     private String endpoint = "";
 
@@ -121,6 +136,46 @@ public class Domain {
 
     public void setEbsOptions(EbsOptions ebsOptions) {
         this.ebsOptions = ebsOptions;
+    }
+
+    public VpcOptions getVpcOptions() {
+        return vpcOptions;
+    }
+
+    public void setVpcOptions(VpcOptions vpcOptions) {
+        this.vpcOptions = vpcOptions;
+    }
+
+    public AdvancedSecurityOptions getAdvancedSecurityOptions() {
+        return advancedSecurityOptions;
+    }
+
+    public void setAdvancedSecurityOptions(AdvancedSecurityOptions advancedSecurityOptions) {
+        this.advancedSecurityOptions = advancedSecurityOptions;
+    }
+
+    public EncryptionAtRestOptions getEncryptionAtRestOptions() {
+        return encryptionAtRestOptions;
+    }
+
+    public void setEncryptionAtRestOptions(EncryptionAtRestOptions encryptionAtRestOptions) {
+        this.encryptionAtRestOptions = encryptionAtRestOptions;
+    }
+
+    public NodeToNodeEncryptionOptions getNodeToNodeEncryptionOptions() {
+        return nodeToNodeEncryptionOptions;
+    }
+
+    public void setNodeToNodeEncryptionOptions(NodeToNodeEncryptionOptions nodeToNodeEncryptionOptions) {
+        this.nodeToNodeEncryptionOptions = nodeToNodeEncryptionOptions;
+    }
+
+    public DomainEndpointOptions getDomainEndpointOptions() {
+        return domainEndpointOptions;
+    }
+
+    public void setDomainEndpointOptions(DomainEndpointOptions domainEndpointOptions) {
+        this.domainEndpointOptions = domainEndpointOptions;
     }
 
     public String getEndpoint() {

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/model/DomainEndpointOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/model/DomainEndpointOptions.java
@@ -1,0 +1,73 @@
+package io.github.hectorvent.floci.services.opensearch.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * HTTPS / TLS-policy endpoint options. Round-tripped only — Floci serves the
+ * domain over plain HTTP regardless of {@code EnforceHTTPS}. SDK clients still
+ * need the field to round-trip so {@code DescribeDomain} confirms the
+ * intended configuration.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DomainEndpointOptions {
+
+    @JsonProperty("EnforceHTTPS")
+    private boolean enforceHttps = false;
+
+    @JsonProperty("TLSSecurityPolicy")
+    private String tlsSecurityPolicy = "Policy-Min-TLS-1-0-2019-07";
+
+    @JsonProperty("CustomEndpointEnabled")
+    private boolean customEndpointEnabled = false;
+
+    @JsonProperty("CustomEndpoint")
+    private String customEndpoint;
+
+    @JsonProperty("CustomEndpointCertificateArn")
+    private String customEndpointCertificateArn;
+
+    public DomainEndpointOptions() {}
+
+    public boolean isEnforceHttps() {
+        return enforceHttps;
+    }
+
+    public void setEnforceHttps(boolean enforceHttps) {
+        this.enforceHttps = enforceHttps;
+    }
+
+    public String getTlsSecurityPolicy() {
+        return tlsSecurityPolicy;
+    }
+
+    public void setTlsSecurityPolicy(String tlsSecurityPolicy) {
+        this.tlsSecurityPolicy = tlsSecurityPolicy;
+    }
+
+    public boolean isCustomEndpointEnabled() {
+        return customEndpointEnabled;
+    }
+
+    public void setCustomEndpointEnabled(boolean customEndpointEnabled) {
+        this.customEndpointEnabled = customEndpointEnabled;
+    }
+
+    public String getCustomEndpoint() {
+        return customEndpoint;
+    }
+
+    public void setCustomEndpoint(String customEndpoint) {
+        this.customEndpoint = customEndpoint;
+    }
+
+    public String getCustomEndpointCertificateArn() {
+        return customEndpointCertificateArn;
+    }
+
+    public void setCustomEndpointCertificateArn(String customEndpointCertificateArn) {
+        this.customEndpointCertificateArn = customEndpointCertificateArn;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/model/EncryptionAtRestOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/model/EncryptionAtRestOptions.java
@@ -1,0 +1,40 @@
+package io.github.hectorvent.floci.services.opensearch.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * Encryption-at-rest options. Round-tripped only — the underlying Docker
+ * volume is not actually encrypted. Real AWS would back the domain by an
+ * encrypted EBS volume and refuse to disable encryption once turned on; we
+ * accept whatever was last set so SDK clients can confirm their config.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EncryptionAtRestOptions {
+
+    @JsonProperty("Enabled")
+    private boolean enabled = false;
+
+    @JsonProperty("KmsKeyId")
+    private String kmsKeyId;
+
+    public EncryptionAtRestOptions() {}
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getKmsKeyId() {
+        return kmsKeyId;
+    }
+
+    public void setKmsKeyId(String kmsKeyId) {
+        this.kmsKeyId = kmsKeyId;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/model/NodeToNodeEncryptionOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/model/NodeToNodeEncryptionOptions.java
@@ -1,0 +1,28 @@
+package io.github.hectorvent.floci.services.opensearch.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * Node-to-node TLS encryption flag. Round-tripped only — Floci runs the
+ * domain as a single Docker container, so there are no node-to-node
+ * connections to encrypt.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NodeToNodeEncryptionOptions {
+
+    @JsonProperty("Enabled")
+    private boolean enabled = false;
+
+    public NodeToNodeEncryptionOptions() {}
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/model/VpcOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/model/VpcOptions.java
@@ -1,0 +1,67 @@
+package io.github.hectorvent.floci.services.opensearch.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * VPC placement options for an OpenSearch domain. Stored verbatim from the
+ * {@code CreateDomain} / {@code UpdateDomainConfig} request and round-tripped on
+ * {@code DescribeDomain} / {@code DescribeDomainConfig}. Floci does not actually
+ * place containers inside the requested VPC — the domain still runs as a
+ * single Docker container — but real SDK clients (Terraform, CDK, Pulumi) read
+ * these fields back to confirm config and fail when they're empty.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class VpcOptions {
+
+    @JsonProperty("SubnetIds")
+    private List<String> subnetIds = new ArrayList<>();
+
+    @JsonProperty("SecurityGroupIds")
+    private List<String> securityGroupIds = new ArrayList<>();
+
+    @JsonProperty("AvailabilityZones")
+    private List<String> availabilityZones = new ArrayList<>();
+
+    @JsonProperty("VPCId")
+    private String vpcId;
+
+    public VpcOptions() {}
+
+    public List<String> getSubnetIds() {
+        return subnetIds;
+    }
+
+    public void setSubnetIds(List<String> subnetIds) {
+        this.subnetIds = subnetIds != null ? new ArrayList<>(subnetIds) : new ArrayList<>();
+    }
+
+    public List<String> getSecurityGroupIds() {
+        return securityGroupIds;
+    }
+
+    public void setSecurityGroupIds(List<String> securityGroupIds) {
+        this.securityGroupIds = securityGroupIds != null ? new ArrayList<>(securityGroupIds) : new ArrayList<>();
+    }
+
+    public List<String> getAvailabilityZones() {
+        return availabilityZones;
+    }
+
+    public void setAvailabilityZones(List<String> availabilityZones) {
+        this.availabilityZones = availabilityZones != null ? new ArrayList<>(availabilityZones) : new ArrayList<>();
+    }
+
+    public String getVpcId() {
+        return vpcId;
+    }
+
+    public void setVpcId(String vpcId) {
+        this.vpcId = vpcId;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainOptionsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainOptionsIntegrationTest.java
@@ -1,0 +1,183 @@
+package io.github.hectorvent.floci.services.opensearch;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * Verifies that VPC, advanced security, encryption, and endpoint option
+ * blocks round-trip from {@code CreateDomain} / {@code UpdateDomainConfig}
+ * through {@code DescribeDomain} / {@code DescribeDomainConfig}.
+ *
+ * <p>Real SDK clients (Terraform / CDK / Pulumi) read these fields back to
+ * detect drift; if they don't survive the round-trip, every plan re-applies
+ * the same change forever.
+ */
+@QuarkusTest
+class OpenSearchDomainOptionsIntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/es/aws4_request";
+
+    @AfterEach
+    void cleanup() {
+        // Delete every domain we touch so test order is irrelevant.
+        for (String name : new String[]{"opts-vpc", "opts-adv", "opts-enc", "opts-endpoint", "opts-update"}) {
+            given().header("Authorization", AUTH_HEADER)
+                .when().delete("/2021-01-01/opensearch/domain/" + name);
+        }
+    }
+
+    @Test
+    void vpcOptionsRoundTrip() {
+        String body = "{"
+                + "\"DomainName\":\"opts-vpc\","
+                + "\"EngineVersion\":\"OpenSearch_2.19\","
+                + "\"VPCOptions\":{"
+                + "  \"SubnetIds\":[\"subnet-aaa\",\"subnet-bbb\"],"
+                + "  \"SecurityGroupIds\":[\"sg-111\"],"
+                + "  \"VPCId\":\"vpc-zzz\""
+                + "}}";
+
+        given().contentType("application/json").header("Authorization", AUTH_HEADER).body(body)
+            .when().post("/2021-01-01/opensearch/domain")
+            .then().statusCode(200)
+            .body("DomainStatus.VPCOptions.SubnetIds", contains("subnet-aaa", "subnet-bbb"))
+            .body("DomainStatus.VPCOptions.SecurityGroupIds", contains("sg-111"))
+            .body("DomainStatus.VPCOptions.VPCId", equalTo("vpc-zzz"));
+
+        given().header("Authorization", AUTH_HEADER)
+            .when().get("/2021-01-01/opensearch/domain/opts-vpc")
+            .then().statusCode(200)
+            .body("DomainStatus.VPCOptions.SubnetIds", hasItem("subnet-aaa"))
+            .body("DomainStatus.VPCOptions.VPCId", equalTo("vpc-zzz"));
+
+        given().header("Authorization", AUTH_HEADER)
+            .when().get("/2021-01-01/opensearch/domain/opts-vpc/config")
+            .then().statusCode(200)
+            .body("DomainConfig.VPCOptions.Options.VPCId", equalTo("vpc-zzz"))
+            .body("DomainConfig.VPCOptions.Status.State", equalTo("Active"));
+    }
+
+    @Test
+    void advancedSecurityOptionsRoundTripsButNeverEchoesPassword() {
+        String body = "{"
+                + "\"DomainName\":\"opts-adv\","
+                + "\"EngineVersion\":\"OpenSearch_2.19\","
+                + "\"AdvancedSecurityOptions\":{"
+                + "  \"Enabled\":true,"
+                + "  \"InternalUserDatabaseEnabled\":true,"
+                + "  \"MasterUserOptions\":{"
+                + "    \"MasterUserName\":\"admin\","
+                + "    \"MasterUserPassword\":\"super-secret\""
+                + "  }}"
+                + "}";
+
+        given().contentType("application/json").header("Authorization", AUTH_HEADER).body(body)
+            .when().post("/2021-01-01/opensearch/domain")
+            .then().statusCode(200)
+            .body("DomainStatus.AdvancedSecurityOptions.Enabled", is(true))
+            .body("DomainStatus.AdvancedSecurityOptions.InternalUserDatabaseEnabled", is(true))
+            .body("DomainStatus.AdvancedSecurityOptions.MasterUserOptions.MasterUserName", equalTo("admin"))
+            // Master password must not leak — AWS doesn't echo it back either.
+            .body("DomainStatus.AdvancedSecurityOptions.MasterUserOptions.MasterUserPassword", nullValue());
+    }
+
+    @Test
+    void advancedSecurityRequiresMasterUserWhenInternalDbEnabled() {
+        // Reject the same combination AWS rejects so Terraform plans surface
+        // the validation error here instead of waiting for prod.
+        String body = "{"
+                + "\"DomainName\":\"opts-adv\","
+                + "\"EngineVersion\":\"OpenSearch_2.19\","
+                + "\"AdvancedSecurityOptions\":{"
+                + "  \"Enabled\":true,"
+                + "  \"InternalUserDatabaseEnabled\":true"
+                + "}}";
+
+        given().contentType("application/json").header("Authorization", AUTH_HEADER).body(body)
+            .when().post("/2021-01-01/opensearch/domain")
+            .then().statusCode(400);
+    }
+
+    @Test
+    void encryptionAndNodeToNodeOptionsRoundTrip() {
+        String body = "{"
+                + "\"DomainName\":\"opts-enc\","
+                + "\"EngineVersion\":\"OpenSearch_2.19\","
+                + "\"EncryptionAtRestOptions\":{"
+                + "  \"Enabled\":true,"
+                + "  \"KmsKeyId\":\"arn:aws:kms:us-east-1:000000000000:key/my-key\""
+                + "},"
+                + "\"NodeToNodeEncryptionOptions\":{\"Enabled\":true}"
+                + "}";
+
+        given().contentType("application/json").header("Authorization", AUTH_HEADER).body(body)
+            .when().post("/2021-01-01/opensearch/domain")
+            .then().statusCode(200)
+            .body("DomainStatus.EncryptionAtRestOptions.Enabled", is(true))
+            .body("DomainStatus.EncryptionAtRestOptions.KmsKeyId",
+                    equalTo("arn:aws:kms:us-east-1:000000000000:key/my-key"))
+            .body("DomainStatus.NodeToNodeEncryptionOptions.Enabled", is(true));
+    }
+
+    @Test
+    void domainEndpointOptionsRoundTripAndRejectMissingCustomEndpoint() {
+        String okBody = "{"
+                + "\"DomainName\":\"opts-endpoint\","
+                + "\"EngineVersion\":\"OpenSearch_2.19\","
+                + "\"DomainEndpointOptions\":{"
+                + "  \"EnforceHTTPS\":true,"
+                + "  \"TLSSecurityPolicy\":\"Policy-Min-TLS-1-2-2019-07\""
+                + "}}";
+
+        given().contentType("application/json").header("Authorization", AUTH_HEADER).body(okBody)
+            .when().post("/2021-01-01/opensearch/domain")
+            .then().statusCode(200)
+            .body("DomainStatus.DomainEndpointOptions.EnforceHTTPS", is(true))
+            .body("DomainStatus.DomainEndpointOptions.TLSSecurityPolicy",
+                    equalTo("Policy-Min-TLS-1-2-2019-07"));
+
+        // Custom endpoint without a value set is malformed — match AWS behavior.
+        String badBody = "{"
+                + "\"DomainName\":\"opts-endpoint-bad\","
+                + "\"EngineVersion\":\"OpenSearch_2.19\","
+                + "\"DomainEndpointOptions\":{"
+                + "  \"CustomEndpointEnabled\":true"
+                + "}}";
+
+        given().contentType("application/json").header("Authorization", AUTH_HEADER).body(badBody)
+            .when().post("/2021-01-01/opensearch/domain")
+            .then().statusCode(400);
+    }
+
+    @Test
+    void updateDomainConfigPersistsNewVpcOptions() {
+        // Create with one set of subnets; update to a different set.
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"DomainName\":\"opts-update\",\"EngineVersion\":\"OpenSearch_2.19\","
+                    + "\"VPCOptions\":{\"SubnetIds\":[\"subnet-old\"]}}")
+            .when().post("/2021-01-01/opensearch/domain")
+            .then().statusCode(200);
+
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"VPCOptions\":{\"SubnetIds\":[\"subnet-new\"],\"SecurityGroupIds\":[\"sg-new\"]}}")
+            .when().post("/2021-01-01/opensearch/domain/opts-update/config")
+            .then().statusCode(200)
+            .body("DomainConfig.VPCOptions.Options.SubnetIds", contains("subnet-new"));
+
+        given().header("Authorization", AUTH_HEADER)
+            .when().get("/2021-01-01/opensearch/domain/opts-update")
+            .then().statusCode(200)
+            .body("DomainStatus.VPCOptions.SubnetIds", contains("subnet-new"))
+            .body("DomainStatus.VPCOptions.SubnetIds", not(hasItem("subnet-old")));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/opensearch/OpenSearchInstanceTypesTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/opensearch/OpenSearchInstanceTypesTest.java
@@ -1,0 +1,63 @@
+package io.github.hectorvent.floci.services.opensearch;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+class OpenSearchInstanceTypesTest {
+
+    @Test
+    void listAllIncludesEbsAndOr1Families() {
+        assertThat(OpenSearchInstanceTypes.listAll(),
+                hasItems("m5.large.search", "m6g.large.search", "m7g.large.search",
+                        "or1.medium.search", "or1.2xlarge.search",
+                        "i3.large.search"));
+    }
+
+    @Test
+    void or1FamilyIsS3BackedAndNotEbsAttachable() {
+        OpenSearchInstanceTypes.InstanceTypeSpec spec = OpenSearchInstanceTypes.specOf("or1.2xlarge.search");
+        assertThat(spec, notNullValue());
+        // or1 backs storage by S3 — not EBS. Real fidelity here matters for
+        // SDK clients (Terraform, CDK) that reject EBS config on or1.
+        assertThat(spec.storageType(), equalTo("s3-backed"));
+        assertThat(spec.ebsAttachable(), is(false));
+        assertThat(spec.maxVolumeSizeGib(), greaterThan(8000));
+    }
+
+    @Test
+    void ebsFamilyHas3584GibCeiling() {
+        // 3584 GiB ceiling matches AWS's published gp2/gp3 limit; regression
+        // here would mislead cost calculators into allowing impossible volume
+        // sizes.
+        OpenSearchInstanceTypes.InstanceTypeSpec spec = OpenSearchInstanceTypes.specOf("m6g.2xlarge.search");
+        assertThat(spec.storageType(), equalTo("ebs"));
+        assertThat(spec.ebsAttachable(), is(true));
+        assertThat(spec.maxVolumeSizeGib(), equalTo(3584));
+    }
+
+    @Test
+    void i3FamilyHasInstanceStoreNotEbs() {
+        OpenSearchInstanceTypes.InstanceTypeSpec spec = OpenSearchInstanceTypes.specOf("i3.4xlarge.search");
+        assertThat(spec.storageType(), equalTo("instance-store"));
+    }
+
+    @Test
+    void specOfReturnsNullForUnknownType() {
+        assertThat(OpenSearchInstanceTypes.specOf("imaginary.10xlarge.search"), nullValue());
+    }
+
+    @Test
+    void genericFallbackIsEbsWithStandardLimits() {
+        OpenSearchInstanceTypes.InstanceTypeSpec spec = OpenSearchInstanceTypes.genericFallback("future.99xlarge.search");
+        assertThat(spec.storageType(), equalTo("ebs"));
+        assertThat(spec.maxVolumeSizeGib(), equalTo(3584));
+        assertThat(spec.ebsAttachable(), is(true));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/opensearch/OpenSearchIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/opensearch/OpenSearchIntegrationTest.java
@@ -272,19 +272,38 @@ class OpenSearchIntegrationTest {
             .get("/2021-01-01/opensearch/instanceTypeDetails/OpenSearch_2.11")
         .then()
             .statusCode(200)
-            .body("InstanceTypeDetails", not(empty()));
+            .body("InstanceTypeDetails", not(empty()))
+            // or1 family must show up in the catalog; SDK clients filter on it.
+            .body("InstanceTypeDetails.InstanceType", hasItem("or1.2xlarge.search"));
     }
 
     @Test
     @Order(16)
-    void describeInstanceTypeLimits() {
+    void describeInstanceTypeLimitsForEbsFamily() {
         given()
             .header("Authorization", AUTH_HEADER)
         .when()
             .get("/2021-01-01/opensearch/instanceTypeLimits/OpenSearch_2.11/m5.large.search")
         .then()
             .statusCode(200)
-            .body("LimitsByRole", notNullValue());
+            .body("LimitsByRole.data.StorageTypes[0].StorageTypeName", equalTo("ebs"))
+            .body("LimitsByRole.data.StorageTypes[0].StorageTypeLimits[1].LimitValues[0]", equalTo("3584"));
+    }
+
+    @Test
+    @Order(16)
+    void describeInstanceTypeLimitsForOr1FamilyExposesS3Backed() {
+        // or1 differs from the ebs-only families AWS used to ship — Floci
+        // needs to report s3-backed storage and the larger volume ceiling.
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/2021-01-01/opensearch/instanceTypeLimits/OpenSearch_2.11/or1.2xlarge.search")
+        .then()
+            .statusCode(200)
+            .body("LimitsByRole.data.StorageTypes[0].StorageTypeName", equalTo("s3-backed"))
+            .body("LimitsByRole.data.StorageTypes[0].StorageTypeLimits[1].LimitValues[0]",
+                    equalTo("36864"));
     }
 
     // ── Stubs ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes the two follow-ups from #1025:

1. **Domain option blocks now round-trip.** `VPCOptions`, `AdvancedSecurityOptions`, `EncryptionAtRestOptions`, `NodeToNodeEncryptionOptions`, `DomainEndpointOptions` survive `CreateDomain` → `DescribeDomain`. Previously they were silently dropped, so SDK clients (Terraform, CDK, Pulumi) couldn't detect drift and re-applied the same change forever.
2. **Per-family instance type metadata.** `or1.*` now reports s3-backed storage with the 8–36 TiB ceiling AWS documents. `i3.*` reports instance-store. Everything else stays EBS / 3584 GiB. SDK clients that introspect `DescribeInstanceTypeLimits` now see realistic per-family limits instead of one canned response.

## What changed

### Round-trip support

- New model classes: `VpcOptions`, `AdvancedSecurityOptions` (+ `MasterUserOptions`), `EncryptionAtRestOptions`, `NodeToNodeEncryptionOptions`, `DomainEndpointOptions`.
- `OpenSearchService.DomainOptions` record bundles them through the service layer.
- Parsers + emitters in `OpenSearchController` cover both `DescribeDomain` (flat) and `DescribeDomainConfig` (with `Status` wrapper).
- Backward-compatible: existing `createDomain` / `updateDomainConfig` overloads forward to `DomainOptions.EMPTY`.

### Validation

- `AdvancedSecurityOptions.Enabled=true` + `InternalUserDatabaseEnabled=true` without a `MasterUserName` → `ValidationException`. Matches AWS behavior so Terraform plans surface the same error here.
- `DomainEndpointOptions.CustomEndpointEnabled=true` without `CustomEndpoint` → `ValidationException`.
- VPC `SubnetIds` rejects blank entries.
- `MasterUserPassword` and `MasterUserARN` are accepted on input but the password is never echoed on Describe — matches AWS.

### Instance type catalog (new `OpenSearchInstanceTypes`)

Single source of truth for the instance type list and per-family metadata:

| Family | Storage | Max volume |
|---|---|---|
| `t3.*`, `m5/m6g/m7g.*`, `r5/r6g/r7g.*`, `c5/c6g/c7g.*` | `ebs` | 3584 GiB |
| `i3.*` | `instance-store` | 100 GiB |
| `or1.*` | `s3-backed` | 8192–36864 GiB by size |

Unknown types fall back to a generic EBS spec instead of 404'ing — AWS announces new types faster than emulators can keep up.

## Tests

60 OpenSearch tests pass (was 47 in #1025). New:
- 6 `OpenSearchInstanceTypesTest` pure-unit (or1 s3-backed, EBS ceilings, i3 instance-store, fallback for unknown types).
- 6 `OpenSearchDomainOptionsIntegrationTest` end-to-end (VPC round-trip, FGAC password not echoed, FGAC validation, encryption + N2N round-trip, endpoint options + custom-endpoint validation, update persists new VPC).
- 2 `OpenSearchIntegrationTest` additions covering or1 vs EBS limits.

## Live Docker validation

Built JVM image, mounted `/var/run/docker.sock`, exercised:

- `CreateDomain` with `VPCOptions` + `EncryptionAtRestOptions` + `NodeToNodeEncryptionOptions` + `DomainEndpointOptions` → `DescribeDomain` returns all four blocks intact, domain reaches `Created: True`.
- `DescribeInstanceTypeLimits or1.2xlarge.search` → `s3-backed` / 36864 GiB.
- `DescribeInstanceTypeLimits m6g.large.search` → `ebs` / 3584 GiB.
- `CreateDomain` with `AdvancedSecurityOptions.Enabled=true,InternalUserDatabaseEnabled=true` and no master user → `ValidationException`.

## Known limitations (unchanged)

- Floci still serves the domain over plain HTTP with the security plugin disabled regardless of `EnforceHTTPS` / `AdvancedSecurityOptions.Enabled` / `EncryptionAtRest`. Round-trip parity is enough for SDK drift detection; the running container is not a real production cluster.
- One Docker container per domain regardless of instance type — the family metadata fidelity matters for management-API introspection, not data-plane behavior.
