### PR TITLE
fix(s3): error on unsupported S3 Select expressions

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3SelectEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3SelectEvaluator.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.s3;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.CsvParser;
 import org.jboss.logging.Logger;
 
@@ -141,7 +142,9 @@ class S3SelectEvaluator {
                 return inner;
             }
             String col = consumeOperand();
-            if (pos >= tokens.size()) return new CompNode(col, "=", "");
+            if (pos >= tokens.size()) {
+                throw unsupportedWhereExpression("Missing predicate operator after: " + col);
+            }
             Token next = tokens.get(pos);
             if (next.type() == TokenType.KEYWORD) {
                 return switch (next.value()) {
@@ -173,19 +176,25 @@ class S3SelectEvaluator {
                         advance();
                         yield new LikeNode(col, consumeOperand());
                     }
-                    default -> new CompNode(col, "=", "");
+                    default -> throw unsupportedWhereExpression("Unsupported predicate keyword: " + next.value());
                 };
             }
             if (next.type() == TokenType.OP) {
                 String op = next.value(); advance();
                 return new CompNode(col, op, consumeOperand());
             }
-            return new CompNode(col, "=", "");
+            throw unsupportedWhereExpression("Unsupported predicate near: " + next.value());
         }
 
         private String consumeOperand() {
-            if (pos >= tokens.size()) return "";
-            return tokens.get(pos++).value();
+            if (pos >= tokens.size()) {
+                throw unsupportedWhereExpression("Missing predicate operand");
+            }
+            Token token = tokens.get(pos++);
+            if (token.type() == TokenType.LPAREN || token.type() == TokenType.RPAREN || token.type() == TokenType.COMMA) {
+                throw unsupportedWhereExpression("Unsupported predicate operand: " + token.value());
+            }
+            return token.value();
         }
 
         private boolean peekKeyword(String kw) {
@@ -195,6 +204,14 @@ class S3SelectEvaluator {
         }
 
         private void advance() { if (pos < tokens.size()) pos++; }
+    }
+
+    private static AwsException unsupportedWhereExpression(String expression) {
+        return new AwsException(
+                "ExternalEvalException",
+                "Unsupported S3 Select WHERE expression: " + expression,
+                400
+        );
     }
 
     private static WhereNode parseWhere(String where) {
@@ -253,9 +270,11 @@ class S3SelectEvaluator {
         try {
             WhereNode tree = parseWhere(processed);
             return rows.stream().filter(row -> evalCsv(tree, row, headers)).toList();
+        } catch (AwsException e) {
+            throw e;
         } catch (Exception e) {
-            LOG.warnv("WHERE parse error, returning all rows: {0}", e.getMessage());
-            return rows;
+            LOG.warnv("WHERE parse error: {0}", e.getMessage());
+            throw unsupportedWhereExpression(processed);
         }
     }
 
@@ -357,8 +376,11 @@ class S3SelectEvaluator {
             }
             try {
                 tree = parseWhere(processed);
+            } catch (AwsException e) {
+                throw e;
             } catch (Exception e) {
                 LOG.warnv("JSON WHERE parse error: {0}", e.getMessage());
+                throw unsupportedWhereExpression(processed);
             }
         }
 

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3SelectIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3SelectIntegrationTest.java
@@ -39,6 +39,32 @@ class S3SelectIntegrationTest {
                 .when().post("/" + key)
                 .then().statusCode(200);
     }
+    
+    private static io.restassured.response.ValidatableResponse selectExpectingStatus(
+            String bucket,
+            String key,
+            String expression,
+            String inputSerialization,
+            String outputSerialization,
+            int expectedStatus) {
+        String safeExpr = expression.replace("&", "&amp;").replace("<", "&lt;");
+        String requestXml = """
+                <SelectObjectContentRequest>
+                  <Expression>%s</Expression>
+                  <ExpressionType>SQL</ExpressionType>
+                  <InputSerialization>%s</InputSerialization>
+                  <OutputSerialization>%s</OutputSerialization>
+                </SelectObjectContentRequest>
+                """.formatted(safeExpr, inputSerialization, outputSerialization);
+
+        return given()
+                .header("Host", bucket + ".localhost")
+                .queryParam("select", "")
+                .queryParam("select-type", "2")
+                .body(requestXml)
+                .when().post("/" + key)
+                .then().statusCode(expectedStatus);
+    }
 
     private static final String CSV_OUT = "<CSV/>";
     private static final String JSON_OUT = "<JSON/>";
@@ -49,6 +75,21 @@ class S3SelectIntegrationTest {
 
     // ── Existing tests (preserved) ────────────────────────────────────────
 
+    @Test
+    void select_unsupportedCastExpressionReturnsError() {
+        String bucket = "sel-cast-unsupported";
+        createBucketAndPut(bucket, "d.csv", "Alice,30\nBob,25\nCharlie,35");
+
+        selectExpectingStatus(
+                bucket,
+                "d.csv",
+                "SELECT * FROM S3Object s WHERE CAST(s._2 AS INTEGER) > 25",
+                CSV_NONE,
+                CSV_OUT,
+                400
+        ).body(containsString("ExternalEvalException"));
+    }
+    
     @Test
     void select_withWhereClause() {
         String bucket = "select-bucket";


### PR DESCRIPTION
## Summary

Updates the Java fallback S3 Select evaluator to fail explicitly for unsupported `WHERE` expressions instead of silently converting them into no-match predicates or returning successful incorrect results.

This prevents unsupported expressions such as `CAST(...)` from returning HTTP 200 with misleading output.

Closes #1097

## Type of change

* [x] Bug fix (`fix:`)
* [ ] New feature (`feat:`)
* [ ] Breaking change (`feat!:` or `fix!:`)
* [ ] Docs / chore

## AWS Compatibility

Incorrect behavior:

The Java fallback S3 Select evaluator could silently treat unsupported predicates as no-match expressions, causing unsupported SQL such as `CAST(...)` to return HTTP 200 with empty or misleading output.

Updated behavior:

Unsupported S3 Select `WHERE` expressions now fail explicitly with an S3 Select-style `ExternalEvalException` error instead of returning a successful response.

## Checklist

* [x] `./mvnw test` passes locally
* [x] New or updated integration test added
* [x] Commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/)