### PR TITLE
fix(s3): implement TaggingDirective=COPY default in CopyObject

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -1619,11 +1619,18 @@ public class S3Controller {
         String copyCacheControl = httpHeaders.getHeaderString("Cache-Control");
         String copyServerSideEncryption = httpHeaders.getHeaderString("x-amz-server-side-encryption");
         String cannedAcl = httpHeaders.getHeaderString("x-amz-acl");
+        String taggingDirective = httpHeaders.getHeaderString("x-amz-tagging-directive");
+        String taggingHeader = httpHeaders.getHeaderString("x-amz-tagging");
+        Map<String, String> replacementTagging = "REPLACE".equalsIgnoreCase(taggingDirective) && taggingHeader != null
+                ? parseInlineTaggingHeader(taggingHeader)
+                : null;
         S3Object copy = s3Service.copyObject(sourceBucket, sourceObject.objectKey(), destBucket, destKey,
                 sourceObject.versionId(),
                 new CopyObjectOptions()
                         .withMetadataDirective(httpHeaders.getHeaderString("x-amz-metadata-directive"))
                         .withReplacementMetadata(extractUserMetadata(httpHeaders))
+                        .withTaggingDirective(taggingDirective)
+                        .withReplacementTagging(replacementTagging)
                         .withStorageClass(httpHeaders.getHeaderString("x-amz-storage-class"))
                         .withContentType(contentType)
                         .withContentEncoding(copyContentEncoding)

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -1621,8 +1621,8 @@ public class S3Controller {
         String cannedAcl = httpHeaders.getHeaderString("x-amz-acl");
         String taggingDirective = httpHeaders.getHeaderString("x-amz-tagging-directive");
         String taggingHeader = httpHeaders.getHeaderString("x-amz-tagging");
-        Map<String, String> replacementTagging = "REPLACE".equalsIgnoreCase(taggingDirective) && taggingHeader != null
-                ? parseInlineTaggingHeader(taggingHeader)
+        Map<String, String> replacementTagging = "REPLACE".equalsIgnoreCase(taggingDirective)
+                ? (taggingHeader != null ? parseInlineTaggingHeader(taggingHeader) : Map.of())
                 : null;
         S3Object copy = s3Service.copyObject(sourceBucket, sourceObject.objectKey(), destBucket, destKey,
                 sourceObject.versionId(),

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -2135,6 +2135,11 @@ public class S3Service {
         String effectiveServerSideEncryption = normalizedServerSideEncryption != null
                 ? normalizedServerSideEncryption
                 : source.getServerSideEncryption();
+        boolean replaceTags = "REPLACE".equalsIgnoreCase(effectiveOptions.getTaggingDirective());
+        Map<String, String> effectiveTags = replaceTags
+                ? effectiveOptions.getReplacementTagging()
+                : source.getTags();
+
         S3Object copy = storeObject(destBucket, destKey, source.getData(), effectiveContentType, metadata,
                 source.getChecksum(), source.getParts(),
                 new PutObjectOptions()
@@ -2143,7 +2148,8 @@ public class S3Service {
                         .withContentDisposition(effectiveContentDisposition)
                         .withCacheControl(effectiveCacheControl)
                         .withServerSideEncryption(effectiveServerSideEncryption)
-                        .withAcl(effectiveOptions.getAcl()));
+                        .withAcl(effectiveOptions.getAcl())
+                        .withTagging(effectiveTags));
         copy.setETag(source.getETag());
         LOG.debugv("Copied object: {0}/{1} -> {2}/{3}", sourceBucket, sourceKey, destBucket, destKey);
         fireNotifications(destBucket, destKey, "ObjectCreated:Copy", copy);

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/CopyObjectOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/CopyObjectOptions.java
@@ -5,6 +5,8 @@ import java.util.Map;
 public class CopyObjectOptions {
     private String metadataDirective;
     private Map<String, String> replacementMetadata;
+    private String taggingDirective;
+    private Map<String, String> replacementTagging;
     private String storageClass;
     private String contentType;
     private String contentEncoding;
@@ -18,6 +20,12 @@ public class CopyObjectOptions {
 
     public Map<String, String> getReplacementMetadata() { return replacementMetadata; }
     public CopyObjectOptions withReplacementMetadata(Map<String, String> replacementMetadata) { this.replacementMetadata = replacementMetadata; return this; }
+
+    public String getTaggingDirective() { return taggingDirective; }
+    public CopyObjectOptions withTaggingDirective(String taggingDirective) { this.taggingDirective = taggingDirective; return this; }
+
+    public Map<String, String> getReplacementTagging() { return replacementTagging; }
+    public CopyObjectOptions withReplacementTagging(Map<String, String> replacementTagging) { this.replacementTagging = replacementTagging; return this; }
 
     public String getStorageClass() { return storageClass; }
     public CopyObjectOptions withStorageClass(String storageClass) { this.storageClass = storageClass; return this; }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningIntegrationTest.java
@@ -245,4 +245,89 @@ class S3VersioningIntegrationTest {
             .header("x-amz-version-id", headersTestMarkerId)
             .header("x-amz-delete-marker", "true");
     }
+
+    @Test
+    @Order(19)
+    void rollbackScenario_copyWithReplaceMetadataPreservesVersionKey() {
+        String rollbackBucket = "rollback-scenario-test";
+        given().when().put("/" + rollbackBucket).then().statusCode(200);
+        String xml = "<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>";
+        given().body(xml).when().put("/" + rollbackBucket + "?versioning").then().statusCode(200);
+
+        String key = "bank/config.properties";
+
+        // Upload v1 with metadata version=v1
+        String vid1 = given()
+            .body("v1-content")
+            .contentType("text/plain")
+            .header("x-amz-meta-version", "20231103")
+        .when()
+            .put("/" + rollbackBucket + "/" + key)
+        .then()
+            .statusCode(200)
+            .extract().header("x-amz-version-id");
+
+        // Tag v1
+        String tagXml = "<Tagging><TagSet><Tag><Key>version</Key><Value>20231103</Value></Tag></TagSet></Tagging>";
+        given().body(tagXml).when().put("/" + rollbackBucket + "/" + key + "?tagging").then().statusCode(200);
+
+        // Upload v2 with metadata version=v2
+        given()
+            .body("v2-content")
+            .contentType("text/plain")
+            .header("x-amz-meta-version", "20231204")
+        .when()
+            .put("/" + rollbackBucket + "/" + key)
+        .then()
+            .statusCode(200);
+
+        // Tag v2 (latest)
+        String tagXml2 = "<Tagging><TagSet><Tag><Key>version</Key><Value>20231204</Value></Tag></TagSet></Tagging>";
+        given().body(tagXml2).when().put("/" + rollbackBucket + "/" + key + "?tagging").then().statusCode(200);
+
+        // HEAD latest — should have version=20231204
+        given()
+        .when()
+            .head("/" + rollbackBucket + "/" + key)
+        .then()
+            .statusCode(200)
+            .header("x-amz-meta-version", "20231204");
+
+        // HEAD v1 by versionId — should have version=20231103
+        given()
+        .when()
+            .head("/" + rollbackBucket + "/" + key + "?versionId=" + vid1)
+        .then()
+            .statusCode(200)
+            .header("x-amz-meta-version", "20231103");
+
+        // Rollback copy: copy v1 to same key with MetadataDirective=REPLACE, setting last_operation + version
+        given()
+            .header("x-amz-copy-source", "/" + rollbackBucket + "/" + key + "?versionId=" + vid1)
+            .header("x-amz-metadata-directive", "REPLACE")
+            .header("x-amz-meta-last_operation", "roll_back")
+            .header("x-amz-meta-version", "20231103")
+        .when()
+            .put("/" + rollbackBucket + "/" + key)
+        .then()
+            .statusCode(200);
+
+        // HEAD after rollback — both metadata keys must be present
+        given()
+        .when()
+            .head("/" + rollbackBucket + "/" + key)
+        .then()
+            .statusCode(200)
+            .header("x-amz-meta-last_operation", "roll_back")
+            .header("x-amz-meta-version", "20231103");
+
+        // GET tagging after rollback — source tags should be preserved (TaggingDirective defaults to COPY)
+        given()
+        .when()
+            .get("/" + rollbackBucket + "/" + key + "?tagging")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Key>version</Key>"))
+            .body(containsString("<Value>20231103</Value>"));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
@@ -279,4 +279,39 @@ class S3VersioningServiceTest {
         assertEquals("v2-tag", tags.get("version"),
                 "copyObject without TaggingDirective should copy source tags to destination");
     }
+
+    @Test
+    void copyObjectWithReplaceTaggerReplacesSourceTags() {
+        s3Service.putBucketVersioning("versioned-bucket", "Enabled");
+        s3Service.putObject("versioned-bucket", "replace-key",
+                "content".getBytes(StandardCharsets.UTF_8), "text/plain", null);
+        s3Service.putObjectTagging("versioned-bucket", "replace-key", Map.of("original", "tag"));
+
+        s3Service.copyObject("versioned-bucket", "replace-key", "versioned-bucket", "replace-key",
+                null,
+                new CopyObjectOptions()
+                        .withTaggingDirective("REPLACE")
+                        .withReplacementTagging(Map.of("new", "value")));
+
+        Map<String, String> tags = s3Service.getObjectTagging("versioned-bucket", "replace-key");
+        assertEquals("value", tags.get("new"), "REPLACE should apply replacement tags");
+        assertNull(tags.get("original"), "REPLACE should not preserve source tags");
+    }
+
+    @Test
+    void copyObjectWithReplaceTaggerAndNoTagsClearsTags() {
+        s3Service.putBucketVersioning("versioned-bucket", "Enabled");
+        s3Service.putObject("versioned-bucket", "clear-key",
+                "content".getBytes(StandardCharsets.UTF_8), "text/plain", null);
+        s3Service.putObjectTagging("versioned-bucket", "clear-key", Map.of("should", "disappear"));
+
+        s3Service.copyObject("versioned-bucket", "clear-key", "versioned-bucket", "clear-key",
+                null,
+                new CopyObjectOptions()
+                        .withTaggingDirective("REPLACE")
+                        .withReplacementTagging(Map.of()));
+
+        Map<String, String> tags = s3Service.getObjectTagging("versioned-bucket", "clear-key");
+        assertTrue(tags.isEmpty(), "REPLACE with empty tags should clear all source tags");
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
@@ -12,6 +12,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -254,5 +255,28 @@ class S3VersioningServiceTest {
         List<S3Object> objects = s3Service.listObjects("versioned-bucket", null, null, 100);
         assertEquals(1, objects.size());
         assertEquals("keep.txt", objects.get(0).getKey());
+    }
+
+    @Test
+    void copyObjectPreservesSourceTagsByDefault() {
+        s3Service.putBucketVersioning("versioned-bucket", "Enabled");
+        s3Service.putObject("versioned-bucket", "key",
+                "v1".getBytes(StandardCharsets.UTF_8), "text/plain", null);
+
+        s3Service.putObjectTagging("versioned-bucket", "key", Map.of("version", "v1-tag"));
+
+        S3Object v2 = s3Service.putObject("versioned-bucket", "key",
+                "v2".getBytes(StandardCharsets.UTF_8), "text/plain", null);
+
+        // Copy v2 to itself without specifying TaggingDirective — source tags should be preserved
+        // First tag v2
+        s3Service.putObjectTagging("versioned-bucket", "key", Map.of("version", "v2-tag"));
+
+        s3Service.copyObject("versioned-bucket", "key", "versioned-bucket", "key",
+                v2.getVersionId(), new CopyObjectOptions());
+
+        Map<String, String> tags = s3Service.getObjectTagging("versioned-bucket", "key");
+        assertEquals("v2-tag", tags.get("version"),
+                "copyObject without TaggingDirective should copy source tags to destination");
     }
 }


### PR DESCRIPTION
## Summary

Implements the TaggingDirective parameter for CopyObject. Prior to this fix, source object tags were never propagated to the destination — GetObjectTagging on a copied object always returned an empty TagSet, regardless of the source's tags.

The default AWS behaviour (TaggingDirective=COPY) is now applied: source tags are copied to the destination unless TaggingDirective: REPLACE is specified, in which case the tags provided via x-amz-tagging are used instead.

Closes #1048

## Type of change

- Bug fix (fix:)

## AWS Compatibility

Incorrect behavior: CopyObject without TaggingDirective produced a destination object with no tags. AWS S3 defaults TaggingDirective to COPY, meaning source tags must be propagated.

Verified against boto3 1.28 / botocore 1.43 and AWS CLI 2.x wire protocol. The x-amz-tagging-directive and x-amz-tagging request headers are now extracted in handleCopyObject and forwarded through CopyObjectOptions to copyS3Object.

## Checklist

-[x] ./mvnw test passes locally
-[x] New or updated integration test added (rollbackScenario_copyWithReplaceMetadataPreservesVersionKey in S3VersioningIntegrationTest, copyObjectPreservesSourceTagsByDefault in S3VersioningServiceTest)
-[x] Commit messages follow Conventional Commits
