### PR TITLE
fix(ec2): add missing subnet attributes and instance block device attachTime

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2InstanceResponseShapeTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2InstanceResponseShapeTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.*;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.*;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.*;
 
 /**
@@ -187,7 +189,7 @@ class Ec2InstanceResponseShapeTest {
 
     @Test
     @Order(10)
-    @DisplayName("blockDeviceMappings contains root device entry")
+    @DisplayName("blockDeviceMappings contains root device entry with all required EBS fields")
     void blockDeviceMappings() {
         assertThat(instance.blockDeviceMappings())
                 .as("blockDeviceMappings must not be empty — Terraform reads root_block_device attributes")
@@ -199,9 +201,39 @@ class Ec2InstanceResponseShapeTest {
         assertThat(rootDevice.ebs())
                 .as("blockDeviceMapping ebs must not be null")
                 .isNotNull();
+        assertThat(rootDevice.ebs().volumeId())
+                .as("blockDeviceMapping ebs.volumeId must not be null — Terraform calls DescribeVolumes(volumeId); " +
+                    "empty/null causes InvalidVolume.NotFound for volume '' (issue #871)")
+                .isNotNull()
+                .startsWith("vol-");
+        assertThat(rootDevice.ebs().status())
+                .as("blockDeviceMapping ebs.status must not be null")
+                .isNotNull()
+                .isEqualTo(AttachmentStatus.ATTACHED);
         assertThat(rootDevice.ebs().deleteOnTermination())
                 .as("blockDeviceMapping ebs.deleteOnTermination must not be null")
                 .isNotNull();
+        assertThat(rootDevice.ebs().attachTime())
+                .as("blockDeviceMapping ebs.attachTime must not be null — present in all real AWS responses")
+                .isNotNull();
+    }
+
+    @Test
+    @Order(16)
+    @DisplayName("root volume referenced in blockDeviceMappings is queryable via DescribeVolumes")
+    void rootVolumeDescribable() {
+        String volumeId = instance.blockDeviceMappings().get(0).ebs().volumeId();
+        assertThat(volumeId).as("volumeId from blockDeviceMapping must not be null").isNotNull();
+
+        DescribeVolumesResponse resp = ec2.describeVolumes(
+                DescribeVolumesRequest.builder().volumeIds(volumeId).build());
+
+        assertThat(resp.volumes()).as("DescribeVolumes must return the root volume").isNotEmpty();
+        Volume vol = resp.volumes().get(0);
+        assertThat(vol.volumeId()).isEqualTo(volumeId);
+        assertThat(vol.stateAsString())
+                .as("root volume state must be in-use while instance is running")
+                .isEqualTo("in-use");
     }
 
     // ── Primary network interface (ENI) ──────────────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -607,9 +607,17 @@ public class Ec2QueryHandler {
 
     private Response handleModifySubnetAttribute(MultivaluedMap<String, String> p, String region) {
         String subnetId = p.getFirst("SubnetId");
-        String val = p.getFirst("MapPublicIpOnLaunch.Value");
-        if (val != null) {
-            service.modifySubnetAttribute(region, subnetId, "mapPublicIpOnLaunch", val);
+        for (String attr : List.of(
+                "MapPublicIpOnLaunch",
+                "AssignIpv6AddressOnCreation",
+                "EnableDns64",
+                "MapCustomerOwnedIpOnLaunch")) {
+            String val = p.getFirst(attr + ".Value");
+            if (val != null) {
+                String camel = Character.toLowerCase(attr.charAt(0)) + attr.substring(1);
+                service.modifySubnetAttribute(region, subnetId, camel, val);
+                break;
+            }
         }
         return booleanResponse("ModifySubnetAttribute");
     }
@@ -1333,6 +1341,7 @@ public class Ec2QueryHandler {
                 .elem("volumeId", inst.getRootVolumeId())
                 .elem("status", "attached")
                 .elem("deleteOnTermination", "true")
+                .elem("attachTime", inst.getLaunchTime() != null ? ISO_FMT.format(inst.getLaunchTime()) : "")
                 .end("ebs")
                 .end("item")
                 .end("blockDeviceMapping");
@@ -1375,6 +1384,10 @@ public class Ec2QueryHandler {
                 .elem("availabilityZoneId", s.getAvailabilityZoneId())
                 .elem("defaultForAz", String.valueOf(s.isDefaultForAz()))
                 .elem("mapPublicIpOnLaunch", String.valueOf(s.isMapPublicIpOnLaunch()))
+                .elem("assignIpv6AddressOnCreation", String.valueOf(s.isAssignIpv6AddressOnCreation()))
+                .elem("enableDns64", String.valueOf(s.isEnableDns64()))
+                .elem("mapCustomerOwnedIpOnLaunch", String.valueOf(s.isMapCustomerOwnedIpOnLaunch()))
+                .start("ipv6CidrBlockAssociationSet").end("ipv6CidrBlockAssociationSet")
                 .elem("ownerId", s.getOwnerId())
                 .raw(tagSetXml(s.getTags()));
         return xml.build();

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -670,8 +670,11 @@ public class Ec2Service {
         if (subnet == null) {
             throw new AwsException("InvalidSubnetID.NotFound", "The subnet ID '" + subnetId + "' does not exist", 400);
         }
-        if ("mapPublicIpOnLaunch".equals(attribute)) {
-            subnet.setMapPublicIpOnLaunch(Boolean.parseBoolean(value));
+        switch (attribute) {
+            case "mapPublicIpOnLaunch"           -> subnet.setMapPublicIpOnLaunch(Boolean.parseBoolean(value));
+            case "assignIpv6AddressOnCreation"   -> subnet.setAssignIpv6AddressOnCreation(Boolean.parseBoolean(value));
+            case "enableDns64"                   -> subnet.setEnableDns64(Boolean.parseBoolean(value));
+            case "mapCustomerOwnedIpOnLaunch"    -> subnet.setMapCustomerOwnedIpOnLaunch(Boolean.parseBoolean(value));
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/Subnet.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/Subnet.java
@@ -19,6 +19,9 @@ public class Subnet {
     private int availableIpAddressCount;
     private boolean defaultForAz;
     private boolean mapPublicIpOnLaunch;
+    private boolean assignIpv6AddressOnCreation = false;
+    private boolean enableDns64 = false;
+    private boolean mapCustomerOwnedIpOnLaunch = false;
     private String ownerId;
     private String region;
     private String subnetArn;
@@ -52,6 +55,15 @@ public class Subnet {
 
     public boolean isMapPublicIpOnLaunch() { return mapPublicIpOnLaunch; }
     public void setMapPublicIpOnLaunch(boolean mapPublicIpOnLaunch) { this.mapPublicIpOnLaunch = mapPublicIpOnLaunch; }
+
+    public boolean isAssignIpv6AddressOnCreation() { return assignIpv6AddressOnCreation; }
+    public void setAssignIpv6AddressOnCreation(boolean assignIpv6AddressOnCreation) { this.assignIpv6AddressOnCreation = assignIpv6AddressOnCreation; }
+
+    public boolean isEnableDns64() { return enableDns64; }
+    public void setEnableDns64(boolean enableDns64) { this.enableDns64 = enableDns64; }
+
+    public boolean isMapCustomerOwnedIpOnLaunch() { return mapCustomerOwnedIpOnLaunch; }
+    public void setMapCustomerOwnedIpOnLaunch(boolean mapCustomerOwnedIpOnLaunch) { this.mapCustomerOwnedIpOnLaunch = mapCustomerOwnedIpOnLaunch; }
 
     public String getOwnerId() { return ownerId; }
     public void setOwnerId(String ownerId) { this.ownerId = ownerId; }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -288,6 +288,22 @@ class Ec2IntegrationTest {
     }
 
     @Test
+    @Order(21)
+    void createSubnetHasAssignIpv6AddressOnCreation() {
+        given()
+            .formParam("Action", "DescribeSubnets")
+            .formParam("SubnetId.1", subnetId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeSubnetsResponse.subnetSet.item.assignIpv6AddressOnCreation", equalTo("false"))
+            .body("DescribeSubnetsResponse.subnetSet.item.enableDns64", equalTo("false"))
+            .body("DescribeSubnetsResponse.subnetSet.item.mapCustomerOwnedIpOnLaunch", equalTo("false"));
+    }
+
+    @Test
     @Order(22)
     void modifySubnetAttribute() {
         given()


### PR DESCRIPTION
## Summary

ModifySubnetAttribute only handled MapPublicIpOnLaunch; the other three AWS-defined attributes  AssignIpv6AddressOnCreation, EnableDns64, and MapCustomerOwnedIpOnLaunch. Were silently ignored. Added them to the handler loop and to the Subnet model, and included them in the DescribeSubnets XML response alongside an empty ipv6CidrBlockAssociationSet element that AWS always returns.

DescribeInstances was missing attachTime on blockDeviceMapping/ebs, causing
SDK response shape validation to fail for callers that inspect that field.

Closes #1037
Closes #871

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
