### PR TITLE
fix(ecs): preserve create-time resource tags

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
@@ -131,7 +131,8 @@ public class EcsJsonHandler {
 
     private Response handleCreateCluster(JsonNode req, String region) {
         String name = req.path("clusterName").asText(null);
-        EcsCluster cluster = service.createCluster(name, region);
+        Map<String, String> tags = parseTagMap(req.path("tags"));
+        EcsCluster cluster = service.createCluster(name, tags, region);
         ObjectNode resp = objectMapper.createObjectNode();
         resp.set("cluster", clusterNode(cluster));
         return Response.ok(resp).build();
@@ -203,9 +204,10 @@ public class EcsJsonHandler {
         String memory = req.has("memory") ? req.path("memory").asText() : null;
         String taskRoleArn = req.hasNonNull("taskRoleArn") ? req.path("taskRoleArn").asText() : null;
         String executionRoleArn = req.hasNonNull("executionRoleArn") ? req.path("executionRoleArn").asText() : null;
+        Map<String, String> tags = parseTagMap(req.path("tags"));
 
         TaskDefinition td = service.registerTaskDefinition(family, containerDefs, networkMode, cpu, memory,
-                taskRoleArn, executionRoleArn, region);
+                taskRoleArn, executionRoleArn, tags, region);
 
         ObjectNode resp = objectMapper.createObjectNode();
         resp.set("taskDefinition", taskDefinitionNode(td));
@@ -379,9 +381,10 @@ public class EcsJsonHandler {
         LaunchType launchType = parseEnum(req, "launchType", LaunchType.class);
         List<EcsLoadBalancer> loadBalancers = parseLoadBalancers(req.path("loadBalancers"));
         NetworkConfiguration networkConfiguration = parseNetworkConfiguration(req.path("networkConfiguration"));
+        Map<String, String> tags = parseTagMap(req.path("tags"));
 
         EcsServiceModel svc = service.createService(cluster, serviceName, taskDefinition,
-                desiredCount, launchType, loadBalancers, networkConfiguration, region);
+                desiredCount, launchType, loadBalancers, networkConfiguration, tags, region);
 
         ObjectNode resp = objectMapper.createObjectNode();
         resp.set("service", serviceNode(svc));

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
@@ -105,6 +105,10 @@ public class EcsService {
     // ── Clusters ─────────────────────────────────────────────────────────────
 
     public EcsCluster createCluster(String clusterName, String region) {
+        return createCluster(clusterName, null, region);
+    }
+
+    public EcsCluster createCluster(String clusterName, Map<String, String> tags, String region) {
         String name = (clusterName == null || clusterName.isBlank()) ? DEFAULT_CLUSTER : clusterName;
         String key = clusterKey(region, name);
         if (clusters.containsKey(key)) {
@@ -114,6 +118,9 @@ public class EcsService {
         cluster.setClusterName(name);
         cluster.setClusterArn(regionResolver.buildArn("ecs", region, "cluster/" + name));
         cluster.setStatus("ACTIVE");
+        if (tags != null && !tags.isEmpty()) {
+            cluster.setTags(new LinkedHashMap<>(tags));
+        }
         clusters.put(key, cluster);
         LOG.infov("Created ECS cluster: {0} in {1}", name, region);
         return cluster;
@@ -184,6 +191,14 @@ public class EcsService {
                                                   NetworkMode networkMode, String cpu, String memory,
                                                   String taskRoleArn, String executionRoleArn,
                                                   String region) {
+        return registerTaskDefinition(family, containerDefs, networkMode, cpu, memory,
+                taskRoleArn, executionRoleArn, null, region);
+    }
+
+    public TaskDefinition registerTaskDefinition(String family, List<ContainerDefinition> containerDefs,
+                                                  NetworkMode networkMode, String cpu, String memory,
+                                                  String taskRoleArn, String executionRoleArn,
+                                                  Map<String, String> tags, String region) {
         int revision = latestRevisions.merge(family, 1, Integer::sum);
 
         TaskDefinition td = new TaskDefinition();
@@ -198,6 +213,9 @@ public class EcsService {
         td.setContainerDefinitions(containerDefs != null ? containerDefs : List.of());
         td.setTaskDefinitionArn(regionResolver.buildArn("ecs", region,
                 "task-definition/" + family + ":" + revision));
+        if (tags != null && !tags.isEmpty()) {
+            td.setTags(new LinkedHashMap<>(tags));
+        }
 
         taskDefinitions.put(family + ":" + revision, td);
         LOG.infov("Registered task definition: {0}:{1}", family, revision);
@@ -448,6 +466,15 @@ public class EcsService {
                                           int desiredCount, LaunchType launchType,
                                           List<EcsLoadBalancer> loadBalancers,
                                           NetworkConfiguration networkConfiguration, String region) {
+        return createService(clusterRef, serviceName, taskDefinition, desiredCount, launchType,
+                loadBalancers, networkConfiguration, null, region);
+    }
+
+    public EcsServiceModel createService(String clusterRef, String serviceName, String taskDefinition,
+                                          int desiredCount, LaunchType launchType,
+                                          List<EcsLoadBalancer> loadBalancers,
+                                          NetworkConfiguration networkConfiguration,
+                                          Map<String, String> tags, String region) {
         EcsCluster cluster = resolveClusterOrDefault(clusterRef, region);
         resolveTaskDefinitionOrThrow(taskDefinition, region);
 
@@ -469,6 +496,9 @@ public class EcsService {
         svc.setNetworkConfiguration(networkConfiguration);
         svc.setStatus("ACTIVE");
         svc.setCreatedAt(Instant.now());
+        if (tags != null && !tags.isEmpty()) {
+            svc.setTags(new LinkedHashMap<>(tags));
+        }
 
         services.put(key, svc);
         cluster.setActiveServicesCount(cluster.getActiveServicesCount() + 1);

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/EcsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/EcsIntegrationTest.java
@@ -31,6 +31,9 @@ class EcsIntegrationTest {
     private static final String CLUSTER_NAME = "test-cluster";
     private static final String CLUSTER_ARN =
             "arn:aws:ecs:" + REGION + ":" + ACCOUNT + ":cluster/" + CLUSTER_NAME;
+    private static final String TAGGED_CLUSTER_NAME = "tagged-create-cluster";
+    private static final String TAGGED_CLUSTER_ARN =
+            "arn:aws:ecs:" + REGION + ":" + ACCOUNT + ":cluster/" + TAGGED_CLUSTER_NAME;
     private static final String TASK_DEF_FAMILY = "test-task";
     private static final String SERVICE_NAME = "test-service";
 
@@ -114,6 +117,38 @@ class EcsIntegrationTest {
             .body("clusterArns", hasItem(containsString(CLUSTER_NAME)));
     }
 
+    @Test
+    @Order(5)
+    void createClusterWithTagsAvailableThroughListTagsForResource() {
+        ecs("CreateCluster")
+            .body("""
+                {
+                    "clusterName": "%s",
+                    "tags": [
+                        {"key": "Environment", "value": "dev"},
+                        {"key": "Project", "value": "project1"}
+                    ]
+                }
+                """.formatted(TAGGED_CLUSTER_NAME))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("cluster.clusterName", equalTo(TAGGED_CLUSTER_NAME));
+
+        ecs("ListTagsForResource")
+            .body("""
+                {"resourceArn": "%s"}
+                """.formatted(TAGGED_CLUSTER_ARN))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("tags", hasSize(2))
+            .body("tags.find { it.key == 'Environment' }.value", equalTo("dev"))
+            .body("tags.find { it.key == 'Project' }.value", equalTo("project1"));
+    }
+
     // ── Task Definitions ──────────────────────────────────────────────────────
 
     @Test
@@ -136,7 +171,11 @@ class EcsIntegrationTest {
                     "requiresCompatibilities": ["FARGATE"],
                     "cpu": "256",
                     "memory": "512",
-                    "networkMode": "awsvpc"
+                    "networkMode": "awsvpc",
+                    "tags": [
+                        {"key": "Environment", "value": "dev"},
+                        {"key": "Project", "value": "project1"}
+                    ]
                 }
                 """.formatted(TASK_DEF_FAMILY))
         .when()
@@ -151,6 +190,18 @@ class EcsIntegrationTest {
             .body("taskDefinition.containerDefinitions[0].name", equalTo("app"))
         .extract()
             .path("taskDefinition.taskDefinitionArn");
+
+        ecs("ListTagsForResource")
+            .body("""
+                {"resourceArn": "%s"}
+                """.formatted(taskDefArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("tags", hasSize(2))
+            .body("tags.find { it.key == 'Environment' }.value", equalTo("dev"))
+            .body("tags.find { it.key == 'Project' }.value", equalTo("project1"));
     }
 
     @Test
@@ -284,7 +335,11 @@ class EcsIntegrationTest {
                     "serviceName": "%s",
                     "taskDefinition": "%s",
                     "desiredCount": 1,
-                    "launchType": "FARGATE"
+                    "launchType": "FARGATE",
+                    "tags": [
+                        {"key": "Environment", "value": "dev"},
+                        {"key": "Project", "value": "project1"}
+                    ]
                 }
                 """.formatted(CLUSTER_NAME, SERVICE_NAME, TASK_DEF_FAMILY))
         .when()
@@ -298,6 +353,18 @@ class EcsIntegrationTest {
             .body("service.status", equalTo("ACTIVE"))
         .extract()
             .path("service.serviceArn");
+
+        ecs("ListTagsForResource")
+            .body("""
+                {"resourceArn": "%s"}
+                """.formatted(serviceArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("tags", hasSize(2))
+            .body("tags.find { it.key == 'Environment' }.value", equalTo("dev"))
+            .body("tags.find { it.key == 'Project' }.value", equalTo("project1"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #1131
Closes #1132
Closes #1133

Preserves create-time ECS tags for clusters, services, and task definitions so `ListTagsForResource` returns the tags supplied to `CreateCluster`, `CreateService`, and `RegisterTaskDefinition`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The incorrect behavior was that ECS create handlers parsed/created resources without carrying request `tags` into the in-memory models, even though tagging and `ListTagsForResource` already supported those resources. This PR keeps the existing wire shape and propagates the request tags at creation time.

## Checklist

- [x] `./mvnw test` passes locally — focused equivalent `mvn -q -Dtest=EcsIntegrationTest test` passed; `./mvnw` could not extract its Maven distribution in this environment
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
