### PR TITLE
feat(ses): add SES V2 configuration set event destination operations

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesConfigurationSetEventDestinationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesConfigurationSetEventDestinationTest.java
@@ -1,0 +1,200 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.CreateConfigurationSetEventDestinationRequest;
+import software.amazon.awssdk.services.sesv2.model.CreateConfigurationSetRequest;
+import software.amazon.awssdk.services.sesv2.model.DeleteConfigurationSetEventDestinationRequest;
+import software.amazon.awssdk.services.sesv2.model.DeleteConfigurationSetRequest;
+import software.amazon.awssdk.services.sesv2.model.EventDestinationDefinition;
+import software.amazon.awssdk.services.sesv2.model.EventType;
+import software.amazon.awssdk.services.sesv2.model.GetConfigurationSetEventDestinationsRequest;
+import software.amazon.awssdk.services.sesv2.model.GetConfigurationSetEventDestinationsResponse;
+import software.amazon.awssdk.services.sesv2.model.SnsDestination;
+import software.amazon.awssdk.services.sesv2.model.UpdateConfigurationSetEventDestinationRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * SES V2 ConfigurationSet event destination compatibility tests using the
+ * real AWS SDK for Java v2 (SesV2Client) against a live Floci instance.
+ */
+@DisplayName("SES Configuration Set Event Destinations")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesConfigurationSetEventDestinationTest {
+
+    private static SesV2Client ses;
+    private static String csName;
+    private static final String ED_NAME = "ed-sns";
+    private static final String TOPIC_ARN = "arn:aws:sns:us-east-1:000000000000:ses-events";
+    private static final String TOPIC_ARN_2 = "arn:aws:sns:us-east-1:000000000000:ses-events-2";
+
+    @BeforeAll
+    static void setup() {
+        ses = TestFixtures.sesV2Client();
+        csName = "sdk-ed-cs-" + TestFixtures.uniqueName();
+        ses.createConfigurationSet(CreateConfigurationSetRequest.builder()
+                .configurationSetName(csName)
+                .build());
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (ses == null) {
+            return;
+        }
+        try {
+            ses.deleteConfigurationSetEventDestination(DeleteConfigurationSetEventDestinationRequest.builder()
+                    .configurationSetName(csName)
+                    .eventDestinationName(ED_NAME)
+                    .build());
+        } catch (Exception ignored) {}
+        try {
+            ses.deleteConfigurationSet(DeleteConfigurationSetRequest.builder()
+                    .configurationSetName(csName)
+                    .build());
+        } catch (Exception ignored) {}
+        ses.close();
+    }
+
+    @Test
+    @Order(1)
+    void createEventDestination() {
+        ses.createConfigurationSetEventDestination(CreateConfigurationSetEventDestinationRequest.builder()
+                .configurationSetName(csName)
+                .eventDestinationName(ED_NAME)
+                .eventDestination(EventDestinationDefinition.builder()
+                        .enabled(true)
+                        .matchingEventTypes(EventType.SEND, EventType.BOUNCE)
+                        .snsDestination(SnsDestination.builder().topicArn(TOPIC_ARN).build())
+                        .build())
+                .build());
+    }
+
+    @Test
+    @Order(2)
+    void getEventDestinationsReturnsRoundTrip() {
+        GetConfigurationSetEventDestinationsResponse response =
+                ses.getConfigurationSetEventDestinations(GetConfigurationSetEventDestinationsRequest.builder()
+                        .configurationSetName(csName)
+                        .build());
+
+        assertThat(response.eventDestinations()).hasSize(1);
+        assertThat(response.eventDestinations().get(0).name()).isEqualTo(ED_NAME);
+        assertThat(response.eventDestinations().get(0).enabled()).isTrue();
+        assertThat(response.eventDestinations().get(0).matchingEventTypes())
+                .contains(EventType.SEND, EventType.BOUNCE);
+        assertThat(response.eventDestinations().get(0).snsDestination().topicArn()).isEqualTo(TOPIC_ARN);
+    }
+
+    @Test
+    @Order(3)
+    void createDuplicateRejectedWith400() {
+        assertThatThrownBy(() -> ses.createConfigurationSetEventDestination(
+                CreateConfigurationSetEventDestinationRequest.builder()
+                        .configurationSetName(csName)
+                        .eventDestinationName(ED_NAME)
+                        .eventDestination(EventDestinationDefinition.builder()
+                                .matchingEventTypes(EventType.SEND)
+                                .snsDestination(SnsDestination.builder().topicArn(TOPIC_ARN).build())
+                                .build())
+                        .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(400);
+    }
+
+    @Test
+    @Order(4)
+    void updateReplacesDefinition() {
+        ses.updateConfigurationSetEventDestination(UpdateConfigurationSetEventDestinationRequest.builder()
+                .configurationSetName(csName)
+                .eventDestinationName(ED_NAME)
+                .eventDestination(EventDestinationDefinition.builder()
+                        .enabled(false)
+                        .matchingEventTypes(EventType.DELIVERY)
+                        .snsDestination(SnsDestination.builder().topicArn(TOPIC_ARN_2).build())
+                        .build())
+                .build());
+
+        GetConfigurationSetEventDestinationsResponse response =
+                ses.getConfigurationSetEventDestinations(GetConfigurationSetEventDestinationsRequest.builder()
+                        .configurationSetName(csName)
+                        .build());
+        assertThat(response.eventDestinations()).hasSize(1);
+        assertThat(response.eventDestinations().get(0).enabled()).isFalse();
+        assertThat(response.eventDestinations().get(0).matchingEventTypes()).contains(EventType.DELIVERY);
+        assertThat(response.eventDestinations().get(0).snsDestination().topicArn()).isEqualTo(TOPIC_ARN_2);
+    }
+
+    @Test
+    @Order(5)
+    void updateUnknownReturns404() {
+        assertThatThrownBy(() -> ses.updateConfigurationSetEventDestination(
+                UpdateConfigurationSetEventDestinationRequest.builder()
+                        .configurationSetName(csName)
+                        .eventDestinationName("ed-ghost")
+                        .eventDestination(EventDestinationDefinition.builder()
+                                .matchingEventTypes(EventType.SEND)
+                                .snsDestination(SnsDestination.builder().topicArn(TOPIC_ARN).build())
+                                .build())
+                        .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(404);
+    }
+
+    @Test
+    @Order(6)
+    void deleteEventDestination() {
+        ses.deleteConfigurationSetEventDestination(DeleteConfigurationSetEventDestinationRequest.builder()
+                .configurationSetName(csName)
+                .eventDestinationName(ED_NAME)
+                .build());
+
+        GetConfigurationSetEventDestinationsResponse response =
+                ses.getConfigurationSetEventDestinations(GetConfigurationSetEventDestinationsRequest.builder()
+                        .configurationSetName(csName)
+                        .build());
+        assertThat(response.eventDestinations()).isEmpty();
+    }
+
+    @Test
+    @Order(7)
+    void deleteUnknownReturns404() {
+        assertThatThrownBy(() -> ses.deleteConfigurationSetEventDestination(
+                DeleteConfigurationSetEventDestinationRequest.builder()
+                        .configurationSetName(csName)
+                        .eventDestinationName("ed-ghost")
+                        .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(404);
+    }
+
+    @Test
+    @Order(8)
+    void createOnUnknownConfigSetReturns404() {
+        assertThatThrownBy(() -> ses.createConfigurationSetEventDestination(
+                CreateConfigurationSetEventDestinationRequest.builder()
+                        .configurationSetName("sdk-ed-cs-missing-" + System.currentTimeMillis())
+                        .eventDestinationName("ed-x")
+                        .eventDestination(EventDestinationDefinition.builder()
+                                .matchingEventTypes(EventType.SEND)
+                                .snsDestination(SnsDestination.builder().topicArn(TOPIC_ARN).build())
+                                .build())
+                        .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).statusCode())
+                .isEqualTo(404);
+    }
+}

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -183,6 +183,10 @@ Alongside the classic Query API, Floci implements a subset of the SES v2 REST JS
 | `GET` | `/v2/email/configuration-sets` | `ListConfigurationSets` |
 | `GET` | `/v2/email/configuration-sets/{name}` | `GetConfigurationSet` |
 | `DELETE` | `/v2/email/configuration-sets/{name}` | `DeleteConfigurationSet` |
+| `POST` | `/v2/email/configuration-sets/{name}/event-destinations` | `CreateConfigurationSetEventDestination` |
+| `GET` | `/v2/email/configuration-sets/{name}/event-destinations` | `GetConfigurationSetEventDestinations` |
+| `PUT` | `/v2/email/configuration-sets/{name}/event-destinations/{eventDestinationName}` | `UpdateConfigurationSetEventDestination` |
+| `DELETE` | `/v2/email/configuration-sets/{name}/event-destinations/{eventDestinationName}` | `DeleteConfigurationSetEventDestination` |
 | `PUT` | `/v2/email/suppression/addresses` | `PutSuppressedDestination` |
 | `GET` | `/v2/email/suppression/addresses/{EmailAddress}` | `GetSuppressedDestination` |
 | `DELETE` | `/v2/email/suppression/addresses/{EmailAddress}` | `DeleteSuppressedDestination` |
@@ -190,6 +194,8 @@ Alongside the classic Query API, Floci implements a subset of the SES v2 REST JS
 | `POST` | `/v2/email/tags` | `TagResource` |
 | `DELETE` | `/v2/email/tags?ResourceArn=...&TagKeys=...` | `UntagResource` |
 | `GET` | `/v2/email/tags?ResourceArn=...` | `ListTagsForResource` |
+
+Configuration set event destinations are stored as configuration only. The target (SNS, CloudWatch, Kinesis Firehose, EventBridge, or Pinpoint) is not validated for existence, and Floci does not emit send/bounce/delivery events to it. Each event destination must specify exactly one destination type and at least one matching event type. A CloudWatch destination requires a non-empty dimension configuration list, and a Pinpoint destination requires an application ARN.
 
 Suppression list entries are stored per region. `Reason` is `BOUNCE` or `COMPLAINT`. `SendEmail` is not yet integrated with the suppression list, so suppressed addresses are still delivered locally.
 

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.services.ses.model.BulkEmailEntry;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
+import io.github.hectorvent.floci.services.ses.model.EventDestination;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.SuppressedDestination;
 import io.github.hectorvent.floci.services.ses.model.Tag;
@@ -645,6 +646,95 @@ public class SesController {
         try {
             sesService.deleteConfigurationSet(name, region);
             LOG.infov("SES V2 DeleteConfigurationSet: {0}", name);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        }
+    }
+
+    // ──────────────── Configuration Set Event Destinations ────────────────
+
+    @POST
+    @Path("/configuration-sets/{configurationSetName}/event-destinations")
+    public Response createConfigurationSetEventDestination(@Context HttpHeaders headers,
+                                                           @PathParam("configurationSetName") String configurationSetName,
+                                                           String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode request = objectMapper.readTree(body);
+            String edName = request.path("EventDestinationName").asText(null);
+            if (edName == null || edName.isBlank()) {
+                throw new AwsException("BadRequestException", "EventDestinationName is required.", 400);
+            }
+            JsonNode edNode = request.path("EventDestination");
+            if (!edNode.isObject()) {
+                throw new AwsException("BadRequestException", "EventDestination is required.", 400);
+            }
+            EventDestination dest = objectMapper.treeToValue(edNode, EventDestination.class);
+            sesService.createConfigurationSetEventDestination(configurationSetName, edName, dest, region);
+            LOG.infov("SES V2 CreateConfigurationSetEventDestination: {0} on {1}", edName, configurationSetName);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        } catch (Exception e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @GET
+    @Path("/configuration-sets/{configurationSetName}/event-destinations")
+    public Response getConfigurationSetEventDestinations(@Context HttpHeaders headers,
+                                                         @PathParam("configurationSetName") String configurationSetName) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            List<EventDestination> dests =
+                    sesService.getConfigurationSetEventDestinations(configurationSetName, region);
+            ObjectNode result = objectMapper.createObjectNode();
+            ArrayNode arr = result.putArray("EventDestinations");
+            for (EventDestination ed : dests) {
+                arr.add(objectMapper.valueToTree(ed));
+            }
+            return Response.ok(result).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        }
+    }
+
+    @PUT
+    @Path("/configuration-sets/{configurationSetName}/event-destinations/{eventDestinationName}")
+    public Response updateConfigurationSetEventDestination(@Context HttpHeaders headers,
+                                                           @PathParam("configurationSetName") String configurationSetName,
+                                                           @PathParam("eventDestinationName") String eventDestinationName,
+                                                           String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode request = objectMapper.readTree(body);
+            JsonNode edNode = request.path("EventDestination");
+            if (!edNode.isObject()) {
+                throw new AwsException("BadRequestException", "EventDestination is required.", 400);
+            }
+            EventDestination dest = objectMapper.treeToValue(edNode, EventDestination.class);
+            sesService.updateConfigurationSetEventDestination(configurationSetName, eventDestinationName, dest, region);
+            LOG.infov("SES V2 UpdateConfigurationSetEventDestination: {0} on {1}",
+                    eventDestinationName, configurationSetName);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        } catch (Exception e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @DELETE
+    @Path("/configuration-sets/{configurationSetName}/event-destinations/{eventDestinationName}")
+    public Response deleteConfigurationSetEventDestination(@Context HttpHeaders headers,
+                                                           @PathParam("configurationSetName") String configurationSetName,
+                                                           @PathParam("eventDestinationName") String eventDestinationName) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            sesService.deleteConfigurationSetEventDestination(configurationSetName, eventDestinationName, region);
+            LOG.infov("SES V2 DeleteConfigurationSetEventDestination: {0} on {1}",
+                    eventDestinationName, configurationSetName);
             return Response.ok(objectMapper.createObjectNode()).build();
         } catch (AwsException e) {
             throw remapV1Exception(e);

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -509,7 +509,7 @@ public class SesService {
         validateEventDestinationName(eventDestinationName);
         validateEventDestination(dest);
         ConfigurationSet cs = getConfigurationSet(configSetName, region);
-        if (findEventDestination(cs, eventDestinationName) != null) {
+        if (indexOfEventDestination(cs.getEventDestinations(), eventDestinationName) >= 0) {
             throw new AwsException("AlreadyExists",
                     "An event destination with name <" + eventDestinationName
                             + "> already exists for configuration set <" + configSetName + ">.", 400);
@@ -522,7 +522,7 @@ public class SesService {
     }
 
     public List<EventDestination> getConfigurationSetEventDestinations(String configSetName, String region) {
-        return getConfigurationSet(configSetName, region).getEventDestinations();
+        return List.copyOf(getConfigurationSet(configSetName, region).getEventDestinations());
     }
 
     public void updateConfigurationSetEventDestination(String configSetName, String eventDestinationName,
@@ -530,14 +530,14 @@ public class SesService {
         validateEventDestinationName(eventDestinationName);
         validateEventDestination(dest);
         ConfigurationSet cs = getConfigurationSet(configSetName, region);
-        if (findEventDestination(cs, eventDestinationName) == null) {
+        int index = indexOfEventDestination(cs.getEventDestinations(), eventDestinationName);
+        if (index < 0) {
             throw new AwsException("NotFoundException",
                     "An event destination with name <" + eventDestinationName
                             + "> does not exist for configuration set <" + configSetName + ">.", 404);
         }
         dest.setName(eventDestinationName);
-        cs.getEventDestinations().removeIf(ed -> eventDestinationName.equals(ed.getName()));
-        cs.getEventDestinations().add(dest);
+        cs.getEventDestinations().set(index, dest);
         configSetStore.put(configSetKey(region, configSetName), cs);
         LOG.infov("Updated SES event destination {0} on configuration set {1} in region {2}",
                 eventDestinationName, configSetName, region);
@@ -558,13 +558,13 @@ public class SesService {
                 eventDestinationName, configSetName, region);
     }
 
-    private static EventDestination findEventDestination(ConfigurationSet cs, String name) {
-        for (EventDestination ed : cs.getEventDestinations()) {
-            if (name != null && name.equals(ed.getName())) {
-                return ed;
+    private static int indexOfEventDestination(List<EventDestination> destinations, String name) {
+        for (int i = 0; i < destinations.size(); i++) {
+            if (name != null && name.equals(destinations.get(i).getName())) {
+                return i;
             }
         }
-        return null;
+        return -1;
     }
 
     static void validateEventDestinationName(String name) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.services.ses.model.BulkEmailEntry;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
+import io.github.hectorvent.floci.services.ses.model.EventDestination;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.SentEmail;
 import io.github.hectorvent.floci.services.ses.model.SuppressedDestination;
@@ -453,7 +454,7 @@ public class SesService {
     public ConfigurationSet getConfigurationSet(String name, String region) {
         return configSetStore.get(configSetKey(region, name))
                 .orElseThrow(() -> new AwsException("ConfigurationSetDoesNotExist",
-                        "Configuration set " + name + " does not exist.", 400));
+                        "Configuration set <" + name + "> does not exist.", 400));
     }
 
     public List<ConfigurationSet> listConfigurationSets(String region) {
@@ -470,7 +471,7 @@ public class SesService {
         String key = configSetKey(region, name);
         if (configSetStore.get(key).isEmpty()) {
             throw new AwsException("ConfigurationSetDoesNotExist",
-                    "Configuration set " + name + " does not exist.", 400);
+                    "Configuration set <" + name + "> does not exist.", 400);
         }
         configSetStore.delete(key);
         LOG.infov("Deleted SES configuration set: {0} in region {1}", name, region);
@@ -493,6 +494,150 @@ public class SesService {
                     "ConfigurationSetName must be 1-64 characters and may only contain "
                             + "alphanumeric characters, underscores, and hyphens.", 400);
         }
+    }
+
+    private static final Pattern EVENT_DESTINATION_NAME_CHARS = Pattern.compile("^[A-Za-z0-9_-]+$");
+
+    private static final int MAX_EVENT_DESTINATION_NAME_LENGTH = 64;
+
+    private static final List<String> VALID_EVENT_TYPES = List.of(
+            "SEND", "REJECT", "BOUNCE", "COMPLAINT", "DELIVERY", "OPEN", "CLICK",
+            "RENDERING_FAILURE", "DELIVERY_DELAY", "SUBSCRIPTION");
+
+    public void createConfigurationSetEventDestination(String configSetName, String eventDestinationName,
+                                                       EventDestination dest, String region) {
+        validateEventDestinationName(eventDestinationName);
+        validateEventDestination(dest);
+        ConfigurationSet cs = getConfigurationSet(configSetName, region);
+        if (findEventDestination(cs, eventDestinationName) != null) {
+            throw new AwsException("AlreadyExists",
+                    "An event destination with name <" + eventDestinationName
+                            + "> already exists for configuration set <" + configSetName + ">.", 400);
+        }
+        dest.setName(eventDestinationName);
+        cs.getEventDestinations().add(dest);
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Created SES event destination {0} on configuration set {1} in region {2}",
+                eventDestinationName, configSetName, region);
+    }
+
+    public List<EventDestination> getConfigurationSetEventDestinations(String configSetName, String region) {
+        return getConfigurationSet(configSetName, region).getEventDestinations();
+    }
+
+    public void updateConfigurationSetEventDestination(String configSetName, String eventDestinationName,
+                                                       EventDestination dest, String region) {
+        validateEventDestinationName(eventDestinationName);
+        validateEventDestination(dest);
+        ConfigurationSet cs = getConfigurationSet(configSetName, region);
+        if (findEventDestination(cs, eventDestinationName) == null) {
+            throw new AwsException("NotFoundException",
+                    "An event destination with name <" + eventDestinationName
+                            + "> does not exist for configuration set <" + configSetName + ">.", 404);
+        }
+        dest.setName(eventDestinationName);
+        cs.getEventDestinations().removeIf(ed -> eventDestinationName.equals(ed.getName()));
+        cs.getEventDestinations().add(dest);
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Updated SES event destination {0} on configuration set {1} in region {2}",
+                eventDestinationName, configSetName, region);
+    }
+
+    public void deleteConfigurationSetEventDestination(String configSetName, String eventDestinationName,
+                                                       String region) {
+        validateEventDestinationName(eventDestinationName);
+        ConfigurationSet cs = getConfigurationSet(configSetName, region);
+        boolean removed = cs.getEventDestinations().removeIf(ed -> eventDestinationName.equals(ed.getName()));
+        if (!removed) {
+            throw new AwsException("NotFoundException",
+                    "An event destination with name <" + eventDestinationName
+                            + "> does not exist for configuration set <" + configSetName + ">.", 404);
+        }
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Deleted SES event destination {0} on configuration set {1} in region {2}",
+                eventDestinationName, configSetName, region);
+    }
+
+    private static EventDestination findEventDestination(ConfigurationSet cs, String name) {
+        for (EventDestination ed : cs.getEventDestinations()) {
+            if (name != null && name.equals(ed.getName())) {
+                return ed;
+            }
+        }
+        return null;
+    }
+
+    static void validateEventDestinationName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "EventDestinationName is required.", 400);
+        }
+        if (!EVENT_DESTINATION_NAME_CHARS.matcher(name).matches()) {
+            throw new AwsException("InvalidParameterValue",
+                    "Invalid event destination name <" + name + ">: only alphanumeric ASCII characters, "
+                            + "'_', and '-' are allowed.", 400);
+        }
+        if (name.length() > MAX_EVENT_DESTINATION_NAME_LENGTH) {
+            throw new AwsException("InvalidParameterValue",
+                    "Event destination name cannot exceed 64 characters.", 400);
+        }
+    }
+
+    static void validateEventDestination(EventDestination dest) {
+        if (dest == null) {
+            throw new AwsException("InvalidParameterValue", "EventDestination is required.", 400);
+        }
+        List<String> types = dest.getMatchingEventTypes();
+        if (types == null || types.isEmpty()) {
+            throw new AwsException("InvalidParameterValue", "At least one event type must be specified.", 400);
+        }
+        for (String t : types) {
+            if (t == null || !VALID_EVENT_TYPES.contains(t)) {
+                throw new AwsException("InvalidParameterValue",
+                        "Invalid event type: " + t + ". Valid values are " + VALID_EVENT_TYPES + ".", 400);
+            }
+        }
+        int destinationCount = countDestinations(dest);
+        if (destinationCount == 0) {
+            throw new AwsException("InvalidParameterValue", "Event destination is not provided.", 400);
+        }
+        if (destinationCount > 1) {
+            throw new AwsException("InvalidParameterValue",
+                    "Please provide only one destination with each request. Either a Firehose Destination "
+                            + "or a Cloudwatch Destination or an SNS Destination or an EventBridge Destination.", 400);
+        }
+        if (dest.getCloudWatchDestination() != null
+                && (dest.getCloudWatchDestination().getDimensionConfigurations() == null
+                || dest.getCloudWatchDestination().getDimensionConfigurations().isEmpty())) {
+            throw new AwsException("InvalidParameterValue",
+                    "CloudWatch metrics dimension configuration list cannot be empty.", 400);
+        }
+        if (dest.getPinpointDestination() != null
+                && (dest.getPinpointDestination().getApplicationArn() == null
+                || dest.getPinpointDestination().getApplicationArn().isBlank())) {
+            throw new AwsException("InvalidParameterValue",
+                    "Invalid Pinpoint application ARN provided: "
+                            + dest.getPinpointDestination().getApplicationArn() + ".", 400);
+        }
+    }
+
+    private static int countDestinations(EventDestination dest) {
+        int count = 0;
+        if (dest.getSnsDestination() != null) {
+            count++;
+        }
+        if (dest.getCloudWatchDestination() != null) {
+            count++;
+        }
+        if (dest.getKinesisFirehoseDestination() != null) {
+            count++;
+        }
+        if (dest.getEventBridgeDestination() != null) {
+            count++;
+        }
+        if (dest.getPinpointDestination() != null) {
+            count++;
+        }
+        return count;
     }
 
     public List<Tag> listResourceTags(String arn, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/CloudWatchDestination.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/CloudWatchDestination.java
@@ -1,0 +1,25 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CloudWatchDestination {
+
+    @JsonProperty("DimensionConfigurations")
+    private List<CloudWatchDimensionConfiguration> dimensionConfigurations = new ArrayList<>();
+
+    public CloudWatchDestination() {}
+
+    public List<CloudWatchDimensionConfiguration> getDimensionConfigurations() { return dimensionConfigurations; }
+    public void setDimensionConfigurations(List<CloudWatchDimensionConfiguration> dimensionConfigurations) {
+        this.dimensionConfigurations = dimensionConfigurations != null ? dimensionConfigurations : new ArrayList<>();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/CloudWatchDimensionConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/CloudWatchDimensionConfiguration.java
@@ -1,0 +1,32 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CloudWatchDimensionConfiguration {
+
+    @JsonProperty("DimensionName")
+    private String dimensionName;
+
+    @JsonProperty("DimensionValueSource")
+    private String dimensionValueSource;
+
+    @JsonProperty("DefaultDimensionValue")
+    private String defaultDimensionValue;
+
+    public CloudWatchDimensionConfiguration() {}
+
+    public String getDimensionName() { return dimensionName; }
+    public void setDimensionName(String dimensionName) { this.dimensionName = dimensionName; }
+
+    public String getDimensionValueSource() { return dimensionValueSource; }
+    public void setDimensionValueSource(String dimensionValueSource) { this.dimensionValueSource = dimensionValueSource; }
+
+    public String getDefaultDimensionValue() { return defaultDimensionValue; }
+    public void setDefaultDimensionValue(String defaultDimensionValue) { this.defaultDimensionValue = defaultDimensionValue; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/ConfigurationSet.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/ConfigurationSet.java
@@ -21,6 +21,9 @@ public class ConfigurationSet {
     @JsonProperty("Tags")
     private List<Tag> tags = new ArrayList<>();
 
+    @JsonProperty("EventDestinations")
+    private List<EventDestination> eventDestinations = new ArrayList<>();
+
     public ConfigurationSet() {}
 
     public ConfigurationSet(String name) {
@@ -36,4 +39,9 @@ public class ConfigurationSet {
 
     public List<Tag> getTags() { return tags; }
     public void setTags(List<Tag> tags) { this.tags = tags != null ? tags : new ArrayList<>(); }
+
+    public List<EventDestination> getEventDestinations() { return eventDestinations; }
+    public void setEventDestinations(List<EventDestination> eventDestinations) {
+        this.eventDestinations = eventDestinations != null ? eventDestinations : new ArrayList<>();
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/EventBridgeDestination.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/EventBridgeDestination.java
@@ -1,0 +1,20 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EventBridgeDestination {
+
+    @JsonProperty("EventBusArn")
+    private String eventBusArn;
+
+    public EventBridgeDestination() {}
+
+    public String getEventBusArn() { return eventBusArn; }
+    public void setEventBusArn(String eventBusArn) { this.eventBusArn = eventBusArn; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/EventDestination.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/EventDestination.java
@@ -1,0 +1,67 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EventDestination {
+
+    @JsonProperty("Name")
+    private String name;
+
+    @JsonProperty("Enabled")
+    private boolean enabled;
+
+    @JsonProperty("MatchingEventTypes")
+    private List<String> matchingEventTypes = new ArrayList<>();
+
+    @JsonProperty("SnsDestination")
+    private SnsDestination snsDestination;
+
+    @JsonProperty("CloudWatchDestination")
+    private CloudWatchDestination cloudWatchDestination;
+
+    @JsonProperty("KinesisFirehoseDestination")
+    private KinesisFirehoseDestination kinesisFirehoseDestination;
+
+    @JsonProperty("EventBridgeDestination")
+    private EventBridgeDestination eventBridgeDestination;
+
+    @JsonProperty("PinpointDestination")
+    private PinpointDestination pinpointDestination;
+
+    public EventDestination() {}
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+    public List<String> getMatchingEventTypes() { return matchingEventTypes; }
+    public void setMatchingEventTypes(List<String> matchingEventTypes) {
+        this.matchingEventTypes = matchingEventTypes != null ? matchingEventTypes : new ArrayList<>();
+    }
+
+    public SnsDestination getSnsDestination() { return snsDestination; }
+    public void setSnsDestination(SnsDestination snsDestination) { this.snsDestination = snsDestination; }
+
+    public CloudWatchDestination getCloudWatchDestination() { return cloudWatchDestination; }
+    public void setCloudWatchDestination(CloudWatchDestination cloudWatchDestination) { this.cloudWatchDestination = cloudWatchDestination; }
+
+    public KinesisFirehoseDestination getKinesisFirehoseDestination() { return kinesisFirehoseDestination; }
+    public void setKinesisFirehoseDestination(KinesisFirehoseDestination kinesisFirehoseDestination) { this.kinesisFirehoseDestination = kinesisFirehoseDestination; }
+
+    public EventBridgeDestination getEventBridgeDestination() { return eventBridgeDestination; }
+    public void setEventBridgeDestination(EventBridgeDestination eventBridgeDestination) { this.eventBridgeDestination = eventBridgeDestination; }
+
+    public PinpointDestination getPinpointDestination() { return pinpointDestination; }
+    public void setPinpointDestination(PinpointDestination pinpointDestination) { this.pinpointDestination = pinpointDestination; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/KinesisFirehoseDestination.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/KinesisFirehoseDestination.java
@@ -1,0 +1,26 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class KinesisFirehoseDestination {
+
+    @JsonProperty("IamRoleArn")
+    private String iamRoleArn;
+
+    @JsonProperty("DeliveryStreamArn")
+    private String deliveryStreamArn;
+
+    public KinesisFirehoseDestination() {}
+
+    public String getIamRoleArn() { return iamRoleArn; }
+    public void setIamRoleArn(String iamRoleArn) { this.iamRoleArn = iamRoleArn; }
+
+    public String getDeliveryStreamArn() { return deliveryStreamArn; }
+    public void setDeliveryStreamArn(String deliveryStreamArn) { this.deliveryStreamArn = deliveryStreamArn; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/PinpointDestination.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/PinpointDestination.java
@@ -1,0 +1,20 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PinpointDestination {
+
+    @JsonProperty("ApplicationArn")
+    private String applicationArn;
+
+    public PinpointDestination() {}
+
+    public String getApplicationArn() { return applicationArn; }
+    public void setApplicationArn(String applicationArn) { this.applicationArn = applicationArn; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/SnsDestination.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/SnsDestination.java
@@ -1,0 +1,20 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SnsDestination {
+
+    @JsonProperty("TopicArn")
+    private String topicArn;
+
+    public SnsDestination() {}
+
+    public String getTopicArn() { return topicArn; }
+    public void setTopicArn(String topicArn) { this.topicArn = topicArn; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetEventDestinationV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetEventDestinationV2IntegrationTest.java
@@ -1,0 +1,309 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * Integration tests for SES V2 ConfigurationSetEventDestination endpoints under
+ * /v2/email/configuration-sets/{name}/event-destinations.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesConfigurationSetEventDestinationV2IntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/ses/aws4_request";
+
+    private static final String CS = "v2-cs-ed";
+
+    @Test
+    @Order(1)
+    void createConfigurationSet() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"ConfigurationSetName\": \"" + CS + "\"}")
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void createEventDestination() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "EventDestinationName": "ed-sns",
+                  "EventDestination": {
+                    "Enabled": true,
+                    "MatchingEventTypes": ["SEND", "BOUNCE"],
+                    "SnsDestination": {"TopicArn": "arn:aws:sns:us-east-1:000000000000:ses-events"}
+                  }
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets/" + CS + "/event-destinations")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(3)
+    void getEventDestinations_returnsRoundTrip() {
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/configuration-sets/" + CS + "/event-destinations")
+        .then()
+            .statusCode(200)
+            .body("EventDestinations", hasSize(1))
+            .body("EventDestinations[0].Name", equalTo("ed-sns"))
+            .body("EventDestinations[0].Enabled", equalTo(true))
+            .body("EventDestinations[0].MatchingEventTypes", hasItem("SEND"))
+            .body("EventDestinations[0].MatchingEventTypes", hasItem("BOUNCE"))
+            .body("EventDestinations[0].SnsDestination.TopicArn",
+                    equalTo("arn:aws:sns:us-east-1:000000000000:ses-events"));
+    }
+
+    @Test
+    @Order(4)
+    void createEventDestination_duplicateRejected() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "EventDestinationName": "ed-sns",
+                  "EventDestination": {
+                    "MatchingEventTypes": ["SEND"],
+                    "SnsDestination": {"TopicArn": "arn:aws:sns:us-east-1:000000000000:dup"}
+                  }
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets/" + CS + "/event-destinations")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("AlreadyExistsException"))
+            .body("message", equalTo(
+                    "An event destination with name <ed-sns> already exists for configuration set <v2-cs-ed>."));
+    }
+
+    @Test
+    @Order(5)
+    void createEventDestination_unknownConfigSetReturns404() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "EventDestinationName": "ed-x",
+                  "EventDestination": {
+                    "MatchingEventTypes": ["SEND"],
+                    "SnsDestination": {"TopicArn": "arn:aws:sns:us-east-1:000000000000:ghost"}
+                  }
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets/v2-cs-ghost/event-destinations")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", equalTo("Configuration set <v2-cs-ghost> does not exist."));
+    }
+
+    @Test
+    @Order(6)
+    void createEventDestination_emptyMatchingEventTypes_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "EventDestinationName": "ed-empty",
+                  "EventDestination": {
+                    "MatchingEventTypes": [],
+                    "SnsDestination": {"TopicArn": "arn:aws:sns:us-east-1:000000000000:x"}
+                  }
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets/" + CS + "/event-destinations")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(7)
+    void createEventDestination_noDestination_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "EventDestinationName": "ed-nodest",
+                  "EventDestination": {
+                    "MatchingEventTypes": ["SEND"]
+                  }
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets/" + CS + "/event-destinations")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(8)
+    void updateEventDestination_replacesDefinition() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "EventDestination": {
+                    "Enabled": false,
+                    "MatchingEventTypes": ["DELIVERY"],
+                    "SnsDestination": {"TopicArn": "arn:aws:sns:us-east-1:000000000000:ses-events-2"}
+                  }
+                }
+                """)
+        .when()
+            .put("/v2/email/configuration-sets/" + CS + "/event-destinations/ed-sns")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/configuration-sets/" + CS + "/event-destinations")
+        .then()
+            .statusCode(200)
+            .body("EventDestinations", hasSize(1))
+            .body("EventDestinations[0].Name", equalTo("ed-sns"))
+            .body("EventDestinations[0].Enabled", equalTo(false))
+            .body("EventDestinations[0].MatchingEventTypes", hasItem("DELIVERY"))
+            .body("EventDestinations[0].SnsDestination.TopicArn",
+                    equalTo("arn:aws:sns:us-east-1:000000000000:ses-events-2"));
+    }
+
+    @Test
+    @Order(9)
+    void updateEventDestination_unknownReturns404() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "EventDestination": {
+                    "MatchingEventTypes": ["SEND"],
+                    "SnsDestination": {"TopicArn": "arn:aws:sns:us-east-1:000000000000:x"}
+                  }
+                }
+                """)
+        .when()
+            .put("/v2/email/configuration-sets/" + CS + "/event-destinations/ed-ghost")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", equalTo(
+                    "An event destination with name <ed-ghost> does not exist for configuration set <v2-cs-ed>."));
+    }
+
+    @Test
+    @Order(10)
+    void deleteEventDestination() {
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .delete("/v2/email/configuration-sets/" + CS + "/event-destinations/ed-sns")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/configuration-sets/" + CS + "/event-destinations")
+        .then()
+            .statusCode(200)
+            .body("EventDestinations", hasSize(0));
+    }
+
+    @Test
+    @Order(11)
+    void deleteEventDestination_unknownReturns404() {
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .delete("/v2/email/configuration-sets/" + CS + "/event-destinations/ed-ghost")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", equalTo(
+                    "An event destination with name <ed-ghost> does not exist for configuration set <v2-cs-ed>."));
+    }
+
+    @Test
+    @Order(12)
+    void getEventDestinations_unknownConfigSetReturns404() {
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/configuration-sets/v2-cs-ghost/event-destinations")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", equalTo("Configuration set <v2-cs-ghost> does not exist."));
+    }
+
+    @Test
+    @Order(13)
+    void updateEventDestination_invalidName_returns400() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "EventDestination": {
+                    "MatchingEventTypes": ["SEND"],
+                    "SnsDestination": {"TopicArn": "arn:aws:sns:us-east-1:000000000000:x"}
+                  }
+                }
+                """)
+        .when()
+            .put("/v2/email/configuration-sets/" + CS + "/event-destinations/bad.name")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("Invalid event destination name <bad.name>: only alphanumeric ASCII "
+                    + "characters, '_', and '-' are allowed."));
+    }
+
+    @Test
+    @Order(14)
+    void deleteEventDestination_invalidName_returns400() {
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .delete("/v2/email/configuration-sets/" + CS + "/event-destinations/bad.name")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("Invalid event destination name <bad.name>: only alphanumeric ASCII "
+                    + "characters, '_', and '-' are allowed."));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetEventDestinationV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetEventDestinationV2IntegrationTest.java
@@ -306,4 +306,68 @@ class SesConfigurationSetEventDestinationV2IntegrationTest {
             .body("message", equalTo("Invalid event destination name <bad.name>: only alphanumeric ASCII "
                     + "characters, '_', and '-' are allowed."));
     }
+
+    @Test
+    @Order(15)
+    void updateEventDestination_preservesOrderAmongMultiple() {
+        String cs = "v2-cs-ed-multi";
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"ConfigurationSetName\": \"" + cs + "\"}")
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(200);
+
+        for (String n : new String[]{"ed-a", "ed-b"}) {
+            given()
+                .contentType("application/json")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                    {
+                      "EventDestinationName": "%s",
+                      "EventDestination": {
+                        "Enabled": true,
+                        "MatchingEventTypes": ["SEND"],
+                        "SnsDestination": {"TopicArn": "arn:aws:sns:us-east-1:000000000000:%s"}
+                      }
+                    }
+                    """.formatted(n, n))
+            .when()
+                .post("/v2/email/configuration-sets/" + cs + "/event-destinations")
+            .then()
+                .statusCode(200);
+        }
+
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "EventDestination": {
+                    "Enabled": false,
+                    "MatchingEventTypes": ["DELIVERY"],
+                    "SnsDestination": {"TopicArn": "arn:aws:sns:us-east-1:000000000000:ed-a-updated"}
+                  }
+                }
+                """)
+        .when()
+            .put("/v2/email/configuration-sets/" + cs + "/event-destinations/ed-a")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/configuration-sets/" + cs + "/event-destinations")
+        .then()
+            .statusCode(200)
+            .body("EventDestinations", hasSize(2))
+            .body("EventDestinations[0].Name", equalTo("ed-a"))
+            .body("EventDestinations[1].Name", equalTo("ed-b"))
+            .body("EventDestinations[0].Enabled", equalTo(false))
+            .body("EventDestinations[0].SnsDestination.TopicArn",
+                    equalTo("arn:aws:sns:us-east-1:000000000000:ed-a-updated"));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceEventDestinationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceEventDestinationTest.java
@@ -1,0 +1,156 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.ses.model.CloudWatchDestination;
+import io.github.hectorvent.floci.services.ses.model.CloudWatchDimensionConfiguration;
+import io.github.hectorvent.floci.services.ses.model.EventDestination;
+import io.github.hectorvent.floci.services.ses.model.PinpointDestination;
+import io.github.hectorvent.floci.services.ses.model.SnsDestination;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for the static input validation behind the SES V2
+ * ConfigurationSetEventDestination operations. These fail-closed paths are
+ * pure logic and live here rather than in the integration test. Error
+ * messages mirror the real AWS SESv2 wire responses.
+ */
+class SesServiceEventDestinationTest {
+
+    private static EventDestination withSns(List<String> matchingEventTypes) {
+        EventDestination ed = new EventDestination();
+        ed.setMatchingEventTypes(matchingEventTypes);
+        SnsDestination sns = new SnsDestination();
+        sns.setTopicArn("arn:aws:sns:us-east-1:000000000000:ses-events");
+        ed.setSnsDestination(sns);
+        return ed;
+    }
+
+    @Test
+    void validName_passes() {
+        assertDoesNotThrow(() -> SesService.validateEventDestinationName("my-dest_1"));
+    }
+
+    @Test
+    void blankName_throwsInvalidParameterValue() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> SesService.validateEventDestinationName("   "));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+    }
+
+    @Test
+    void invalidNameCharacters_throws() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> SesService.validateEventDestinationName("bad name!"));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals("Invalid event destination name <bad name!>: only alphanumeric ASCII characters, "
+                + "'_', and '-' are allowed.", ex.getMessage());
+    }
+
+    @Test
+    void nameTooLong_throws() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> SesService.validateEventDestinationName("a".repeat(65)));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals("Event destination name cannot exceed 64 characters.", ex.getMessage());
+    }
+
+    @Test
+    void validDestination_passes() {
+        assertDoesNotThrow(() -> SesService.validateEventDestination(withSns(List.of("SEND", "BOUNCE"))));
+    }
+
+    @Test
+    void emptyMatchingEventTypes_throws() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> SesService.validateEventDestination(withSns(List.of())));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals("At least one event type must be specified.", ex.getMessage());
+    }
+
+    @Test
+    void invalidEventType_throws() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> SesService.validateEventDestination(withSns(List.of("SEND", "NOPE"))));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals("Invalid event type: NOPE. Valid values are [SEND, REJECT, BOUNCE, COMPLAINT, "
+                + "DELIVERY, OPEN, CLICK, RENDERING_FAILURE, DELIVERY_DELAY, SUBSCRIPTION].", ex.getMessage());
+    }
+
+    @Test
+    void zeroDestinations_throws() {
+        EventDestination ed = new EventDestination();
+        ed.setMatchingEventTypes(List.of("SEND"));
+        AwsException ex = assertThrows(AwsException.class,
+                () -> SesService.validateEventDestination(ed));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals("Event destination is not provided.", ex.getMessage());
+    }
+
+    @Test
+    void multipleDestinations_throws() {
+        EventDestination ed = withSns(List.of("SEND"));
+        ed.setCloudWatchDestination(cloudWatch());
+        AwsException ex = assertThrows(AwsException.class,
+                () -> SesService.validateEventDestination(ed));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals("Please provide only one destination with each request. Either a Firehose Destination "
+                + "or a Cloudwatch Destination or an SNS Destination or an EventBridge Destination.",
+                ex.getMessage());
+    }
+
+    @Test
+    void cloudWatchEmptyDimensions_throws() {
+        EventDestination ed = new EventDestination();
+        ed.setMatchingEventTypes(List.of("SEND"));
+        ed.setCloudWatchDestination(new CloudWatchDestination());
+        AwsException ex = assertThrows(AwsException.class,
+                () -> SesService.validateEventDestination(ed));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals("CloudWatch metrics dimension configuration list cannot be empty.", ex.getMessage());
+    }
+
+    @Test
+    void validCloudWatchDestination_passes() {
+        EventDestination ed = new EventDestination();
+        ed.setMatchingEventTypes(List.of("SEND"));
+        ed.setCloudWatchDestination(cloudWatch());
+        assertDoesNotThrow(() -> SesService.validateEventDestination(ed));
+    }
+
+    @Test
+    void pinpointNullArn_throws() {
+        EventDestination ed = new EventDestination();
+        ed.setMatchingEventTypes(List.of("SEND"));
+        ed.setPinpointDestination(new PinpointDestination());
+        AwsException ex = assertThrows(AwsException.class,
+                () -> SesService.validateEventDestination(ed));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals("Invalid Pinpoint application ARN provided: null.", ex.getMessage());
+    }
+
+    @Test
+    void validPinpointDestination_passes() {
+        EventDestination ed = new EventDestination();
+        ed.setMatchingEventTypes(List.of("SEND"));
+        PinpointDestination pp = new PinpointDestination();
+        pp.setApplicationArn("arn:aws:mobiletargeting:us-east-1:000000000000:apps/abc");
+        ed.setPinpointDestination(pp);
+        assertDoesNotThrow(() -> SesService.validateEventDestination(ed));
+    }
+
+    private static CloudWatchDestination cloudWatch() {
+        CloudWatchDestination cw = new CloudWatchDestination();
+        CloudWatchDimensionConfiguration dim = new CloudWatchDimensionConfiguration();
+        dim.setDimensionName("floci-dim");
+        dim.setDimensionValueSource("MESSAGE_TAG");
+        dim.setDefaultDimensionValue("default");
+        cw.setDimensionConfigurations(List.of(dim));
+        return cw;
+    }
+}


### PR DESCRIPTION
## Summary

Add the SES V2 configuration set event destination management operations to the SESv2 REST JSON API:

- `CreateConfigurationSetEventDestination` — `POST /v2/email/configuration-sets/{name}/event-destinations`
- `GetConfigurationSetEventDestinations` — `GET /v2/email/configuration-sets/{name}/event-destinations`
- `UpdateConfigurationSetEventDestination` — `PUT /v2/email/configuration-sets/{name}/event-destinations/{eventDestinationName}`
- `DeleteConfigurationSetEventDestination` — `DELETE /v2/email/configuration-sets/{name}/event-destinations/{eventDestinationName}`

Event destinations are stored on the configuration set and support SNS, CloudWatch, Kinesis Firehose, EventBridge, and Pinpoint destination types. As an initial step, this PR implements the management API only (create/read/update/delete of the destination configuration): the destination target is not validated for existence, and Floci does not yet emit send/bounce/delivery events to the configured destinations. Actually publishing those events to the destinations is planned for a follow-up PR.

Relates to #1077.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against the AWS SDK for Java v2 (2.31.8) via the compatibility suite (`SesV2Client`) and the AWS CLI `aws sesv2` against real AWS. Validation rules and error types/messages (`AlreadyExistsException`, `NotFoundException`, `BadRequestException`) mirror the live SESv2 responses captured via the CLI. Local verification: SES test suite (357), event-destination service unit tests (9), and the new SDK compatibility test (8) all pass.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
