### PR TITLE
fix(cloudfront): provision distributions in CloudFormation and fix list response parsing

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -31,6 +31,9 @@ import io.github.hectorvent.floci.services.apigatewayv2.model.*;
 import io.github.hectorvent.floci.services.cognito.CognitoService;
 import io.github.hectorvent.floci.services.cognito.model.UserPool;
 import io.github.hectorvent.floci.services.cognito.model.UserPoolClient;
+import io.github.hectorvent.floci.services.cloudfront.CloudFrontService;
+import io.github.hectorvent.floci.services.cloudfront.model.Distribution;
+import io.github.hectorvent.floci.services.cloudfront.model.DistributionConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -77,6 +80,7 @@ public class CloudFormationResourceProvisioner {
     private final EcrService ecrService;
     private final PipesService pipesService;
     private final CognitoService cognitoService;
+    private final CloudFrontService cloudFrontService;
 
     @Inject
     public CloudFormationResourceProvisioner(S3Service s3Service, SqsService sqsService,
@@ -89,7 +93,8 @@ public class CloudFormationResourceProvisioner {
                                              ApiGatewayV2Service apiGatewayV2Service,
                                              EcrService ecrService,
                                              PipesService pipesService,
-                                             CognitoService cognitoService) {
+                                             CognitoService cognitoService,
+                                             CloudFrontService cloudFrontService) {
         this.s3Service = s3Service;
         this.sqsService = sqsService;
         this.snsService = snsService;
@@ -105,6 +110,7 @@ public class CloudFormationResourceProvisioner {
         this.ecrService = ecrService;
         this.pipesService = pipesService;
         this.cognitoService = cognitoService;
+        this.cloudFrontService = cloudFrontService;
     }
 
     /**
@@ -178,6 +184,8 @@ public class CloudFormationResourceProvisioner {
                         provisionCognitoUserPool(resource, properties, engine, region, accountId, stackName);
                 case "AWS::Cognito::UserPoolClient" ->
                         provisionCognitoUserPoolClient(resource, properties, engine, region, accountId, stackName);
+                case "AWS::CloudFront::Distribution" ->
+                        provisionCloudFrontDistribution(resource, properties, engine);
                 default -> {
                     LOG.debugv("Stubbing unsupported resource type: {0} ({1})", resourceType, logicalId);
                     resource.setPhysicalId(logicalId + "-" + UUID.randomUUID().toString().substring(0, 8));
@@ -220,11 +228,94 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::Lambda::EventSourceMapping" -> lambdaService.deleteEventSourceMapping(physicalId);
                 case "AWS::Cognito::UserPool" -> cognitoService.deleteUserPool(physicalId);
                 case "AWS::Cognito::UserPoolClient" -> cognitoService.deleteUserPoolClient(physicalId);
+                case "AWS::CloudFront::Distribution" -> deleteCloudFrontDistribution(physicalId);
                 default -> LOG.debugv("Skipping delete of unsupported resource type: {0}", resourceType);
             }
         } catch (Exception e) {
             LOG.debugv("Error deleting {0} ({1}): {2}", resourceType, physicalId, e.getMessage());
         }
+    }
+
+    // ── CloudFront ──────────────────────────────────────────────────────────────
+
+    /**
+     * Provisions an AWS::CloudFront::Distribution. CloudFront in Floci is management-plane only:
+     * the service generates a distribution id and DomainName ({@code <id>.cloudfront.net}) and stores
+     * the config. Setting the DomainName attribute is what lets Fn::GetAtt [Dist, DomainName] resolve,
+     * and creating the distribution in CloudFrontService is what makes list/get-distribution return it.
+     */
+    private void provisionCloudFrontDistribution(StackResource r, JsonNode props,
+                                                 CloudFormationTemplateEngine engine) {
+        DistributionConfig config = buildDistributionConfig(props, engine);
+        Map<String, String> tags = parseCfnTags(props != null ? props.get("Tags") : null, engine);
+
+        Distribution dist = new Distribution();
+        dist.setConfig(config);
+
+        Distribution result;
+        if (r.getPhysicalId() == null) {
+            result = cloudFrontService.createDistribution(dist, tags);
+        } else {
+            Distribution existing = cloudFrontService.getDistribution(r.getPhysicalId());
+            result = cloudFrontService.updateDistribution(r.getPhysicalId(), existing.getEtag(), dist);
+        }
+
+        r.setPhysicalId(result.getId());
+        r.getAttributes().put("Id", result.getId());
+        r.getAttributes().put("DomainName", result.getDomainName());
+        r.getAttributes().put("Arn", result.getArn());
+    }
+
+    /**
+     * Maps the top-level scalar fields of a CloudFormation DistributionConfig onto Floci's model.
+     * Nested origins/cache behaviors are intentionally left sparse — CloudFront does not serve
+     * content in Floci, so these only affect what get/list-distribution echoes back.
+     */
+    private DistributionConfig buildDistributionConfig(JsonNode props, CloudFormationTemplateEngine engine) {
+        DistributionConfig cfg = new DistributionConfig();
+        if (props == null || !props.has("DistributionConfig") || props.get("DistributionConfig").isNull()) {
+            return cfg;
+        }
+        JsonNode dc = engine.resolveNode(props.get("DistributionConfig"));
+        if (dc == null || dc.isNull()) {
+            return cfg;
+        }
+        if (dc.has("Enabled")) {
+            cfg.setEnabled(dc.get("Enabled").asBoolean(false));
+        }
+        if (dc.hasNonNull("Comment")) {
+            cfg.setComment(dc.get("Comment").asText());
+        }
+        if (dc.hasNonNull("DefaultRootObject")) {
+            cfg.setDefaultRootObject(dc.get("DefaultRootObject").asText());
+        }
+        if (dc.hasNonNull("HttpVersion")) {
+            cfg.setHttpVersion(dc.get("HttpVersion").asText());
+        }
+        if (dc.hasNonNull("PriceClass")) {
+            cfg.setPriceClass(dc.get("PriceClass").asText());
+        }
+        if (dc.has("IPV6Enabled")) {
+            cfg.setIPV6Enabled(dc.get("IPV6Enabled").asBoolean(true));
+        }
+        if (dc.hasNonNull("WebACLId")) {
+            cfg.setWebAclId(dc.get("WebACLId").asText());
+        }
+        return cfg;
+    }
+
+    /**
+     * Deletes a distribution. CloudFrontService refuses to delete an enabled distribution
+     * (mirroring AWS), so disable it first, then delete using the refreshed ETag.
+     */
+    private void deleteCloudFrontDistribution(String id) {
+        Distribution dist = cloudFrontService.getDistribution(id);
+        String etag = dist.getEtag();
+        if (dist.getConfig() != null && dist.getConfig().isEnabled()) {
+            dist.getConfig().setEnabled(false);
+            etag = cloudFrontService.updateDistribution(id, etag, dist).getEtag();
+        }
+        cloudFrontService.deleteDistribution(id, etag);
     }
 
     // ── S3 ────────────────────────────────────────────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontController.java
@@ -141,8 +141,7 @@ public class CloudFrontController {
             boolean truncated = dists.size() == maxItems && dists.size() < total;
 
             XmlBuilder xml = new XmlBuilder()
-                    .start("ListDistributionsResult", NS)
-                    .start("DistributionList")
+                    .start("DistributionList", NS)
                     .elem("Marker", marker != null ? marker : "")
                     .elem("MaxItems", maxItems)
                     .elem("IsTruncated", truncated);
@@ -155,8 +154,7 @@ public class CloudFrontController {
                 xml.raw(xmlDistributionSummary(d));
             }
             xml.end("Items")
-                    .end("DistributionList")
-                    .end("ListDistributionsResult");
+                    .end("DistributionList");
             return Response.ok(xml.build(), XML).build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
@@ -338,8 +336,7 @@ public class CloudFrontController {
             boolean truncated = policies.size() == maxItems;
 
             XmlBuilder xml = new XmlBuilder()
-                    .start("ListCachePoliciesResult", NS)
-                    .start("CachePolicyList")
+                    .start("CachePolicyList", NS)
                     .elem("Marker", marker != null ? marker : "")
                     .elem("MaxItems", maxItems)
                     .elem("IsTruncated", truncated)
@@ -351,7 +348,7 @@ public class CloudFrontController {
                         .raw(xmlCachePolicyResponse(p))
                         .end("CachePolicySummary");
             }
-            xml.end("Items").end("CachePolicyList").end("ListCachePoliciesResult");
+            xml.end("Items").end("CachePolicyList");
             return Response.ok(xml.build(), XML).build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
@@ -451,8 +448,7 @@ public class CloudFrontController {
             boolean truncated = policies.size() == maxItems;
 
             XmlBuilder xml = new XmlBuilder()
-                    .start("ListOriginRequestPoliciesResult", NS)
-                    .start("OriginRequestPolicyList")
+                    .start("OriginRequestPolicyList", NS)
                     .elem("Marker", marker != null ? marker : "")
                     .elem("MaxItems", maxItems)
                     .elem("IsTruncated", truncated)
@@ -464,7 +460,7 @@ public class CloudFrontController {
                         .raw(xmlOriginRequestPolicyResponse(p))
                         .end("OriginRequestPolicySummary");
             }
-            xml.end("Items").end("OriginRequestPolicyList").end("ListOriginRequestPoliciesResult");
+            xml.end("Items").end("OriginRequestPolicyList");
             return Response.ok(xml.build(), XML).build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
@@ -565,8 +561,7 @@ public class CloudFrontController {
             boolean truncated = policies.size() == maxItems;
 
             XmlBuilder xml = new XmlBuilder()
-                    .start("ListResponseHeadersPoliciesResult", NS)
-                    .start("ResponseHeadersPolicyList")
+                    .start("ResponseHeadersPolicyList", NS)
                     .elem("Marker", marker != null ? marker : "")
                     .elem("MaxItems", maxItems)
                     .elem("IsTruncated", truncated)
@@ -578,7 +573,7 @@ public class CloudFrontController {
                         .raw(xmlResponseHeadersPolicyResponse(p))
                         .end("ResponseHeadersPolicySummary");
             }
-            xml.end("Items").end("ResponseHeadersPolicyList").end("ListResponseHeadersPoliciesResult");
+            xml.end("Items").end("ResponseHeadersPolicyList");
             return Response.ok(xml.build(), XML).build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
@@ -680,8 +675,7 @@ public class CloudFrontController {
             boolean truncated = oacs.size() == maxItems;
 
             XmlBuilder xml = new XmlBuilder()
-                    .start("ListOriginAccessControlsResult", NS)
-                    .start("OriginAccessControlList")
+                    .start("OriginAccessControlList", NS)
                     .elem("Marker", marker != null ? marker : "")
                     .elem("MaxItems", maxItems)
                     .elem("IsTruncated", truncated)
@@ -690,7 +684,7 @@ public class CloudFrontController {
             for (OriginAccessControl o : oacs) {
                 xml.raw(xmlOriginAccessControlSummary(o));
             }
-            xml.end("Items").end("OriginAccessControlList").end("ListOriginAccessControlsResult");
+            xml.end("Items").end("OriginAccessControlList");
             return Response.ok(xml.build(), XML).build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
@@ -790,8 +784,7 @@ public class CloudFrontController {
             boolean truncated = oais.size() == maxItems;
 
             XmlBuilder xml = new XmlBuilder()
-                    .start("ListCloudFrontOriginAccessIdentitiesResult", NS)
-                    .start("CloudFrontOriginAccessIdentityList")
+                    .start("CloudFrontOriginAccessIdentityList", NS)
                     .elem("Marker", marker != null ? marker : "")
                     .elem("MaxItems", maxItems)
                     .elem("IsTruncated", truncated)
@@ -804,8 +797,7 @@ public class CloudFrontController {
                         .elem("Comment", o.getComment() != null ? o.getComment() : "")
                         .end("CloudFrontOriginAccessIdentitySummary");
             }
-            xml.end("Items").end("CloudFrontOriginAccessIdentityList")
-                    .end("ListCloudFrontOriginAccessIdentitiesResult");
+            xml.end("Items").end("CloudFrontOriginAccessIdentityList");
             return Response.ok(xml.build(), XML).build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
@@ -901,8 +893,7 @@ public class CloudFrontController {
         try {
             List<CloudFrontFunction> fns = service.listFunctions(stage);
             XmlBuilder xml = new XmlBuilder()
-                    .start("ListFunctionsResult", NS)
-                    .start("FunctionList")
+                    .start("FunctionList", NS)
                     .elem("MaxItems", maxItems)
                     .elem("Quantity", fns.size())
                     .start("Items");
@@ -924,7 +915,7 @@ public class CloudFrontController {
                         .end("FunctionMetadata")
                         .end("FunctionSummary");
             }
-            xml.end("Items").end("FunctionList").end("ListFunctionsResult");
+            xml.end("Items").end("FunctionList");
             return Response.ok(xml.build(), XML).build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
@@ -939,8 +930,7 @@ public class CloudFrontController {
         try {
             Map<String, String> tags = service.listTagsForResource(resource);
             XmlBuilder xml = new XmlBuilder()
-                    .start("ListTagsForResourceResult", NS)
-                    .start("Tags")
+                    .start("Tags", NS)
                     .start("Items");
             for (Map.Entry<String, String> entry : tags.entrySet()) {
                 xml.start("Tag")
@@ -948,7 +938,7 @@ public class CloudFrontController {
                         .elem("Value", entry.getValue())
                         .end("Tag");
             }
-            xml.end("Items").end("Tags").end("ListTagsForResourceResult");
+            xml.end("Items").end("Tags");
             return Response.ok(xml.build(), XML).build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
@@ -1052,8 +1042,7 @@ public class CloudFrontController {
             boolean truncated = policies.size() == maxItems;
 
             XmlBuilder xml = new XmlBuilder()
-                    .start("ListContinuousDeploymentPoliciesResult", NS)
-                    .start("ContinuousDeploymentPolicyList")
+                    .start("ContinuousDeploymentPolicyList", NS)
                     .elem("Marker", marker != null ? marker : "")
                     .elem("MaxItems", maxItems)
                     .elem("IsTruncated", truncated)
@@ -1065,8 +1054,7 @@ public class CloudFrontController {
                         .raw(xmlContinuousDeploymentPolicyResponse(p))
                         .end("ContinuousDeploymentPolicySummary");
             }
-            xml.end("Items").end("ContinuousDeploymentPolicyList")
-                    .end("ListContinuousDeploymentPoliciesResult");
+            xml.end("Items").end("ContinuousDeploymentPolicyList");
             return Response.ok(xml.build(), XML).build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
@@ -1186,8 +1174,7 @@ public class CloudFrontController {
             boolean truncated = keys.size() == maxItems;
 
             XmlBuilder xml = new XmlBuilder()
-                    .start("ListPublicKeysResult", NS)
-                    .start("PublicKeyList")
+                    .start("PublicKeyList", NS)
                     .elem("Marker", marker != null ? marker : "")
                     .elem("MaxItems", maxItems)
                     .elem("IsTruncated", truncated)
@@ -1196,7 +1183,7 @@ public class CloudFrontController {
             for (PublicKey k : keys) {
                 xml.raw(xmlPublicKeySummary(k));
             }
-            xml.end("Items").end("PublicKeyList").end("ListPublicKeysResult");
+            xml.end("Items").end("PublicKeyList");
             return Response.ok(xml.build(), XML).build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
@@ -1296,8 +1283,7 @@ public class CloudFrontController {
             boolean truncated = groups.size() == maxItems;
 
             XmlBuilder xml = new XmlBuilder()
-                    .start("ListKeyGroupsResult", NS)
-                    .start("KeyGroupList")
+                    .start("KeyGroupList", NS)
                     .elem("Marker", marker != null ? marker : "")
                     .elem("MaxItems", maxItems)
                     .elem("IsTruncated", truncated)
@@ -1306,7 +1292,7 @@ public class CloudFrontController {
             for (KeyGroup g : groups) {
                 xml.start("KeyGroupSummary").raw(xmlKeyGroupResponse(g)).end("KeyGroupSummary");
             }
-            xml.end("Items").end("KeyGroupList").end("ListKeyGroupsResult");
+            xml.end("Items").end("KeyGroupList");
             return Response.ok(xml.build(), XML).build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
@@ -1392,8 +1378,7 @@ public class CloudFrontController {
             boolean truncated = configs.size() == maxItems;
 
             XmlBuilder xml = new XmlBuilder()
-                    .start("ListRealtimeLogConfigsResult", NS)
-                    .start("RealtimeLogConfigs")
+                    .start("RealtimeLogConfigs", NS)
                     .elem("MaxItems", maxItems)
                     .elem("IsTruncated", truncated)
                     .elem("Quantity", configs.size())
@@ -1401,7 +1386,7 @@ public class CloudFrontController {
             for (RealtimeLogConfig c : configs) {
                 xml.raw(xmlRealtimeLogConfigBody(c));
             }
-            xml.end("Items").end("RealtimeLogConfigs").end("ListRealtimeLogConfigsResult");
+            xml.end("Items").end("RealtimeLogConfigs");
             return Response.ok(xml.build(), XML).build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
@@ -1562,8 +1547,7 @@ public class CloudFrontController {
             boolean truncated = configs.size() == maxItems;
 
             XmlBuilder xml = new XmlBuilder()
-                    .start("ListFieldLevelEncryptionConfigsResult", NS)
-                    .start("FieldLevelEncryptionList")
+                    .start("FieldLevelEncryptionList", NS)
                     .elem("Marker", marker != null ? marker : "")
                     .elem("MaxItems", maxItems)
                     .elem("IsTruncated", truncated)
@@ -1572,7 +1556,7 @@ public class CloudFrontController {
             for (FieldLevelEncryptionConfig c : configs) {
                 xml.raw(xmlFieldLevelEncryptionConfigResponse(c));
             }
-            xml.end("Items").end("FieldLevelEncryptionList").end("ListFieldLevelEncryptionConfigsResult");
+            xml.end("Items").end("FieldLevelEncryptionList");
             return Response.ok(xml.build(), XML).build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
@@ -1656,8 +1640,7 @@ public class CloudFrontController {
             boolean truncated = profiles.size() == maxItems;
 
             XmlBuilder xml = new XmlBuilder()
-                    .start("ListFieldLevelEncryptionProfilesResult", NS)
-                    .start("FieldLevelEncryptionProfileList")
+                    .start("FieldLevelEncryptionProfileList", NS)
                     .elem("Marker", marker != null ? marker : "")
                     .elem("MaxItems", maxItems)
                     .elem("IsTruncated", truncated)
@@ -1666,8 +1649,7 @@ public class CloudFrontController {
             for (FieldLevelEncryptionProfile p : profiles) {
                 xml.raw(xmlFieldLevelEncryptionProfileResponse(p));
             }
-            xml.end("Items").end("FieldLevelEncryptionProfileList")
-                    .end("ListFieldLevelEncryptionProfilesResult");
+            xml.end("Items").end("FieldLevelEncryptionProfileList");
             return Response.ok(xml.build(), XML).build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -1710,6 +1710,81 @@ class CloudFormationIntegrationTest {
     }
 
     @Test
+    void createStack_cloudFrontDistribution_resolvesDomainNameAndStoresDistribution() {
+        // Regression: AWS::CloudFront::Distribution used to hit the default stub, so
+        // Fn::GetAtt [Dist, DomainName] resolved to the raw token "Distribution.DomainName"
+        // and the distribution was never created in the CloudFront service.
+        String template = """
+            {
+              "Resources": {
+                "Distribution": {
+                  "Type": "AWS::CloudFront::Distribution",
+                  "Properties": {
+                    "DistributionConfig": {
+                      "Enabled": true,
+                      "Comment": "repro",
+                      "Origins": [
+                        {
+                          "Id": "origin",
+                          "DomainName": "example.com",
+                          "CustomOriginConfig": {"OriginProtocolPolicy": "https-only"}
+                        }
+                      ],
+                      "DefaultCacheBehavior": {
+                        "TargetOriginId": "origin",
+                        "ViewerProtocolPolicy": "redirect-to-https",
+                        "ForwardedValues": {"QueryString": false}
+                      }
+                    }
+                  }
+                }
+              },
+              "Outputs": {
+                "DistributionDomainName": {
+                  "Value": {"Fn::GetAtt": ["Distribution", "DomainName"]}
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cloudfront-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        // The DomainName output must be a generated <id>.cloudfront.net, NOT the raw token.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cloudfront-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<OutputKey>DistributionDomainName</OutputKey>"))
+            .body(containsString(".cloudfront.net"))
+            .body(not(containsString("Distribution.DomainName")));
+
+        // The distribution must actually exist in the CloudFront service, and the list response
+        // must be rooted at the payload element <DistributionList> (not wrapped in
+        // <ListDistributionsResult>), otherwise the AWS CLI/SDKs parse it as empty.
+        given()
+        .when()
+            .get("/2020-05-31/distribution")
+        .then()
+            .statusCode(200)
+            .body(containsString(".cloudfront.net"))
+            .body(containsString("<DistributionList"))
+            .body(not(containsString("ListDistributionsResult")));
+    }
+
+    @Test
     void createStack_snsAutoName_refReturnsArn() {
         // SNS Ref returns TopicArn. AWS example: arn:aws:sns:us-east-1:123456789012:mystack-mytopic-NZJ5JSMVGFIE
         // See: https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-sns-topic.html


### PR DESCRIPTION
## Summary

Closes #1147. Two related CloudFront fixes:

1. **Provision `AWS::CloudFront::Distribution` in CloudFormation.** The resource type had no handler in `CloudFormationResourceProvisioner` and fell through to the default stub, so `Fn::GetAtt [Dist, DomainName]` resolved to the raw token `Distribution.DomainName` and no distribution was created. It now creates/updates/deletes the distribution via `CloudFrontService` and sets the `DomainName`/`Id`/`Arn` attributes (delete disables first, mirroring AWS).
2. **Root all 14 CloudFront `list-*` responses at their payload element.** Responses were wrapped in `<ListXxxResult>`, but these operations are payload-rooted in the AWS model (e.g. `ListDistributions` payload = `DistributionList`), so the AWS CLI/SDKs parsed them as empty. Each now roots at the payload element (e.g. `<DistributionList>`), with the namespace moved there.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Bug fix.

- **Before:** `AWS::CloudFront::Distribution` was stubbed (`Fn::GetAtt DomainName` → raw token, distribution never stored); CloudFront `list-*` responses were wrapped in `<ListXxxResult>` and unparseable by SDK clients.
- **After:** distribution is provisioned and `DomainName` resolves to `<id>.cloudfront.net`; list responses root at the payload element.
- Verified against `mvn quarkus:dev` with AWS CLI 2.13.22 and AWS CDK 2.x: `cdk deploy` output yields a real `*.cloudfront.net` domain, and `aws cloudfront list-distributions` / `get-distribution` return the distribution.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
