### PR TITLE
fix(lambda): support path-style ECR URIs for image functions

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -108,8 +108,7 @@ public class ContainerLauncher {
         String region = m.group(2);
         String repoAndTag = m.group(3);
         ecrRegistryManager.ensureStarted();
-        int port = ecrRegistryManager.effectivePort();
-        String rewritten = account + ".dkr.ecr." + region + ".localhost:" + port + "/" + repoAndTag;
+        String rewritten = ecrRegistryManager.getRepositoryUri(account, region, repoAndTag);
         LOG.infov("Rewriting ECR image URI {0} -> {1}", image, rewritten);
         return rewritten;
     }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
@@ -95,7 +95,7 @@ class ContainerLauncherTest {
         // prevent the background PipedOutputStream writer thread from blocking
         // when the pipe buffer fills.
         capturedRemotePaths.clear();
-        when(dockerClient.copyArchiveToContainerCmd(any())).thenAnswer(inv -> {
+        lenient().when(dockerClient.copyArchiveToContainerCmd(any())).thenAnswer(inv -> {
             CopyArchiveToContainerCmd cmd = mock(CopyArchiveToContainerCmd.class);
             final java.io.InputStream[] captured = {null};
             when(cmd.withRemotePath(any())).thenAnswer(pathInv -> {
@@ -305,6 +305,46 @@ class ContainerLauncherTest {
         // AWS_SESSION_TOKEN was not overridden so the default remains.
         assertEquals(1, env.stream().filter(e -> e.startsWith("AWS_SESSION_TOKEN=")).count(),
                 "AWS_SESSION_TOKEN should retain its default exactly once");
+    }
+
+    @Test
+    void launchImageFunction_rewritesAwsEcrUriUsingRegistryManagerHostnameStyle() {
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("image-fn");
+        fn.setPackageType("Image");
+        fn.setImageUri("123456789012.dkr.ecr.us-east-1.amazonaws.com/backend-user:1");
+
+        when(ecrRegistryManager.getRepositoryUri("123456789012", "us-east-1", "backend-user:1"))
+                .thenReturn("123456789012.dkr.ecr.us-east-1.localhost:5100/backend-user:1");
+
+        launcher.launch(fn);
+
+        ArgumentCaptor<ContainerSpec> specCaptor = ArgumentCaptor.forClass(ContainerSpec.class);
+        verify(lifecycleManager).create(specCaptor.capture());
+        verify(ecrRegistryManager).ensureStarted();
+        verify(ecrRegistryManager).getRepositoryUri("123456789012", "us-east-1", "backend-user:1");
+        assertEquals("123456789012.dkr.ecr.us-east-1.localhost:5100/backend-user:1",
+                specCaptor.getValue().image());
+    }
+
+    @Test
+    void launchImageFunction_rewritesAwsEcrUriUsingRegistryManagerPathStyle() {
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("image-path-fn");
+        fn.setPackageType("Image");
+        fn.setImageUri("123456789012.dkr.ecr.us-east-1.amazonaws.com/backend-user:1");
+
+        when(ecrRegistryManager.getRepositoryUri("123456789012", "us-east-1", "backend-user:1"))
+                .thenReturn("localhost:5100/123456789012/us-east-1/backend-user:1");
+
+        launcher.launch(fn);
+
+        ArgumentCaptor<ContainerSpec> specCaptor = ArgumentCaptor.forClass(ContainerSpec.class);
+        verify(lifecycleManager).create(specCaptor.capture());
+        verify(ecrRegistryManager).ensureStarted();
+        verify(ecrRegistryManager).getRepositoryUri("123456789012", "us-east-1", "backend-user:1");
+        assertEquals("localhost:5100/123456789012/us-east-1/backend-user:1",
+                specCaptor.getValue().image());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fix Lambda image URI rewriting to honor ECR path-style URIs by reusing `EcrRegistryManager#getRepositoryUri(...)` instead of rebuilding hostname-style URIs inside `ContainerLauncher`. This keeps Lambda image pulls aligned with `FLOCI_SERVICES_ECR_URI_STYLE=path`.

Closes #1134

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

When `FLOCI_SERVICES_ECR_URI_STYLE=path` was enabled, Floci returned path-style `repositoryUri` values from ECR, but Lambda image functions still rewrote AWS-shaped ECR image URIs to hostname style at invoke time. This caused ECR configuration and Lambda runtime behavior to diverge for image-backed functions.

## Checklist

- [ ] `./mvnw test` passes locally
  Currently fails in unrelated tests:
  `ApiGatewayRequestAuthorizerIntegrationTest` (4 `SocketTimeout` errors) and
  `ElastiCacheMemcachedIntegrationTest` (2 `Connection refused` errors)
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
