### PR TITLE
fix(cloudformation): implement nested stack deployment via AWS::CloudFormation::Stack

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -153,7 +153,6 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::KMS::Key" -> provisionKmsKey(resource, properties, engine, region, accountId);
                 case "AWS::KMS::Alias" -> provisionKmsAlias(resource, properties, engine, region);
                 case "AWS::SecretsManager::Secret" -> provisionSecret(resource, properties, engine, region, accountId, stackName);
-                case "AWS::CloudFormation::Stack" -> provisionNestedStack(resource, properties, engine, region);
                 case "AWS::CDK::Metadata" -> provisionCdkMetadata(resource);
                 case "AWS::S3::BucketPolicy" -> provisionS3BucketPolicy(resource, properties, engine);
                 case "AWS::SQS::QueuePolicy" -> provisionSqsQueuePolicy(resource, properties, engine);
@@ -1178,17 +1177,6 @@ public class CloudFormationResourceProvisioner {
         }
 
         return password;
-    }
-
-    // ── Nested Stack ──────────────────────────────────────────────────────────
-
-    private void provisionNestedStack(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
-                                      String region) {
-        // Nested stacks are stubbed — return a synthetic stack ID
-        String nestedId = AwsArnUtils.Arn.of("cloudformation", region, "", "stack/nested-" + UUID.randomUUID().toString().substring(0, 8) + "/").toString();
-        r.setPhysicalId(nestedId);
-        r.getAttributes().put("Arn", nestedId);
-        r.getAttributes().put("Outputs.BootstrapVersion", "21");
     }
 
     // ── EventBridge ─────────────────────────────────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
@@ -307,9 +307,15 @@ public class CloudFormationService {
                     }
 
                     addEvent(stack, logicalId, null, type, "CREATE_IN_PROGRESS", null);
-                    resource = provisioner.provision(logicalId, type, props.isMissingNode() ? null : props,
-                            engine, region, accountId, stack.getStackName(),
-                            resource.getPhysicalId(), resource.getAttributes());
+                    if ("AWS::CloudFormation::Stack".equals(type)) {
+                        resource = executeNestedStack(stack, logicalId,
+                                props.isMissingNode() ? null : props,
+                                engine, region, accountId, isCreate);
+                    } else {
+                        resource = provisioner.provision(logicalId, type, props.isMissingNode() ? null : props,
+                                engine, region, accountId, stack.getStackName(),
+                                resource.getPhysicalId(), resource.getAttributes());
+                    }
                     stack.getResources().put(logicalId, resource);
 
                     physicalIds.put(logicalId, resource.getPhysicalId());
@@ -560,6 +566,49 @@ public class CloudFormationService {
         String normalizedSuffix = suffix.toLowerCase(Locale.ROOT);
         return normalizedHost.length() > normalizedSuffix.length() + 1
                 && normalizedHost.endsWith("." + normalizedSuffix);
+    }
+
+    private StackResource executeNestedStack(Stack parentStack, String logicalId, JsonNode props,
+                                             CloudFormationTemplateEngine engine, String region,
+                                             String accountId, boolean isCreate) {
+        StackResource resource = new StackResource();
+        resource.setLogicalId(logicalId);
+        resource.setResourceType("AWS::CloudFormation::Stack");
+
+        String templateUrl = props != null ? engine.resolve(props.path("TemplateURL")) : null;
+        if (templateUrl == null || templateUrl.isBlank()) {
+            resource.setStatus("CREATE_FAILED");
+            resource.setStatusReason("Missing TemplateURL");
+            return resource;
+        }
+
+        String childTemplate = fetchTemplateFromS3(templateUrl);
+        String childStackName = parentStack.getStackName() + "-" + logicalId;
+
+        Stack childStack = newStack(childStackName, region);
+        childStack.setStatus("CREATE_IN_PROGRESS");
+        stacks.put(key(childStackName, region), childStack);
+
+        Map<String, String> childParams = new LinkedHashMap<>();
+        if (props != null && props.has("Parameters") && props.get("Parameters").isObject()) {
+            props.get("Parameters").fields().forEachRemaining(e ->
+                    childParams.put(e.getKey(), engine.resolve(e.getValue())));
+        }
+
+        executeTemplate(childStack, childTemplate, childParams, isCreate, region, accountId);
+
+        resource.setPhysicalId(childStack.getStackId());
+        resource.getAttributes().put("Arn", childStack.getStackId());
+        childStack.getOutputs().forEach((k, v) -> resource.getAttributes().put("Outputs." + k, v));
+
+        if ("CREATE_FAILED".equals(childStack.getStatus()) || "UPDATE_FAILED".equals(childStack.getStatus())) {
+            resource.setStatus("CREATE_FAILED");
+            resource.setStatusReason("Nested stack " + childStackName + " failed: " + childStack.getStatusReason());
+        } else {
+            resource.setStatus("CREATE_COMPLETE");
+        }
+
+        return resource;
     }
 
     private Stack newStack(String stackName, String region) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -4426,4 +4426,93 @@ class CloudFormationIntegrationTest {
             .statusCode(404);
     }
 
