### PR TITLE
fix(ApiGateway): implement EndpointConfiguration for REST APIs

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
@@ -17,6 +17,8 @@ import io.github.hectorvent.floci.services.apigateway.model.ApiGatewayResource;
 import io.github.hectorvent.floci.services.apigateway.model.ApiKey;
 import io.github.hectorvent.floci.services.apigateway.model.BasePathMapping;
 import io.github.hectorvent.floci.services.apigateway.model.CustomDomain;
+import io.github.hectorvent.floci.services.apigateway.model.EndpointConfiguration;
+import io.github.hectorvent.floci.services.apigateway.model.EndpointType;
 import io.github.hectorvent.floci.services.apigateway.model.MethodConfig;
 import io.github.hectorvent.floci.services.apigateway.model.MethodResponse;
 import io.github.hectorvent.floci.services.apigateway.model.RequestValidator;
@@ -1517,6 +1519,20 @@ public class ApiGatewayController {
             api.getTags().forEach(tagsNode::put);
             node.set("tags", tagsNode);
         }
+
+        EndpointConfiguration epConfig = api.getEndpointConfiguration();
+        if (epConfig == null) {
+            epConfig = new EndpointConfiguration();
+            epConfig.setTypes(List.of(EndpointType.REGIONAL));
+        }
+
+        ObjectNode epNode = objectMapper.createObjectNode();
+        ArrayNode types = epNode.putArray("types");
+        epConfig.getTypes().forEach(t -> types.add(t.name()));
+        ArrayNode vpcIds = epNode.putArray("vpcEndpointIds");
+        epConfig.getVpcEndpointIds().forEach(vpcIds::add);
+        node.set("endpointConfiguration", epNode);
+
         return node;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
@@ -1,10 +1,13 @@
 package io.github.hectorvent.floci.services.apigateway;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import io.github.hectorvent.floci.services.apigateway.model.EndpointConfiguration;
