### PR TITLE
feat(kms): handle RotateKeyOnDemand rotation limit

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -290,6 +290,7 @@ public class KmsService {
         LOG.infov("Disabled key rotation for KMS key: {0} in {1}", key.getKeyId(), region);
     }
 
+    private static final int ON_DEMAND_ROTATION_LIMIT = 25;
     public String rotateKeyOnDemand(String keyId, String region) {
         KmsKey key = resolveKey(keyId, region);
         if (!key.isEnabled()) {
@@ -297,6 +298,12 @@ public class KmsService {
                     "KMS key " + key.getKeyId() + " is disabled.", 400);
         }
         validateRotationSupported(key);
+        if (key.getOnDemandRotationCount() >= ON_DEMAND_ROTATION_LIMIT) {
+            throw new AwsException("LimitExceededException",
+                    "On-demand rotation quota for KMS key " + key.getKeyId() + " is exceeded.", 400);
+        }
+        key.setOnDemandRotationCount(key.getOnDemandRotationCount() + 1);
+        keyStore.put(region + "::" + key.getKeyId(), key);
         return key.getKeyId();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/kms/model/KmsKey.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/model/KmsKey.java
@@ -24,6 +24,7 @@ public class KmsKey {
     private Map<String, String> tags = new HashMap<>();
     private String privateKeyEncoded;
     private String publicKeyEncoded;
+    private int onDemandRotationCount;
 
     public KmsKey() {
         this.creationDate = Instant.now().getEpochSecond();
@@ -70,4 +71,7 @@ public class KmsKey {
 
     public String getPublicKeyEncoded() { return publicKeyEncoded; }
     public void setPublicKeyEncoded(String publicKeyEncoded) { this.publicKeyEncoded = publicKeyEncoded; }
+
+    public int getOnDemandRotationCount() { return onDemandRotationCount; }
+    public void setOnDemandRotationCount(int onDemandRotationCount) { this.onDemandRotationCount = onDemandRotationCount; }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -663,6 +663,22 @@ class KmsServiceTest {
         assertEquals(400, ex.getHttpStatus());
     }
 
+    @Test
+    void rotateKeyOnDemandLimitExceededThrows() {
+        KmsKey key = kmsService.createKey(null, REGION);
+
+        for (int i = 0; i < 25; i++) {
+            kmsService.rotateKeyOnDemand(key.getKeyId(), REGION);
+        }
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                kmsService.rotateKeyOnDemand(key.getKeyId(), REGION));
+
+        assertEquals("LimitExceededException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+        assertEquals(25, kmsService.describeKey(key.getKeyId(), REGION).getOnDemandRotationCount());
+    }
+
     // ── Issue #497 — HMAC key specs ─────────────────────────────────────────
 
     @ParameterizedTest


### PR DESCRIPTION
## Summary

Adds on-demand rotation count tracking for KMS and enforces the AWS `RotateKeyOnDemand` quota by returning `LimitExceededException` when the limit is exceeded.

Closes #1041 

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified with the AWS CLI that `RotateKeyOnDemand` increments count and returns `LimitExceededException` after the quota is exceeded.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
