### PR TITLE
fix(s3): handle empty object suffix ranges

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -594,20 +594,24 @@ public class S3Controller {
                 return handleRangeRequest(obj, rangeHeader, overrides);
             }
 
-            var resp = Response.ok(obj.getData())
-                    .header("Content-Type", overrides.contentType() != null ? overrides.contentType() : obj.getContentType())
-                    .header("Content-Length", obj.getSize())
-                    .header("ETag", obj.getETag())
-                    .header("Last-Modified", RFC_822.format(obj.getLastModified()))
-                    .header("Accept-Ranges", "bytes");
-            if (obj.getVersionId() != null) {
-                resp.header("x-amz-version-id", obj.getVersionId());
-            }
-            appendObjectHeaders(resp, obj, overrides);
-            return resp.build();
+            return fullObjectResponse(obj, overrides);
         } catch (AwsException e) {
             return xmlErrorResponse(e);
         }
+    }
+
+    private Response fullObjectResponse(S3Object obj, ResponseHeaderOverrides overrides) {
+        var resp = Response.ok(obj.getData())
+                .header("Content-Type", overrides.contentType() != null ? overrides.contentType() : obj.getContentType())
+                .header("Content-Length", obj.getSize())
+                .header("ETag", obj.getETag())
+                .header("Last-Modified", RFC_822.format(obj.getLastModified()))
+                .header("Accept-Ranges", "bytes");
+        if (obj.getVersionId() != null) {
+            resp.header("x-amz-version-id", obj.getVersionId());
+        }
+        appendObjectHeaders(resp, obj, overrides);
+        return resp.build();
     }
 
     private Response handleRangeRequest(S3Object obj, String rangeHeader, ResponseHeaderOverrides overrides) {
@@ -642,6 +646,9 @@ public class S3Controller {
         }
 
         if (start < 0 || start >= totalSize || start > end) {
+            if (totalSize == 0 && rangeSpec.startsWith("-")) {
+                return fullObjectResponse(obj, overrides);
+            }
             return invalidRangeResponse(totalSize);
         }
 

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -591,6 +591,35 @@ class S3IntegrationTest {
     }
 
     @Test
+    @Order(41)
+    void getObjectWithSuffixRangeForEmptyObject() {
+        given()
+            .header("x-amz-meta-kind", "empty")
+            .body(new byte[0])
+        .when()
+            .put("/test-bucket/empty.txt")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Range", "bytes=-13")
+        .when()
+            .get("/test-bucket/empty.txt")
+        .then()
+            .statusCode(200)
+            .header("Content-Length", equalTo("0"))
+            .header("Accept-Ranges", equalTo("bytes"))
+            .header("x-amz-meta-kind", equalTo("empty"))
+            .body(equalTo(""));
+
+        given()
+        .when()
+            .delete("/test-bucket/empty.txt")
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
     @Order(50)
     void getObjectIfNoneMatchReturns304() {
         String eTag = given()


### PR DESCRIPTION
## Summary

Closes #1141

Allow S3 suffix range reads on empty objects to return an empty successful response instead of `InvalidRange`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Empty objects can be read by clients that issue suffix range requests for tail reads.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
