### PR TITLE
feat(s3): enforce SSE-C customer keys

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -471,8 +471,15 @@ public class S3Controller {
                 }
                 byte[] partData = decodeAwsChunked(body, contentEncoding, contentSha256);
                 validateChecksumHeaders(httpHeaders, partData, httpHeaders.getHeaderString("x-amz-sdk-checksum-algorithm"));
-                String eTag = s3Service.uploadPart(bucket, key, uploadId, partNumber, partData);
-                return Response.ok().header("ETag", eTag).build();
+                String eTag = s3Service.uploadPart(bucket, key, uploadId, partNumber, partData,
+                        httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-algorithm"),
+                        httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-key"),
+                        httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-key-MD5"));
+                Response.ResponseBuilder response = Response.ok().header("ETag", eTag);
+                appendSseCustomerHeaders(response,
+                        httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-algorithm"),
+                        httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-key-MD5"));
+                return response.build();
             }
 
             if (copySource != null && !copySource.isEmpty()) {
@@ -498,6 +505,9 @@ public class S3Controller {
             String contentDisposition = httpHeaders.getHeaderString("Content-Disposition");
             String cacheControl = httpHeaders.getHeaderString("Cache-Control");
             String serverSideEncryption = httpHeaders.getHeaderString("x-amz-server-side-encryption");
+            String sseCustomerAlgorithm = httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-algorithm");
+            String sseCustomerKey = httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-key");
+            String sseCustomerKeyMd5 = httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-key-MD5");
             String cannedAcl = httpHeaders.getHeaderString("x-amz-acl");
             S3Object obj = s3Service.putObject(bucket, key, data, contentType, extractUserMetadata(httpHeaders),
                     new PutObjectOptions()
@@ -509,6 +519,9 @@ public class S3Controller {
                             .withContentDisposition(contentDisposition)
                             .withCacheControl(cacheControl)
                             .withServerSideEncryption(serverSideEncryption)
+                            .withSseCustomerAlgorithm(sseCustomerAlgorithm)
+                            .withSseCustomerKey(sseCustomerKey)
+                            .withSseCustomerKeyMd5(sseCustomerKeyMd5)
                             .withAcl(cannedAcl)
                             .withChecksumAlgorithm(checksumAlgorithm)
                             .withClientChecksum(extractChecksumFromHeaders(httpHeaders))
@@ -582,6 +595,11 @@ public class S3Controller {
                 }
             }
             S3Object obj = s3Service.getObject(bucket, key, versionId);
+            S3Service.validateSseCustomerAccess(
+                    obj,
+                    httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-algorithm"),
+                    httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-key"),
+                    httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-key-MD5"));
             ResponseHeaderOverrides overrides = new ResponseHeaderOverrides(
                     responseContentType, responseContentLanguage, responseExpires,
                     responseCacheControl, responseContentDisposition, responseContentEncoding);
@@ -698,6 +716,11 @@ public class S3Controller {
         try {
             key = extractObjectKey(uriInfo, bucket);
             S3Object obj = s3Service.headObject(bucket, key, versionId);
+            S3Service.validateSseCustomerAccess(
+                    obj,
+                    httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-algorithm"),
+                    httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-key"),
+                    httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-key-MD5"));
             Response preconditionResponse = checkPreconditions(obj, ifMatch, ifNoneMatch, ifModifiedSince, ifUnmodifiedSince);
             if (preconditionResponse != null) {
                 return preconditionResponse;
@@ -877,7 +900,10 @@ public class S3Controller {
                         httpHeaders.getHeaderString("x-amz-storage-class"),
                         httpHeaders.getHeaderString("Content-Disposition"),
                         httpHeaders.getHeaderString("x-amz-server-side-encryption"),
-                        httpHeaders.getHeaderString("x-amz-acl"));
+                        httpHeaders.getHeaderString("x-amz-acl"),
+                        httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-algorithm"),
+                        httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-key"),
+                        httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-key-MD5"));
                 String xml = new XmlBuilder()
                         .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
                         .start("InitiateMultipartUploadResult", AwsNamespaces.S3)
@@ -886,7 +912,9 @@ public class S3Controller {
                         .elem("UploadId", upload.getUploadId())
                         .end("InitiateMultipartUploadResult")
                         .build();
-                return Response.ok(xml).build();
+                Response.ResponseBuilder response = Response.ok(xml);
+                appendSseCustomerHeaders(response, upload);
+                return response.build();
             }
 
             if (hasQueryParam(uriInfo, "restore")) {
@@ -928,6 +956,7 @@ public class S3Controller {
                 if (obj.getVersionId() != null) {
                     resp.header("x-amz-version-id", obj.getVersionId());
                 }
+                appendSseCustomerHeaders(resp, obj);
                 return resp.build();
             }
 
@@ -1557,6 +1586,7 @@ public class S3Controller {
         if (obj.getServerSideEncryption() != null) {
             resp.header("x-amz-server-side-encryption", obj.getServerSideEncryption());
         }
+        appendSseCustomerHeaders(resp, obj);
         appendChecksumHeaders(resp, obj.getChecksum());
         appendLockHeaders(resp, obj);
     }
@@ -1588,6 +1618,7 @@ public class S3Controller {
         if (obj.getServerSideEncryption() != null) {
             resp.header("x-amz-server-side-encryption", obj.getServerSideEncryption());
         }
+        appendSseCustomerHeaders(resp, obj);
         if (overrides.contentLanguage() != null) {
             resp.header("Content-Language", overrides.contentLanguage());
         }
@@ -1603,6 +1634,25 @@ public class S3Controller {
             appendChecksumHeaders(resp, obj.getChecksum());
         }
         appendLockHeaders(resp, obj);
+    }
+
+    private void appendSseCustomerHeaders(Response.ResponseBuilder resp, S3Object obj) {
+        appendSseCustomerHeaders(resp, obj.getSseCustomerAlgorithm(), obj.getSseCustomerKeyMd5());
+    }
+
+    private void appendSseCustomerHeaders(Response.ResponseBuilder resp, MultipartUpload upload) {
+        appendSseCustomerHeaders(resp, upload.getSseCustomerAlgorithm(), upload.getSseCustomerKeyMd5());
+    }
+
+    private void appendSseCustomerHeaders(Response.ResponseBuilder resp, String algorithm, String keyMd5) {
+        if (hasText(algorithm) && hasText(keyMd5)) {
+            resp.header("x-amz-server-side-encryption-customer-algorithm", algorithm.trim());
+            resp.header("x-amz-server-side-encryption-customer-key-MD5", keyMd5.trim());
+        }
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 
     private void appendLockHeaders(Response.ResponseBuilder resp, S3Object obj) {
@@ -1662,6 +1712,12 @@ public class S3Controller {
                         .withContentDisposition(copyContentDisposition)
                         .withCacheControl(copyCacheControl)
                         .withServerSideEncryption(copyServerSideEncryption)
+                        .withSseCustomerAlgorithm(httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-algorithm"))
+                        .withSseCustomerKey(httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-key"))
+                        .withSseCustomerKeyMd5(httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-key-MD5"))
+                        .withCopySourceSseCustomerAlgorithm(httpHeaders.getHeaderString("x-amz-copy-source-server-side-encryption-customer-algorithm"))
+                        .withCopySourceSseCustomerKey(httpHeaders.getHeaderString("x-amz-copy-source-server-side-encryption-customer-key"))
+                        .withCopySourceSseCustomerKeyMd5(httpHeaders.getHeaderString("x-amz-copy-source-server-side-encryption-customer-key-MD5"))
                         .withAcl(cannedAcl));
         String xml = new XmlBuilder()
                 .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
@@ -1670,7 +1726,9 @@ public class S3Controller {
                 .elem("ETag", copy.getETag())
                 .end("CopyObjectResult")
                 .build();
-        return Response.ok(xml).build();
+        Response.ResponseBuilder response = Response.ok(xml);
+        appendSseCustomerHeaders(response, copy);
+        return response.build();
     }
 
     private Response handleUploadPartCopy(String copySource, String destBucket, String destKey,
@@ -1694,7 +1752,9 @@ public class S3Controller {
         ParsedCopySource sourceObject = parseCopySourceObject(pathAfterBucket);
         String copySourceRange = httpHeaders.getHeaderString("x-amz-copy-source-range");
         String eTag = s3Service.uploadPartCopy(destBucket, destKey, uploadId, partNumber,
-                sourceBucket, sourceObject.objectKey(), sourceObject.versionId(), copySourceRange);
+                sourceBucket, sourceObject.objectKey(), sourceObject.versionId(), copySourceRange,
+                copySourceSseCustomerHeaders(httpHeaders),
+                sseCustomerHeaders(httpHeaders));
         String xml = new XmlBuilder()
                 .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
                 .start("CopyPartResult", AwsNamespaces.S3)
@@ -1702,7 +1762,25 @@ public class S3Controller {
                 .elem("ETag", eTag)
                 .end("CopyPartResult")
                 .build();
-        return Response.ok(xml).type(MediaType.APPLICATION_XML).build();
+        Response.ResponseBuilder response = Response.ok(xml).type(MediaType.APPLICATION_XML);
+        appendSseCustomerHeaders(response,
+                httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-algorithm"),
+                httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-key-MD5"));
+        return response.build();
+    }
+
+    private S3Service.SseCustomerHeaders copySourceSseCustomerHeaders(HttpHeaders httpHeaders) {
+        return new S3Service.SseCustomerHeaders(
+                httpHeaders.getHeaderString("x-amz-copy-source-server-side-encryption-customer-algorithm"),
+                httpHeaders.getHeaderString("x-amz-copy-source-server-side-encryption-customer-key"),
+                httpHeaders.getHeaderString("x-amz-copy-source-server-side-encryption-customer-key-MD5"));
+    }
+
+    private S3Service.SseCustomerHeaders sseCustomerHeaders(HttpHeaders httpHeaders) {
+        return new S3Service.SseCustomerHeaders(
+                httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-algorithm"),
+                httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-key"),
+                httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-key-MD5"));
     }
 
     private Response handleGetObjectAttributes(String bucket, String key, String versionId,

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -44,6 +44,8 @@ public class S3Service {
     private static final String ALL_USERS_GROUP_URI = "http://acs.amazonaws.com/groups/global/AllUsers";
     private static final String AUTHENTICATED_USERS_GROUP_URI = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers";
     private static final Set<String> SUPPORTED_SERVER_SIDE_ENCRYPTION_VALUES = Set.of("AES256", "aws:kms", "aws:kms:dsse", "aws:fsx");
+    private static final String SSE_C_ALGORITHM = "AES256";
+    private static final int SSE_C_KEY_BYTES = 32;
 
     @FunctionalInterface
     interface LambdaInvoker {
@@ -281,6 +283,8 @@ public class S3Service {
                         "The specified bucket does not exist.", 404));
         PutObjectOptions effectiveOptions = options != null ? options : new PutObjectOptions();
         String normalizedServerSideEncryption = normalizeServerSideEncryption(effectiveOptions.getServerSideEncryption());
+        SseCustomerKey sseCustomerKey = validateSseCustomerKey(effectiveOptions.getSseCustomerAlgorithm(), effectiveOptions.getSseCustomerKey(), effectiveOptions.getSseCustomerKeyMd5());
+        rejectConflictingServerSideEncryption(normalizedServerSideEncryption, sseCustomerKey);
 
         S3Object object = new S3Object(bucketName, key, data, contentType);
         if (metadata != null) {
@@ -296,6 +300,10 @@ public class S3Service {
         object.setContentDisposition(effectiveOptions.getContentDisposition());
         object.setCacheControl(effectiveOptions.getCacheControl());
         object.setServerSideEncryption(normalizedServerSideEncryption);
+        if (sseCustomerKey != null) {
+            object.setSseCustomerAlgorithm(sseCustomerKey.algorithm());
+            object.setSseCustomerKeyMd5(sseCustomerKey.keyMd5());
+        }
         object.setAcl(cannedObjectAclXml(effectiveOptions.getAcl()));
         if (effectiveOptions.getTagging() != null && !effectiveOptions.getTagging().isEmpty()) {
             object.setTags(new HashMap<>(effectiveOptions.getTagging()));
@@ -737,15 +745,25 @@ public class S3Service {
     public S3Object copyObject(String sourceBucket, String sourceKey,
                                String destBucket, String destKey, String versionId, CopyObjectOptions options)
     {
+        CopyObjectOptions effectiveOptions = options != null ? options : new CopyObjectOptions();
         S3Object source = getObject(sourceBucket, sourceKey, versionId);
+        validateSseCustomerAccess(source,
+                effectiveOptions.getCopySourceSseCustomerAlgorithm(),
+                effectiveOptions.getCopySourceSseCustomerKey(),
+                effectiveOptions.getCopySourceSseCustomerKeyMd5());
         return copyS3Object(sourceBucket, sourceKey,
-                destBucket, destKey, source, options);
+                destBucket, destKey, source, effectiveOptions);
     }
 
     public S3Object copyObject(String sourceBucket, String sourceKey,
                                String destBucket, String destKey, CopyObjectOptions options) {
+        CopyObjectOptions effectiveOptions = options != null ? options : new CopyObjectOptions();
         S3Object source = getObject(sourceBucket, sourceKey);
-        return copyS3Object(sourceBucket, sourceKey, destBucket, destKey, source, options);
+        validateSseCustomerAccess(source,
+                effectiveOptions.getCopySourceSseCustomerAlgorithm(),
+                effectiveOptions.getCopySourceSseCustomerKey(),
+                effectiveOptions.getCopySourceSseCustomerKeyMd5());
+        return copyS3Object(sourceBucket, sourceKey, destBucket, destKey, source, effectiveOptions);
     }
 
     // --- Versioning Operations ---
@@ -1073,11 +1091,21 @@ public class S3Service {
     public MultipartUpload initiateMultipartUpload(String bucket, String key, String contentType,
                                                    Map<String, String> metadata, String storageClass,
                                                    String contentDisposition, String serverSideEncryption, String acl) {
+        return initiateMultipartUpload(bucket, key, contentType, metadata, storageClass, contentDisposition,
+                serverSideEncryption, acl, null, null, null);
+    }
+
+    public MultipartUpload initiateMultipartUpload(String bucket, String key, String contentType,
+                                                   Map<String, String> metadata, String storageClass,
+                                                   String contentDisposition, String serverSideEncryption, String acl,
+                                                   String sseCustomerAlgorithm, String sseCustomerKey, String sseCustomerKeyMd5) {
         ensureBucketExists(bucket);
         if (acl != null && !acl.isBlank()) {
             cannedObjectAclXml(acl);
         }
         String normalizedServerSideEncryption = normalizeServerSideEncryption(serverSideEncryption);
+        SseCustomerKey customerKey = validateSseCustomerKey(sseCustomerAlgorithm, sseCustomerKey, sseCustomerKeyMd5);
+        rejectConflictingServerSideEncryption(normalizedServerSideEncryption, customerKey);
         MultipartUpload upload = new MultipartUpload(bucket, key, contentType);
         if (metadata != null) {
             upload.getMetadata().putAll(metadata);
@@ -1085,6 +1113,10 @@ public class S3Service {
         upload.setStorageClass(ObjectAttributeName.normalizeStorageClass(storageClass));
         upload.setContentDisposition(contentDisposition);
         upload.setServerSideEncryption(normalizedServerSideEncryption);
+        if (customerKey != null) {
+            upload.setSseCustomerAlgorithm(customerKey.algorithm());
+            upload.setSseCustomerKeyMd5(customerKey.keyMd5());
+        }
         upload.setAcl(acl);
 
         if (inMemory) {
@@ -1103,6 +1135,11 @@ public class S3Service {
     }
 
     public String uploadPart(String bucket, String key, String uploadId, int partNumber, byte[] data) {
+        return uploadPart(bucket, key, uploadId, partNumber, data, null, null, null);
+    }
+
+    public String uploadPart(String bucket, String key, String uploadId, int partNumber, byte[] data,
+                             String sseCustomerAlgorithm, String sseCustomerKey, String sseCustomerKeyMd5) {
         MultipartUpload upload = multipartUploads.get(uploadId);
         if (upload == null || !upload.getBucket().equals(bucket) || !upload.getKey().equals(key)) {
             throw new AwsException("NoSuchUpload",
@@ -1112,6 +1149,7 @@ public class S3Service {
             throw new AwsException("InvalidArgument",
                     "Part number must be between 1 and 10000.", 400);
         }
+        validateSseCustomerAccess(upload, sseCustomerAlgorithm, sseCustomerKey, sseCustomerKeyMd5);
 
         if (inMemory) {
             memoryMultipartStore.get(uploadId).put(partNumber, data);
@@ -1135,7 +1173,20 @@ public class S3Service {
     public String uploadPartCopy(String destBucket, String destKey, String uploadId, int partNumber,
                                   String sourceBucket, String sourceKey, String sourceVersionId,
                                   String copySourceRange) {
+        return uploadPartCopy(destBucket, destKey, uploadId, partNumber, sourceBucket, sourceKey,
+                sourceVersionId, copySourceRange, SseCustomerHeaders.EMPTY, SseCustomerHeaders.EMPTY);
+    }
+
+    public String uploadPartCopy(String destBucket, String destKey, String uploadId, int partNumber,
+                                  String sourceBucket, String sourceKey, String sourceVersionId,
+                                  String copySourceRange,
+                                  SseCustomerHeaders copySourceSseCustomerHeaders,
+                                  SseCustomerHeaders sseCustomerHeaders) {
         S3Object source = getObject(sourceBucket, sourceKey, sourceVersionId);
+        validateSseCustomerAccess(source,
+                copySourceSseCustomerHeaders.algorithm(),
+                copySourceSseCustomerHeaders.key(),
+                copySourceSseCustomerHeaders.keyMd5());
         byte[] data = source.getData();
 
         if (copySourceRange != null && !copySourceRange.isBlank()) {
@@ -1150,7 +1201,8 @@ public class S3Service {
             data = Arrays.copyOfRange(data, start, end + 1);
         }
 
-        return uploadPart(destBucket, destKey, uploadId, partNumber, data);
+        return uploadPart(destBucket, destKey, uploadId, partNumber, data,
+                sseCustomerHeaders.algorithm(), sseCustomerHeaders.key(), sseCustomerHeaders.keyMd5());
     }
 
     public S3Object completeMultipartUpload(String bucket, String key, String uploadId, List<Integer> partNumbers) {
@@ -1198,6 +1250,10 @@ public class S3Service {
                             .withContentDisposition(upload.getContentDisposition())
                             .withServerSideEncryption(upload.getServerSideEncryption())
                             .withAcl(upload.getAcl()));
+            if (upload.getSseCustomerAlgorithm() != null) {
+                object.setSseCustomerAlgorithm(upload.getSseCustomerAlgorithm());
+                object.setSseCustomerKeyMd5(upload.getSseCustomerKeyMd5());
+            }
             // Override the ETag with the composite multipart ETag
             object.setETag(compositeETag);
             objectStore.put(objectKey(bucket, key), object);
@@ -1641,6 +1697,101 @@ public class S3Service {
         return normalized;
     }
 
+    static SseCustomerKey validateSseCustomerKey(String algorithm, String key, String keyMd5) {
+        boolean hasAnySseCustomerHeader = hasText(algorithm) || hasText(key) || hasText(keyMd5);
+        if (!hasAnySseCustomerHeader) {
+            return null;
+        }
+        if (!hasText(algorithm) || !hasText(key) || !hasText(keyMd5)) {
+            throw new AwsException("InvalidRequest",
+                    "SSE-C requests require algorithm, key, and key MD5 headers.", 400);
+        }
+        String normalizedAlgorithm = algorithm.trim();
+        if (!SSE_C_ALGORITHM.equals(normalizedAlgorithm)) {
+            throw new AwsException("InvalidArgument",
+                    "Unsupported x-amz-server-side-encryption-customer-algorithm value: " + normalizedAlgorithm, 400);
+        }
+        String normalizedKey = key.trim();
+        String computedMd5 = computeSseCustomerKeyMd5(normalizedKey);
+        if (!computedMd5.equals(keyMd5.trim())) {
+            throw new AwsException("InvalidDigest",
+                    "The x-amz-server-side-encryption-customer-key-MD5 value is invalid.", 400);
+        }
+        return new SseCustomerKey(normalizedAlgorithm, computedMd5);
+    }
+
+    static void validateSseCustomerAccess(S3Object object, String algorithm, String key, String keyMd5) {
+        if (object.getSseCustomerAlgorithm() == null) {
+            return;
+        }
+        SseCustomerKey requestKey = validateSseCustomerKey(algorithm, key, keyMd5);
+        if (requestKey == null) {
+            throw new AwsException("InvalidRequest",
+                    "SSE-C encrypted objects require customer key headers.", 400);
+        }
+        if (!object.getSseCustomerAlgorithm().equals(requestKey.algorithm()) ||
+                !object.getSseCustomerKeyMd5().equals(requestKey.keyMd5())) {
+            throw new AwsException("AccessDenied",
+                    "The provided SSE-C customer key does not match the object.", 403);
+        }
+    }
+
+    static void validateSseCustomerAccess(MultipartUpload upload, String algorithm, String key, String keyMd5) {
+        if (upload.getSseCustomerAlgorithm() == null) {
+            if (hasText(algorithm) || hasText(key) || hasText(keyMd5)) {
+                throw new AwsException("InvalidRequest",
+                        "SSE-C headers are not valid for multipart uploads initiated without SSE-C.", 400);
+            }
+            return;
+        }
+        SseCustomerKey requestKey = validateSseCustomerKey(algorithm, key, keyMd5);
+        if (requestKey == null) {
+            throw new AwsException("InvalidRequest",
+                    "SSE-C multipart uploads require customer key headers.", 400);
+        }
+        if (!upload.getSseCustomerAlgorithm().equals(requestKey.algorithm()) ||
+                !upload.getSseCustomerKeyMd5().equals(requestKey.keyMd5())) {
+            throw new AwsException("AccessDenied",
+                    "The provided SSE-C customer key does not match the multipart upload.", 403);
+        }
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private static void rejectConflictingServerSideEncryption(String serverSideEncryption, SseCustomerKey sseCustomerKey) {
+        if (serverSideEncryption != null && sseCustomerKey != null) {
+            throw new AwsException("InvalidRequest",
+                    "SSE-C cannot be combined with x-amz-server-side-encryption.", 400);
+        }
+    }
+
+    private static String computeSseCustomerKeyMd5(String key) {
+        try {
+            byte[] decodedKey = Base64.getDecoder().decode(key.trim());
+            if (decodedKey.length != SSE_C_KEY_BYTES) {
+                throw new AwsException("InvalidArgument",
+                        "The x-amz-server-side-encryption-customer-key must be a 256-bit key.", 400);
+            }
+            byte[] md5 = MessageDigest.getInstance("MD5").digest(decodedKey);
+            return Base64.getEncoder().encodeToString(md5);
+        }
+        catch (IllegalArgumentException e) {
+            throw new AwsException("InvalidArgument",
+                    "The x-amz-server-side-encryption-customer-key value is not valid base64.", 400);
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("MD5 is not available", e);
+        }
+    }
+
+    record SseCustomerKey(String algorithm, String keyMd5) {}
+
+    record SseCustomerHeaders(String algorithm, String key, String keyMd5) {
+        static final SseCustomerHeaders EMPTY = new SseCustomerHeaders(null, null, null);
+    }
+
     private String ownerFullControlGrant() {
         return canonicalUserGrant(ownerId(), DEFAULT_OWNER_DISPLAY_NAME, "FULL_CONTROL");
     }
@@ -1923,6 +2074,8 @@ public class S3Service {
         copy.setContentDisposition(source.getContentDisposition());
         copy.setCacheControl(source.getCacheControl());
         copy.setServerSideEncryption(source.getServerSideEncryption());
+        copy.setSseCustomerAlgorithm(source.getSseCustomerAlgorithm());
+        copy.setSseCustomerKeyMd5(source.getSseCustomerKeyMd5());
         copy.setSize(source.getSize());
         copy.setLastModified(source.getLastModified());
         copy.setETag(source.getETag());
@@ -2135,6 +2288,11 @@ public class S3Service {
         ensureBucketExists(destBucket);
         CopyObjectOptions effectiveOptions = options != null ? options : new CopyObjectOptions();
         String normalizedServerSideEncryption = normalizeServerSideEncryption(effectiveOptions.getServerSideEncryption());
+        SseCustomerKey destinationCustomerKey = validateSseCustomerKey(
+                effectiveOptions.getSseCustomerAlgorithm(),
+                effectiveOptions.getSseCustomerKey(),
+                effectiveOptions.getSseCustomerKeyMd5());
+        rejectConflictingServerSideEncryption(normalizedServerSideEncryption, destinationCustomerKey);
 
         boolean replaceMetadata = "REPLACE".equalsIgnoreCase(effectiveOptions.getMetadataDirective());
         Map<String, String> metadata = replaceMetadata ? new LinkedHashMap<>() : new LinkedHashMap<>(source.getMetadata());
@@ -2157,9 +2315,9 @@ public class S3Service {
         String effectiveCacheControl = replaceMetadata && effectiveOptions.getCacheControl() != null
                 ? effectiveOptions.getCacheControl()
                 : source.getCacheControl();
-        String effectiveServerSideEncryption = normalizedServerSideEncryption != null
-                ? normalizedServerSideEncryption
-                : source.getServerSideEncryption();
+        String effectiveServerSideEncryption = destinationCustomerKey != null
+                ? null
+                : (normalizedServerSideEncryption != null ? normalizedServerSideEncryption : source.getServerSideEncryption());
         boolean replaceTags = "REPLACE".equalsIgnoreCase(effectiveOptions.getTaggingDirective());
         Map<String, String> effectiveTags = replaceTags
                 ? effectiveOptions.getReplacementTagging()
@@ -2173,6 +2331,9 @@ public class S3Service {
                         .withContentDisposition(effectiveContentDisposition)
                         .withCacheControl(effectiveCacheControl)
                         .withServerSideEncryption(effectiveServerSideEncryption)
+                        .withSseCustomerAlgorithm(effectiveOptions.getSseCustomerAlgorithm())
+                        .withSseCustomerKey(effectiveOptions.getSseCustomerKey())
+                        .withSseCustomerKeyMd5(effectiveOptions.getSseCustomerKeyMd5())
                         .withAcl(effectiveOptions.getAcl())
                         .withTagging(effectiveTags));
         copy.setETag(source.getETag());

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/CopyObjectOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/CopyObjectOptions.java
@@ -13,6 +13,12 @@ public class CopyObjectOptions {
     private String contentDisposition;
     private String cacheControl;
     private String serverSideEncryption;
+    private String sseCustomerAlgorithm;
+    private String sseCustomerKey;
+    private String sseCustomerKeyMd5;
+    private String copySourceSseCustomerAlgorithm;
+    private String copySourceSseCustomerKey;
+    private String copySourceSseCustomerKeyMd5;
     private String acl;
 
     public String getMetadataDirective() { return metadataDirective; }
@@ -44,6 +50,24 @@ public class CopyObjectOptions {
 
     public String getServerSideEncryption() { return serverSideEncryption; }
     public CopyObjectOptions withServerSideEncryption(String serverSideEncryption) { this.serverSideEncryption = serverSideEncryption; return this; }
+
+    public String getSseCustomerAlgorithm() { return sseCustomerAlgorithm; }
+    public CopyObjectOptions withSseCustomerAlgorithm(String sseCustomerAlgorithm) { this.sseCustomerAlgorithm = sseCustomerAlgorithm; return this; }
+
+    public String getSseCustomerKey() { return sseCustomerKey; }
+    public CopyObjectOptions withSseCustomerKey(String sseCustomerKey) { this.sseCustomerKey = sseCustomerKey; return this; }
+
+    public String getSseCustomerKeyMd5() { return sseCustomerKeyMd5; }
+    public CopyObjectOptions withSseCustomerKeyMd5(String sseCustomerKeyMd5) { this.sseCustomerKeyMd5 = sseCustomerKeyMd5; return this; }
+
+    public String getCopySourceSseCustomerAlgorithm() { return copySourceSseCustomerAlgorithm; }
+    public CopyObjectOptions withCopySourceSseCustomerAlgorithm(String copySourceSseCustomerAlgorithm) { this.copySourceSseCustomerAlgorithm = copySourceSseCustomerAlgorithm; return this; }
+
+    public String getCopySourceSseCustomerKey() { return copySourceSseCustomerKey; }
+    public CopyObjectOptions withCopySourceSseCustomerKey(String copySourceSseCustomerKey) { this.copySourceSseCustomerKey = copySourceSseCustomerKey; return this; }
+
+    public String getCopySourceSseCustomerKeyMd5() { return copySourceSseCustomerKeyMd5; }
+    public CopyObjectOptions withCopySourceSseCustomerKeyMd5(String copySourceSseCustomerKeyMd5) { this.copySourceSseCustomerKeyMd5 = copySourceSseCustomerKeyMd5; return this; }
 
     public String getAcl() { return acl; }
     public CopyObjectOptions withAcl(String acl) { this.acl = acl; return this; }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/MultipartUpload.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/MultipartUpload.java
@@ -18,6 +18,8 @@ public class MultipartUpload {
     private String storageClass;
     private String contentDisposition;
     private String serverSideEncryption;
+    private String sseCustomerAlgorithm;
+    private String sseCustomerKeyMd5;
     private String acl;
     private Map<String, String> metadata;
     private Instant initiated;
@@ -58,6 +60,12 @@ public class MultipartUpload {
 
     public String getServerSideEncryption() { return serverSideEncryption; }
     public void setServerSideEncryption(String serverSideEncryption) { this.serverSideEncryption = serverSideEncryption; }
+
+    public String getSseCustomerAlgorithm() { return sseCustomerAlgorithm; }
+    public void setSseCustomerAlgorithm(String sseCustomerAlgorithm) { this.sseCustomerAlgorithm = sseCustomerAlgorithm; }
+
+    public String getSseCustomerKeyMd5() { return sseCustomerKeyMd5; }
+    public void setSseCustomerKeyMd5(String sseCustomerKeyMd5) { this.sseCustomerKeyMd5 = sseCustomerKeyMd5; }
 
     public String getAcl() { return acl; }
     public void setAcl(String acl) { this.acl = acl; }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/PutObjectOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/PutObjectOptions.java
@@ -12,6 +12,9 @@ public class PutObjectOptions {
     private String contentDisposition;
     private String cacheControl;
     private String serverSideEncryption;
+    private String sseCustomerAlgorithm;
+    private String sseCustomerKey;
+    private String sseCustomerKeyMd5;
     private String acl;
     private String checksumAlgorithm;
     private Map<String, String> tagging;
@@ -39,6 +42,15 @@ public class PutObjectOptions {
 
     public String getServerSideEncryption() { return serverSideEncryption; }
     public PutObjectOptions withServerSideEncryption(String serverSideEncryption) { this.serverSideEncryption = serverSideEncryption; return this; }
+
+    public String getSseCustomerAlgorithm() { return sseCustomerAlgorithm; }
+    public PutObjectOptions withSseCustomerAlgorithm(String sseCustomerAlgorithm) { this.sseCustomerAlgorithm = sseCustomerAlgorithm; return this; }
+
+    public String getSseCustomerKey() { return sseCustomerKey; }
+    public PutObjectOptions withSseCustomerKey(String sseCustomerKey) { this.sseCustomerKey = sseCustomerKey; return this; }
+
+    public String getSseCustomerKeyMd5() { return sseCustomerKeyMd5; }
+    public PutObjectOptions withSseCustomerKeyMd5(String sseCustomerKeyMd5) { this.sseCustomerKeyMd5 = sseCustomerKeyMd5; return this; }
 
     public String getAcl() { return acl; }
     public PutObjectOptions withAcl(String acl) { this.acl = acl; return this; }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/S3Object.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/S3Object.java
@@ -25,6 +25,8 @@ public class S3Object {
     private String contentDisposition;
     private String cacheControl;
     private String serverSideEncryption;
+    private String sseCustomerAlgorithm;
+    private String sseCustomerKeyMd5;
     private long size;
     private Instant lastModified;
     private String eTag;
@@ -92,6 +94,12 @@ public class S3Object {
 
     public String getServerSideEncryption() { return serverSideEncryption; }
     public void setServerSideEncryption(String serverSideEncryption) { this.serverSideEncryption = serverSideEncryption; }
+
+    public String getSseCustomerAlgorithm() { return sseCustomerAlgorithm; }
+    public void setSseCustomerAlgorithm(String sseCustomerAlgorithm) { this.sseCustomerAlgorithm = sseCustomerAlgorithm; }
+
+    public String getSseCustomerKeyMd5() { return sseCustomerKeyMd5; }
+    public void setSseCustomerKeyMd5(String sseCustomerKeyMd5) { this.sseCustomerKeyMd5 = sseCustomerKeyMd5; }
 
     public long getSize() { return size; }
     public void setSize(long size) { this.size = size; }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -8,7 +8,11 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import io.restassured.config.DecoderConfig;
 import io.restassured.config.RestAssuredConfig;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
@@ -16,6 +20,12 @@ import static org.hamcrest.Matchers.*;
 @QuarkusTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class S3IntegrationTest {
+    private static final String SSE_CUSTOMER_KEY = Base64.getEncoder().encodeToString("0123456789abcdef0123456789abcdef".getBytes(StandardCharsets.UTF_8));
+    private static final String SSE_CUSTOMER_KEY_MD5 = customerKeyMd5(SSE_CUSTOMER_KEY);
+    private static final String WRONG_SSE_CUSTOMER_KEY = Base64.getEncoder().encodeToString("abcdef0123456789abcdef0123456789".getBytes(StandardCharsets.UTF_8));
+    private static final String WRONG_SSE_CUSTOMER_KEY_MD5 = customerKeyMd5(WRONG_SSE_CUSTOMER_KEY);
+    private static final String SHORT_SSE_CUSTOMER_KEY = Base64.getEncoder().encodeToString("short-key".getBytes(StandardCharsets.UTF_8));
+    private static final String SHORT_SSE_CUSTOMER_KEY_MD5 = customerKeyMd5(SHORT_SSE_CUSTOMER_KEY);
 
     @Test
     @Order(1)
@@ -1205,9 +1215,222 @@ class S3IntegrationTest {
 
     @Test
     @Order(141)
+    void putObjectWithSseCustomerKey() {
+        given()
+            .contentType("text/plain")
+            .header("x-amz-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-server-side-encryption-customer-key", SSE_CUSTOMER_KEY)
+            .header("x-amz-server-side-encryption-customer-key-MD5", SSE_CUSTOMER_KEY_MD5)
+            .body("sse-c-content")
+        .when()
+            .put("/sse-bucket/sse-c.txt")
+        .then()
+            .statusCode(200)
+            .header("x-amz-server-side-encryption-customer-algorithm", equalTo("AES256"))
+            .header("x-amz-server-side-encryption-customer-key-MD5", equalTo(SSE_CUSTOMER_KEY_MD5));
+    }
+
+    @Test
+    @Order(142)
+    void getObjectWithSseCustomerKeyRequiresMatchingKey() {
+        given()
+        .when()
+            .get("/sse-bucket/sse-c.txt")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidRequest"));
+
+        given()
+            .header("x-amz-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-server-side-encryption-customer-key", WRONG_SSE_CUSTOMER_KEY)
+            .header("x-amz-server-side-encryption-customer-key-MD5", WRONG_SSE_CUSTOMER_KEY_MD5)
+        .when()
+            .get("/sse-bucket/sse-c.txt")
+        .then()
+            .statusCode(403)
+            .body(containsString("AccessDenied"));
+
+        given()
+            .header("x-amz-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-server-side-encryption-customer-key", SSE_CUSTOMER_KEY)
+            .header("x-amz-server-side-encryption-customer-key-MD5", SSE_CUSTOMER_KEY_MD5)
+        .when()
+            .get("/sse-bucket/sse-c.txt")
+        .then()
+            .statusCode(200)
+            .header("x-amz-server-side-encryption-customer-algorithm", equalTo("AES256"))
+            .header("x-amz-server-side-encryption-customer-key-MD5", equalTo(SSE_CUSTOMER_KEY_MD5))
+            .body(equalTo("sse-c-content"));
+    }
+
+    @Test
+    @Order(143)
+    void headObjectWithSseCustomerKeyRequiresMatchingKey() {
+        given()
+        .when()
+            .head("/sse-bucket/sse-c.txt")
+        .then()
+            .statusCode(400);
+
+        given()
+            .header("x-amz-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-server-side-encryption-customer-key", SSE_CUSTOMER_KEY)
+            .header("x-amz-server-side-encryption-customer-key-MD5", SSE_CUSTOMER_KEY_MD5)
+        .when()
+            .head("/sse-bucket/sse-c.txt")
+        .then()
+            .statusCode(200)
+            .header("x-amz-server-side-encryption-customer-algorithm", equalTo("AES256"))
+            .header("x-amz-server-side-encryption-customer-key-MD5", equalTo(SSE_CUSTOMER_KEY_MD5));
+    }
+
+    @Test
+    @Order(144)
+    void copyObjectWithSseCustomerKeyRequiresSourceKeyAndSupportsDestinationKey() {
+        given()
+            .header("x-amz-copy-source", "/sse-bucket/sse-c.txt")
+        .when()
+            .put("/sse-bucket/sse-c-copy.txt")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidRequest"));
+
+        given()
+            .header("x-amz-copy-source", "/sse-bucket/sse-c.txt")
+            .header("x-amz-copy-source-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-copy-source-server-side-encryption-customer-key", WRONG_SSE_CUSTOMER_KEY)
+            .header("x-amz-copy-source-server-side-encryption-customer-key-MD5", WRONG_SSE_CUSTOMER_KEY_MD5)
+        .when()
+            .put("/sse-bucket/sse-c-copy.txt")
+        .then()
+            .statusCode(403)
+            .body(containsString("AccessDenied"));
+
+        given()
+            .header("x-amz-copy-source", "/sse-bucket/sse-c.txt")
+            .header("x-amz-copy-source-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-copy-source-server-side-encryption-customer-key", SSE_CUSTOMER_KEY)
+            .header("x-amz-copy-source-server-side-encryption-customer-key-MD5", SSE_CUSTOMER_KEY_MD5)
+            .header("x-amz-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-server-side-encryption-customer-key", SSE_CUSTOMER_KEY)
+            .header("x-amz-server-side-encryption-customer-key-MD5", SSE_CUSTOMER_KEY_MD5)
+        .when()
+            .put("/sse-bucket/sse-c-copy.txt")
+        .then()
+            .statusCode(200)
+            .header("x-amz-server-side-encryption-customer-algorithm", equalTo("AES256"))
+            .header("x-amz-server-side-encryption-customer-key-MD5", equalTo(SSE_CUSTOMER_KEY_MD5));
+
+        given()
+        .when()
+            .get("/sse-bucket/sse-c-copy.txt")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidRequest"));
+
+        given()
+            .header("x-amz-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-server-side-encryption-customer-key", SSE_CUSTOMER_KEY)
+            .header("x-amz-server-side-encryption-customer-key-MD5", SSE_CUSTOMER_KEY_MD5)
+        .when()
+            .get("/sse-bucket/sse-c-copy.txt")
+        .then()
+            .statusCode(200)
+            .body(equalTo("sse-c-content"));
+    }
+
+    @Test
+    @Order(145)
+    void putObjectRejectsInvalidSseCustomerKeyMd5() {
+        given()
+            .contentType("text/plain")
+            .header("x-amz-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-server-side-encryption-customer-key", SSE_CUSTOMER_KEY)
+            .header("x-amz-server-side-encryption-customer-key-MD5", WRONG_SSE_CUSTOMER_KEY_MD5)
+            .body("bad sse-c")
+        .when()
+            .put("/sse-bucket/sse-c-invalid.txt")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidDigest"));
+    }
+
+    @Test
+    @Order(146)
+    void putObjectRejectsUnsupportedSseCustomerAlgorithm() {
+        given()
+            .contentType("text/plain")
+            .header("x-amz-server-side-encryption-customer-algorithm", "aws:kms")
+            .header("x-amz-server-side-encryption-customer-key", SSE_CUSTOMER_KEY)
+            .header("x-amz-server-side-encryption-customer-key-MD5", SSE_CUSTOMER_KEY_MD5)
+            .body("bad sse-c")
+        .when()
+            .put("/sse-bucket/sse-c-invalid-algorithm.txt")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidArgument"))
+            .body(containsString("Unsupported x-amz-server-side-encryption-customer-algorithm value"));
+    }
+
+    @Test
+    @Order(147)
+    void putObjectRejectsInvalidSseCustomerKeyBase64() {
+        given()
+            .contentType("text/plain")
+            .header("x-amz-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-server-side-encryption-customer-key", "not-base64")
+            .header("x-amz-server-side-encryption-customer-key-MD5", SSE_CUSTOMER_KEY_MD5)
+            .body("bad sse-c")
+        .when()
+            .put("/sse-bucket/sse-c-invalid-key.txt")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidArgument"))
+            .body(containsString("not valid base64"));
+    }
+
+    @Test
+    @Order(148)
+    void putObjectRejectsInvalidSseCustomerKeyLength() {
+        given()
+            .contentType("text/plain")
+            .header("x-amz-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-server-side-encryption-customer-key", SHORT_SSE_CUSTOMER_KEY)
+            .header("x-amz-server-side-encryption-customer-key-MD5", SHORT_SSE_CUSTOMER_KEY_MD5)
+            .body("bad sse-c")
+        .when()
+            .put("/sse-bucket/sse-c-invalid-length.txt")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidArgument"))
+            .body(containsString("256-bit key"));
+    }
+
+    @Test
+    @Order(149)
+    void putObjectRejectsConflictingServerSideEncryption() {
+        given()
+            .contentType("text/plain")
+            .header("x-amz-server-side-encryption", "AES256")
+            .header("x-amz-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-server-side-encryption-customer-key", SSE_CUSTOMER_KEY)
+            .header("x-amz-server-side-encryption-customer-key-MD5", SSE_CUSTOMER_KEY_MD5)
+            .body("bad sse-c")
+        .when()
+            .put("/sse-bucket/sse-c-conflicting-encryption.txt")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidRequest"))
+            .body(containsString("SSE-C cannot be combined"));
+    }
+
+    @Test
+    @Order(153)
     void cleanupSseBucket() {
         given().delete("/sse-bucket/encrypted.txt");
         given().delete("/sse-bucket/encrypted-copy.txt");
+        given().delete("/sse-bucket/sse-c.txt");
+        given().delete("/sse-bucket/sse-c-copy.txt");
         given().delete("/sse-bucket");
     }
 
@@ -1684,5 +1907,15 @@ class S3IntegrationTest {
         .then()
             .statusCode(400)
             .body(containsString("BadDigest"));
+    }
+
+    private static String customerKeyMd5(String customerKey) {
+        try {
+            byte[] md5 = MessageDigest.getInstance("MD5").digest(Base64.getDecoder().decode(customerKey));
+            return Base64.getEncoder().encodeToString(md5);
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("MD5 is not available", e);
+        }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
@@ -6,6 +6,11 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 
@@ -15,6 +20,10 @@ class S3MultipartIntegrationTest {
 
     private static final String BUCKET = "multipart-test-bucket";
     private static final String KEY = "large-file.bin";
+    private static final String SSE_CUSTOMER_KEY = Base64.getEncoder().encodeToString("0123456789abcdef0123456789abcdef".getBytes(StandardCharsets.UTF_8));
+    private static final String SSE_CUSTOMER_KEY_MD5 = customerKeyMd5(SSE_CUSTOMER_KEY);
+    private static final String WRONG_SSE_CUSTOMER_KEY = Base64.getEncoder().encodeToString("abcdef0123456789abcdef0123456789".getBytes(StandardCharsets.UTF_8));
+    private static final String WRONG_SSE_CUSTOMER_KEY_MD5 = customerKeyMd5(WRONG_SSE_CUSTOMER_KEY);
     private static String uploadId;
 
     @Test
@@ -275,10 +284,223 @@ class S3MultipartIntegrationTest {
 
     @Test
     @Order(15)
+    void multipartUploadWithSseCustomerKeyRequiresMatchingPartKeys() {
+        String sseUploadId = given()
+            .header("x-amz-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-server-side-encryption-customer-key", SSE_CUSTOMER_KEY)
+            .header("x-amz-server-side-encryption-customer-key-MD5", SSE_CUSTOMER_KEY_MD5)
+        .when()
+            .post("/" + BUCKET + "/sse-c-multipart.bin?uploads")
+        .then()
+            .statusCode(200)
+            .header("x-amz-server-side-encryption-customer-algorithm", equalTo("AES256"))
+            .header("x-amz-server-side-encryption-customer-key-MD5", equalTo(SSE_CUSTOMER_KEY_MD5))
+            .extract().xmlPath().getString("InitiateMultipartUploadResult.UploadId");
+
+        given()
+            .body("missing-key")
+        .when()
+            .put("/" + BUCKET + "/sse-c-multipart.bin?uploadId=" + sseUploadId + "&partNumber=1")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidRequest"));
+
+        given()
+            .header("x-amz-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-server-side-encryption-customer-key", WRONG_SSE_CUSTOMER_KEY)
+            .header("x-amz-server-side-encryption-customer-key-MD5", WRONG_SSE_CUSTOMER_KEY_MD5)
+            .body("wrong-key")
+        .when()
+            .put("/" + BUCKET + "/sse-c-multipart.bin?uploadId=" + sseUploadId + "&partNumber=1")
+        .then()
+            .statusCode(403)
+            .body(containsString("AccessDenied"));
+
+        String partETag = given()
+            .header("x-amz-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-server-side-encryption-customer-key", SSE_CUSTOMER_KEY)
+            .header("x-amz-server-side-encryption-customer-key-MD5", SSE_CUSTOMER_KEY_MD5)
+            .body("sse-c-part")
+        .when()
+            .put("/" + BUCKET + "/sse-c-multipart.bin?uploadId=" + sseUploadId + "&partNumber=1")
+        .then()
+            .statusCode(200)
+            .header("x-amz-server-side-encryption-customer-algorithm", equalTo("AES256"))
+            .header("x-amz-server-side-encryption-customer-key-MD5", equalTo(SSE_CUSTOMER_KEY_MD5))
+            .extract().header("ETag");
+
+        String completeXml = """
+                <CompleteMultipartUpload>
+                    <Part><PartNumber>1</PartNumber><ETag>%s</ETag></Part>
+                </CompleteMultipartUpload>""".formatted(partETag);
+        given()
+            .contentType("application/xml")
+            .body(completeXml)
+        .when()
+            .post("/" + BUCKET + "/sse-c-multipart.bin?uploadId=" + sseUploadId)
+        .then()
+            .statusCode(200)
+            .header("x-amz-server-side-encryption-customer-algorithm", equalTo("AES256"))
+            .header("x-amz-server-side-encryption-customer-key-MD5", equalTo(SSE_CUSTOMER_KEY_MD5));
+
+        given()
+        .when()
+            .get("/" + BUCKET + "/sse-c-multipart.bin")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidRequest"));
+
+        given()
+            .header("x-amz-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-server-side-encryption-customer-key", SSE_CUSTOMER_KEY)
+            .header("x-amz-server-side-encryption-customer-key-MD5", SSE_CUSTOMER_KEY_MD5)
+        .when()
+            .get("/" + BUCKET + "/sse-c-multipart.bin")
+        .then()
+            .statusCode(200)
+            .header("x-amz-server-side-encryption-customer-algorithm", equalTo("AES256"))
+            .header("x-amz-server-side-encryption-customer-key-MD5", equalTo(SSE_CUSTOMER_KEY_MD5))
+            .body(equalTo("sse-c-part"));
+    }
+
+    @Test
+    @Order(16)
+    void uploadPartCopyWithSseCustomerSourceRequiresSourceKey() {
+        given()
+            .header("x-amz-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-server-side-encryption-customer-key", SSE_CUSTOMER_KEY)
+            .header("x-amz-server-side-encryption-customer-key-MD5", SSE_CUSTOMER_KEY_MD5)
+            .body("SSE-C-COPY")
+        .when()
+            .put("/" + BUCKET + "/sse-c-source-for-copy.bin")
+        .then()
+            .statusCode(200);
+
+        String copyUploadId = given()
+            .when()
+                .post("/" + BUCKET + "/sse-c-upload-part-copy.bin?uploads")
+            .then()
+                .statusCode(200)
+                .extract().xmlPath().getString("InitiateMultipartUploadResult.UploadId");
+
+        given()
+            .header("x-amz-copy-source", "/" + BUCKET + "/sse-c-source-for-copy.bin")
+        .when()
+            .put("/" + BUCKET + "/sse-c-upload-part-copy.bin?uploadId=" + copyUploadId + "&partNumber=1")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidRequest"));
+
+        given()
+            .header("x-amz-copy-source", "/" + BUCKET + "/sse-c-source-for-copy.bin")
+            .header("x-amz-copy-source-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-copy-source-server-side-encryption-customer-key", SSE_CUSTOMER_KEY)
+            .header("x-amz-copy-source-server-side-encryption-customer-key-MD5", SSE_CUSTOMER_KEY_MD5)
+        .when()
+            .put("/" + BUCKET + "/sse-c-upload-part-copy.bin?uploadId=" + copyUploadId + "&partNumber=1")
+        .then()
+            .statusCode(200)
+            .body(containsString("<CopyPartResult"));
+
+        given()
+        .when()
+            .delete("/" + BUCKET + "/sse-c-upload-part-copy.bin?uploadId=" + copyUploadId)
+        .then()
+            .statusCode(204);
+
+        String normalUploadId = given()
+            .when()
+                .post("/" + BUCKET + "/sse-c-headers-on-normal-upload.bin?uploads")
+            .then()
+                .statusCode(200)
+                .extract().xmlPath().getString("InitiateMultipartUploadResult.UploadId");
+
+        given()
+            .header("x-amz-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-server-side-encryption-customer-key", SSE_CUSTOMER_KEY)
+            .header("x-amz-server-side-encryption-customer-key-MD5", SSE_CUSTOMER_KEY_MD5)
+            .body("unexpected-sse-c-part")
+        .when()
+            .put("/" + BUCKET + "/sse-c-headers-on-normal-upload.bin?uploadId=" + normalUploadId + "&partNumber=1")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidRequest"));
+
+        given()
+        .when()
+            .delete("/" + BUCKET + "/sse-c-headers-on-normal-upload.bin?uploadId=" + normalUploadId)
+        .then()
+            .statusCode(204);
+
+        String sseCopyUploadId = given()
+            .header("x-amz-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-server-side-encryption-customer-key", SSE_CUSTOMER_KEY)
+            .header("x-amz-server-side-encryption-customer-key-MD5", SSE_CUSTOMER_KEY_MD5)
+            .when()
+                .post("/" + BUCKET + "/sse-c-upload-part-copy-dest.bin?uploads")
+            .then()
+                .statusCode(200)
+                .header("x-amz-server-side-encryption-customer-algorithm", equalTo("AES256"))
+                .header("x-amz-server-side-encryption-customer-key-MD5", equalTo(SSE_CUSTOMER_KEY_MD5))
+                .extract().xmlPath().getString("InitiateMultipartUploadResult.UploadId");
+
+        given()
+            .header("x-amz-copy-source", "/" + BUCKET + "/sse-c-source-for-copy.bin")
+            .header("x-amz-copy-source-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-copy-source-server-side-encryption-customer-key", SSE_CUSTOMER_KEY)
+            .header("x-amz-copy-source-server-side-encryption-customer-key-MD5", SSE_CUSTOMER_KEY_MD5)
+            .header("x-amz-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-server-side-encryption-customer-key", SSE_CUSTOMER_KEY)
+            .header("x-amz-server-side-encryption-customer-key-MD5", SSE_CUSTOMER_KEY_MD5)
+        .when()
+            .put("/" + BUCKET + "/sse-c-upload-part-copy-dest.bin?uploadId=" + sseCopyUploadId + "&partNumber=1")
+        .then()
+            .statusCode(200)
+            .header("x-amz-server-side-encryption-customer-algorithm", equalTo("AES256"))
+            .header("x-amz-server-side-encryption-customer-key-MD5", equalTo(SSE_CUSTOMER_KEY_MD5))
+            .body(containsString("<CopyPartResult"));
+
+        given()
+        .when()
+            .delete("/" + BUCKET + "/sse-c-upload-part-copy-dest.bin?uploadId=" + sseCopyUploadId)
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    @Order(17)
+    void initiateMultipartUploadRejectsConflictingServerSideEncryption() {
+        given()
+            .header("x-amz-server-side-encryption", "AES256")
+            .header("x-amz-server-side-encryption-customer-algorithm", "AES256")
+            .header("x-amz-server-side-encryption-customer-key", SSE_CUSTOMER_KEY)
+            .header("x-amz-server-side-encryption-customer-key-MD5", SSE_CUSTOMER_KEY_MD5)
+        .when()
+            .post("/" + BUCKET + "/conflicting-sse-c-multipart.bin?uploads")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidRequest"))
+            .body(containsString("SSE-C cannot be combined"));
+    }
+
+    @Test
+    @Order(18)
     void cleanUp() {
         given().when().delete("/" + BUCKET + "/" + KEY).then().statusCode(204);
         given().when().delete("/" + BUCKET + "/source-for-copy.bin").then().statusCode(204);
         given().when().delete("/" + BUCKET + "/copy-dest.bin").then().statusCode(204);
+        given().when().delete("/" + BUCKET + "/sse-c-multipart.bin").then().statusCode(204);
+        given().when().delete("/" + BUCKET + "/sse-c-source-for-copy.bin").then().statusCode(204);
         given().when().delete("/" + BUCKET).then().statusCode(204);
+    }
+
+    private static String customerKeyMd5(String customerKey) {
+        try {
+            byte[] md5 = MessageDigest.getInstance("MD5").digest(Base64.getDecoder().decode(customerKey));
+            return Base64.getEncoder().encodeToString(md5);
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("MD5 is not available", e);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #1140

Add SSE-C customer-key metadata checks for S3 object reads and heads. Objects written with SSE-C now require matching customer key headers before Floci returns object data or metadata.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

SSE-C objects now require matching customer key headers for `GetObject` and `HeadObject`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)