+    @Test
+    void createStack_withNestedStack_resourcesAreProvisioned() {
+        String childTemplate = """
+            {
+              "Resources": {
+                "ChildQueue": {
+                  "Type": "AWS::SQS::Queue",
+                  "Properties": {
+                    "QueueName": "nested-stack-child-queue"
+                  }
+                }
+              },
+              "Outputs": {
+                "QueueUrl": {
+                  "Value": {"Ref": "ChildQueue"}
+                }
+              }
+            }
+            """;
+
+        // Upload child template to S3
+        given().when().put("/nested-stack-templates").then().statusCode(200);
+        given()
+            .contentType("application/json")
+            .body(childTemplate)
+        .when()
+            .put("/nested-stack-templates/child.json")
+        .then()
+            .statusCode(200);
+
+        String parentTemplate = """
+            {
+              "Resources": {
+                "ChildStack": {
+                  "Type": "AWS::CloudFormation::Stack",
+                  "Properties": {
+                    "TemplateURL": "http://localhost/nested-stack-templates/child.json"
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "parent-nested-stack")
+            .formParam("TemplateBody", parentTemplate)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        // Parent stack reaches CREATE_COMPLETE
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "parent-nested-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        // Nested stack resource itself is CREATE_COMPLETE
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStackResources")
+            .formParam("StackName", "parent-nested-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<ResourceType>AWS::CloudFormation::Stack</ResourceType>"))
+            .body(containsString("<ResourceStatus>CREATE_COMPLETE</ResourceStatus>"));
+
+        // SQS queue defined in the nested template actually exists
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "GetQueueUrl")
+            .formParam("QueueName", "nested-stack-child-queue")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("nested-stack-child-queue"));
+    }
+
 }


### PR DESCRIPTION
## Summary

- `AWS::CloudFormation::Stack` was previously stubbed — it returned a synthetic stack ID but never fetched or deployed the child template, so all resources defined in nested stacks were silently skipped despite the deployment reporting `CREATE_COMPLETE`
- Intercept `AWS::CloudFormation::Stack` in `CloudFormationService.executeTemplate()` before delegating to the provisioner — resolve `TemplateURL` via the template engine, fetch the child template from S3, create a child `Stack`, and execute it recursively on the same thread
- Child stack outputs are surfaced as `Outputs.X` attributes on the parent resource so `Fn::GetAtt` cross-stack references resolve correctly
- Removes the `provisionNestedStack` stub from `CloudFormationResourceProvisioner`

Closes #1051

## Test plan

- [x] New integration test `createStack_withNestedStack_resourcesAreProvisioned`: uploads a child template (SQS queue) to S3, deploys a parent stack with a nested stack resource, asserts parent is `CREATE_COMPLETE`, nested resource is `CREATE_COMPLETE`, and the SQS queue from the child template actually exists
- [x] Full `CloudFormationIntegrationTest` suite passes (66 tests)