### PR TITLE
fix(athena): align metadata behavior with AWS

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/athena/AthenaJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/AthenaJsonHandler.java
@@ -59,6 +59,36 @@ public class AthenaJsonHandler {
                         athenaService.listQueryExecutions().stream()
                                 .map(QueryExecution::getQueryExecutionId).toList())).build();
             }
+            case "StopQueryExecution" -> {
+                athenaService.stopQueryExecution(request.get("QueryExecutionId").asText());
+                yield Response.ok(Map.of()).build();
+            }
+            case "GetWorkGroup" -> {
+                String name = request.has("WorkGroup") ? request.get("WorkGroup").asText() : "primary";
+                yield Response.ok(Map.of("WorkGroup", athenaService.getWorkGroup(name))).build();
+            }
+            case "ListWorkGroups" -> Response.ok(Map.of("WorkGroups", athenaService.listWorkGroups())).build();
+            case "CreateWorkGroup" -> Response.ok(Map.of()).build();
+            case "ListDataCatalogs" -> Response.ok(Map.of("DataCatalogsSummary", athenaService.listDataCatalogs())).build();
+            case "GetDataCatalog" -> {
+                String name = request.has("Name") ? request.get("Name").asText() : AthenaService.DEFAULT_CATALOG;
+                yield Response.ok(Map.of("DataCatalog", athenaService.getDataCatalog(name))).build();
+            }
+            case "ListDatabases" -> {
+                String catalog = request.has("CatalogName") ? request.get("CatalogName").asText() : AthenaService.DEFAULT_CATALOG;
+                yield Response.ok(Map.of("DatabaseList", athenaService.listDatabases(catalog))).build();
+            }
+            case "ListTableMetadata" -> {
+                String catalog = request.has("CatalogName") ? request.get("CatalogName").asText() : AthenaService.DEFAULT_CATALOG;
+                String database = request.path("DatabaseName").asText(request.path("Database").asText(""));
+                yield Response.ok(Map.of("TableMetadataList", athenaService.listTableMetadata(catalog, database))).build();
+            }
+            case "GetTableMetadata" -> {
+                String catalog = request.has("CatalogName") ? request.get("CatalogName").asText() : AthenaService.DEFAULT_CATALOG;
+                String database = request.path("DatabaseName").asText(request.path("Database").asText(""));
+                String tableName = request.get("TableName").asText();
+                yield Response.ok(Map.of("TableMetadata", athenaService.getTableMetadata(catalog, database, tableName))).build();
+            }
             default -> throw new AwsException("InvalidAction", "Action " + action + " is not supported", 400);
         };
     }

--- a/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
@@ -7,8 +7,10 @@ import io.github.hectorvent.floci.core.common.CsvParser;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.athena.model.*;
+import io.github.hectorvent.floci.services.glue.model.Column;
 import io.github.hectorvent.floci.services.floci.FlociDuckClient;
 import io.github.hectorvent.floci.services.glue.GlueService;
+import io.github.hectorvent.floci.services.glue.model.Database;
 import io.github.hectorvent.floci.services.glue.model.Table;
 import io.github.hectorvent.floci.services.s3.S3Service;
 import io.github.hectorvent.floci.services.s3.model.S3Object;
