### PR TITLE
fix(ecr): resolve backing registry endpoint from the control plane

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManager.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
+import io.github.hectorvent.floci.core.common.docker.CurrentContainerNetworkResolver;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
 import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
 import io.github.hectorvent.floci.core.common.docker.PortAllocator;
@@ -50,6 +51,7 @@ public class EcrRegistryManager {
     private final ContainerLifecycleManager lifecycleManager;
     private final ContainerLogStreamer logStreamer;
     private final ContainerDetector containerDetector;
+    private final CurrentContainerNetworkResolver currentContainerNetworkResolver;
     private final PortAllocator portAllocator;
     private final EmulatorConfig config;
     private final RegionResolver regionResolver;
@@ -66,6 +68,7 @@ public class EcrRegistryManager {
                               ContainerLifecycleManager lifecycleManager,
                               ContainerLogStreamer logStreamer,
                               ContainerDetector containerDetector,
+                              CurrentContainerNetworkResolver currentContainerNetworkResolver,
                               PortAllocator portAllocator,
                               EmulatorConfig config,
                               RegionResolver regionResolver) {
@@ -73,6 +76,7 @@ public class EcrRegistryManager {
         this.lifecycleManager = lifecycleManager;
         this.logStreamer = logStreamer;
         this.containerDetector = containerDetector;
+        this.currentContainerNetworkResolver = currentContainerNetworkResolver;
         this.portAllocator = portAllocator;
         this.config = config;
         this.regionResolver = regionResolver;
@@ -107,6 +111,10 @@ public class EcrRegistryManager {
 
     /** Returns a {@link RegistryHttpClient} bound to the current registry endpoint. */
     public RegistryHttpClient httpClient() {
+        if (containerDetector.isRunningInContainer()) {
+            return new RegistryHttpClient("http://" + config.services().ecr().registryContainerName()
+                    + ":" + CONTAINER_INTERNAL_PORT);
+        }
         return new RegistryHttpClient("http://localhost:" + effectivePort());
     }
 
@@ -156,7 +164,7 @@ public class EcrRegistryManager {
                     .withName(name)
                     .withEnv(env)
                     .withPortBinding(CONTAINER_INTERNAL_PORT, chosenPort)
-                    .withDockerNetwork(config.services().ecr().dockerNetwork())
+                    .withDockerNetwork(resolveRegistryDockerNetwork())
                     .withLogRotation();
 
             // Handle persistence mounting based on storage configuration
@@ -212,6 +220,17 @@ public class EcrRegistryManager {
 
         this.logStream = logStreamer.attach(
                 containerId, logGroup, logStreamName, region, "ecr:registry");
+    }
+
+    private java.util.Optional<String> resolveRegistryDockerNetwork() {
+        java.util.Optional<String> configured = config.services().ecr().dockerNetwork();
+        if (configured.isPresent() && !configured.get().isBlank()) {
+            return configured;
+        }
+        if (containerDetector.isRunningInContainer()) {
+            return currentContainerNetworkResolver.resolveNetworkName();
+        }
+        return java.util.Optional.empty();
     }
 
     private void runReconcileOnce() {

--- a/src/test/java/io/github/hectorvent/floci/services/ecr/EcrServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecr/EcrServiceTest.java
@@ -4,14 +4,23 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.ecr.model.ImageDetail;
+import io.github.hectorvent.floci.services.ecr.model.ImageIdentifier;
 import io.github.hectorvent.floci.services.ecr.model.AuthorizationData;
 import io.github.hectorvent.floci.services.ecr.model.ImageMetadata;
 import io.github.hectorvent.floci.services.ecr.model.Repository;
 import io.github.hectorvent.floci.services.ecr.registry.EcrRegistryManager;
+import io.github.hectorvent.floci.services.ecr.registry.RegistryHttpClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -167,6 +176,60 @@ class EcrServiceTest {
         Mockito.verify(registryManager).ensureStarted();
     }
 
+    @Test
+    void pathStyleSeededRegistryEntriesAreVisibleViaListAndDescribeImages() throws Exception {
+        String repositoryName = "backend-user";
+        String internalRepository = ACCOUNT + "/" + REGION + "/" + repositoryName;
+        String tag = "1";
+        String digest = "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+        String manifest = """
+                {
+                  "schemaVersion": 2,
+                  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                  "config": {
+                    "mediaType": "application/vnd.docker.container.image.v1+json",
+                    "size": 123,
+                    "digest": "sha256:config"
+                  },
+                  "layers": [
+                    {
+                      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                      "size": 456,
+                      "digest": "sha256:layer"
+                    }
+                  ]
+                }
+                """;
+
+        try (FakeRegistryServer registry = new FakeRegistryServer(internalRepository, tag, digest, manifest)) {
+            when(registryManager.getRepositoryUri(ACCOUNT, REGION, repositoryName))
+                    .thenReturn("localhost:" + registry.port() + "/" + internalRepository);
+            when(registryManager.httpClient())
+                    .thenReturn(new RegistryHttpClient("http://localhost:" + registry.port()));
+
+            service.createRepository(repositoryName, null, null, null, null, null, null, REGION);
+
+            List<ImageIdentifier> imageIds = service.listImages(repositoryName, null, REGION);
+            assertEquals(1, imageIds.size());
+            assertEquals(tag, imageIds.get(0).getImageTag());
+            assertEquals(digest, imageIds.get(0).getImageDigest());
+
+            EcrService.DescribeImagesResult described = service.describeImages(repositoryName, null, null, REGION);
+            assertTrue(described.failures().isEmpty());
+            assertEquals(1, described.imageDetails().size());
+
+            ImageDetail detail = described.imageDetails().get(0);
+            assertEquals(ACCOUNT, detail.getRegistryId());
+            assertEquals(repositoryName, detail.getRepositoryName());
+            assertEquals(digest, detail.getImageDigest());
+            assertEquals(List.of(tag), detail.getImageTags());
+            assertEquals(579L, detail.getImageSizeInBytes());
+            assertEquals("application/vnd.docker.distribution.manifest.v2+json", detail.getImageManifestMediaType());
+            assertEquals("application/vnd.docker.container.image.v1+json", detail.getArtifactMediaType());
+            assertNotNull(detail.getImagePushedAt());
+        }
+    }
+
     // ------------------------------------------------------------
     // PutImageTagMutability
     // ------------------------------------------------------------
@@ -276,5 +339,75 @@ class EcrServiceTest {
         Repository existing = service.describeRepositories(List.of(REPO), null, REGION).get(0);
         // Tag is still present → existing entry was NOT overwritten by reconcile
         assertEquals("yes", existing.getTags().get("preserved"));
+    }
+
+    private static final class FakeRegistryServer implements AutoCloseable {
+        private final HttpServer server;
+        private final String repository;
+        private final String tag;
+        private final String digest;
+        private final String manifest;
+
+        private FakeRegistryServer(String repository, String tag, String digest, String manifest) throws IOException {
+            this.repository = repository;
+            this.tag = tag;
+            this.digest = digest;
+            this.manifest = manifest;
+            this.server = HttpServer.create(new InetSocketAddress(0), 0);
+            this.server.createContext("/v2/", this::handle);
+            this.server.start();
+        }
+
+        private int port() {
+            return server.getAddress().getPort();
+        }
+
+        private void handle(HttpExchange exchange) throws IOException {
+            String path = exchange.getRequestURI().getPath();
+            String method = exchange.getRequestMethod();
+            if ("/v2/".equals(path) && "GET".equals(method)) {
+                send(exchange, 200, "");
+                return;
+            }
+            if (("/v2/" + repository + "/tags/list").equals(path) && "GET".equals(method)) {
+                sendJson(exchange, 200, "{\"name\":\"" + repository + "\",\"tags\":[\"" + tag + "\"]}");
+                return;
+            }
+            if (("/v2/" + repository + "/manifests/" + tag).equals(path) && "HEAD".equals(method)) {
+                exchange.getResponseHeaders().add("Docker-Content-Digest", digest);
+                exchange.sendResponseHeaders(200, -1);
+                exchange.close();
+                return;
+            }
+            if ((("/v2/" + repository + "/manifests/" + tag).equals(path)
+                    || ("/v2/" + repository + "/manifests/" + digest).equals(path))
+                    && "GET".equals(method)) {
+                exchange.getResponseHeaders().add("Docker-Content-Digest", digest);
+                exchange.getResponseHeaders().add("Content-Type",
+                        "application/vnd.docker.distribution.manifest.v2+json");
+                send(exchange, 200, manifest);
+                return;
+            }
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+        }
+
+        private static void sendJson(HttpExchange exchange, int status, String body) throws IOException {
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            send(exchange, status, body);
+        }
+
+        private static void send(HttpExchange exchange, int status, String body) throws IOException {
+            byte[] bytes = body.getBytes();
+            exchange.sendResponseHeaders(status, bytes.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(bytes);
+            }
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+        }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManagerTest.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
 import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
+import io.github.hectorvent.floci.core.common.docker.CurrentContainerNetworkResolver;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
 import io.github.hectorvent.floci.core.common.docker.PortAllocator;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,6 +15,7 @@ import org.mockito.Mockito;
 
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -30,9 +32,12 @@ class EcrRegistryManagerTest {
 
     private static final int BASE_PORT = 6100;
     private static final int MAX_PORT = 6101; // pool of exactly two ports
+    private static final String REGISTRY_NAME = "floci-test-ecr-registry";
 
     private PortAllocator portAllocator;
     private ContainerLifecycleManager lifecycleManager;
+    private ContainerDetector containerDetector;
+    private CurrentContainerNetworkResolver currentContainerNetworkResolver;
     private EcrRegistryManager manager;
 
     @BeforeEach
@@ -49,7 +54,8 @@ class EcrRegistryManagerTest {
         when(lifecycleManager.findByName(anyString())).thenReturn(Optional.empty());
 
         ContainerLogStreamer logStreamer = Mockito.mock(ContainerLogStreamer.class);
-        ContainerDetector containerDetector = Mockito.mock(ContainerDetector.class);
+        containerDetector = Mockito.mock(ContainerDetector.class);
+        currentContainerNetworkResolver = Mockito.mock(CurrentContainerNetworkResolver.class);
         RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
 
         EmulatorConfig config = Mockito.mock(EmulatorConfig.class);
@@ -60,14 +66,14 @@ class EcrRegistryManagerTest {
         when(config.storage()).thenReturn(storage);
         // Empty host-persistent-path selects named-volume mode (no host bind-mount logic).
         when(storage.hostPersistentPath()).thenReturn("");
-        when(ecr.registryContainerName()).thenReturn("floci-test-ecr-registry");
+        when(ecr.registryContainerName()).thenReturn(REGISTRY_NAME);
         when(ecr.registryImage()).thenReturn("registry:2");
         when(ecr.registryBasePort()).thenReturn(BASE_PORT);
         when(ecr.registryMaxPort()).thenReturn(MAX_PORT);
         when(ecr.dockerNetwork()).thenReturn(Optional.empty());
 
         manager = new EcrRegistryManager(containerBuilder, lifecycleManager, logStreamer,
-                containerDetector, portAllocator, config, regionResolver);
+                containerDetector, currentContainerNetworkResolver, portAllocator, config, regionResolver);
     }
 
     @Test
@@ -86,5 +92,12 @@ class EcrRegistryManagerTest {
             assertFalse(ex.getMessage().contains("No free port available"),
                     "port pool leaked on attempt " + attempt + ": " + ex.getMessage());
         }
+    }
+
+    @Test
+    void httpClient_usesRegistryContainerDnsWhenRunningInsideDocker() {
+        when(containerDetector.isRunningInContainer()).thenReturn(true);
+
+        assertEquals("http://" + REGISTRY_NAME + ":5000", manager.httpClient().baseUrl());
     }
 }


### PR DESCRIPTION
## Summary

Fixes ECR control plane registry endpoint resolution when Floci is running inside Docker.

In the reported case, `docker push` succeeded and the backing registry showed the pushed repository/tag, but `ecr describe-images` returned an empty image list for the same repository. This change makes the ECR control plane resolve the backing registry via the sibling container endpoint instead of incorrectly relying on `localhost` from inside the Floci container, and makes the backing registry join the same Docker network when needed.

Closes #1112

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior before this fix:

- `CreateRepository` returned a valid `repositoryUri`
- `docker push` to the backing registry succeeded
- the backing registry contained the pushed repository/tag
- but `ecr describe-images` returned an empty `imageDetails` list for the repository

This PR fixes that inconsistency in Docker-based Floci setups.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Local test note: `./mvnw test` does not pass cleanly in my environment due to unrelated failures in `ElastiCacheMemcachedIntegrationTest` (`memcachedAcceptsSetAndGet` and `versionCommandResponds`, both `Connection refused`). Targeted ECR
  tests for this change pass locally.
