### PR TITLE
feat(ses): support V1 ConfigurationSetEventDestination CRUD

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesConfigurationSetEventDestinationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesConfigurationSetEventDestinationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.ses.SesClient;
 import software.amazon.awssdk.services.sesv2.SesV2Client;
 import software.amazon.awssdk.services.sesv2.model.CreateConfigurationSetEventDestinationRequest;
 import software.amazon.awssdk.services.sesv2.model.CreateConfigurationSetRequest;
@@ -25,52 +26,77 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * SES V2 ConfigurationSet event destination compatibility tests using the
- * real AWS SDK for Java v2 (SesV2Client) against a live Floci instance.
+ * SES ConfigurationSet event destination compatibility tests against both the
+ * V1 (query) SES API via {@link SesClient} and the V2 (REST JSON) SESv2 API via
+ * {@link SesV2Client}. Each protocol gets its own configuration set so V1 and V2
+ * tests don't fight each other; the orderings within each cluster mirror the
+ * AWS create / describe / duplicate / update / delete lifecycle.
  */
 @DisplayName("SES Configuration Set Event Destinations")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class SesConfigurationSetEventDestinationTest {
 
-    private static SesV2Client ses;
-    private static String csName;
+    private static SesClient sesV1;
+    private static SesV2Client sesV2;
+    private static String v1CsName;
+    private static String v2CsName;
     private static final String ED_NAME = "ed-sns";
     private static final String TOPIC_ARN = "arn:aws:sns:us-east-1:000000000000:ses-events";
     private static final String TOPIC_ARN_2 = "arn:aws:sns:us-east-1:000000000000:ses-events-2";
 
     @BeforeAll
     static void setup() {
-        ses = TestFixtures.sesV2Client();
-        csName = "sdk-ed-cs-" + TestFixtures.uniqueName();
-        ses.createConfigurationSet(CreateConfigurationSetRequest.builder()
-                .configurationSetName(csName)
+        sesV1 = TestFixtures.sesClient();
+        sesV2 = TestFixtures.sesV2Client();
+        String suffix = TestFixtures.uniqueName();
+        v1CsName = "sdk-v1-ed-cs-" + suffix;
+        v2CsName = "sdk-v2-ed-cs-" + suffix;
+        sesV1.createConfigurationSet(software.amazon.awssdk.services.ses.model.CreateConfigurationSetRequest.builder()
+                .configurationSet(b -> b.name(v1CsName))
+                .build());
+        sesV2.createConfigurationSet(CreateConfigurationSetRequest.builder()
+                .configurationSetName(v2CsName)
                 .build());
     }
 
     @AfterAll
     static void cleanup() {
-        if (ses == null) {
-            return;
+        if (sesV2 != null) {
+            try {
+                sesV2.deleteConfigurationSetEventDestination(DeleteConfigurationSetEventDestinationRequest.builder()
+                        .configurationSetName(v2CsName)
+                        .eventDestinationName(ED_NAME)
+                        .build());
+            } catch (Exception ignored) {}
+            try {
+                sesV2.deleteConfigurationSet(DeleteConfigurationSetRequest.builder()
+                        .configurationSetName(v2CsName)
+                        .build());
+            } catch (Exception ignored) {}
+            sesV2.close();
         }
-        try {
-            ses.deleteConfigurationSetEventDestination(DeleteConfigurationSetEventDestinationRequest.builder()
-                    .configurationSetName(csName)
-                    .eventDestinationName(ED_NAME)
-                    .build());
-        } catch (Exception ignored) {}
-        try {
-            ses.deleteConfigurationSet(DeleteConfigurationSetRequest.builder()
-                    .configurationSetName(csName)
-                    .build());
-        } catch (Exception ignored) {}
-        ses.close();
+        if (sesV1 != null) {
+            try {
+                sesV1.deleteConfigurationSetEventDestination(
+                        software.amazon.awssdk.services.ses.model.DeleteConfigurationSetEventDestinationRequest.builder()
+                                .configurationSetName(v1CsName)
+                                .eventDestinationName(ED_NAME)
+                                .build());
+            } catch (Exception ignored) {}
+            try {
+                sesV1.deleteConfigurationSet(software.amazon.awssdk.services.ses.model.DeleteConfigurationSetRequest.builder()
+                        .configurationSetName(v1CsName)
+                        .build());
+            } catch (Exception ignored) {}
+            sesV1.close();
+        }
     }
 
     @Test
     @Order(1)
     void createEventDestination() {
-        ses.createConfigurationSetEventDestination(CreateConfigurationSetEventDestinationRequest.builder()
-                .configurationSetName(csName)
+        sesV2.createConfigurationSetEventDestination(CreateConfigurationSetEventDestinationRequest.builder()
+                .configurationSetName(v2CsName)
                 .eventDestinationName(ED_NAME)
                 .eventDestination(EventDestinationDefinition.builder()
                         .enabled(true)
@@ -84,8 +110,8 @@ class SesConfigurationSetEventDestinationTest {
     @Order(2)
     void getEventDestinationsReturnsRoundTrip() {
         GetConfigurationSetEventDestinationsResponse response =
-                ses.getConfigurationSetEventDestinations(GetConfigurationSetEventDestinationsRequest.builder()
-                        .configurationSetName(csName)
+                sesV2.getConfigurationSetEventDestinations(GetConfigurationSetEventDestinationsRequest.builder()
+                        .configurationSetName(v2CsName)
                         .build());
 
         assertThat(response.eventDestinations()).hasSize(1);
@@ -99,9 +125,9 @@ class SesConfigurationSetEventDestinationTest {
     @Test
     @Order(3)
     void createDuplicateRejectedWith400() {
-        assertThatThrownBy(() -> ses.createConfigurationSetEventDestination(
+        assertThatThrownBy(() -> sesV2.createConfigurationSetEventDestination(
                 CreateConfigurationSetEventDestinationRequest.builder()
-                        .configurationSetName(csName)
+                        .configurationSetName(v2CsName)
                         .eventDestinationName(ED_NAME)
                         .eventDestination(EventDestinationDefinition.builder()
                                 .matchingEventTypes(EventType.SEND)
@@ -116,8 +142,8 @@ class SesConfigurationSetEventDestinationTest {
     @Test
     @Order(4)
     void updateReplacesDefinition() {
-        ses.updateConfigurationSetEventDestination(UpdateConfigurationSetEventDestinationRequest.builder()
-                .configurationSetName(csName)
+        sesV2.updateConfigurationSetEventDestination(UpdateConfigurationSetEventDestinationRequest.builder()
+                .configurationSetName(v2CsName)
                 .eventDestinationName(ED_NAME)
                 .eventDestination(EventDestinationDefinition.builder()
                         .enabled(false)
@@ -127,8 +153,8 @@ class SesConfigurationSetEventDestinationTest {
                 .build());
 
         GetConfigurationSetEventDestinationsResponse response =
-                ses.getConfigurationSetEventDestinations(GetConfigurationSetEventDestinationsRequest.builder()
-                        .configurationSetName(csName)
+                sesV2.getConfigurationSetEventDestinations(GetConfigurationSetEventDestinationsRequest.builder()
+                        .configurationSetName(v2CsName)
                         .build());
         assertThat(response.eventDestinations()).hasSize(1);
         assertThat(response.eventDestinations().get(0).enabled()).isFalse();
@@ -139,9 +165,9 @@ class SesConfigurationSetEventDestinationTest {
     @Test
     @Order(5)
     void updateUnknownReturns404() {
-        assertThatThrownBy(() -> ses.updateConfigurationSetEventDestination(
+        assertThatThrownBy(() -> sesV2.updateConfigurationSetEventDestination(
                 UpdateConfigurationSetEventDestinationRequest.builder()
-                        .configurationSetName(csName)
+                        .configurationSetName(v2CsName)
                         .eventDestinationName("ed-ghost")
                         .eventDestination(EventDestinationDefinition.builder()
                                 .matchingEventTypes(EventType.SEND)
@@ -156,14 +182,14 @@ class SesConfigurationSetEventDestinationTest {
     @Test
     @Order(6)
     void deleteEventDestination() {
-        ses.deleteConfigurationSetEventDestination(DeleteConfigurationSetEventDestinationRequest.builder()
-                .configurationSetName(csName)
+        sesV2.deleteConfigurationSetEventDestination(DeleteConfigurationSetEventDestinationRequest.builder()
+                .configurationSetName(v2CsName)
                 .eventDestinationName(ED_NAME)
                 .build());
 
         GetConfigurationSetEventDestinationsResponse response =
-                ses.getConfigurationSetEventDestinations(GetConfigurationSetEventDestinationsRequest.builder()
-                        .configurationSetName(csName)
+                sesV2.getConfigurationSetEventDestinations(GetConfigurationSetEventDestinationsRequest.builder()
+                        .configurationSetName(v2CsName)
                         .build());
         assertThat(response.eventDestinations()).isEmpty();
     }
@@ -171,9 +197,9 @@ class SesConfigurationSetEventDestinationTest {
     @Test
     @Order(7)
     void deleteUnknownReturns404() {
-        assertThatThrownBy(() -> ses.deleteConfigurationSetEventDestination(
+        assertThatThrownBy(() -> sesV2.deleteConfigurationSetEventDestination(
                 DeleteConfigurationSetEventDestinationRequest.builder()
-                        .configurationSetName(csName)
+                        .configurationSetName(v2CsName)
                         .eventDestinationName("ed-ghost")
                         .build()))
                 .isInstanceOf(AwsServiceException.class)
@@ -184,7 +210,7 @@ class SesConfigurationSetEventDestinationTest {
     @Test
     @Order(8)
     void createOnUnknownConfigSetReturns404() {
-        assertThatThrownBy(() -> ses.createConfigurationSetEventDestination(
+        assertThatThrownBy(() -> sesV2.createConfigurationSetEventDestination(
                 CreateConfigurationSetEventDestinationRequest.builder()
                         .configurationSetName("sdk-ed-cs-missing-" + System.currentTimeMillis())
                         .eventDestinationName("ed-x")
@@ -196,5 +222,176 @@ class SesConfigurationSetEventDestinationTest {
                 .isInstanceOf(AwsServiceException.class)
                 .extracting(e -> ((AwsServiceException) e).statusCode())
                 .isEqualTo(404);
+    }
+
+    // ─────────────────────────── V1 (Query/XML) ───────────────────────────
+
+    @Test
+    @Order(10)
+    void v1_createEventDestination() {
+        sesV1.createConfigurationSetEventDestination(
+                software.amazon.awssdk.services.ses.model.CreateConfigurationSetEventDestinationRequest.builder()
+                        .configurationSetName(v1CsName)
+                        .eventDestination(software.amazon.awssdk.services.ses.model.EventDestination.builder()
+                                .name(ED_NAME)
+                                .enabled(true)
+                                .matchingEventTypes(
+                                        software.amazon.awssdk.services.ses.model.EventType.SEND,
+                                        software.amazon.awssdk.services.ses.model.EventType.BOUNCE)
+                                .snsDestination(software.amazon.awssdk.services.ses.model.SNSDestination.builder()
+                                        .topicARN(TOPIC_ARN)
+                                        .build())
+                                .build())
+                        .build());
+    }
+
+    @Test
+    @Order(11)
+    void v1_describeConfigurationSet_withEventDestinationsAttribute_returnsRoundTrip() {
+        software.amazon.awssdk.services.ses.model.DescribeConfigurationSetResponse resp =
+                sesV1.describeConfigurationSet(
+                        software.amazon.awssdk.services.ses.model.DescribeConfigurationSetRequest.builder()
+                                .configurationSetName(v1CsName)
+                                .configurationSetAttributeNames(
+                                        software.amazon.awssdk.services.ses.model.ConfigurationSetAttribute.EVENT_DESTINATIONS)
+                                .build());
+        assertThat(resp.eventDestinations()).hasSize(1);
+        software.amazon.awssdk.services.ses.model.EventDestination ed = resp.eventDestinations().get(0);
+        assertThat(ed.name()).isEqualTo(ED_NAME);
+        assertThat(ed.enabled()).isTrue();
+        assertThat(ed.matchingEventTypes()).contains(
+                software.amazon.awssdk.services.ses.model.EventType.SEND,
+                software.amazon.awssdk.services.ses.model.EventType.BOUNCE);
+        assertThat(ed.snsDestination()).isNotNull();
+        assertThat(ed.snsDestination().topicARN()).isEqualTo(TOPIC_ARN);
+    }
+
+    @Test
+    @Order(12)
+    void v1_describeConfigurationSet_withoutEventDestinationsAttribute_returnsEmptyList() {
+        software.amazon.awssdk.services.ses.model.DescribeConfigurationSetResponse resp =
+                sesV1.describeConfigurationSet(
+                        software.amazon.awssdk.services.ses.model.DescribeConfigurationSetRequest.builder()
+                                .configurationSetName(v1CsName)
+                                .build());
+        assertThat(resp.eventDestinations()).isEmpty();
+    }
+
+    @Test
+    @Order(13)
+    void v1_createDuplicateRejected() {
+        assertThatThrownBy(() -> sesV1.createConfigurationSetEventDestination(
+                software.amazon.awssdk.services.ses.model.CreateConfigurationSetEventDestinationRequest.builder()
+                        .configurationSetName(v1CsName)
+                        .eventDestination(software.amazon.awssdk.services.ses.model.EventDestination.builder()
+                                .name(ED_NAME)
+                                .enabled(true)
+                                .matchingEventTypes(software.amazon.awssdk.services.ses.model.EventType.SEND)
+                                .snsDestination(software.amazon.awssdk.services.ses.model.SNSDestination.builder()
+                                        .topicARN(TOPIC_ARN)
+                                        .build())
+                                .build())
+                        .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .extracting(e -> ((AwsServiceException) e).awsErrorDetails().errorCode())
+                .isEqualTo("AlreadyExists");
+    }
+
+    @Test
+    @Order(14)
+    void v1_updateReplacesDefinition() {
+        sesV1.updateConfigurationSetEventDestination(
+                software.amazon.awssdk.services.ses.model.UpdateConfigurationSetEventDestinationRequest.builder()
+                        .configurationSetName(v1CsName)
+                        .eventDestination(software.amazon.awssdk.services.ses.model.EventDestination.builder()
+                                .name(ED_NAME)
+                                .enabled(false)
+                                .matchingEventTypes(software.amazon.awssdk.services.ses.model.EventType.COMPLAINT)
+                                .snsDestination(software.amazon.awssdk.services.ses.model.SNSDestination.builder()
+                                        .topicARN(TOPIC_ARN_2)
+                                        .build())
+                                .build())
+                        .build());
+
+        software.amazon.awssdk.services.ses.model.DescribeConfigurationSetResponse resp =
+                sesV1.describeConfigurationSet(
+                        software.amazon.awssdk.services.ses.model.DescribeConfigurationSetRequest.builder()
+                                .configurationSetName(v1CsName)
+                                .configurationSetAttributeNames(
+                                        software.amazon.awssdk.services.ses.model.ConfigurationSetAttribute.EVENT_DESTINATIONS)
+                                .build());
+        software.amazon.awssdk.services.ses.model.EventDestination ed = resp.eventDestinations().get(0);
+        assertThat(ed.enabled()).isFalse();
+        assertThat(ed.matchingEventTypes())
+                .containsExactly(software.amazon.awssdk.services.ses.model.EventType.COMPLAINT);
+        assertThat(ed.snsDestination().topicARN()).isEqualTo(TOPIC_ARN_2);
+    }
+
+    @Test
+    @Order(15)
+    void v1_updateUnknown_throws() {
+        assertThatThrownBy(() -> sesV1.updateConfigurationSetEventDestination(
+                software.amazon.awssdk.services.ses.model.UpdateConfigurationSetEventDestinationRequest.builder()
+                        .configurationSetName(v1CsName)
+                        .eventDestination(software.amazon.awssdk.services.ses.model.EventDestination.builder()
+                                .name("ed-ghost")
+                                .enabled(true)
+                                .matchingEventTypes(software.amazon.awssdk.services.ses.model.EventType.SEND)
+                                .snsDestination(software.amazon.awssdk.services.ses.model.SNSDestination.builder()
+                                        .topicARN(TOPIC_ARN)
+                                        .build())
+                                .build())
+                        .build()))
+                .isInstanceOf(AwsServiceException.class);
+    }
+
+    @Test
+    @Order(16)
+    void v1_partialFirehoseRejected() {
+        assertThatThrownBy(() -> sesV1.createConfigurationSetEventDestination(
+                software.amazon.awssdk.services.ses.model.CreateConfigurationSetEventDestinationRequest.builder()
+                        .configurationSetName(v1CsName)
+                        .eventDestination(software.amazon.awssdk.services.ses.model.EventDestination.builder()
+                                .name("ed-firehose-bad")
+                                .enabled(true)
+                                .matchingEventTypes(software.amazon.awssdk.services.ses.model.EventType.SEND)
+                                .kinesisFirehoseDestination(
+                                        software.amazon.awssdk.services.ses.model.KinesisFirehoseDestination.builder()
+                                                .iamRoleARN("arn:aws:iam::000000000000:role/ses-firehose")
+                                                .build())
+                                .build())
+                        .build()))
+                .isInstanceOf(AwsServiceException.class)
+                .hasMessageContaining("KinesisFirehoseDestination requires both");
+    }
+
+    @Test
+    @Order(17)
+    void v1_deleteEventDestination() {
+        sesV1.deleteConfigurationSetEventDestination(
+                software.amazon.awssdk.services.ses.model.DeleteConfigurationSetEventDestinationRequest.builder()
+                        .configurationSetName(v1CsName)
+                        .eventDestinationName(ED_NAME)
+                        .build());
+
+        software.amazon.awssdk.services.ses.model.DescribeConfigurationSetResponse resp =
+                sesV1.describeConfigurationSet(
+                        software.amazon.awssdk.services.ses.model.DescribeConfigurationSetRequest.builder()
+                                .configurationSetName(v1CsName)
+                                .configurationSetAttributeNames(
+                                        software.amazon.awssdk.services.ses.model.ConfigurationSetAttribute.EVENT_DESTINATIONS)
+                                .build());
+        assertThat(resp.eventDestinations()).isEmpty();
+    }
+
+    @Test
+    @Order(18)
+    void v1_deleteUnknown_throws() {
+        assertThatThrownBy(() -> sesV1.deleteConfigurationSetEventDestination(
+                software.amazon.awssdk.services.ses.model.DeleteConfigurationSetEventDestinationRequest.builder()
+                        .configurationSetName(v1CsName)
+                        .eventDestinationName("ed-ghost")
+                        .build()))
+                .isInstanceOf(AwsServiceException.class);
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -332,7 +332,10 @@ public class AwsQueryController {
             "ListTemplates", "SendTemplatedEmail", "SendBulkTemplatedEmail",
             "TestRenderTemplate",
             "CreateConfigurationSet", "DescribeConfigurationSet",
-            "ListConfigurationSets", "DeleteConfigurationSet"
+            "ListConfigurationSets", "DeleteConfigurationSet",
+            "CreateConfigurationSetEventDestination",
+            "UpdateConfigurationSetEventDestination",
+            "DeleteConfigurationSetEventDestination"
     );
 
     private static final Set<String> COGNITO_ACTIONS = Set.of(

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
@@ -6,10 +6,15 @@ import io.github.hectorvent.floci.core.common.AwsQueryResponse;
 import io.github.hectorvent.floci.core.common.XmlBuilder;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntry;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
+import io.github.hectorvent.floci.services.ses.model.CloudWatchDestination;
+import io.github.hectorvent.floci.services.ses.model.CloudWatchDimensionConfiguration;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
+import io.github.hectorvent.floci.services.ses.model.EventDestination;
 import io.github.hectorvent.floci.services.ses.model.Identity;
+import io.github.hectorvent.floci.services.ses.model.KinesisFirehoseDestination;
 import io.github.hectorvent.floci.services.ses.model.MessageTag;
+import io.github.hectorvent.floci.services.ses.model.SnsDestination;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -77,6 +82,12 @@ public class SesQueryHandler {
                 case "DescribeConfigurationSet" -> handleDescribeConfigurationSet(params, region);
                 case "ListConfigurationSets" -> handleListConfigurationSets(region);
                 case "DeleteConfigurationSet" -> handleDeleteConfigurationSet(params, region);
+                case "CreateConfigurationSetEventDestination" ->
+                        handleCreateConfigurationSetEventDestination(params, region);
+                case "UpdateConfigurationSetEventDestination" ->
+                        handleUpdateConfigurationSetEventDestination(params, region);
+                case "DeleteConfigurationSetEventDestination" ->
+                        handleDeleteConfigurationSetEventDestination(params, region);
                 default -> AwsQueryResponse.error("UnsupportedOperation",
                         "Operation " + action + " is not supported by SES.", AwsNamespaces.SES, 400);
             };
@@ -545,12 +556,84 @@ public class SesQueryHandler {
             throw new AwsException("InvalidParameterValue", "ConfigurationSetName is required.", 400);
         }
         ConfigurationSet cs = sesService.getConfigurationSet(name, region);
-        String result = new XmlBuilder()
+        List<String> attrs = extractMembers(params, "ConfigurationSetAttributeNames");
+        XmlBuilder xml = new XmlBuilder()
                 .start("ConfigurationSet")
                     .elem("Name", cs.getName())
-                .end("ConfigurationSet")
-                .build();
-        return Response.ok(AwsQueryResponse.envelope("DescribeConfigurationSet", AwsNamespaces.SES, result)).build();
+                .end("ConfigurationSet");
+        if (attrs.contains("eventDestinations")) {
+            xml.start("EventDestinations");
+            List<EventDestination> destinations = cs.getEventDestinations();
+            if (destinations != null) {
+                for (EventDestination ed : destinations) {
+                    xml.start("member");
+                    writeEventDestination(xml, ed);
+                    xml.end("member");
+                }
+            }
+            xml.end("EventDestinations");
+        }
+        return Response.ok(AwsQueryResponse.envelope("DescribeConfigurationSet",
+                AwsNamespaces.SES, xml.build())).build();
+    }
+
+    /**
+     * Render an {@link EventDestination} into the V1 SES XML shape. V1 wire names use the
+     * uppercase {@code ARN}/{@code NS} suffix variants (e.g., {@code SNSDestination},
+     * {@code TopicARN}, {@code IAMRoleARN}, {@code DeliveryStreamARN}). Skips destination
+     * blocks for which no configuration is present.
+     */
+    private static void writeEventDestination(XmlBuilder xml, EventDestination ed) {
+        xml.elem("Name", ed.getName())
+           .elem("Enabled", String.valueOf(ed.isEnabled()));
+        xml.start("MatchingEventTypes");
+        if (ed.getMatchingEventTypes() != null) {
+            for (String t : ed.getMatchingEventTypes()) {
+                xml.elem("member", INTERNAL_EVENT_TYPE_TO_V1.getOrDefault(t, t));
+            }
+        }
+        xml.end("MatchingEventTypes");
+        if (ed.getSnsDestination() != null
+                && ed.getSnsDestination().getTopicArn() != null
+                && !ed.getSnsDestination().getTopicArn().isBlank()) {
+            xml.start("SNSDestination")
+               .elem("TopicARN", ed.getSnsDestination().getTopicArn())
+               .end("SNSDestination");
+        }
+        if (ed.getKinesisFirehoseDestination() != null
+                && ed.getKinesisFirehoseDestination().getIamRoleArn() != null
+                && !ed.getKinesisFirehoseDestination().getIamRoleArn().isBlank()
+                && ed.getKinesisFirehoseDestination().getDeliveryStreamArn() != null
+                && !ed.getKinesisFirehoseDestination().getDeliveryStreamArn().isBlank()) {
+            xml.start("KinesisFirehoseDestination")
+               .elem("IAMRoleARN", ed.getKinesisFirehoseDestination().getIamRoleArn())
+               .elem("DeliveryStreamARN", ed.getKinesisFirehoseDestination().getDeliveryStreamArn())
+               .end("KinesisFirehoseDestination");
+        }
+        if (ed.getCloudWatchDestination() != null
+                && ed.getCloudWatchDestination().getDimensionConfigurations() != null) {
+            List<CloudWatchDimensionConfiguration> validDims = new ArrayList<>();
+            for (CloudWatchDimensionConfiguration dim
+                    : ed.getCloudWatchDestination().getDimensionConfigurations()) {
+                if (dim != null
+                        && dim.getDimensionName() != null && !dim.getDimensionName().isBlank()
+                        && dim.getDimensionValueSource() != null && !dim.getDimensionValueSource().isBlank()
+                        && dim.getDefaultDimensionValue() != null && !dim.getDefaultDimensionValue().isBlank()) {
+                    validDims.add(dim);
+                }
+            }
+            if (!validDims.isEmpty()) {
+                xml.start("CloudWatchDestination").start("DimensionConfigurations");
+                for (CloudWatchDimensionConfiguration dim : validDims) {
+                    xml.start("member")
+                       .elem("DimensionName", dim.getDimensionName())
+                       .elem("DimensionValueSource", dim.getDimensionValueSource())
+                       .elem("DefaultDimensionValue", dim.getDefaultDimensionValue())
+                       .end("member");
+                }
+                xml.end("DimensionConfigurations").end("CloudWatchDestination");
+            }
+        }
     }
 
     private Response handleListConfigurationSets(String region) {
@@ -570,6 +653,131 @@ public class SesQueryHandler {
         }
         sesService.deleteConfigurationSet(name, region);
         return Response.ok(AwsQueryResponse.envelopeEmptyResult("DeleteConfigurationSet", AwsNamespaces.SES)).build();
+    }
+
+    private Response handleCreateConfigurationSetEventDestination(MultivaluedMap<String, String> params,
+                                                                  String region) {
+        String configSet = requireParam(params, "ConfigurationSetName");
+        String edName = requireParam(params, "EventDestination.Name");
+        EventDestination dest = readEventDestination(params, "EventDestination");
+        sesService.createConfigurationSetEventDestination(configSet, edName, dest, region);
+        return Response.ok(AwsQueryResponse.envelopeEmptyResult(
+                "CreateConfigurationSetEventDestination", AwsNamespaces.SES)).build();
+    }
+
+    private Response handleUpdateConfigurationSetEventDestination(MultivaluedMap<String, String> params,
+                                                                  String region) {
+        String configSet = requireParam(params, "ConfigurationSetName");
+        String edName = requireParam(params, "EventDestination.Name");
+        EventDestination dest = readEventDestination(params, "EventDestination");
+        sesService.updateConfigurationSetEventDestination(configSet, edName, dest, region);
+        return Response.ok(AwsQueryResponse.envelopeEmptyResult(
+                "UpdateConfigurationSetEventDestination", AwsNamespaces.SES)).build();
+    }
+
+    private Response handleDeleteConfigurationSetEventDestination(MultivaluedMap<String, String> params,
+                                                                  String region) {
+        String configSet = requireParam(params, "ConfigurationSetName");
+        String edName = requireParam(params, "EventDestinationName");
+        sesService.deleteConfigurationSetEventDestination(configSet, edName, region);
+        return Response.ok(AwsQueryResponse.envelopeEmptyResult(
+                "DeleteConfigurationSetEventDestination", AwsNamespaces.SES)).build();
+    }
+
+    /**
+     * AWS V1 SES uses lowercased event-type names on the wire (e.g. {@code send},
+     * {@code complaint}, {@code renderingFailure}) while V2 uses
+     * {@code SCREAMING_SNAKE_CASE} (e.g. {@code SEND}, {@code RENDERING_FAILURE}).
+     * Floci stores the V2 canonical form internally, so the V1 handler translates
+     * in both directions.
+     */
+    private static final java.util.Map<String, String> V1_EVENT_TYPE_TO_INTERNAL =
+            java.util.Map.ofEntries(
+                    java.util.Map.entry("send", "SEND"),
+                    java.util.Map.entry("reject", "REJECT"),
+                    java.util.Map.entry("bounce", "BOUNCE"),
+                    java.util.Map.entry("complaint", "COMPLAINT"),
+                    java.util.Map.entry("delivery", "DELIVERY"),
+                    java.util.Map.entry("open", "OPEN"),
+                    java.util.Map.entry("click", "CLICK"),
+                    java.util.Map.entry("renderingFailure", "RENDERING_FAILURE"),
+                    java.util.Map.entry("deliveryDelay", "DELIVERY_DELAY"),
+                    java.util.Map.entry("subscription", "SUBSCRIPTION"));
+
+    private static final java.util.Map<String, String> INTERNAL_EVENT_TYPE_TO_V1;
+    static {
+        java.util.Map<String, String> reverse = new java.util.HashMap<>();
+        for (var e : V1_EVENT_TYPE_TO_INTERNAL.entrySet()) {
+            reverse.put(e.getValue(), e.getKey());
+        }
+        INTERNAL_EVENT_TYPE_TO_V1 = java.util.Map.copyOf(reverse);
+    }
+
+    /**
+     * Parse a V1 SES Query {@code EventDestination.*} parameter group into an
+     * {@link EventDestination}. V1 wire names use uppercase {@code ARN} / {@code NS}
+     * suffixes ({@code SNSDestination.TopicARN}, {@code KinesisFirehoseDestination.IAMRoleARN}
+     * / {@code DeliveryStreamARN}) which are mapped onto the model's Title-cased fields,
+     * and the lowercase event-type wire forms are normalized to the V2 canonical form
+     * via {@link #V1_EVENT_TYPE_TO_INTERNAL}.
+     */
+    private EventDestination readEventDestination(MultivaluedMap<String, String> params, String prefix) {
+        EventDestination dest = new EventDestination();
+        dest.setName(getParam(params, prefix + ".Name"));
+        dest.setEnabled(parseOptionalBoolean(params, prefix + ".Enabled", false));
+        List<String> rawTypes = extractMembers(params, prefix + ".MatchingEventTypes");
+        List<String> normalizedTypes = new ArrayList<>(rawTypes.size());
+        for (String t : rawTypes) {
+            normalizedTypes.add(V1_EVENT_TYPE_TO_INTERNAL.getOrDefault(t, t));
+        }
+        dest.setMatchingEventTypes(normalizedTypes);
+
+        String topicArn = getParam(params, prefix + ".SNSDestination.TopicARN");
+        if (topicArn != null) {
+            SnsDestination sns = new SnsDestination();
+            sns.setTopicArn(topicArn);
+            dest.setSnsDestination(sns);
+        }
+
+        String firehoseIam = getParam(params, prefix + ".KinesisFirehoseDestination.IAMRoleARN");
+        String firehoseStream = getParam(params, prefix + ".KinesisFirehoseDestination.DeliveryStreamARN");
+        if (firehoseIam != null || firehoseStream != null) {
+            KinesisFirehoseDestination fh = new KinesisFirehoseDestination();
+            fh.setIamRoleArn(firehoseIam);
+            fh.setDeliveryStreamArn(firehoseStream);
+            dest.setKinesisFirehoseDestination(fh);
+        }
+
+        List<CloudWatchDimensionConfiguration> cwDims = new ArrayList<>();
+        for (int i = 1; ; i++) {
+            String dimPrefix = prefix + ".CloudWatchDestination.DimensionConfigurations.member." + i;
+            String name = getParam(params, dimPrefix + ".DimensionName");
+            String source = getParam(params, dimPrefix + ".DimensionValueSource");
+            String def = getParam(params, dimPrefix + ".DefaultDimensionValue");
+            if (name == null && source == null && def == null) {
+                break;
+            }
+            CloudWatchDimensionConfiguration dim = new CloudWatchDimensionConfiguration();
+            dim.setDimensionName(name);
+            dim.setDimensionValueSource(source);
+            dim.setDefaultDimensionValue(def);
+            cwDims.add(dim);
+        }
+        if (!cwDims.isEmpty()) {
+            CloudWatchDestination cw = new CloudWatchDestination();
+            cw.setDimensionConfigurations(cwDims);
+            dest.setCloudWatchDestination(cw);
+        }
+
+        return dest;
+    }
+
+    private static String requireParam(MultivaluedMap<String, String> params, String name) {
+        String v = params.getFirst(name);
+        if (v == null || v.isBlank()) {
+            throw new AwsException("InvalidParameterValue", name + " is required.", 400);
+        }
+        return v;
     }
 
     private EmailTemplate readTemplateParams(MultivaluedMap<String, String> params) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntry;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
+import io.github.hectorvent.floci.services.ses.model.CloudWatchDimensionConfiguration;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.EventDestination;
@@ -732,11 +733,42 @@ public class SesService {
                     "Please provide only one destination with each request. Either a Firehose Destination "
                             + "or a Cloudwatch Destination or an SNS Destination or an EventBridge Destination.", 400);
         }
-        if (dest.getCloudWatchDestination() != null
-                && (dest.getCloudWatchDestination().getDimensionConfigurations() == null
-                || dest.getCloudWatchDestination().getDimensionConfigurations().isEmpty())) {
+        if (dest.getSnsDestination() != null
+                && (dest.getSnsDestination().getTopicArn() == null
+                || dest.getSnsDestination().getTopicArn().isBlank())) {
             throw new AwsException("InvalidParameterValue",
-                    "CloudWatch metrics dimension configuration list cannot be empty.", 400);
+                    "SnsDestination requires a non-blank TopicArn.", 400);
+        }
+        if (dest.getKinesisFirehoseDestination() != null
+                && (dest.getKinesisFirehoseDestination().getIamRoleArn() == null
+                || dest.getKinesisFirehoseDestination().getIamRoleArn().isBlank()
+                || dest.getKinesisFirehoseDestination().getDeliveryStreamArn() == null
+                || dest.getKinesisFirehoseDestination().getDeliveryStreamArn().isBlank())) {
+            throw new AwsException("InvalidParameterValue",
+                    "KinesisFirehoseDestination requires both IamRoleArn and DeliveryStreamArn.",
+                    400);
+        }
+        if (dest.getCloudWatchDestination() != null) {
+            List<CloudWatchDimensionConfiguration> dims =
+                    dest.getCloudWatchDestination().getDimensionConfigurations();
+            if (dims == null || dims.isEmpty()) {
+                throw new AwsException("InvalidParameterValue",
+                        "CloudWatch metrics dimension configuration list cannot be empty.", 400);
+            }
+            for (int i = 0; i < dims.size(); i++) {
+                CloudWatchDimensionConfiguration dim = dims.get(i);
+                if (dim == null
+                        || dim.getDimensionName() == null || dim.getDimensionName().isBlank()
+                        || dim.getDimensionValueSource() == null
+                        || dim.getDimensionValueSource().isBlank()
+                        || dim.getDefaultDimensionValue() == null
+                        || dim.getDefaultDimensionValue().isBlank()) {
+                    throw new AwsException("InvalidParameterValue",
+                            "CloudWatchDestination dimension configurations require "
+                                    + "DimensionName, DimensionValueSource, and DefaultDimensionValue "
+                                    + "(missing on member " + (i + 1) + ").", 400);
+                }
+            }
         }
         if (dest.getPinpointDestination() != null
                 && (dest.getPinpointDestination().getApplicationArn() == null

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetEventDestinationV1IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetEventDestinationV1IntegrationTest.java
@@ -1,0 +1,321 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Integration tests for SES V1 Query-protocol ConfigurationSet EventDestination CRUD —
+ * {@code CreateConfigurationSetEventDestination} / {@code UpdateConfigurationSetEventDestination} /
+ * {@code DeleteConfigurationSetEventDestination}. The DescribeConfigurationSet response is
+ * exercised with {@code ConfigurationSetAttributeNames.member.1=eventDestinations} to verify
+ * the stored event destination round-trips through the V1 XML response shape.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesConfigurationSetEventDestinationV1IntegrationTest {
+
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/email/aws4_request";
+    private static final String CS = "v1-evt-cs";
+    private static final String ED = "v1-ed-sns";
+    private static final String TOPIC_ARN_A = "arn:aws:sns:us-east-1:000000000000:topic-a";
+    private static final String TOPIC_ARN_B = "arn:aws:sns:us-east-1:000000000000:topic-b";
+
+    @Test
+    @Order(1)
+    void setupConfigurationSet() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateConfigurationSet")
+            .formParam("ConfigurationSet.Name", CS)
+        .when().post("/")
+        .then().statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void createConfigurationSetEventDestination() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateConfigurationSetEventDestination")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("EventDestination.Name", ED)
+            .formParam("EventDestination.Enabled", "true")
+            .formParam("EventDestination.MatchingEventTypes.member.1", "send")
+            .formParam("EventDestination.MatchingEventTypes.member.2", "delivery")
+            .formParam("EventDestination.SNSDestination.TopicARN", TOPIC_ARN_A)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("CreateConfigurationSetEventDestinationResponse"));
+    }
+
+    @Test
+    @Order(3)
+    void describeConfigurationSet_withEventDestinationsAttribute_returnsEventDestination() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "DescribeConfigurationSet")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("ConfigurationSetAttributeNames.member.1", "eventDestinations")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Name>" + ED + "</Name>"))
+            .body(containsString("<Enabled>true</Enabled>"))
+            .body(containsString("<member>send</member>"))
+            .body(containsString("<member>delivery</member>"))
+            .body(containsString("<TopicARN>" + TOPIC_ARN_A + "</TopicARN>"));
+    }
+
+    @Test
+    @Order(4)
+    void describeConfigurationSet_withoutEventDestinationsAttribute_omitsEventDestinations() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "DescribeConfigurationSet")
+            .formParam("ConfigurationSetName", CS)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Name>" + CS + "</Name>"))
+            .body(not(containsString("<EventDestinations>")));
+    }
+
+    @Test
+    @Order(5)
+    void createConfigurationSetEventDestination_duplicateRejected() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateConfigurationSetEventDestination")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("EventDestination.Name", ED)
+            .formParam("EventDestination.Enabled", "true")
+            .formParam("EventDestination.MatchingEventTypes.member.1", "send")
+            .formParam("EventDestination.SNSDestination.TopicARN", TOPIC_ARN_A)
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>AlreadyExists</Code>"));
+    }
+
+    @Test
+    @Order(6)
+    void updateConfigurationSetEventDestination_changesFields() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "UpdateConfigurationSetEventDestination")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("EventDestination.Name", ED)
+            .formParam("EventDestination.Enabled", "false")
+            .formParam("EventDestination.MatchingEventTypes.member.1", "bounce")
+            .formParam("EventDestination.SNSDestination.TopicARN", TOPIC_ARN_B)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("UpdateConfigurationSetEventDestinationResponse"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "DescribeConfigurationSet")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("ConfigurationSetAttributeNames.member.1", "eventDestinations")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Enabled>false</Enabled>"))
+            .body(containsString("<member>bounce</member>"))
+            .body(containsString("<TopicARN>" + TOPIC_ARN_B + "</TopicARN>"));
+    }
+
+    @Test
+    @Order(7)
+    void updateConfigurationSetEventDestination_unknownName_returnsNotFound() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "UpdateConfigurationSetEventDestination")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("EventDestination.Name", "v1-ed-ghost")
+            .formParam("EventDestination.Enabled", "true")
+            .formParam("EventDestination.MatchingEventTypes.member.1", "send")
+            .formParam("EventDestination.SNSDestination.TopicARN", TOPIC_ARN_A)
+        .when().post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("<Code>NotFoundException</Code>"));
+    }
+
+    @Test
+    @Order(8)
+    void deleteConfigurationSetEventDestination() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "DeleteConfigurationSetEventDestination")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("EventDestinationName", ED)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("DeleteConfigurationSetEventDestinationResponse"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "DescribeConfigurationSet")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("ConfigurationSetAttributeNames.member.1", "eventDestinations")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(not(containsString("<Name>" + ED + "</Name>")));
+    }
+
+    @Test
+    @Order(9)
+    void deleteConfigurationSetEventDestination_unknownName_returnsNotFound() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "DeleteConfigurationSetEventDestination")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("EventDestinationName", "v1-ed-ghost")
+        .when().post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("<Code>NotFoundException</Code>"));
+    }
+
+    @Test
+    @Order(10)
+    void createConfigurationSetEventDestination_routedViaActionFallback_whenAuthHeaderAbsent() {
+        // Exercises AwsQueryController.inferServiceFromAction → SES_ACTIONS dispatch
+        // when no Authorization header is present (no SigV4 credential scope to resolve).
+        String edFallback = "v1-ed-routing-fallback";
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateConfigurationSetEventDestination")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("EventDestination.Name", edFallback)
+            .formParam("EventDestination.Enabled", "true")
+            .formParam("EventDestination.MatchingEventTypes.member.1", "send")
+            .formParam("EventDestination.SNSDestination.TopicARN", TOPIC_ARN_A)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("CreateConfigurationSetEventDestinationResponse"));
+
+        // Clean up so the cleanup test in @Order(99) doesn't fight a lingering ED.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "DeleteConfigurationSetEventDestination")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("EventDestinationName", edFallback)
+        .when().post("/")
+        .then().statusCode(200);
+    }
+
+    @Test
+    @Order(11)
+    void describeConfigurationSet_eventDestinationsAttribute_returnsEmptyContainerWhenNoDestinations() {
+        // After the @Order(8) delete the CS has no event destinations. The attribute was
+        // requested, so an empty <EventDestinations/> container should still be returned.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "DescribeConfigurationSet")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("ConfigurationSetAttributeNames.member.1", "eventDestinations")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<EventDestinations"))
+            .body(not(containsString("<member>")));
+    }
+
+    @Test
+    @Order(12)
+    void createConfigurationSetEventDestination_partialFirehose_rejected() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateConfigurationSetEventDestination")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("EventDestination.Name", "v1-ed-firehose-bad")
+            .formParam("EventDestination.Enabled", "true")
+            .formParam("EventDestination.MatchingEventTypes.member.1", "send")
+            .formParam("EventDestination.KinesisFirehoseDestination.IAMRoleARN",
+                       "arn:aws:iam::000000000000:role/x")
+            // DeliveryStreamARN intentionally omitted.
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("KinesisFirehoseDestination requires both IamRoleArn and DeliveryStreamArn"));
+    }
+
+    @Test
+    @Order(13)
+    void createConfigurationSetEventDestination_partialCloudWatchDimension_rejected() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateConfigurationSetEventDestination")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("EventDestination.Name", "v1-ed-cw-bad")
+            .formParam("EventDestination.Enabled", "true")
+            .formParam("EventDestination.MatchingEventTypes.member.1", "send")
+            .formParam("EventDestination.CloudWatchDestination.DimensionConfigurations.member.1.DimensionName",
+                       "MyDim")
+            // DimensionValueSource and DefaultDimensionValue intentionally omitted.
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("CloudWatchDestination dimension configurations require"));
+    }
+
+    @Test
+    @Order(14)
+    void createConfigurationSetEventDestination_blankSnsTopicArn_rejected() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateConfigurationSetEventDestination")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("EventDestination.Name", "v1-ed-sns-blank")
+            .formParam("EventDestination.Enabled", "true")
+            .formParam("EventDestination.MatchingEventTypes.member.1", "send")
+            .formParam("EventDestination.SNSDestination.TopicARN", "")
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("SnsDestination requires a non-blank TopicArn"));
+    }
+
+    @Test
+    @Order(99)
+    void cleanup() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "DeleteConfigurationSet")
+            .formParam("ConfigurationSetName", CS)
+        .when().post("/")
+        .then().statusCode(200);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceEventDestinationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceEventDestinationTest.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.ses.model.CloudWatchDestination;
 import io.github.hectorvent.floci.services.ses.model.CloudWatchDimensionConfiguration;
 import io.github.hectorvent.floci.services.ses.model.EventDestination;
+import io.github.hectorvent.floci.services.ses.model.KinesisFirehoseDestination;
 import io.github.hectorvent.floci.services.ses.model.PinpointDestination;
 import io.github.hectorvent.floci.services.ses.model.SnsDestination;
 import org.junit.jupiter.api.Test;
@@ -142,6 +143,115 @@ class SesServiceEventDestinationTest {
         pp.setApplicationArn("arn:aws:mobiletargeting:us-east-1:000000000000:apps/abc");
         ed.setPinpointDestination(pp);
         assertDoesNotThrow(() -> SesService.validateEventDestination(ed));
+    }
+
+    @Test
+    void snsBlankTopicArn_throws() {
+        EventDestination ed = new EventDestination();
+        ed.setMatchingEventTypes(List.of("SEND"));
+        SnsDestination sns = new SnsDestination();
+        sns.setTopicArn("");
+        ed.setSnsDestination(sns);
+        AwsException ex = assertThrows(AwsException.class,
+                () -> SesService.validateEventDestination(ed));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals("SnsDestination requires a non-blank TopicArn.", ex.getMessage());
+    }
+
+    @Test
+    void snsNullTopicArn_throws() {
+        EventDestination ed = new EventDestination();
+        ed.setMatchingEventTypes(List.of("SEND"));
+        ed.setSnsDestination(new SnsDestination()); // TopicArn left null
+        AwsException ex = assertThrows(AwsException.class,
+                () -> SesService.validateEventDestination(ed));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals("SnsDestination requires a non-blank TopicArn.", ex.getMessage());
+    }
+
+    @Test
+    void firehoseMissingDeliveryStream_throws() {
+        EventDestination ed = new EventDestination();
+        ed.setMatchingEventTypes(List.of("SEND"));
+        KinesisFirehoseDestination fh = new KinesisFirehoseDestination();
+        fh.setIamRoleArn("arn:aws:iam::000000000000:role/ses-firehose");
+        // DeliveryStreamArn left null
+        ed.setKinesisFirehoseDestination(fh);
+        AwsException ex = assertThrows(AwsException.class,
+                () -> SesService.validateEventDestination(ed));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertEquals("KinesisFirehoseDestination requires both IamRoleArn and DeliveryStreamArn.",
+                ex.getMessage());
+    }
+
+    @Test
+    void firehoseMissingIamRole_throws() {
+        EventDestination ed = new EventDestination();
+        ed.setMatchingEventTypes(List.of("SEND"));
+        KinesisFirehoseDestination fh = new KinesisFirehoseDestination();
+        fh.setDeliveryStreamArn("arn:aws:firehose:us-east-1:000000000000:deliverystream/ses");
+        // IamRoleArn left null
+        ed.setKinesisFirehoseDestination(fh);
+        assertThrows(AwsException.class, () -> SesService.validateEventDestination(ed));
+    }
+
+    @Test
+    void firehoseValid_passes() {
+        EventDestination ed = new EventDestination();
+        ed.setMatchingEventTypes(List.of("SEND"));
+        KinesisFirehoseDestination fh = new KinesisFirehoseDestination();
+        fh.setIamRoleArn("arn:aws:iam::000000000000:role/ses-firehose");
+        fh.setDeliveryStreamArn("arn:aws:firehose:us-east-1:000000000000:deliverystream/ses");
+        ed.setKinesisFirehoseDestination(fh);
+        assertDoesNotThrow(() -> SesService.validateEventDestination(ed));
+    }
+
+    @Test
+    void cloudWatchDimensionMissingName_throws() {
+        EventDestination ed = new EventDestination();
+        ed.setMatchingEventTypes(List.of("SEND"));
+        CloudWatchDestination cw = new CloudWatchDestination();
+        CloudWatchDimensionConfiguration dim = new CloudWatchDimensionConfiguration();
+        // DimensionName left null
+        dim.setDimensionValueSource("MESSAGE_TAG");
+        dim.setDefaultDimensionValue("default");
+        cw.setDimensionConfigurations(List.of(dim));
+        ed.setCloudWatchDestination(cw);
+        AwsException ex = assertThrows(AwsException.class,
+                () -> SesService.validateEventDestination(ed));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        // Member index 1-based for callers, included in the error message.
+        assertEquals("CloudWatchDestination dimension configurations require "
+                + "DimensionName, DimensionValueSource, and DefaultDimensionValue "
+                + "(missing on member 1).", ex.getMessage());
+    }
+
+    @Test
+    void cloudWatchDimensionBlankValueSource_throws() {
+        EventDestination ed = new EventDestination();
+        ed.setMatchingEventTypes(List.of("SEND"));
+        CloudWatchDestination cw = new CloudWatchDestination();
+        CloudWatchDimensionConfiguration dim = new CloudWatchDimensionConfiguration();
+        dim.setDimensionName("dim");
+        dim.setDimensionValueSource("");
+        dim.setDefaultDimensionValue("default");
+        cw.setDimensionConfigurations(List.of(dim));
+        ed.setCloudWatchDestination(cw);
+        assertThrows(AwsException.class, () -> SesService.validateEventDestination(ed));
+    }
+
+    @Test
+    void cloudWatchDimensionMissingDefaultValue_throws() {
+        EventDestination ed = new EventDestination();
+        ed.setMatchingEventTypes(List.of("SEND"));
+        CloudWatchDestination cw = new CloudWatchDestination();
+        CloudWatchDimensionConfiguration dim = new CloudWatchDimensionConfiguration();
+        dim.setDimensionName("dim");
+        dim.setDimensionValueSource("MESSAGE_TAG");
+        // DefaultDimensionValue left null
+        cw.setDimensionConfigurations(List.of(dim));
+        ed.setCloudWatchDestination(cw);
+        assertThrows(AwsException.class, () -> SesService.validateEventDestination(ed));
     }
 
     private static CloudWatchDestination cloudWatch() {


### PR DESCRIPTION
## Summary

Follow-up to #1106. V2 SES already exposes ConfigurationSetEventDestination CRUD via REST JSON; this PR adds the matching V1 Query actions and extends `DescribeConfigurationSet` so V1 callers can round-trip stored destinations. The service layer (`SesService.createConfigurationSetEventDestination` etc.) already had the persistence logic, so the bulk of this change is wire-format work: parse V1 Query parameter shapes, render V1 XML, and route the new action names.

- `SesQueryHandler` gains three new Query actions
  - `CreateConfigurationSetEventDestination`
  - `UpdateConfigurationSetEventDestination`
  - `DeleteConfigurationSetEventDestination`

  A new `readEventDestination(params, prefix)` helper maps the V1 wire field names (`SNSDestination.TopicARN`, `KinesisFirehoseDestination.IAMRoleARN` / `DeliveryStreamARN`, `CloudWatchDestination.DimensionConfigurations.member.N`) onto the existing model classes. The `EventDestination.Enabled` default mirrors the V2 primitive-boolean default of `false` when the parameter is omitted.
- V1 event-type wire forms are lowercase camelCase (`send`, `complaint`, `renderingFailure`) while Floci stores the V2 canonical form (SCREAMING_SNAKE). New `V1_EVENT_TYPE_TO_INTERNAL` / `INTERNAL_EVENT_TYPE_TO_V1` maps translate in both directions on read and write; unknown values pass through so the existing validate-against-`VALID_EVENT_TYPES` check still catches typos.
- `SesQueryHandler.handleDescribeConfigurationSet`: when `ConfigurationSetAttributeNames.member.N=eventDestinations` is requested, render the stored event destinations as a V1 XML block. The container is emitted even when the list is empty so the response shape depends only on requested attributes. Other ConfigurationSet attribute names (`trackingOptions` / `deliveryOptions` / `reputationOptions`) remain unsupported and silently ignored — they will land with their respective `Put*Options` PRs.
- `SesService.validateEventDestination`: centralize required-field validation for SNS (`TopicArn` non-blank) / Firehose (both `IamRoleArn` and `DeliveryStreamArn` non-blank) / CloudWatch dimensions (all three fields non-blank, with offending member index in the error message). Both V1 and V2 now reject partial destinations at create/update with `InvalidParameterValue`.
- `AwsQueryController.SES_ACTIONS`: include the three new actions in the action-name → `email` service routing fallback. Without this, SigV4 requests whose credential scope doesn't pin the service get routed away from SES.

Tests: V1 `SesConfigurationSetEventDestinationV1IntegrationTest` (15 cases — create / describe / duplicate / update / delete / partial-data rejections / SES_ACTIONS routing fallback when the `Authorization` header is absent), 8 new unit cases in `SesServiceEventDestinationTest` exercising the centralized validation, and the SDK compat `SesConfigurationSetEventDestinationTest` extended to drive both V1 (`SesClient`) and V2 (`SesV2Client`) against a live Floci.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The V1 wire format follows the AWS [CreateConfigurationSetEventDestination](https://docs.aws.amazon.com/ses/latest/APIReference/API_CreateConfigurationSetEventDestination.html) / [UpdateConfigurationSetEventDestination](https://docs.aws.amazon.com/ses/latest/APIReference/API_UpdateConfigurationSetEventDestination.html) / [DeleteConfigurationSetEventDestination](https://docs.aws.amazon.com/ses/latest/APIReference/API_DeleteConfigurationSetEventDestination.html) references, including the uppercase `ARN` / `NS` suffix variants (`SNSDestination`, `TopicARN`, `IAMRoleARN`, `DeliveryStreamARN`) that V1 uses but V2 does not. Lowercase event-type names follow the [V1 EventDestination](https://docs.aws.amazon.com/ses/latest/APIReference/API_EventDestination.html) reference. `DescribeConfigurationSet`'s `ConfigurationSetAttributeNames` follows the V1 contract: the response carries only the requested attribute blocks. Verified with AWS SDK for Java v2 `SesClient` (V1) and `SesV2Client` (V2).

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)