### PR TITLE
feat(ecs): provision ECS resources via CloudFormation

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -14,6 +14,18 @@ import io.github.hectorvent.floci.services.dynamodb.model.LocalSecondaryIndex;
 import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
 import io.github.hectorvent.floci.services.ecr.EcrService;
 import io.github.hectorvent.floci.services.ecr.model.Repository;
+import io.github.hectorvent.floci.services.ecs.EcsService;
+import io.github.hectorvent.floci.services.ecs.model.AwsVpcConfiguration;
+import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
+import io.github.hectorvent.floci.services.ecs.model.EcsCluster;
+import io.github.hectorvent.floci.services.ecs.model.EcsLoadBalancer;
+import io.github.hectorvent.floci.services.ecs.model.EcsServiceModel;
+import io.github.hectorvent.floci.services.ecs.model.KeyValuePair;
+import io.github.hectorvent.floci.services.ecs.model.LaunchType;
+import io.github.hectorvent.floci.services.ecs.model.NetworkConfiguration;
+import io.github.hectorvent.floci.services.ecs.model.NetworkMode;
+import io.github.hectorvent.floci.services.ecs.model.PortMapping;
+import io.github.hectorvent.floci.services.ecs.model.TaskDefinition;
 import io.github.hectorvent.floci.services.iam.IamService;
 import io.github.hectorvent.floci.services.kms.KmsService;
 import io.github.hectorvent.floci.services.lambda.LambdaService;
