### PR TITLE
feat(ecs): honour RunTask containerOverrides (command + environment)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.services.ecs.model.CapacityProvider;
 import io.github.hectorvent.floci.services.ecs.model.ClusterSetting;
 import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
 import io.github.hectorvent.floci.services.ecs.model.ContainerInstance;
+import io.github.hectorvent.floci.services.ecs.model.ContainerOverride;
 import io.github.hectorvent.floci.services.ecs.model.EcsCluster;
 import io.github.hectorvent.floci.services.ecs.model.EcsLoadBalancer;
 import io.github.hectorvent.floci.services.ecs.model.EcsServiceModel;
@@ -269,9 +270,11 @@ public class EcsJsonHandler {
         LaunchType launchType = parseEnum(req, "launchType", LaunchType.class);
         String group = req.has("group") ? req.path("group").asText() : null;
         String startedBy = req.has("startedBy") ? req.path("startedBy").asText() : null;
+        List<ContainerOverride> containerOverrides =
+                parseContainerOverrides(req.path("overrides").path("containerOverrides"));
 
         List<EcsTask> launched = service.runTask(cluster, taskDefinition, count,
-                launchType, group, startedBy, region);
+                launchType, group, startedBy, containerOverrides, region);
 
         ObjectNode resp = objectMapper.createObjectNode();
         ArrayNode arr = objectMapper.createArrayNode();
