### PR TITLE
fix(elb): return TargetGroupNotFound for missing target groups

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
@@ -238,13 +238,16 @@ public class ElbV2Service {
         if (tgArns != null && !tgArns.isEmpty()) {
             Set<String> arnSet = new HashSet<>(tgArns);
             result = result.stream().filter(tg -> arnSet.contains(tg.getTargetGroupArn())).collect(Collectors.toList());
-            if (result.isEmpty()) {
+            if (result.size() != arnSet.size()) {
                 throw new AwsException("TargetGroupNotFound", "One or more target groups not found.", 400);
             }
         }
         if (names != null && !names.isEmpty()) {
             Set<String> nameSet = new HashSet<>(names);
             result = result.stream().filter(tg -> nameSet.contains(tg.getTargetGroupName())).collect(Collectors.toList());
+            if (result.size() != nameSet.size()) {
+                throw new AwsException("TargetGroupNotFound", "One or more target groups not found.", 400);
+            }
         }
         return result;
     }

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
@@ -246,6 +246,35 @@ class ElbV2IntegrationTest {
                         equalTo("deregistration_delay.timeout_seconds"));
     }
 
+    @Test
+    @Order(14)
+    void describeTargetGroupsByMissingNameThrows() {
+        given()
+                .formParam("Action", "DescribeTargetGroups")
+                .formParam("Names.member.1", "target-group-that-does-not-exist")
+                .header("Authorization", AUTH)
+                .when()
+                .post("/")
+                .then()
+                .statusCode(400)
+                .body("ErrorResponse.Error.Code", equalTo("TargetGroupNotFound"));
+    }
+
+    @Test
+    @Order(15)
+    void describeTargetGroupsByMissingArnThrows() {
+        given()
+                .formParam("Action", "DescribeTargetGroups")
+                .formParam("TargetGroupArns.member.1",
+                        "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/missing/0123456789abcdef")
+                .header("Authorization", AUTH)
+                .when()
+                .post("/")
+                .then()
+                .statusCode(400)
+                .body("ErrorResponse.Error.Code", equalTo("TargetGroupNotFound"));
+    }
+
     // ── Targets ───────────────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

Fix `DescribeTargetGroups` to return `TargetGroupNotFound` when requested target groups are not found.

Closes #1065

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified with the AWS Query API that `DescribeTargetGroups` returns `TargetGroupNotFound` with HTTP 400 when requested target group names or ARNs are missing.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
