### PR TITLE
fix(s3): clean up versioned file data on permanent version deletion

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -546,12 +546,16 @@ public class S3Service {
                         newLatest.setLatest(true);
                         objectStore.put(versionedKey(bucketName, key, newLatest.getVersionId()), newLatest);
                         objectStore.put(latestKey, newLatest);
-                        // Sync the latest file pointer to the promoted version's content
-                        byte[] promotedData = readVersionedFile(bucketName, key, newLatest.getVersionId());
-                        if (promotedData != null) {
-                            writeFile(bucketName, key, promotedData);
-                        } else {
+                        // Delete markers have no versioned file — readVersionedFile throws in persistent mode.
+                        if (newLatest.isDeleteMarker()) {
                             deleteFile(bucketName, key);
+                        } else {
+                            byte[] promotedData = readVersionedFile(bucketName, key, newLatest.getVersionId());
+                            if (promotedData != null) {
+                                writeFile(bucketName, key, promotedData);
+                            } else {
+                                deleteFile(bucketName, key);
+                            }
                         }
                     }
                 }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -526,8 +526,9 @@ public class S3Service {
             if (toDelete != null && !toDelete.isDeleteMarker()) {
                 checkLockProtection(toDelete, bypassGovernance);
             }
-            // Permanently delete a specific version
+            // Permanently delete a specific version (metadata + file data)
             objectStore.delete(versionedKey(bucketName, key, versionId));
+            deleteVersionedFile(bucketName, key, versionId);
             LOG.debugv("Permanently deleted version: {0}/{1} v={2}", bucketName, key, versionId);
             // Promote the next most-recent version when the deleted one was the latest
             String latestKey = objectKey(bucketName, key);
@@ -537,6 +538,7 @@ public class S3Service {
                     List<S3Object> remaining = objectStore.scan(k -> k.startsWith(vPrefix));
                     if (remaining.isEmpty()) {
                         objectStore.delete(latestKey);
+                        deleteFile(bucketName, key);
                     } else {
                         S3Object newLatest = remaining.stream()
                                 .max(Comparator.comparing(S3Object::getLastModified))
@@ -544,6 +546,11 @@ public class S3Service {
                         newLatest.setLatest(true);
                         objectStore.put(versionedKey(bucketName, key, newLatest.getVersionId()), newLatest);
                         objectStore.put(latestKey, newLatest);
+                        // Sync the latest file pointer to the promoted version's content
+                        byte[] promotedData = readVersionedFile(bucketName, key, newLatest.getVersionId());
+                        if (promotedData != null) {
+                            writeFile(bucketName, key, promotedData);
+                        }
                     }
                 }
             });
