### PR TITLE
fix(cloudformation): forward ApiGatewayV2 Api properties to apigatewayv2 service

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -1530,10 +1530,66 @@ public class CloudFormationResourceProvisioner {
         Map<String, Object> req = new HashMap<>();
         req.put("name", name);
         req.put("protocolType", resolveOrDefault(props, "ProtocolType", engine, "HTTP"));
+        req.put("routeSelectionExpression", resolveOptional(props, "RouteSelectionExpression", engine));
+        req.put("description", resolveOptional(props, "Description", engine));
+        req.put("apiKeySelectionExpression", resolveOptional(props, "ApiKeySelectionExpression", engine));
+
+        Map<String, String> tags = parseApiGatewayV2Tags(props != null ? props.get("Tags") : null, engine);
+        if (!tags.isEmpty()) {
+            req.put("tags", tags);
+        }
+
+        Map<String, Object> cors = parseApiGatewayV2Cors(props != null ? props.get("CorsConfiguration") : null, engine);
+        if (cors != null) {
+            req.put("corsConfiguration", cors);
+        }
 
         Api api = apiGatewayV2Service.createApi(region, req);
         r.setPhysicalId(api.getApiId());
         r.getAttributes().put("ApiEndpoint", api.getApiEndpoint());
+    }
+
+    private Map<String, String> parseApiGatewayV2Tags(JsonNode tagsNode, CloudFormationTemplateEngine engine) {
+        Map<String, String> out = new HashMap<>();
+        if (tagsNode == null || tagsNode.isNull()) {
+            return out;
+        }
+        JsonNode resolved = engine.resolveNode(tagsNode);
+        if (!resolved.isObject()) {
+            return out;
+        }
+        resolved.properties().forEach(e -> out.put(e.getKey(), e.getValue().asText("")));
+        return out;
+    }
+
+    private Map<String, Object> parseApiGatewayV2Cors(JsonNode corsNode, CloudFormationTemplateEngine engine) {
+        if (corsNode == null || corsNode.isNull()) {
+            return null;
+        }
+        JsonNode resolved = engine.resolveNode(corsNode);
+        if (!resolved.isObject()) {
+            return null;
+        }
+        Map<String, Object> out = new HashMap<>();
+        resolved.properties().forEach(e -> {
+            String key = e.getKey();
+            String camel = key.isEmpty() || !Character.isUpperCase(key.charAt(0))
+                    ? key
+                    : Character.toLowerCase(key.charAt(0)) + key.substring(1);
+            JsonNode v = e.getValue();
+            if (v.isArray()) {
+                List<String> list = new ArrayList<>();
+                v.forEach(item -> list.add(item.asText()));
+                out.put(camel, list);
+            } else if (v.isBoolean()) {
+                out.put(camel, v.booleanValue());
+            } else if (v.isNumber()) {
+                out.put(camel, v.numberValue());
+            } else if (!v.isNull()) {
+                out.put(camel, v.asText());
+            }
+        });
+        return out;
     }
 
     private void provisionApiGatewayV2Route(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -4691,4 +4691,85 @@ class CloudFormationIntegrationTest {
             .body(containsString("nested-stack-child-queue"));
     }
 
+    // ── Issue #1072: AWS::ApiGatewayV2::Api WEBSOCKET drops RouteSelectionExpression ───
+
+    @Test
+    void createStack_apiGatewayV2WebSocketApi_forwardsRouteSelectionExpression() {
+        String template = """
+            {
+              "Resources": {
+                "MyWsApi": {
+                  "Type": "AWS::ApiGatewayV2::Api",
+                  "Properties": {
+                    "Name": "cfn-ws-api",
+                    "ProtocolType": "WEBSOCKET",
+                    "RouteSelectionExpression": "$request.body.action",
+                    "Description": "ws api created via cfn",
+                    "ApiKeySelectionExpression": "$request.header.x-custom-key",
+                    "CorsConfiguration": {
+                      "AllowOrigins": ["https://example.com"],
+                      "AllowMethods": ["GET", "POST"],
+                      "AllowHeaders": ["content-type"],
+                      "ExposeHeaders": ["x-request-id"],
+                      "MaxAge": 600,
+                      "AllowCredentials": true
+                    },
+                    "Tags": {
+                      "Environment": "test",
+                      "Owner": "floci"
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "ws-api-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStackResources")
+            .formParam("StackName", "ws-api-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<LogicalResourceId>MyWsApi</LogicalResourceId>"))
+            .body(containsString("<ResourceStatus>CREATE_COMPLETE</ResourceStatus>"))
+            .body(not(containsString("CREATE_FAILED")));
+
+        String apisJson = given()
+            .header("X-Amz-Target", "AmazonApiGatewayV2.GetApis")
+            .contentType("application/x-amz-json-1.1")
+            .body("{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().asString();
+
+        assertThat(apisJson, containsString("\"Name\":\"cfn-ws-api\""));
+        assertThat(apisJson, containsString("\"ProtocolType\":\"WEBSOCKET\""));
+        assertThat(apisJson, containsString("\"RouteSelectionExpression\":\"$request.body.action\""));
+        assertThat(apisJson, containsString("\"Description\":\"ws api created via cfn\""));
+        assertThat(apisJson, containsString("\"ApiKeySelectionExpression\":\"$request.header.x-custom-key\""));
+        assertThat(apisJson, containsString("\"Environment\":\"test\""));
+        assertThat(apisJson, containsString("\"Owner\":\"floci\""));
+        assertThat(apisJson, containsString("\"AllowOrigins\":[\"https://example.com\"]"));
+        assertThat(apisJson, containsString("\"AllowMethods\":[\"GET\",\"POST\"]"));
+        assertThat(apisJson, containsString("\"AllowHeaders\":[\"content-type\"]"));
+        assertThat(apisJson, containsString("\"ExposeHeaders\":[\"x-request-id\"]"));
+        assertThat(apisJson, containsString("\"MaxAge\":600"));
+        assertThat(apisJson, containsString("\"AllowCredentials\":true"));
+    }
+
 }


### PR DESCRIPTION
## Summary

- `provisionApiGatewayV2Api` only forwarded `Name` and `ProtocolType`, causing WEBSOCKET stacks to fail with _"RouteSelectionExpression is required for WEBSOCKET protocol"_ even when the field was present in the template
- `Description`, `ApiKeySelectionExpression`, `CorsConfiguration`, and `Tags` were silently dropped

Wires the missing fields by forwarding scalar properties through `resolveOptional` and adding two helpers:
- `parseApiGatewayV2Tags` — handles the JSON-object tag shape `{"k": "v"}` that `AWS::ApiGatewayV2::Api` uses (distinct from the `[{Key, Value}]` array form `parseCfnTags` handles)
- `parseApiGatewayV2Cors` — converts PascalCase CFN sub-object keys to the camelCase the service layer expects; guards against intrinsic functions resolving to non-object nodes after `resolveNode`

Closes #1072

## Test plan

- Regression test `createStack_apiGatewayV2WebSocketApi_forwardsRouteSelectionExpression` added to `CloudFormationIntegrationTest` — was failing before this fix, covers all five newly wired properties end-to-end via `AmazonApiGatewayV2.GetApis`
- Full `CloudFormationIntegrationTest` (69 tests) passes