+import io.github.hectorvent.floci.services.apigateway.model.EndpointType;
 import org.jboss.logging.Logger;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -55,6 +58,11 @@ public class ApiGatewayService {
     private final StorageBackend<String, Account> accountStore;
     private final StorageBackend<String, CustomDomain> domainStore;
     private final StorageBackend<String, BasePathMapping> basePathMappingStore;
+
+    // Constants
+    private static final String EPC_KEY = "endpointConfiguration";
+    private static final String EPC_TYPES_KEY = "types";
+    private static final String EPC_VPC_IDS_KEY = "vpcEndpointIds";
 
     @Inject
     public ApiGatewayService(StorageFactory storageFactory, EmulatorConfig config) {
@@ -173,6 +181,60 @@ public class ApiGatewayService {
         api.setDescription(description);
         api.setCreatedDate(System.currentTimeMillis() / 1000L);
         api.setTags(tags);
+
+        EndpointConfiguration endpointConfiguration = new EndpointConfiguration();
+        if (request.get(EPC_KEY) instanceof Map<?, ?> epMap) {
+            epMap.forEach((k, v) -> {
+                if (k instanceof String ks && v instanceof List<?> list) {
+                    if (EPC_TYPES_KEY.equals(ks)) {
+                        List<EndpointType> types = list.stream()
+                                .filter(String.class::isInstance)
+                                .map(String.class::cast)
+                                .map(String::toUpperCase)
+                                .map(typeStr -> {
+                                    try {
+                                        return EndpointType.valueOf(typeStr);
+                                    } catch (IllegalArgumentException e) {
+                                        throw new AwsException("BadRequestException",
+                                                "Endpoint configuration type must be REGIONAL, EDGE, or PRIVATE.", 400);
+                                    }
+                                })
+                                .toList();
+                        endpointConfiguration.setTypes(types);
+                    } else if (EPC_VPC_IDS_KEY.equals(ks)) {
+                        List<String> vpcIds = list.stream()
+                                .filter(String.class::isInstance)
+                                .map(String.class::cast)
+                                .toList();
+                        endpointConfiguration.setVpcEndpointIds(vpcIds);
+                    }
+                }
+            });
+        }
+
+        // Set default type if omitted
+        if (endpointConfiguration.getTypes().isEmpty()) {
+            endpointConfiguration.setTypes(List.of(EndpointType.REGIONAL));
+        }
+
+        // Enforce exactly one type
+        if (endpointConfiguration.getTypes().size() != 1) {
+            throw new AwsException("BadRequestException",
+                    "Endpoint configuration types must contain exactly one value.", 400);
+        }
+
+        EndpointType type = endpointConfiguration.getTypes().getFirst();
+        if (EndpointType.PRIVATE.equals(type)) {
+            if (endpointConfiguration.getVpcEndpointIds().isEmpty()) {
+                throw new AwsException("BadRequestException",
+                        "At least one vpcEndpointId is required for PRIVATE APIs.", 400);
+            }
+        } else {
+            // Reject/ignore vpcEndpointIds for REGIONAL and EDGE
+            endpointConfiguration.setVpcEndpointIds(new ArrayList<>());
+        }
+
+        api.setEndpointConfiguration(endpointConfiguration);
 
         apiStore.put(apiKey(region, api.getId()), api);
 

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/model/EndpointConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/model/EndpointConfiguration.java
@@ -1,0 +1,29 @@
+package io.github.hectorvent.floci.services.apigateway.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EndpointConfiguration {
+
+    private List<EndpointType> types = new ArrayList<>();
+    private List<String> vpcEndpointIds = new ArrayList<>();
+
+    public List<EndpointType> getTypes() {
+        return types;
+    }
+
+    public void setTypes(List<EndpointType> types) {
+        this.types = types != null ? types : new ArrayList<>();
+    }
+
+    public List<String> getVpcEndpointIds() {
+        return vpcEndpointIds;
+    }
+
+    public void setVpcEndpointIds(List<String> vpcEndpointIds) {
+        this.vpcEndpointIds = vpcEndpointIds != null ? vpcEndpointIds : new ArrayList<>();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/model/EndpointType.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/model/EndpointType.java
@@ -1,0 +1,7 @@
+package io.github.hectorvent.floci.services.apigateway.model;
+
+public enum EndpointType {
+    REGIONAL,
+    EDGE,
+    PRIVATE
+}

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/model/RestApi.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/model/RestApi.java
@@ -13,6 +13,8 @@ public class RestApi {
     private String description;
     private long createdDate;
     private Map<String, String> tags = new HashMap<>();
+    private EndpointConfiguration endpointConfiguration;
+
 
     public String getId() {
         return id;
@@ -52,5 +54,13 @@ public class RestApi {
 
     public void setTags(Map<String, String> tags) {
         this.tags = tags != null ? tags : new HashMap<>();
+    }
+
+    public EndpointConfiguration getEndpointConfiguration() {
+        return endpointConfiguration;
+    }
+
+    public void setEndpointConfiguration(EndpointConfiguration endpointConfiguration) {
+        this.endpointConfiguration = endpointConfiguration;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -1475,6 +1475,14 @@ public class CloudFormationResourceProvisioner {
         req.put("name", name);
         req.put("description", resolveOptional(props, "Description", engine));
 
+        if (props.has("EndpointConfiguration")) {
+            JsonNode epNode = props.get("EndpointConfiguration");
+            Map<String, Object> epReq = new HashMap<>();
+            epReq.put("types", resolveStringListOrEmpty(epNode, "Types", engine));
+            epReq.put("vpcEndpointIds", resolveStringListOrEmpty(epNode, "VpcEndpointIds", engine));
+            req.put("endpointConfiguration", epReq);
+        }
+
         var api = apiGatewayService.createRestApi(region, req);
         r.setPhysicalId(api.getId());
         r.getAttributes().put("RootResourceId", apiGatewayService.getResources(region, api.getId()).get(0).getId());

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayEndpointConfigurationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayEndpointConfigurationIntegrationTest.java
@@ -1,0 +1,127 @@
+package io.github.hectorvent.floci.services.apigateway;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+class ApiGatewayEndpointConfigurationIntegrationTest {
+
+    @Test
+    void createRestApi_withEndpointConfiguration_Private() {
+        String body = """
+                {
+                  "name": "private-api",
+                  "endpointConfiguration": {
+                    "types": ["PRIVATE"],
+                    "vpcEndpointIds": ["vpce-123"]
+                  }
+                }
+                """;
+
+        String apiId = given()
+                .contentType(ContentType.JSON)
+                .body(body)
+                .when().post("/restapis")
+                .then()
+                .statusCode(201)
+                .body("endpointConfiguration.types", contains("PRIVATE"))
+                .body("endpointConfiguration.vpcEndpointIds", contains("vpce-123"))
+                .extract().path("id");
+
+        // Verify preservation during OpenAPI update (putRestApi)
+        String openApiSpec = """
+                openapi: 3.0.0
+                info:
+                  title: Updated API
+                  version: 1.0.0
+                paths:
+                  /:
+                    get:
+                      responses:
+                        '200':
+                          description: OK
+                """;
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(openApiSpec)
+                .when().put("/restapis/" + apiId)
+                .then()
+                .statusCode(200)
+                .body("name", equalTo("Updated API"))
+                .body("endpointConfiguration.types", contains("PRIVATE"))
+                .body("endpointConfiguration.vpcEndpointIds", contains("vpce-123"));
+    }
+
+    @Test
+    void createRestApi_withDefaultEndpointConfiguration() {
+        String body = """
+                {"name": "default-api"}
+                """;
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(body)
+                .when().post("/restapis")
+                .then()
+                .statusCode(201)
+                .body("endpointConfiguration.types", contains("REGIONAL"))
+                .body("endpointConfiguration.vpcEndpointIds", empty());
+    }
+
+    @Test
+    void createRestApi_ValidationFailures() {
+        // Multiple types
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"name\":\"bad-api\", \"endpointConfiguration\":{\"types\":[\"REGIONAL\", \"EDGE\"]}}")
+                .when().post("/restapis")
+                .then()
+                .statusCode(400)
+                .body("message", containsString("exactly one value"));
+
+        // Invalid type
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"name\":\"bad-api\", \"endpointConfiguration\":{\"types\":[\"INVALID\"]}}")
+                .when().post("/restapis")
+                .then()
+                .statusCode(400)
+                .body("message", containsString("REGIONAL, EDGE, or PRIVATE"));
+
+        // Private without VPC IDs
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"name\":\"bad-api\", \"endpointConfiguration\":{\"types\":[\"PRIVATE\"]}}")
+                .when().post("/restapis")
+                .then()
+                .statusCode(400)
+                .body("message", containsString("At least one vpcEndpointId is required"));
+    }
+
+    @Test
+    void createRestApi_RegionalIgnoresVpcIds() {
+        String body = """
+                {
+                  "name": "regional-api",
+                  "endpointConfiguration": {
+                    "types": ["REGIONAL"],
+                    "vpcEndpointIds": ["vpce-123"]
+                  }
+                }
+                """;
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(body)
+                .when().post("/restapis")
+                .then()
+                .statusCode(201)
+                .body("endpointConfiguration.types", contains("REGIONAL"))
+                .body("endpointConfiguration.vpcEndpointIds", empty());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -19,6 +19,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -5779,6 +5780,60 @@ class CloudFormationIntegrationTest {
         .then()
             .statusCode(200)
             .body(containsString("CREATE_FAILED"));
+    }
+
+    @Test
+    void createStack_apiGatewayRestApi_withEndpointConfiguration() {
+        String template = """
+            {
+              "Resources": {
+                "MyPrivateApi": {
+                  "Type": "AWS::ApiGateway::RestApi",
+                  "Properties": {
+                    "Name": "cfn-private-api",
+                    "EndpointConfiguration": {
+                      "Types": ["PRIVATE"],
+                      "VpcEndpointIds": ["vpce-12345678"]
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        String stackName = "apigw-ep-stack";
+
+        given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "CreateStack")
+                .formParam("StackName", stackName)
+                .formParam("TemplateBody", template)
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .body(containsString("<StackId>"));
+
+        String resourcesXml = given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "DescribeStackResources")
+                .formParam("StackName", stackName)
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .extract().asString();
+
+        String apiId = physicalIdByLogicalId(resourcesXml, "MyPrivateApi");
+
+        given()
+                .when()
+                .get("/restapis/" + apiId)
+                .then()
+                .statusCode(200)
+                .body("name", equalTo("cfn-private-api"))
+                .body("endpointConfiguration.types", contains("PRIVATE"))
+                .body("endpointConfiguration.vpcEndpointIds", contains("vpce-12345678"));
     }
 
 }


### PR DESCRIPTION
## Summary
Closes #999 
- Added the missing functionality to capture endpoint keys from createRestAPI requests.
- Added logic to return endpoint keys in response to fix terraform unwrapping issue.
- Added validation logic regarding endpoint types to keep in line with AWS behavior.
- Also applied fix to REST APIs created through CloudFormation.

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility
Tested with hashicorp/aws v6.46.0 & AWS SDK 2.25.0.
<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Working Proof
### Before:
<img width="1412" height="515" alt="image" src="https://github.com/user-attachments/assets/05023bd2-a540-4918-99df-5c698c037e9d" />

### After:
<img width="890" height="323" alt="image" src="https://github.com/user-attachments/assets/59f51547-050c-4543-af89-d1af1e9e8bf7" />