### PR TITLE
fix(logging): render port numbers without locale grouping separators

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/config/TlsProxyServer.java
+++ b/src/main/java/io/github/hectorvent/floci/config/TlsProxyServer.java
@@ -100,7 +100,7 @@ public class TlsProxyServer {
                                 LOG.debugv("TLS proxy: pipe back→front failed: {0}", err.getMessage()));
                     } else {
                         LOG.warnv("TLS proxy: failed to connect to backend port {0}: {1}",
-                                backendPort, ar.cause().getMessage());
+                                String.valueOf(backendPort), ar.cause().getMessage());
                         frontSocket.close();
                     }
                 });
@@ -113,10 +113,10 @@ public class TlsProxyServer {
         proxyServer.listen().onComplete(ar -> {
             if (ar.succeeded()) {
                 LOG.infov("TLS proxy: listening on port {0} (HTTP→{1}, HTTPS→{2})",
-                        publicPort, HTTP_BACKEND_PORT, HTTPS_BACKEND_PORT);
+                        String.valueOf(publicPort), String.valueOf(HTTP_BACKEND_PORT), String.valueOf(HTTPS_BACKEND_PORT));
             } else {
                 LOG.errorv("TLS proxy: failed to start on port {0}: {1}",
-                        publicPort, ar.cause().getMessage());
+                        String.valueOf(publicPort), ar.cause().getMessage());
             }
         });
     }

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
@@ -385,7 +385,7 @@ public class ContainerLifecycleManager {
                 }
 
                 ports.bind(ExposedPort.tcp(containerPort), Ports.Binding.bindPort(hostPort));
