### PR TITLE
fix(lambda): Lambda WarmPool timeout when stopping multiple contai…

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/WarmPool.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/WarmPool.java
@@ -15,7 +15,9 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -202,8 +204,28 @@ public class WarmPool {
             queue.clear();
         }
         LOG.infov("Draining {0} container(s) for function: {1}", toStop.size(), functionName);
-        for (ContainerHandle handle : toStop) {
-            stopQuietly(handle);
+        stopInParallel(toStop);
+    }
+
+    private void stopInParallel(List<ContainerHandle> handles) {
+        if (handles.isEmpty()) return;
+        int parallelism = Math.min(handles.size(), 16);
+        ExecutorService pool = Executors.newFixedThreadPool(parallelism,
+                r -> { Thread t = new Thread(r, "warm-pool-drainer"); t.setDaemon(true); return t; });
+        try {
+            List<Future<?>> futures = new ArrayList<>(handles.size());
+            for (ContainerHandle handle : handles) {
+                futures.add(pool.submit(() -> stopQuietly(handle)));
+            }
+            for (Future<?> f : futures) {
+                try {
+                    f.get(15, TimeUnit.SECONDS);
+                } catch (Exception e) {
+                    LOG.warnv("Drain task did not finish cleanly: {0}", e.getMessage());
+                }
+            }
+        } finally {
+            pool.shutdownNow();
         }
     }
 


### PR DESCRIPTION
…ners; run in parallel

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

Fixes lambda not being able to shutdown multiple containers on floci lifecycle shutdown in WarmPool.java .
This won't fix the problem entirely, but remediate the current problem.

On floci shutdown, WarmPool.drainFunction stops containers serially with
a 5s per-container timeout. Quarkus's shutdown grace finishes before
more than ~1 container is stopped, so the rest leak as orphaned
running containers on the host.

This PR fans the stop calls out across a small thread pool (capped at
16) so all warm containers get a stop request in parallel. On an 8-
concurrent-invoke repro, shutdown now cleans up all 8 containers
in ~9s; previously only 1 survived the grace window.

Note: this only addresses the Lambda WarmPool path. Other on-demand
services going through ContainerLifecycleManager (CodeBuild, ECS,
Neptune, OpenSearch etc) have the same shape and should be audited
separately - tracked in #1054.

Refs: floci-io/floci#937

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
