### PR TITLE
fix(dynamodb): merge nested map paths in ProjectionExpression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@ package-lock.json
 test-results.xml
 
 *.log
-
+test-results

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluator.java
@@ -142,15 +142,17 @@ final class ProjectionEvaluator {
         if (child == null) return;
 
         if (idx == segments.size() - 1) {
-            // Leaf: copy the whole attribute node
-            dest.set(seg, child);
+            // Leaf: deep-copy to avoid placing a live source reference into the
+            // destination, which could be mutated by a subsequent sibling path.
+            dest.set(seg, child.deepCopy());
         } else {
             String nextSeg = segments.get(idx + 1);
             if (nextSeg.matches("\\[\\d+\\]")) {
-                // Next is a list index — extract just that element
+                // Next is a list index — extract just that element.
+                // Reuse existing wrapper if already projected (same fix as the M branch).
                 int listIdx = Integer.parseInt(nextSeg.substring(1, nextSeg.length() - 1));
                 JsonNode listNode = child.has("L") ? child.get("L") : child;
-                if (listNode.isArray() && listIdx < listNode.size()) {
+                if (listNode.isArray() && listIdx < listNode.size() && !dest.has(seg)) {
                     JsonNode element = listNode.get(listIdx);
                     // Build {"L": [element]} wrapper
                     ObjectNode wrapper = MAPPER.createObjectNode();
@@ -160,16 +162,25 @@ final class ProjectionEvaluator {
                     dest.set(seg, wrapper);
                 }
             } else if (child.has("M")) {
-                // Nested map — recurse
-                ObjectNode nestedDest = MAPPER.createObjectNode();
+                // Nested map — reuse existing projected map if present
+                ObjectNode existing = dest.has(seg) && dest.get(seg).has("M")
+                        ? (ObjectNode) dest.get(seg).get("M") : null;
+                ObjectNode nestedDest = existing != null ? existing : MAPPER.createObjectNode();
                 copyPath(child.get("M"), nestedDest, segments, idx + 1);
-                ObjectNode wrapper = MAPPER.createObjectNode();
-                wrapper.set("M", nestedDest);
-                dest.set(seg, wrapper);
+                if (existing == null) {
+                    ObjectNode wrapper = MAPPER.createObjectNode();
+                    wrapper.set("M", nestedDest);
+                    dest.set(seg, wrapper);
+                }
             } else if (child.isObject()) {
-                ObjectNode nestedDest = MAPPER.createObjectNode();
+                // Reuse existing nested object if present
+                ObjectNode existing = dest.has(seg) && dest.get(seg).isObject()
+                        ? (ObjectNode) dest.get(seg) : null;
+                ObjectNode nestedDest = existing != null ? existing : MAPPER.createObjectNode();
                 copyPath(child, nestedDest, segments, idx + 1);
-                dest.set(seg, nestedDest);
+                if (existing == null) {
+                    dest.set(seg, nestedDest);
+                }
             } else {
                 dest.set(seg, child);
             }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbProjectionIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbProjectionIntegrationTest.java
@@ -1,0 +1,217 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for DynamoDB ProjectionExpression with nested map paths.
+ * <p>
+ * Covers <a href="https://github.com/floci-io/floci/issues/852">#852</a>:
+ * multiple nested paths sharing the same parent map must all be returned,
+ * not just the last one.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class DynamoDbProjectionIntegrationTest {
+
+    private static final String CT = "application/x-amz-json-1.0";
+    private static final String TABLE = "ProjectionBugTable";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    @Order(1)
+    void createTable() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(CT)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """.formatted(TABLE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TableDescription.TableName", equalTo(TABLE));
+    }
+
+    @Test
+    @Order(2)
+    void putItemWithNestedMap() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(CT)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Item": {
+                        "pk": {"S": "item1"},
+                        "data": {"M": {
+                            "title": {"S": "Hello"},
+                            "answer": {"S": "World"},
+                            "sources": {"L": [{"M": {"id": {"S": "1"}}}]}
+                        }}
+                    }
+                }
+                """.formatted(TABLE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    /**
+     * Regression test for #852 — Query with multiple nested paths on the same map.
+     * Before the fix, only "sources" (the last path) was returned;
+     * "title" and "answer" were silently dropped.
+     */
+    @Test
+    @Order(3)
+    void queryWithMultipleNestedPathsReturnAllProjected() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(CT)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeyConditionExpression": "pk = :pk",
+                    "ExpressionAttributeValues": {":pk": {"S": "item1"}},
+                    "ExpressionAttributeNames": {"#d": "data"},
+                    "ProjectionExpression": "pk, #d.title, #d.answer, #d.sources"
+                }
+                """.formatted(TABLE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Count", equalTo(1))
+            .body("Items[0].pk.S", equalTo("item1"))
+            .body("Items[0].data.M.title.S", equalTo("Hello"))
+            .body("Items[0].data.M.answer.S", equalTo("World"))
+            .body("Items[0].data.M.sources.L[0].M.id.S", equalTo("1"));
+    }
+
+    /**
+     * Same regression test via Scan to verify both code paths.
+     */
+    @Test
+    @Order(4)
+    void scanWithMultipleNestedPathsReturnAllProjected() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Scan")
+            .contentType(CT)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "ExpressionAttributeNames": {"#d": "data"},
+                    "ProjectionExpression": "pk, #d.title, #d.answer, #d.sources"
+                }
+                """.formatted(TABLE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Count", equalTo(1))
+            .body("Items[0].pk.S", equalTo("item1"))
+            .body("Items[0].data.M.title.S", equalTo("Hello"))
+            .body("Items[0].data.M.answer.S", equalTo("World"))
+            .body("Items[0].data.M.sources.L[0].M.id.S", equalTo("1"));
+    }
+
+    /**
+     * Verify that projecting a single nested path (no merge needed) still works.
+     */
+    @Test
+    @Order(5)
+    void queryWithSingleNestedPathStillWorks() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(CT)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeyConditionExpression": "pk = :pk",
+                    "ExpressionAttributeValues": {":pk": {"S": "item1"}},
+                    "ExpressionAttributeNames": {"#d": "data"},
+                    "ProjectionExpression": "pk, #d.title"
+                }
+                """.formatted(TABLE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Count", equalTo(1))
+            .body("Items[0].pk.S", equalTo("item1"))
+            .body("Items[0].data.M.title.S", equalTo("Hello"))
+            .body("Items[0].data.M.answer", nullValue())
+            .body("Items[0].data.M.sources", nullValue());
+    }
+
+    @AfterAll
+    static void cleanup() {
+        try {
+            given()
+                .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+                .contentType(CT)
+                .body("""
+                    {"TableName": "%s"}
+                    """.formatted(TABLE))
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+        } catch (Exception ignored) {}
+    }
+
+    /**
+     * Unit test for the child.isObject() branch — plain (non-DynamoDB-typed) ObjectNode.
+     * Verifies that multiple sibling paths sharing the same plain object parent
+     * are merged rather than overwritten.
+     */
+    @Test
+    @Order(10)
+    void projectPlainObjectBranchMergesMultipleSiblingPaths() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        // Simulate an item where a nested value is a plain ObjectNode (not DynamoDB-typed).
+        // In normal DynamoDB this would use {"M":{...}}, but the isObject() branch
+        // handles non-typed internal objects as a defensive fallback.
+        ObjectNode item = (ObjectNode) mapper.readTree("""
+            {
+              "plain": {
+                "alpha": "A",
+                "beta":  "B",
+                "gamma": "C"
+              }
+            }
+            """);
+
+        ObjectNode result = ProjectionEvaluator.project(item, "plain.alpha, plain.beta", null);
+
+        // Both sibling fields must be present — overwrite bug would leave only "beta".
+        assertNotNull(result.at("/plain/alpha"), "plain.alpha must be projected");
+        assertNotNull(result.at("/plain/beta"),  "plain.beta must be projected");
+        assertFalse(result.at("/plain/gamma").isTextual(), "plain.gamma must not be projected");
+        assertEquals("A", result.at("/plain/alpha").asText());
+        assertEquals("B", result.at("/plain/beta").asText());
+    }
+}


### PR DESCRIPTION
## Summary

When a `ProjectionExpression` contains multiple paths sharing the same parent map (e.g. `data.title, data.answer, data.sources`), `copyPath()` created a fresh `ObjectNode` for each path and called `dest.set(seg, ...)` unconditionally, overwriting the previous projection. Only the last sibling path was included in the result. 

## Changes

**`ProjectionEvaluator`**
- `{"M": ...}` branch: reuse existing destination node when the parent key is already projected; only call `dest.set()` when creating a new node
- `isObject()` branch: same merge logic for plain (non-typed) ObjectNodes
- `[n]` list-index branch: added `!dest.has(seg)` guard — same overwrite bug existed here (repeated access to the same list key would overwrite)
- Leaf case: `child.deepCopy()` instead of direct reference — prevents placing a live source node into the destination, which a subsequent sibling path could mutate through the reuse logic
  
**`DynamoDbProjectionIntegrationTest`** (new, 6 tests)
- Query with three sibling nested paths on the same `{"M": ...}` map — all three must appear in the result (was the original bug)
- Scan with the same multi-path projection 
- Single nested path — existing behaviour unchanged
- Direct `ProjectionEvaluator.project()` call with plain JSON to cover the `isObject()` branch
- `@AfterAll` cleanup instead of `@Order(100)` so the table is always deleted even when a test fails

Fixes #852

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
