### PR TITLE
fix(s3): reject response-* overrides on unsigned requests

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -585,6 +585,10 @@ public class S3Controller {
             ResponseHeaderOverrides overrides = new ResponseHeaderOverrides(
                     responseContentType, responseContentLanguage, responseExpires,
                     responseCacheControl, responseContentDisposition, responseContentEncoding);
+            if (overrides.hasAny() && !isSigned(httpHeaders, uriInfo)) {
+                return xmlErrorResponse(new AwsException("InvalidRequest",
+                        "Request specific response headers cannot be used for anonymous GET requests.", 400));
+            }
 
             if (rangeHeader != null && rangeHeader.startsWith("bytes=")) {
                 return handleRangeRequest(obj, rangeHeader, overrides);
@@ -689,7 +693,8 @@ public class S3Controller {
                                @HeaderParam("If-None-Match") String ifNoneMatch,
                                @HeaderParam("If-Modified-Since") String ifModifiedSince,
                                @HeaderParam("If-Unmodified-Since") String ifUnmodifiedSince,
-                               @Context UriInfo uriInfo) {
+                               @Context UriInfo uriInfo,
+                               @Context HttpHeaders httpHeaders) {
         try {
             key = extractObjectKey(uriInfo, bucket);
             S3Object obj = s3Service.headObject(bucket, key, versionId);
@@ -700,6 +705,10 @@ public class S3Controller {
             ResponseHeaderOverrides overrides = new ResponseHeaderOverrides(
                     responseContentType, responseContentLanguage, responseExpires,
                     responseCacheControl, responseContentDisposition, responseContentEncoding);
+            if (overrides.hasAny() && !isSigned(httpHeaders, uriInfo)) {
+                return xmlErrorResponse(new AwsException("InvalidRequest",
+                        "Request specific response headers cannot be used for anonymous GET requests.", 400));
+            }
             var resp = Response.ok()
                     .header("Content-Type", overrides.contentType() != null ? overrides.contentType() : obj.getContentType())
                     .header("Content-Length", obj.getSize())
@@ -1515,6 +1524,11 @@ public class S3Controller {
             String contentEncoding) {
         static final ResponseHeaderOverrides NONE = new ResponseHeaderOverrides(null, null, null, null, null, null);
 
+        boolean hasAny() {
+            return contentType != null || contentLanguage != null || expires != null
+                    || cacheControl != null || contentDisposition != null || contentEncoding != null;
+        }
+
         ResponseHeaderOverrides {
             // Real S3 ignores empty `response-*` values; @QueryParam binds "?foo=" as "" rather than null.
             contentType = emptyToNull(contentType);
@@ -1906,6 +1920,11 @@ public class S3Controller {
             return preconditionFailedResponse();
         }
         return null;
+    }
+
+    private static boolean isSigned(HttpHeaders httpHeaders, UriInfo uriInfo) {
+        return httpHeaders.getHeaderString("Authorization") != null
+                || uriInfo.getQueryParameters().containsKey("X-Amz-Algorithm");
     }
 
     private boolean hasPreconditions(String ifMatch, String ifNoneMatch,

--- a/src/test/java/io/github/hectorvent/floci/services/s3/PreSignedUrlIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/PreSignedUrlIntegrationTest.java
@@ -19,6 +19,9 @@ class PreSignedUrlIntegrationTest {
 
     private static final String BUCKET = "presign-test-bucket";
 
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/s3/aws4_request";
+
     @Inject
     PreSignedUrlGenerator presignGenerator;
 
@@ -138,8 +141,10 @@ class PreSignedUrlIntegrationTest {
     @Order(11)
     void getObjectAppliesResponseContentDispositionOverride() {
         // Stored disposition is "inline"; override should win.
+        // Must be a signed request per AWS spec (response-* params require Authorization or presigned URL).
         given()
             .urlEncodingEnabled(false)
+            .header("Authorization", AUTH_HEADER)
         .when()
             .get("/" + BUCKET + "/disposition-file.txt?response-content-disposition=attachment%3B%20filename%3D%22file.txt%22")
         .then()
@@ -152,6 +157,7 @@ class PreSignedUrlIntegrationTest {
     void getObjectAppliesAllResponseOverrides() {
         given()
             .urlEncodingEnabled(false)
+            .header("Authorization", AUTH_HEADER)
         .when()
             .get("/" + BUCKET + "/disposition-file.txt"
                 + "?response-content-type=application%2Fpdf"
@@ -187,6 +193,7 @@ class PreSignedUrlIntegrationTest {
     void headObjectAppliesResponseContentDispositionOverride() {
         given()
             .urlEncodingEnabled(false)
+            .header("Authorization", AUTH_HEADER)
         .when()
             .head("/" + BUCKET + "/disposition-file.txt?response-content-disposition=attachment%3B%20filename%3D%22head.txt%22")
         .then()
@@ -212,6 +219,7 @@ class PreSignedUrlIntegrationTest {
     void rangeRequestAppliesResponseContentDispositionOverride() {
         given()
             .urlEncodingEnabled(false)
+            .header("Authorization", AUTH_HEADER)
             .header("Range", "bytes=0-3")
         .when()
             .get("/" + BUCKET + "/disposition-file.txt?response-content-disposition=attachment%3B%20filename%3D%22range.txt%22")

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ResponseHeaderOverrideIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ResponseHeaderOverrideIntegrationTest.java
@@ -1,0 +1,198 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Verifies response-* header override behaviour on GetObject / HeadObject.
+ *
+ * Empirically confirmed against real AWS S3:
+ *   HTTP 400, Code=InvalidRequest,
+ *   Message="Request specific response headers cannot be used for anonymous GET requests."
+ *
+ * Unsigned requests that supply any response-* query parameter must be rejected.
+ * Signed requests (Authorization header present) must be accepted and the override
+ * applied to the response.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class S3ResponseHeaderOverrideIntegrationTest {
+
+    private static final String BUCKET = "response-override-test-bucket";
+    private static final String KEY    = "test-object.txt";
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/s3/aws4_request";
+
+    @Test
+    @Order(1)
+    void setup_createBucketAndObject() {
+        given().put("/" + BUCKET).then().statusCode(200);
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .contentType("text/plain")
+            .body("hello")
+            .put("/" + BUCKET + "/" + KEY)
+            .then().statusCode(200);
+    }
+
+    // ── Anonymous requests must be rejected (400 InvalidRequest) ─────────────
+
+    @Test
+    @Order(2)
+    void anonymousGetWithResponseCacheControl_returns400() {
+        given()
+            .queryParam("response-cache-control", "no-cache")
+        .when()
+            .get("/" + BUCKET + "/" + KEY)
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidRequest"))
+            .body(containsString("anonymous GET requests"));
+    }
+
+    @Test
+    @Order(3)
+    void anonymousGetWithResponseContentType_returns400() {
+        given()
+            .queryParam("response-content-type", "text/html")
+        .when()
+            .get("/" + BUCKET + "/" + KEY)
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidRequest"));
+    }
+
+    @Test
+    @Order(4)
+    void anonymousGetWithResponseContentDisposition_returns400() {
+        given()
+            .queryParam("response-content-disposition", "attachment; filename=x.txt")
+        .when()
+            .get("/" + BUCKET + "/" + KEY)
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidRequest"));
+    }
+
+    @Test
+    @Order(5)
+    void anonymousGetWithResponseContentEncoding_returns400() {
+        given()
+            .queryParam("response-content-encoding", "gzip")
+        .when()
+            .get("/" + BUCKET + "/" + KEY)
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidRequest"));
+    }
+
+    @Test
+    @Order(6)
+    void anonymousGetWithResponseContentLanguage_returns400() {
+        given()
+            .queryParam("response-content-language", "en-US")
+        .when()
+            .get("/" + BUCKET + "/" + KEY)
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidRequest"));
+    }
+
+    @Test
+    @Order(7)
+    void anonymousGetWithResponseExpires_returns400() {
+        given()
+            .queryParam("response-expires", "Thu, 01 Jan 2099 00:00:00 GMT")
+        .when()
+            .get("/" + BUCKET + "/" + KEY)
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidRequest"));
+    }
+
+    @Test
+    @Order(8)
+    void anonymousHeadWithResponseCacheControl_returns400() {
+        given()
+            .queryParam("response-cache-control", "no-cache")
+        .when()
+            .head("/" + BUCKET + "/" + KEY)
+        .then()
+            .statusCode(400);
+    }
+
+    // ── Signed requests must be accepted and the override applied ────────────
+
+    @Test
+    @Order(9)
+    void signedGetWithResponseCacheControl_appliesOverride() {
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("response-cache-control", "max-age=3600")
+        .when()
+            .get("/" + BUCKET + "/" + KEY)
+        .then()
+            .statusCode(200)
+            .header("Cache-Control", equalTo("max-age=3600"));
+    }
+
+    @Test
+    @Order(10)
+    void signedGetWithResponseContentType_appliesOverride() {
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("response-content-type", "application/octet-stream")
+        .when()
+            .get("/" + BUCKET + "/" + KEY)
+        .then()
+            .statusCode(200)
+            .header("Content-Type", containsString("application/octet-stream"));
+    }
+
+    @Test
+    @Order(11)
+    void signedGetWithResponseContentDisposition_appliesOverride() {
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("response-content-disposition", "attachment; filename=download.txt")
+        .when()
+            .get("/" + BUCKET + "/" + KEY)
+        .then()
+            .statusCode(200)
+            .header("Content-Disposition", equalTo("attachment; filename=download.txt"));
+    }
+
+    // ── Anonymous request without response-* params must still work ──────────
+
+    @Test
+    @Order(12)
+    void anonymousGetWithoutOverrides_returns200() {
+        given()
+        .when()
+            .get("/" + BUCKET + "/" + KEY)
+        .then()
+            .statusCode(200);
+    }
+
+    // ── Empty response-* values are ignored (not treated as present) ─────────
+
+    @Test
+    @Order(13)
+    void anonymousGetWithEmptyResponseCacheControl_returns200() {
+        // Real S3 ignores ?response-cache-control= (empty value) — should not reject.
+        given()
+            .queryParam("response-cache-control", "")
+        .when()
+            .get("/" + BUCKET + "/" + KEY)
+        .then()
+            .statusCode(200);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #918.

AWS S3 rejects any `GetObject` or `HeadObject` request that supplies a `response-*` query parameter (`response-cache-control`, `response-content-disposition`, `response-content-encoding`, `response-content-language`, `response-content-type`, `response-expires`)
without a signed Authorization header or presigned URL. Floci was silently honouring them on anonymous requests.
  
## AWS behavior (empirically verified)

Tested against a real public S3 bucket with an unsigned request carrying `?response-cache-control=no-cache`:

HTTP 400  InvalidRequest "Request specific response headers cannot be used for anonymous GET requests."

## Changes

**`S3Controller`**
  - `ResponseHeaderOverrides.hasAny()` — returns true if any of the six
    fields is non-null (empty values are already normalised to null by the
    compact constructor)
  - `isSigned(HttpHeaders, UriInfo)` — presence of `Authorization` header
    (SigV4) or `X-Amz-Algorithm` query param (presigned URL)
  - Guard in `getObject` and `headObject`: if `overrides.hasAny() &&
    !isSigned(...)` → `InvalidRequest` 400 with the exact AWS message

**`S3ResponseHeaderOverrideIntegrationTest`** (13 tests)
  - All 6 params rejected individually on anonymous `GET` → 400
  - Anonymous `HEAD` with override → 400
  - Signed `GET` with 3 params → 200 + override applied to response header
  - Anonymous `GET` without overrides → 200 (no regression)
  - Empty `?response-cache-control=` → 200 (empty values ignored per existing behaviour)


## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
