### PR TITLE
fix(ec2): skip terminated instances in DescribeNetworkInterfaces

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1558,6 +1558,11 @@ public class Ec2Service {
         Set<String> foundIds = new HashSet<>();
         for (Instance inst : instances.values()) {
             if (!inst.getRegion().equals(region)) continue;
+            if (inst.getState() != null
+                    && inst.getState().getName() != null
+                    && "terminated".equals(inst.getState().getName())) {
+                continue;
+            }
             for (InstanceNetworkInterface eni : inst.getNetworkInterfaces()) {
                 if (!networkInterfaceIds.isEmpty()
                         && !networkInterfaceIds.contains(eni.getNetworkInterfaceId())) {


### PR DESCRIPTION
## Summary

Fixes `DescribeNetworkInterfaces` to skip instances in the `terminated` state so stale ENIs do not leak into unfiltered network-interface listings.

This resolves the EC2 pagination regression reproduced locally, where `Ec2NetworkInterfacePaginationTest` returned extra ENIs from terminated instances and failed pagination expectations.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The incorrect behavior was that `DescribeNetworkInterfaces` included ENIs sourced from terminated instances still retained in in-memory EC2 state.

AWS documents `terminated` as a valid EC2 instance state, but not as a network-interface state. With `DeleteOnTermination=true`, primary ENIs should not remain attached to terminated instances. Filtering terminated instances from ENI enumeration is therefore consistent with AWS behavior.

Local validation:
- Reproduced the failure on `main`
- Verified the targeted regression test passes after the fix: `Ec2NetworkInterfacePaginationTest`

## Checklist

- [x] `./mvnw test` passes locally (other unrelated failures)
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)