### PR TITLE
fix(eventbridge): tag rules on custom buses whose name contains "event-bus"

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -388,36 +388,23 @@ public class EventBridgeService {
     // ──────────────────────────── Tags ────────────────────────────
 
     public Map<String, String> listTagsForResource(String resourceArn, String region) {
-        // Check if it's an event bus ARN (contains "event-bus/")
-        if (resourceArn.contains("event-bus/")) {
-            String busName = resourceArn.substring(resourceArn.lastIndexOf("event-bus/") + "event-bus/".length());
+        String resource = AwsArnUtils.parse(resourceArn).resource();
+        if (resource.startsWith("event-bus/")) {
+            String busName = resource.substring("event-bus/".length());
             String key = busKey(region, busName);
             return busStore.get(key)
                     .map(EventBus::getTags)
                     .orElse(Map.of());
         }
-        // Check if it's a rule ARN (contains "rule/")
-        if (resourceArn.contains("rule/")) {
-            String afterRule = resourceArn.substring(resourceArn.lastIndexOf("rule/") + "rule/".length());
-            String busName;
-            String ruleName;
-            if (afterRule.contains("/")) {
-                // Custom bus: rule/{busName}/{ruleName}
-                int slashIdx = afterRule.indexOf('/');
-                busName = afterRule.substring(0, slashIdx);
-                ruleName = afterRule.substring(slashIdx + 1);
-            } else {
-                // Default bus: rule/{ruleName}
-                busName = "default";
-                ruleName = afterRule;
-            }
-            String key = ruleKey(region, busName, ruleName);
+        if (resource.startsWith("rule/")) {
+            RuleRef ref = parseRuleResource(resource);
+            String key = ruleKey(region, ref.busName(), ref.ruleName());
             return ruleStore.get(key)
                     .map(Rule::getTags)
                     .orElse(Map.of());
         }
-        if (resourceArn.contains("archive/")) {
-            String archiveName = resourceArn.substring(resourceArn.lastIndexOf("archive/") + "archive/".length());
+        if (resource.startsWith("archive/")) {
+            String archiveName = resource.substring("archive/".length());
             String key = archiveKey(region, archiveName);
             return archiveStore.get(key)
                     .map(Archive::getTags)
@@ -426,9 +413,24 @@ public class EventBridgeService {
         return Map.of();
     }
 
+    /** Resolves the bus and rule name from a {@code rule/...} ARN resource segment. */
+    private record RuleRef(String busName, String ruleName) {}
+
+    private static RuleRef parseRuleResource(String resource) {
+        String afterRule = resource.substring("rule/".length());
+        int slashIdx = afterRule.indexOf('/');
+        if (slashIdx >= 0) {
+            // Custom bus: rule/{busName}/{ruleName}
+            return new RuleRef(afterRule.substring(0, slashIdx), afterRule.substring(slashIdx + 1));
+        }
+        // Default bus: rule/{ruleName}
+        return new RuleRef("default", afterRule);
+    }
+
     public void tagResource(String resourceArn, Map<String, String> tags, String region) {
-        if (resourceArn.contains("archive/")) {
-            String archiveName = resourceArn.substring(resourceArn.lastIndexOf("archive/") + "archive/".length());
+        String resource = AwsArnUtils.parse(resourceArn).resource();
+        if (resource.startsWith("archive/")) {
+            String archiveName = resource.substring("archive/".length());
             String key = archiveKey(region, archiveName);
             Archive archive = archiveStore.get(key)
                     .orElseThrow(() -> new AwsException("ResourceNotFoundException",
@@ -437,8 +439,8 @@ public class EventBridgeService {
             archiveStore.put(key, archive);
             return;
         }
-        if (resourceArn.contains("event-bus/")) {
-            String busName = resourceArn.substring(resourceArn.lastIndexOf("event-bus/") + "event-bus/".length());
+        if (resource.startsWith("event-bus/")) {
+            String busName = resource.substring("event-bus/".length());
             String key = busKey(region, busName);
             EventBus bus = busStore.get(key)
                     .orElseThrow(() -> new AwsException("ResourceNotFoundException",
@@ -447,19 +449,9 @@ public class EventBridgeService {
             busStore.put(key, bus);
             return;
         }
-        if (resourceArn.contains("rule/")) {
-            String afterRule = resourceArn.substring(resourceArn.lastIndexOf("rule/") + "rule/".length());
-            String busName;
-            String ruleName;
-            if (afterRule.contains("/")) {
-                int slashIdx = afterRule.indexOf('/');
-                busName = afterRule.substring(0, slashIdx);
-                ruleName = afterRule.substring(slashIdx + 1);
-            } else {
-                busName = "default";
-                ruleName = afterRule;
-            }
-            String key = ruleKey(region, busName, ruleName);
+        if (resource.startsWith("rule/")) {
+            RuleRef ref = parseRuleResource(resource);
+            String key = ruleKey(region, ref.busName(), ref.ruleName());
             Rule rule = ruleStore.get(key)
                     .orElseThrow(() -> new AwsException("ResourceNotFoundException",
                             "Resource not found: " + resourceArn, 404));
@@ -471,8 +463,9 @@ public class EventBridgeService {
     }
 
     public void untagResource(String resourceArn, List<String> tagKeys, String region) {
-        if (resourceArn.contains("archive/")) {
-            String archiveName = resourceArn.substring(resourceArn.lastIndexOf("archive/") + "archive/".length());
+        String resource = AwsArnUtils.parse(resourceArn).resource();
+        if (resource.startsWith("archive/")) {
+            String archiveName = resource.substring("archive/".length());
             String key = archiveKey(region, archiveName);
             Archive archive = archiveStore.get(key)
                     .orElseThrow(() -> new AwsException("ResourceNotFoundException",
@@ -481,8 +474,8 @@ public class EventBridgeService {
             archiveStore.put(key, archive);
             return;
         }
-        if (resourceArn.contains("event-bus/")) {
-            String busName = resourceArn.substring(resourceArn.lastIndexOf("event-bus/") + "event-bus/".length());
+        if (resource.startsWith("event-bus/")) {
+            String busName = resource.substring("event-bus/".length());
             String key = busKey(region, busName);
             EventBus bus = busStore.get(key)
                     .orElseThrow(() -> new AwsException("ResourceNotFoundException",
@@ -491,19 +484,9 @@ public class EventBridgeService {
             busStore.put(key, bus);
             return;
         }
-        if (resourceArn.contains("rule/")) {
-            String afterRule = resourceArn.substring(resourceArn.lastIndexOf("rule/") + "rule/".length());
-            String busName;
-            String ruleName;
-            if (afterRule.contains("/")) {
-                int slashIdx = afterRule.indexOf('/');
-                busName = afterRule.substring(0, slashIdx);
-                ruleName = afterRule.substring(slashIdx + 1);
-            } else {
-                busName = "default";
-                ruleName = afterRule;
-            }
-            String key = ruleKey(region, busName, ruleName);
+        if (resource.startsWith("rule/")) {
+            RuleRef ref = parseRuleResource(resource);
+            String key = ruleKey(region, ref.busName(), ref.ruleName());
             Rule rule = ruleStore.get(key)
                     .orElseThrow(() -> new AwsException("ResourceNotFoundException",
                             "Resource not found: " + resourceArn, 404));

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeTagResourceIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeTagResourceIntegrationTest.java
@@ -256,4 +256,103 @@ class EventBridgeTagResourceIntegrationTest {
         .then()
             .statusCode(200);
     }
+
+    /**
+     * Regression test for #963 — a rule on a custom bus whose name contains the
+     * substring "event-bus" must be tagged/listed/untagged as a rule, not a bus.
+     */
+    @Test
+    @Order(8)
+    void tagRuleOnBusNamedWithEventBusSubstring() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.CreateEventBus")
+            .body("{\"Name\":\"my-event-bus\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.PutRule")
+            .body("{\"Name\":\"regression-rule\",\"EventBusName\":\"my-event-bus\",\"EventPattern\":\"{\\\"source\\\":[\\\"test\\\"]}\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String ruleArn = given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.DescribeRule")
+            .body("{\"Name\":\"regression-rule\",\"EventBusName\":\"my-event-bus\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().jsonPath().getString("Arn");
+
+        // Tag the rule — before the fix this matched the bus branch and failed.
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.TagResource")
+            .body("""
+                {
+                    "ResourceARN": "%s",
+                    "Tags": [{"Key": "env", "Value": "dev"}]
+                }
+                """.formatted(ruleArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.ListTagsForResource")
+            .body("{\"ResourceARN\":\"" + ruleArn + "\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(1))
+            .body("Tags.find { it.Key == 'env' }.Value", equalTo("dev"));
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.UntagResource")
+            .body("""
+                {
+                    "ResourceARN": "%s",
+                    "TagKeys": ["env"]
+                }
+                """.formatted(ruleArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.ListTagsForResource")
+            .body("{\"ResourceARN\":\"" + ruleArn + "\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Tags", hasSize(0));
+
+        // Cleanup
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.DeleteRule")
+            .body("{\"Name\":\"regression-rule\",\"EventBusName\":\"my-event-bus\"}")
+        .when().post("/").then().statusCode(200);
+
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSEvents.DeleteEventBus")
+            .body("{\"Name\":\"my-event-bus\"}")
+        .when().post("/").then().statusCode(200);
+    }
 }


### PR DESCRIPTION
## Summary

`TagResource`, `UntagResource`, and `ListTagsForResource` used `resourceArn.contains("event-bus/")` to detect event-bus ARNs. A rule on a custom bus has an ARN like `rule/my-event-bus/test-rule`, which also contains the substring `event-bus/` so, it matched the bus branch and failed with `ResourceNotFoundException`. Rules on buses without `event-bus` in the name worked fine, making the bug name-dependent.

## Fix

- Parse the ARN once with `AwsArnUtils.parse(resourceArn).resource()` (the established pattern, already used in `AppConfigTagHandler` and `CloudFormationService`) and dispatch with `resource.startsWith(...)` on the resource segment instead of `contains(...)` over the whole ARN. A bus-name substring can no longer cause a false branch match.
- Extract the repeated rule-name/bus-name split into a `parseRuleResource` helper returning a `RuleRef` record (was duplicated across all three methods).
- Applied to all three tag operations, not just `ListTagsForResource`.

Closes #963

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