@@ -77,6 +89,7 @@ public class CloudFormationResourceProvisioner {
     private final EcrService ecrService;
     private final PipesService pipesService;
     private final CognitoService cognitoService;
+    private final EcsService ecsService;
 
     @Inject
     public CloudFormationResourceProvisioner(S3Service s3Service, SqsService sqsService,
@@ -89,7 +102,8 @@ public class CloudFormationResourceProvisioner {
                                              ApiGatewayV2Service apiGatewayV2Service,
                                              EcrService ecrService,
                                              PipesService pipesService,
-                                             CognitoService cognitoService) {
+                                             CognitoService cognitoService,
+                                             EcsService ecsService) {
         this.s3Service = s3Service;
         this.sqsService = sqsService;
         this.snsService = snsService;
@@ -105,6 +119,7 @@ public class CloudFormationResourceProvisioner {
         this.ecrService = ecrService;
         this.pipesService = pipesService;
         this.cognitoService = cognitoService;
+        this.ecsService = ecsService;
     }
 
     /**
@@ -178,6 +193,9 @@ public class CloudFormationResourceProvisioner {
                         provisionCognitoUserPool(resource, properties, engine, region, accountId, stackName);
                 case "AWS::Cognito::UserPoolClient" ->
                         provisionCognitoUserPoolClient(resource, properties, engine, region, accountId, stackName);
+                case "AWS::ECS::Cluster" -> provisionEcsCluster(resource, properties, engine, region, stackName);
+                case "AWS::ECS::TaskDefinition" -> provisionEcsTaskDefinition(resource, properties, engine, region, stackName);
+                case "AWS::ECS::Service" -> provisionEcsService(resource, properties, engine, region, stackName);
                 default -> {
                     LOG.debugv("Stubbing unsupported resource type: {0} ({1})", resourceType, logicalId);
                     resource.setPhysicalId(logicalId + "-" + UUID.randomUUID().toString().substring(0, 8));
@@ -220,6 +238,9 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::Lambda::EventSourceMapping" -> lambdaService.deleteEventSourceMapping(physicalId);
                 case "AWS::Cognito::UserPool" -> cognitoService.deleteUserPool(physicalId);
                 case "AWS::Cognito::UserPoolClient" -> cognitoService.deleteUserPoolClient(physicalId);
+                case "AWS::ECS::Cluster" -> ecsService.deleteCluster(physicalId, region);
+                case "AWS::ECS::TaskDefinition" -> ecsService.deregisterTaskDefinition(physicalId, region);
+                case "AWS::ECS::Service" -> deleteEcsServiceSafe(physicalId, region);
                 default -> LOG.debugv("Skipping delete of unsupported resource type: {0}", resourceType);
             }
         } catch (Exception e) {
@@ -1701,6 +1722,238 @@ public class CloudFormationResourceProvisioner {
         r.getAttributes().put("ClientName", client.getClientName());
         if (client.getClientSecret() != null) {
             r.getAttributes().put("ClientSecret", client.getClientSecret());
+        }
+    }
+
+    // ── ECS ──────────────────────────────────────────────────────────────────
+
+    private void provisionEcsCluster(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                     String region, String stackName) {
+        String clusterName = resolveOptional(props, "ClusterName", engine);
+        if (clusterName == null || clusterName.isBlank()) {
+            clusterName = generatePhysicalName(stackName, r.getLogicalId(), 255, false);
+        }
+        // createCluster is idempotent, so re-running it on a stack update reuses the existing cluster.
+        EcsCluster cluster = ecsService.createCluster(clusterName, region);
+        r.setPhysicalId(cluster.getClusterName());
+        r.getAttributes().put("Arn", cluster.getClusterArn());
+    }
+
+    private void provisionEcsTaskDefinition(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                            String region, String stackName) {
+        String family = resolveOptional(props, "Family", engine);
+        if (family == null || family.isBlank()) {
+            family = generatePhysicalName(stackName, r.getLogicalId(), 255, false);
+        }
+        List<ContainerDefinition> containerDefs =
+                parseContainerDefinitions(props != null ? props.get("ContainerDefinitions") : null, engine);
+        NetworkMode networkMode = parseNetworkMode(resolveOptional(props, "NetworkMode", engine));
+        String cpu = resolveOptional(props, "Cpu", engine);
+        String memory = resolveOptional(props, "Memory", engine);
+        String taskRoleArn = resolveOptional(props, "TaskRoleArn", engine);
+        String executionRoleArn = resolveOptional(props, "ExecutionRoleArn", engine);
+
+        // Task definitions are immutable; each CFN update registers a fresh revision.
+        TaskDefinition td = ecsService.registerTaskDefinition(family, containerDefs, networkMode, cpu, memory,
+                taskRoleArn, executionRoleArn, region);
+
+        r.setPhysicalId(td.getTaskDefinitionArn());
+        r.getAttributes().put("TaskDefinitionArn", td.getTaskDefinitionArn());
+    }
+
+    private void provisionEcsService(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                     String region, String stackName) {
+        String clusterRef = resolveOptional(props, "Cluster", engine);
+        String taskDefinition = resolveOptional(props, "TaskDefinition", engine);
+        int desiredCount = intOrDefault(resolveOptional(props, "DesiredCount", engine), 1);
+        LaunchType launchType = parseLaunchType(resolveOptional(props, "LaunchType", engine));
+        List<EcsLoadBalancer> loadBalancers =
+                parseEcsLoadBalancers(props != null ? props.get("LoadBalancers") : null, engine);
+        NetworkConfiguration networkConfiguration =
+                parseEcsNetworkConfiguration(props != null ? props.get("NetworkConfiguration") : null, engine);
+
+        String serviceName = resolveOptional(props, "ServiceName", engine);
+        if (serviceName == null || serviceName.isBlank()) {
+            serviceName = r.getAttributes().get("Name");
+        }
+        if (serviceName == null || serviceName.isBlank()) {
+            serviceName = generatePhysicalName(stackName, r.getLogicalId(), 255, false);
+        }
+
+        EcsServiceModel svc;
+        if (r.getPhysicalId() == null) {
+            svc = ecsService.createService(clusterRef, serviceName, taskDefinition,
+                    desiredCount, launchType, loadBalancers, networkConfiguration, region);
+        } else {
+            svc = ecsService.updateService(clusterRef, serviceName, taskDefinition,
+                    desiredCount, networkConfiguration, region);
+        }
+
+        r.setPhysicalId(svc.getServiceArn());
+        r.getAttributes().put("Name", svc.getServiceName());
+        r.getAttributes().put("ServiceArn", svc.getServiceArn());
+    }
+
+    private void deleteEcsServiceSafe(String serviceArn, String region) {
+        // Floci service ARNs embed the cluster: arn:aws:ecs:<region>:<acct>:service/<cluster>/<service>.
+        // Parse both so the right cluster's tasks get stopped during teardown.
+        String clusterRef = null;
+        String serviceName = serviceArn;
+        try {
+            String[] segments = AwsArnUtils.parse(serviceArn).resource().split("/");
+            if (segments.length == 3) {
+                clusterRef = segments[1];
+                serviceName = segments[2];
+            } else if (segments.length == 2) {
+                // Legacy ARN format without an embedded cluster: service/<service>.
+                serviceName = segments[1];
+            }
+        } catch (IllegalArgumentException e) {
+            // Not an ARN; treat the value as a bare service name.
+        }
+        ecsService.deleteService(clusterRef, serviceName, true, region);
+    }
+
+    private List<ContainerDefinition> parseContainerDefinitions(JsonNode node, CloudFormationTemplateEngine engine) {
+        List<ContainerDefinition> result = new ArrayList<>();
+        if (node == null || node.isNull()) {
+            return result;
+        }
+        JsonNode resolved = engine.resolveNode(node);
+        if (resolved == null || !resolved.isArray()) {
+            return result;
+        }
+        for (JsonNode item : resolved) {
+            ContainerDefinition def = new ContainerDefinition();
+            def.setName(item.path("Name").asText(null));
+            def.setImage(item.path("Image").asText(null));
+            def.setEssential(item.path("Essential").asBoolean(true));
+            if (item.hasNonNull("Cpu")) {
+                def.setCpu(item.path("Cpu").asInt());
+            }
+            if (item.hasNonNull("Memory")) {
+                def.setMemory(item.path("Memory").asInt());
+            }
+            if (item.hasNonNull("MemoryReservation")) {
+                def.setMemoryReservation(item.path("MemoryReservation").asInt());
+            }
+            def.setPortMappings(parseCfnPortMappings(item.path("PortMappings")));
+            def.setEnvironment(parseCfnEnvironment(item.path("Environment")));
+            if (item.path("Command").isArray()) {
+                List<String> cmd = new ArrayList<>();
+                item.path("Command").forEach(c -> cmd.add(c.asText()));
+                def.setCommand(cmd);
+            }
+            if (item.path("EntryPoint").isArray()) {
+                List<String> ep = new ArrayList<>();
+                item.path("EntryPoint").forEach(e -> ep.add(e.asText()));
+                def.setEntryPoint(ep);
+            }
+            result.add(def);
+        }
+        return result;
+    }
+
+    private List<PortMapping> parseCfnPortMappings(JsonNode node) {
+        List<PortMapping> result = new ArrayList<>();
+        if (node == null || !node.isArray()) {
+            return result;
+        }
+        for (JsonNode item : node) {
+            int containerPort = item.path("ContainerPort").asInt(0);
+            int hostPort = item.path("HostPort").asInt(0);
+            String protocol = item.path("Protocol").asText("tcp");
+            result.add(new PortMapping(containerPort, hostPort, protocol));
+        }
+        return result;
+    }
+
+    private List<KeyValuePair> parseCfnEnvironment(JsonNode node) {
+        List<KeyValuePair> result = new ArrayList<>();
+        if (node == null || !node.isArray()) {
+            return result;
+        }
+        for (JsonNode item : node) {
+            result.add(new KeyValuePair(item.path("Name").asText(), item.path("Value").asText()));
+        }
+        return result;
+    }
+
+    private List<EcsLoadBalancer> parseEcsLoadBalancers(JsonNode node, CloudFormationTemplateEngine engine) {
+        List<EcsLoadBalancer> result = new ArrayList<>();
+        if (node == null || node.isNull()) {
+            return result;
+        }
+        JsonNode resolved = engine.resolveNode(node);
+        if (resolved == null || !resolved.isArray()) {
+            return result;
+        }
+        for (JsonNode item : resolved) {
+            EcsLoadBalancer lb = new EcsLoadBalancer();
+            if (item.hasNonNull("TargetGroupArn")) {
+                lb.setTargetGroupArn(item.path("TargetGroupArn").asText());
+            }
+            if (item.hasNonNull("LoadBalancerName")) {
+                lb.setLoadBalancerName(item.path("LoadBalancerName").asText());
+            }
+            if (item.hasNonNull("ContainerName")) {
+                lb.setContainerName(item.path("ContainerName").asText());
+            }
+            if (item.hasNonNull("ContainerPort")) {
+                lb.setContainerPort(item.path("ContainerPort").asInt());
+            }
+            result.add(lb);
+        }
+        return result;
+    }
+
+    private NetworkConfiguration parseEcsNetworkConfiguration(JsonNode node, CloudFormationTemplateEngine engine) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        JsonNode resolved = engine.resolveNode(node);
+        if (resolved == null || !resolved.isObject() || !resolved.hasNonNull("AwsvpcConfiguration")) {
+            return null;
+        }
+        JsonNode awsvpc = resolved.path("AwsvpcConfiguration");
+        AwsVpcConfiguration awsvpcConfig = new AwsVpcConfiguration();
+        awsvpcConfig.setSubnets(jsonArrayToStringList(awsvpc.path("Subnets")));
+        awsvpcConfig.setSecurityGroups(jsonArrayToStringList(awsvpc.path("SecurityGroups")));
+        if (awsvpc.hasNonNull("AssignPublicIp")) {
+            awsvpcConfig.setAssignPublicIp(awsvpc.path("AssignPublicIp").asText());
+        }
+        NetworkConfiguration networkConfiguration = new NetworkConfiguration();
+        networkConfiguration.setAwsvpcConfiguration(awsvpcConfig);
+        return networkConfiguration;
+    }
+
+    private static List<String> jsonArrayToStringList(JsonNode node) {
+        List<String> result = new ArrayList<>();
+        if (node != null && node.isArray()) {
+            node.forEach(v -> result.add(v.asText()));
+        }
+        return result;
+    }
+
+    private static NetworkMode parseNetworkMode(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return NetworkMode.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private static LaunchType parseLaunchType(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return LaunchType.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            return null;
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.ecs;
 import io.github.hectorvent.floci.core.common.AwsErrorResponse;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.ecs.model.Attribute;
+import io.github.hectorvent.floci.services.ecs.model.AwsVpcConfiguration;
 import io.github.hectorvent.floci.services.ecs.model.CapacityProvider;
 import io.github.hectorvent.floci.services.ecs.model.ClusterSetting;
 import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
@@ -14,6 +15,7 @@ import io.github.hectorvent.floci.services.ecs.model.EcsTask;
 import io.github.hectorvent.floci.services.ecs.model.KeyValuePair;
 import io.github.hectorvent.floci.services.ecs.model.LaunchType;
 import io.github.hectorvent.floci.services.ecs.model.NetworkBinding;
+import io.github.hectorvent.floci.services.ecs.model.NetworkConfiguration;
 import io.github.hectorvent.floci.services.ecs.model.NetworkMode;
 import io.github.hectorvent.floci.services.ecs.model.PortMapping;
 import io.github.hectorvent.floci.services.ecs.model.ProtectedTask;
@@ -199,8 +201,11 @@ public class EcsJsonHandler {
         NetworkMode networkMode = parseEnum(req, "networkMode", NetworkMode.class);
         String cpu = req.has("cpu") ? req.path("cpu").asText() : null;
         String memory = req.has("memory") ? req.path("memory").asText() : null;
+        String taskRoleArn = req.hasNonNull("taskRoleArn") ? req.path("taskRoleArn").asText() : null;
+        String executionRoleArn = req.hasNonNull("executionRoleArn") ? req.path("executionRoleArn").asText() : null;
 
-        TaskDefinition td = service.registerTaskDefinition(family, containerDefs, networkMode, cpu, memory, region);
+        TaskDefinition td = service.registerTaskDefinition(family, containerDefs, networkMode, cpu, memory,
+                taskRoleArn, executionRoleArn, region);
 
         ObjectNode resp = objectMapper.createObjectNode();
         resp.set("taskDefinition", taskDefinitionNode(td));
@@ -373,9 +378,10 @@ public class EcsJsonHandler {
         int desiredCount = req.path("desiredCount").asInt(1);
         LaunchType launchType = parseEnum(req, "launchType", LaunchType.class);
         List<EcsLoadBalancer> loadBalancers = parseLoadBalancers(req.path("loadBalancers"));
+        NetworkConfiguration networkConfiguration = parseNetworkConfiguration(req.path("networkConfiguration"));
 
         EcsServiceModel svc = service.createService(cluster, serviceName, taskDefinition,
-                desiredCount, launchType, loadBalancers, region);
+                desiredCount, launchType, loadBalancers, networkConfiguration, region);
 
         ObjectNode resp = objectMapper.createObjectNode();
         resp.set("service", serviceNode(svc));
@@ -425,13 +431,31 @@ public class EcsJsonHandler {
         return result;
     }
 
+    private NetworkConfiguration parseNetworkConfiguration(JsonNode node) {
+        if (node == null || !node.isObject() || !node.hasNonNull("awsvpcConfiguration")) {
+            return null;
+        }
+        JsonNode awsvpc = node.path("awsvpcConfiguration");
+        AwsVpcConfiguration awsvpcConfig = new AwsVpcConfiguration();
+        awsvpcConfig.setSubnets(jsonArrayToList(awsvpc.path("subnets")));
+        awsvpcConfig.setSecurityGroups(jsonArrayToList(awsvpc.path("securityGroups")));
+        if (awsvpc.hasNonNull("assignPublicIp")) {
+            awsvpcConfig.setAssignPublicIp(awsvpc.path("assignPublicIp").asText());
+        }
+        NetworkConfiguration networkConfiguration = new NetworkConfiguration();
+        networkConfiguration.setAwsvpcConfiguration(awsvpcConfig);
+        return networkConfiguration;
+    }
+
     private Response handleUpdateService(JsonNode req, String region) {
         String cluster = req.has("cluster") ? req.path("cluster").asText() : null;
         String serviceName = req.path("service").asText();
         String taskDefinition = req.has("taskDefinition") ? req.path("taskDefinition").asText() : null;
         Integer desiredCount = req.has("desiredCount") ? req.path("desiredCount").asInt() : null;
+        NetworkConfiguration networkConfiguration = parseNetworkConfiguration(req.path("networkConfiguration"));
 
-        EcsServiceModel svc = service.updateService(cluster, serviceName, taskDefinition, desiredCount, region);
+        EcsServiceModel svc = service.updateService(cluster, serviceName, taskDefinition, desiredCount,
+                networkConfiguration, region);
 
         ObjectNode resp = objectMapper.createObjectNode();
         resp.set("service", serviceNode(svc));
@@ -885,6 +909,8 @@ public class EcsJsonHandler {
         }
         if (td.getCpu() != null) { n.put("cpu", td.getCpu()); }
         if (td.getMemory() != null) { n.put("memory", td.getMemory()); }
+        if (td.getTaskRoleArn() != null) { n.put("taskRoleArn", td.getTaskRoleArn()); }
+        if (td.getExecutionRoleArn() != null) { n.put("executionRoleArn", td.getExecutionRoleArn()); }
 
         ArrayNode containers = objectMapper.createArrayNode();
         if (td.getContainerDefinitions() != null) {
@@ -1012,6 +1038,23 @@ public class EcsJsonHandler {
                 lbs.add(ln);
             }
             n.set("loadBalancers", lbs);
+        }
+        if (s.getNetworkConfiguration() != null
+                && s.getNetworkConfiguration().getAwsvpcConfiguration() != null) {
+            AwsVpcConfiguration awsvpc = s.getNetworkConfiguration().getAwsvpcConfiguration();
+            ObjectNode awsvpcNode = objectMapper.createObjectNode();
+            ArrayNode subnets = objectMapper.createArrayNode();
+            awsvpc.getSubnets().forEach(subnets::add);
+            awsvpcNode.set("subnets", subnets);
+            ArrayNode securityGroups = objectMapper.createArrayNode();
+            awsvpc.getSecurityGroups().forEach(securityGroups::add);
+            awsvpcNode.set("securityGroups", securityGroups);
+            if (awsvpc.getAssignPublicIp() != null) {
+                awsvpcNode.put("assignPublicIp", awsvpc.getAssignPublicIp());
+            }
+            ObjectNode networkConfig = objectMapper.createObjectNode();
+            networkConfig.set("awsvpcConfiguration", awsvpcNode);
+            n.set("networkConfiguration", networkConfig);
         }
         return n;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
@@ -15,6 +15,7 @@ import io.github.hectorvent.floci.services.ecs.model.EcsLoadBalancer;
 import io.github.hectorvent.floci.services.ecs.model.EcsServiceModel;
 import io.github.hectorvent.floci.services.ecs.model.EcsTask;
 import io.github.hectorvent.floci.services.ecs.model.LaunchType;
+import io.github.hectorvent.floci.services.ecs.model.NetworkConfiguration;
 import io.github.hectorvent.floci.services.ecs.model.NetworkMode;
 import io.github.hectorvent.floci.services.ecs.model.ProtectedTask;
 import io.github.hectorvent.floci.services.ecs.model.ServiceDeployment;
@@ -181,6 +182,7 @@ public class EcsService {
 
     public TaskDefinition registerTaskDefinition(String family, List<ContainerDefinition> containerDefs,
                                                   NetworkMode networkMode, String cpu, String memory,
+                                                  String taskRoleArn, String executionRoleArn,
                                                   String region) {
         int revision = latestRevisions.merge(family, 1, Integer::sum);
 
@@ -191,6 +193,8 @@ public class EcsService {
         td.setNetworkMode(networkMode != null ? networkMode : NetworkMode.bridge);
         td.setCpu(cpu);
         td.setMemory(memory);
+        td.setTaskRoleArn(taskRoleArn);
+        td.setExecutionRoleArn(executionRoleArn);
         td.setContainerDefinitions(containerDefs != null ? containerDefs : List.of());
         td.setTaskDefinitionArn(regionResolver.buildArn("ecs", region,
                 "task-definition/" + family + ":" + revision));
@@ -442,7 +446,8 @@ public class EcsService {
 
     public EcsServiceModel createService(String clusterRef, String serviceName, String taskDefinition,
                                           int desiredCount, LaunchType launchType,
-                                          List<EcsLoadBalancer> loadBalancers, String region) {
+                                          List<EcsLoadBalancer> loadBalancers,
+                                          NetworkConfiguration networkConfiguration, String region) {
         EcsCluster cluster = resolveClusterOrDefault(clusterRef, region);
         resolveTaskDefinitionOrThrow(taskDefinition, region);
 
@@ -461,6 +466,7 @@ public class EcsService {
         svc.setLaunchType(launchType != null ? launchType : LaunchType.FARGATE);
         svc.setDesiredCount(desiredCount);
         svc.setLoadBalancers(loadBalancers);
+        svc.setNetworkConfiguration(networkConfiguration);
         svc.setStatus("ACTIVE");
         svc.setCreatedAt(Instant.now());
 
@@ -472,7 +478,8 @@ public class EcsService {
     }
 
     public EcsServiceModel updateService(String clusterRef, String serviceName, String taskDefinition,
-                                          Integer desiredCount, String region) {
+                                          Integer desiredCount, NetworkConfiguration networkConfiguration,
+                                          String region) {
         EcsCluster cluster = resolveClusterOrDefault(clusterRef, region);
         String key = serviceKey(region, cluster.getClusterName(), serviceName);
         EcsServiceModel svc = services.get(key);
@@ -481,6 +488,9 @@ public class EcsService {
         }
         if (desiredCount != null) {
             svc.setDesiredCount(desiredCount);
+        }
+        if (networkConfiguration != null) {
+            svc.setNetworkConfiguration(networkConfiguration);
         }
         if (taskDefinition != null) {
             resolveTaskDefinitionOrThrow(taskDefinition, region);

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/AwsVpcConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/AwsVpcConfiguration.java
@@ -1,0 +1,34 @@
+package io.github.hectorvent.floci.services.ecs.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The VPC subnets and security groups associated with a task or service that uses
+ * the {@code awsvpc} network mode ({@code CreateService}'s
+ * {@code networkConfiguration.awsvpcConfiguration} block).
+ */
+@RegisterForReflection
+public class AwsVpcConfiguration {
+
+    private List<String> subnets = new ArrayList<>();
+    private List<String> securityGroups = new ArrayList<>();
+    private String assignPublicIp;
+
+    public AwsVpcConfiguration() {}
+
+    public List<String> getSubnets() { return subnets; }
+    public void setSubnets(List<String> subnets) {
+        this.subnets = subnets != null ? subnets : new ArrayList<>();
+    }
+
+    public List<String> getSecurityGroups() { return securityGroups; }
+    public void setSecurityGroups(List<String> securityGroups) {
+        this.securityGroups = securityGroups != null ? securityGroups : new ArrayList<>();
+    }
+
+    public String getAssignPublicIp() { return assignPublicIp; }
+    public void setAssignPublicIp(String assignPublicIp) { this.assignPublicIp = assignPublicIp; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/EcsServiceModel.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/EcsServiceModel.java
@@ -25,6 +25,7 @@ public class EcsServiceModel {
     private String deploymentController;
     private Map<String, String> tags = new HashMap<>();
     private List<EcsLoadBalancer> loadBalancers = new ArrayList<>();
+    private NetworkConfiguration networkConfiguration;
 
     public String getServiceArn() { return serviceArn; }
     public void setServiceArn(String serviceArn) { this.serviceArn = serviceArn; }
@@ -68,5 +69,10 @@ public class EcsServiceModel {
     public List<EcsLoadBalancer> getLoadBalancers() { return loadBalancers; }
     public void setLoadBalancers(List<EcsLoadBalancer> loadBalancers) {
         this.loadBalancers = loadBalancers != null ? loadBalancers : new ArrayList<>();
+    }
+
+    public NetworkConfiguration getNetworkConfiguration() { return networkConfiguration; }
+    public void setNetworkConfiguration(NetworkConfiguration networkConfiguration) {
+        this.networkConfiguration = networkConfiguration;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/NetworkConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/NetworkConfiguration.java
@@ -1,0 +1,20 @@
+package io.github.hectorvent.floci.services.ecs.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * The network configuration for an ECS service. Required for task definitions that use
+ * the {@code awsvpc} network mode so each task receives its own elastic network interface.
+ */
+@RegisterForReflection
+public class NetworkConfiguration {
+
+    private AwsVpcConfiguration awsvpcConfiguration;
+
+    public NetworkConfiguration() {}
+
+    public AwsVpcConfiguration getAwsvpcConfiguration() { return awsvpcConfiguration; }
+    public void setAwsvpcConfiguration(AwsVpcConfiguration awsvpcConfiguration) {
+        this.awsvpcConfiguration = awsvpcConfiguration;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/TaskDefinition.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/TaskDefinition.java
@@ -16,6 +16,8 @@ public class TaskDefinition {
     private NetworkMode networkMode;
     private String cpu;
     private String memory;
+    private String taskRoleArn;
+    private String executionRoleArn;
     private List<ContainerDefinition> containerDefinitions;
     private Map<String, String> tags = new HashMap<>();
 
@@ -39,6 +41,12 @@ public class TaskDefinition {
 
     public String getMemory() { return memory; }
     public void setMemory(String memory) { this.memory = memory; }
+
+    public String getTaskRoleArn() { return taskRoleArn; }
+    public void setTaskRoleArn(String taskRoleArn) { this.taskRoleArn = taskRoleArn; }
+
+    public String getExecutionRoleArn() { return executionRoleArn; }
+    public void setExecutionRoleArn(String executionRoleArn) { this.executionRoleArn = executionRoleArn; }
 
     public List<ContainerDefinition> getContainerDefinitions() { return containerDefinitions; }
     public void setContainerDefinitions(List<ContainerDefinition> containerDefinitions) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -4772,4 +4772,326 @@ class CloudFormationIntegrationTest {
         assertThat(apisJson, containsString("\"AllowCredentials\":true"));
     }
 
+    // ── Issue #924: ECS provisioning via CloudFormation ──────────────────────
+
+    private static final String ECS_TARGET_PREFIX = "AmazonEC2ContainerServiceV20141113.";
+    private static final String ECS_CONTENT_TYPE = "application/x-amz-json-1.1";
+
+    private static String outputValue(String describeXml, String key) {
+        return describeXml.split("<OutputKey>" + key + "</OutputKey>")[1]
+                .split("<OutputValue>")[1].split("</OutputValue>")[0];
+    }
+
+    @Test
+    void createStack_withEcsClusterTaskDefAndService() {
+        String template = """
+            {
+              "Resources": {
+                "EcsCluster": {
+                  "Type": "AWS::ECS::Cluster",
+                  "Properties": { "ClusterName": "cfn-ecs-cluster" }
+                },
+                "TaskDef": {
+                  "Type": "AWS::ECS::TaskDefinition",
+                  "Properties": {
+                    "Family": "cfn-ecs-taskdef",
+                    "Cpu": "256",
+                    "Memory": "512",
+                    "NetworkMode": "awsvpc",
+                    "TaskRoleArn": "arn:aws:iam::000000000000:role/cfn-ecs-task-role",
+                    "ExecutionRoleArn": "arn:aws:iam::000000000000:role/cfn-ecs-exec-role",
+                    "ContainerDefinitions": [
+                      {
+                        "Name": "web",
+                        "Image": "nginx:latest",
+                        "Essential": true,
+                        "Cpu": 128,
+                        "Memory": 256,
+                        "PortMappings": [ { "ContainerPort": 80, "Protocol": "tcp" } ],
+                        "Environment": [ { "Name": "STAGE", "Value": "test" } ]
+                      }
+                    ]
+                  }
+                },
+                "EcsService": {
+                  "Type": "AWS::ECS::Service",
+                  "Properties": {
+                    "ServiceName": "cfn-ecs-service",
+                    "Cluster": { "Ref": "EcsCluster" },
+                    "TaskDefinition": { "Ref": "TaskDef" },
+                    "DesiredCount": 2,
+                    "LaunchType": "FARGATE",
+                    "NetworkConfiguration": {
+                      "AwsvpcConfiguration": {
+                        "Subnets": ["subnet-aaa", "subnet-bbb"],
+                        "SecurityGroups": ["sg-123"],
+                        "AssignPublicIp": "ENABLED"
+                      }
+                    }
+                  }
+                }
+              },
+              "Outputs": {
+                "ClusterRef": { "Value": { "Ref": "EcsCluster" } },
+                "ClusterArn": { "Value": { "Fn::GetAtt": ["EcsCluster", "Arn"] } },
+                "TaskDefRef": { "Value": { "Ref": "TaskDef" } },
+                "ServiceRef": { "Value": { "Ref": "EcsService" } },
+                "ServiceName": { "Value": { "Fn::GetAtt": ["EcsService", "Name"] } },
+                "ServiceArn": { "Value": { "Fn::GetAtt": ["EcsService", "ServiceArn"] } }
+              }
+            }
+            """;
+
+        String stackName = "cfn-ecs-stack";
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        String describeXml = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"))
+            .extract().asString();
+
+        // Ref/GetAtt parity with AWS CloudFormation:
+        //  - Cluster Ref = name, GetAtt Arn = ARN
+        //  - TaskDefinition Ref = full ARN including revision
+        //  - Service Ref = ARN; GetAtt Name = service name, GetAtt ServiceArn = ARN
+        assertThat(outputValue(describeXml, "ClusterRef"), equalTo("cfn-ecs-cluster"));
+        assertThat(outputValue(describeXml, "ClusterArn"),
+                equalTo("arn:aws:ecs:us-east-1:000000000000:cluster/cfn-ecs-cluster"));
+        assertThat(outputValue(describeXml, "TaskDefRef"),
+                equalTo("arn:aws:ecs:us-east-1:000000000000:task-definition/cfn-ecs-taskdef:1"));
+        String serviceArn = "arn:aws:ecs:us-east-1:000000000000:service/cfn-ecs-cluster/cfn-ecs-service";
+        assertThat(outputValue(describeXml, "ServiceRef"), equalTo(serviceArn));
+        assertThat(outputValue(describeXml, "ServiceArn"), equalTo(serviceArn));
+        assertThat(outputValue(describeXml, "ServiceName"), equalTo("cfn-ecs-service"));
+
+        // Task definition carries role ARNs (Part 5a) and container definitions
+        given()
+            .header("X-Amz-Target", ECS_TARGET_PREFIX + "DescribeTaskDefinition")
+            .contentType(ECS_CONTENT_TYPE)
+            .body("{\"taskDefinition\": \"cfn-ecs-taskdef\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("taskDefinition.family", equalTo("cfn-ecs-taskdef"))
+            .body("taskDefinition.networkMode", equalTo("awsvpc"))
+            .body("taskDefinition.taskRoleArn", equalTo("arn:aws:iam::000000000000:role/cfn-ecs-task-role"))
+            .body("taskDefinition.executionRoleArn", equalTo("arn:aws:iam::000000000000:role/cfn-ecs-exec-role"))
+            .body("taskDefinition.containerDefinitions[0].name", equalTo("web"))
+            .body("taskDefinition.containerDefinitions[0].image", equalTo("nginx:latest"))
+            .body("taskDefinition.containerDefinitions[0].portMappings[0].containerPort", equalTo(80))
+            .body("taskDefinition.containerDefinitions[0].environment[0].name", equalTo("STAGE"));
+
+        // Service carries desiredCount and network configuration (Part 5b)
+        given()
+            .header("X-Amz-Target", ECS_TARGET_PREFIX + "DescribeServices")
+            .contentType(ECS_CONTENT_TYPE)
+            .body("{\"cluster\": \"cfn-ecs-cluster\", \"services\": [\"cfn-ecs-service\"]}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("services[0].serviceName", equalTo("cfn-ecs-service"))
+            .body("services[0].desiredCount", equalTo(2))
+            .body("services[0].launchType", equalTo("FARGATE"))
+            .body("services[0].networkConfiguration.awsvpcConfiguration.subnets", hasItem("subnet-aaa"))
+            .body("services[0].networkConfiguration.awsvpcConfiguration.securityGroups", hasItem("sg-123"))
+            .body("services[0].networkConfiguration.awsvpcConfiguration.assignPublicIp", equalTo("ENABLED"));
+    }
+
+    @Test
+    void updateStack_ecsService_registersNewTaskDefRevisionAndUpdatesDesiredCount() {
+        String stackName = "cfn-ecs-update-stack";
+        String template = """
+            {
+              "Resources": {
+                "EcsCluster": {
+                  "Type": "AWS::ECS::Cluster",
+                  "Properties": { "ClusterName": "cfn-ecs-update-cluster" }
+                },
+                "TaskDef": {
+                  "Type": "AWS::ECS::TaskDefinition",
+                  "Properties": {
+                    "Family": "cfn-ecs-update-taskdef",
+                    "ContainerDefinitions": [
+                      { "Name": "app", "Image": "%s", "Essential": true }
+                    ]
+                  }
+                },
+                "EcsService": {
+                  "Type": "AWS::ECS::Service",
+                  "Properties": {
+                    "ServiceName": "cfn-ecs-update-service",
+                    "Cluster": { "Ref": "EcsCluster" },
+                    "TaskDefinition": { "Ref": "TaskDef" },
+                    "DesiredCount": %d,
+                    "LaunchType": "FARGATE"
+                  }
+                }
+              },
+              "Outputs": {
+                "TaskDefRef": { "Value": { "Ref": "TaskDef" } }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template.formatted("app:v1", 1))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String createXml = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().asString();
+        assertThat(outputValue(createXml, "TaskDefRef"),
+                equalTo("arn:aws:ecs:us-east-1:000000000000:task-definition/cfn-ecs-update-taskdef:1"));
+
+        // Update: new container image registers a fresh revision; desiredCount changes 1 -> 3
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "UpdateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template.formatted("app:v2", 3))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String updateXml = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().asString();
+        assertThat(outputValue(updateXml, "TaskDefRef"),
+                equalTo("arn:aws:ecs:us-east-1:000000000000:task-definition/cfn-ecs-update-taskdef:2"));
+
+        given()
+            .header("X-Amz-Target", ECS_TARGET_PREFIX + "DescribeServices")
+            .contentType(ECS_CONTENT_TYPE)
+            .body("{\"cluster\": \"cfn-ecs-update-cluster\", \"services\": [\"cfn-ecs-update-service\"]}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("services[0].desiredCount", equalTo(3))
+            .body("services[0].taskDefinition",
+                    equalTo("arn:aws:ecs:us-east-1:000000000000:task-definition/cfn-ecs-update-taskdef:2"));
+    }
+
+    @Test
+    void deleteStack_ecs_leavesNoOrphans() {
+        String stackName = "cfn-ecs-delete-stack";
+        String template = """
+            {
+              "Resources": {
+                "EcsCluster": {
+                  "Type": "AWS::ECS::Cluster",
+                  "Properties": { "ClusterName": "cfn-ecs-delete-cluster" }
+                },
+                "TaskDef": {
+                  "Type": "AWS::ECS::TaskDefinition",
+                  "Properties": {
+                    "Family": "cfn-ecs-delete-taskdef",
+                    "ContainerDefinitions": [
+                      { "Name": "app", "Image": "app:latest", "Essential": true }
+                    ]
+                  }
+                },
+                "EcsService": {
+                  "Type": "AWS::ECS::Service",
+                  "Properties": {
+                    "ServiceName": "cfn-ecs-delete-service",
+                    "Cluster": { "Ref": "EcsCluster" },
+                    "TaskDefinition": { "Ref": "TaskDef" },
+                    "DesiredCount": 0,
+                    "LaunchType": "FARGATE"
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Sanity: cluster exists before delete
+        given()
+            .header("X-Amz-Target", ECS_TARGET_PREFIX + "DescribeClusters")
+            .contentType(ECS_CONTENT_TYPE)
+            .body("{\"clusters\": [\"cfn-ecs-delete-cluster\"]}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("clusters[0].clusterName", equalTo("cfn-ecs-delete-cluster"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DeleteStack")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Cluster is gone (deleted in reverse order, after the service)
+        given()
+            .header("X-Amz-Target", ECS_TARGET_PREFIX + "DescribeClusters")
+            .contentType(ECS_CONTENT_TYPE)
+            .body("{\"clusters\": [\"cfn-ecs-delete-cluster\"]}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("clusters", org.hamcrest.Matchers.empty());
+
+        // Task definition is deregistered (INACTIVE)
+        given()
+            .header("X-Amz-Target", ECS_TARGET_PREFIX + "DescribeTaskDefinition")
+            .contentType(ECS_CONTENT_TYPE)
+            .body("{\"taskDefinition\": \"cfn-ecs-delete-taskdef\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("taskDefinition.status", equalTo("INACTIVE"));
+    }
 }


### PR DESCRIPTION
## Summary 

**What** — Provision `AWS::ECS::{Cluster,TaskDefinition,Service}` through CloudFormation instead of the synthetic stub branch. Adds Ref/GetAtt parity (Cluster Ref=name + `Arn`; TaskDefinition Ref=ARN, immutable→new revision per update; Service Ref=ARN + `Name`/`ServiceArn`), orphan-free delete, and the service gaps real CDK templates need: TaskDefinition `taskRoleArn`/`executionRoleArn` and Service `NetworkConfiguration` (awsvpc subnets/security groups/assignPublicIp) via new `NetworkConfiguration`/`AwsVpcConfiguration` models, surfaced in describe.

**Why** — ECS resource types fell through to the synthetic stub (synthetic id + `arn:aws:stub:::`), so CDK/CFN couldn't really create/update/delete them.

**Services** — cloudformation, ecs

**Tests** — `CloudFormationIntegrationTest`: create (cluster+task def+service), update (new task-def revision + desiredCount), delete-no-orphans.

**Refs** — #924

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
