### PR TITLE
fix: tag rpc-v2-cbor timestamp lists so GetMetricData decodes

### DIFF
--- a/compatibility-tests/sdk-test-go/tests/cloudwatch_test.go
+++ b/compatibility-tests/sdk-test-go/tests/cloudwatch_test.go
@@ -107,4 +107,57 @@ func TestCloudWatch(t *testing.T) {
 		assert.NotNil(t, dp.Average)
 		assert.Equal(t, 30.0, *dp.Average) // sum / sampleCount
 	})
+
+	t.Run("GetMetricData", func(t *testing.T) {
+		now := time.Now()
+		namespace := "GoTestGetMetricData"
+
+		_, err := svc.PutMetricData(ctx, &cloudwatch.PutMetricDataInput{
+			Namespace: aws.String(namespace),
+			MetricData: []cwtypes.MetricDatum{
+				{
+					MetricName: aws.String("RequestCount"),
+					Value:      aws.Float64(123),
+					Unit:       cwtypes.StandardUnitCount,
+					Timestamp:  aws.Time(now),
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// GetMetricData round-trips through the rpc-v2-cbor protocol. The response
+		// MetricDataResults[].Timestamps list must be encoded as CBOR tag(1)
+		// timestamps; otherwise the SDK fails to decode it (unexpected value type
+		// cbor.Uint), so this require.NoError is the core regression guard.
+		r, err := svc.GetMetricData(ctx, &cloudwatch.GetMetricDataInput{
+			StartTime: aws.Time(now.Add(-5 * time.Minute)),
+			EndTime:   aws.Time(now.Add(5 * time.Minute)),
+			MetricDataQueries: []cwtypes.MetricDataQuery{
+				{
+					Id: aws.String("m1"),
+					MetricStat: &cwtypes.MetricStat{
+						Metric: &cwtypes.Metric{
+							Namespace:  aws.String(namespace),
+							MetricName: aws.String("RequestCount"),
+						},
+						Period: aws.Int32(60),
+						Stat:   aws.String("Sum"),
+					},
+					ReturnData: aws.Bool(true),
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, r.MetricDataResults)
+
+		var result cwtypes.MetricDataResult
+		for _, res := range r.MetricDataResults {
+			if res.Id != nil && *res.Id == "m1" {
+				result = res
+				break
+			}
+		}
+		assert.NotEmpty(t, result.Timestamps)
+		assert.NotEmpty(t, result.Values)
+	})
 }

--- a/compatibility-tests/sdk-test-go/tests/cloudwatch_test.go
+++ b/compatibility-tests/sdk-test-go/tests/cloudwatch_test.go
@@ -150,13 +150,14 @@ func TestCloudWatch(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, r.MetricDataResults)
 
-		var result cwtypes.MetricDataResult
-		for _, res := range r.MetricDataResults {
-			if res.Id != nil && *res.Id == "m1" {
-				result = res
+		var result *cwtypes.MetricDataResult
+		for i := range r.MetricDataResults {
+			if r.MetricDataResults[i].Id != nil && *r.MetricDataResults[i].Id == "m1" {
+				result = &r.MetricDataResults[i]
 				break
 			}
 		}
+		require.NotNil(t, result, "expected a MetricDataResult with Id \"m1\" in the response")
 		assert.NotEmpty(t, result.Timestamps)
 		assert.NotEmpty(t, result.Values)
 	})

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsJsonCborController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsJsonCborController.java
@@ -72,38 +72,50 @@ public class AwsJsonCborController {
 
 
     /**
-     * Serializes a JsonNode to CBOR bytes, encoding fields named "Timestamp" with CBOR tag 1
-     * as required by the smithy-rpc-v2-cbor protocol specification.
+     * Serializes a JsonNode to CBOR bytes, encoding timestamp shapes with CBOR tag 1
+     * (epoch seconds, RFC 8949 section 3.4.2) as required by the smithy-rpc-v2-cbor
+     * protocol specification.
+     * <p>
+     * Package-private so the timestamp-tagging behaviour can be unit-tested directly
+     * without booting Quarkus.
      */
-    private static byte[] nodeToSmithyCbor(JsonNode node) throws Exception {
+    static byte[] nodeToSmithyCbor(JsonNode node) throws Exception {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         CBORFactory factory = (CBORFactory) CBOR_MAPPER.getFactory();
         try (CBORGenerator gen = factory.createGenerator(out)) {
-            writeNodeToCbor(gen, node, null);
+            writeNodeToCbor(gen, node, false);
         }
         return out.toByteArray();
     }
 
-    private static void writeNodeToCbor(CBORGenerator gen, JsonNode node, String fieldName) throws Exception {
+    /**
+     * Recursively writes a JsonNode to CBOR. The {@code numberIsTimestamp} flag carries
+     * timestamp context down the tree (this serializer is schema-less, so it cannot look
+     * up the Smithy shape): when set and the node is a number, it is emitted as a CBOR
+     * tag(1) timestamp. The flag is set by {@link #isTimestampField(String)} for matching
+     * object fields and is propagated into array elements, so both scalar timestamps and
+     * elements of timestamp lists are tagged.
+     */
+    private static void writeNodeToCbor(CBORGenerator gen, JsonNode node, boolean numberIsTimestamp) throws Exception {
         if (node.isObject()) {
             gen.writeStartObject();
             Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
             while (fields.hasNext()) {
                 Map.Entry<String, JsonNode> entry = fields.next();
                 gen.writeFieldName(entry.getKey());
-                writeNodeToCbor(gen, entry.getValue(), entry.getKey());
+                writeNodeToCbor(gen, entry.getValue(), isTimestampField(entry.getKey()));
             }
             gen.writeEndObject();
         } else if (node.isArray()) {
             gen.writeStartArray();
             for (JsonNode item : node) {
-                writeNodeToCbor(gen, item, null);
+                // Propagate the timestamp context so every element of a timestamp list
+                // (e.g. CloudWatch GetMetricData MetricDataResults[].Timestamps) is tagged.
+                writeNodeToCbor(gen, item, numberIsTimestamp);
             }
             gen.writeEndArray();
-        } else if ("Timestamp".equals(fieldName) && node.isNumber()) {
-            gen.writeTag(1);
-            // Smithy rpc-v2-cbor timestamps are epoch seconds encoded as tagged floating-point numbers.
-            gen.writeNumber(node.doubleValue());
+        } else if (numberIsTimestamp && node.isNumber()) {
+            writeCborTimestamp(gen, node);
         } else if (node.isTextual()) {
             gen.writeString(node.textValue());
         } else if (node.isDouble() || node.isFloat()) {
@@ -116,6 +128,38 @@ public class AwsJsonCborController {
             gen.writeNull();
         } else {
             gen.writeString(node.asText());
+        }
+    }
+
+    /**
+     * Name-based heuristic for detecting timestamp shapes. Since this serializer is
+     * schema-less it cannot consult the Smithy model, so it matches field names by their
+     * conventional suffix: AWS timestamp members end in {@code "Timestamp"} (e.g.
+     * GetMetricStatistics' scalar {@code Timestamp}, or alarm fields such as
+     * {@code StateUpdatedTimestamp}), and list-of-timestamp members end in
+     * {@code "Timestamps"} (e.g. CloudWatch GetMetricData's
+     * {@code MetricDataResults[].Timestamps}). The flag is propagated into array elements,
+     * so both scalar timestamps and timestamp lists are tagged.
+     * <p>
+     * This is a pragmatic heuristic; a shape carrying a differently-named time value would
+     * need to be driven from the Smithy model instead.
+     */
+    private static boolean isTimestampField(String fieldName) {
+        return fieldName.endsWith("Timestamp") || fieldName.endsWith("Timestamps");
+    }
+
+    /**
+     * Writes a numeric node as a CBOR tag(1) epoch-seconds timestamp, preserving
+     * integer-ness. Integral epoch seconds are emitted as a tag(1) integer and
+     * fractional values as a tag(1) float; both are spec-valid (RFC 8949 section 3.4.2)
+     * and accepted by AWS SDK decoders.
+     */
+    private static void writeCborTimestamp(CBORGenerator gen, JsonNode node) throws Exception {
+        gen.writeTag(1);
+        if (node.isIntegralNumber()) {
+            gen.writeNumber(node.longValue());
+        } else {
+            gen.writeNumber(node.doubleValue());
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/core/common/AwsJsonCborSerializerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/AwsJsonCborSerializerTest.java
@@ -1,0 +1,146 @@
+package io.github.hectorvent.floci.core.common;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Fast, schema-less unit test for {@link AwsJsonCborController#nodeToSmithyCbor(JsonNode)}.
+ * <p>
+ * Verifies that timestamp shapes are encoded as CBOR tag(1) values per the
+ * smithy-rpc-v2-cbor spec, for both scalar timestamps and timestamp lists, and that
+ * integral epoch seconds are preserved as CBOR integers (not floats). CBOR tag 1 is the
+ * single byte {@code 0xC1} (major type 6, value 1) immediately preceding the encoded
+ * number. These assertions are deterministic and do not boot Quarkus.
+ * <p>
+ * The end-to-end acceptance gate that tag(1)+integer is actually accepted by
+ * aws-sdk-go-v2 / smithy-go is the OTel awscloudwatch receiver run; this test guards the
+ * wire format so a regression fails fast in CI without needing the live receiver.
+ */
+class AwsJsonCborSerializerTest {
+
+    private static final byte CBOR_TAG_1 = (byte) 0xC1;
+    private static final int CBOR_MAJOR_UNSIGNED_INT = 0; // major type 0
+    private static final int CBOR_MAJOR_FLOAT = 7;         // major type 7 (0xF9/0xFA/0xFB)
+
+    private final ObjectMapper jsonMapper = new ObjectMapper();
+    private final ObjectMapper cborMapper = new ObjectMapper(new CBORFactory());
+
+    /** Counts occurrences of the tag(1) marker byte in the encoded output. */
+    private static int countTag1(byte[] bytes) {
+        int count = 0;
+        for (byte b : bytes) {
+            if (b == CBOR_TAG_1) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /** CBOR major type of a head byte (top 3 bits). */
+    private static int majorType(byte headByte) {
+        return (headByte & 0xFF) >> 5;
+    }
+
+    @Test
+    void scalarTimestampIsTaggedAsInteger() throws Exception {
+        JsonNode node = jsonMapper.readTree("{\"Timestamp\": 1700000000}");
+
+        byte[] cbor = AwsJsonCborController.nodeToSmithyCbor(node);
+
+        // Exactly one tag(1) byte, and it is immediately followed by an unsigned integer
+        // (major type 0) — i.e. integer-ness is preserved, not coerced to a float.
+        assertEquals(1, countTag1(cbor), "scalar Timestamp must be tagged exactly once");
+        int tagIndex = indexOf(cbor, CBOR_TAG_1);
+        assertTrue(tagIndex >= 0, "tag(1) byte must be present");
+        assertEquals(CBOR_MAJOR_UNSIGNED_INT, majorType(cbor[tagIndex + 1]),
+                "integral epoch seconds must be encoded as a CBOR integer, not a float");
+
+        JsonNode decoded = cborMapper.readTree(cbor);
+        assertTrue(decoded.path("Timestamp").isIntegralNumber(), "decoded timestamp must be integral");
+        assertEquals(1700000000L, decoded.path("Timestamp").asLong());
+    }
+
+    @Test
+    void timestampListTagsEveryElementAsInteger() throws Exception {
+        // Core regression guard for CloudWatch GetMetricData: every element of a
+        // Timestamps list must be tagged (not just a scalar named "Timestamp").
+        JsonNode node = jsonMapper.readTree("{\"Timestamps\": [1700000000, 1700000060]}");
+
+        byte[] cbor = AwsJsonCborController.nodeToSmithyCbor(node);
+
+        assertEquals(2, countTag1(cbor), "each Timestamps element must be tagged with tag(1)");
+        // Both tagged elements must be integers, not floats.
+        for (int i = 0; i < cbor.length; i++) {
+            if (cbor[i] == CBOR_TAG_1) {
+                assertEquals(CBOR_MAJOR_UNSIGNED_INT, majorType(cbor[i + 1]),
+                        "timestamp list elements must be encoded as CBOR integers");
+            }
+        }
+
+        JsonNode decoded = cborMapper.readTree(cbor);
+        JsonNode ts = decoded.path("Timestamps");
+        assertTrue(ts.isArray());
+        assertEquals(2, ts.size());
+        assertEquals(1700000000L, ts.get(0).asLong());
+        assertEquals(1700000060L, ts.get(1).asLong());
+    }
+
+    @Test
+    void suffixedTimestampFieldIsTagged() throws Exception {
+        // Future-proofing: the heuristic matches by "Timestamp" suffix, so AWS fields such
+        // as StateUpdatedTimestamp are tagged even though Floci does not emit them today.
+        JsonNode node = jsonMapper.readTree("{\"StateUpdatedTimestamp\": 1700000000}");
+
+        byte[] cbor = AwsJsonCborController.nodeToSmithyCbor(node);
+
+        assertEquals(1, countTag1(cbor), "a *Timestamp-suffixed field must be tagged");
+        assertEquals(1700000000L, cborMapper.readTree(cbor).path("StateUpdatedTimestamp").asLong());
+    }
+
+    @Test
+    void fractionalTimestampIsTaggedAsFloat() throws Exception {
+        // A non-integral timestamp is a valid tag(1) floating-point value (RFC 8949 3.4.2).
+        JsonNode node = jsonMapper.readTree("{\"Timestamp\": 1700000000.5}");
+
+        byte[] cbor = AwsJsonCborController.nodeToSmithyCbor(node);
+
+        assertEquals(1, countTag1(cbor), "fractional Timestamp must still be tagged");
+        int tagIndex = indexOf(cbor, CBOR_TAG_1);
+        assertEquals(CBOR_MAJOR_FLOAT, majorType(cbor[tagIndex + 1]),
+                "fractional epoch seconds must be encoded as a CBOR float");
+        assertEquals(1700000000.5, cborMapper.readTree(cbor).path("Timestamp").asDouble());
+    }
+
+    @Test
+    void nonTimestampNumberIsNotTagged() throws Exception {
+        // A plain numeric field (e.g. CloudWatch Period) must remain an untagged integer.
+        JsonNode node = jsonMapper.readTree("{\"Period\": 60}");
+
+        byte[] cbor = AwsJsonCborController.nodeToSmithyCbor(node);
+
+        assertEquals(0, countTag1(cbor), "non-timestamp numbers must not carry a tag(1) byte");
+        assertFalse(contains(cbor, CBOR_TAG_1));
+
+        JsonNode decoded = cborMapper.readTree(cbor);
+        assertEquals(60L, decoded.path("Period").asLong());
+    }
+
+    private static int indexOf(byte[] bytes, byte target) {
+        for (int i = 0; i < bytes.length; i++) {
+            if (bytes[i] == target) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static boolean contains(byte[] bytes, byte target) {
+        return indexOf(bytes, target) >= 0;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/core/common/AwsJsonCborSerializerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/AwsJsonCborSerializerTest.java
@@ -58,6 +58,7 @@ class AwsJsonCborSerializerTest {
         assertEquals(1, countTag1(cbor), "scalar Timestamp must be tagged exactly once");
         int tagIndex = indexOf(cbor, CBOR_TAG_1);
         assertTrue(tagIndex >= 0, "tag(1) byte must be present");
+        assertTrue(tagIndex + 1 < cbor.length, "tag(1) byte must not be the last byte in the output");
         assertEquals(CBOR_MAJOR_UNSIGNED_INT, majorType(cbor[tagIndex + 1]),
                 "integral epoch seconds must be encoded as a CBOR integer, not a float");
 
@@ -78,6 +79,7 @@ class AwsJsonCborSerializerTest {
         // Both tagged elements must be integers, not floats.
         for (int i = 0; i < cbor.length; i++) {
             if (cbor[i] == CBOR_TAG_1) {
+                assertTrue(i + 1 < cbor.length, "tag(1) byte at index " + i + " must not be the last byte in the output");
                 assertEquals(CBOR_MAJOR_UNSIGNED_INT, majorType(cbor[i + 1]),
                         "timestamp list elements must be encoded as CBOR integers");
             }
@@ -112,6 +114,7 @@ class AwsJsonCborSerializerTest {
 
         assertEquals(1, countTag1(cbor), "fractional Timestamp must still be tagged");
         int tagIndex = indexOf(cbor, CBOR_TAG_1);
+        assertTrue(tagIndex + 1 < cbor.length, "tag(1) byte must not be the last byte in the output");
         assertEquals(CBOR_MAJOR_FLOAT, majorType(cbor[tagIndex + 1]),
                 "fractional epoch seconds must be encoded as a CBOR float");
         assertEquals(1700000000.5, cborMapper.readTree(cbor).path("Timestamp").asDouble());


### PR DESCRIPTION
## Summary

GetMetricData responses encode MetricDataResults[].Timestamps as a list, but the rpc-v2-cbor serializer only tags scalar fields named "Timestamp". The untagged list elements caused aws-sdk-go-v2 (and the OpenTelemetry Collector awscloudwatch metrics receiver) to fail decoding with "unexpected value type cbor.Uint".

The fix is to carry timestamp context into array elements and match timestamp members by their "Timestamp"/"Timestamps" suffix, so every element of a timestamp list is emitted as a CBOR tag(1) value (epoch seconds, RFC 8949 3.4.2) with integer-ness preserved. Scalar timestamp handling is unchanged.

Tests:
- AwsJsonCborSerializerTest: asserts tag(1) bytes for scalar and list timestamps, integer preservation, and that non-timestamp numbers stay untagged.
- Go SDK compatibility suite: a GetMetricData case that exercises the real aws-sdk-go-v2 CBOR client end to end.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Tested with `aws-sdk-go-v2/service/cloudwatch v1.57.0` (via `otel/opentelemetry-collector-contrib:0.153.0`)

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
