### PR TITLE
docs: add Neptune service page and fix missing index entries (#950, #951)

### DIFF
--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -29,6 +29,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [CloudFormation](cloudformation.md) | `POST /` with `Action=` param | Query | 19 |
 | [EventBridge](eventbridge.md) | `POST /` + `X-Amz-Target: AmazonEventBridge.*` | JSON 1.1 | 16 |
 | [EventBridge Scheduler](scheduler.md) | `/schedules/*`, `/schedule-groups/*`, `/tags/*` | REST JSON | 12 |
+| [EventBridge Pipes](pipes.md) | `/v1/pipes/*` | REST JSON | 7 |
 | [CloudWatch Logs](cloudwatch.md) | `POST /` + `X-Amz-Target: Logs.*` | JSON 1.1 | 17 |
 | [CloudWatch Metrics](cloudwatch.md#metrics) | `POST /` with `Action=` or JSON 1.1 | Query / JSON | 11 |
 | [ElastiCache](elasticache.md) | `POST /` with `Action=` param + TCP proxy | Query + RESP | 8 |
@@ -36,6 +37,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [MSK](msk.md) | `/v1/clusters/...`, `/api/v2/clusters/...` + Redpanda broker | REST JSON + Kafka | 8 |
 | [Athena](athena.md) | `POST /` + `X-Amz-Target: AmazonAthena.*` | JSON 1.1 | 4 |
 | [Glue](glue.md) | `POST /` + `X-Amz-Target: AWSGlue.*` | JSON 1.1 | 32 |
+| [Neptune](neptune.md) | `POST /` with `Action=` param + Gremlin TCP proxy | Query + WebSocket | 8 |
 | [Data Firehose](firehose.md) | `POST /` + `X-Amz-Target: Firehose_20150804.*` | JSON 1.1 | 6 |
 | [ECS](ecs.md) | `POST /` + `X-Amz-Target: AmazonEC2ContainerServiceV20141113.*` | JSON 1.1 | 58 |
 | [EC2](ec2.md) | `POST /` with `Action=` param | EC2 Query | 61 |

--- a/docs/services/neptune.md
+++ b/docs/services/neptune.md
@@ -1,0 +1,131 @@
+# Neptune
+
+**Protocol:** Query (XML) for management API + Gremlin / HTTP for data plane
+**Management Endpoint:** `POST http://localhost:4566/`
+**Data Endpoint:** `localhost:<proxy-port>` (TCP / WebSocket)
+
+Floci manages real [Apache TinkerPop Gremlin Server](https://tinkerpop.apache.org/) Docker containers and proxies connections to them, providing an API-compatible Neptune emulation for local development and testing.
+
+## Supported Actions
+
+| Action | Description |
+|--------|-------------|
+| `CreateDBCluster` | Create a Neptune cluster and start a Gremlin Server container |
+| `DescribeDBClusters` | List clusters and their connection details |
+| `DeleteDBCluster` | Stop and remove a cluster |
+| `ModifyDBCluster` | Update cluster settings |
+| `CreateDBInstance` | Add an instance to a cluster |
+| `DescribeDBInstances` | List instances |
+| `DeleteDBInstance` | Remove an instance from a cluster |
+| `ModifyDBInstance` | Update instance settings |
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FLOCI_SERVICES_NEPTUNE_ENABLED` | `true` | Enable or disable Neptune |
+| `FLOCI_SERVICES_NEPTUNE_PROXY_BASE_PORT` | `8182` | First host port in the Gremlin proxy range |
+| `FLOCI_SERVICES_NEPTUNE_PROXY_MAX_PORT` | `8282` | Last host port in the Gremlin proxy range |
+| `FLOCI_SERVICES_NEPTUNE_DEFAULT_IMAGE` | `tinkerpop/gremlin-server:3.7.3` | Gremlin Server Docker image |
+| `FLOCI_SERVICES_NEPTUNE_DOCKER_NETWORK` | _(host default)_ | Docker network for container connectivity |
+
+### Docker Compose
+
+Neptune requires the Docker socket and the Gremlin proxy port range to be exposed. The first cluster claims `PROXY_BASE_PORT`; each additional cluster increments the port.
+
+```yaml
+services:
+  floci:
+    image: floci/floci:latest
+    ports:
+      - "4566:4566"
+      - "8182-8282:8182-8282"   # Neptune Gremlin proxy ports
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      FLOCI_SERVICES_DOCKER_NETWORK: my-project_default
+```
+
+For private registry authentication and other Docker settings see [Docker Configuration](../configuration/docker.md).
+
+## Examples
+
+### Management API (AWS CLI)
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:4566
+export AWS_DEFAULT_REGION=us-east-1
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+
+# Create a Neptune cluster
+aws neptune create-db-cluster \
+  --db-cluster-identifier my-neptune \
+  --engine neptune
+
+# Get cluster details and Gremlin endpoint port
+aws neptune describe-db-clusters \
+  --db-cluster-identifier my-neptune \
+  --query 'DBClusters[0].{Endpoint:Endpoint,Port:Port}'
+
+# Create an instance in the cluster
+aws neptune create-db-instance \
+  --db-instance-identifier my-neptune-instance \
+  --db-cluster-identifier my-neptune \
+  --db-instance-class db.r5.large \
+  --engine neptune
+
+# Delete instance and cluster
+aws neptune delete-db-instance \
+  --db-instance-identifier my-neptune-instance
+aws neptune delete-db-cluster \
+  --db-cluster-identifier my-neptune \
+  --skip-final-snapshot
+```
+
+### Graph data plane (Python + gremlin-python)
+
+```python
+from gremlin_python.driver import client, serializer
+
+# Use the port returned by DescribeDBClusters
+gremlin = client.Client(
+    "ws://localhost:8182/gremlin",
+    "g",
+    message_serializer=serializer.GraphSONSerializersV2d0(),
+)
+
+# Add a vertex
+gremlin.submit("g.addV('person').property('name', 'Alice')").all().result()
+
+# Query vertices
+result = gremlin.submit("g.V().valueMap(true)").all().result()
+print(result)
+
+gremlin.close()
+```
+
+### Management API (Python / boto3)
+
+```python
+import boto3
+
+neptune = boto3.client(
+    "neptune",
+    endpoint_url="http://localhost:4566",
+    region_name="us-east-1",
+)
+
+cluster = neptune.create_db_cluster(
+    DBClusterIdentifier="my-neptune",
+    Engine="neptune",
+)
+print(cluster["DBCluster"]["Endpoint"])
+```
+
+## Out of Scope
+
+- IAM database authentication for Gremlin connections.
+- Neptune Analytics (vector search, graph analytics).
+- Neptune Serverless auto-pause/resume.
+- Snapshot and restore operations.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
     - RDS: services/rds.md
     - MSK (Kafka): services/msk.md
     - Glue: services/glue.md
+    - Neptune: services/neptune.md
     - Athena: services/athena.md
     - Data Firehose: services/firehose.md
     - EventBridge: services/eventbridge.md


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->
Covers the 8 supported management actions, all 5 configuration variables (proxy port range, Docker image, network), a Docker Compose snippet for port exposure, and examples for the management API (AWS CLI + boto3) and the Gremlin data plane (gremlin-python).
- **#951** — Adds the missing `EventBridge Pipes` row to the service matrix in `docs/services/index.md`. The `pipes.md` page already existed and was complete.
- **#953** — No changes needed; `resource-groups-tagging.md` and its index entry were already in place. Issue commented and ready to close. 

Closes #953 
Closes #951
Closes #950

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore


## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
