### PR TITLE
feat(cloudformation): persist stacks across restart

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
@@ -5,13 +5,18 @@ import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.dns.EmbeddedDnsServer;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.cloudformation.model.ChangeSet;
 import io.github.hectorvent.floci.services.cloudformation.model.Stack;
 import io.github.hectorvent.floci.services.cloudformation.model.StackEvent;
 import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -49,10 +54,19 @@ public class CloudFormationService {
     private final SamTransformProcessor samTransformProcessor;
     private final Clock clock;
 
+    // Persisted state so stacks survive a restart (criteria #10, #11). The in-memory maps above are
+    // the live working copy; these backends are write-through + loaded on startup. CloudFormation is
+    // account-blind (keyed by stack+region), so everything is stored under one fixed account
+    // namespace for thread-consistent access from both request and background executor threads.
+    private final AccountAwareStorageBackend<Stack> stackBackend;
+    private final AccountAwareStorageBackend<String> exportBackend;
+    private final String storageAccount;
+
     @Inject
     public CloudFormationService(CloudFormationResourceProvisioner provisioner, S3Service s3Service,
                                  ObjectMapper objectMapper, EmulatorConfig config,
-                                 RegionResolver regionResolver, Clock clock) {
+                                 RegionResolver regionResolver, Clock clock,
+                                 StorageFactory storageFactory) {
         this.provisioner = provisioner;
         this.s3Service = s3Service;
         this.objectMapper = objectMapper;
@@ -60,6 +74,39 @@ public class CloudFormationService {
         this.regionResolver = regionResolver;
         this.samTransformProcessor = new SamTransformProcessor(objectMapper);
         this.clock = clock;
+        this.storageAccount = config.defaultAccountId();
+        this.stackBackend = asAccountAware(storageFactory.create(
+                "cloudformation", "cloudformation-stacks.json", new TypeReference<Map<String, Stack>>() {}));
+        this.exportBackend = asAccountAware(storageFactory.create(
+                "cloudformation", "cloudformation-exports.json", new TypeReference<Map<String, String>>() {}));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <V> AccountAwareStorageBackend<V> asAccountAware(StorageBackend<String, V> backend) {
+        return (AccountAwareStorageBackend<V>) backend;
+    }
+
+    @PostConstruct
+    void loadPersistedState() {
+        for (Stack stack : stackBackend.scanForAccount(storageAccount, k -> true)) {
+            stacks.put(key(stack.getStackName(), stack.getRegion()), stack);
+        }
+        for (String exportKey : exportBackend.keysForAccount(storageAccount)) {
+            exportBackend.getForAccount(storageAccount, exportKey)
+                    .ifPresent(value -> exports.put(exportKey, value));
+        }
+        if (!stacks.isEmpty() || !exports.isEmpty()) {
+            LOG.infov("Loaded {0} CloudFormation stack(s) and {1} export(s) from storage",
+                    stacks.size(), exports.size());
+        }
+    }
+
+    private void persistStack(Stack stack) {
+        stackBackend.putForAccount(storageAccount, key(stack.getStackName(), stack.getRegion()), stack);
+    }
+
+    private void unpersistStack(String stackName, String region) {
+        stackBackend.deleteForAccount(storageAccount, key(stackName, region));
     }
 
     // ── DescribeStacks ────────────────────────────────────────────────────────
@@ -106,6 +153,7 @@ public class CloudFormationService {
         cs.setExecutionStatus("AVAILABLE");
 
         stack.getChangeSets().put(changeSetName, cs);
+        persistStack(stack);
         return cs;
     }
 
@@ -138,6 +186,7 @@ public class CloudFormationService {
         stack.setLastUpdatedTime(now());
         addEvent(stack, stack.getStackName(), stack.getStackId(),
                 "AWS::CloudFormation::Stack", isCreate ? "CREATE_IN_PROGRESS" : "UPDATE_IN_PROGRESS", null);
+        persistStack(stack);
 
         String templateBody = cs.getTemplateBody();
         Map<String, String> params = cs.getParameters() != null ? cs.getParameters() : Map.of();
@@ -157,6 +206,7 @@ public class CloudFormationService {
                     "ChangeSet [" + changeSetName + "] does not exist", 400);
         }
         stack.getChangeSets().remove(name);
+        persistStack(stack);
     }
 
     // ── DeleteStack ───────────────────────────────────────────────────────────
@@ -231,7 +281,9 @@ public class CloudFormationService {
 
     private void removeStackExports(Stack stack, String region) {
         for (String exportName : stack.getExports().keySet()) {
-            exports.remove(exportKey(region, exportName));
+            String exportKey = exportKey(region, exportName);
+            exports.remove(exportKey);
+            exportBackend.deleteForAccount(storageAccount, exportKey);
         }
     }
 
@@ -383,7 +435,9 @@ public class CloudFormationService {
             stack.getOutputExportNames().clear();
             stack.getOutputExportNames().putAll(newOutputExportNames);
             newExports.forEach((exportName, value) -> {
-                exports.put(exportKey(region, exportName), value);
+                String exportKey = exportKey(region, exportName);
+                exports.put(exportKey, value);
+                exportBackend.putForAccount(storageAccount, exportKey, value);
                 LOG.infov("Registered export {0} = {1} from stack {2}",
                         exportName, value, stack.getStackName());
             });
@@ -393,6 +447,7 @@ public class CloudFormationService {
             stack.setLastUpdatedTime(now());
             addEvent(stack, stack.getStackName(), stack.getStackId(),
                     "AWS::CloudFormation::Stack", completeStatus, null);
+            persistStack(stack);
             LOG.infov("Stack {0} execution complete: {1}", stack.getStackName(), completeStatus);
 
         } catch (Exception e) {
@@ -402,6 +457,7 @@ public class CloudFormationService {
             stack.setStatusReason(e.getMessage());
             addEvent(stack, stack.getStackName(), stack.getStackId(),
                     "AWS::CloudFormation::Stack", failStatus, e.getMessage());
+            persistStack(stack);
         }
     }
 
@@ -426,6 +482,7 @@ public class CloudFormationService {
                     "AWS::CloudFormation::Stack", "DELETE_COMPLETE", null);
             removeStackExports(stack, region);
             stacks.remove(key(stack.getStackName(), region));
+            unpersistStack(stack.getStackName(), region);
             deletedStacks.put(stack.getStackId(), new DeletedStackEntry(
                     stack,
                     now().plusSeconds(config.services().cloudformation().deletedStackRetentionSeconds())));

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/model/ChangeSet.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/model/ChangeSet.java
@@ -1,9 +1,14 @@
 package io.github.hectorvent.floci.services.cloudformation.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ChangeSet {
     private String changeSetId;
     private String changeSetName;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/model/Stack.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/model/Stack.java
@@ -1,8 +1,13 @@
 package io.github.hectorvent.floci.services.cloudformation.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.*;
 
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Stack {
     private String stackId;
     private String stackName;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/model/StackEvent.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/model/StackEvent.java
@@ -1,8 +1,13 @@
 package io.github.hectorvent.floci.services.cloudformation.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.UUID;
 
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class StackEvent {
     private String eventId = UUID.randomUUID().toString();
     private String stackId;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/model/StackResource.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/model/StackResource.java
@@ -1,9 +1,14 @@
 package io.github.hectorvent.floci.services.cloudformation.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class StackResource {
     private String logicalId;
     private String physicalId;

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationPersistenceIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationPersistenceIntegrationTest.java
@@ -1,0 +1,98 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.core.storage.PersistentStorage;
+import io.github.hectorvent.floci.services.cloudformation.model.Stack;
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end check that a created stack is written to persistent storage so it survives a restart
+ * (criteria #10, #11). Runs with the {@code persistent} storage mode; verifies the on-disk file
+ * directly with a fresh {@link PersistentStorage} (what the service would read on the next boot).
+ */
+@QuarkusTest
+@TestProfile(CloudFormationPersistenceIntegrationTest.PersistentStorageProfile.class)
+class CloudFormationPersistenceIntegrationTest {
+
+    static final String STORAGE_DIR = "target/cfn-persistence-it";
+    private static final Path STACKS_FILE = Path.of(STORAGE_DIR, "cloudformation-stacks.json");
+
+    @BeforeAll
+    static void setup() throws Exception {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+        Files.deleteIfExists(STACKS_FILE);
+    }
+
+    @Test
+    void createdStackIsPersistedToDiskForRestart() {
+        String template = """
+            {
+              "Resources": {
+                "PersistBucket": {
+                  "Type": "AWS::S3::Bucket",
+                  "Properties": { "BucketName": "cfn-persist-it-bucket" }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "persist-it-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "persist-it-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        // Read the on-disk file the way a fresh Floci process would on the next boot.
+        var store = new PersistentStorage<String, Stack>(
+                STACKS_FILE, new TypeReference<Map<String, Stack>>() {});
+        store.load();
+
+        // Account-prefixed key: <defaultAccount>/<region>:<stackName>
+        Optional<Stack> loaded = store.get("000000000000/us-east-1:persist-it-stack");
+        assertTrue(loaded.isPresent(), "Stack must be written to persistent storage to survive a restart");
+        assertEquals("CREATE_COMPLETE", loaded.get().getStatus());
+        assertEquals("us-east-1", loaded.get().getRegion());
+        assertTrue(loaded.get().getResources().containsKey("PersistBucket"),
+                "Persisted stack must retain its resources");
+        assertEquals("cfn-persist-it-bucket",
+                loaded.get().getResources().get("PersistBucket").getPhysicalId());
+    }
+
+    public static final class PersistentStorageProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "floci.storage.mode", "persistent",
+                    "floci.storage.persistent-path", STORAGE_DIR);
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationStackPersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationStackPersistenceTest.java
@@ -1,0 +1,129 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.core.storage.PersistentStorage;
+import io.github.hectorvent.floci.services.cloudformation.model.ChangeSet;
+import io.github.hectorvent.floci.services.cloudformation.model.Stack;
+import io.github.hectorvent.floci.services.cloudformation.model.StackEvent;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the CloudFormation stack model graph survives a restart by round-tripping it through a
+ * fresh {@link PersistentStorage} instance (criteria #10, #11). Mirrors {@code RulePersistenceTest}.
+ */
+class CloudFormationStackPersistenceTest {
+
+    @TempDir
+    Path tempDir;
+
+    private static final String KEY = "000000000000/my-stack:us-east-1";
+
+    @Test
+    void stackGraphPersistsAcrossInstances() {
+        Path filePath = tempDir.resolve("cloudformation-stacks.json");
+
+        Stack stack = new Stack();
+        stack.setStackId("arn:aws:cloudformation:us-east-1:000000000000:stack/my-stack/abc123");
+        stack.setStackName("my-stack");
+        stack.setRegion("us-east-1");
+        stack.setStatus("CREATE_COMPLETE");
+        stack.setTemplateBody("{\"Resources\":{}}");
+        stack.getParameters().put("Env", "prod");
+        stack.getOutputs().put("BucketArn", "arn:aws:s3:::my-bucket");
+        stack.getExports().put("MyExport", "exported-value");
+        stack.getTags().put("team", "platform");
+
+        StackResource resource = new StackResource();
+        resource.setLogicalId("MyBucket");
+        resource.setPhysicalId("my-bucket");
+        resource.setResourceType("AWS::S3::Bucket");
+        resource.setStatus("CREATE_COMPLETE");
+        resource.getAttributes().put("Arn", "arn:aws:s3:::my-bucket");
+        stack.getResources().put("MyBucket", resource);
+
+        StackEvent event = new StackEvent();
+        event.setStackName("my-stack");
+        event.setLogicalResourceId("MyBucket");
+        event.setResourceStatus("CREATE_COMPLETE");
+        stack.getEvents().add(event);
+
+        ChangeSet changeSet = new ChangeSet();
+        changeSet.setChangeSetName("initial-create");
+        changeSet.setStackName("my-stack");
+        changeSet.setStatus("CREATE_COMPLETE");
+        stack.getChangeSets().put("initial-create", changeSet);
+
+        var writer = new PersistentStorage<String, Stack>(
+                filePath, new TypeReference<Map<String, Stack>>() {});
+        writer.put(KEY, stack);
+
+        // Fresh instance + load() simulates a Floci restart reading the same file
+        var reader = new PersistentStorage<String, Stack>(
+                filePath, new TypeReference<Map<String, Stack>>() {});
+        reader.load();
+
+        Optional<Stack> loadedOpt = reader.get(KEY);
+        assertTrue(loadedOpt.isPresent(), "Stack should survive a fresh PersistentStorage + load()");
+        Stack loaded = loadedOpt.get();
+
+        assertEquals("my-stack", loaded.getStackName());
+        assertEquals("us-east-1", loaded.getRegion());
+        assertEquals("CREATE_COMPLETE", loaded.getStatus());
+        assertEquals("arn:aws:cloudformation:us-east-1:000000000000:stack/my-stack/abc123", loaded.getStackId());
+        assertNotNull(loaded.getCreationTime(), "Instant fields must round-trip");
+        assertEquals("prod", loaded.getParameters().get("Env"));
+        assertEquals("arn:aws:s3:::my-bucket", loaded.getOutputs().get("BucketArn"));
+        assertEquals("exported-value", loaded.getExports().get("MyExport"));
+        assertEquals("platform", loaded.getTags().get("team"));
+
+        StackResource loadedResource = loaded.getResources().get("MyBucket");
+        assertNotNull(loadedResource, "Nested stack resources must round-trip");
+        assertEquals("my-bucket", loadedResource.getPhysicalId());
+        assertEquals("AWS::S3::Bucket", loadedResource.getResourceType());
+        assertEquals("CREATE_COMPLETE", loadedResource.getStatus());
+        assertEquals("arn:aws:s3:::my-bucket", loadedResource.getAttributes().get("Arn"));
+
+        assertEquals(1, loaded.getEvents().size());
+        assertEquals("CREATE_COMPLETE", loaded.getEvents().get(0).getResourceStatus());
+        assertTrue(loaded.getChangeSets().containsKey("initial-create"));
+        assertEquals("CREATE_COMPLETE", loaded.getChangeSets().get("initial-create").getStatus());
+    }
+
+    @Test
+    void ignoresUnknownPropertiesOnLoad() throws Exception {
+        // A persisted file may contain fields a newer/older Floci version does not recognize.
+        // Loading must not fail (forward/backward compatibility).
+        Path filePath = tempDir.resolve("cloudformation-stacks.json");
+        String legacyJson = """
+                {
+                  "%s" : {
+                    "stackName" : "legacy-stack",
+                    "region" : "us-east-1",
+                    "status" : "CREATE_COMPLETE",
+                    "fieldFromFutureVersion" : "whatever"
+                  }
+                }
+                """.formatted(KEY);
+        Files.writeString(filePath, legacyJson);
+
+        var store = new PersistentStorage<String, Stack>(
+                filePath, new TypeReference<Map<String, Stack>>() {});
+        store.load();
+
+        Optional<Stack> loaded = store.get(KEY);
+        assertTrue(loaded.isPresent(), "Stacks with unknown extra fields should still load");
+        assertEquals("legacy-stack", loaded.get().getStackName());
+        assertEquals("CREATE_COMPLETE", loaded.get().getStatus());
+    }
+}


### PR DESCRIPTION
## Summary

**What** — Back the `stacks` and `exports` registries with `StorageFactory` (`cloudformation-stacks.json` / `cloudformation-exports.json`). The in-memory maps stay the live working copy with write-through at each lifecycle checkpoint and a load on startup; everything is stored under one fixed account namespace (CloudFormation is account-blind), consistent across request and background executor threads. `Stack`/`StackResource`/`ChangeSet`/`StackEvent` are now reflection- and unknown-field-tolerant. Follows the configured global storage mode.

**Why** — Stacks lived only in memory, so after a Floci restart CloudFormation forgot every stack and `cdk deploy`/`destroy` could no longer find them, orphaning the underlying resources.

**Services** — cloudformation

**Tests** — full stack-graph round-trip across fresh storage instances; end-to-end persistent-mode check that a created stack is written to disk under the expected key.

**Refs** — #924

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
