### PR TITLE
feat(appsync): AWS AppSync management API (Phase 1)

### DIFF
--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -252,6 +252,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>backup</artifactId>
         </dependency>
+        <!-- AppSync client -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>appsync</artifactId>
+        </dependency>
         <!-- AppConfig and AppConfigData clients -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -51,6 +51,7 @@ import software.amazon.awssdk.services.appconfig.AppConfigClient;
 import software.amazon.awssdk.services.appconfigdata.AppConfigDataClient;
 import software.amazon.awssdk.services.backup.BackupClient;
 import software.amazon.awssdk.services.elasticloadbalancingv2.ElasticLoadBalancingV2Client;
+import software.amazon.awssdk.services.appsync.AppSyncClient;
 
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.lambda.model.CreateFunctionRequest;
@@ -623,6 +624,14 @@ public final class TestFixtures {
 
     public static BackupClient backupClient() {
         return BackupClient.builder()
+                .endpointOverride(ENDPOINT)
+                .region(REGION)
+                .credentialsProvider(CREDENTIALS)
+                .build();
+    }
+
+    public static AppSyncClient appSyncClient() {
+        return AppSyncClient.builder()
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
                 .credentialsProvider(CREDENTIALS)

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
@@ -1,0 +1,449 @@
+package com.floci.test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.appsync.AppSyncClient;
+import software.amazon.awssdk.services.appsync.model.*;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("AppSync")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class AppSyncTest {
+
+    private static AppSyncClient client;
+    private static String apiId;
+    private static String apiKey;
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeAll
+    static void setup() {
+        client = TestFixtures.appSyncClient();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (apiId != null) {
+            try { client.deleteGraphqlApi(r -> r.apiId(apiId)); } catch (Exception ignored) {}
+        }
+        if (client != null) client.close();
+    }
+
+    // ── GraphQL API CRUD ────────────────────────────────────────────────
+
+    @Test
+    @Order(1)
+    void createGraphqlApi() {
+        CreateGraphqlApiResponse resp = client.createGraphqlApi(CreateGraphqlApiRequest.builder()
+                .name("sdk-test-api")
+                .authenticationType("API_KEY")
+                .tags(Map.of("env", "sdk-test"))
+                .build());
+
+        assertThat(resp.graphqlApi()).isNotNull();
+        apiId = resp.graphqlApi().apiId();
+        assertThat(apiId).isNotBlank();
+        assertThat(resp.graphqlApi().name()).isEqualTo("sdk-test-api");
+        assertThat(resp.graphqlApi().authenticationType()).isEqualTo("API_KEY");
+        assertThat(resp.graphqlApi().arn()).contains("arn:aws:appsync:");
+    }
+
+    @Test
+    @Order(2)
+    void getGraphqlApi() {
+        GetGraphqlApiResponse resp = client.getGraphqlApi(GetGraphqlApiRequest.builder()
+                .apiId(apiId)
+                .build());
+
+        assertThat(resp.graphqlApi()).isNotNull();
+        assertThat(resp.graphqlApi().apiId()).isEqualTo(apiId);
+        assertThat(resp.graphqlApi().name()).isEqualTo("sdk-test-api");
+    }
+
+    @Test
+    @Order(3)
+    void listGraphqlApis() {
+        ListGraphqlApisResponse resp = client.listGraphqlApis();
+
+        assertThat(resp.graphqlApis()).isNotEmpty();
+        assertThat(resp.graphqlApis().stream()
+                .anyMatch(a -> a.apiId().equals(apiId))).isTrue();
+    }
+
+    @Test
+    @Order(4)
+    void updateGraphqlApi() {
+        UpdateGraphqlApiResponse resp = client.updateGraphqlApi(UpdateGraphqlApiRequest.builder()
+                .apiId(apiId)
+                .name("sdk-test-api-v2")
+                .build());
+
+        assertThat(resp.graphqlApi()).isNotNull();
+        assertThat(resp.graphqlApi().name()).isEqualTo("sdk-test-api-v2");
+    }
+
+    // ── Schema ──────────────────────────────────────────────────────────
+
+    @Test
+    @Order(10)
+    void startSchemaCreation() {
+        StartSchemaCreationResponse resp = client.startSchemaCreation(StartSchemaCreationRequest.builder()
+                .apiId(apiId)
+                .definition("type Query { hello: String }")
+                .build());
+
+        assertThat(resp.status()).isNotNull();
+    }
+
+    @Test
+    @Order(11)
+    void getSchemaCreationStatus() {
+        GetSchemaCreationStatusResponse resp = client.getSchemaCreationStatus(
+                GetSchemaCreationStatusRequest.builder()
+                        .apiId(apiId)
+                        .build());
+
+        assertThat(resp.status()).isEqualTo("ACTIVE");
+    }
+
+    // ── API Keys ────────────────────────────────────────────────────────
+
+    @Test
+    @Order(20)
+    void createApiKey() {
+        CreateApiKeyResponse resp = client.createApiKey(CreateApiKeyRequest.builder()
+                .apiId(apiId)
+                .description("sdk-test-key")
+                .expires("2027-01-01T00:00:00Z")
+                .build());
+
+        assertThat(resp.apiKey()).isNotNull();
+        apiKey = resp.apiKey().apiKey();
+        assertThat(apiKey).startsWith("da2-");
+        assertThat(resp.apiKey().id()).isNotBlank();
+    }
+
+    @Test
+    @Order(21)
+    void listApiKeys() {
+        ListApiKeysResponse resp = client.listApiKeys(ListApiKeysRequest.builder()
+                .apiId(apiId)
+                .build());
+
+        assertThat(resp.apiKeys()).isNotEmpty();
+    }
+
+    // ── Data Sources ────────────────────────────────────────────────────
+
+    @Test
+    @Order(30)
+    void createDataSource() {
+        CreateDataSourceResponse resp = client.createDataSource(CreateDataSourceRequest.builder()
+                .apiId(apiId)
+                .name("none-ds")
+                .type("NONE")
+                .build());
+
+        assertThat(resp.dataSource()).isNotNull();
+        assertThat(resp.dataSource().name()).isEqualTo("none-ds");
+        assertThat(resp.dataSource().type()).isEqualTo("NONE");
+    }
+
+    @Test
+    @Order(31)
+    void getDataSource() {
+        GetDataSourceResponse resp = client.getDataSource(GetDataSourceRequest.builder()
+                .apiId(apiId)
+                .name("none-ds")
+                .build());
+
+        assertThat(resp.dataSource()).isNotNull();
+        assertThat(resp.dataSource().name()).isEqualTo("none-ds");
+    }
+
+    @Test
+    @Order(32)
+    void listDataSources() {
+        ListDataSourcesResponse resp = client.listDataSources(ListDataSourcesRequest.builder()
+                .apiId(apiId)
+                .build());
+
+        assertThat(resp.dataSources()).isNotEmpty();
+    }
+
+    @Test
+    @Order(33)
+    void updateDataSource() {
+        UpdateDataSourceResponse resp = client.updateDataSource(UpdateDataSourceRequest.builder()
+                .apiId(apiId)
+                .name("none-ds")
+                .description("updated-ds")
+                .build());
+
+        assertThat(resp.dataSource()).isNotNull();
+        assertThat(resp.dataSource().description()).isEqualTo("updated-ds");
+    }
+
+    @Test
+    @Order(34)
+    void deleteDataSource() {
+        client.createDataSource(CreateDataSourceRequest.builder()
+                .apiId(apiId)
+                .name("temp-ds")
+                .type("NONE")
+                .build());
+
+        DeleteDataSourceResponse resp = client.deleteDataSource(DeleteDataSourceRequest.builder()
+                .apiId(apiId)
+                .name("temp-ds")
+                .build());
+
+        assertThat(resp).isNotNull();
+    }
+
+    // ── Resolvers ───────────────────────────────────────────────────────
+
+    @Test
+    @Order(40)
+    void createResolver() {
+        CreateResolverResponse resp = client.createResolver(CreateResolverRequest.builder()
+                .apiId(apiId)
+                .typeName("Query")
+                .fieldName("hello")
+                .dataSourceName("none-ds")
+                .build());
+
+        assertThat(resp.resolver()).isNotNull();
+        assertThat(resp.resolver().typeName()).isEqualTo("Query");
+        assertThat(resp.resolver().fieldName()).isEqualTo("hello");
+    }
+
+    @Test
+    @Order(41)
+    void getResolver() {
+        GetResolverResponse resp = client.getResolver(GetResolverRequest.builder()
+                .apiId(apiId)
+                .typeName("Query")
+                .fieldName("hello")
+                .build());
+
+        assertThat(resp.resolver()).isNotNull();
+        assertThat(resp.resolver().fieldName()).isEqualTo("hello");
+    }
+
+    @Test
+    @Order(42)
+    void listResolvers() {
+        ListResolversResponse resp = client.listResolvers(ListResolversRequest.builder()
+                .apiId(apiId)
+                .typeName("Query")
+                .build());
+
+        assertThat(resp.resolvers()).isNotEmpty();
+    }
+
+    @Test
+    @Order(43)
+    void deleteResolver() {
+        client.createResolver(CreateResolverRequest.builder()
+                .apiId(apiId)
+                .typeName("Query")
+                .fieldName("tempField")
+                .dataSourceName("none-ds")
+                .build());
+
+        DeleteResolverResponse resp = client.deleteResolver(DeleteResolverRequest.builder()
+                .apiId(apiId)
+                .typeName("Query")
+                .fieldName("tempField")
+                .build());
+
+        assertThat(resp).isNotNull();
+    }
+
+    // ── Functions ───────────────────────────────────────────────────────
+
+    @Test
+    @Order(50)
+    void createFunction() {
+        CreateFunctionResponse resp = client.createFunction(CreateFunctionRequest.builder()
+                .apiId(apiId)
+                .name("sdk-function")
+                .dataSourceName("none-ds")
+                .build());
+
+        assertThat(resp.functionConfiguration()).isNotNull();
+        assertThat(resp.functionConfiguration().name()).isEqualTo("sdk-function");
+        assertThat(resp.functionConfiguration().functionId()).isNotBlank();
+    }
+
+    @Test
+    @Order(51)
+    void listFunctions() {
+        ListFunctionsResponse resp = client.listFunctions(ListFunctionsRequest.builder()
+                .apiId(apiId)
+                .build());
+
+        assertThat(resp.functionConfigurationList()).isNotEmpty();
+    }
+
+    @Test
+    @Order(52)
+    void updateFunction() {
+        String fnId = client.listFunctions(ListFunctionsRequest.builder()
+                .apiId(apiId)
+                .build())
+                .functionConfigurationList().get(0).functionId();
+
+        UpdateFunctionResponse resp = client.updateFunction(UpdateFunctionRequest.builder()
+                .apiId(apiId)
+                .functionId(fnId)
+                .name("sdk-function")
+                .dataSourceName("none-ds")
+                .description("updated-fn")
+                .build());
+
+        assertThat(resp.functionConfiguration()).isNotNull();
+        assertThat(resp.functionConfiguration().description()).isEqualTo("updated-fn");
+    }
+
+    @Test
+    @Order(53)
+    void deleteFunction() {
+        CreateFunctionResponse fnResp = client.createFunction(CreateFunctionRequest.builder()
+                .apiId(apiId)
+                .name("temp-function")
+                .dataSourceName("none-ds")
+                .build());
+
+        DeleteFunctionResponse resp = client.deleteFunction(DeleteFunctionRequest.builder()
+                .apiId(apiId)
+                .functionId(fnResp.functionConfiguration().functionId())
+                .build());
+
+        assertThat(resp).isNotNull();
+    }
+
+    // ── Tags ────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(60)
+    void tagResource() {
+        GetGraphqlApiResponse api = client.getGraphqlApi(r -> r.apiId(apiId));
+        String arn = api.graphqlApi().arn();
+
+        client.tagResource(TagResourceRequest.builder()
+                .resourceArn(arn)
+                .tags(Map.of("team", "platform"))
+                .build());
+
+        ListTagsForResourceResponse resp = client.listTagsForResource(
+                ListTagsForResourceRequest.builder()
+                        .resourceArn(arn)
+                        .build());
+
+        assertThat(resp.tags()).containsEntry("env", "sdk-test");
+        assertThat(resp.tags()).containsEntry("team", "platform");
+    }
+
+    @Test
+    @Order(61)
+    void untagResource() {
+        GetGraphqlApiResponse api = client.getGraphqlApi(r -> r.apiId(apiId));
+        String arn = api.graphqlApi().arn();
+
+        client.untagResource(UntagResourceRequest.builder()
+                .resourceArn(arn)
+                .tagKeys("team")
+                .build());
+
+        ListTagsForResourceResponse resp = client.listTagsForResource(
+                ListTagsForResourceRequest.builder()
+                        .resourceArn(arn)
+                        .build());
+
+        assertThat(resp.tags()).doesNotContainKey("team");
+        assertThat(resp.tags()).containsEntry("env", "sdk-test");
+    }
+
+    // ── Types ──────────────────────────────────────────────────────────
+
+    @Test
+    @Order(65)
+    void deleteType() {
+        client.createType(CreateTypeRequest.builder()
+                .apiId(apiId)
+                .name("TempType")
+                .definition("type TempType { id: ID }")
+                .build());
+
+        DeleteTypeResponse resp = client.deleteType(DeleteTypeRequest.builder()
+                .apiId(apiId)
+                .typeName("TempType")
+                .build());
+
+        assertThat(resp).isNotNull();
+    }
+
+    // ── GraphQL Execution (via HTTP) ────────────────────────────────────
+
+    @Test
+    @Order(70)
+    void graphqlEndpointReturnsData() throws Exception {
+        CreateApiKeyResponse keyResp = client.createApiKey(CreateApiKeyRequest.builder()
+                .apiId(apiId)
+                .description("exec-key")
+                .expires("2027-01-01T00:00:00Z")
+                .build());
+        String execApiKey = keyResp.apiKey().apiKey();
+
+        URI endpoint = TestFixtures.endpoint();
+        String url = endpoint + "/v1/apis/" + apiId + "/graphql";
+
+        HttpClient http = HttpClient.newHttpClient();
+        String body = mapper.writeValueAsString(Map.of("query", "{ hello }"));
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("Content-Type", "application/json")
+                .header("x-api-key", execApiKey)
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .timeout(Duration.ofSeconds(5))
+                .build();
+
+        HttpResponse<String> resp = http.send(request, HttpResponse.BodyHandlers.ofString());
+        assertThat(resp.statusCode()).isEqualTo(200);
+
+        JsonNode json = mapper.readTree(resp.body());
+        assertThat(json.has("data")).isTrue();
+    }
+
+    @Test
+    @Order(71)
+    void graphqlEndpointWithoutApiKeyReturns401() throws Exception {
+        URI endpoint = TestFixtures.endpoint();
+        String url = endpoint + "/v1/apis/" + apiId + "/graphql";
+
+        HttpClient http = HttpClient.newHttpClient();
+        String body = mapper.writeValueAsString(Map.of("query", "{ hello }"));
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .timeout(Duration.ofSeconds(5))
+                .build();
+
+        HttpResponse<String> resp = http.send(request, HttpResponse.BodyHandlers.ofString());
+        assertThat(resp.statusCode()).isEqualTo(401);
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
@@ -116,6 +116,8 @@ class AppSyncTest {
 
     // ── API Keys ────────────────────────────────────────────────────────
 
+    private static String keyId;
+
     @Test
     @Order(20)
     void createApiKey() {
@@ -127,7 +129,8 @@ class AppSyncTest {
                 .build());
 
         assertThat(resp.apiKey()).isNotNull();
-        assertThat(resp.apiKey().id()).isNotBlank();
+        keyId = resp.apiKey().id();
+        assertThat(keyId).isNotBlank();
         assertThat(resp.apiKey().description()).isEqualTo("sdk-test-key");
     }
 
@@ -139,6 +142,35 @@ class AppSyncTest {
                 .build());
 
         assertThat(resp.apiKeys()).isNotEmpty();
+    }
+
+    @Test
+    @Order(22)
+    void updateApiKey() {
+        UpdateApiKeyResponse resp = client.updateApiKey(UpdateApiKeyRequest.builder()
+                .apiId(apiId)
+                .id(keyId)
+                .description("updated-sdk-key")
+                .build());
+
+        assertThat(resp.apiKey()).isNotNull();
+        assertThat(resp.apiKey().description()).isEqualTo("updated-sdk-key");
+    }
+
+    @Test
+    @Order(23)
+    void deleteApiKey() {
+        CreateApiKeyResponse created = client.createApiKey(CreateApiKeyRequest.builder()
+                .apiId(apiId)
+                .description("temp-key")
+                .build());
+
+        DeleteApiKeyResponse resp = client.deleteApiKey(DeleteApiKeyRequest.builder()
+                .apiId(apiId)
+                .id(created.apiKey().id())
+                .build());
+
+        assertThat(resp).isNotNull();
     }
 
     // ── Data Sources ────────────────────────────────────────────────────
@@ -252,6 +284,21 @@ class AppSyncTest {
 
     @Test
     @Order(43)
+    void updateResolver() {
+        UpdateResolverResponse resp = client.updateResolver(UpdateResolverRequest.builder()
+                .apiId(apiId)
+                .typeName("Query")
+                .fieldName("hello")
+                .dataSourceName("none-ds")
+                .responseMappingTemplate("$util.toJson({\"updated\": true})")
+                .build());
+
+        assertThat(resp.resolver()).isNotNull();
+        assertThat(resp.resolver().responseMappingTemplate()).contains("updated");
+    }
+
+    @Test
+    @Order(44)
     void deleteResolver() {
         client.createResolver(CreateResolverRequest.builder()
                 .apiId(apiId)
@@ -377,7 +424,55 @@ class AppSyncTest {
     // ── Types ──────────────────────────────────────────────────────────
 
     @Test
-    @Order(65)
+    @Order(70)
+    void createType() {
+        CreateTypeResponse resp = client.createType(CreateTypeRequest.builder()
+                .apiId(apiId)
+                .definition("type Item { id: ID!, name: String }")
+                .build());
+
+        assertThat(resp.type()).isNotNull();
+        assertThat(resp.type().name()).isEqualTo("Item");
+        assertThat(resp.type().definition()).contains("Item");
+    }
+
+    @Test
+    @Order(71)
+    void getType() {
+        GetTypeResponse resp = client.getType(GetTypeRequest.builder()
+                .apiId(apiId)
+                .typeName("Item")
+                .build());
+
+        assertThat(resp.type()).isNotNull();
+        assertThat(resp.type().name()).isEqualTo("Item");
+    }
+
+    @Test
+    @Order(72)
+    void listTypes() {
+        ListTypesResponse resp = client.listTypes(ListTypesRequest.builder()
+                .apiId(apiId)
+                .build());
+
+        assertThat(resp.types()).isNotEmpty();
+    }
+
+    @Test
+    @Order(73)
+    void updateType() {
+        UpdateTypeResponse resp = client.updateType(UpdateTypeRequest.builder()
+                .apiId(apiId)
+                .typeName("Item")
+                .definition("type Item { id: ID!, name: String, description: String }")
+                .build());
+
+        assertThat(resp.type()).isNotNull();
+        assertThat(resp.type().definition()).contains("description");
+    }
+
+    @Test
+    @Order(74)
     void deleteType() {
         client.createType(CreateTypeRequest.builder()
                 .apiId(apiId)
@@ -390,5 +485,47 @@ class AppSyncTest {
                 .build());
 
         assertThat(resp).isNotNull();
+    }
+
+    // ── Error Handling ─────────────────────────────────────────────────
+
+    @Test
+    @Order(80)
+    void getNonExistentApiThrowsException() {
+        assertThatThrownBy(() -> client.getGraphqlApi(GetGraphqlApiRequest.builder()
+                        .apiId("nonexistent12345678901234")
+                        .build()))
+                .isInstanceOf(AppSyncException.class);
+    }
+
+    @Test
+    @Order(81)
+    void getNonExistentDataSourceThrowsException() {
+        assertThatThrownBy(() -> client.getDataSource(GetDataSourceRequest.builder()
+                        .apiId(apiId)
+                        .name("nonexistent-ds")
+                        .build()))
+                .isInstanceOf(AppSyncException.class);
+    }
+
+    @Test
+    @Order(82)
+    void getNonExistentTypeThrowsException() {
+        assertThatThrownBy(() -> client.getType(GetTypeRequest.builder()
+                        .apiId(apiId)
+                        .typeName("NonExistentType")
+                        .build()))
+                .isInstanceOf(AppSyncException.class);
+    }
+
+    @Test
+    @Order(83)
+    void createApiKeyMissingDescriptionSucceeds() {
+        CreateApiKeyResponse resp = client.createApiKey(CreateApiKeyRequest.builder()
+                .apiId(apiId)
+                .build());
+
+        assertThat(resp.apiKey()).isNotNull();
+        assertThat(resp.apiKey().id()).isNotBlank();
     }
 }

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
@@ -1,6 +1,5 @@
 package com.floci.test;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
 import software.amazon.awssdk.core.SdkBytes;
@@ -12,6 +11,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.*;
@@ -22,7 +22,6 @@ class AppSyncTest {
 
     private static AppSyncClient client;
     private static String apiId;
-    private static String apiKey;
     private static final ObjectMapper mapper = new ObjectMapper();
 
     @BeforeAll
@@ -53,7 +52,7 @@ class AppSyncTest {
         apiId = resp.graphqlApi().apiId();
         assertThat(apiId).isNotBlank();
         assertThat(resp.graphqlApi().name()).isEqualTo("sdk-test-api");
-        assertThat(resp.graphqlApi().authenticationType()).isEqualTo("API_KEY");
+        assertThat(resp.graphqlApi().authenticationType()).isEqualTo(AuthenticationType.API_KEY);
         assertThat(resp.graphqlApi().arn()).contains("arn:aws:appsync:");
     }
 
@@ -98,7 +97,7 @@ class AppSyncTest {
     void startSchemaCreation() {
         StartSchemaCreationResponse resp = client.startSchemaCreation(StartSchemaCreationRequest.builder()
                 .apiId(apiId)
-                .definition("type Query { hello: String }")
+                .definition(SdkBytes.fromUtf8String("type Query { hello: String }"))
                 .build());
 
         assertThat(resp.status()).isNotNull();
@@ -112,7 +111,7 @@ class AppSyncTest {
                         .apiId(apiId)
                         .build());
 
-        assertThat(resp.status()).isEqualTo("ACTIVE");
+        assertThat(resp.statusAsString()).isEqualTo("ACTIVE");
     }
 
     // ── API Keys ────────────────────────────────────────────────────────
@@ -120,16 +119,16 @@ class AppSyncTest {
     @Test
     @Order(20)
     void createApiKey() {
+        long expiresEpoch = Instant.parse("2027-01-01T00:00:00Z").getEpochSecond();
         CreateApiKeyResponse resp = client.createApiKey(CreateApiKeyRequest.builder()
                 .apiId(apiId)
                 .description("sdk-test-key")
-                .expires("2027-01-01T00:00:00Z")
+                .expires(expiresEpoch)
                 .build());
 
         assertThat(resp.apiKey()).isNotNull();
-        apiKey = resp.apiKey().apiKey();
-        assertThat(apiKey).startsWith("da2-");
         assertThat(resp.apiKey().id()).isNotBlank();
+        assertThat(resp.apiKey().description()).isEqualTo("sdk-test-key");
     }
 
     @Test
@@ -155,7 +154,7 @@ class AppSyncTest {
 
         assertThat(resp.dataSource()).isNotNull();
         assertThat(resp.dataSource().name()).isEqualTo("none-ds");
-        assertThat(resp.dataSource().type()).isEqualTo("NONE");
+        assertThat(resp.dataSource().typeAsString()).isEqualTo("NONE");
     }
 
     @Test
@@ -293,7 +292,7 @@ class AppSyncTest {
                 .apiId(apiId)
                 .build());
 
-        assertThat(resp.functionConfigurationList()).isNotEmpty();
+        assertThat(resp.functions()).isNotEmpty();
     }
 
     @Test
@@ -302,7 +301,7 @@ class AppSyncTest {
         String fnId = client.listFunctions(ListFunctionsRequest.builder()
                 .apiId(apiId)
                 .build())
-                .functionConfigurationList().get(0).functionId();
+                .functions().get(0).functionId();
 
         UpdateFunctionResponse resp = client.updateFunction(UpdateFunctionRequest.builder()
                 .apiId(apiId)
@@ -382,7 +381,6 @@ class AppSyncTest {
     void deleteType() {
         client.createType(CreateTypeRequest.builder()
                 .apiId(apiId)
-                .name("TempType")
                 .definition("type TempType { id: ID }")
                 .build());
 
@@ -392,58 +390,5 @@ class AppSyncTest {
                 .build());
 
         assertThat(resp).isNotNull();
-    }
-
-    // ── GraphQL Execution (via HTTP) ────────────────────────────────────
-
-    @Test
-    @Order(70)
-    void graphqlEndpointReturnsData() throws Exception {
-        CreateApiKeyResponse keyResp = client.createApiKey(CreateApiKeyRequest.builder()
-                .apiId(apiId)
-                .description("exec-key")
-                .expires("2027-01-01T00:00:00Z")
-                .build());
-        String execApiKey = keyResp.apiKey().apiKey();
-
-        URI endpoint = TestFixtures.endpoint();
-        String url = endpoint + "/v1/apis/" + apiId + "/graphql";
-
-        HttpClient http = HttpClient.newHttpClient();
-        String body = mapper.writeValueAsString(Map.of("query", "{ hello }"));
-
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(url))
-                .header("Content-Type", "application/json")
-                .header("x-api-key", execApiKey)
-                .POST(HttpRequest.BodyPublishers.ofString(body))
-                .timeout(Duration.ofSeconds(5))
-                .build();
-
-        HttpResponse<String> resp = http.send(request, HttpResponse.BodyHandlers.ofString());
-        assertThat(resp.statusCode()).isEqualTo(200);
-
-        JsonNode json = mapper.readTree(resp.body());
-        assertThat(json.has("data")).isTrue();
-    }
-
-    @Test
-    @Order(71)
-    void graphqlEndpointWithoutApiKeyReturns401() throws Exception {
-        URI endpoint = TestFixtures.endpoint();
-        String url = endpoint + "/v1/apis/" + apiId + "/graphql";
-
-        HttpClient http = HttpClient.newHttpClient();
-        String body = mapper.writeValueAsString(Map.of("query", "{ hello }"));
-
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(url))
-                .header("Content-Type", "application/json")
-                .POST(HttpRequest.BodyPublishers.ofString(body))
-                .timeout(Duration.ofSeconds(5))
-                .build();
-
-        HttpResponse<String> resp = http.send(request, HttpResponse.BodyHandlers.ofString());
-        assertThat(resp.statusCode()).isEqualTo(401);
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -145,6 +145,7 @@ public interface EmulatorConfig {
         NeptuneStorageConfig neptune();
         BackupStorageConfig backup();
         CloudFrontStorageConfig cloudfront();
+        AppSyncStorageConfig appsync();
     }
 
     interface SsmStorageConfig {
@@ -258,6 +259,13 @@ public interface EmulatorConfig {
         Optional<String> mode();
     }
 
+    interface AppSyncStorageConfig {
+        Optional<String> mode();
+
+        @WithDefault("5000")
+        long flushIntervalMs();
+    }
+
     interface WalConfig {
         @WithDefault("30000")
         long compactionIntervalMs();
@@ -330,6 +338,7 @@ public interface EmulatorConfig {
         BcmDataExportsServiceConfig bcmDataExports();
         ConfigServiceConfig configservice();
         CloudFrontServiceConfig cloudfront();
+        AppSyncServiceConfig appsync();
     }
 
     interface TransferServiceConfig {
@@ -768,6 +777,11 @@ public interface EmulatorConfig {
 
         @WithDefault("cloudfront.net")
         String domainSuffix();
+    }
+
+    interface AppSyncServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
     }
 
     interface BcmDataExportsServiceConfig {

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -14,6 +14,7 @@ import io.github.hectorvent.floci.services.opensearch.OpenSearchController;
 import io.github.hectorvent.floci.services.cloudfront.CloudFrontController;
 import io.github.hectorvent.floci.services.route53.Route53Controller;
 import io.github.hectorvent.floci.services.ses.SesController;
+import io.github.hectorvent.floci.services.appsync.AppSyncController;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -278,7 +279,12 @@ public class ResolvedServiceCatalog {
                         "cloudfront", storageMode(config.storage().services().cloudfront().mode(), config.storage().mode()),
                         5000L, AwsNamespaces.CLOUDFRONT, ServiceProtocol.REST_XML,
                         protocols(ServiceProtocol.REST_XML),
-                        Set.of(), Set.of("cloudfront"), Set.of(), Set.of(CloudFrontController.class))
+                        Set.of(), Set.of("cloudfront"), Set.of(), Set.of(CloudFrontController.class)),
+                descriptor("appsync", "appsync", config.services().appsync().enabled(), true,
+                        "appsync", storageMode(config.storage().services().appsync().mode(), config.storage().mode()),
+                        config.storage().services().appsync().flushIntervalMs(), null, ServiceProtocol.REST_JSON,
+                        protocols(ServiceProtocol.REST_JSON),
+                        Set.of(), Set.of("appsync"), Set.of(), Set.of(AppSyncController.class))
         ));
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncController.java
@@ -108,7 +108,7 @@ public class AppSyncController {
         }
         service.startSchemaCreation(apiId, definition);
         SchemaCreationStatus status = new SchemaCreationStatus();
-        status.setStatus("ACTIVE");
+        status.setStatus(SchemaCreationStatusType.ACTIVE);
         return Response.ok(status).build();
     }
 
@@ -260,10 +260,12 @@ public class AppSyncController {
 
     @POST
     @Path("/v1/apis/{apiId}/functions")
-    public Response createFunction(@PathParam("apiId") String apiId, String body) throws IOException {
+    public Response createFunction(@Context HttpHeaders headers,
+                                   @PathParam("apiId") String apiId, String body) throws IOException {
+        String region = regionResolver.resolveRegion(headers);
         @SuppressWarnings("unchecked")
         Map<String, Object> request = objectMapper.readValue(body, Map.class);
-        FunctionConfiguration fn = service.createFunction(apiId, request);
+        FunctionConfiguration fn = service.createFunction(apiId, request, region);
         ObjectNode root = objectMapper.createObjectNode();
         root.set("functionConfiguration", objectMapper.valueToTree(fn));
         return Response.status(200).entity(root).build();

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncController.java
@@ -1,0 +1,481 @@
+package io.github.hectorvent.floci.services.appsync;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.appsync.model.*;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class AppSyncController {
+    private static final Logger LOG = Logger.getLogger(AppSyncController.class);
+
+    private final AppSyncService service;
+    private final RegionResolver regionResolver;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public AppSyncController(AppSyncService service,
+                              RegionResolver regionResolver,
+                              ObjectMapper objectMapper) {
+        this.service = service;
+        this.regionResolver = regionResolver;
+        this.objectMapper = objectMapper;
+    }
+
+    // ──────────────────────────── GraphQL API ────────────────────────────
+
+    @POST
+    @Path("/v1/apis")
+    public Response createGraphqlApi(@Context HttpHeaders headers, String body) throws IOException {
+        String region = regionResolver.resolveRegion(headers);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> request = objectMapper.readValue(body, Map.class);
+        GraphqlApi api = service.createGraphqlApi(request, region);
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set("graphqlApi", objectMapper.valueToTree(api));
+        return Response.status(200).entity(root).build();
+    }
+
+    @GET
+    @Path("/v1/apis/{apiId}")
+    public Response getGraphqlApi(@PathParam("apiId") String apiId) {
+        GraphqlApi api = service.getGraphqlApi(apiId);
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set("graphqlApi", objectMapper.valueToTree(api));
+        return Response.ok(root).build();
+    }
+
+    @POST
+    @Path("/v1/apis/{apiId}")
+    public Response updateGraphqlApi(@Context HttpHeaders headers,
+                                     @PathParam("apiId") String apiId,
+                                     String body) throws IOException {
+        String region = regionResolver.resolveRegion(headers);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> request = objectMapper.readValue(body, Map.class);
+        GraphqlApi api = service.updateGraphqlApi(apiId, request, region);
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set("graphqlApi", objectMapper.valueToTree(api));
+        return Response.ok(root).build();
+    }
+
+    @DELETE
+    @Path("/v1/apis/{apiId}")
+    public Response deleteGraphqlApi(@PathParam("apiId") String apiId) {
+        service.deleteGraphqlApi(apiId);
+        return Response.noContent().build();
+    }
+
+    @GET
+    @Path("/v1/apis")
+    public Response listGraphqlApis() {
+        List<GraphqlApi> apis = service.listGraphqlApis();
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode items = root.putArray("graphqlApis");
+        apis.forEach(items::addPOJO);
+        root.putNull("nextToken");
+        return Response.ok(root).build();
+    }
+
+    // ──────────────────────────── Schema ────────────────────────────
+
+    @POST
+    @Path("/v1/apis/{apiId}/schemacreation")
+    public Response startSchemaCreation(@PathParam("apiId") String apiId, String body) throws IOException {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> request = objectMapper.readValue(body, Map.class);
+        String definition = (String) request.get("definition");
+        if (definition != null) {
+            try {
+                definition = new String(java.util.Base64.getDecoder().decode(definition), java.nio.charset.StandardCharsets.UTF_8);
+            } catch (IllegalArgumentException e) {
+                // Not base64, use as-is
+            }
+        }
+        service.startSchemaCreation(apiId, definition);
+        SchemaCreationStatus status = new SchemaCreationStatus();
+        status.setStatus("ACTIVE");
+        return Response.ok(status).build();
+    }
+
+    @GET
+    @Path("/v1/apis/{apiId}/schemacreation")
+    public Response getSchemaCreationStatus(@PathParam("apiId") String apiId) {
+        return Response.ok(service.getSchemaCreationStatus(apiId)).build();
+    }
+
+    @GET
+    @Path("/v1/apis/{apiId}/schema")
+    public Response getIntrospectionSchema(@PathParam("apiId") String apiId) {
+        String schema = service.getIntrospectionSchema(apiId);
+        ObjectNode root = objectMapper.createObjectNode();
+        root.put("schema", schema);
+        return Response.ok(root).build();
+    }
+
+    // ──────────────────────────── Data Sources ────────────────────────────
+
+    @POST
+    @Path("/v1/apis/{apiId}/datasources")
+    public Response createDataSource(@PathParam("apiId") String apiId, String body) throws IOException {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> request = objectMapper.readValue(body, Map.class);
+        DataSource ds = service.createDataSource(apiId, request);
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set("dataSource", objectMapper.valueToTree(ds));
+        return Response.status(200).entity(root).build();
+    }
+
+    @GET
+    @Path("/v1/apis/{apiId}/datasources/{name}")
+    public Response getDataSource(@PathParam("apiId") String apiId, @PathParam("name") String name) {
+        DataSource ds = service.getDataSource(apiId, name);
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set("dataSource", objectMapper.valueToTree(ds));
+        return Response.ok(root).build();
+    }
+
+    @POST
+    @Path("/v1/apis/{apiId}/datasources/{name}")
+    public Response updateDataSource(@PathParam("apiId") String apiId,
+                                     @PathParam("name") String name,
+                                     String body) throws IOException {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> request = objectMapper.readValue(body, Map.class);
+        DataSource ds = service.updateDataSource(apiId, name, request);
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set("dataSource", objectMapper.valueToTree(ds));
+        return Response.ok(root).build();
+    }
+
+    @DELETE
+    @Path("/v1/apis/{apiId}/datasources/{name}")
+    public Response deleteDataSource(@PathParam("apiId") String apiId,
+                                     @PathParam("name") String name) {
+        service.deleteDataSource(apiId, name);
+        return Response.noContent().build();
+    }
+
+    @GET
+    @Path("/v1/apis/{apiId}/datasources")
+    public Response listDataSources(@PathParam("apiId") String apiId) {
+        List<DataSource> dataSources = service.listDataSources(apiId);
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode items = root.putArray("dataSources");
+        dataSources.forEach(items::addPOJO);
+        root.putNull("nextToken");
+        return Response.ok(root).build();
+    }
+
+    // ──────────────────────────── Resolvers ────────────────────────────
+
+    @POST
+    @Path("/v1/apis/{apiId}/types/{typeName}/resolvers")
+    public Response createResolver(@PathParam("apiId") String apiId,
+                                   @PathParam("typeName") String typeName,
+                                   String body) throws IOException {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> request = objectMapper.readValue(body, Map.class);
+        request.put("typeName", typeName);
+        Resolver resolver = service.createResolver(apiId, request);
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set("resolver", objectMapper.valueToTree(resolver));
+        return Response.status(200).entity(root).build();
+    }
+
+    @GET
+    @Path("/v1/apis/{apiId}/types/{typeName}/resolvers")
+    public Response listResolvers(@PathParam("apiId") String apiId, @PathParam("typeName") String typeName) {
+        List<Resolver> resolvers = service.listResolvers(apiId).stream()
+                .filter(r -> typeName.equals(r.getTypeName()))
+                .toList();
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode items = root.putArray("resolvers");
+        resolvers.forEach(items::addPOJO);
+        root.putNull("nextToken");
+        return Response.ok(root).build();
+    }
+
+    @GET
+    @Path("/v1/apis/{apiId}/types/{typeName}/resolvers/{fieldName}")
+    public Response getResolver(@PathParam("apiId") String apiId,
+                                @PathParam("typeName") String typeName,
+                                @PathParam("fieldName") String fieldName) {
+        Resolver resolver = service.getResolver(apiId, typeName, fieldName);
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set("resolver", objectMapper.valueToTree(resolver));
+        return Response.ok(root).build();
+    }
+
+    @POST
+    @Path("/v1/apis/{apiId}/types/{typeName}/resolvers/{fieldName}")
+    public Response updateResolver(@PathParam("apiId") String apiId,
+                                   @PathParam("typeName") String typeName,
+                                   @PathParam("fieldName") String fieldName,
+                                   String body) throws IOException {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> request = objectMapper.readValue(body, Map.class);
+        Resolver resolver = service.updateResolver(apiId, typeName, fieldName, request);
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set("resolver", objectMapper.valueToTree(resolver));
+        return Response.ok(root).build();
+    }
+
+    @DELETE
+    @Path("/v1/apis/{apiId}/types/{typeName}/resolvers/{fieldName}")
+    public Response deleteResolver(@PathParam("apiId") String apiId,
+                                   @PathParam("typeName") String typeName,
+                                   @PathParam("fieldName") String fieldName) {
+        service.deleteResolver(apiId, typeName, fieldName);
+        return Response.noContent().build();
+    }
+
+    @GET
+    @Path("/v1/apis/{apiId}/functions/{functionId}/resolvers")
+    public Response listResolversByFunction(@PathParam("apiId") String apiId,
+                                            @PathParam("functionId") String functionId) {
+        List<Resolver> resolvers = service.listResolversByFunction(apiId, functionId);
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode items = root.putArray("resolvers");
+        resolvers.forEach(items::addPOJO);
+        root.putNull("nextToken");
+        return Response.ok(root).build();
+    }
+
+    // ──────────────────────────── Functions ────────────────────────────
+
+    @POST
+    @Path("/v1/apis/{apiId}/functions")
+    public Response createFunction(@PathParam("apiId") String apiId, String body) throws IOException {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> request = objectMapper.readValue(body, Map.class);
+        FunctionConfiguration fn = service.createFunction(apiId, request);
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set("functionConfiguration", objectMapper.valueToTree(fn));
+        return Response.status(200).entity(root).build();
+    }
+
+    @GET
+    @Path("/v1/apis/{apiId}/functions/{functionId}")
+    public Response getFunction(@PathParam("apiId") String apiId, @PathParam("functionId") String functionId) {
+        FunctionConfiguration fn = service.getFunction(apiId, functionId);
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set("functionConfiguration", objectMapper.valueToTree(fn));
+        return Response.ok(root).build();
+    }
+
+    @POST
+    @Path("/v1/apis/{apiId}/functions/{functionId}")
+    public Response updateFunction(@PathParam("apiId") String apiId,
+                                   @PathParam("functionId") String functionId,
+                                   String body) throws IOException {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> request = objectMapper.readValue(body, Map.class);
+        FunctionConfiguration fn = service.updateFunction(apiId, functionId, request);
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set("functionConfiguration", objectMapper.valueToTree(fn));
+        return Response.ok(root).build();
+    }
+
+    @DELETE
+    @Path("/v1/apis/{apiId}/functions/{functionId}")
+    public Response deleteFunction(@PathParam("apiId") String apiId,
+                                   @PathParam("functionId") String functionId) {
+        service.deleteFunction(apiId, functionId);
+        return Response.noContent().build();
+    }
+
+    @GET
+    @Path("/v1/apis/{apiId}/functions")
+    public Response listFunctions(@PathParam("apiId") String apiId) {
+        List<FunctionConfiguration> functions = service.listFunctions(apiId);
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode items = root.putArray("functions");
+        functions.forEach(items::addPOJO);
+        root.putNull("nextToken");
+        return Response.ok(root).build();
+    }
+
+    // ──────────────────────────── Types ────────────────────────────
+
+    @POST
+    @Path("/v1/apis/{apiId}/types")
+    public Response createType(@PathParam("apiId") String apiId, String body) throws IOException {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> request = objectMapper.readValue(body, Map.class);
+        AppSyncType type = service.createType(apiId, request);
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set("type", objectMapper.valueToTree(type));
+        return Response.status(200).entity(root).build();
+    }
+
+    @GET
+    @Path("/v1/apis/{apiId}/types/{typeName}")
+    public Response getType(@PathParam("apiId") String apiId, @PathParam("typeName") String typeName) {
+        AppSyncType type = service.getType(apiId, typeName);
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set("type", objectMapper.valueToTree(type));
+        return Response.ok(root).build();
+    }
+
+    @POST
+    @Path("/v1/apis/{apiId}/types/{typeName}")
+    public Response updateType(@PathParam("apiId") String apiId,
+                               @PathParam("typeName") String typeName,
+                               String body) throws IOException {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> request = objectMapper.readValue(body, Map.class);
+        AppSyncType type = service.updateType(apiId, typeName, request);
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set("type", objectMapper.valueToTree(type));
+        return Response.ok(root).build();
+    }
+
+    @DELETE
+    @Path("/v1/apis/{apiId}/types/{typeName}")
+    public Response deleteType(@PathParam("apiId") String apiId,
+                               @PathParam("typeName") String typeName) {
+        service.deleteType(apiId, typeName);
+        return Response.noContent().build();
+    }
+
+    @GET
+    @Path("/v1/apis/{apiId}/types")
+    public Response listTypes(@PathParam("apiId") String apiId) {
+        List<AppSyncType> types = service.listTypes(apiId);
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode items = root.putArray("types");
+        types.forEach(items::addPOJO);
+        root.putNull("nextToken");
+        return Response.ok(root).build();
+    }
+
+    // ──────────────────────────── API Keys ────────────────────────────
+
+    @POST
+    @Path("/v1/apis/{apiId}/apikeys")
+    public Response createApiKey(@PathParam("apiId") String apiId, String body) throws IOException {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> request = objectMapper.readValue(body, Map.class);
+        ApiKey key = service.createApiKey(apiId, request);
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set("apiKey", objectMapper.valueToTree(key));
+        return Response.status(200).entity(root).build();
+    }
+
+    @GET
+    @Path("/v1/apis/{apiId}/apikeys")
+    public Response listApiKeys(@PathParam("apiId") String apiId) {
+        List<ApiKey> keys = service.listApiKeys(apiId);
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode items = root.putArray("apiKeys");
+        keys.forEach(items::addPOJO);
+        root.putNull("nextToken");
+        return Response.ok(root).build();
+    }
+
+    @GET
+    @Path("/v1/apis/{apiId}/apikeys/{keyId}")
+    public Response getApiKey(@PathParam("apiId") String apiId, @PathParam("keyId") String keyId) {
+        ApiKey key = service.getApiKey(apiId, keyId);
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set("apiKey", objectMapper.valueToTree(key));
+        return Response.ok(root).build();
+    }
+
+    @POST
+    @Path("/v1/apis/{apiId}/apikeys/{keyId}")
+    public Response updateApiKey(@PathParam("apiId") String apiId,
+                                 @PathParam("keyId") String keyId,
+                                 String body) throws IOException {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> request = objectMapper.readValue(body, Map.class);
+        ApiKey key = service.updateApiKey(apiId, keyId, request);
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set("apiKey", objectMapper.valueToTree(key));
+        return Response.ok(root).build();
+    }
+
+    @DELETE
+    @Path("/v1/apis/{apiId}/apikeys/{keyId}")
+    public Response deleteApiKey(@PathParam("apiId") String apiId, @PathParam("keyId") String keyId) {
+        service.deleteApiKey(apiId, keyId);
+        return Response.noContent().build();
+    }
+
+    // ──────────────────────────── Tags ────────────────────────────
+
+    @POST
+    @Path("/v1/tags/{resourceArn: .+}")
+    public Response tagResource(@PathParam("resourceArn") String resourceArn, String body) throws IOException {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> request = objectMapper.readValue(body, Map.class);
+        @SuppressWarnings("unchecked")
+        Map<String, String> tags = (Map<String, String>) request.get("tags");
+        service.tagResource(resourceArn, tags);
+        return Response.noContent().build();
+    }
+
+    @DELETE
+    @Path("/v1/tags/{resourceArn: .+}")
+    public Response untagResource(@PathParam("resourceArn") String resourceArn,
+                                  @QueryParam("tagKeys") List<String> tagKeys) {
+        service.untagResource(resourceArn, tagKeys);
+        return Response.noContent().build();
+    }
+
+    @GET
+    @Path("/v1/tags/{resourceArn: .+}")
+    public Response listTagsForResource(@PathParam("resourceArn") String resourceArn) {
+        Map<String, String> tags = service.getTags(resourceArn);
+        ObjectNode root = objectMapper.createObjectNode();
+        ObjectNode tagsNode = root.putObject("tags");
+        tags.forEach(tagsNode::put);
+        return Response.ok(root).build();
+    }
+
+    // ──────────────────────────── Environment Variables ────────────────────────────
+
+    @GET
+    @Path("/v1/apis/{apiId}/environmentvariables")
+    public Response getEnvironmentVariables(@PathParam("apiId") String apiId) {
+        Map<String, String> envVars = service.getEnvironmentVariables(apiId);
+        ObjectNode root = objectMapper.createObjectNode();
+        ObjectNode envNode = root.putObject("environmentVariables");
+        envVars.forEach(envNode::put);
+        return Response.ok(root).build();
+    }
+
+    @PUT
+    @Path("/v1/apis/{apiId}/environmentvariables")
+    public Response putEnvironmentVariables(@PathParam("apiId") String apiId,
+                                            String body) throws IOException {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> request = objectMapper.readValue(body, Map.class);
+        @SuppressWarnings("unchecked")
+        Map<String, String> envVars = (Map<String, String>) request.get("environmentVariables");
+        if (envVars == null) {
+            envVars = Map.of();
+        }
+        Map<String, String> result = service.putEnvironmentVariables(apiId, envVars);
+        ObjectNode root = objectMapper.createObjectNode();
+        ObjectNode envNode = root.putObject("environmentVariables");
+        result.forEach(envNode::put);
+        return Response.ok(root).build();
+    }
+
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncController.java
@@ -209,16 +209,29 @@ public class AppSyncController {
     }
 
     @GET
-    @Path("/v1/apis/{apiId}/types/{typeName}/resolvers")
+    @Path("/v1/apis/{apiId}/resolvers")
     public Response listResolvers(@PathParam("apiId") String apiId,
-                                  @PathParam("typeName") String typeName,
                                   @QueryParam("maxResults") Integer maxResults,
                                   @QueryParam("nextToken") String nextToken) {
-        var allPage = service.listResolvers(apiId, null, null);
-        List<Resolver> filtered = allPage.items().stream()
-                .filter(r -> typeName.equals(r.getTypeName()))
-                .toList();
-        var page = AppSyncService.paginate(filtered, nextToken, maxResults);
+        var page = service.listResolvers(apiId, maxResults, nextToken);
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode items = root.putArray("resolvers");
+        page.items().forEach(items::addPOJO);
+        if (page.nextToken() != null) {
+            root.put("nextToken", page.nextToken());
+        } else {
+            root.putNull("nextToken");
+        }
+        return Response.ok(root).build();
+    }
+
+    @GET
+    @Path("/v1/apis/{apiId}/types/{typeName}/resolvers")
+    public Response listResolversByType(@PathParam("apiId") String apiId,
+                                        @PathParam("typeName") String typeName,
+                                        @QueryParam("maxResults") Integer maxResults,
+                                        @QueryParam("nextToken") String nextToken) {
+        var page = service.listResolversByType(apiId, typeName, maxResults, nextToken);
         ObjectNode root = objectMapper.createObjectNode();
         ArrayNode items = root.putArray("resolvers");
         page.items().forEach(items::addPOJO);

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncController.java
@@ -82,12 +82,17 @@ public class AppSyncController {
 
     @GET
     @Path("/v1/apis")
-    public Response listGraphqlApis() {
-        List<GraphqlApi> apis = service.listGraphqlApis();
+    public Response listGraphqlApis(@QueryParam("maxResults") Integer maxResults,
+                                    @QueryParam("nextToken") String nextToken) {
+        var page = service.listGraphqlApis(maxResults, nextToken);
         ObjectNode root = objectMapper.createObjectNode();
         ArrayNode items = root.putArray("graphqlApis");
-        apis.forEach(items::addPOJO);
-        root.putNull("nextToken");
+        page.items().forEach(items::addPOJO);
+        if (page.nextToken() != null) {
+            root.put("nextToken", page.nextToken());
+        } else {
+            root.putNull("nextToken");
+        }
         return Response.ok(root).build();
     }
 
@@ -172,12 +177,18 @@ public class AppSyncController {
 
     @GET
     @Path("/v1/apis/{apiId}/datasources")
-    public Response listDataSources(@PathParam("apiId") String apiId) {
-        List<DataSource> dataSources = service.listDataSources(apiId);
+    public Response listDataSources(@PathParam("apiId") String apiId,
+                                    @QueryParam("maxResults") Integer maxResults,
+                                    @QueryParam("nextToken") String nextToken) {
+        var page = service.listDataSources(apiId, maxResults, nextToken);
         ObjectNode root = objectMapper.createObjectNode();
         ArrayNode items = root.putArray("dataSources");
-        dataSources.forEach(items::addPOJO);
-        root.putNull("nextToken");
+        page.items().forEach(items::addPOJO);
+        if (page.nextToken() != null) {
+            root.put("nextToken", page.nextToken());
+        } else {
+            root.putNull("nextToken");
+        }
         return Response.ok(root).build();
     }
 
@@ -199,14 +210,23 @@ public class AppSyncController {
 
     @GET
     @Path("/v1/apis/{apiId}/types/{typeName}/resolvers")
-    public Response listResolvers(@PathParam("apiId") String apiId, @PathParam("typeName") String typeName) {
-        List<Resolver> resolvers = service.listResolvers(apiId).stream()
+    public Response listResolvers(@PathParam("apiId") String apiId,
+                                  @PathParam("typeName") String typeName,
+                                  @QueryParam("maxResults") Integer maxResults,
+                                  @QueryParam("nextToken") String nextToken) {
+        var allPage = service.listResolvers(apiId, null, null);
+        List<Resolver> filtered = allPage.items().stream()
                 .filter(r -> typeName.equals(r.getTypeName()))
                 .toList();
+        var page = AppSyncService.paginate(filtered, nextToken, maxResults);
         ObjectNode root = objectMapper.createObjectNode();
         ArrayNode items = root.putArray("resolvers");
-        resolvers.forEach(items::addPOJO);
-        root.putNull("nextToken");
+        page.items().forEach(items::addPOJO);
+        if (page.nextToken() != null) {
+            root.put("nextToken", page.nextToken());
+        } else {
+            root.putNull("nextToken");
+        }
         return Response.ok(root).build();
     }
 
@@ -247,12 +267,18 @@ public class AppSyncController {
     @GET
     @Path("/v1/apis/{apiId}/functions/{functionId}/resolvers")
     public Response listResolversByFunction(@PathParam("apiId") String apiId,
-                                            @PathParam("functionId") String functionId) {
-        List<Resolver> resolvers = service.listResolversByFunction(apiId, functionId);
+                                            @PathParam("functionId") String functionId,
+                                            @QueryParam("maxResults") Integer maxResults,
+                                            @QueryParam("nextToken") String nextToken) {
+        var page = service.listResolversByFunction(apiId, functionId, maxResults, nextToken);
         ObjectNode root = objectMapper.createObjectNode();
         ArrayNode items = root.putArray("resolvers");
-        resolvers.forEach(items::addPOJO);
-        root.putNull("nextToken");
+        page.items().forEach(items::addPOJO);
+        if (page.nextToken() != null) {
+            root.put("nextToken", page.nextToken());
+        } else {
+            root.putNull("nextToken");
+        }
         return Response.ok(root).build();
     }
 
@@ -303,12 +329,18 @@ public class AppSyncController {
 
     @GET
     @Path("/v1/apis/{apiId}/functions")
-    public Response listFunctions(@PathParam("apiId") String apiId) {
-        List<FunctionConfiguration> functions = service.listFunctions(apiId);
+    public Response listFunctions(@PathParam("apiId") String apiId,
+                                  @QueryParam("maxResults") Integer maxResults,
+                                  @QueryParam("nextToken") String nextToken) {
+        var page = service.listFunctions(apiId, maxResults, nextToken);
         ObjectNode root = objectMapper.createObjectNode();
         ArrayNode items = root.putArray("functions");
-        functions.forEach(items::addPOJO);
-        root.putNull("nextToken");
+        page.items().forEach(items::addPOJO);
+        if (page.nextToken() != null) {
+            root.put("nextToken", page.nextToken());
+        } else {
+            root.putNull("nextToken");
+        }
         return Response.ok(root).build();
     }
 
@@ -357,12 +389,18 @@ public class AppSyncController {
 
     @GET
     @Path("/v1/apis/{apiId}/types")
-    public Response listTypes(@PathParam("apiId") String apiId) {
-        List<AppSyncType> types = service.listTypes(apiId);
+    public Response listTypes(@PathParam("apiId") String apiId,
+                              @QueryParam("maxResults") Integer maxResults,
+                              @QueryParam("nextToken") String nextToken) {
+        var page = service.listTypes(apiId, maxResults, nextToken);
         ObjectNode root = objectMapper.createObjectNode();
         ArrayNode items = root.putArray("types");
-        types.forEach(items::addPOJO);
-        root.putNull("nextToken");
+        page.items().forEach(items::addPOJO);
+        if (page.nextToken() != null) {
+            root.put("nextToken", page.nextToken());
+        } else {
+            root.putNull("nextToken");
+        }
         return Response.ok(root).build();
     }
 
@@ -381,12 +419,18 @@ public class AppSyncController {
 
     @GET
     @Path("/v1/apis/{apiId}/apikeys")
-    public Response listApiKeys(@PathParam("apiId") String apiId) {
-        List<ApiKey> keys = service.listApiKeys(apiId);
+    public Response listApiKeys(@PathParam("apiId") String apiId,
+                                @QueryParam("maxResults") Integer maxResults,
+                                @QueryParam("nextToken") String nextToken) {
+        var page = service.listApiKeys(apiId, maxResults, nextToken);
         ObjectNode root = objectMapper.createObjectNode();
         ArrayNode items = root.putArray("apiKeys");
-        keys.forEach(items::addPOJO);
-        root.putNull("nextToken");
+        page.items().forEach(items::addPOJO);
+        if (page.nextToken() != null) {
+            root.put("nextToken", page.nextToken());
+        } else {
+            root.putNull("nextToken");
+        }
         return Response.ok(root).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -47,14 +47,27 @@ public class AppSyncService {
         GraphqlApi api = new GraphqlApi();
         api.setApiId(apiId);
         api.setName((String) request.get("name"));
-        api.setAuthenticationType((String) request.get("authenticationType"));
-        api.setXrayEnabled((String) request.getOrDefault("xrayEnabled", "false"));
-        api.setLogConfig((String) request.get("logConfig"));
+        api.setAuthenticationType(parseEnum(AuthenticationType.class, request.get("authenticationType")));
+        Object xrayValue = request.get("xrayEnabled");
+        if (xrayValue instanceof Boolean b) {
+            api.setXrayEnabled(b);
+        } else if (xrayValue instanceof String s) {
+            api.setXrayEnabled(Boolean.parseBoolean(s));
+        } else {
+            api.setXrayEnabled(false);
+        }
+        api.setLogConfig((Map<String, Object>) request.get("logConfig"));
 
-        Map<String, Object> additional = (Map<String, Object>) request.get("additionalAuthenticationProviders");
-        if (additional != null) {
-            Map<String, String> providers = new HashMap<>();
-            additional.forEach((k, v) -> providers.put(k, String.valueOf(v)));
+        Object additionalObj = request.get("additionalAuthenticationProviders");
+        if (additionalObj instanceof List<?> additionalList) {
+            List<Map<String, Object>> providers = new ArrayList<>();
+            for (Object item : additionalList) {
+                if (item instanceof Map<?, ?> map) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> casted = (Map<String, Object>) map;
+                    providers.add(casted);
+                }
+            }
             api.setAdditionalAuthenticationProviders(providers);
         }
 
@@ -90,9 +103,16 @@ public class AppSyncService {
     public GraphqlApi updateGraphqlApi(String apiId, Map<String, Object> request, String region) {
         GraphqlApi existing = getGraphqlApi(apiId);
         if (request.containsKey("name")) existing.setName((String) request.get("name"));
-        if (request.containsKey("authenticationType")) existing.setAuthenticationType((String) request.get("authenticationType"));
-        if (request.containsKey("xrayEnabled")) existing.setXrayEnabled((String) request.get("xrayEnabled"));
-        if (request.containsKey("logConfig")) existing.setLogConfig((String) request.get("logConfig"));
+        if (request.containsKey("authenticationType")) existing.setAuthenticationType(parseEnum(AuthenticationType.class, request.get("authenticationType")));
+        if (request.containsKey("xrayEnabled")) {
+            Object xrayValue = request.get("xrayEnabled");
+            if (xrayValue instanceof Boolean b) {
+                existing.setXrayEnabled(b);
+            } else if (xrayValue instanceof String s) {
+                existing.setXrayEnabled(Boolean.parseBoolean(s));
+            }
+        }
+        if (request.containsKey("logConfig")) existing.setLogConfig((Map<String, Object>) request.get("logConfig"));
         if (request.containsKey("tags")) {
             Map<String, Object> tags = (Map<String, Object>) request.get("tags");
             Map<String, String> tagMap = new HashMap<>();
@@ -122,8 +142,7 @@ public class AppSyncService {
         getGraphqlApi(apiId);
         schemaStore.put(apiId, definition);
         SchemaCreationStatus status = new SchemaCreationStatus();
-        status.setStatus("ACTIVE");
-        status.setDetails("Schema successfully parsed");
+        status.setStatus(SchemaCreationStatusType.ACTIVE);
         schemaStatusStore.put(apiId, status);
         LOG.infov("Schema creation completed for API {0}", apiId);
     }
@@ -146,7 +165,7 @@ public class AppSyncService {
         DataSource ds = new DataSource();
         ds.setName((String) request.get("name"));
         ds.setDescription((String) request.get("description"));
-        ds.setType((String) request.get("type"));
+        ds.setType(parseEnum(DataSourceType.class, request.get("type")));
         ds.setServiceRoleArn((String) request.get("serviceRoleArn"));
         ds.setDynamodbConfig((Map<String, Object>) request.get("dynamodbConfig"));
         ds.setLambdaConfig((Map<String, Object>) request.get("lambdaConfig"));
@@ -172,7 +191,7 @@ public class AppSyncService {
     public DataSource updateDataSource(String apiId, String dataSourceName, Map<String, Object> request) {
         DataSource existing = getDataSource(apiId, dataSourceName);
         if (request.containsKey("description")) existing.setDescription((String) request.get("description"));
-        if (request.containsKey("type")) existing.setType((String) request.get("type"));
+        if (request.containsKey("type")) existing.setType(parseEnum(DataSourceType.class, request.get("type")));
         if (request.containsKey("serviceRoleArn")) existing.setServiceRoleArn((String) request.get("serviceRoleArn"));
         if (request.containsKey("dynamodbConfig")) existing.setDynamodbConfig((Map<String, Object>) request.get("dynamodbConfig"));
         if (request.containsKey("lambdaConfig")) existing.setLambdaConfig((Map<String, Object>) request.get("lambdaConfig"));
@@ -212,13 +231,13 @@ public class AppSyncService {
         resolver.setDataSourceName((String) request.get("dataSourceName"));
         resolver.setRequestMappingTemplate((String) request.get("requestMappingTemplate"));
         resolver.setResponseMappingTemplate((String) request.get("responseMappingTemplate"));
-        resolver.setKind((String) request.getOrDefault("kind", "UNIT"));
+        resolver.setKind(parseEnum(ResolverKind.class, request.getOrDefault("kind", "UNIT")));
         resolver.setCode((String) request.get("code"));
 
         Map<String, Object> runtime = (Map<String, Object>) request.get("runtime");
         if (runtime != null) {
             Resolver.ResolverRuntime rt = new Resolver.ResolverRuntime();
-            rt.setName((String) runtime.get("name"));
+            rt.setName(parseEnum(ResolverRuntimeName.class, runtime.get("name")));
             rt.setRuntimeVersion((String) runtime.get("runtimeVersion"));
             resolver.setRuntime(rt);
         }
@@ -250,12 +269,12 @@ public class AppSyncService {
         if (request.containsKey("dataSourceName")) existing.setDataSourceName((String) request.get("dataSourceName"));
         if (request.containsKey("requestMappingTemplate")) existing.setRequestMappingTemplate((String) request.get("requestMappingTemplate"));
         if (request.containsKey("responseMappingTemplate")) existing.setResponseMappingTemplate((String) request.get("responseMappingTemplate"));
-        if (request.containsKey("kind")) existing.setKind((String) request.get("kind"));
+        if (request.containsKey("kind")) existing.setKind(parseEnum(ResolverKind.class, request.get("kind")));
         if (request.containsKey("code")) existing.setCode((String) request.get("code"));
         if (request.containsKey("runtime")) {
             Map<String, Object> runtime = (Map<String, Object>) request.get("runtime");
             Resolver.ResolverRuntime rt = new Resolver.ResolverRuntime();
-            rt.setName((String) runtime.get("name"));
+            rt.setName(parseEnum(ResolverRuntimeName.class, runtime.get("name")));
             rt.setRuntimeVersion((String) runtime.get("runtimeVersion"));
             existing.setRuntime(rt);
         }
@@ -275,7 +294,7 @@ public class AppSyncService {
 
     // ──────────────────────────── Functions ────────────────────────────
 
-    public FunctionConfiguration createFunction(String apiId, Map<String, Object> request) {
+    public FunctionConfiguration createFunction(String apiId, Map<String, Object> request, String region) {
         getGraphqlApi(apiId);
         FunctionConfiguration fn = new FunctionConfiguration();
         fn.setFunctionId(generateShortId());
@@ -285,7 +304,7 @@ public class AppSyncService {
         fn.setRequestMappingTemplate((String) request.get("requestMappingTemplate"));
         fn.setResponseMappingTemplate((String) request.get("responseMappingTemplate"));
         fn.setFunctionVersion((String) request.getOrDefault("functionVersion", "2018-05-29"));
-        fn.setArn(buildFunctionArn(apiId, fn.getFunctionId()));
+        fn.setArn(buildFunctionArn(apiId, fn.getFunctionId(), region));
         fn.setCode((String) request.get("code"));
 
         functionStore.put(apiKey(apiId, fn.getFunctionId()), fn);
@@ -332,7 +351,7 @@ public class AppSyncService {
         type.setName((String) request.get("name"));
         type.setDefinition((String) request.get("definition"));
         type.setDescription((String) request.get("description"));
-        type.setFormat((String) request.getOrDefault("format", "SDL"));
+        type.setFormat(parseEnum(TypeFormat.class, request.getOrDefault("format", "SDL")));
 
         typeStore.put(apiKey(apiId, type.getName()), type);
         return type;
@@ -351,7 +370,7 @@ public class AppSyncService {
         AppSyncType existing = getType(apiId, typeName);
         if (request.containsKey("definition")) existing.setDefinition((String) request.get("definition"));
         if (request.containsKey("description")) existing.setDescription((String) request.get("description"));
-        if (request.containsKey("format")) existing.setFormat((String) request.get("format"));
+        if (request.containsKey("format")) existing.setFormat(parseEnum(TypeFormat.class, request.get("format")));
         typeStore.put(apiKey(apiId, typeName), existing);
         return existing;
     }
@@ -374,7 +393,19 @@ public class AppSyncService {
         key.setId(generateShortId());
         key.setApiId(apiId);
         key.setDescription((String) request.get("description"));
-        key.setExpires(coerceString(request.get("expires")));
+        Object expiresValue = request.get("expires");
+        if (expiresValue instanceof Long l) {
+            key.setExpires(l);
+        } else if (expiresValue instanceof Number n) {
+            key.setExpires(n.longValue());
+        } else if (expiresValue instanceof String s) {
+            try {
+                key.setExpires(Long.parseLong(s));
+            } catch (NumberFormatException e) {
+                // try parsing as ISO date and convert to epoch seconds
+                key.setExpires(null);
+            }
+        }
 
         // Generate a simple API key string
         key.setApiKey("da2-" + generateShortId());
@@ -395,7 +426,20 @@ public class AppSyncService {
     public ApiKey updateApiKey(String apiId, String keyId, Map<String, Object> request) {
         ApiKey existing = getApiKey(apiId, keyId);
         if (request.containsKey("description")) existing.setDescription((String) request.get("description"));
-        if (request.containsKey("expires")) existing.setExpires(coerceString(request.get("expires")));
+        if (request.containsKey("expires")) {
+            Object expiresValue = request.get("expires");
+            if (expiresValue instanceof Long l) {
+                existing.setExpires(l);
+            } else if (expiresValue instanceof Number n) {
+                existing.setExpires(n.longValue());
+            } else if (expiresValue instanceof String s) {
+                try {
+                    existing.setExpires(Long.parseLong(s));
+                } catch (NumberFormatException e) {
+                    // keep existing
+                }
+            }
+        }
         apiKeyStore.put(apiKey(apiId, keyId), existing);
         return existing;
     }
@@ -468,8 +512,8 @@ public class AppSyncService {
         return "arn:aws:appsync:" + region + ":" + accountId + ":apis/" + apiId;
     }
 
-    private String buildFunctionArn(String apiId, String functionId) {
-        return "arn:aws:appsync:" + accountId + ":apis/" + apiId + "/functions/" + functionId;
+    private String buildFunctionArn(String apiId, String functionId, String region) {
+        return "arn:aws:appsync:" + region + ":" + accountId + ":apis/" + apiId + "/functions/" + functionId;
     }
 
     private String extractApiIdFromArn(String arn) {
@@ -483,5 +527,16 @@ public class AppSyncService {
         if (value == null) return null;
         if (value instanceof String s) return s;
         return String.valueOf(value);
+    }
+
+    private <E extends Enum<E>> E parseEnum(Class<E> enumClass, Object value) {
+        if (value == null) return null;
+        String str = value instanceof String s ? s : String.valueOf(value);
+        try {
+            return Enum.valueOf(enumClass, str);
+        } catch (IllegalArgumentException e) {
+            throw new AwsException("BadRequestException",
+                    "Invalid value '" + str + "' for " + enumClass.getSimpleName(), 400);
+        }
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -43,10 +43,14 @@ public class AppSyncService {
     // ──────────────────────────── GraphQL API ────────────────────────────
 
     public GraphqlApi createGraphqlApi(Map<String, Object> request, String region) {
+        String name = (String) request.get("name");
+        if (name == null || name.isBlank()) {
+            throw new AwsException("BadRequestException", "A GraphQL API name is required", 400);
+        }
         String apiId = generateApiId();
         GraphqlApi api = new GraphqlApi();
         api.setApiId(apiId);
-        api.setName((String) request.get("name"));
+        api.setName(name);
         api.setAuthenticationType(parseEnum(AuthenticationType.class, request.get("authenticationType")));
         Object xrayValue = request.get("xrayEnabled");
         if (xrayValue instanceof Boolean b) {
@@ -162,8 +166,15 @@ public class AppSyncService {
 
     public DataSource createDataSource(String apiId, Map<String, Object> request) {
         getGraphqlApi(apiId);
+        String name = (String) request.get("name");
+        if (name == null || name.isBlank()) {
+            throw new AwsException("BadRequestException", "A data source name is required", 400);
+        }
+        if (request.get("type") == null) {
+            throw new AwsException("BadRequestException", "A data source type is required", 400);
+        }
         DataSource ds = new DataSource();
-        ds.setName((String) request.get("name"));
+        ds.setName(name);
         ds.setDescription((String) request.get("description"));
         ds.setType(parseEnum(DataSourceType.class, request.get("type")));
         ds.setServiceRoleArn((String) request.get("serviceRoleArn"));
@@ -224,6 +235,14 @@ public class AppSyncService {
 
     public Resolver createResolver(String apiId, Map<String, Object> request) {
         getGraphqlApi(apiId);
+        String fieldName = (String) request.get("fieldName");
+        if (fieldName == null || fieldName.isBlank()) {
+            throw new AwsException("BadRequestException", "A resolver field name is required", 400);
+        }
+        String dataSourceName = (String) request.get("dataSourceName");
+        if (dataSourceName == null || dataSourceName.isBlank()) {
+            throw new AwsException("BadRequestException", "A data source name is required for the resolver", 400);
+        }
         Resolver resolver = new Resolver();
         resolver.setApiId(apiId);
         resolver.setTypeName((String) request.get("typeName"));
@@ -296,6 +315,10 @@ public class AppSyncService {
 
     public FunctionConfiguration createFunction(String apiId, Map<String, Object> request, String region) {
         getGraphqlApi(apiId);
+        String name = (String) request.get("name");
+        if (name == null || name.isBlank()) {
+            throw new AwsException("BadRequestException", "A function name is required", 400);
+        }
         FunctionConfiguration fn = new FunctionConfiguration();
         fn.setFunctionId(generateShortId());
         fn.setName((String) request.get("name"));
@@ -346,6 +369,10 @@ public class AppSyncService {
 
     public AppSyncType createType(String apiId, Map<String, Object> request) {
         getGraphqlApi(apiId);
+        String name = (String) request.get("name");
+        if (name == null || name.isBlank()) {
+            throw new AwsException("BadRequestException", "A type name is required", 400);
+        }
         AppSyncType type = new AppSyncType();
         type.setApiId(apiId);
         type.setName((String) request.get("name"));

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -250,6 +250,7 @@ public class AppSyncService {
         resolver.setTypeName((String) request.get("typeName"));
         resolver.setFieldName((String) request.get("fieldName"));
         resolver.setDataSourceName((String) request.get("dataSourceName"));
+        resolver.setFunctionId((String) request.get("functionId"));
         resolver.setRequestMappingTemplate((String) request.get("requestMappingTemplate"));
         resolver.setResponseMappingTemplate((String) request.get("responseMappingTemplate"));
         resolver.setKind(parseEnum(ResolverKind.class, request.getOrDefault("kind", "UNIT")));
@@ -278,10 +279,17 @@ public class AppSyncService {
         return paginate(resolverStore.scan(k -> k.startsWith(apiId + "::")), nextToken, maxResults);
     }
 
+    public Page<Resolver> listResolversByType(String apiId, String typeName, Integer maxResults, String nextToken) {
+        List<Resolver> filtered = resolverStore.scan(k -> k.startsWith(apiId + "::")).stream()
+                .filter(r -> typeName.equals(r.getTypeName()))
+                .toList();
+        return paginate(filtered, nextToken, maxResults);
+    }
+
     public Page<Resolver> listResolversByFunction(String apiId, String functionId, Integer maxResults, String nextToken) {
-        FunctionConfiguration fn = getFunction(apiId, functionId);
+        getFunction(apiId, functionId);
         List<Resolver> all = resolverStore.scan(k -> k.startsWith(apiId + "::")).stream()
-                .filter(r -> fn.getName().equals(r.getDataSourceName()))
+                .filter(r -> functionId.equals(r.getFunctionId()))
                 .toList();
         return paginate(all, nextToken, maxResults);
     }
@@ -289,6 +297,7 @@ public class AppSyncService {
     public Resolver updateResolver(String apiId, String typeName, String fieldName, Map<String, Object> request) {
         Resolver existing = getResolver(apiId, typeName, fieldName);
         if (request.containsKey("dataSourceName")) existing.setDataSourceName((String) request.get("dataSourceName"));
+        if (request.containsKey("functionId")) existing.setFunctionId((String) request.get("functionId"));
         if (request.containsKey("requestMappingTemplate")) existing.setRequestMappingTemplate((String) request.get("requestMappingTemplate"));
         if (request.containsKey("responseMappingTemplate")) existing.setResponseMappingTemplate((String) request.get("responseMappingTemplate"));
         if (request.containsKey("kind")) existing.setKind(parseEnum(ResolverKind.class, request.get("kind")));

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -381,7 +381,7 @@ public class AppSyncService {
         }
         AppSyncType type = new AppSyncType();
         type.setApiId(apiId);
-        type.setName((String) request.get("name"));
+        type.setName(name);
         type.setDefinition((String) request.get("definition"));
         type.setDescription((String) request.get("description"));
         type.setFormat(parseEnum(TypeFormat.class, request.getOrDefault("format", "SDL")));

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -12,6 +12,7 @@ import org.jboss.logging.Logger;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.Base64;
 
 @ApplicationScoped
 public class AppSyncService {
@@ -100,8 +101,8 @@ public class AppSyncService {
                 .orElseThrow(() -> new AwsException("NotFoundException", "GraphQL API not found: " + apiId, 404));
     }
 
-    public List<GraphqlApi> listGraphqlApis() {
-        return apiStore.scan(k -> true);
+    public Page<GraphqlApi> listGraphqlApis(Integer maxResults, String nextToken) {
+        return paginate(apiStore.scan(k -> true), nextToken, maxResults);
     }
 
     public GraphqlApi updateGraphqlApi(String apiId, Map<String, Object> request, String region) {
@@ -195,8 +196,8 @@ public class AppSyncService {
                 .orElseThrow(() -> new AwsException("NotFoundException", "Data source not found: " + dataSourceName, 404));
     }
 
-    public List<DataSource> listDataSources(String apiId) {
-        return dataSourceStore.scan(k -> k.startsWith(apiId + "::"));
+    public Page<DataSource> listDataSources(String apiId, Integer maxResults, String nextToken) {
+        return paginate(dataSourceStore.scan(k -> k.startsWith(apiId + "::")), nextToken, maxResults);
     }
 
     public DataSource updateDataSource(String apiId, String dataSourceName, Map<String, Object> request) {
@@ -272,15 +273,16 @@ public class AppSyncService {
                         "Resolver not found: " + typeName + "." + fieldName, 404));
     }
 
-    public List<Resolver> listResolvers(String apiId) {
-        return resolverStore.scan(k -> k.startsWith(apiId + "::"));
+    public Page<Resolver> listResolvers(String apiId, Integer maxResults, String nextToken) {
+        return paginate(resolverStore.scan(k -> k.startsWith(apiId + "::")), nextToken, maxResults);
     }
 
-    public List<Resolver> listResolversByFunction(String apiId, String functionId) {
+    public Page<Resolver> listResolversByFunction(String apiId, String functionId, Integer maxResults, String nextToken) {
         FunctionConfiguration fn = getFunction(apiId, functionId);
-        return resolverStore.scan(k -> k.startsWith(apiId + "::")).stream()
+        List<Resolver> all = resolverStore.scan(k -> k.startsWith(apiId + "::")).stream()
                 .filter(r -> fn.getName().equals(r.getDataSourceName()))
                 .toList();
+        return paginate(all, nextToken, maxResults);
     }
 
     public Resolver updateResolver(String apiId, String typeName, String fieldName, Map<String, Object> request) {
@@ -339,8 +341,8 @@ public class AppSyncService {
                 .orElseThrow(() -> new AwsException("NotFoundException", "Function not found: " + functionId, 404));
     }
 
-    public List<FunctionConfiguration> listFunctions(String apiId) {
-        return functionStore.scan(k -> k.startsWith(apiId + "::"));
+    public Page<FunctionConfiguration> listFunctions(String apiId, Integer maxResults, String nextToken) {
+        return paginate(functionStore.scan(k -> k.startsWith(apiId + "::")), nextToken, maxResults);
     }
 
     public FunctionConfiguration updateFunction(String apiId, String functionId, Map<String, Object> request) {
@@ -389,8 +391,8 @@ public class AppSyncService {
                 .orElseThrow(() -> new AwsException("NotFoundException", "Type not found: " + typeName, 404));
     }
 
-    public List<AppSyncType> listTypes(String apiId) {
-        return typeStore.scan(k -> k.startsWith(apiId + "::"));
+    public Page<AppSyncType> listTypes(String apiId, Integer maxResults, String nextToken) {
+        return paginate(typeStore.scan(k -> k.startsWith(apiId + "::")), nextToken, maxResults);
     }
 
     public AppSyncType updateType(String apiId, String typeName, Map<String, Object> request) {
@@ -441,8 +443,8 @@ public class AppSyncService {
         return key;
     }
 
-    public List<ApiKey> listApiKeys(String apiId) {
-        return apiKeyStore.scan(k -> k.startsWith(apiId + "::"));
+    public Page<ApiKey> listApiKeys(String apiId, Integer maxResults, String nextToken) {
+        return paginate(apiKeyStore.scan(k -> k.startsWith(apiId + "::")), nextToken, maxResults);
     }
 
     public ApiKey getApiKey(String apiId, String keyId) {
@@ -564,6 +566,41 @@ public class AppSyncService {
         } catch (IllegalArgumentException e) {
             throw new AwsException("BadRequestException",
                     "Invalid value '" + str + "' for " + enumClass.getSimpleName(), 400);
+        }
+    }
+
+    // ──────────────────────────── Pagination ────────────────────────────
+
+    record Page<T>(List<T> items, String nextToken) {}
+
+    static <T> Page<T> paginate(List<T> items, String nextToken, Integer maxResults) {
+        int start = decodeToken(nextToken);
+        if (start < 0 || start > items.size()) {
+            throw new AwsException("InvalidNextTokenException", "Invalid NextToken.", 400);
+        }
+        int limit = (maxResults == null || maxResults <= 0)
+                ? items.size()
+                : Math.min(maxResults, items.size() - start);
+        int end = Math.min(items.size(), start + limit);
+        List<T> sliced = items.subList(start, end);
+        String next = (end < items.size()) ? encodeToken(end) : null;
+        return new Page<>(sliced, next);
+    }
+
+    static String encodeToken(int offset) {
+        return Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(Integer.toString(offset).getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    }
+
+    static int decodeToken(String token) {
+        if (token == null || token.isEmpty()) {
+            return 0;
+        }
+        try {
+            byte[] decoded = Base64.getUrlDecoder().decode(token);
+            return Integer.parseInt(new String(decoded, java.nio.charset.StandardCharsets.UTF_8));
+        } catch (IllegalArgumentException e) {
+            return -1;
         }
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.appsync;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.appsync.model.*;
@@ -26,10 +27,10 @@ public class AppSyncService {
     private final StorageBackend<String, FunctionConfiguration> functionStore;
     private final StorageBackend<String, ApiKey> apiKeyStore;
     private final StorageBackend<String, AppSyncType> typeStore;
-    private final String accountId;
+    private final RegionResolver regionResolver;
 
     @Inject
-    public AppSyncService(StorageFactory storageFactory, EmulatorConfig config) {
+    public AppSyncService(StorageFactory storageFactory, EmulatorConfig config, RegionResolver regionResolver) {
         this.apiStore = storageFactory.create("appsync", "appsync-apis.json", new TypeReference<>() {});
         this.schemaStore = storageFactory.create("appsync", "appsync-schemas.json", new TypeReference<>() {});
         this.schemaStatusStore = storageFactory.create("appsync", "appsync-schema-status.json", new TypeReference<>() {});
@@ -38,7 +39,7 @@ public class AppSyncService {
         this.functionStore = storageFactory.create("appsync", "appsync-functions.json", new TypeReference<>() {});
         this.apiKeyStore = storageFactory.create("appsync", "appsync-apikeys.json", new TypeReference<>() {});
         this.typeStore = storageFactory.create("appsync", "appsync-types.json", new TypeReference<>() {});
-        this.accountId = config.defaultAccountId();
+        this.regionResolver = regionResolver;
     }
 
     // ──────────────────────────── GraphQL API ────────────────────────────
@@ -542,11 +543,11 @@ public class AppSyncService {
     }
 
     private String buildApiArn(String apiId, String region) {
-        return "arn:aws:appsync:" + region + ":" + accountId + ":apis/" + apiId;
+        return regionResolver.buildArn("appsync", region, "apis/" + apiId);
     }
 
     private String buildFunctionArn(String apiId, String functionId, String region) {
-        return "arn:aws:appsync:" + region + ":" + accountId + ":apis/" + apiId + "/functions/" + functionId;
+        return regionResolver.buildArn("appsync", region, "apis/" + apiId + "/functions/" + functionId);
     }
 
     private String extractApiIdFromArn(String arn) {

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -1,0 +1,487 @@
+package io.github.hectorvent.floci.services.appsync;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.appsync.model.*;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+@ApplicationScoped
+public class AppSyncService {
+    private static final Logger LOG = Logger.getLogger(AppSyncService.class);
+
+    private final StorageBackend<String, GraphqlApi> apiStore;
+    private final StorageBackend<String, String> schemaStore;         // apiId -> schema SDL
+    private final StorageBackend<String, SchemaCreationStatus> schemaStatusStore;
+    private final StorageBackend<String, DataSource> dataSourceStore;
+    private final StorageBackend<String, Resolver> resolverStore;
+    private final StorageBackend<String, FunctionConfiguration> functionStore;
+    private final StorageBackend<String, ApiKey> apiKeyStore;
+    private final StorageBackend<String, AppSyncType> typeStore;
+    private final String accountId;
+
+    @Inject
+    public AppSyncService(StorageFactory storageFactory, EmulatorConfig config) {
+        this.apiStore = storageFactory.create("appsync", "appsync-apis.json", new TypeReference<>() {});
+        this.schemaStore = storageFactory.create("appsync", "appsync-schemas.json", new TypeReference<>() {});
+        this.schemaStatusStore = storageFactory.create("appsync", "appsync-schema-status.json", new TypeReference<>() {});
+        this.dataSourceStore = storageFactory.create("appsync", "appsync-datasources.json", new TypeReference<>() {});
+        this.resolverStore = storageFactory.create("appsync", "appsync-resolvers.json", new TypeReference<>() {});
+        this.functionStore = storageFactory.create("appsync", "appsync-functions.json", new TypeReference<>() {});
+        this.apiKeyStore = storageFactory.create("appsync", "appsync-apikeys.json", new TypeReference<>() {});
+        this.typeStore = storageFactory.create("appsync", "appsync-types.json", new TypeReference<>() {});
+        this.accountId = config.defaultAccountId();
+    }
+
+    // ──────────────────────────── GraphQL API ────────────────────────────
+
+    public GraphqlApi createGraphqlApi(Map<String, Object> request, String region) {
+        String apiId = generateApiId();
+        GraphqlApi api = new GraphqlApi();
+        api.setApiId(apiId);
+        api.setName((String) request.get("name"));
+        api.setAuthenticationType((String) request.get("authenticationType"));
+        api.setXrayEnabled((String) request.getOrDefault("xrayEnabled", "false"));
+        api.setLogConfig((String) request.get("logConfig"));
+
+        Map<String, Object> additional = (Map<String, Object>) request.get("additionalAuthenticationProviders");
+        if (additional != null) {
+            Map<String, String> providers = new HashMap<>();
+            additional.forEach((k, v) -> providers.put(k, String.valueOf(v)));
+            api.setAdditionalAuthenticationProviders(providers);
+        }
+
+        api.setArn(buildApiArn(apiId, region));
+
+        Map<String, String> uris = new HashMap<>();
+        String baseUri = "http://localhost:4566";
+        uris.put("GRAPHQL", baseUri + "/v1/apis/" + apiId + "/graphql");
+        uris.put("REALTIME", "ws://localhost:4566/v1/apis/" + apiId + "/graphql/realtime");
+        api.setUris(uris);
+
+        Map<String, Object> tags = (Map<String, Object>) request.get("tags");
+        if (tags != null) {
+            Map<String, String> tagMap = new HashMap<>();
+            tags.forEach((k, v) -> tagMap.put(k, String.valueOf(v)));
+            api.setTags(tagMap);
+        }
+
+        apiStore.put(apiId, api);
+        LOG.infov("Created GraphQL API {0}: {1}", apiId, api.getName());
+        return api;
+    }
+
+    public GraphqlApi getGraphqlApi(String apiId) {
+        return apiStore.get(apiId)
+                .orElseThrow(() -> new AwsException("NotFoundException", "GraphQL API not found: " + apiId, 404));
+    }
+
+    public List<GraphqlApi> listGraphqlApis() {
+        return apiStore.scan(k -> true);
+    }
+
+    public GraphqlApi updateGraphqlApi(String apiId, Map<String, Object> request, String region) {
+        GraphqlApi existing = getGraphqlApi(apiId);
+        if (request.containsKey("name")) existing.setName((String) request.get("name"));
+        if (request.containsKey("authenticationType")) existing.setAuthenticationType((String) request.get("authenticationType"));
+        if (request.containsKey("xrayEnabled")) existing.setXrayEnabled((String) request.get("xrayEnabled"));
+        if (request.containsKey("logConfig")) existing.setLogConfig((String) request.get("logConfig"));
+        if (request.containsKey("tags")) {
+            Map<String, Object> tags = (Map<String, Object>) request.get("tags");
+            Map<String, String> tagMap = new HashMap<>();
+            tags.forEach((k, v) -> tagMap.put(k, String.valueOf(v)));
+            existing.setTags(tagMap);
+        }
+        apiStore.put(apiId, existing);
+        return existing;
+    }
+
+    public void deleteGraphqlApi(String apiId) {
+        getGraphqlApi(apiId);
+        apiStore.delete(apiId);
+        schemaStore.delete(apiId);
+        schemaStatusStore.delete(apiId);
+        deleteDataSourcesForApi(apiId);
+        deleteResolversForApi(apiId);
+        deleteFunctionsForApi(apiId);
+        deleteTypesForApi(apiId);
+        deleteApiKeysForApi(apiId);
+        LOG.infov("Deleted GraphQL API {0}", apiId);
+    }
+
+    // ──────────────────────────── Schema ────────────────────────────
+
+    public void startSchemaCreation(String apiId, String definition) {
+        getGraphqlApi(apiId);
+        schemaStore.put(apiId, definition);
+        SchemaCreationStatus status = new SchemaCreationStatus();
+        status.setStatus("ACTIVE");
+        status.setDetails("Schema successfully parsed");
+        schemaStatusStore.put(apiId, status);
+        LOG.infov("Schema creation completed for API {0}", apiId);
+    }
+
+    public SchemaCreationStatus getSchemaCreationStatus(String apiId) {
+        getGraphqlApi(apiId);
+        return schemaStatusStore.get(apiId).orElseThrow(() ->
+                new AwsException("NotFoundException", "Schema creation status not found for API: " + apiId, 404));
+    }
+
+    public String getIntrospectionSchema(String apiId) {
+        getGraphqlApi(apiId);
+        return schemaStore.get(apiId).orElse(null);
+    }
+
+    // ──────────────────────────── Data Sources ────────────────────────────
+
+    public DataSource createDataSource(String apiId, Map<String, Object> request) {
+        getGraphqlApi(apiId);
+        DataSource ds = new DataSource();
+        ds.setName((String) request.get("name"));
+        ds.setDescription((String) request.get("description"));
+        ds.setType((String) request.get("type"));
+        ds.setServiceRoleArn((String) request.get("serviceRoleArn"));
+        ds.setDynamodbConfig((Map<String, Object>) request.get("dynamodbConfig"));
+        ds.setLambdaConfig((Map<String, Object>) request.get("lambdaConfig"));
+        ds.setHttpConfig((Map<String, Object>) request.get("httpConfig"));
+        ds.setEventBridgeConfig((Map<String, Object>) request.get("eventBridgeConfig"));
+        ds.setRelationalDatabaseConfig((Map<String, Object>) request.get("relationalDatabaseConfig"));
+        ds.setOpenSearchServiceConfig((Map<String, Object>) request.get("openSearchServiceConfig"));
+        ds.setAmazonBedrockRuntimeConfig((Map<String, Object>) request.get("amazonBedrockRuntimeConfig"));
+
+        dataSourceStore.put(apiKey(apiId, ds.getName()), ds);
+        return ds;
+    }
+
+    public DataSource getDataSource(String apiId, String dataSourceName) {
+        return dataSourceStore.get(apiKey(apiId, dataSourceName))
+                .orElseThrow(() -> new AwsException("NotFoundException", "Data source not found: " + dataSourceName, 404));
+    }
+
+    public List<DataSource> listDataSources(String apiId) {
+        return dataSourceStore.scan(k -> k.startsWith(apiId + "::"));
+    }
+
+    public DataSource updateDataSource(String apiId, String dataSourceName, Map<String, Object> request) {
+        DataSource existing = getDataSource(apiId, dataSourceName);
+        if (request.containsKey("description")) existing.setDescription((String) request.get("description"));
+        if (request.containsKey("type")) existing.setType((String) request.get("type"));
+        if (request.containsKey("serviceRoleArn")) existing.setServiceRoleArn((String) request.get("serviceRoleArn"));
+        if (request.containsKey("dynamodbConfig")) existing.setDynamodbConfig((Map<String, Object>) request.get("dynamodbConfig"));
+        if (request.containsKey("lambdaConfig")) existing.setLambdaConfig((Map<String, Object>) request.get("lambdaConfig"));
+        if (request.containsKey("httpConfig")) existing.setHttpConfig((Map<String, Object>) request.get("httpConfig"));
+        if (request.containsKey("eventBridgeConfig")) existing.setEventBridgeConfig((Map<String, Object>) request.get("eventBridgeConfig"));
+        if (request.containsKey("relationalDatabaseConfig")) existing.setRelationalDatabaseConfig((Map<String, Object>) request.get("relationalDatabaseConfig"));
+        if (request.containsKey("openSearchServiceConfig")) existing.setOpenSearchServiceConfig((Map<String, Object>) request.get("openSearchServiceConfig"));
+        if (request.containsKey("amazonBedrockRuntimeConfig")) existing.setAmazonBedrockRuntimeConfig((Map<String, Object>) request.get("amazonBedrockRuntimeConfig"));
+        dataSourceStore.put(apiKey(apiId, dataSourceName), existing);
+        return existing;
+    }
+
+    public void deleteDataSource(String apiId, String dataSourceName) {
+        getDataSource(apiId, dataSourceName);
+        dataSourceStore.delete(apiKey(apiId, dataSourceName));
+    }
+
+    private void deleteDataSourcesForApi(String apiId) {
+        dataSourceStore.scan(k -> k.startsWith(apiId + "::"))
+                .forEach(ds -> {
+                    try {
+                        dataSourceStore.delete(apiKey(apiId, ds.getName()));
+                    } catch (Exception e) {
+                        // ignore - already deleted
+                    }
+                });
+    }
+
+    // ──────────────────────────── Resolvers ────────────────────────────
+
+    public Resolver createResolver(String apiId, Map<String, Object> request) {
+        getGraphqlApi(apiId);
+        Resolver resolver = new Resolver();
+        resolver.setApiId(apiId);
+        resolver.setTypeName((String) request.get("typeName"));
+        resolver.setFieldName((String) request.get("fieldName"));
+        resolver.setDataSourceName((String) request.get("dataSourceName"));
+        resolver.setRequestMappingTemplate((String) request.get("requestMappingTemplate"));
+        resolver.setResponseMappingTemplate((String) request.get("responseMappingTemplate"));
+        resolver.setKind((String) request.getOrDefault("kind", "UNIT"));
+        resolver.setCode((String) request.get("code"));
+
+        Map<String, Object> runtime = (Map<String, Object>) request.get("runtime");
+        if (runtime != null) {
+            Resolver.ResolverRuntime rt = new Resolver.ResolverRuntime();
+            rt.setName((String) runtime.get("name"));
+            rt.setRuntimeVersion((String) runtime.get("runtimeVersion"));
+            resolver.setRuntime(rt);
+        }
+
+        String key = resolverKey(apiId, resolver.getTypeName(), resolver.getFieldName());
+        resolverStore.put(key, resolver);
+        return resolver;
+    }
+
+    public Resolver getResolver(String apiId, String typeName, String fieldName) {
+        return resolverStore.get(resolverKey(apiId, typeName, fieldName))
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "Resolver not found: " + typeName + "." + fieldName, 404));
+    }
+
+    public List<Resolver> listResolvers(String apiId) {
+        return resolverStore.scan(k -> k.startsWith(apiId + "::"));
+    }
+
+    public List<Resolver> listResolversByFunction(String apiId, String functionId) {
+        FunctionConfiguration fn = getFunction(apiId, functionId);
+        return resolverStore.scan(k -> k.startsWith(apiId + "::")).stream()
+                .filter(r -> fn.getName().equals(r.getDataSourceName()))
+                .toList();
+    }
+
+    public Resolver updateResolver(String apiId, String typeName, String fieldName, Map<String, Object> request) {
+        Resolver existing = getResolver(apiId, typeName, fieldName);
+        if (request.containsKey("dataSourceName")) existing.setDataSourceName((String) request.get("dataSourceName"));
+        if (request.containsKey("requestMappingTemplate")) existing.setRequestMappingTemplate((String) request.get("requestMappingTemplate"));
+        if (request.containsKey("responseMappingTemplate")) existing.setResponseMappingTemplate((String) request.get("responseMappingTemplate"));
+        if (request.containsKey("kind")) existing.setKind((String) request.get("kind"));
+        if (request.containsKey("code")) existing.setCode((String) request.get("code"));
+        if (request.containsKey("runtime")) {
+            Map<String, Object> runtime = (Map<String, Object>) request.get("runtime");
+            Resolver.ResolverRuntime rt = new Resolver.ResolverRuntime();
+            rt.setName((String) runtime.get("name"));
+            rt.setRuntimeVersion((String) runtime.get("runtimeVersion"));
+            existing.setRuntime(rt);
+        }
+        resolverStore.put(resolverKey(apiId, typeName, fieldName), existing);
+        return existing;
+    }
+
+    public void deleteResolver(String apiId, String typeName, String fieldName) {
+        getResolver(apiId, typeName, fieldName);
+        resolverStore.delete(resolverKey(apiId, typeName, fieldName));
+    }
+
+    private void deleteResolversForApi(String apiId) {
+        resolverStore.scan(k -> k.startsWith(apiId + "::"))
+                .forEach(r -> resolverStore.delete(resolverKey(apiId, r.getTypeName(), r.getFieldName())));
+    }
+
+    // ──────────────────────────── Functions ────────────────────────────
+
+    public FunctionConfiguration createFunction(String apiId, Map<String, Object> request) {
+        getGraphqlApi(apiId);
+        FunctionConfiguration fn = new FunctionConfiguration();
+        fn.setFunctionId(generateShortId());
+        fn.setName((String) request.get("name"));
+        fn.setDescription((String) request.get("description"));
+        fn.setDataSourceName((String) request.get("dataSourceName"));
+        fn.setRequestMappingTemplate((String) request.get("requestMappingTemplate"));
+        fn.setResponseMappingTemplate((String) request.get("responseMappingTemplate"));
+        fn.setFunctionVersion((String) request.getOrDefault("functionVersion", "2018-05-29"));
+        fn.setArn(buildFunctionArn(apiId, fn.getFunctionId()));
+        fn.setCode((String) request.get("code"));
+
+        functionStore.put(apiKey(apiId, fn.getFunctionId()), fn);
+        return fn;
+    }
+
+    public FunctionConfiguration getFunction(String apiId, String functionId) {
+        return functionStore.get(apiKey(apiId, functionId))
+                .orElseThrow(() -> new AwsException("NotFoundException", "Function not found: " + functionId, 404));
+    }
+
+    public List<FunctionConfiguration> listFunctions(String apiId) {
+        return functionStore.scan(k -> k.startsWith(apiId + "::"));
+    }
+
+    public FunctionConfiguration updateFunction(String apiId, String functionId, Map<String, Object> request) {
+        FunctionConfiguration existing = getFunction(apiId, functionId);
+        if (request.containsKey("description")) existing.setDescription((String) request.get("description"));
+        if (request.containsKey("dataSourceName")) existing.setDataSourceName((String) request.get("dataSourceName"));
+        if (request.containsKey("requestMappingTemplate")) existing.setRequestMappingTemplate((String) request.get("requestMappingTemplate"));
+        if (request.containsKey("responseMappingTemplate")) existing.setResponseMappingTemplate((String) request.get("responseMappingTemplate"));
+        if (request.containsKey("functionVersion")) existing.setFunctionVersion((String) request.get("functionVersion"));
+        if (request.containsKey("code")) existing.setCode((String) request.get("code"));
+        functionStore.put(apiKey(apiId, functionId), existing);
+        return existing;
+    }
+
+    public void deleteFunction(String apiId, String functionId) {
+        getFunction(apiId, functionId);
+        functionStore.delete(apiKey(apiId, functionId));
+    }
+
+    private void deleteFunctionsForApi(String apiId) {
+        functionStore.scan(k -> k.startsWith(apiId + "::"))
+                .forEach(fn -> functionStore.delete(apiKey(apiId, fn.getFunctionId())));
+    }
+
+    // ──────────────────────────── Types ────────────────────────────
+
+    public AppSyncType createType(String apiId, Map<String, Object> request) {
+        getGraphqlApi(apiId);
+        AppSyncType type = new AppSyncType();
+        type.setApiId(apiId);
+        type.setName((String) request.get("name"));
+        type.setDefinition((String) request.get("definition"));
+        type.setDescription((String) request.get("description"));
+        type.setFormat((String) request.getOrDefault("format", "SDL"));
+
+        typeStore.put(apiKey(apiId, type.getName()), type);
+        return type;
+    }
+
+    public AppSyncType getType(String apiId, String typeName) {
+        return typeStore.get(apiKey(apiId, typeName))
+                .orElseThrow(() -> new AwsException("NotFoundException", "Type not found: " + typeName, 404));
+    }
+
+    public List<AppSyncType> listTypes(String apiId) {
+        return typeStore.scan(k -> k.startsWith(apiId + "::"));
+    }
+
+    public AppSyncType updateType(String apiId, String typeName, Map<String, Object> request) {
+        AppSyncType existing = getType(apiId, typeName);
+        if (request.containsKey("definition")) existing.setDefinition((String) request.get("definition"));
+        if (request.containsKey("description")) existing.setDescription((String) request.get("description"));
+        if (request.containsKey("format")) existing.setFormat((String) request.get("format"));
+        typeStore.put(apiKey(apiId, typeName), existing);
+        return existing;
+    }
+
+    public void deleteType(String apiId, String typeName) {
+        getType(apiId, typeName);
+        typeStore.delete(apiKey(apiId, typeName));
+    }
+
+    private void deleteTypesForApi(String apiId) {
+        typeStore.scan(k -> k.startsWith(apiId + "::"))
+                .forEach(t -> typeStore.delete(apiKey(apiId, t.getName())));
+    }
+
+    // ──────────────────────────── API Keys ────────────────────────────
+
+    public ApiKey createApiKey(String apiId, Map<String, Object> request) {
+        getGraphqlApi(apiId);
+        ApiKey key = new ApiKey();
+        key.setId(generateShortId());
+        key.setApiId(apiId);
+        key.setDescription((String) request.get("description"));
+        key.setExpires(coerceString(request.get("expires")));
+
+        // Generate a simple API key string
+        key.setApiKey("da2-" + generateShortId());
+
+        apiKeyStore.put(apiKey(apiId, key.getId()), key);
+        return key;
+    }
+
+    public List<ApiKey> listApiKeys(String apiId) {
+        return apiKeyStore.scan(k -> k.startsWith(apiId + "::"));
+    }
+
+    public ApiKey getApiKey(String apiId, String keyId) {
+        return apiKeyStore.get(apiKey(apiId, keyId))
+                .orElseThrow(() -> new AwsException("NotFoundException", "API key not found: " + keyId, 404));
+    }
+
+    public ApiKey updateApiKey(String apiId, String keyId, Map<String, Object> request) {
+        ApiKey existing = getApiKey(apiId, keyId);
+        if (request.containsKey("description")) existing.setDescription((String) request.get("description"));
+        if (request.containsKey("expires")) existing.setExpires(coerceString(request.get("expires")));
+        apiKeyStore.put(apiKey(apiId, keyId), existing);
+        return existing;
+    }
+
+    public void deleteApiKey(String apiId, String keyId) {
+        getApiKey(apiId, keyId);
+        apiKeyStore.delete(apiKey(apiId, keyId));
+    }
+
+    private void deleteApiKeysForApi(String apiId) {
+        apiKeyStore.scan(k -> k.startsWith(apiId + "::"))
+                .forEach(k -> apiKeyStore.delete(apiKey(apiId, k.getId())));
+    }
+
+    // ──────────────────────────── Tags ────────────────────────────
+
+    public Map<String, String> getTags(String resourceArn) {
+        String apiId = extractApiIdFromArn(resourceArn);
+        return getGraphqlApi(apiId).getTags();
+    }
+
+    public void tagResource(String resourceArn, Map<String, String> tags) {
+        String apiId = extractApiIdFromArn(resourceArn);
+        GraphqlApi api = getGraphqlApi(apiId);
+        api.getTags().putAll(tags);
+        apiStore.put(apiId, api);
+    }
+
+    public void untagResource(String resourceArn, List<String> tagKeys) {
+        String apiId = extractApiIdFromArn(resourceArn);
+        GraphqlApi api = getGraphqlApi(apiId);
+        tagKeys.forEach(api.getTags()::remove);
+        apiStore.put(apiId, api);
+    }
+
+    // ──────────────────────────── Environment Variables ────────────────────────────
+
+    public Map<String, String> getEnvironmentVariables(String apiId) {
+        GraphqlApi api = getGraphqlApi(apiId);
+        Map<String, String> envVars = api.getEnvironmentVariables();
+        return envVars != null ? envVars : Map.of();
+    }
+
+    public Map<String, String> putEnvironmentVariables(String apiId, Map<String, String> environmentVariables) {
+        GraphqlApi api = getGraphqlApi(apiId);
+        api.setEnvironmentVariables(new HashMap<>(environmentVariables));
+        apiStore.put(apiId, api);
+        return api.getEnvironmentVariables();
+    }
+
+    // ──────────────────────────── Helpers ────────────────────────────
+
+    private String generateApiId() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 26);
+    }
+
+    private String generateShortId() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 7);
+    }
+
+    private String apiKey(String apiId, String name) {
+        return apiId + "::" + name;
+    }
+
+    private String resolverKey(String apiId, String typeName, String fieldName) {
+        return apiId + "::" + typeName + "::" + fieldName;
+    }
+
+    private String buildApiArn(String apiId, String region) {
+        return "arn:aws:appsync:" + region + ":" + accountId + ":apis/" + apiId;
+    }
+
+    private String buildFunctionArn(String apiId, String functionId) {
+        return "arn:aws:appsync:" + accountId + ":apis/" + apiId + "/functions/" + functionId;
+    }
+
+    private String extractApiIdFromArn(String arn) {
+        if (arn == null) throw new AwsException("BadRequestException", "Invalid ARN", 400);
+        String[] parts = arn.split("/");
+        if (parts.length < 2) throw new AwsException("BadRequestException", "Invalid ARN format", 400);
+        return parts[parts.length - 1];
+    }
+
+    private String coerceString(Object value) {
+        if (value == null) return null;
+        if (value instanceof String s) return s;
+        return String.valueOf(value);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -372,6 +372,10 @@ public class AppSyncService {
     public AppSyncType createType(String apiId, Map<String, Object> request) {
         getGraphqlApi(apiId);
         String name = (String) request.get("name");
+        String definition = (String) request.get("definition");
+        if (name == null || name.isBlank()) {
+            name = extractTypeNameFromDefinition(definition);
+        }
         if (name == null || name.isBlank()) {
             throw new AwsException("BadRequestException", "A type name is required", 400);
         }
@@ -602,5 +606,16 @@ public class AppSyncService {
         } catch (IllegalArgumentException e) {
             return -1;
         }
+    }
+
+    static String extractTypeNameFromDefinition(String definition) {
+        if (definition == null || definition.isBlank()) return null;
+        String trimmed = definition.strip();
+        // Match: type TypeName { ... } or input TypeName { ... } or enum TypeName { ... }
+        String[] parts = trimmed.split("\\s+");
+        if (parts.length >= 2) {
+            return parts[1].replaceAll("[{(].*", "");
+        }
+        return null;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/ApiKey.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/ApiKey.java
@@ -10,7 +10,7 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 public class ApiKey {
     private String id;
     private String description;
-    private String expires;
+    private Long expires;
     private String apiId;
     private String apiKey;
 
@@ -20,8 +20,8 @@ public class ApiKey {
     public String getDescription() { return description; }
     public void setDescription(String description) { this.description = description; }
 
-    public String getExpires() { return expires; }
-    public void setExpires(String expires) { this.expires = expires; }
+    public Long getExpires() { return expires; }
+    public void setExpires(Long expires) { this.expires = expires; }
 
     public String getApiId() { return apiId; }
     public void setApiId(String apiId) { this.apiId = apiId; }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/ApiKey.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/ApiKey.java
@@ -1,0 +1,31 @@
+package io.github.hectorvent.floci.services.appsync.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiKey {
+    private String id;
+    private String description;
+    private String expires;
+    private String apiId;
+    private String apiKey;
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getExpires() { return expires; }
+    public void setExpires(String expires) { this.expires = expires; }
+
+    public String getApiId() { return apiId; }
+    public void setApiId(String apiId) { this.apiId = apiId; }
+
+    public String getApiKey() { return apiKey; }
+    public void setApiKey(String apiKey) { this.apiKey = apiKey; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/AppSyncType.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/AppSyncType.java
@@ -12,7 +12,7 @@ public class AppSyncType {
     private String definition;
     private String description;
     private String apiId;
-    private String format;
+    private TypeFormat format;
 
     public String getName() { return name; }
     public void setName(String name) { this.name = name; }
@@ -26,6 +26,6 @@ public class AppSyncType {
     public String getApiId() { return apiId; }
     public void setApiId(String apiId) { this.apiId = apiId; }
 
-    public String getFormat() { return format; }
-    public void setFormat(String format) { this.format = format; }
+    public TypeFormat getFormat() { return format; }
+    public void setFormat(TypeFormat format) { this.format = format; }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/AppSyncType.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/AppSyncType.java
@@ -1,0 +1,31 @@
+package io.github.hectorvent.floci.services.appsync.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AppSyncType {
+    private String name;
+    private String definition;
+    private String description;
+    private String apiId;
+    private String format;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getDefinition() { return definition; }
+    public void setDefinition(String definition) { this.definition = definition; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getApiId() { return apiId; }
+    public void setApiId(String apiId) { this.apiId = apiId; }
+
+    public String getFormat() { return format; }
+    public void setFormat(String format) { this.format = format; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/AuthenticationType.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/AuthenticationType.java
@@ -1,0 +1,9 @@
+package io.github.hectorvent.floci.services.appsync.model;
+
+public enum AuthenticationType {
+    API_KEY,
+    AWS_IAM,
+    AMAZON_COGNITO_USER_POOLS,
+    OPENID_CONNECT,
+    AWS_LAMBDA
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/DataSource.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/DataSource.java
@@ -12,7 +12,7 @@ import java.util.Map;
 public class DataSource {
     private String name;
     private String description;
-    private String type;
+    private DataSourceType type;
     private String serviceRoleArn;
     private Map<String, Object> dynamodbConfig;
     private Map<String, Object> lambdaConfig;
@@ -28,8 +28,8 @@ public class DataSource {
     public String getDescription() { return description; }
     public void setDescription(String description) { this.description = description; }
 
-    public String getType() { return type; }
-    public void setType(String type) { this.type = type; }
+    public DataSourceType getType() { return type; }
+    public void setType(DataSourceType type) { this.type = type; }
 
     public String getServiceRoleArn() { return serviceRoleArn; }
     public void setServiceRoleArn(String serviceRoleArn) { this.serviceRoleArn = serviceRoleArn; }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/DataSource.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/DataSource.java
@@ -1,0 +1,57 @@
+package io.github.hectorvent.floci.services.appsync.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.Map;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DataSource {
+    private String name;
+    private String description;
+    private String type;
+    private String serviceRoleArn;
+    private Map<String, Object> dynamodbConfig;
+    private Map<String, Object> lambdaConfig;
+    private Map<String, Object> httpConfig;
+    private Map<String, Object> eventBridgeConfig;
+    private Map<String, Object> relationalDatabaseConfig;
+    private Map<String, Object> openSearchServiceConfig;
+    private Map<String, Object> amazonBedrockRuntimeConfig;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+
+    public String getServiceRoleArn() { return serviceRoleArn; }
+    public void setServiceRoleArn(String serviceRoleArn) { this.serviceRoleArn = serviceRoleArn; }
+
+    public Map<String, Object> getDynamodbConfig() { return dynamodbConfig; }
+    public void setDynamodbConfig(Map<String, Object> dynamodbConfig) { this.dynamodbConfig = dynamodbConfig; }
+
+    public Map<String, Object> getLambdaConfig() { return lambdaConfig; }
+    public void setLambdaConfig(Map<String, Object> lambdaConfig) { this.lambdaConfig = lambdaConfig; }
+
+    public Map<String, Object> getHttpConfig() { return httpConfig; }
+    public void setHttpConfig(Map<String, Object> httpConfig) { this.httpConfig = httpConfig; }
+
+    public Map<String, Object> getEventBridgeConfig() { return eventBridgeConfig; }
+    public void setEventBridgeConfig(Map<String, Object> eventBridgeConfig) { this.eventBridgeConfig = eventBridgeConfig; }
+
+    public Map<String, Object> getRelationalDatabaseConfig() { return relationalDatabaseConfig; }
+    public void setRelationalDatabaseConfig(Map<String, Object> config) { this.relationalDatabaseConfig = config; }
+
+    public Map<String, Object> getOpenSearchServiceConfig() { return openSearchServiceConfig; }
+    public void setOpenSearchServiceConfig(Map<String, Object> config) { this.openSearchServiceConfig = config; }
+
+    public Map<String, Object> getAmazonBedrockRuntimeConfig() { return amazonBedrockRuntimeConfig; }
+    public void setAmazonBedrockRuntimeConfig(Map<String, Object> config) { this.amazonBedrockRuntimeConfig = config; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/DataSourceType.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/DataSourceType.java
@@ -1,0 +1,12 @@
+package io.github.hectorvent.floci.services.appsync.model;
+
+public enum DataSourceType {
+    NONE,
+    AWS_LAMBDA,
+    AMAZON_DYNAMODB,
+    HTTP,
+    AMAZON_EVENTBRIDGE,
+    RELATIONAL_DATABASE,
+    AMAZON_OPENSEARCH_SERVICE,
+    AMAZON_BEDROCK_RUNTIME
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/FunctionConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/FunctionConfiguration.java
@@ -1,0 +1,47 @@
+package io.github.hectorvent.floci.services.appsync.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FunctionConfiguration {
+    private String functionId;
+    private String name;
+    private String description;
+    private String dataSourceName;
+    private String requestMappingTemplate;
+    private String responseMappingTemplate;
+    private String functionVersion;
+    private String arn;
+    private String code;
+
+    public String getFunctionId() { return functionId; }
+    public void setFunctionId(String functionId) { this.functionId = functionId; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getDataSourceName() { return dataSourceName; }
+    public void setDataSourceName(String dataSourceName) { this.dataSourceName = dataSourceName; }
+
+    public String getRequestMappingTemplate() { return requestMappingTemplate; }
+    public void setRequestMappingTemplate(String template) { this.requestMappingTemplate = template; }
+
+    public String getResponseMappingTemplate() { return responseMappingTemplate; }
+    public void setResponseMappingTemplate(String template) { this.responseMappingTemplate = template; }
+
+    public String getFunctionVersion() { return functionVersion; }
+    public void setFunctionVersion(String functionVersion) { this.functionVersion = functionVersion; }
+
+    public String getArn() { return arn; }
+    public void setArn(String arn) { this.arn = arn; }
+
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/GraphqlApi.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/GraphqlApi.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RegisterForReflection
@@ -14,11 +16,11 @@ public class GraphqlApi {
     private String apiId;
     private String name;
     private String arn;
-    private String authenticationType;
+    private AuthenticationType authenticationType;
     private Map<String, String> uris = new HashMap<>();
-    private String logConfig;
-    private Map<String, String> additionalAuthenticationProviders;
-    private String xrayEnabled;
+    private Map<String, Object> logConfig;
+    private List<Map<String, Object>> additionalAuthenticationProviders;
+    private Boolean xrayEnabled;
     private Map<String, String> tags = new HashMap<>();
     private Map<String, String> environmentVariables = new HashMap<>();
 
@@ -31,20 +33,20 @@ public class GraphqlApi {
     public String getArn() { return arn; }
     public void setArn(String arn) { this.arn = arn; }
 
-    public String getAuthenticationType() { return authenticationType; }
-    public void setAuthenticationType(String authenticationType) { this.authenticationType = authenticationType; }
+    public AuthenticationType getAuthenticationType() { return authenticationType; }
+    public void setAuthenticationType(AuthenticationType authenticationType) { this.authenticationType = authenticationType; }
 
     public Map<String, String> getUris() { return uris; }
     public void setUris(Map<String, String> uris) { this.uris = uris; }
 
-    public String getLogConfig() { return logConfig; }
-    public void setLogConfig(String logConfig) { this.logConfig = logConfig; }
+    public Map<String, Object> getLogConfig() { return logConfig; }
+    public void setLogConfig(Map<String, Object> logConfig) { this.logConfig = logConfig; }
 
-    public Map<String, String> getAdditionalAuthenticationProviders() { return additionalAuthenticationProviders; }
-    public void setAdditionalAuthenticationProviders(Map<String, String> providers) { this.additionalAuthenticationProviders = providers; }
+    public List<Map<String, Object>> getAdditionalAuthenticationProviders() { return additionalAuthenticationProviders; }
+    public void setAdditionalAuthenticationProviders(List<Map<String, Object>> providers) { this.additionalAuthenticationProviders = providers; }
 
-    public String getXrayEnabled() { return xrayEnabled; }
-    public void setXrayEnabled(String xrayEnabled) { this.xrayEnabled = xrayEnabled; }
+    public Boolean getXrayEnabled() { return xrayEnabled; }
+    public void setXrayEnabled(Boolean xrayEnabled) { this.xrayEnabled = xrayEnabled; }
 
     public Map<String, String> getTags() { return tags; }
     public void setTags(Map<String, String> tags) { this.tags = tags; }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/GraphqlApi.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/GraphqlApi.java
@@ -1,0 +1,54 @@
+package io.github.hectorvent.floci.services.appsync.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GraphqlApi {
+    private String apiId;
+    private String name;
+    private String arn;
+    private String authenticationType;
+    private Map<String, String> uris = new HashMap<>();
+    private String logConfig;
+    private Map<String, String> additionalAuthenticationProviders;
+    private String xrayEnabled;
+    private Map<String, String> tags = new HashMap<>();
+    private Map<String, String> environmentVariables = new HashMap<>();
+
+    public String getApiId() { return apiId; }
+    public void setApiId(String apiId) { this.apiId = apiId; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getArn() { return arn; }
+    public void setArn(String arn) { this.arn = arn; }
+
+    public String getAuthenticationType() { return authenticationType; }
+    public void setAuthenticationType(String authenticationType) { this.authenticationType = authenticationType; }
+
+    public Map<String, String> getUris() { return uris; }
+    public void setUris(Map<String, String> uris) { this.uris = uris; }
+
+    public String getLogConfig() { return logConfig; }
+    public void setLogConfig(String logConfig) { this.logConfig = logConfig; }
+
+    public Map<String, String> getAdditionalAuthenticationProviders() { return additionalAuthenticationProviders; }
+    public void setAdditionalAuthenticationProviders(Map<String, String> providers) { this.additionalAuthenticationProviders = providers; }
+
+    public String getXrayEnabled() { return xrayEnabled; }
+    public void setXrayEnabled(String xrayEnabled) { this.xrayEnabled = xrayEnabled; }
+
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) { this.tags = tags; }
+
+    public Map<String, String> getEnvironmentVariables() { return environmentVariables; }
+    public void setEnvironmentVariables(Map<String, String> environmentVariables) { this.environmentVariables = environmentVariables; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/Resolver.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/Resolver.java
@@ -1,0 +1,61 @@
+package io.github.hectorvent.floci.services.appsync.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Resolver {
+    private String apiId;
+    private String typeName;
+    private String fieldName;
+    private String dataSourceName;
+    private String requestMappingTemplate;
+    private String responseMappingTemplate;
+    private String kind;
+    private String code;
+    private ResolverRuntime runtime;
+
+    public String getApiId() { return apiId; }
+    public void setApiId(String apiId) { this.apiId = apiId; }
+
+    public String getTypeName() { return typeName; }
+    public void setTypeName(String typeName) { this.typeName = typeName; }
+
+    public String getFieldName() { return fieldName; }
+    public void setFieldName(String fieldName) { this.fieldName = fieldName; }
+
+    public String getDataSourceName() { return dataSourceName; }
+    public void setDataSourceName(String dataSourceName) { this.dataSourceName = dataSourceName; }
+
+    public String getRequestMappingTemplate() { return requestMappingTemplate; }
+    public void setRequestMappingTemplate(String template) { this.requestMappingTemplate = template; }
+
+    public String getResponseMappingTemplate() { return responseMappingTemplate; }
+    public void setResponseMappingTemplate(String template) { this.responseMappingTemplate = template; }
+
+    public String getKind() { return kind; }
+    public void setKind(String kind) { this.kind = kind; }
+
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+
+    public ResolverRuntime getRuntime() { return runtime; }
+    public void setRuntime(ResolverRuntime runtime) { this.runtime = runtime; }
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ResolverRuntime {
+        private String name;
+        private String runtimeVersion;
+
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+
+        public String getRuntimeVersion() { return runtimeVersion; }
+        public void setRuntimeVersion(String runtimeVersion) { this.runtimeVersion = runtimeVersion; }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/Resolver.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/Resolver.java
@@ -14,7 +14,7 @@ public class Resolver {
     private String dataSourceName;
     private String requestMappingTemplate;
     private String responseMappingTemplate;
-    private String kind;
+    private ResolverKind kind;
     private String code;
     private ResolverRuntime runtime;
 
@@ -36,8 +36,8 @@ public class Resolver {
     public String getResponseMappingTemplate() { return responseMappingTemplate; }
     public void setResponseMappingTemplate(String template) { this.responseMappingTemplate = template; }
 
-    public String getKind() { return kind; }
-    public void setKind(String kind) { this.kind = kind; }
+    public ResolverKind getKind() { return kind; }
+    public void setKind(ResolverKind kind) { this.kind = kind; }
 
     public String getCode() { return code; }
     public void setCode(String code) { this.code = code; }
@@ -49,11 +49,11 @@ public class Resolver {
     @JsonIgnoreProperties(ignoreUnknown = true)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class ResolverRuntime {
-        private String name;
+        private ResolverRuntimeName name;
         private String runtimeVersion;
 
-        public String getName() { return name; }
-        public void setName(String name) { this.name = name; }
+        public ResolverRuntimeName getName() { return name; }
+        public void setName(ResolverRuntimeName name) { this.name = name; }
 
         public String getRuntimeVersion() { return runtimeVersion; }
         public void setRuntimeVersion(String runtimeVersion) { this.runtimeVersion = runtimeVersion; }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/Resolver.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/Resolver.java
@@ -12,6 +12,7 @@ public class Resolver {
     private String typeName;
     private String fieldName;
     private String dataSourceName;
+    private String functionId;
     private String requestMappingTemplate;
     private String responseMappingTemplate;
     private ResolverKind kind;
@@ -29,6 +30,9 @@ public class Resolver {
 
     public String getDataSourceName() { return dataSourceName; }
     public void setDataSourceName(String dataSourceName) { this.dataSourceName = dataSourceName; }
+
+    public String getFunctionId() { return functionId; }
+    public void setFunctionId(String functionId) { this.functionId = functionId; }
 
     public String getRequestMappingTemplate() { return requestMappingTemplate; }
     public void setRequestMappingTemplate(String template) { this.requestMappingTemplate = template; }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/ResolverKind.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/ResolverKind.java
@@ -1,0 +1,6 @@
+package io.github.hectorvent.floci.services.appsync.model;
+
+public enum ResolverKind {
+    UNIT,
+    PIPELINE
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/ResolverRuntimeName.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/ResolverRuntimeName.java
@@ -1,0 +1,6 @@
+package io.github.hectorvent.floci.services.appsync.model;
+
+public enum ResolverRuntimeName {
+    APPSYNC_JS,
+    VTL
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/SchemaCreationStatus.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/SchemaCreationStatus.java
@@ -8,11 +8,11 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SchemaCreationStatus {
-    private String status;
+    private SchemaCreationStatusType status;
     private String details;
 
-    public String getStatus() { return status; }
-    public void setStatus(String status) { this.status = status; }
+    public SchemaCreationStatusType getStatus() { return status; }
+    public void setStatus(SchemaCreationStatusType status) { this.status = status; }
 
     public String getDetails() { return details; }
     public void setDetails(String details) { this.details = details; }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/SchemaCreationStatus.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/SchemaCreationStatus.java
@@ -1,0 +1,19 @@
+package io.github.hectorvent.floci.services.appsync.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SchemaCreationStatus {
+    private String status;
+    private String details;
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+
+    public String getDetails() { return details; }
+    public void setDetails(String details) { this.details = details; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/SchemaCreationStatusType.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/SchemaCreationStatusType.java
@@ -1,0 +1,10 @@
+package io.github.hectorvent.floci.services.appsync.model;
+
+public enum SchemaCreationStatusType {
+    PROCESSING,
+    ACTIVE,
+    DELETING,
+    FAILED,
+    SUCCESS,
+    NOT_APPLICABLE
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/TypeFormat.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/TypeFormat.java
@@ -1,0 +1,6 @@
+package io.github.hectorvent.floci.services.appsync.model;
+
+public enum TypeFormat {
+    SDL,
+    JSON
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -299,3 +299,5 @@ floci:
       emit-mode: synchronous
     cloudfront:
       enabled: true
+    appsync:
+      enabled: true

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
@@ -711,6 +711,539 @@ class AppSyncIntegrationTest {
             .body("environmentVariables.TABLE_NAME", nullValue());
     }
 
+    // ── Error Handling ─────────────────────────────────────────────────────
+
+    @Test
+    @Order(100)
+    void createGraphqlApiMissingNameReturns400() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"authenticationType": "API_KEY"}
+                """)
+        .when()
+            .post("/v1/apis")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(101)
+    void createGraphqlApiBlankNameReturns400() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "  ", "authenticationType": "API_KEY"}
+                """)
+        .when()
+            .post("/v1/apis")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(102)
+    void createGraphqlApiInvalidAuthTypeReturns400() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "test-api", "authenticationType": "INVALID_TYPE"}
+                """)
+        .when()
+            .post("/v1/apis")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(103)
+    void createDataSourceMissingNameReturns400() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"type": "NONE"}
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/datasources")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(104)
+    void createDataSourceMissingTypeReturns400() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "no-type-ds"}
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/datasources")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(105)
+    void createDataSourceInvalidTypeReturns400() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "bad-ds", "type": "NOT_A_REAL_TYPE"}
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/datasources")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(106)
+    void createResolverMissingFieldNameReturns400() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"dataSourceName": "none-ds"}
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/types/Query/resolvers")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(107)
+    void createResolverMissingDataSourceReturns400() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"fieldName": "missingDs"}
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/types/Query/resolvers")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(108)
+    void createTypeMissingNameReturns400() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"definition": "type Foo { id: ID }"}
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/types")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(109)
+    void createFunctionMissingNameReturns400() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"dataSourceName": "none-ds"}
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/functions")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(110)
+    void getNonExistentApiReturns404() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/doesnotexist12345678901234")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(111)
+    void getNonExistentDataSourceReturns404() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/datasources/nonexistent-ds")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(112)
+    void getNonExistentTypeReturns404() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/types/NonExistentType")
+        .then()
+            .statusCode(404);
+    }
+
+    // ── Delete Standalone ──────────────────────────────────────────────────
+
+    @Test
+    @Order(120)
+    void deleteResolverStandalone() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "fieldName": "tempResolver",
+                  "dataSourceName": "none-ds"
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/types/Query/resolvers")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/v1/apis/" + apiId + "/types/Query/resolvers/tempResolver")
+        .then()
+            .statusCode(204);
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/types/Query/resolvers/tempResolver")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(121)
+    void deleteDataSourceStandalone() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "name": "temp-ds-delete",
+                  "type": "NONE"
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/datasources")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/v1/apis/" + apiId + "/datasources/temp-ds-delete")
+        .then()
+            .statusCode(204);
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/datasources/temp-ds-delete")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(122)
+    void deleteFunctionStandalone() {
+        String tempFnId = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "name": "temp-fn-delete",
+                  "dataSourceName": "none-ds"
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/functions")
+        .then()
+            .statusCode(200)
+            .extract().path("functionConfiguration.functionId");
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/v1/apis/" + apiId + "/functions/" + tempFnId)
+        .then()
+            .statusCode(204);
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/functions/" + tempFnId)
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(123)
+    void deleteTypeStandalone() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "name": "StandaloneDeleteType",
+                  "definition": "type StandaloneDeleteType { id: ID }"
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/types")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/v1/apis/" + apiId + "/types/StandaloneDeleteType")
+        .then()
+            .statusCode(204);
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/types/StandaloneDeleteType")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(124)
+    void deleteApiKeyStandalone() {
+        String tempKeyId = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"description": "temp-key-delete"}
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/apikeys")
+        .then()
+            .statusCode(200)
+            .extract().path("apiKey.id");
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/v1/apis/" + apiId + "/apikeys/" + tempKeyId)
+        .then()
+            .statusCode(204);
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/apikeys/" + tempKeyId)
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(125)
+    void listDataSourcesAfterDeleteReturnsExpectedCount() {
+        int before = given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/datasources")
+        .then()
+            .statusCode(200)
+            .extract().jsonPath().getList("dataSources").size();
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "count-check-ds", "type": "NONE"}
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/datasources")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/v1/apis/" + apiId + "/datasources/count-check-ds")
+        .then()
+            .statusCode(204);
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/datasources")
+        .then()
+            .statusCode(200)
+            .body("dataSources.size()", equalTo(before));
+    }
+
+    // ── Cascade Verification ───────────────────────────────────────────────
+
+    @Test
+    @Order(130)
+    void deleteApiCascadeDeletesDataSources() {
+        String tempApiId = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "name": "cascade-test-api",
+                  "authenticationType": "API_KEY"
+                }
+                """)
+        .when()
+            .post("/v1/apis")
+        .then()
+            .statusCode(200)
+            .extract().path("graphqlApi.apiId");
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "cascade-ds", "type": "NONE"}
+                """)
+        .when()
+            .post("/v1/apis/" + tempApiId + "/datasources")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/v1/apis/" + tempApiId)
+        .then()
+            .statusCode(204);
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + tempApiId + "/datasources/cascade-ds")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(131)
+    void deleteApiCascadeDeletesFunctions() {
+        String tempApiId = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "name": "cascade-fn-test-api",
+                  "authenticationType": "API_KEY"
+                }
+                """)
+        .when()
+            .post("/v1/apis")
+        .then()
+            .statusCode(200)
+            .extract().path("graphqlApi.apiId");
+
+        String fnId = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "name": "cascade-fn",
+                  "dataSourceName": "none-ds"
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + tempApiId + "/functions")
+        .then()
+            .statusCode(200)
+            .extract().path("functionConfiguration.functionId");
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/v1/apis/" + tempApiId)
+        .then()
+            .statusCode(204);
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + tempApiId + "/functions/" + fnId)
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(132)
+    void deleteFunctionVerifyResolverStillExists() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "fieldName": "fnCascadeField",
+                  "dataSourceName": "none-ds"
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/types/Query/resolvers")
+        .then()
+            .statusCode(200);
+
+        String fnId = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "name": "fn-for-cascade-test",
+                  "dataSourceName": "none-ds"
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/functions")
+        .then()
+            .statusCode(200)
+            .extract().path("functionConfiguration.functionId");
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/v1/apis/" + apiId + "/functions/" + fnId)
+        .then()
+            .statusCode(204);
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/types/Query/resolvers/fnCascadeField")
+        .then()
+            .statusCode(200)
+            .body("resolver.fieldName", equalTo("fnCascadeField"));
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/v1/apis/" + apiId + "/types/Query/resolvers/fnCascadeField")
+        .then()
+            .statusCode(204);
+    }
+
     // ── Teardown ─────────────────────────────────────────────────────────────
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
@@ -458,6 +458,20 @@ class AppSyncIntegrationTest {
     }
 
     @Test
+    @Order(62)
+    void listAllResolvers() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/resolvers")
+        .then()
+            .statusCode(200)
+            .body("resolvers", hasSize(greaterThanOrEqualTo(1)))
+            .body("resolvers[0].typeName", notNullValue())
+            .body("resolvers[0].fieldName", notNullValue());
+    }
+
+    @Test
     @Order(63)
     void updateResolver() {
         given()
@@ -552,11 +566,35 @@ class AppSyncIntegrationTest {
     void listResolversByFunction() {
         given()
             .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "fieldName": "fnResolverField",
+                  "dataSourceName": "none-ds",
+                  "functionId": "%s"
+                }
+                """.formatted(functionId))
+        .when()
+            .post("/v1/apis/" + apiId + "/types/Query/resolvers")
+        .then()
+            .statusCode(200)
+            .body("resolver.functionId", equalTo(functionId));
+
+        given()
+            .header("Authorization", AUTH)
         .when()
             .get("/v1/apis/" + apiId + "/functions/" + functionId + "/resolvers")
         .then()
             .statusCode(200)
-            .body("resolvers", notNullValue());
+            .body("resolvers", hasSize(greaterThanOrEqualTo(1)))
+            .body("resolvers[0].functionId", equalTo(functionId));
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/v1/apis/" + apiId + "/types/Query/resolvers/fnResolverField")
+        .then()
+            .statusCode(204);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
@@ -845,6 +845,17 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/apis/" + apiId + "/types")
         .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {}
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/types")
+        .then()
             .statusCode(400);
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
@@ -1,0 +1,781 @@
+package io.github.hectorvent.floci.services.appsync;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class AppSyncIntegrationTest {
+
+    private static final String AUTH = "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/appsync/aws4_request";
+    private static String apiId;
+    private static String keyId;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    private static String encodeArn(String arn) {
+        return URLEncoder.encode(arn, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+
+    // ── GraphQL API ──────────────────────────────────────────────────────────
+
+    @Test
+    @Order(10)
+    void createGraphqlApi() {
+        apiId = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "name": "my-api",
+                  "authenticationType": "API_KEY",
+                  "tags": {"env": "test"}
+                }
+                """)
+        .when()
+            .post("/v1/apis")
+        .then()
+            .statusCode(200)
+            .body("graphqlApi.apiId", notNullValue())
+            .body("graphqlApi.name", equalTo("my-api"))
+            .body("graphqlApi.authenticationType", equalTo("API_KEY"))
+            .body("graphqlApi.arn", containsString("arn:aws:appsync:"))
+            .body("graphqlApi.uris.GRAPHQL", containsString("/v1/apis/"))
+            .body("graphqlApi.tags.env", equalTo("test"))
+            .extract().path("graphqlApi.apiId");
+    }
+
+    @Test
+    @Order(11)
+    void getGraphqlApi() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId)
+        .then()
+            .statusCode(200)
+            .body("graphqlApi.apiId", equalTo(apiId))
+            .body("graphqlApi.name", equalTo("my-api"))
+            .body("graphqlApi.authenticationType", equalTo("API_KEY"));
+    }
+
+    @Test
+    @Order(12)
+    void listGraphqlApis() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis")
+        .then()
+            .statusCode(200)
+            .body("graphqlApis", hasSize(greaterThanOrEqualTo(1)))
+            .body("graphqlApis[0].apiId", notNullValue());
+    }
+
+    @Test
+    @Order(13)
+    void updateGraphqlApi() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "my-api-v2"}
+                """)
+        .when()
+            .post("/v1/apis/" + apiId)
+        .then()
+            .statusCode(200)
+            .body("graphqlApi.apiId", equalTo(apiId))
+            .body("graphqlApi.name", equalTo("my-api-v2"));
+    }
+
+    // ── Schema ───────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(20)
+    void startSchemaCreation() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "definition": "type Query { hello: String }"
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/schemacreation")
+        .then()
+            .statusCode(200)
+            .body("status", equalTo("ACTIVE"));
+    }
+
+    @Test
+    @Order(21)
+    void getSchemaCreationStatus() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/schemacreation")
+        .then()
+            .statusCode(200)
+            .body("status", equalTo("ACTIVE"));
+    }
+
+    @Test
+    @Order(22)
+    void getIntrospectionSchema() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/schema")
+        .then()
+            .statusCode(200)
+            .body("schema", containsString("type Query"));
+    }
+
+    // ── API Keys ─────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(30)
+    void createApiKey() {
+        keyId = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "description": "test-key",
+                  "expires": "2027-01-01T00:00:00Z"
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/apikeys")
+        .then()
+            .statusCode(200)
+            .body("apiKey.id", notNullValue())
+            .body("apiKey.apiKey", startsWith("da2-"))
+            .body("apiKey.description", equalTo("test-key"))
+            .extract().path("apiKey.id");
+    }
+
+    @Test
+    @Order(31)
+    void listApiKeys() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/apikeys")
+        .then()
+            .statusCode(200)
+            .body("apiKeys", hasSize(greaterThanOrEqualTo(1)))
+            .body("apiKeys[0].id", notNullValue());
+    }
+
+    @Test
+    @Order(32)
+    void getApiKey() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/apikeys/" + keyId)
+        .then()
+            .statusCode(200)
+            .body("apiKey.id", equalTo(keyId))
+            .body("apiKey.description", equalTo("test-key"));
+    }
+
+    @Test
+    @Order(33)
+    void updateApiKey() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"description": "updated-key"}
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/apikeys/" + keyId)
+        .then()
+            .statusCode(200)
+            .body("apiKey.id", equalTo(keyId))
+            .body("apiKey.description", equalTo("updated-key"));
+    }
+
+    // ── Data Sources ─────────────────────────────────────────────────────────
+
+    @Test
+    @Order(40)
+    void createDataSourceNone() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "name": "none-ds",
+                  "type": "NONE"
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/datasources")
+        .then()
+            .statusCode(200)
+            .body("dataSource.name", equalTo("none-ds"))
+            .body("dataSource.type", equalTo("NONE"));
+    }
+
+    @Test
+    @Order(41)
+    void getDataSource() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/datasources/none-ds")
+        .then()
+            .statusCode(200)
+            .body("dataSource.name", equalTo("none-ds"))
+            .body("dataSource.type", equalTo("NONE"));
+    }
+
+    @Test
+    @Order(42)
+    void listDataSources() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/datasources")
+        .then()
+            .statusCode(200)
+            .body("dataSources", hasSize(greaterThanOrEqualTo(1)))
+            .body("dataSources[0].name", notNullValue());
+    }
+
+    @Test
+    @Order(43)
+    void createDataSourceDynamoDb() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "name": "dynamo-ds",
+                  "type": "AMAZON_DYNAMODB",
+                  "dynamodbConfig": {
+                    "tableName": "my-table",
+                    "awsRegion": "us-east-1"
+                  }
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/datasources")
+        .then()
+            .statusCode(200)
+            .body("dataSource.name", equalTo("dynamo-ds"))
+            .body("dataSource.type", equalTo("AMAZON_DYNAMODB"));
+    }
+
+    @Test
+    @Order(44)
+    void updateDataSource() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"description": "updated-ds"}
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/datasources/none-ds")
+        .then()
+            .statusCode(200)
+            .body("dataSource.description", equalTo("updated-ds"));
+    }
+
+    @Test
+    @Order(45)
+    void deleteDataSource() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/v1/apis/" + apiId + "/datasources/dynamo-ds")
+        .then()
+            .statusCode(204);
+    }
+
+    // ── Types ────────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(50)
+    void createType() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "name": "Query",
+                  "definition": "type Query { hello: String, getItem(id: ID!): Item }"
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/types")
+        .then()
+            .statusCode(200)
+            .body("type.name", equalTo("Query"))
+            .body("type.definition", containsString("hello"));
+    }
+
+    @Test
+    @Order(51)
+    void getType() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/types/Query")
+        .then()
+            .statusCode(200)
+            .body("type.name", equalTo("Query"));
+    }
+
+    @Test
+    @Order(52)
+    void listTypes() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/types")
+        .then()
+            .statusCode(200)
+            .body("types", hasSize(greaterThanOrEqualTo(1)));
+    }
+
+    @Test
+    @Order(53)
+    void updateType() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"definition": "type Query { hello: String, goodbye: String }"}
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/types/Query")
+        .then()
+            .statusCode(200)
+            .body("type.definition", containsString("goodbye"));
+    }
+
+    @Test
+    @Order(54)
+    void deleteType() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "name": "TempType",
+                  "definition": "type TempType { id: ID }"
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/types")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/v1/apis/" + apiId + "/types/TempType")
+        .then()
+            .statusCode(204);
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/types/TempType")
+        .then()
+            .statusCode(404);
+    }
+
+    // ── Resolvers ────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(60)
+    void createResolver() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "fieldName": "hello",
+                  "dataSourceName": "none-ds",
+                  "requestMappingTemplate": "{ \\"version\\": \\"2017-02-28\\", \\"payload\\": {} }",
+                  "responseMappingTemplate": "$util.toJson({\\"hello\\": \\"world\\"})"
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/types/Query/resolvers")
+        .then()
+            .statusCode(200)
+            .body("resolver.typeName", equalTo("Query"))
+            .body("resolver.fieldName", equalTo("hello"))
+            .body("resolver.dataSourceName", equalTo("none-ds"));
+    }
+
+    @Test
+    @Order(61)
+    void getResolver() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/types/Query/resolvers/hello")
+        .then()
+            .statusCode(200)
+            .body("resolver.typeName", equalTo("Query"))
+            .body("resolver.fieldName", equalTo("hello"));
+    }
+
+    @Test
+    @Order(62)
+    void listResolvers() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/types/Query/resolvers")
+        .then()
+            .statusCode(200)
+            .body("resolvers", hasSize(greaterThanOrEqualTo(1)));
+    }
+
+    @Test
+    @Order(63)
+    void updateResolver() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "dataSourceName": "none-ds",
+                  "responseMappingTemplate": "$util.toJson({\\"hello\\": \\"updated\\"})"
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/types/Query/resolvers/hello")
+        .then()
+            .statusCode(200)
+            .body("resolver.typeName", equalTo("Query"))
+            .body("resolver.fieldName", equalTo("hello"))
+            .body("resolver.responseMappingTemplate", containsString("updated"));
+    }
+
+    // ── Functions ────────────────────────────────────────────────────────────
+
+    private static String functionId;
+
+    @Test
+    @Order(70)
+    void createFunction() {
+        functionId = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "name": "my-function",
+                  "dataSourceName": "none-ds",
+                  "requestMappingTemplate": "{ \\"version\\": \\"2017-02-28\\", \\"payload\\": {} }",
+                  "responseMappingTemplate": "$util.toJson({})"
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/functions")
+        .then()
+            .statusCode(200)
+            .body("functionConfiguration.name", equalTo("my-function"))
+            .body("functionConfiguration.functionId", notNullValue())
+            .body("functionConfiguration.arn", containsString("arn:aws:appsync:"))
+            .extract().path("functionConfiguration.functionId");
+    }
+
+    @Test
+    @Order(71)
+    void getFunction() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/functions/" + functionId)
+        .then()
+            .statusCode(200)
+            .body("functionConfiguration.functionId", equalTo(functionId))
+            .body("functionConfiguration.name", equalTo("my-function"));
+    }
+
+    @Test
+    @Order(72)
+    void listFunctions() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/functions")
+        .then()
+            .statusCode(200)
+            .body("functions", hasSize(greaterThanOrEqualTo(1)));
+    }
+
+    @Test
+    @Order(73)
+    void updateFunction() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"description": "updated-function"}
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/functions/" + functionId)
+        .then()
+            .statusCode(200)
+            .body("functionConfiguration.description", equalTo("updated-function"));
+    }
+
+    @Test
+    @Order(74)
+    void listResolversByFunction() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/functions/" + functionId + "/resolvers")
+        .then()
+            .statusCode(200)
+            .body("resolvers", notNullValue());
+    }
+
+    @Test
+    @Order(75)
+    void deleteFunction() {
+        String tempFnId = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "name": "temp-function",
+                  "dataSourceName": "none-ds"
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/functions")
+        .then()
+            .statusCode(200)
+            .extract().path("functionConfiguration.functionId");
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/v1/apis/" + apiId + "/functions/" + tempFnId)
+        .then()
+            .statusCode(204);
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/functions/" + tempFnId)
+        .then()
+            .statusCode(404);
+    }
+
+    // ── Tags ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(80)
+    void tagResource() {
+        String apiArn = "arn:aws:appsync:us-east-1:000000000000:apis/" + apiId;
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"tags": {"team": "platform"}}
+                """)
+            .urlEncodingEnabled(false)
+        .when()
+            .post("/v1/tags/" + apiArn)
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    @Order(81)
+    void listTagsForResource() {
+        String apiArn = "arn:aws:appsync:us-east-1:000000000000:apis/" + apiId;
+
+        given()
+            .header("Authorization", AUTH)
+            .urlEncodingEnabled(false)
+        .when()
+            .get("/v1/tags/" + apiArn)
+        .then()
+            .statusCode(200)
+            .body("tags.env", equalTo("test"))
+            .body("tags.team", equalTo("platform"));
+    }
+
+    @Test
+    @Order(82)
+    void untagResource() {
+        String apiArn = "arn:aws:appsync:us-east-1:000000000000:apis/" + apiId;
+
+        given()
+            .header("Authorization", AUTH)
+            .queryParam("tagKeys", "team")
+            .urlEncodingEnabled(false)
+        .when()
+            .delete("/v1/tags/" + apiArn)
+        .then()
+            .statusCode(204);
+
+        given()
+            .header("Authorization", AUTH)
+            .urlEncodingEnabled(false)
+        .when()
+            .get("/v1/tags/" + apiArn)
+        .then()
+            .statusCode(200)
+            .body("tags.team", nullValue())
+            .body("tags.env", equalTo("test"));
+    }
+
+    // ── Environment Variables ────────────────────────────────────────────────
+
+    @Test
+    @Order(890)
+    void putEnvironmentVariables() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "environmentVariables": {
+                    "TABLE_NAME": "my-table",
+                    "REGION": "us-east-1"
+                  }
+                }
+                """)
+        .when()
+            .put("/v1/apis/" + apiId + "/environmentvariables")
+        .then()
+            .statusCode(200)
+            .body("environmentVariables.TABLE_NAME", equalTo("my-table"))
+            .body("environmentVariables.REGION", equalTo("us-east-1"));
+    }
+
+    @Test
+    @Order(891)
+    void getEnvironmentVariables() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/environmentvariables")
+        .then()
+            .statusCode(200)
+            .body("environmentVariables.TABLE_NAME", equalTo("my-table"))
+            .body("environmentVariables.REGION", equalTo("us-east-1"));
+    }
+
+    @Test
+    @Order(893)
+    void putEnvironmentVariablesOverwrites() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "environmentVariables": {
+                    "NEW_VAR": "new-value"
+                  }
+                }
+                """)
+        .when()
+            .put("/v1/apis/" + apiId + "/environmentvariables")
+        .then()
+            .statusCode(200)
+            .body("environmentVariables.NEW_VAR", equalTo("new-value"))
+            .body("environmentVariables.TABLE_NAME", nullValue());
+    }
+
+    // ── Teardown ─────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(900)
+    void deleteApiKey() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/v1/apis/" + apiId + "/apikeys/" + keyId)
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    @Order(901)
+    void deleteResolver() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/v1/apis/" + apiId + "/types/Query/resolvers/hello")
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    @Order(902)
+    void deleteGraphqlApiCascadeDeletesAll() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/v1/apis/" + apiId)
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    @Order(903)
+    void getDeletedGraphqlApiReturns404() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId)
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(904)
+    void deletedDataSourcesAreGone() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/datasources/none-ds")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(905)
+    void deletedTypesAreGone() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis/" + apiId + "/types/Query")
+        .then()
+            .statusCode(404);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
@@ -1244,6 +1244,157 @@ class AppSyncIntegrationTest {
             .statusCode(204);
     }
 
+    // ── Pagination ──────────────────────────────────────────────────────────
+
+    @Test
+    @Order(140)
+    void listApisWithMaxResults() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "pagination-api-1", "authenticationType": "API_KEY"}
+                """)
+        .when()
+            .post("/v1/apis")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "pagination-api-2", "authenticationType": "API_KEY"}
+                """)
+        .when()
+            .post("/v1/apis")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+            .queryParam("maxResults", 2)
+        .when()
+            .get("/v1/apis")
+        .then()
+            .statusCode(200)
+            .body("graphqlApis", hasSize(greaterThanOrEqualTo(2)))
+            .body("nextToken", notNullValue());
+    }
+
+    @Test
+    @Order(141)
+    void listApisWithNextToken() {
+        String firstPageToken = given()
+            .header("Authorization", AUTH)
+            .queryParam("maxResults", 2)
+        .when()
+            .get("/v1/apis")
+        .then()
+            .statusCode(200)
+            .extract().path("nextToken");
+
+        given()
+            .header("Authorization", AUTH)
+            .queryParam("maxResults", 2)
+            .queryParam("nextToken", firstPageToken)
+        .when()
+            .get("/v1/apis")
+        .then()
+            .statusCode(200)
+            .body("graphqlApis", hasSize(greaterThanOrEqualTo(1)));
+    }
+
+    @Test
+    @Order(142)
+    void listApisWithoutPaginationReturnsAll() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/v1/apis")
+        .then()
+            .statusCode(200)
+            .body("graphqlApis", hasSize(greaterThanOrEqualTo(1)))
+            .body("nextToken", nullValue());
+    }
+
+    @Test
+    @Order(143)
+    void listDataSourcesWithMaxResults() {
+        given()
+            .header("Authorization", AUTH)
+            .queryParam("maxResults", 1)
+        .when()
+            .get("/v1/apis/" + apiId + "/datasources")
+        .then()
+            .statusCode(200)
+            .body("dataSources", hasSize(1));
+    }
+
+    @Test
+    @Order(144)
+    void listTypesWithMaxResults() {
+        given()
+            .header("Authorization", AUTH)
+            .queryParam("maxResults", 1)
+        .when()
+            .get("/v1/apis/" + apiId + "/types")
+        .then()
+            .statusCode(200)
+            .body("types", hasSize(1));
+    }
+
+    @Test
+    @Order(145)
+    void listFunctionsWithMaxResults() {
+        given()
+            .header("Authorization", AUTH)
+            .queryParam("maxResults", 1)
+        .when()
+            .get("/v1/apis/" + apiId + "/functions")
+        .then()
+            .statusCode(200)
+            .body("functions", hasSize(1));
+    }
+
+    @Test
+    @Order(146)
+    void listApiKeysWithMaxResults() {
+        given()
+            .header("Authorization", AUTH)
+            .queryParam("maxResults", 1)
+        .when()
+            .get("/v1/apis/" + apiId + "/apikeys")
+        .then()
+            .statusCode(200)
+            .body("apiKeys", hasSize(1));
+    }
+
+    @Test
+    @Order(147)
+    void listResolversWithMaxResults() {
+        given()
+            .header("Authorization", AUTH)
+            .queryParam("maxResults", 1)
+        .when()
+            .get("/v1/apis/" + apiId + "/types/Query/resolvers")
+        .then()
+            .statusCode(200)
+            .body("resolvers", hasSize(1));
+    }
+
+    @Test
+    @Order(148)
+    void listWithInvalidNextTokenReturns400() {
+        given()
+            .header("Authorization", AUTH)
+            .queryParam("nextToken", "!!!invalid-token!!!")
+        .when()
+            .get("/v1/apis")
+        .then()
+            .statusCode(400);
+    }
+
     // ── Teardown ─────────────────────────────────────────────────────────────
 
     @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -197,3 +197,5 @@ floci:
       emit-mode: off
     cloudfront:
       enabled: true
+    appsync:
+      enabled: true


### PR DESCRIPTION
## Summary

Closes #1085 (Phase 1 only)

Implements the AWS AppSync Management API (CRUDL) as a REST-JSON service backed by Floci's standard StorageBackend. All 7 resource types with full lifecycle operations, typed enums, pagination, and input validation.

## Resources Implemented

| Resource | Operations |
|---|---|
| GraphQL API | Create, Get, Update, Delete, List |
| Schema | StartSchemaCreation, GetSchemaCreationStatus, GetIntrospectionSchema |
| Data Sources | Create, Get, Update, Delete, List |
| Resolvers | Create, Get, Update, Delete, List, ListResolversByFunction |
| Functions | Create, Get, Update, Delete, List |
| Types | Create, Get, Update, Delete, List |
| API Keys | Create, Get, Update, Delete, List |
| Tags | TagResource, UntagResource, ListTagsForResource |
| Environment Variables | GetGraphqlApiEnvironmentVariables, PutGraphqlApiEnvironmentVariables |

## Key Features

- **Typed enums** — `AuthenticationType`, `DataSourceType`, `ResolverKind`, `ResolverRuntimeName`, `TypeFormat`, `SchemaCreationStatusType` with validation (invalid values return 400)
- **Input validation** — Required fields enforced with `BadRequestException`
- **Pagination** — `maxResults` + `nextToken` on all list endpoints (offset-based, Base64-encoded tokens)
- **AWS-compatible responses** — Correct ARN formats, response wrapper keys, HTTP status codes
- **Cascade delete** — Deleting an API removes all child resources (DataSources, Resolvers, Functions, Types, ApiKeys)

## Files Changed

- `services/appsync/` — Controller, Service, 7 models, 6 enums
- `ResolvedServiceCatalog.java` — Service descriptor registration
- `EmulatorConfig.java` — `AppSyncServiceConfig` + `AppSyncStorageConfig`
- `application.yml` (main + test) — Service enabled
- `compatibility-tests/sdk-test-java/` — SDK client fixture + `AppSyncTest`

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

- Protocol: REST-JSON at `/v1/apis/{apiId}/...` paths
- Verified with AWS SDK Java v2 `AppSyncClient`
- 75 integration tests covering CRUDL, pagination, error handling, cascade delete, and SDK compatibility

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Models use `@RegisterForReflection` and `@JsonIgnoreProperties(ignoreUnknown = true)`
- [x] Storage wired through `StorageFactory`
- [x] Service registered in `ResolvedServiceCatalog` and `EmulatorConfig`