### PR TITLE
fix(ec2): Volume throughput, DescribeAddressesAttribute, and IAM instance profile parity

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -157,6 +157,8 @@ public class AwsQueryController {
             "CreateRouteTable", "DescribeRouteTables", "DeleteRouteTable",
             "AssociateRouteTable", "DisassociateRouteTable", "CreateRoute", "DeleteRoute",
             "AllocateAddress", "AssociateAddress", "DisassociateAddress", "ReleaseAddress", "DescribeAddresses",
+            "DescribeAddressesAttribute",
+            "DescribeIamInstanceProfileAssociations",
             "DescribeAvailabilityZones", "DescribeRegions", "DescribeAccountAttributes",
             "DescribeInstanceTypes",
             "DescribeNetworkInterfaces"

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -38,6 +38,7 @@ public class Ec2QueryHandler {
                 // Instances
                 case "RunInstances" -> handleRunInstances(params, region);
                 case "DescribeInstances" -> handleDescribeInstances(params, region);
+                case "DescribeIamInstanceProfileAssociations" -> handleDescribeIamInstanceProfileAssociations(params, region);
                 case "TerminateInstances" -> handleTerminateInstances(params, region);
                 case "StartInstances" -> handleStartInstances(params, region);
                 case "StopInstances" -> handleStopInstances(params, region);
@@ -103,6 +104,7 @@ public class Ec2QueryHandler {
                 case "DisassociateAddress" -> handleDisassociateAddress(params, region);
                 case "ReleaseAddress" -> handleReleaseAddress(params, region);
                 case "DescribeAddresses" -> handleDescribeAddresses(params, region);
+                case "DescribeAddressesAttribute" -> handleDescribeAddressesAttribute(params, region);
                 // Regions & Account
                 case "DescribeAvailabilityZones" -> handleDescribeAvailabilityZones(params, region);
                 case "DescribeRegions" -> handleDescribeRegions(params, region);
@@ -272,6 +274,67 @@ public class Ec2QueryHandler {
         xml.end("instancesSet")
                 .end("RunInstancesResponse");
         return xmlResponse(xml.build());
+    }
+
+    private Response handleDescribeIamInstanceProfileAssociations(MultivaluedMap<String, String> p, String region) {
+        List<String> associationIds = getList(p, "AssociationId");
+        Map<String, List<String>> filters = getFilters(p);
+        List<String> instanceFilter = filters.get("instance-id");
+
+        List<Reservation> reservations = service.describeInstances(region, List.of(), Map.of());
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeIamInstanceProfileAssociationsResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .start("iamInstanceProfileAssociationSet");
+        for (Reservation res : reservations) {
+            for (Instance inst : res.getInstances()) {
+                if (inst.getIamInstanceProfileArn() == null) {
+                    continue;
+                }
+                String assocId = iamInstanceProfileAssociationId(inst.getInstanceId());
+                if (instanceFilter != null && !instanceFilter.contains(inst.getInstanceId())) {
+                    continue;
+                }
+                if (!associationIds.isEmpty() && !associationIds.contains(assocId)) {
+                    continue;
+                }
+                xml.start("item")
+                        .elem("associationId", assocId)
+                        .elem("instanceId", inst.getInstanceId())
+                        .start("iamInstanceProfile")
+                        .elem("arn", inst.getIamInstanceProfileArn())
+                        .elem("id", iamInstanceProfileId(inst.getInstanceId()))
+                        .end("iamInstanceProfile")
+                        .elem("state", "associated")
+                        .end("item");
+            }
+        }
+        xml.end("iamInstanceProfileAssociationSet")
+                .end("DescribeIamInstanceProfileAssociationsResponse");
+        return xmlResponse(xml.build());
+    }
+
+    /** Deterministic instance-profile id derived from the instance id so repeated describes are stable. */
+    private static String iamInstanceProfileId(String instanceId) {
+        return "AIPA" + stableSuffix(instanceId, 17).toUpperCase();
+    }
+
+    /** Deterministic association id derived from the instance id so repeated describes are stable. */
+    private static String iamInstanceProfileAssociationId(String instanceId) {
+        return "iip-assoc-" + stableSuffix(instanceId, 17);
+    }
+
+    private static String stableSuffix(String seed, int length) {
+        StringBuilder sb = new StringBuilder();
+        int h = seed.hashCode();
+        String alphabet = "0123456789abcdefghijklmnopqrstuvwxyz";
+        long v = ((long) h) & 0xFFFFFFFFL;
+        for (int i = 0; i < length; i++) {
+            sb.append(alphabet.charAt((int) (v % alphabet.length())));
+            v = v * 1103515245L + 12345L + i;
+            v &= 0xFFFFFFFFL;
+        }
+        return sb.toString();
     }
 
     private Response handleDescribeInstances(MultivaluedMap<String, String> p, String region) {
@@ -1050,6 +1113,26 @@ public class Ec2QueryHandler {
         return xmlResponse(xml.build());
     }
 
+    private Response handleDescribeAddressesAttribute(MultivaluedMap<String, String> p, String region) {
+        List<String> allocationIds = getList(p, "AllocationId");
+        List<Address> addrs = service.describeAddresses(region, allocationIds, Map.of());
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeAddressesAttributeResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .start("addressSet");
+        for (Address addr : addrs) {
+            // AddressAttribute carries allocationId, publicIp and (optionally) ptrRecord.
+            // Floci does not model reverse DNS, so ptrRecord is omitted (null), matching
+            // real EC2 behaviour for EIPs without a configured PTR record.
+            xml.start("item")
+                    .elem("allocationId", addr.getAllocationId())
+                    .elem("publicIp", addr.getPublicIp())
+                    .end("item");
+        }
+        xml.end("addressSet").end("DescribeAddressesAttributeResponse");
+        return xmlResponse(xml.build());
+    }
+
     // ─── Region / AZ / Account handlers ──────────────────────────────────────
 
     private Response handleDescribeAvailabilityZones(MultivaluedMap<String, String> p, String region) {
@@ -1346,6 +1429,12 @@ public class Ec2QueryHandler {
                 .end("item")
                 .end("blockDeviceMapping");
         }
+        if (inst.getIamInstanceProfileArn() != null) {
+            xml.start("iamInstanceProfile")
+                .elem("arn", inst.getIamInstanceProfileArn())
+                .elem("id", iamInstanceProfileId(inst.getInstanceId()))
+                .end("iamInstanceProfile");
+        }
         xml.raw(tagSetXml(inst.getTags()));
         return xml.build();
     }
@@ -1505,6 +1594,8 @@ public class Ec2QueryHandler {
         boolean encrypted = "true".equalsIgnoreCase(encryptedStr);
         String iopsStr = p.getFirst("Iops");
         int iops = iopsStr != null ? Integer.parseInt(iopsStr) : 0;
+        String throughputStr = p.getFirst("Throughput");
+        Integer throughput = throughputStr != null ? Integer.parseInt(throughputStr) : null;
         String snapshotId = p.getFirst("SnapshotId");
 
         List<Tag> volumeTags = new ArrayList<>();
@@ -1522,7 +1613,7 @@ public class Ec2QueryHandler {
         }
 
         Volume vol = service.createVolume(region, availabilityZone, volumeType, size,
-                encrypted, iops, snapshotId, volumeTags);
+                encrypted, iops, throughput, snapshotId, volumeTags);
         XmlBuilder xml = new XmlBuilder()
                 .start("CreateVolumeResponse", AwsNamespaces.EC2)
                 .elem("requestId", UUID.randomUUID().toString())
@@ -1563,6 +1654,9 @@ public class Ec2QueryHandler {
                 .elem("encrypted", String.valueOf(vol.isEncrypted()));
         if (vol.getIops() > 0) {
             xml.elem("iops", String.valueOf(vol.getIops()));
+        }
+        if (vol.getThroughput() != null) {
+            xml.elem("throughput", String.valueOf(vol.getThroughput()));
         }
         if (vol.getSnapshotId() != null) {
             xml.elem("snapshotId", vol.getSnapshotId());

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -15,7 +15,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-import java.util.Base64;
 
 @ApplicationScoped
 public class Ec2QueryHandler {
@@ -38,7 +37,8 @@ public class Ec2QueryHandler {
                 // Instances
                 case "RunInstances" -> handleRunInstances(params, region);
                 case "DescribeInstances" -> handleDescribeInstances(params, region);
-                case "DescribeIamInstanceProfileAssociations" -> handleDescribeIamInstanceProfileAssociations(params, region);
+                case "DescribeIamInstanceProfileAssociations" ->
+                        handleDescribeIamInstanceProfileAssociations(params, region);
                 case "TerminateInstances" -> handleTerminateInstances(params, region);
                 case "StartInstances" -> handleStartInstances(params, region);
                 case "StopInstances" -> handleStopInstances(params, region);
@@ -71,8 +71,10 @@ public class Ec2QueryHandler {
                 case "RevokeSecurityGroupEgress" -> handleRevokeSecurityGroupEgress(params, region);
                 case "DescribeSecurityGroupRules" -> handleDescribeSecurityGroupRules(params, region);
                 case "ModifySecurityGroupRules" -> handleModifySecurityGroupRules(params, region);
-                case "UpdateSecurityGroupRuleDescriptionsIngress" -> handleUpdateSgRuleDescriptionsIngress(params, region);
-                case "UpdateSecurityGroupRuleDescriptionsEgress" -> handleUpdateSgRuleDescriptionsEgress(params, region);
+                case "UpdateSecurityGroupRuleDescriptionsIngress" ->
+                        handleUpdateSgRuleDescriptionsIngress(params, region);
+                case "UpdateSecurityGroupRuleDescriptionsEgress" ->
+                        handleUpdateSgRuleDescriptionsEgress(params, region);
                 // Key Pairs
                 case "CreateKeyPair" -> handleCreateKeyPair(params, region);
                 case "DescribeKeyPairs" -> handleDescribeKeyPairs(params, region);
@@ -133,13 +135,13 @@ public class Ec2QueryHandler {
     private Response ec2Error(String code, String message, int status) {
         String xml = new XmlBuilder()
                 .start("Response")
-                  .start("Errors")
-                    .start("Error")
-                      .elem("Code", code)
-                      .elem("Message", message)
-                    .end("Error")
-                  .end("Errors")
-                  .elem("RequestID", UUID.randomUUID().toString())
+                .start("Errors")
+                .start("Error")
+                .elem("Code", code)
+                .elem("Message", message)
+                .end("Error")
+                .end("Errors")
+                .elem("RequestID", UUID.randomUUID().toString())
                 .end("Response")
                 .build();
         return Response.status(status).entity(xml).type(MediaType.APPLICATION_XML).build();
@@ -314,12 +316,16 @@ public class Ec2QueryHandler {
         return xmlResponse(xml.build());
     }
 
-    /** Deterministic instance-profile id derived from the instance id so repeated describes are stable. */
+    /**
+     * Deterministic instance-profile id derived from the instance id so repeated describes are stable.
+     */
     private static String iamInstanceProfileId(String instanceId) {
         return "AIPA" + stableSuffix(instanceId, 17).toUpperCase();
     }
 
-    /** Deterministic association id derived from the instance id so repeated describes are stable. */
+    /**
+     * Deterministic association id derived from the instance id so repeated describes are stable.
+     */
     private static String iamInstanceProfileAssociationId(String instanceId) {
         return "iip-assoc-" + stableSuffix(instanceId, 17);
     }
@@ -1036,7 +1042,7 @@ public class Ec2QueryHandler {
                 .elem("requestId", UUID.randomUUID().toString())
                 .elem("associationId", assoc.getRouteTableAssociationId())
                 .start("associationState")
-                    .elem("state", assoc.getAssociationState())
+                .elem("state", assoc.getAssociationState())
                 .end("associationState")
                 .end("AssociateRouteTableResponse");
         return xmlResponse(xml.build());
@@ -1418,22 +1424,22 @@ public class Ec2QueryHandler {
                 .end("capacityReservationSpecification");
         if (inst.getRootVolumeId() != null) {
             xml.start("blockDeviceMapping")
-                .start("item")
-                .elem("deviceName", inst.getRootDeviceName())
-                .start("ebs")
-                .elem("volumeId", inst.getRootVolumeId())
-                .elem("status", "attached")
-                .elem("deleteOnTermination", "true")
-                .elem("attachTime", inst.getLaunchTime() != null ? ISO_FMT.format(inst.getLaunchTime()) : "")
-                .end("ebs")
-                .end("item")
-                .end("blockDeviceMapping");
+                    .start("item")
+                    .elem("deviceName", inst.getRootDeviceName())
+                    .start("ebs")
+                    .elem("volumeId", inst.getRootVolumeId())
+                    .elem("status", "attached")
+                    .elem("deleteOnTermination", "true")
+                    .elem("attachTime", inst.getLaunchTime() != null ? ISO_FMT.format(inst.getLaunchTime()) : "")
+                    .end("ebs")
+                    .end("item")
+                    .end("blockDeviceMapping");
         }
         if (inst.getIamInstanceProfileArn() != null) {
             xml.start("iamInstanceProfile")
-                .elem("arn", inst.getIamInstanceProfileArn())
-                .elem("id", iamInstanceProfileId(inst.getInstanceId()))
-                .end("iamInstanceProfile");
+                    .elem("arn", inst.getIamInstanceProfileArn())
+                    .elem("id", iamInstanceProfileId(inst.getInstanceId()))
+                    .end("iamInstanceProfile");
         }
         xml.raw(tagSetXml(inst.getTags()));
         return xml.build();
@@ -1595,7 +1601,15 @@ public class Ec2QueryHandler {
         String iopsStr = p.getFirst("Iops");
         int iops = iopsStr != null ? Integer.parseInt(iopsStr) : 0;
         String throughputStr = p.getFirst("Throughput");
-        Integer throughput = throughputStr != null ? Integer.parseInt(throughputStr) : null;
+        Integer throughput = null;
+        if (throughputStr != null) {
+            try {
+                throughput = Integer.parseInt(throughputStr);
+            } catch (NumberFormatException e) {
+                throw new AwsException("ValidationException", "Invalid Throughput value: " + throughputStr, 400);
+            }
+        }
+
         String snapshotId = p.getFirst("SnapshotId");
 
         List<Tag> volumeTags = new ArrayList<>();

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1483,17 +1483,24 @@ public class Ec2Service {
     // ─── Volumes ───────────────────────────────────────────────────────────────
 
     public Volume createVolume(String region, String availabilityZone, String volumeType,
-                               int size, boolean encrypted, int iops, String snapshotId,
-                               List<Tag> volumeTags) {
+                               int size, boolean encrypted, int iops, Integer throughput,
+                               String snapshotId, List<Tag> volumeTags) {
         ensureDefaultResources(region);
         String volumeId = "vol-" + randomHex(17);
+        String effectiveType = volumeType != null ? volumeType : "gp2";
         Volume vol = new Volume();
         vol.setVolumeId(volumeId);
         vol.setAvailabilityZone(availabilityZone != null ? availabilityZone : region + "a");
-        vol.setVolumeType(volumeType != null ? volumeType : "gp2");
+        vol.setVolumeType(effectiveType);
         vol.setSize(size > 0 ? size : 8);
         vol.setEncrypted(encrypted);
         vol.setIops(iops > 0 ? iops : (volumeType != null && volumeType.startsWith("io") ? iops : 0));
+        // Throughput is a gp3-only attribute; AWS reports 125 MiB/s by default for gp3.
+        if ("gp3".equals(effectiveType)) {
+            vol.setThroughput(throughput != null && throughput > 0 ? throughput : 125);
+        } else {
+            vol.setThroughput(throughput);
+        }
         vol.setSnapshotId(snapshotId);
         vol.setCreateTime(Instant.now());
         vol.setState("available");

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/Volume.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/Volume.java
@@ -18,6 +18,7 @@ public class Volume {
     private String availabilityZone;
     private boolean encrypted;
     private int iops;
+    private Integer throughput;        // MiB/s; only meaningful for gp3 (null otherwise)
     private String snapshotId;
     private Instant createTime;
     private String region;
@@ -46,6 +47,9 @@ public class Volume {
 
     public int getIops() { return iops; }
     public void setIops(int iops) { this.iops = iops; }
+
+    public Integer getThroughput() { return throughput; }
+    public void setThroughput(Integer throughput) { this.throughput = throughput; }
 
     public String getSnapshotId() { return snapshotId; }
     public void setSnapshotId(String snapshotId) { this.snapshotId = snapshotId; }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2VolumeThroughputAndIamProfileIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2VolumeThroughputAndIamProfileIntegrationTest.java
@@ -1,0 +1,177 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
+
+/**
+ * Covers EC2 read-path parity gaps that broke Terraform/OpenTofu:
+ * <ul>
+ *   <li>#1083 — gp3 Volume must report {@code throughput} in CreateVolume/DescribeVolumes</li>
+ *   <li>#1090 — DescribeAddressesAttribute must be supported (VPC module EIP read cycle)</li>
+ *   <li>#1094 — IamInstanceProfile in DescribeInstances + DescribeIamInstanceProfileAssociations</li>
+ * </ul>
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class Ec2VolumeThroughputAndIamProfileIntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20250101/us-east-1/ec2/aws4_request";
+
+    // ── #1083: Volume throughput ──────────────────────────────────────────────
+
+    @Test
+    @Order(1)
+    void gp3VolumeReportsDefaultThroughput() {
+        String volumeId = given()
+                .header("Authorization", AUTH_HEADER)
+                .formParam("Action", "CreateVolume")
+                .formParam("AvailabilityZone", "us-east-1a")
+                .formParam("VolumeType", "gp3")
+                .formParam("Size", "10")
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body("CreateVolumeResponse.volumeId", notNullValue())
+                .body("CreateVolumeResponse.throughput", equalTo("125"))
+                .extract().path("CreateVolumeResponse.volumeId");
+
+        given()
+                .header("Authorization", AUTH_HEADER)
+                .formParam("Action", "DescribeVolumes")
+                .formParam("VolumeId.1", volumeId)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body("DescribeVolumesResponse.volumeSet.item.throughput", equalTo("125"));
+    }
+
+    @Test
+    @Order(2)
+    void gp3VolumeHonoursExplicitThroughput() {
+        given()
+                .header("Authorization", AUTH_HEADER)
+                .formParam("Action", "CreateVolume")
+                .formParam("AvailabilityZone", "us-east-1a")
+                .formParam("VolumeType", "gp3")
+                .formParam("Size", "10")
+                .formParam("Throughput", "250")
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body("CreateVolumeResponse.throughput", equalTo("250"));
+    }
+
+    @Test
+    @Order(3)
+    void gp2VolumeOmitsThroughput() {
+        given()
+                .header("Authorization", AUTH_HEADER)
+                .formParam("Action", "CreateVolume")
+                .formParam("AvailabilityZone", "us-east-1a")
+                .formParam("VolumeType", "gp2")
+                .formParam("Size", "10")
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                // gp2 is not a throughput-provisionable type; only volumeType is asserted.
+                // The handler omits the <throughput> element when the value is null
+                // (positively verified for gp3 in the tests above).
+                .body("CreateVolumeResponse.volumeType", equalTo("gp2"));
+    }
+
+    // ── #1090: DescribeAddressesAttribute ─────────────────────────────────────
+
+    @Test
+    @Order(10)
+    void describeAddressesAttributeReturnsAllocation() {
+        String allocationId = given()
+                .header("Authorization", AUTH_HEADER)
+                .formParam("Action", "AllocateAddress")
+                .formParam("Domain", "vpc")
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body("AllocateAddressResponse.allocationId", startsWith("eipalloc-"))
+                .extract().path("AllocateAddressResponse.allocationId");
+
+        given()
+                .header("Authorization", AUTH_HEADER)
+                .formParam("Action", "DescribeAddressesAttribute")
+                .formParam("AllocationId.1", allocationId)
+                .formParam("Attribute", "domain-name")
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body("DescribeAddressesAttributeResponse.addressSet.item.allocationId", equalTo(allocationId))
+                .body("DescribeAddressesAttributeResponse.addressSet.item.publicIp", notNullValue());
+    }
+
+    // ── #1094: IAM instance profile ───────────────────────────────────────────
+
+    @Test
+    @Order(20)
+    void instanceWithIamProfileExposesItInDescribeAndAssociations() {
+        String instanceId = given()
+                .header("Authorization", AUTH_HEADER)
+                .formParam("Action", "RunInstances")
+                .formParam("ImageId", "ami-12345678")
+                .formParam("InstanceType", "t2.micro")
+                .formParam("MinCount", "1")
+                .formParam("MaxCount", "1")
+                .formParam("IamInstanceProfile.Arn",
+                        "arn:aws:iam::000000000000:instance-profile/my-profile")
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract().path("RunInstancesResponse.instancesSet.item.instanceId");
+
+        // DescribeInstances must now carry the iamInstanceProfile block.
+        given()
+                .header("Authorization", AUTH_HEADER)
+                .formParam("Action", "DescribeInstances")
+                .formParam("InstanceId.1", instanceId)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body("DescribeInstancesResponse.reservationSet.item.instancesSet.item.iamInstanceProfile.arn",
+                        equalTo("arn:aws:iam::000000000000:instance-profile/my-profile"))
+                .body("DescribeInstancesResponse.reservationSet.item.instancesSet.item.iamInstanceProfile.id",
+                        startsWith("AIPA"));
+
+        // DescribeIamInstanceProfileAssociations must resolve the association.
+        given()
+                .header("Authorization", AUTH_HEADER)
+                .formParam("Action", "DescribeIamInstanceProfileAssociations")
+                .formParam("Filter.1.Name", "instance-id")
+                .formParam("Filter.1.Value.1", instanceId)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body("DescribeIamInstanceProfileAssociationsResponse.iamInstanceProfileAssociationSet.item.instanceId",
+                        equalTo(instanceId))
+                .body("DescribeIamInstanceProfileAssociationsResponse.iamInstanceProfileAssociationSet.item.associationId",
+                        startsWith("iip-assoc-"))
+                .body("DescribeIamInstanceProfileAssociationsResponse.iamInstanceProfileAssociationSet.item.state",
+                        equalTo("associated"))
+                .body("DescribeIamInstanceProfileAssociationsResponse.iamInstanceProfileAssociationSet.item.iamInstanceProfile.arn",
+                        equalTo("arn:aws:iam::000000000000:instance-profile/my-profile"));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes three EC2 read-path parity gaps that broke Terraform/OpenTofu `apply` cycles against Floci.

## Changes

#1083 — Volume `throughput` The `Volume` shape's `throughput` field was missing from `CreateVolume` and `DescribeVolumes`. Added `Integer throughput` to the model, parsed the `Throughput` request param, and emit it when present. gp3 defaults to 125 MiB/s (AWS behavior); other types leave it null.

#1090 — `DescribeAddressesAttribute` Returned `UnsupportedOperation`, breaking the VPC community module's `aws_eip` read cycle. Implemented the operation — returns `allocationId` and `publicIp` per `AddressAttribute` — and added it to the EC2 action routing allowlist. (`ptrRecord` is omitted since Floci doesn't model reverse DNS, matching AWS for EIPs without a configured PTR.)

#1094 — IAM instance profile
- `DescribeInstances` now emits `<iamInstanceProfile>` (`arn` + `id`) when the instance was launched with a profile (the ARN was already stored, just never serialized).
- `DescribeIamInstanceProfileAssociations` is implemented (was `UnsupportedOperation`), supporting the `instance-id` filter and `AssociationId` lookup, returning `associationId`, `instanceId`, `iamInstanceProfile`, and `state=associated`.
- Profile id (`AIPA…`) and association id (`iip-assoc-…`) are derived deterministically from the instance id so repeated describes are stable
— eliminating the drift→failure loop Terraform hit.

Closes #1083
Closes #1090
Closes #1094

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
