### PR TITLE
fix(apigw-v2): populate pathParameters in Lambda proxy event for HTTP API integrations

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2NetworkInterfacePaginationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2NetworkInterfacePaginationTest.java
@@ -110,12 +110,17 @@ class Ec2NetworkInterfacePaginationTest {
         }
     }
 
+    private DescribeNetworkInterfacesRequest.Builder vpcFilter() {
+        return DescribeNetworkInterfacesRequest.builder()
+                .filters(Filter.builder().name("vpc-id").values(vpcId).build());
+    }
+
     @Test
     @Order(1)
     @DisplayName("DescribeNetworkInterfaces without pagination returns all 6 ENIs")
     void describeNetworkInterfacesAll() {
         DescribeNetworkInterfacesResponse resp = ec2.describeNetworkInterfaces(
-                DescribeNetworkInterfacesRequest.builder().build());
+                vpcFilter().build());
 
         assertThat(resp.networkInterfaces()).hasSize(6);
         assertThat(resp.nextToken()).isNull();
@@ -126,9 +131,7 @@ class Ec2NetworkInterfacePaginationTest {
     @DisplayName("MaxResults=5 truncates first page and returns nextToken")
     void describeNetworkInterfacesFirstPage() {
         DescribeNetworkInterfacesResponse resp = ec2.describeNetworkInterfaces(
-                DescribeNetworkInterfacesRequest.builder()
-                        .maxResults(5)
-                        .build());
+                vpcFilter().maxResults(5).build());
 
         assertThat(resp.networkInterfaces()).hasSize(5);
         assertThat(resp.nextToken()).isNotNull().isNotEmpty();
@@ -140,17 +143,12 @@ class Ec2NetworkInterfacePaginationTest {
     void describeNetworkInterfacesContinuation() {
         // Page 1: get nextToken
         DescribeNetworkInterfacesResponse page1 = ec2.describeNetworkInterfaces(
-                DescribeNetworkInterfacesRequest.builder()
-                        .maxResults(5)
-                        .build());
+                vpcFilter().maxResults(5).build());
         assertThat(page1.nextToken()).isNotNull();
 
         // Page 2: use nextToken
         DescribeNetworkInterfacesResponse page2 = ec2.describeNetworkInterfaces(
-                DescribeNetworkInterfacesRequest.builder()
-                        .maxResults(5)
-                        .nextToken(page1.nextToken())
-                        .build());
+                vpcFilter().maxResults(5).nextToken(page1.nextToken()).build());
 
         assertThat(page2.networkInterfaces()).hasSize(1);
         assertThat(page2.nextToken()).isNull();
@@ -175,25 +173,17 @@ class Ec2NetworkInterfacePaginationTest {
     void describeNetworkInterfacesTokenPastEnd() {
         // Get a valid token from first page
         DescribeNetworkInterfacesResponse page1 = ec2.describeNetworkInterfaces(
-                DescribeNetworkInterfacesRequest.builder()
-                        .maxResults(5)
-                        .build());
+                vpcFilter().maxResults(5).build());
         String token = page1.nextToken();
 
         // Use it to get the last page
         DescribeNetworkInterfacesResponse page2 = ec2.describeNetworkInterfaces(
-                DescribeNetworkInterfacesRequest.builder()
-                        .maxResults(5)
-                        .nextToken(token)
-                        .build());
+                vpcFilter().maxResults(5).nextToken(token).build());
 
         // Using the token from page2 (which is null since it's the last page)
         // would be invalid, but using a valid token again should still work
         DescribeNetworkInterfacesResponse repeat = ec2.describeNetworkInterfaces(
-                DescribeNetworkInterfacesRequest.builder()
-                        .maxResults(5)
-                        .nextToken(token)
-                        .build());
+                vpcFilter().maxResults(5).nextToken(token).build());
 
         assertThat(repeat.networkInterfaces()).hasSize(1);
         assertThat(repeat.nextToken()).isNull();

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -1734,7 +1734,7 @@ public class ApiGatewayExecuteController {
         };
     }
 
