### PR TITLE
fix(cloudformation): roll back failed stack creates

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
@@ -357,6 +357,7 @@ public class CloudFormationService {
                 }
             }
 
+            StackResource failedResource = null;
             if (resources.isObject()) {
                 List<String> sortedLogicalIds = topologicalSort(resources, conditions);
 
@@ -395,7 +396,20 @@ public class CloudFormationService {
 
                     addEvent(stack, logicalId, resource.getPhysicalId(), type,
                             resource.getStatus(), resource.getStatusReason());
+
+                    if ("CREATE_FAILED".equals(resource.getStatus())
+                            || "UPDATE_FAILED".equals(resource.getStatus())) {
+                        failedResource = resource;
+                        break;
+                    }
                 }
+            }
+
+            // A resource failed to provision: stop, and (on create) roll back what we built so a
+            // corrected re-deploy starts from a clean slate (acceptance criterion #9).
+            if (failedResource != null) {
+                rollbackFailedExecution(stack, region, isCreate, failedResource);
+                return;
             }
 
             CloudFormationTemplateEngine finalEngine = new CloudFormationTemplateEngine(
@@ -458,6 +472,61 @@ public class CloudFormationService {
             addEvent(stack, stack.getStackName(), stack.getStackId(),
                     "AWS::CloudFormation::Stack", failStatus, e.getMessage());
             persistStack(stack);
+        }
+    }
+
+    /**
+     * Handles a resource that failed to provision.
+     *
+     * <p>On a <b>create</b>, rolls back by deleting the resources that were successfully created in
+     * this execution, leaving a clean slate ({@code ROLLBACK_COMPLETE}) so a corrected re-deploy can
+     * start from scratch. On an <b>update</b>, marks {@code UPDATE_ROLLBACK_COMPLETE} and keeps the
+     * prior physical IDs so a corrected re-deploy proceeds (full prior-template restoration is out
+     * of scope — see plan Part 7).
+     */
+    private void rollbackFailedExecution(Stack stack, String region, boolean isCreate,
+                                         StackResource failedResource) {
+        String failStatus = isCreate ? "CREATE_FAILED" : "UPDATE_FAILED";
+        stack.setStatus(failStatus);
+        stack.setStatusReason(failedResource.getStatusReason());
+        addEvent(stack, stack.getStackName(), stack.getStackId(),
+                "AWS::CloudFormation::Stack", failStatus, failedResource.getStatusReason());
+        LOG.warnv("Stack {0} resource {1} failed: {2}", stack.getStackName(),
+                failedResource.getLogicalId(), failedResource.getStatusReason());
+
+        if (isCreate) {
+            stack.setStatus("ROLLBACK_IN_PROGRESS");
+            addEvent(stack, stack.getStackName(), stack.getStackId(),
+                    "AWS::CloudFormation::Stack", "ROLLBACK_IN_PROGRESS", failedResource.getStatusReason());
+            rollbackCreatedResources(stack, region);
+            stack.setStatus("ROLLBACK_COMPLETE");
+            stack.setLastUpdatedTime(now());
+            addEvent(stack, stack.getStackName(), stack.getStackId(),
+                    "AWS::CloudFormation::Stack", "ROLLBACK_COMPLETE", null);
+            LOG.infov("Stack {0} rolled back to a clean slate (ROLLBACK_COMPLETE)", stack.getStackName());
+        } else {
+            stack.setStatus("UPDATE_ROLLBACK_COMPLETE");
+            stack.setLastUpdatedTime(now());
+            addEvent(stack, stack.getStackName(), stack.getStackId(),
+                    "AWS::CloudFormation::Stack", "UPDATE_ROLLBACK_COMPLETE", null);
+            LOG.infov("Stack {0} update rolled back (UPDATE_ROLLBACK_COMPLETE)", stack.getStackName());
+        }
+        persistStack(stack);
+    }
+
+    /** Deletes every resource successfully created in this execution, in reverse order. */
+    private void rollbackCreatedResources(Stack stack, String region) {
+        List<StackResource> resources = new ArrayList<>(stack.getResources().values());
+        Collections.reverse(resources);
+        for (StackResource resource : resources) {
+            if (resource.getPhysicalId() != null && "CREATE_COMPLETE".equals(resource.getStatus())) {
+                addEvent(stack, resource.getLogicalId(), resource.getPhysicalId(),
+                        resource.getResourceType(), "DELETE_IN_PROGRESS", null);
+                provisioner.delete(resource.getResourceType(), resource.getPhysicalId(), region);
+                resource.setStatus("DELETE_COMPLETE");
+                addEvent(stack, resource.getLogicalId(), resource.getPhysicalId(),
+                        resource.getResourceType(), "DELETE_COMPLETE", null);
+            }
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -5634,4 +5634,151 @@ class CloudFormationIntegrationTest {
             .statusCode(200);
     }
 
+    // ── Issue #924: roll back failed stack creates (criterion #9) ────────────
+
+    @Test
+    void createStack_resourceFailure_rollsBackCreatedResourcesThenRetrySucceeds() {
+        // GoodBucket provisions first (DependsOn forces ordering); BadSecret then fails because
+        // it sets both SecretString and GenerateSecretString. The successful bucket must be rolled
+        // back so a corrected re-deploy starts from a clean slate.
+        String failingTemplate = """
+            {
+              "Resources": {
+                "GoodBucket": {
+                  "Type": "AWS::S3::Bucket",
+                  "Properties": { "BucketName": "cfn-rollback-bucket" }
+                },
+                "BadSecret": {
+                  "Type": "AWS::SecretsManager::Secret",
+                  "DependsOn": "GoodBucket",
+                  "Properties": {
+                    "Name": "cfn-rollback-secret",
+                    "SecretString": "explicit",
+                    "GenerateSecretString": { "PasswordLength": 32 }
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-rollback-stack")
+            .formParam("TemplateBody", failingTemplate)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // The stack rolled back rather than being left half-built
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-rollback-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>ROLLBACK_COMPLETE</StackStatus>"));
+
+        // The bucket that was successfully created is gone again — rollback cleaned it up
+        given()
+            .header("Host", "cfn-rollback-bucket.localhost")
+        .when()
+            .get("/")
+        .then()
+            .statusCode(404);
+
+        // A corrected re-deploy (no failing resource) succeeds on the now-clean slate
+        String goodTemplate = """
+            {
+              "Resources": {
+                "GoodBucket": {
+                  "Type": "AWS::S3::Bucket",
+                  "Properties": { "BucketName": "cfn-rollback-bucket" }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-rollback-retry-stack")
+            .formParam("TemplateBody", goodTemplate)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-rollback-retry-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        // The bucket now exists again, provisioned by the successful retry
+        given()
+            .header("Host", "cfn-rollback-bucket.localhost")
+        .when()
+            .get("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    void createStack_resourceFailure_setsRollbackComplete_singleResource() {
+        // A lone failing resource still moves the stack to ROLLBACK_COMPLETE (no orphaned state).
+        String template = """
+            {
+              "Resources": {
+                "BadSecret": {
+                  "Type": "AWS::SecretsManager::Secret",
+                  "Properties": {
+                    "Name": "cfn-rollback-lone-secret",
+                    "SecretString": "explicit",
+                    "GenerateSecretString": { "PasswordLength": 32 }
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-rollback-lone-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-rollback-lone-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>ROLLBACK_COMPLETE</StackStatus>"));
+
+        // The failed resource is still reported as CREATE_FAILED in the resource list
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStackResources")
+            .formParam("StackName", "cfn-rollback-lone-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("CREATE_FAILED"));
+    }
+
 }


### PR DESCRIPTION
## Summary

**What** — A resource that fails to provision now stops the run instead of being silently ignored. On a create, the resources already created in that execution are deleted so the stack ends `ROLLBACK_COMPLETE` on a clean slate and a corrected re-deploy can succeed. Updates mark `UPDATE_ROLLBACK_COMPLETE` and keep prior physical ids (full prior-template restoration is out of scope).

**Why** — Failed resources previously left the stack at `CREATE_COMPLETE` and half-built, so retries couldn't succeed.

**Services** — cloudformation

**Tests** — `CloudFormationIntegrationTest`: rollback deletes created resources then a corrected retry succeeds; single-failed-resource → `ROLLBACK_COMPLETE`.

**Refs** — #924

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
