### PR TITLE
fix(s3): omit whole-object checksum headers on range responses

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -647,7 +647,8 @@ public class S3Controller {
         if (obj.getVersionId() != null) {
             resp.header("x-amz-version-id", obj.getVersionId());
         }
-        appendObjectHeaders(resp, obj, overrides);
+        // includeChecksum=false: the stored checksum covers the whole object, not this range.
+        appendObjectHeaders(resp, obj, overrides, false);
         return resp.build();
     }
 
@@ -1541,6 +1542,14 @@ public class S3Controller {
     }
 
     private void appendObjectHeaders(Response.ResponseBuilder resp, S3Object obj, ResponseHeaderOverrides overrides) {
+        appendObjectHeaders(resp, obj, overrides, true);
+    }
+
+    // includeChecksum must be false for partial (206) responses: obj.getChecksum() is the
+    // whole-object checksum, which does not match the range bytes returned. SDKs that
+    // validate it against the received body fail. Real S3 omits it on ranged responses.
+    private void appendObjectHeaders(Response.ResponseBuilder resp, S3Object obj, ResponseHeaderOverrides overrides,
+                                     boolean includeChecksum) {
         if (obj.getStorageClass() != null) {
             resp.header("x-amz-storage-class", obj.getStorageClass());
         }
@@ -1570,7 +1579,9 @@ public class S3Controller {
                 resp.header("x-amz-meta-" + entry.getKey(), entry.getValue());
             }
         }
-        appendChecksumHeaders(resp, obj.getChecksum());
+        if (includeChecksum) {
+            appendChecksumHeaders(resp, obj.getChecksum());
+        }
         appendLockHeaders(resp, obj);
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -573,6 +573,24 @@ class S3IntegrationTest {
     }
 
     @Test
+    @Order(40)
+    void getObjectRangeOmitsWholeObjectChecksum() {
+        // greeting.txt has a stored whole-object CRC64NVME checksum (see getObject).
+        // A 206 partial response must NOT carry that checksum: it is computed over the
+        // full object, so SDKs that validate it against the received range bytes fail.
+        // Real S3 omits whole-object checksum headers on ranged responses.
+        given()
+            .header("Range", "bytes=4-7")
+        .when()
+            .get("/test-bucket/greeting.txt")
+        .then()
+            .statusCode(206)
+            .header("Content-Range", equalTo("bytes 4-7/20"))
+            .body(equalTo("o Wo"))
+            .header("x-amz-checksum-crc64nvme", nullValue());
+    }
+
+    @Test
     @Order(50)
     void getObjectIfNoneMatchReturns304() {
         String eTag = given()


### PR DESCRIPTION
## Summary

Follow-up to #923. That PR routed `handleRangeRequest` through `appendObjectHeaders` so 206 partial-content responses would pick up stored headers and `response-*` overrides — a good fix, but it also pulled in `appendChecksumHeaders`, which emits `obj.getChecksum()`, the **whole-object** checksum, onto partial responses.

SDKs that validate the checksum against the received body then fail. A `bytes=4-7` GET returns the full-object CRC64NVME, and the AWS CLI reports:

```
aws: [ERROR]: Expected checksum CRSFynAYcw4= did not match calculated checksum: LQYlQwQYKmA=
```

Real S3 does not return whole-object checksum headers on ranged responses (the digest covers the full object, not the bytes returned).

Reported by @dwhjames on #923.

## Changes

- Add an `includeChecksum` flag to `appendObjectHeaders`. The existing 3-arg overload delegates with `true`, so `getObject` (200) and `headObject` keep emitting checksum headers unchanged.
- `handleRangeRequest` passes `false`, so 206 responses no longer carry the mismatched whole-object checksum. The override + restored-header improvements from #923 are unaffected.

## Test plan

- New `S3IntegrationTest#getObjectRangeOmitsWholeObjectChecksum` (`@Order(40)`): a `bytes=4-7` GET on a checksummed object returns 206 with `Content-Range`/body intact and **no** `x-amz-checksum-crc64nvme`. Verified the test fails on `main` (header present: `kczo6A92f5o=`) and passes with this fix.
- Full suite green: **4811 run, 0 failures, 0 errors, 8 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)