-    private String buildV2ProxyEvent(String httpMethod, String path, String routeKey,
+    String buildV2ProxyEvent(String httpMethod, String path, String routeKey,
                                      String apiId, String stageName,
                                      HttpHeaders headers, UriInfo uriInfo,
                                      byte[] body, String requestId) {
@@ -1757,6 +1757,12 @@ public class ApiGatewayExecuteController {
             for (Map.Entry<String, java.util.List<String>> e : queryParams.entrySet()) {
                 if (!e.getValue().isEmpty()) qsp.put(e.getKey(), e.getValue().get(0));
             }
+        }
+
+        Map<String, String> pathParams = extractV2PathParams(routeKey, path);
+        if (!pathParams.isEmpty()) {
+            ObjectNode pp = event.putObject("pathParameters");
+            pathParams.forEach(pp::put);
         }
 
         ObjectNode ctx = event.putObject("requestContext");

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2ProxyEventPathParametersTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2ProxyEventPathParametersTest.java
@@ -1,0 +1,78 @@
+package io.github.hectorvent.floci.services.apigateway;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.UriInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that {@link ApiGatewayExecuteController#buildV2ProxyEvent} populates
+ * {@code pathParameters} in the Lambda event payload for HTTP API (V2) integrations.
+ */
+class BuildV2ProxyEventPathParametersTest {
+
+    private ApiGatewayExecuteController controller;
+    private HttpHeaders headers;
+    private UriInfo uriInfo;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        RegionResolver regionResolver = mock(RegionResolver.class);
+        when(regionResolver.getAccountId()).thenReturn("000000000000");
+
+        headers = mock(HttpHeaders.class);
+        when(headers.getRequestHeaders()).thenReturn(new MultivaluedHashMap<>());
+        when(headers.getHeaderString("User-Agent")).thenReturn(null);
+
+        uriInfo = mock(UriInfo.class);
+        when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+        when(uriInfo.getRequestUri()).thenReturn(new URI("http://localhost:4566/api/stage/trpc/health"));
+
+        controller = new ApiGatewayExecuteController(
+                null, null, null,
+                regionResolver, new ObjectMapper(), null,
+                null, null, null
+        );
+    }
+
+    @Test
+    void greedyProxyRoutePopulatesPathParameters() throws Exception {
+        String json = controller.buildV2ProxyEvent(
+                "POST", "/trpc/health", "ANY /{proxy+}",
+                "abc123", "$default", headers, uriInfo, null, "req-1");
+        JsonNode event = new ObjectMapper().readTree(json);
+        assertTrue(event.has("pathParameters"), "pathParameters must be present");
+        assertEquals("trpc/health", event.get("pathParameters").get("proxy").asText());
+    }
+
+    @Test
+    void namedParamRoutePopulatesPathParameters() throws Exception {
+        when(uriInfo.getRequestUri()).thenReturn(new URI("http://localhost:4566/api/stage/users/42"));
+        String json = controller.buildV2ProxyEvent(
+                "GET", "/users/42", "GET /users/{id}",
+                "abc123", "$default", headers, uriInfo, null, "req-2");
+        JsonNode event = new ObjectMapper().readTree(json);
+        assertTrue(event.has("pathParameters"), "pathParameters must be present");
+        assertEquals("42", event.get("pathParameters").get("id").asText());
+    }
+
+    @Test
+    void defaultRouteOmitsPathParameters() throws Exception {
+        when(uriInfo.getRequestUri()).thenReturn(new URI("http://localhost:4566/api/stage/anything"));
+        String json = controller.buildV2ProxyEvent(
+                "GET", "/anything", "$default",
+                "abc123", "$default", headers, uriInfo, null, "req-3");
+        JsonNode event = new ObjectMapper().readTree(json);
+        assertFalse(event.has("pathParameters"), "pathParameters must be absent for $default route");
+    }
+}


### PR DESCRIPTION
## Summary

`buildV2ProxyEvent` never called `extractV2PathParams`, so `pathParameters` was always absent from the Lambda event payload for HTTP API (V2) Lambda proxy integrations. This broke any framework relying on `pathParameters` for routing — notably the tRPC AWS Lambda adapter, which uses `pathParameters.proxy` with an `ANY /{proxy+}` route.

## Approach

Wire `extractV2PathParams` into `buildV2ProxyEvent` after the `queryStringParameters` block, mirroring how `dispatchHttpProxyV2` (line ~1250) already uses it. Only emit the `pathParameters` node when the map is non-empty, so `$default` routes (no path params) are unaffected.

`buildV2ProxyEvent` is also relaxed from `private` to package-private to allow direct unit testing without reflection.

## Assumptions & clarifications

- `pathParameters` should be omitted entirely (not set to `null`) when there are no path parameters, consistent with the AWS payload format v2.0 spec and the existing behaviour of routes without params.
- The `extractV2PathParams` method is already correct and cached — no changes needed there.

## Verification

### Manual

Deployed a CDK `HttpApi` with `ANY /{proxy+}` → Lambda echo function against both the unpatched and patched builds:

- **Before fix:** `GET /trpc/health` → `{ "pathParameters": null }` (exit 1)
- **After fix:** `GET /trpc/health` → `{ "pathParameters": { "proxy": "trpc/health" } }` (exit 0)

### Automated tests

Added `BuildV2ProxyEventPathParametersTest` covering:
- `ANY /{proxy+}` with `/trpc/health` → `pathParameters = { "proxy": "trpc/health" }`
- `GET /users/{id}` with `/users/42` → `pathParameters = { "id": "42" }`
- `$default` route → `pathParameters` key absent

## Warnings

None.

## Concerns

- The visibility change (`private` → package-private) on `buildV2ProxyEvent` is the minimal change needed for testability. It remains internal to the package.

## Also fixes: flaky `Ec2NetworkInterfacePaginationTest`

`sdk-test-java` was failing intermittently on this PR (and potentially others) due to a pre-existing test isolation issue in `Ec2NetworkInterfacePaginationTest`. The tests called `DescribeNetworkInterfaces` with no filter, so they counted ENIs created by other concurrently-running tests (e.g. `sdk-test-instance` from `Ec2DescribeNetworkInterfacesTest`). Fixed by scoping all four test calls with a `vpc-id` filter against the VPC the test itself created.

Closes #1066