@@ -2087,6 +2094,18 @@ public class S3Service {
             Files.deleteIfExists(resolveObjectPath(bucketName, key));
         } catch (IOException e) {
             LOG.errorv(e, "Failed to delete S3 object file: {0}/{1}", bucketName, key);
+        }
+    }
+
+    private void deleteVersionedFile(String bucketName, String key, String versionId) {
+        if (inMemory) {
+            memoryDataStore.remove(versionedKey(bucketName, key, versionId));
+            return;
+        }
+        try {
+            Files.deleteIfExists(resolveVersionedPath(bucketName, key, versionId));
+        } catch (IOException e) {
+            LOG.errorv(e, "Failed to delete versioned S3 object file: {0}/{1} v={2}", bucketName, key, versionId);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -550,6 +550,8 @@ public class S3Service {
                         byte[] promotedData = readVersionedFile(bucketName, key, newLatest.getVersionId());
                         if (promotedData != null) {
                             writeFile(bucketName, key, promotedData);
+                        } else {
+                            deleteFile(bucketName, key);
                         }
                     }
                 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningIntegrationTest.java
@@ -247,7 +247,7 @@ class S3VersioningIntegrationTest {
     }
 
     @Test
-    @Order(19)
+    @Order(18)
     void rollbackScenario_copyWithReplaceMetadataPreservesVersionKey() {
         String rollbackBucket = "rollback-scenario-test";
         given().when().put("/" + rollbackBucket).then().statusCode(200);
@@ -329,5 +329,70 @@ class S3VersioningIntegrationTest {
             .statusCode(200)
             .body(containsString("<Key>version</Key>"))
             .body(containsString("<Value>20231103</Value>"));
+    }
+
+    @Test
+    @Order(19)
+    void deleteAllVersionsThenReuploadSameContent_noResurrection() {
+        String resBucket = "resurrection-test";
+        given().when().put("/" + resBucket).then().statusCode(200);
+        String xml = "<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>";
+        given().body(xml).when().put("/" + resBucket + "?versioning").then().statusCode(200);
+
+        String key = "resurrection-test.txt";
+
+        // Upload two versions
+        String vid1 = given()
+            .body("v1-content")
+            .contentType("text/plain")
+        .when()
+            .put("/" + resBucket + "/" + key)
+        .then()
+            .statusCode(200)
+            .extract().header("x-amz-version-id");
+
+        String vid2 = given()
+            .body("v2-content")
+            .contentType("text/plain")
+        .when()
+            .put("/" + resBucket + "/" + key)
+        .then()
+            .statusCode(200)
+            .extract().header("x-amz-version-id");
+
+        // Permanently delete both versions (latest first)
+        given().when().delete("/" + resBucket + "/" + key + "?versionId=" + vid2).then().statusCode(204);
+        given().when().delete("/" + resBucket + "/" + key + "?versionId=" + vid1).then().statusCode(204);
+
+        // Confirm zero versions for this key
+        String afterDeleteXml = given()
+        .when()
+            .get("/" + resBucket + "?versions&prefix=" + key)
+        .then()
+            .statusCode(200)
+            .extract().body().asString();
+        assertFalse(afterDeleteXml.contains("<Version>"),
+                "no versions should remain after permanent delete, got: " + afterDeleteXml);
+
+        // Re-upload with same content as v1
+        given()
+            .body("v1-content")
+            .contentType("text/plain")
+        .when()
+            .put("/" + resBucket + "/" + key)
+        .then()
+            .statusCode(200);
+
+        // Verify exactly 1 version exists
+        String afterReuploadXml = given()
+        .when()
+            .get("/" + resBucket + "?versions&prefix=" + key)
+        .then()
+            .statusCode(200)
+            .extract().body().asString();
+
+        int versionCount = afterReuploadXml.split("<Version>").length - 1;
+        assertEquals(1, versionCount,
+                "only the newly uploaded version should exist — deleted versions must not resurrect, got: " + afterReuploadXml);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningIntegrationTest.java
@@ -384,15 +384,15 @@ class S3VersioningIntegrationTest {
             .statusCode(200);
 
         // Verify exactly 1 version exists
-        String afterReuploadXml = given()
+        var versions = given()
         .when()
             .get("/" + resBucket + "?versions&prefix=" + key)
         .then()
             .statusCode(200)
-            .extract().body().asString();
+            .extract().xmlPath()
+            .getList("ListVersionsResult.Version");
 
-        int versionCount = afterReuploadXml.split("<Version>").length - 1;
-        assertEquals(1, versionCount,
-                "only the newly uploaded version should exist — deleted versions must not resurrect, got: " + afterReuploadXml);
+        assertEquals(1, versions.size(),
+                "only the newly uploaded version should exist — deleted versions must not resurrect");
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
@@ -329,7 +329,7 @@ class S3VersioningServiceTest {
 
         // getObject without versionId should return v1's content, not v2's
         S3Object result = s3Service.getObject("versioned-bucket", "key");
-        assertEquals("v1", new String(result.getData()),
+        assertEquals("v1", new String(result.getData(), StandardCharsets.UTF_8),
                 "getObject should return the promoted version's content after deleting the latest");
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
@@ -314,4 +314,23 @@ class S3VersioningServiceTest {
         Map<String, String> tags = s3Service.getObjectTagging("versioned-bucket", "clear-key");
         assertTrue(tags.isEmpty(), "REPLACE with empty tags should clear all source tags");
     }
+
+    @Test
+    void getObjectReturnsPromotedContentAfterLatestVersionDeleted() {
+        s3Service.putBucketVersioning("versioned-bucket", "Enabled");
+
+        s3Service.putObject("versioned-bucket", "key",
+                "v1".getBytes(StandardCharsets.UTF_8), "text/plain", null);
+        S3Object v2 = s3Service.putObject("versioned-bucket", "key",
+                "v2".getBytes(StandardCharsets.UTF_8), "text/plain", null);
+
+        // Delete the latest version (v2) — v1 should be promoted
+        s3Service.deleteObject("versioned-bucket", "key", v2.getVersionId());
+
+        // getObject without versionId should return v1's content, not v2's
+        S3Object result = s3Service.getObject("versioned-bucket", "key");
+        assertEquals("v1", new String(result.getData()),
+                "getObject should return the promoted version's content after deleting the latest");
+    }
+
 }


### PR DESCRIPTION
## Summary

When deleteObject(bucket, key, versionId) permanently deletes a specific version, objectStore (metadata) was cleaned up but memoryDataStore (file content) was not. This caused three related bugs:

1. Data leak: versioned file data was never removed from memoryDataStore when a version was permanently deleted — stale byte arrays accumulated indefinitely.
2. Wrong content after promote: when the latest version was deleted and an older version was promoted, objectStore's latest pointer was updated but memoryDataStore's latest file pointer was not — getObject without versionId returned the deleted version's content instead of the promoted version's.
3. Stale latest file on full delete: when all versions of a key were permanently deleted, the latest file data in memoryDataStore was not cleaned up.

Adds a deleteVersionedFile method (parallel to the existing deleteFile) and calls it alongside objectStore.delete() in the versioned-delete path. The promote path now also syncs the latest file pointer in memoryDataStore to the promoted version's content.

Closes #1044

## Type of change

- Bug fix (fix:)

## AWS Compatibility

deleteObject with VersionId was returning correct HTTP responses both before and after — the bug was internal state corruption (wrong content served on subsequent getObject calls). No wire protocol changes.

Incorrect behavior: after permanently deleting the latest version of a key, GET /bucket/key (no versionId) returned the deleted version's content instead of the newly-promoted version's content.

## Checklist

- [x] ./mvnw test passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)