### PR TITLE
fix(eventbridge): enforce $or negation in event pattern matching

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -741,6 +741,19 @@ public class EventBridgeService {
         }
         try {
             JsonNode pattern = objectMapper.readTree(eventPattern);
+            JsonNode orClauses = pattern.get("$or");
+            if (orClauses != null && orClauses.isArray()) {
+                boolean anyMatches = false;
+                for (JsonNode subPattern : orClauses) {
+                    if (matchesPattern(event, objectMapper.writeValueAsString(subPattern))) {
+                        anyMatches = true;
+                        break;
+                    }
+                }
+                if (!anyMatches) {
+                    return false;
+                }
+            }
             JsonNode sourceField = pattern.get("source");
             if (sourceField != null && sourceField.isArray()) {
                 String eventSource = (String) event.get("Source");
@@ -806,9 +819,25 @@ public class EventBridgeService {
     }
 
     private boolean matchesDetailNode(JsonNode actual, JsonNode pattern) {
+        JsonNode orClauses = pattern.get("$or");
+        if (orClauses != null && orClauses.isArray()) {
+            boolean anyMatches = false;
+            for (JsonNode subPattern : orClauses) {
+                if (matchesDetailNode(actual, subPattern)) {
+                    anyMatches = true;
+                    break;
+                }
+            }
+            if (!anyMatches) {
+                return false;
+            }
+        }
         var fields = pattern.fields();
         while (fields.hasNext()) {
             var field = fields.next();
+            if ("$or".equals(field.getKey())) {
+                continue;
+            }
             JsonNode expected = field.getValue();
             JsonNode actualField = actual.get(field.getKey());
             if (expected.isArray()) {

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeServiceTest.java
@@ -541,6 +541,72 @@ class EventBridgeServiceTest {
     }
 
     @Test
+    void matchesPatternTopLevelOr_firstBranchMatches() {
+        Map<String, Object> event = Map.of("Source", "aws.ec2", "DetailType", "Other");
+        assertTrue(service.matchesPattern(event,
+                "{\"$or\":[{\"source\":[\"aws.ec2\"]},{\"source\":[\"aws.s3\"]}]}"));
+    }
+
+    @Test
+    void matchesPatternTopLevelOr_secondBranchMatches() {
+        Map<String, Object> event = Map.of("Source", "aws.s3", "DetailType", "Other");
+        assertTrue(service.matchesPattern(event,
+                "{\"$or\":[{\"source\":[\"aws.ec2\"]},{\"source\":[\"aws.s3\"]}]}"));
+    }
+
+    @Test
+    void matchesPatternTopLevelOr_noBranchMatches() {
+        Map<String, Object> event = Map.of("Source", "aws.rds", "DetailType", "Other");
+        assertFalse(service.matchesPattern(event,
+                "{\"$or\":[{\"source\":[\"aws.ec2\"]},{\"source\":[\"aws.s3\"]}]}"));
+    }
+
+    @Test
+    void matchesPatternTopLevelOrCombinedWithOtherField() {
+        Map<String, Object> event = Map.of("Source", "aws.ec2", "DetailType", "EC2 Instance State-change Notification");
+        // source must match AND one of the detail-types must match
+        assertTrue(service.matchesPattern(event,
+                "{\"source\":[\"aws.ec2\"],\"$or\":[{\"detail-type\":[\"EC2 Instance State-change Notification\"]},{\"detail-type\":[\"EC2 Spot Instance Interruption Warning\"]}]}"));
+        // source matches but neither detail-type matches
+        assertFalse(service.matchesPattern(event,
+                "{\"source\":[\"aws.ec2\"],\"$or\":[{\"detail-type\":[\"Something Else\"]},{\"detail-type\":[\"Also Wrong\"]}]}"));
+    }
+
+    @Test
+    void matchesPatternDetailLevelOr_matches() {
+        Map<String, Object> event = Map.of(
+                "Source", "my.app",
+                "Detail", "{\"status\":\"CONFIRMED\"}"
+        );
+        assertTrue(service.matchesPattern(event,
+                "{\"detail\":{\"$or\":[{\"status\":[\"CONFIRMED\"]},{\"status\":[\"PENDING\"]}]}}"));
+    }
+
+    @Test
+    void matchesPatternDetailLevelOr_noMatch() {
+        Map<String, Object> event = Map.of(
+                "Source", "my.app",
+                "Detail", "{\"status\":\"CANCELLED\"}"
+        );
+        assertFalse(service.matchesPattern(event,
+                "{\"detail\":{\"$or\":[{\"status\":[\"CONFIRMED\"]},{\"status\":[\"PENDING\"]}]}}"));
+    }
+
+    @Test
+    void matchesPatternDetailLevelOrCombinedWithOtherField() {
+        Map<String, Object> event = Map.of(
+                "Source", "my.app",
+                "Detail", "{\"status\":\"CONFIRMED\",\"region\":\"us-east-1\"}"
+        );
+        // region matches AND one of the statuses matches
+        assertTrue(service.matchesPattern(event,
+                "{\"detail\":{\"region\":[\"us-east-1\"],\"$or\":[{\"status\":[\"CONFIRMED\"]},{\"status\":[\"PENDING\"]}]}}"));
+        // region matches but status doesn't
+        assertFalse(service.matchesPattern(event,
+                "{\"detail\":{\"region\":[\"us-east-1\"],\"$or\":[{\"status\":[\"CANCELLED\"]},{\"status\":[\"FAILED\"]}]}}"));
+    }
+
+    @Test
     void matchesPatternCombinesAccountRegionAndDetail() {
         Map<String, Object> event = Map.of(
                 "Source", "my.app",


### PR DESCRIPTION
When migrating from localstack to floci it worked out of the box, except for the incorrect handling of $or patterns.

## Summary
- `$or` in EventBridge event patterns was silently ignored — the key was never read from the parsed pattern, so rules using `$or` routed every source/detail-type-matched event regardless of the OR conditions
- Add `$or` handling to `matchesPattern` (top-level envelope) and `matchesDetailNode` (detail sub-patterns)
- Top-level `$or` sub-patterns are full event patterns, evaluated via recursive `matchesPattern`; detail-level sub-patterns are evaluated via recursive `matchesDetailNode` on the same actual node
- Skip the `$or` key in the regular field-by-field AND loop to prevent false negative on `actual.get("$or")` lookup
