### PR TITLE
fix(eventbridge): propagate PutEvents call region and account through pattern matching and delivered envelope

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -618,7 +618,22 @@ public class EventBridgeService {
         int failed = 0;
         List<Map<String, String>> resultEntries = new ArrayList<>();
 
-        for (Map<String, Object> entry : entries) {
+        for (Map<String, Object> originalEntry : entries) {
+            // Defensive copy: callers may pass Map.of(...) (immutable) and we don't want to
+            // mutate caller state regardless. Normalize Region / Account from the PutEvents
+            // call context up front so matchesPattern, buildEventEnvelope, and the archive
+            // capture all see the same values — without this, a pattern's region/account
+            // filter would fall back to the resolver default in matchesPattern while the
+            // delivered envelope would correctly carry the call's region/account, giving an
+            // inconsistent observable.
+            Map<String, Object> entry = new HashMap<>(originalEntry);
+            if (isBlank(entry.get("Region"))) {
+                entry.put("Region", region);
+            }
+            if (isBlank(entry.get("Account"))) {
+                entry.put("Account", accountId != null ? accountId : regionResolver.getAccountId());
+            }
+
             String eventBusNameRaw = (String) entry.get("EventBusName");
             String effectiveBus = resolvedBusName(eventBusNameRaw);
             String busStoreKey = busKey(region, effectiveBus);
@@ -645,7 +660,7 @@ public class EventBridgeService {
                 if (matchesPattern(entry, rule.getEventPattern())) {
                     String ruleKey = ruleKey(region, effectiveBus, rule.getName());
                     List<Target> targets = accountGet(targetStore, accountId, ruleKey).orElse(List.of());
-                    String eventJson = buildEventEnvelope(entry, effectiveBus, eventId);
+                    String eventJson = buildEventEnvelope(entry, effectiveBus, eventId, region, accountId);
                     for (Target target : targets) {
                         invoker.invokeTarget(target, eventJson, region);
                     }
@@ -900,20 +915,37 @@ public class EventBridgeService {
     // ──────────────────────────── Target Routing ────────────────────────────
 
 
-    private String buildEventEnvelope(Map<String, Object> entry, String busName, String eventId) {
+    private String buildEventEnvelope(Map<String, Object> entry, String busName, String eventId,
+                                      String callRegion, String callAccountId) {
         try {
             String source = (String) entry.getOrDefault("Source", "");
             String detailType = (String) entry.getOrDefault("DetailType", "");
             String detail = (String) entry.getOrDefault("Detail", "{}");
             ArrayNode resources = (ArrayNode) entry.getOrDefault("Resources", objectMapper.createArrayNode());
+            // Envelope region/account precedence: entry-supplied "Region"/"Account" (set by
+            // archive replay paths and cross-region producers) wins; otherwise stamp the
+            // region/account the PutEvents call was made against. Only when neither is
+            // available do we fall back to the RegionResolver defaults. This keeps the
+            // envelope consistent with matchesPattern() which also reads entry.Region with
+            // the same fallback chain.
+            String envelopeRegion = (String) entry.get("Region");
+            if (isBlank(envelopeRegion)) {
+                envelopeRegion = isBlank(callRegion)
+                        ? regionResolver.getDefaultRegion() : callRegion;
+            }
+            String envelopeAccount = (String) entry.get("Account");
+            if (isBlank(envelopeAccount)) {
+                envelopeAccount = isBlank(callAccountId)
+                        ? regionResolver.getAccountId() : callAccountId;
+            }
             ObjectNode node = objectMapper.createObjectNode();
             node.put("version", "0");
             node.put("id", eventId);
             node.put("source", source);
             node.put("detail-type", detailType);
-            node.put("account", regionResolver.getAccountId());
+            node.put("account", envelopeAccount);
             node.put("time", Instant.now().toString());
-            node.put("region", regionResolver.getDefaultRegion());
+            node.put("region", envelopeRegion);
             node.putArray("resources").addAll(resources);
             node.set("detail", objectMapper.readTree(detail));
             node.put("event-bus-name", busName);
@@ -939,6 +971,10 @@ public class EventBridgeService {
         busStore.get(busKey(region, busName))
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
                         "EventBus not found: " + busName, 404));
+    }
+
+    private static boolean isBlank(Object value) {
+        return !(value instanceof String s) || s.isBlank();
     }
 
     private static String resolvedBusName(String busName) {

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -628,10 +628,10 @@ public class EventBridgeService {
             // inconsistent observable.
             Map<String, Object> entry = new HashMap<>(originalEntry);
             if (isBlank(entry.get("Region"))) {
-                entry.put("Region", region);
+                entry.put("Region", isBlank(region) ? regionResolver.getDefaultRegion() : region);
             }
             if (isBlank(entry.get("Account"))) {
-                entry.put("Account", accountId != null ? accountId : regionResolver.getAccountId());
+                entry.put("Account", isBlank(accountId) ? regionResolver.getAccountId() : accountId);
             }
 
             String eventBusNameRaw = (String) entry.get("EventBusName");

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -930,13 +930,11 @@ public class EventBridgeService {
             // the same fallback chain.
             String envelopeRegion = (String) entry.get("Region");
             if (isBlank(envelopeRegion)) {
-                envelopeRegion = isBlank(callRegion)
-                        ? regionResolver.getDefaultRegion() : callRegion;
+                envelopeRegion = isBlank(callRegion) ? regionResolver.getDefaultRegion() : callRegion;
             }
             String envelopeAccount = (String) entry.get("Account");
             if (isBlank(envelopeAccount)) {
-                envelopeAccount = isBlank(callAccountId)
-                        ? regionResolver.getAccountId() : callAccountId;
+                envelopeAccount = isBlank(callAccountId) ? regionResolver.getAccountId() : callAccountId;
             }
             ObjectNode node = objectMapper.createObjectNode();
             node.put("version", "0");

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeServiceTest.java
@@ -618,4 +618,127 @@ class EventBridgeServiceTest {
         assertFalse(service.matchesPattern(event,
                 "{\"source\":[\"my.app\"],\"account\":[\"999999999999\"],\"detail\":{\"status\":[\"CONFIRMED\"]}}"));
     }
+
+    // ─────────────── Envelope region/account propagation ───────────────
+
+    @Test
+    void putEvents_envelopeRegionMatchesPutEventsCallRegion() throws Exception {
+        service.putRule("my-rule", null, "{\"source\":[\"my.app\"]}", null, RuleState.ENABLED,
+                "A test rule", null, null, "eu-west-1");
+        Target target = new Target();
+        target.setId("t1");
+        target.setArn("arn:aws:sqs:eu-west-1:000000000000:my-queue");
+        service.putTargets("my-rule", null, List.of(target), "eu-west-1");
+
+        List<Map<String, Object>> entries = List.of(
+                Map.of("Source", "my.app", "DetailType", "Test", "Detail", "{}")
+        );
+
+        EventBridgeService.PutEventsResult result = service.putEvents(entries, "eu-west-1");
+        assertEquals(0, result.failedCount());
+
+        org.mockito.ArgumentCaptor<String> json = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(invokerMock).invokeTarget(eq(target), json.capture(), eq("eu-west-1"));
+        com.fasterxml.jackson.databind.JsonNode envelope = OBJECT_MAPPER.readTree(json.getValue());
+        assertEquals("eu-west-1", envelope.path("region").asText(),
+                "envelope.region should reflect the PutEvents call's region, not the resolver default");
+        assertEquals("000000000000", envelope.path("account").asText());
+    }
+
+    @Test
+    void putEvents_envelopeRegionFromEntryWinsOverCallRegion() throws Exception {
+        // Simulates the archive-replay path which stamps "Region" / "Account" on the
+        // re-emitted entry from the originating event's envelope.
+        service.putRule("my-rule", null, "{\"source\":[\"my.app\"]}", null, RuleState.ENABLED,
+                null, null, null, "us-west-2");
+        Target target = new Target();
+        target.setId("t1");
+        target.setArn("arn:aws:sqs:us-west-2:000000000000:replay-queue");
+        service.putTargets("my-rule", null, List.of(target), "us-west-2");
+
+        java.util.Map<String, Object> entry = new java.util.HashMap<>();
+        entry.put("Source", "my.app");
+        entry.put("DetailType", "Test");
+        entry.put("Detail", "{}");
+        entry.put("Region", "ap-northeast-1");
+        entry.put("Account", "111111111111");
+
+        service.putEvents(List.of(entry), "us-west-2");
+
+        org.mockito.ArgumentCaptor<String> json = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(invokerMock).invokeTarget(eq(target), json.capture(), eq("us-west-2"));
+        com.fasterxml.jackson.databind.JsonNode envelope = OBJECT_MAPPER.readTree(json.getValue());
+        assertEquals("ap-northeast-1", envelope.path("region").asText(),
+                "entry.Region should win over the PutEvents call region");
+        assertEquals("111111111111", envelope.path("account").asText(),
+                "entry.Account should win over the resolver default");
+    }
+
+    @Test
+    void putEvents_matchesPatternUsesCallRegionForRegionFilter() throws Exception {
+        // A rule with a region-filter for the call region (eu-west-1) must match a
+        // PutEvents entry that didn't supply Region — the entry should be normalized to
+        // the call region before matchesPattern() sees it. Without the normalization the
+        // pattern's region filter would compare against the resolver default (us-east-1)
+        // and the rule would miss.
+        service.putRule("region-filtered", null,
+                "{\"source\":[\"my.app\"],\"region\":[\"eu-west-1\"]}",
+                null, RuleState.ENABLED, null, null, null, "eu-west-1");
+        Target target = new Target();
+        target.setId("t1");
+        target.setArn("arn:aws:sqs:eu-west-1:000000000000:filtered-queue");
+        service.putTargets("region-filtered", null, List.of(target), "eu-west-1");
+
+        service.putEvents(List.of(
+                Map.of("Source", "my.app", "DetailType", "Test", "Detail", "{}")), "eu-west-1");
+
+        org.mockito.ArgumentCaptor<String> json = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(invokerMock).invokeTarget(eq(target), json.capture(), eq("eu-west-1"));
+        com.fasterxml.jackson.databind.JsonNode envelope = OBJECT_MAPPER.readTree(json.getValue());
+        assertEquals("eu-west-1", envelope.path("region").asText(),
+                "envelope and pattern matching must agree on the entry's effective region");
+    }
+
+    @Test
+    void putEvents_matchesPatternRejectsWrongRegionFilterUnderNonDefaultCall() {
+        // The mirror of the above: a rule whose region-filter does NOT match the call
+        // region must not fire. Pre-fix, an entry without Region would default to
+        // resolver-default us-east-1 in matchesPattern, accidentally satisfying a filter
+        // like {"region":["us-east-1"]} even when PutEvents was called against
+        // eu-west-1.
+        service.putRule("default-region-filtered", null,
+                "{\"source\":[\"my.app\"],\"region\":[\"us-east-1\"]}",
+                null, RuleState.ENABLED, null, null, null, "eu-west-1");
+        Target target = new Target();
+        target.setId("t1");
+        target.setArn("arn:aws:sqs:eu-west-1:000000000000:wrong-region-queue");
+        service.putTargets("default-region-filtered", null, List.of(target), "eu-west-1");
+
+        service.putEvents(List.of(
+                Map.of("Source", "my.app", "DetailType", "Test", "Detail", "{}")), "eu-west-1");
+
+        verify(invokerMock, org.mockito.Mockito.never()).invokeTarget(eq(target), any(), any());
+    }
+
+    @Test
+    void putEvents_envelopeDefaultsRegressionForDefaultRegionCall() throws Exception {
+        // Regression: when neither the entry nor the call carries a region (callers in
+        // the default region), the envelope still stamps the resolver default — same
+        // behavior as before the fix.
+        service.putRule("my-rule", null, "{\"source\":[\"my.app\"]}", null, RuleState.ENABLED,
+                null, null, null, REGION);
+        Target target = new Target();
+        target.setId("t1");
+        target.setArn("arn:aws:sqs:us-east-1:000000000000:default-queue");
+        service.putTargets("my-rule", null, List.of(target), REGION);
+
+        service.putEvents(List.of(
+                Map.of("Source", "my.app", "DetailType", "Test", "Detail", "{}")), REGION);
+
+        org.mockito.ArgumentCaptor<String> json = org.mockito.ArgumentCaptor.forClass(String.class);
+        verify(invokerMock).invokeTarget(eq(target), json.capture(), eq(REGION));
+        com.fasterxml.jackson.databind.JsonNode envelope = OBJECT_MAPPER.readTree(json.getValue());
+        assertEquals(REGION, envelope.path("region").asText());
+        assertEquals("000000000000", envelope.path("account").asText());
+    }
 }


### PR DESCRIPTION
## Summary

`EventBridgeService.putEvents` had two related defects in how the call's region and account flowed through to rule matching and the delivered EventBridge envelope:

1. **`buildEventEnvelope` hardcoded `region` and `account`** to `RegionResolver.getDefaultRegion()` / `RegionResolver.getAccountId()`, regardless of which region/account the `PutEvents` call was made against. A rule scoped to `eu-west-1` would fire correctly for an `eu-west-1` `PutEvents` call (rules are stored per `(region, bus)`), but the envelope delivered to its target would report `region=us-east-1`. Downstream consumers / re-routing rules that filter on the envelope region saw an incorrect value.

2. **`matchesPattern` fell back to resolver defaults** when reading `entry.Region` / `entry.Account`. For a `PutEvents` entry without explicit `Region` (the common case — the AWS SDK doesn't model per-entry region), the pattern's `region` / `account` filter saw the resolver default while the envelope (once defect 1 above was addressed) saw the actual call region. Same kind of inconsistency, one step earlier.

- `putEvents()` now defensively copies each entry into a mutable `HashMap` and fills missing/blank `Region` / `Account` from the call context (the `region` argument; `accountId` if non-null else `regionResolver.getAccountId()`) at the top of the per-entry loop. `matchesPattern`, `buildEventEnvelope`, and `captureToArchives` all subsequently see the same normalized entry, so a pattern's region/account filter agrees with the delivered envelope.
- `buildEventEnvelope` now takes the `PutEvents` call's region and account and resolves them with the same precedence: entry-supplied value wins (cross-region producers, archive replay paths), then the call's region/accountId, finally the resolver default. For the `putEvents` path the entry is already normalized, so this is defense-in-depth for any other callers.
- A small `isBlank(Object)` helper centralizes the null + blank-string predicate used in both the entry normalization and the envelope fallback.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The delivered envelope now matches the [AWS EventBridge event structure](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-events-structure.html): `region` reflects the region of the `PutEvents` call (or the originating envelope on archive replay), `account` reflects the calling account. Region/account pattern filters now match against the same effective value the envelope carries, so a rule with `{"region":["eu-west-1"]}` fires for an `eu-west-1` `PutEvents` call without requiring the caller to set `entry.Region` explicitly (the AWS SDK doesn't expose per-entry `Region` anyway). Five new `EventBridgeServiceTest` cases pin the new behavior, including a regression-pin that keeps the default-region call producing today's resolver-default envelope unchanged.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)