@@ -28,6 +30,7 @@ import java.util.*;
 public class AthenaService {
 
     private static final Logger LOG = Logger.getLogger(AthenaService.class);
+    public static final String DEFAULT_CATALOG = "AwsDataCatalog";
     private static final String DEFAULT_OUTPUT_BUCKET = "floci-athena-results";
 
     private final StorageBackend<String, QueryExecution> queryStore;
@@ -59,12 +62,17 @@ public class AthenaService {
                                       ResultConfiguration resultConfiguration) {
         String id = UUID.randomUUID().toString();
         String database = context != null && context.getDatabase() != null ? context.getDatabase() : "default";
+        QueryExecutionContext resolvedContext = context != null ? context : new QueryExecutionContext();
+        resolvedContext.setDatabase(database);
+        if (resolvedContext.getCatalog() == null || resolvedContext.getCatalog().isBlank()) {
+            resolvedContext.setCatalog(DEFAULT_CATALOG);
+        }
 
         // Ensure output location has a trailing slash so floci-duck writes into the prefix
         String outputLocation = resolveOutputLocation(resultConfiguration, id);
         ResultConfiguration resolvedResult = new ResultConfiguration(outputLocation);
 
-        QueryExecution execution = new QueryExecution(id, query, workGroup, resolvedResult, context);
+        QueryExecution execution = new QueryExecution(id, query, workGroup, resolvedResult, resolvedContext);
         execution.getStatus().setState(QueryExecutionState.RUNNING);
         queryStore.put(id, execution);
 
@@ -77,9 +85,8 @@ public class AthenaService {
         }
 
         // Submit async — caller gets the ID immediately while execution runs in background
-        String finalDatabase = database;
         vertx.executeBlocking(() -> {
-            String setupDdl = buildGlueDdl(finalDatabase);
+            String setupDdl = buildGlueDdl(database);
             ensureOutputBucket(outputLocation);
             duckClient.execute(query, setupDdl, outputLocation + "results.csv");
             return null;
@@ -106,6 +113,61 @@ public class AthenaService {
 
     public List<QueryExecution> listQueryExecutions() {
         return queryStore.scan(k -> true);
+    }
+
+    public void stopQueryExecution(String id) {
+        QueryExecution execution = getQueryExecution(id);
+        execution.getStatus().setState(QueryExecutionState.CANCELLED);
+        execution.getStatus().setCompletionDateTime(Instant.now());
+        queryStore.put(id, execution);
+    }
+
+    public Map<String, Object> getWorkGroup(String name) {
+        return Map.of(
+                "Name", name == null || name.isBlank() ? "primary" : name,
+                "State", "ENABLED",
+                "Configuration", Map.of(
+                        "EngineVersion", Map.of(
+                                "SelectedEngineVersion", "Athena engine version 3",
+                                "EffectiveEngineVersion", "Athena engine version 3"
+                        ),
+                        "ResultConfiguration", Map.of("OutputLocation", "s3://" + DEFAULT_OUTPUT_BUCKET + "/results/"),
+                        "EnforceWorkGroupConfiguration", false,
+                        "PublishCloudWatchMetricsEnabled", false,
+                        "RequesterPaysEnabled", false
+                )
+        );
+    }
+
+    public List<Map<String, Object>> listWorkGroups() {
+        return List.of(Map.of("Name", "primary", "State", "ENABLED"));
+    }
+
+    public List<Map<String, Object>> listDataCatalogs() {
+        return List.of(Map.of("CatalogName", DEFAULT_CATALOG, "Type", "GLUE"));
+    }
+
+    public Map<String, Object> getDataCatalog(String name) {
+        return Map.of("Name", name == null || name.isBlank() ? DEFAULT_CATALOG : name, "Type", "GLUE");
+    }
+
+    public List<Map<String, Object>> listDatabases(String catalog) {
+        return glueService.getDatabases().stream()
+                .map(Database::getName)
+                .sorted()
+                .map(name -> Map.<String, Object>of("Name", name))
+                .toList();
+    }
+
+    public List<Map<String, Object>> listTableMetadata(String catalog, String database) {
+        return glueService.getTables(database).stream()
+                .sorted(Comparator.comparing(Table::getName))
+                .map(table -> tableMetadata(catalog, database, table))
+                .toList();
+    }
+
+    public Map<String, Object> getTableMetadata(String catalog, String database, String tableName) {
+        return tableMetadata(catalog, database, glueService.getTable(database, tableName));
     }
 
     public ResultSet getQueryResults(String id) {
@@ -143,13 +205,21 @@ public class AthenaService {
                 sb.append("CREATE OR REPLACE VIEW \"")
                   .append(table.getName())
                   .append("\" AS SELECT * FROM ")
-                  .append(readFn)
-                  .append("('").append(normalizedLocation).append("/**');\n");
+                  .append(readExpression(readFn, normalizedLocation))
+                  .append(";\n");
             }
         } catch (Exception e) {
             LOG.debugv("Could not inject Glue DDL for database {0}: {1}", database, e.getMessage());
         }
         return sb.toString();
+    }
+
+    private String readExpression(String readFn, String normalizedLocation) {
+        String glob = normalizedLocation + "/**";
+        if ("read_parquet".equals(readFn)) {
+            return "read_parquet('" + glob + "', union_by_name = true)";
+        }
+        return readFn + "('" + glob + "')";
     }
 
     private String inferReadFunction(Table table) {
@@ -229,7 +299,7 @@ public class AthenaService {
 
             String[] headers = CsvParser.parseLine(headerLine).toArray(String[]::new);
             for (String h : headers) {
-                columns.add(new ResultSet.ColumnInfo(h, "varchar"));
+                columns.add(new ResultSet.ColumnInfo(DEFAULT_CATALOG, "", "", h, "varchar"));
             }
 
             // Header row is included in GetQueryResults per AWS spec
@@ -244,6 +314,38 @@ public class AthenaService {
         }
 
         return new ResultSet(rows, new ResultSet.ResultSetMetadata(columns));
+    }
+
+    private Map<String, Object> tableMetadata(String catalog, String database, Table table) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("Name", table.getName());
+        metadata.put("CreateTime", table.getCreateTime() != null ? table.getCreateTime() : Instant.now());
+        metadata.put("LastAccessTime", table.getLastAccessTime() != null ? table.getLastAccessTime() : Instant.now());
+        metadata.put("TableType", table.getTableType() != null ? table.getTableType() : "EXTERNAL_TABLE");
+        metadata.put("Columns", athenaColumns(table));
+        metadata.put("Parameters", table.getParameters() != null ? table.getParameters() : Map.of());
+        return metadata;
+    }
+
+    private List<Map<String, String>> athenaColumns(Table table) {
+        if (table.getStorageDescriptor() == null || table.getStorageDescriptor().getColumns() == null) {
+            return List.of();
+        }
+        return table.getStorageDescriptor().getColumns().stream()
+                .map(column -> Map.of(
+                        "Name", column.getName(),
+                        "Type", glueTypeToAthena(column)
+                ))
+                .toList();
+    }
+
+    private String glueTypeToAthena(Column column) {
+        String type = column.getType() == null ? "string" : column.getType().toLowerCase(Locale.ROOT);
+        if (type.equals("string") || type.equals("char") || type.equals("varchar")
+                || type.startsWith("struct<") || type.startsWith("array<") || type.startsWith("map<")) {
+            return "varchar";
+        }
+        return type;
     }
 
     private ResultSet.Row toRow(String[] values) {

--- a/src/main/java/io/github/hectorvent/floci/services/athena/model/QueryExecution.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/model/QueryExecution.java
@@ -13,6 +13,12 @@ public class QueryExecution {
     private QueryExecutionStatus status;
     @JsonProperty("WorkGroup")
     private String workGroup;
+    @JsonProperty("StatementType")
+    private String statementType;
+    @JsonProperty("Statistics")
+    private QueryExecutionStatistics statistics;
+    @JsonProperty("EngineVersion")
+    private EngineVersion engineVersion;
 
     @JsonProperty("ResultConfiguration")
     private ResultConfiguration resultConfiguration;
@@ -30,6 +36,9 @@ public class QueryExecution {
         this.status = new QueryExecutionStatus(QueryExecutionState.QUEUED);
         this.resultConfiguration = resultConfiguration;
         this.queryExecutionContext = queryExecutionContext;
+        this.statementType = "DML";
+        this.statistics = new QueryExecutionStatistics();
+        this.engineVersion = new EngineVersion();
     }
 
     public String getQueryExecutionId() { return queryExecutionId; }
@@ -44,4 +53,36 @@ public class QueryExecution {
     public void setResultConfiguration(ResultConfiguration resultConfiguration) { this.resultConfiguration = resultConfiguration; }
     public QueryExecutionContext getQueryExecutionContext() { return queryExecutionContext; }
     public void setQueryExecutionContext(QueryExecutionContext queryExecutionContext) { this.queryExecutionContext = queryExecutionContext; }
+    public String getStatementType() { return statementType; }
+    public void setStatementType(String statementType) { this.statementType = statementType; }
+    public QueryExecutionStatistics getStatistics() { return statistics; }
+    public void setStatistics(QueryExecutionStatistics statistics) { this.statistics = statistics; }
+    public EngineVersion getEngineVersion() { return engineVersion; }
+    public void setEngineVersion(EngineVersion engineVersion) { this.engineVersion = engineVersion; }
+
+    @RegisterForReflection
+    public static class QueryExecutionStatistics {
+        @JsonProperty("EngineExecutionTimeInMillis")
+        private Long engineExecutionTimeInMillis = 1L;
+        @JsonProperty("DataScannedInBytes")
+        private Long dataScannedInBytes = 0L;
+
+        public Long getEngineExecutionTimeInMillis() { return engineExecutionTimeInMillis; }
+        public void setEngineExecutionTimeInMillis(Long engineExecutionTimeInMillis) { this.engineExecutionTimeInMillis = engineExecutionTimeInMillis; }
+        public Long getDataScannedInBytes() { return dataScannedInBytes; }
+        public void setDataScannedInBytes(Long dataScannedInBytes) { this.dataScannedInBytes = dataScannedInBytes; }
+    }
+
+    @RegisterForReflection
+    public static class EngineVersion {
+        @JsonProperty("SelectedEngineVersion")
+        private String selectedEngineVersion = "Athena engine version 3";
+        @JsonProperty("EffectiveEngineVersion")
+        private String effectiveEngineVersion = "Athena engine version 3";
+
+        public String getSelectedEngineVersion() { return selectedEngineVersion; }
+        public void setSelectedEngineVersion(String selectedEngineVersion) { this.selectedEngineVersion = selectedEngineVersion; }
+        public String getEffectiveEngineVersion() { return effectiveEngineVersion; }
+        public void setEffectiveEngineVersion(String effectiveEngineVersion) { this.effectiveEngineVersion = effectiveEngineVersion; }
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/athena/model/ResultSet.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/model/ResultSet.java
@@ -57,16 +57,62 @@ public class ResultSet {
 
     @RegisterForReflection
     public static class ColumnInfo {
+        @JsonProperty("CatalogName")
+        private String catalogName;
+        @JsonProperty("SchemaName")
+        private String schemaName;
+        @JsonProperty("TableName")
+        private String tableName;
         @JsonProperty("Name")
         private String name;
+        @JsonProperty("Label")
+        private String label;
         @JsonProperty("Type")
         private String type;
+        @JsonProperty("Precision")
+        private Integer precision;
+        @JsonProperty("Scale")
+        private Integer scale;
+        @JsonProperty("Nullable")
+        private String nullable;
+        @JsonProperty("CaseSensitive")
+        private Boolean caseSensitive;
 
         public ColumnInfo() {}
-        public ColumnInfo(String name, String type) { this.name = name; this.name = name; this.type = type; }
+        public ColumnInfo(String name, String type) {
+            this("AwsDataCatalog", "", "", name, type);
+        }
+        public ColumnInfo(String catalogName, String schemaName, String tableName, String name, String type) {
+            this.catalogName = catalogName;
+            this.schemaName = schemaName;
+            this.tableName = tableName;
+            this.name = name;
+            this.label = name;
+            this.type = type;
+            this.precision = 0;
+            this.scale = 0;
+            this.nullable = "UNKNOWN";
+            this.caseSensitive = false;
+        }
+        public String getCatalogName() { return catalogName; }
+        public void setCatalogName(String catalogName) { this.catalogName = catalogName; }
+        public String getSchemaName() { return schemaName; }
+        public void setSchemaName(String schemaName) { this.schemaName = schemaName; }
+        public String getTableName() { return tableName; }
+        public void setTableName(String tableName) { this.tableName = tableName; }
         public String getName() { return name; }
         public void setName(String name) { this.name = name; }
+        public String getLabel() { return label; }
+        public void setLabel(String label) { this.label = label; }
         public String getType() { return type; }
         public void setType(String type) { this.type = type; }
+        public Integer getPrecision() { return precision; }
+        public void setPrecision(Integer precision) { this.precision = precision; }
+        public Integer getScale() { return scale; }
+        public void setScale(Integer scale) { this.scale = scale; }
+        public String getNullable() { return nullable; }
+        public void setNullable(String nullable) { this.nullable = nullable; }
+        public Boolean getCaseSensitive() { return caseSensitive; }
+        public void setCaseSensitive(Boolean caseSensitive) { this.caseSensitive = caseSensitive; }
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueJsonHandler.java
@@ -70,6 +70,15 @@ public class GlueJsonHandler {
                 String dbName = request.get("DatabaseName").asText();
                 yield Response.ok(Map.of("TableList", glueService.getTables(dbName))).build();
             }
+            case "UpdateTable" -> {
+                String dbName = request.get("DatabaseName").asText();
+                Table table = mapper.treeToValue(request.get("TableInput"), Table.class);
+                glueService.updateTable(dbName, table);
+                yield Response.ok().build();
+            }
+            case "GetTableVersions" -> {
+                yield Response.ok(Map.of("TableVersions", glueService.getTableVersions())).build();
+            }
             case "DeleteTable" -> {
                 String dbName = request.get("DatabaseName").asText();
                 String tableName = request.get("Name").asText();

--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
@@ -19,6 +19,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -83,6 +84,9 @@ public class GlueService {
         }
         validateSchemaReference(table);
         table.setDatabaseName(databaseName);
+        if (table.getCreateTime() == null) {
+            table.setCreateTime(Instant.now());
+        }
         tableStore.put(key, table);
         LOG.infov("Created Glue Table: {0}.{1}", databaseName, table.getName());
     }
@@ -101,6 +105,24 @@ public class GlueService {
             resolved.add(withResolvedSchemaReference(table));
         }
         return resolved;
+    }
+
+    public void updateTable(String databaseName, Table table) {
+        getDatabase(databaseName);
+        String key = databaseName + ":" + table.getName();
+        Table existing = tableStore.get(key)
+                .orElseThrow(() -> new AwsException("EntityNotFoundException",
+                        "Table not found: " + databaseName + "." + table.getName(), 400));
+        validateSchemaReference(table);
+        table.setDatabaseName(databaseName);
+        table.setCreateTime(existing.getCreateTime());
+        table.setUpdateTime(Instant.now());
+        tableStore.put(key, table);
+        LOG.infov("Updated Glue Table: {0}.{1}", databaseName, table.getName());
+    }
+
+    public List<Map<String, Object>> getTableVersions() {
+        return List.of();
     }
 
     public void deleteTable(String databaseName, String tableName) {

--- a/src/test/java/io/github/hectorvent/floci/services/athena/AthenaIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/athena/AthenaIntegrationTest.java
@@ -58,7 +58,10 @@ class AthenaIntegrationTest {
         .then()
             .statusCode(200)
             .body("QueryExecution.QueryExecutionId", equalTo(queryExecutionId))
-            .body("QueryExecution.Status.State", equalTo("SUCCEEDED"));
+            .body("QueryExecution.Status.State", equalTo("SUCCEEDED"))
+            .body("QueryExecution.StatementType", equalTo("DML"))
+            .body("QueryExecution.EngineVersion.EffectiveEngineVersion", equalTo("Athena engine version 3"))
+            .body("QueryExecution.Statistics.DataScannedInBytes", equalTo(0));
     }
 
     @Test
@@ -102,5 +105,91 @@ class AthenaIntegrationTest {
         .then()
             .statusCode(400)
             .body("__type", equalTo("InvalidRequestException"));
+    }
+
+    @Test
+    @Order(6)
+    void supportsWorkGroupAndCatalogMetadataActions() {
+        given()
+            .header("X-Amz-Target", "AmazonAthena.GetWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("{ \"WorkGroup\": \"primary\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("WorkGroup.Name", equalTo("primary"))
+            .body("WorkGroup.Configuration.EngineVersion.EffectiveEngineVersion", equalTo("Athena engine version 3"));
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.ListDataCatalogs")
+            .contentType(CONTENT_TYPE)
+            .body("{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DataCatalogsSummary[0].CatalogName", equalTo("AwsDataCatalog"))
+            .body("DataCatalogsSummary[0].Type", equalTo("GLUE"));
+    }
+
+    @Test
+    @Order(7)
+    void listsGlueDatabasesAndTablesAsAthenaMetadata() {
+        given()
+            .header("X-Amz-Target", "AWSGlue.CreateDatabase")
+            .contentType(CONTENT_TYPE)
+            .body("{ \"DatabaseInput\": { \"Name\": \"analytics_test\" } }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "AWSGlue.CreateTable")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "DatabaseName": "analytics_test",
+                  "TableInput": {
+                    "Name": "orders",
+                    "TableType": "EXTERNAL_TABLE",
+                    "StorageDescriptor": {
+                      "Location": "s3://bucket/orders",
+                      "Columns": [
+                        { "Name": "id", "Type": "string" },
+                        { "Name": "payload", "Type": "struct<id:string>" }
+                      ]
+                    }
+                  }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.ListDatabases")
+            .contentType(CONTENT_TYPE)
+            .body("{ \"CatalogName\": \"AwsDataCatalog\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DatabaseList.Name", hasItem("analytics_test"));
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.GetTableMetadata")
+            .contentType(CONTENT_TYPE)
+            .body("{ \"CatalogName\": \"AwsDataCatalog\", \"DatabaseName\": \"analytics_test\", \"TableName\": \"orders\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TableMetadata.Name", equalTo("orders"))
+            .body("TableMetadata.Columns[0].Name", equalTo("id"))
+            .body("TableMetadata.Columns[0].Type", equalTo("varchar"))
+            .body("TableMetadata.Columns[1].Type", equalTo("varchar"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
@@ -178,6 +178,36 @@ class GlueServiceTest {
         }
     }
 
+    @Test
+    void updateTableReplacesExistingDefinitionAndPreservesCreateTime() {
+        Table table = new Table();
+        table.setName("plain");
+        StorageDescriptor sd = new StorageDescriptor();
+        sd.setColumns(java.util.List.of(new Column("a", "string")));
+        table.setStorageDescriptor(sd);
+        glueService.createTable("db1", table);
+
+        Table created = glueService.getTable("db1", "plain");
+        Table replacement = new Table();
+        replacement.setName("plain");
+        StorageDescriptor replacementSd = new StorageDescriptor();
+        replacementSd.setColumns(java.util.List.of(new Column("b", "bigint")));
+        replacement.setStorageDescriptor(replacementSd);
+
+        glueService.updateTable("db1", replacement);
+
+        Table fetched = glueService.getTable("db1", "plain");
+        assertEquals(created.getCreateTime(), fetched.getCreateTime());
+        assertNotNull(fetched.getUpdateTime());
+        assertEquals(1, fetched.getStorageDescriptor().getColumns().size());
+        assertEquals("b", fetched.getStorageDescriptor().getColumns().get(0).getName());
+    }
+
+    @Test
+    void getTableVersionsReturnsEmptyListForAthenaCompatibility() {
+        assertTrue(glueService.getTableVersions().isEmpty());
+    }
+
     private Table tableReferencing(String registryName, String schemaName, Long versionNumber, String versionId) {
         Table table = new Table();
         table.setName("withref");


### PR DESCRIPTION
## Summary

Adds Athena and Glue metadata compatibility so AWS-compatible clients can inspect workgroups, data catalogs, databases, and table metadata through Athena/Glue API actions.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The emulator previously exposed only a small subset of Athena actions and did not return enough metadata shape for AWS-compatible clients to discover catalogs, databases, tables, query statistics, engine version, or richer result column metadata.

This PR adds AWS-compatible metadata responses for:

- Athena workgroup actions: `GetWorkGroup`, `ListWorkGroups`, `CreateWorkGroup`
- Athena catalog/database/table actions: `ListDataCatalogs`, `GetDataCatalog`, `ListDatabases`, `ListTableMetadata`, `GetTableMetadata`
- Athena query lifecycle action: `StopQueryExecution`
- Glue table compatibility actions: `UpdateTable`, `GetTableVersions`

Query SQL is still passed through to the execution engine; this PR intentionally does not add SQL dialect rewriting.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Validation:

- `./mvnw test -Dtest=GlueServiceTest,AthenaIntegrationTest -DskipITs` passed locally: 16 tests, 0 failures.
- `./mvnw test` was run locally and failed in `SamTransformIntegrationTest.samFunction_viaChangeSet_createsLambda`; the response was still `CREATE_IN_PROGRESS` when the assertion expected `CREATE_COMPLETE`, and the log completed the stack immediately after. This appears unrelated to the Athena/Glue metadata changes in this PR.