-                LOG.debugv("Port binding: {0} -> {1}", containerPort, hostPort);
+                LOG.debugv("Port binding: {0} -> {1}", String.valueOf(containerPort), String.valueOf(hostPort));
             }
             hostConfig.withPortBindings(ports);
         }

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/PortAllocator.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/PortAllocator.java
@@ -36,7 +36,7 @@ public class PortAllocator {
         for (int port = basePort; port <= maxPort; port++) {
             if (!reserved.contains(port) && isPortFree(port)) {
                 reserved.add(port);
-                LOG.debugv("Allocated port {0} from range {1}-{2}", port, basePort, maxPort);
+                LOG.debugv("Allocated port {0} from range {1}-{2}", String.valueOf(port), String.valueOf(basePort), String.valueOf(maxPort));
                 return port;
             }
         }
@@ -49,7 +49,7 @@ public class PortAllocator {
      */
     public void release(int port) {
         if (reserved.remove(port)) {
-            LOG.debugv("Released port {0}", port);
+            LOG.debugv("Released port {0}", String.valueOf(port));
         }
     }
 
@@ -64,7 +64,7 @@ public class PortAllocator {
         try (ServerSocket socket = new ServerSocket(0)) {
             socket.setReuseAddress(true);
             int port = socket.getLocalPort();
-            LOG.debugv("Allocated ephemeral port {0}", port);
+            LOG.debugv("Allocated ephemeral port {0}", String.valueOf(port));
             return port;
         } catch (IOException e) {
             throw new RuntimeException("Could not find a free port", e);

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
@@ -167,7 +167,7 @@ public class Ec2ContainerManager {
 
                 instance.setState(InstanceState.running());
                 LOG.infov("EC2 instance {0} running in container {1} (SSH host port {2})",
-                        instanceId, containerId, sshHostPort);
+                        instanceId, containerId, String.valueOf(sshHostPort));
 
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/src/main/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManager.java
@@ -168,7 +168,7 @@ public class EcrRegistryManager {
             this.containerId = info.containerId();
             this.hostPort = chosenPort;
             this.started = true;
-            LOG.infov("Started ECR backing registry {0} on host port {1}", name, chosenPort);
+            LOG.infov("Started ECR backing registry {0} on host port {1}", name, String.valueOf(chosenPort));
 
             // Attach log streaming (new feature)
             attachLogStream();
@@ -324,7 +324,7 @@ public class EcrRegistryManager {
             }
             this.started = true;
             LOG.infov("Adopted existing ECR registry container {0} on host port {1}",
-                    containerId, hostPort);
+                    containerId, String.valueOf(hostPort));
 
             // Attach log streaming to adopted container
             attachLogStream();

--- a/src/main/java/io/github/hectorvent/floci/services/eks/EksClusterManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eks/EksClusterManager.java
@@ -118,7 +118,7 @@ public class EksClusterManager {
         }
 
         LOG.infov("k3s container {0} started for cluster {1} on port {2} (internal: {3})",
-                info.containerId(), cluster.getName(), hostPort, cluster.getInternalEndpoint());
+                info.containerId(), cluster.getName(), String.valueOf(hostPort), cluster.getInternalEndpoint());
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
@@ -65,7 +65,7 @@ public class ElastiCacheService {
         String image = config.services().elasticache().defaultImage();
 
         LOG.infov("Creating replication group {0} with authMode={1} on proxy port {2}",
-                groupId, authMode, proxyPort);
+                groupId, authMode, String.valueOf(proxyPort));
 
         ElastiCacheContainerHandle handle = containerManager.start(groupId, image);
 
@@ -84,7 +84,7 @@ public class ElastiCacheService {
                 (username, password) -> validatePassword(groupId, username, password));
 
         groups.put(groupId, group);
-        LOG.infov("Replication group {0} created, endpoint={1}:{2}", groupId, endpointHost, proxyPort);
+        LOG.infov("Replication group {0} created, endpoint={1}:{2}", groupId, endpointHost, String.valueOf(proxyPort));
         return group;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/proxy/ElastiCacheAuthProxy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/proxy/ElastiCacheAuthProxy.java
@@ -58,7 +58,7 @@ public class ElastiCacheAuthProxy {
         running = true;
         Thread.ofVirtual().name("ec-proxy-accept-" + groupId).start(this::acceptLoop);
         LOG.infov("ElastiCache proxy started for group {0} on port {1} → {2}:{3}",
-                groupId, proxyPort, backendHost, backendPort);
+                groupId, String.valueOf(proxyPort), backendHost, String.valueOf(backendPort));
     }
 
     public void stop() {

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
@@ -105,8 +105,8 @@ public class ElbV2DataPlane {
 
         server.requestHandler(req -> handleRequest(req, listenerArn, region));
         server.listen()
-                .onSuccess(s -> LOG.infov("ELBv2 listener started on port {0} for {1}", listener.getPort(), listenerArn))
-                .onFailure(err -> LOG.warnv("ELBv2 listener failed to start on port {0}: {1}", listener.getPort(), err.getMessage()));
+                .onSuccess(s -> LOG.infov("ELBv2 listener started on port {0} for {1}", String.valueOf(listener.getPort()), listenerArn))
+                .onFailure(err -> LOG.warnv("ELBv2 listener failed to start on port {0}: {1}", String.valueOf(listener.getPort()), err.getMessage()));
 
         servers.put(listenerArn, server);
     }

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServer.java
@@ -129,7 +129,7 @@ public class RuntimeApiServer {
 
         // POST /runtime/init/error — runtime initialization failure
         router.post(INIT_ERROR_PATH).handler(ctx -> {
-            LOG.warnv("Lambda runtime reported init error on port {0}", port);
+            LOG.warnv("Lambda runtime reported init error on port {0}", String.valueOf(port));
             ctx.response().setStatusCode(202).end();
         });
 
@@ -145,14 +145,14 @@ public class RuntimeApiServer {
                 .setMaxFormAttributeSize(-1));
         httpServer.requestHandler(router).listen(port, "0.0.0.0", result -> {
             if (result.succeeded()) {
-                LOG.infov("RuntimeApiServer started on port {0}", port);
+                LOG.infov("RuntimeApiServer started on port {0}", String.valueOf(port));
                 started.complete(null);
             } else {
                 if (System.currentTimeMillis() < deadline) {
-                    LOG.debugv("RuntimeApiServer failed to bind on port {0}, retrying in 100ms...", port);
+                    LOG.debugv("RuntimeApiServer failed to bind on port {0}, retrying in 100ms...", String.valueOf(port));
                     httpServer.close(ar -> vertx.setTimer(100, id -> tryListen(started, router, deadline)));
                 } else {
-                    LOG.errorv(result.cause(), "RuntimeApiServer failed to bind on port {0}", port);
+                    LOG.errorv(result.cause(), "RuntimeApiServer failed to bind on port {0}", String.valueOf(port));
                     started.completeExceptionally(result.cause());
                 }
             }
@@ -169,10 +169,10 @@ public class RuntimeApiServer {
         if (httpServer != null) {
             httpServer.close(ar -> {
                 if (ar.succeeded()) {
-                    LOG.debugv("RuntimeApiServer on port {0} closed", port);
+                    LOG.debugv("RuntimeApiServer on port {0} closed", String.valueOf(port));
                     closed.complete(null);
                 } else {
-                    LOG.warnv(ar.cause(), "RuntimeApiServer on port {0} failed to close cleanly", port);
+                    LOG.warnv(ar.cause(), "RuntimeApiServer on port {0} failed to close cleanly", String.valueOf(port));
                     closed.completeExceptionally(ar.cause());
                 }
             });

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServerFactory.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServerFactory.java
@@ -32,7 +32,7 @@ public class RuntimeApiServerFactory {
         try {
             RuntimeApiServer server = new RuntimeApiServer(vertx, port);
             server.start().get(10, TimeUnit.SECONDS);
-            LOG.debugv("Created RuntimeApiServer on port {0}", port);
+            LOG.debugv("Created RuntimeApiServer on port {0}", String.valueOf(port));
             return server;
         } catch (InterruptedException e) {
             portAllocator.release(port);

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneService.java
@@ -64,7 +64,7 @@ public class NeptuneService {
         int proxyPort = allocateProxyPort();
         String image = config.services().neptune().defaultImage();
 
-        LOG.infov("Creating Neptune cluster {0} on proxy port {1}, image={2}", id, proxyPort, image);
+        LOG.infov("Creating Neptune cluster {0} on proxy port {1}, image={2}", id, String.valueOf(proxyPort), image);
 
         NeptuneContainerHandle handle = containerManager.start(id, image);
 
@@ -92,7 +92,7 @@ public class NeptuneService {
         proxyManager.startProxy(id, proxyPort, handle.getHost(), handle.getPort());
 
         clusters.put(id, cluster);
-        LOG.infov("Neptune cluster {0} created, Gremlin endpoint={1}:{2}", id, endpointHost, proxyPort);
+        LOG.infov("Neptune cluster {0} created, Gremlin endpoint={1}:{2}", id, endpointHost, String.valueOf(proxyPort));
         return cluster;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/proxy/NeptuneGremlinProxy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/proxy/NeptuneGremlinProxy.java
@@ -39,7 +39,7 @@ public class NeptuneGremlinProxy {
         running = true;
         Thread.ofVirtual().name("neptune-proxy-accept-" + clusterId).start(this::acceptLoop);
         LOG.infov("Neptune Gremlin proxy started for cluster {0} on port {1} → {2}:{3}",
-                clusterId, proxyPort, backendHost, backendPort);
+                clusterId, String.valueOf(proxyPort), backendHost, String.valueOf(backendPort));
     }
 
     public void stop() {

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainManager.java
@@ -94,7 +94,7 @@ public class OpenSearchDomainManager {
         }
 
         LOG.infov("OpenSearch container {0} started for domain {1} on port {2}",
-                info.containerId(), domain.getDomainName(), hostPort);
+                info.containerId(), domain.getDomainName(), String.valueOf(hostPort));
     }
 
     public boolean isReady(Domain domain) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -170,7 +170,7 @@ public class RdsService {
         }
 
         instances.put(id, instance);
-        LOG.infov("DB instance {0} created, engine={1}, endpoint=localhost:{2}", id, engine, proxyPort);
+        LOG.infov("DB instance {0} created, engine={1}, endpoint=localhost:{2}", id, engine, String.valueOf(proxyPort));
         return instance;
     }
 
@@ -313,7 +313,7 @@ public class RdsService {
                 (user, pw) -> validateDbClusterPassword(id, user, pw));
 
         clusters.put(id, cluster);
-        LOG.infov("DB cluster {0} created, engine={1}, endpoint=localhost:{2}", id, engine, proxyPort);
+        LOG.infov("DB cluster {0} created, engine={1}, endpoint=localhost:{2}", id, engine, String.valueOf(proxyPort));
         return cluster;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/RdsAuthProxy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/RdsAuthProxy.java
@@ -51,7 +51,7 @@ public class RdsAuthProxy {
         running = true;
         Thread.ofVirtual().name("rds-proxy-accept-" + instanceId).start(this::acceptLoop);
         LOG.infov("RDS proxy started for instance {0} on port {1} → {2}:{3}",
-                instanceId, proxyPort, backendHost, backendPort);
+                instanceId, String.valueOf(proxyPort), backendHost, String.valueOf(backendPort));
     }
 
     public void stop() {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SmtpRelay.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SmtpRelay.java
@@ -61,7 +61,7 @@ public class SmtpRelay {
             });
             String host = config.services().ses().smtpHost().get();
             int port = config.services().ses().smtpPort();
-            LOG.infov("SES SMTP relay enabled: {0}:{1}", host, port);
+            LOG.infov("SES SMTP relay enabled: {0}:{1}", host, String.valueOf(port));
 
             MailConfig mailConfig = new MailConfig()
                     .setHostname(host)


### PR DESCRIPTION
## Summary

JBoss Logging's *v methods (infov/warnv/errorv/debugv) format arguments with java.text.MessageFormat, which applies locale grouping to integer placeholders, so an int port 7001 was logged as "7,001". This produced misleading startup/proxy logs like "on port 7,001 → 172.18.0.5:5,432".

Wrap every int port argument passed to a *v log call in String.valueOf() so MessageFormat treats it as a plain string and emits it verbatim. Covers RDS, ElastiCache, Neptune, Lambda runtime, OpenSearch, EKS, ECR, ELBv2, EC2, SES, TLS proxy, and the core PortAllocator / ContainerLifecycleManager. printf-style logf calls and already-string args were unaffected and left unchanged.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