@@ -1232,6 +1235,25 @@ public class EcsJsonHandler {
         }
         for (JsonNode item : node) {
             result.add(new KeyValuePair(item.path("name").asText(), item.path("value").asText()));
+        }
+        return result;
+    }
+
+    private List<ContainerOverride> parseContainerOverrides(JsonNode node) {
+        List<ContainerOverride> result = new ArrayList<>();
+        if (!node.isArray()) {
+            return result;
+        }
+        for (JsonNode item : node) {
+            ContainerOverride co = new ContainerOverride();
+            co.setName(item.path("name").asText());
+            if (item.has("command") && item.path("command").isArray()) {
+                List<String> cmd = new ArrayList<>();
+                item.path("command").forEach(c -> cmd.add(c.asText()));
+                co.setCommand(cmd);
+            }
+            co.setEnvironment(parseKeyValuePairs(item.path("environment")));
+            result.add(co);
         }
         return result;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
@@ -10,6 +10,7 @@ import io.github.hectorvent.floci.services.ecs.model.CapacityProvider;
 import io.github.hectorvent.floci.services.ecs.model.ClusterSetting;
 import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
 import io.github.hectorvent.floci.services.ecs.model.ContainerInstance;
+import io.github.hectorvent.floci.services.ecs.model.ContainerOverride;
 import io.github.hectorvent.floci.services.ecs.model.EcsCluster;
 import io.github.hectorvent.floci.services.ecs.model.EcsLoadBalancer;
 import io.github.hectorvent.floci.services.ecs.model.EcsServiceModel;
@@ -247,10 +248,12 @@ public class EcsService {
     // ── Tasks ─────────────────────────────────────────────────────────────────
 
     public List<EcsTask> runTask(String clusterRef, String taskDefinitionRef, int count,
-                                  LaunchType launchType, String group, String startedBy, String region) {
+                                  LaunchType launchType, String group, String startedBy,
+                                  List<ContainerOverride> containerOverrides, String region) {
         EcsCluster cluster = resolveClusterOrDefault(clusterRef, region);
         TaskDefinition taskDef = resolveTaskDefinitionOrThrow(taskDefinitionRef, region);
-        return launchTasks(cluster, taskDef, count, launchType, group, startedBy, null, region);
+        return launchTasks(cluster, taskDef, count, launchType, group, startedBy, null,
+                containerOverrides, region);
     }
 
     public List<EcsTask> startTask(String clusterRef, List<String> containerInstanceRefs,
@@ -261,7 +264,7 @@ public class EcsService {
         for (String instanceRef : containerInstanceRefs) {
             ContainerInstance instance = resolveContainerInstanceOrThrow(cluster.getClusterArn(), instanceRef);
             List<EcsTask> launched = launchTasks(cluster, taskDef, 1, LaunchType.EC2,
-                    group, startedBy, instance.getContainerInstanceArn(), region);
+                    group, startedBy, instance.getContainerInstanceArn(), null, region);
             result.addAll(launched);
         }
         return result;
@@ -269,7 +272,8 @@ public class EcsService {
 
     private List<EcsTask> launchTasks(EcsCluster cluster, TaskDefinition taskDef, int count,
                                        LaunchType launchType, String group, String startedBy,
-                                       String containerInstanceArn, String region) {
+                                       String containerInstanceArn,
+                                       List<ContainerOverride> containerOverrides, String region) {
         List<EcsTask> launched = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             String taskId = UUID.randomUUID().toString().replace("-", "");
@@ -295,7 +299,7 @@ public class EcsService {
 
             if (dockerMode) {
                 try {
-                    EcsTaskHandle handle = containerManager.startTask(task, taskDef, region);
+                    EcsTaskHandle handle = containerManager.startTask(task, taskDef, containerOverrides, region);
                     taskHandles.put(taskArn, handle);
                     cluster.setRunningTasksCount(cluster.getRunningTasksCount() + 1);
                     LOG.infov("Started ECS task (docker): {0}", taskArn);
@@ -1123,7 +1127,7 @@ public class EcsService {
             for (int i = 0; i < toStart; i++) {
                 try {
                     List<EcsTask> launched = runTask(clusterName, svc.getTaskDefinition(), 1,
-                            svc.getLaunchType(), svc.getServiceName(), "ecs-svc", region);
+                            svc.getLaunchType(), svc.getServiceName(), "ecs-svc", null, region);
                     LOG.infov("Service reconciler started task {0} for service {1}",
                             launched.getFirst().getTaskArn(), svc.getServiceName());
                 } catch (Exception e) {

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManager.java
@@ -10,6 +10,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
 import io.github.hectorvent.floci.services.ecs.model.Container;
 import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
+import io.github.hectorvent.floci.services.ecs.model.ContainerOverride;
 import io.github.hectorvent.floci.services.ecs.model.EcsTask;
 import io.github.hectorvent.floci.services.ecs.model.NetworkBinding;
 import io.github.hectorvent.floci.services.ecs.model.PortMapping;
@@ -63,7 +64,8 @@ public class EcsContainerManager {
      * Starts Docker containers for all container definitions in a task.
      * Updates the task's container list in-place with runtime network bindings and docker IDs.
      */
-    public EcsTaskHandle startTask(EcsTask task, TaskDefinition taskDef, String region) {
+    public EcsTaskHandle startTask(EcsTask task, TaskDefinition taskDef,
+                                   List<ContainerOverride> containerOverrides, String region) {
         String taskId = extractTaskId(task.getTaskArn());
 
         Map<String, String> containerIds = new LinkedHashMap<>();
@@ -73,10 +75,22 @@ public class EcsContainerManager {
         for (ContainerDefinition def : taskDef.getContainerDefinitions()) {
             String containerName = "floci-ecs-" + taskId + "-" + def.getName();
 
+            // RunTask containerOverrides matched by container name: command replaces
+            // the task-def command; environment is merged over the task-def environment.
+            ContainerOverride override = null;
+            if (containerOverrides != null) {
+                for (ContainerOverride co : containerOverrides) {
+                    if (def.getName() != null && def.getName().equals(co.getName())) {
+                        override = co;
+                        break;
+                    }
+                }
+            }
+
             // Build container spec
             ContainerBuilder.Builder specBuilder = containerBuilder.newContainer(def.getImage())
                     .withName(containerName)
-                    .withEnv(buildEnvVars(def))
+                    .withEnv(buildEnvVars(def, override))
                     .withDockerNetwork(config.services().ecs().dockerNetwork())
                     .withLogRotation();
 
@@ -98,9 +112,14 @@ public class EcsContainerManager {
                 }
             }
 
-            // Add command and entrypoint if specified
-            if (def.getCommand() != null && !def.getCommand().isEmpty()) {
-                specBuilder.withCmd(def.getCommand());
+            // Add command and entrypoint if specified. An override command (from
+            // RunTask containerOverrides) takes precedence over the task-def command.
+            List<String> effectiveCommand =
+                    (override != null && override.getCommand() != null && !override.getCommand().isEmpty())
+                            ? override.getCommand()
+                            : def.getCommand();
+            if (effectiveCommand != null && !effectiveCommand.isEmpty()) {
+                specBuilder.withCmd(effectiveCommand);
             }
             if (def.getEntryPoint() != null && !def.getEntryPoint().isEmpty()) {
                 specBuilder.withEntrypoint(def.getEntryPoint());
@@ -232,12 +251,22 @@ public class EcsContainerManager {
         }
     }
 
-    private List<String> buildEnvVars(ContainerDefinition def) {
-        List<String> envVars = new ArrayList<>();
+    private List<String> buildEnvVars(ContainerDefinition def, ContainerOverride override) {
+        // Task-def environment first, then override environment (override wins on key conflict).
+        Map<String, String> envMap = new LinkedHashMap<>();
         if (def.getEnvironment() != null) {
             for (var kv : def.getEnvironment()) {
-                envVars.add(kv.name() + "=" + kv.value());
+                envMap.put(kv.name(), kv.value());
             }
+        }
+        if (override != null && override.getEnvironment() != null) {
+            for (var kv : override.getEnvironment()) {
+                envMap.put(kv.name(), kv.value());
+            }
+        }
+        List<String> envVars = new ArrayList<>();
+        for (var entry : envMap.entrySet()) {
+            envVars.add(entry.getKey() + "=" + entry.getValue());
         }
         return envVars;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/ContainerOverride.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/ContainerOverride.java
@@ -1,0 +1,28 @@
+package io.github.hectorvent.floci.services.ecs.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+
+/**
+ * A per-container override supplied on a RunTask request
+ * (overrides.containerOverrides[]). When present and matched by {@code name}
+ * to a container definition, its {@code command} replaces the task-def command
+ * and its {@code environment} is merged over the task-def environment.
+ */
+@RegisterForReflection
+public class ContainerOverride {
+
+    private String name;
+    private List<String> command;
+    private List<KeyValuePair> environment;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public List<String> getCommand() { return command; }
+    public void setCommand(List<String> command) { this.command = command; }
+
+    public List<KeyValuePair> getEnvironment() { return environment; }
+    public void setEnvironment(List<KeyValuePair> environment) { this.environment = environment; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerOverridesTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerOverridesTest.java
@@ -1,0 +1,135 @@
+package io.github.hectorvent.floci.services.ecs.container;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
+import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
+import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
+import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
+import io.github.hectorvent.floci.services.ecs.model.ContainerOverride;
+import io.github.hectorvent.floci.services.ecs.model.EcsTask;
+import io.github.hectorvent.floci.services.ecs.model.KeyValuePair;
+import io.github.hectorvent.floci.services.ecs.model.TaskDefinition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for RunTask {@code containerOverrides} handling in
+ * {@link EcsContainerManager#startTask}: a per-container override matched by name
+ * must replace the task-def command and merge over the task-def environment
+ * (override wins on key conflict); a container with no matching override is
+ * launched unchanged.
+ *
+ * <p>The container builder and lifecycle manager are mocked, so the test asserts
+ * the command/env that <em>would</em> be handed to Docker without launching one —
+ * runnable under {@code mvn test} (CI) with no Docker daemon.
+ */
+class EcsContainerManagerOverridesTest {
+
+    private ContainerBuilder containerBuilder;
+    private ContainerBuilder.Builder builder;
+    private ContainerLifecycleManager lifecycleManager;
+    private EcsContainerManager manager;
+
+    @BeforeEach
+    void setUp() {
+        // Fluent builder: every withX() returns the builder; build() returns null
+        // (we assert on the captured withCmd/withEnv arguments, not on the spec).
+        builder = mock(ContainerBuilder.Builder.class, RETURNS_SELF);
+        containerBuilder = mock(ContainerBuilder.class);
+        when(containerBuilder.newContainer(anyString())).thenReturn(builder);
+
+        lifecycleManager = mock(ContainerLifecycleManager.class);
+        when(lifecycleManager.createAndStart(any()))
+                .thenReturn(new ContainerInfo("docker-id", Map.of()));
+
+        ContainerLogStreamer logStreamer = mock(ContainerLogStreamer.class);
+        ContainerDetector containerDetector = mock(ContainerDetector.class);
+        EmulatorConfig config = mock(EmulatorConfig.class, RETURNS_DEEP_STUBS);
+        RegionResolver regionResolver = mock(RegionResolver.class);
+
+        manager = new EcsContainerManager(containerBuilder, lifecycleManager, logStreamer,
+                containerDetector, config, regionResolver);
+    }
+
+    @Test
+    void overrideReplacesCommandAndMergesEnvironmentMatchedByName() {
+        // Two container defs in the task; only "app" has a matching override.
+        ContainerDefinition app = containerDef("app", "app:latest",
+                List.of("app-default"),
+                List.of(new KeyValuePair("SHARED", "base"), new KeyValuePair("BASE_ONLY", "b")));
+        ContainerDefinition sidecar = containerDef("sidecar", "sidecar:latest",
+                List.of("sidecar-default"),
+                List.of(new KeyValuePair("SIDE_ONLY", "s")));
+
+        TaskDefinition taskDef = new TaskDefinition();
+        taskDef.setFamily("test-family");
+        taskDef.setContainerDefinitions(List.of(app, sidecar));
+
+        ContainerOverride appOverride = new ContainerOverride();
+        appOverride.setName("app");
+        appOverride.setCommand(List.of("run", "--flag"));
+        appOverride.setEnvironment(List.of(
+                new KeyValuePair("SHARED", "override"),   // wins over task-def SHARED=base
+                new KeyValuePair("NEW_ONLY", "n")));       // added
+
+        EcsTask task = new EcsTask();
+        task.setTaskArn("arn:aws:ecs:us-east-1:000000000000:task/test-cluster/abc123");
+
+        manager.startTask(task, taskDef, List.of(appOverride), "us-east-1");
+
+        // newContainer/withCmd/withEnv are called once per container definition,
+        // in definition order: index 0 = app (overridden), index 1 = sidecar (untouched).
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<String>> cmdCaptor = ArgumentCaptor.forClass(List.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<String>> envCaptor = ArgumentCaptor.forClass(List.class);
+        org.mockito.Mockito.verify(builder, org.mockito.Mockito.times(2)).withCmd(cmdCaptor.capture());
+        org.mockito.Mockito.verify(builder, org.mockito.Mockito.times(2)).withEnv(envCaptor.capture());
+
+        List<List<String>> commands = cmdCaptor.getAllValues();
+        List<List<String>> envs = envCaptor.getAllValues();
+
+        // app: override command replaces the task-def command.
+        assertEquals(List.of("run", "--flag"), commands.get(0),
+                "override command should replace the task-def command for the matched container");
+        // app: environment merged, override wins on conflict, new key added, untouched key kept.
+        List<String> appEnv = envs.get(0);
+        assertTrue(appEnv.contains("SHARED=override"), "override env should win on key conflict");
+        assertFalse(appEnv.contains("SHARED=base"), "task-def value should be overridden");
+        assertTrue(appEnv.contains("BASE_ONLY=b"), "non-overridden task-def env should be kept");
+        assertTrue(appEnv.contains("NEW_ONLY=n"), "override-only env should be added");
+
+        // sidecar: no matching override -> launched with task-def command and env unchanged.
+        assertEquals(List.of("sidecar-default"), commands.get(1),
+                "unmatched container should keep its task-def command");
+        assertEquals(List.of("SIDE_ONLY=s"), envs.get(1),
+                "unmatched container should keep its task-def environment");
+    }
+
+    private static ContainerDefinition containerDef(String name, String image,
+                                                    List<String> command, List<KeyValuePair> env) {
+        ContainerDefinition def = new ContainerDefinition();
+        def.setName(name);
+        def.setImage(image);
+        def.setCommand(command);
+        def.setEnvironment(env);
+        return def;
+    }
+}


### PR DESCRIPTION
## What

floci parses RunTask but ignores `overrides.containerOverrides[]`. AWS ECS clients
that pass per-container command/environment overrides on RunTask see them silently
dropped — the launched container always runs the task-definition's command/env.

This threads containerOverrides through to the docker container launch, matched to
a container definition by name:
  - `command` (when present and non-empty) replaces the task-def command
  - `environment` is merged over the task-def environment (override wins on conflict)

StartTask and the service reconciler are unchanged (they pass no overrides).

## Why

`containerOverrides` is a standard, widely-used part of the RunTask API — a common
pattern is one task definition launched many times with a per-run command/env. Tools
that drive floci as an ECS stand-in (local dev, CI) need overrides to reach the
container; today they don't.

## Changes

- new `model/ContainerOverride` (name, command, environment), `@RegisterForReflection`
- `EcsJsonHandler.runTask`: parse `overrides.containerOverrides`
- `EcsService.runTask`/`launchTasks`: thread the list through
- `EcsContainerManager.startTask`: apply command replace + environment merge by name

## Testing

- `./mvnw test` passes on Java 25 (Temurin); the existing ECS suite
  (`EcsIntegrationTest`) is unchanged and green.
- Added `EcsContainerManagerOverridesTest` — a unit test for `startTask` that
  launches a two-container task where only one container has a matching override,
  and asserts:
  - the override `command` replaces the task-def command for the matched container;
  - the environment is merged with the override winning on a key conflict, a new
    override-only key added, and a non-overridden task-def key preserved;
  - the unmatched container is launched with its task-def command and environment
    untouched (match-by-name).

  The docker builder / lifecycle manager are mocked, so the test asserts the exact
  command and environment that would be handed to Docker without requiring a daemon
  — it runs under `mvn test` in CI.

I also exercised this end-to-end driving floci as a mock ECS: a single task
definition launched repeatedly with distinct per-run commands and environments, and
verified the launched containers received the override command and merged environment.

## Follow-up (separate commit, optional)

A second commit adds `FLOCI_EXTRA_RO_BINDS` — opt-in read-only host binds into
launched tasks — so a local mock-ECS run can mount host credentials (real ECS serves
these via the task-role metadata endpoint, which floci doesn't emulate). Happy to
add it or open it as its own PR if you'd prefer to keep this one focused.
