### PR TITLE
fix(sns): align mobile push error codes, payload resolution, and Token rotation with AWS

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
@@ -59,6 +59,8 @@ public class SnsService {
     /** Mobile-push platforms Floci mocks. iOS and Android only — anything else is rejected. */
     private static final Set<String> SUPPORTED_PUSH_PLATFORMS = Set.of(
             "APNS", "APNS_SANDBOX", "GCM", "FCM");
+    private static final java.util.regex.Pattern PLATFORM_APP_NAME_PATTERN =
+            java.util.regex.Pattern.compile("[a-zA-Z0-9_.\\-]{1,256}");
 
     private final StorageBackend<String, Topic> topicStore;
     private final StorageBackend<String, Subscription> subscriptionStore;
@@ -425,6 +427,13 @@ public class SnsService {
         if (name == null || name.isBlank()) {
             throw new AwsException("InvalidParameter", "Name is required.", 400);
         }
+        if (!PLATFORM_APP_NAME_PATTERN.matcher(name).matches()) {
+            throw new AwsException("InvalidParameter",
+                    "Invalid parameter: Name Reason: must be made up of only uppercase and"
+                            + " lowercase ASCII letters, numbers, underscores, hyphens, and"
+                            + " periods, and must be between 1 and 256 characters long.",
+                    400);
+        }
         if (platform == null || !SUPPORTED_PUSH_PLATFORMS.contains(platform)) {
             throw new AwsException("InvalidParameter",
                     "Invalid parameter: Platform Reason: Floci mocks only APNS, APNS_SANDBOX, GCM, and FCM.",
@@ -494,7 +503,7 @@ public class SnsService {
                 .orElseThrow(() -> new AwsException("NotFound",
                         "PlatformApplication does not exist.", 404));
         if ("false".equalsIgnoreCase(app.getAttributes().get("Enabled"))) {
-            throw new AwsException("PlatformApplicationDisabledException",
+            throw new AwsException("PlatformApplicationDisabled",
                     "Platform application is disabled.", 400);
         }
 
@@ -548,7 +557,11 @@ public class SnsService {
         String key = endpointKey(region, endpointArn);
         PlatformEndpoint endpoint = platformEndpointStore.get(key)
                 .orElseThrow(() -> new AwsException("NotFound", "Endpoint does not exist.", 404));
-        if (attributes != null) endpoint.getAttributes().putAll(attributes);
+        if (attributes != null) {
+            endpoint.getAttributes().putAll(attributes);
+            String newToken = attributes.get("Token");
+            if (newToken != null) endpoint.setToken(newToken);
+        }
         platformEndpointStore.put(key, endpoint);
     }
 
@@ -585,14 +598,14 @@ public class SnsService {
         PlatformEndpoint endpoint = platformEndpointStore.get(endpointKey(region, endpointArn))
                 .orElseThrow(() -> new AwsException("NotFound", "Endpoint does not exist.", 404));
         if (!"true".equalsIgnoreCase(endpoint.getAttributes().getOrDefault("Enabled", "true"))) {
-            throw new AwsException("EndpointDisabledException",
+            throw new AwsException("EndpointDisabled",
                     "Endpoint " + endpointArn + " disabled", 400);
         }
         PlatformApplication app = platformAppStore.get(platformAppKey(region, endpoint.getPlatformApplicationArn()))
                 .orElseThrow(() -> new AwsException("NotFound",
                         "PlatformApplication does not exist.", 404));
         if ("false".equalsIgnoreCase(app.getAttributes().get("Enabled"))) {
-            throw new AwsException("PlatformApplicationDisabledException",
+            throw new AwsException("PlatformApplicationDisabled",
                     "Platform application is disabled.", 400);
         }
         String payload = resolvePushPayload(app.getPlatform(), message, messageStructure);
@@ -621,16 +634,23 @@ public class SnsService {
             throw new AwsException("InvalidParameter",
                     "Invalid parameter: Message Reason: Message is not valid JSON.", 400);
         }
-        if (!root.isObject() || !root.has("default")) {
+        if (!root.isObject()) {
             throw new AwsException("InvalidParameter",
-                    "Invalid parameter: Message Reason: Messages must be a JSON object with a 'default' key.",
+                    "Invalid parameter: Message Reason: Messages must be a JSON object.",
                     400);
         }
         JsonNode platformValue = root.get(platform);
         if (platformValue != null && !platformValue.isNull()) {
             return platformValue.isTextual() ? platformValue.asText() : platformValue.toString();
         }
-        return root.get("default").asText();
+        JsonNode defaultValue = root.get("default");
+        if (defaultValue != null && !defaultValue.isNull()) {
+            return defaultValue.isTextual() ? defaultValue.asText() : defaultValue.toString();
+        }
+        throw new AwsException("InvalidParameter",
+                "Invalid parameter: Message Reason: Messages must have a '" + platform
+                        + "' or 'default' key.",
+                400);
     }
 
     private void recordPushNotification(PushNotification notification) {

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsMobilePushTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsMobilePushTest.java
@@ -72,6 +72,30 @@ class SnsMobilePushTest {
     }
 
     @Test
+    void createPlatformApplication_rejectsNameWithDisallowedCharacters() {
+        // AWS allows only ASCII letters, digits, underscores, hyphens, and periods.
+        AwsException e = assertThrows(AwsException.class,
+                () -> snsService.createPlatformApplication("bad name!", "APNS", Map.of(), REGION));
+        assertEquals("InvalidParameter", e.getErrorCode());
+        assertTrue(e.getMessage().contains("Name"));
+    }
+
+    @Test
+    void createPlatformApplication_rejectsNameLongerThan256Characters() {
+        String tooLong = "a".repeat(257);
+        AwsException e = assertThrows(AwsException.class,
+                () -> snsService.createPlatformApplication(tooLong, "APNS", Map.of(), REGION));
+        assertEquals("InvalidParameter", e.getErrorCode());
+    }
+
+    @Test
+    void createPlatformApplication_acceptsAllAllowedNameCharacters() {
+        PlatformApplication app = snsService.createPlatformApplication(
+                "My-App_1.0", "APNS", Map.of(), REGION);
+        assertEquals("arn:aws:sns:us-east-1:000000000000:app/APNS/My-App_1.0", app.getArn());
+    }
+
+    @Test
     void createPlatformApplication_idempotentByName() {
         PlatformApplication first = snsService.createPlatformApplication("ios-app", "APNS", Map.of(), REGION);
         PlatformApplication second = snsService.createPlatformApplication("ios-app", "APNS", Map.of(), REGION);
@@ -140,7 +164,7 @@ class SnsMobilePushTest {
         snsService.setPlatformApplicationAttributes(app.getArn(), Map.of("Enabled", "false"), REGION);
         AwsException e = assertThrows(AwsException.class,
                 () -> snsService.createPlatformEndpoint(app.getArn(), "tok-1", null, Map.of(), REGION));
-        assertEquals("PlatformApplicationDisabledException", e.getErrorCode());
+        assertEquals("PlatformApplicationDisabled", e.getErrorCode());
     }
 
     // --- Publish: happy paths ---
@@ -211,14 +235,25 @@ class SnsMobilePushTest {
     // --- Publish: error codes ---
 
     @Test
-    void publish_jsonStructureRejectsMissingDefaultKey() {
+    void publish_jsonStructureAcceptsPlatformKeyWithoutDefault() {
+        PlatformApplication app = snsService.createPlatformApplication("ios-app", "APNS", Map.of(), REGION);
+        PlatformEndpoint endpoint = snsService.createPlatformEndpoint(app.getArn(), "ios-token", null, Map.of(), REGION);
+
+        snsService.publish(null, endpoint.getArn(), null,
+                "{\"APNS\":\"x\"}", null, "json", null, null, null, REGION);
+        assertEquals("x", snsService.peekPushNotifications(endpoint.getArn()).get(0).payload());
+    }
+
+    @Test
+    void publish_jsonStructureRejectsWhenNeitherPlatformKeyNorDefaultPresent() {
         PlatformApplication app = snsService.createPlatformApplication("ios-app", "APNS", Map.of(), REGION);
         PlatformEndpoint endpoint = snsService.createPlatformEndpoint(app.getArn(), "ios-token", null, Map.of(), REGION);
 
         AwsException e = assertThrows(AwsException.class, () -> snsService.publish(
-                null, endpoint.getArn(), null, "{\"APNS\":\"x\"}", null, "json",
+                null, endpoint.getArn(), null, "{\"GCM\":\"x\"}", null, "json",
                 null, null, null, REGION));
         assertEquals("InvalidParameter", e.getErrorCode());
+        assertTrue(e.getMessage().contains("APNS"));
         assertTrue(e.getMessage().contains("default"));
     }
 
@@ -234,14 +269,14 @@ class SnsMobilePushTest {
     }
 
     @Test
-    void publish_disabledEndpointThrowsEndpointDisabledException() {
+    void publish_disabledEndpointThrowsEndpointDisabled() {
         PlatformApplication app = snsService.createPlatformApplication("ios-app", "APNS", Map.of(), REGION);
         PlatformEndpoint endpoint = snsService.createPlatformEndpoint(app.getArn(), "ios-token", null, Map.of(), REGION);
         snsService.setEndpointAttributes(endpoint.getArn(), Map.of("Enabled", "false"), REGION);
 
         AwsException e = assertThrows(AwsException.class, () -> snsService.publish(
                 null, endpoint.getArn(), null, "hello", null, null, null, null, null, REGION));
-        assertEquals("EndpointDisabledException", e.getErrorCode());
+        assertEquals("EndpointDisabled", e.getErrorCode());
         assertEquals(400, e.getHttpStatus());
         assertTrue(snsService.peekPushNotifications(endpoint.getArn()).isEmpty());
     }
@@ -255,7 +290,7 @@ class SnsMobilePushTest {
 
         AwsException e = assertThrows(AwsException.class, () -> snsService.publish(
                 null, endpoint.getArn(), null, "hello", null, null, null, null, null, REGION));
-        assertEquals("EndpointDisabledException", e.getErrorCode());
+        assertEquals("EndpointDisabled", e.getErrorCode());
     }
 
     @Test
@@ -284,7 +319,7 @@ class SnsMobilePushTest {
 
         AwsException e = assertThrows(AwsException.class, () -> snsService.publish(
                 null, endpoint.getArn(), null, "hello", null, null, null, null, null, REGION));
-        assertEquals("PlatformApplicationDisabledException", e.getErrorCode());
+        assertEquals("PlatformApplicationDisabled", e.getErrorCode());
     }
 
     // --- Inspection helpers ---
@@ -323,6 +358,20 @@ class SnsMobilePushTest {
         assertEquals("ios-token", attrs.get("Token"));
         assertEquals("user-42", attrs.get("CustomUserData"));
         assertEquals("true", attrs.get("Enabled"));
+    }
+
+    @Test
+    void setEndpointAttributes_tokenRotationPropagatesToPublishedNotifications() {
+        PlatformApplication app = snsService.createPlatformApplication("ios-app", "APNS", Map.of(), REGION);
+        PlatformEndpoint endpoint = snsService.createPlatformEndpoint(app.getArn(), "old-token", null, Map.of(), REGION);
+
+        snsService.setEndpointAttributes(endpoint.getArn(), Map.of("Token", "new-token"), REGION);
+
+        assertEquals("new-token", snsService.getEndpointAttributes(endpoint.getArn(), REGION).get("Token"));
+
+        snsService.publish(null, endpoint.getArn(), null, "hello", null, null, null, null, null, REGION);
+        assertEquals("new-token",
+                snsService.peekPushNotifications(endpoint.getArn()).get(0).token());
     }
 
     @Test


### PR DESCRIPTION
## Summary
  
  Five AWS-compatibility fixes in the SNS mobile-push path so the AWS SDK's
  exception mapping and message-resolution logic work without modification.

  ## Changes

  - **`resolvePushPayload`**: when `MessageStructure=json`, accept a
    platform-specific key (`APNS`, `APNS_SANDBOX`, `GCM`, `FCM`) without a
    `default` key. Only throw `InvalidParameter` when neither is present.
  - **`publishToEndpoint`**: wire code `EndpointDisabledException` →
    `EndpointDisabled` so the SDK maps it correctly.
  - **`createPlatformEndpoint` / `publishToEndpoint`**:
    `PlatformApplicationDisabledException` → `PlatformApplicationDisabled`.
  - **`setEndpointAttributes`**: when `Token` is updated, sync the endpoint's
    `token` field so published notifications carry the rotated token.
  - **`createPlatformApplication`**: validate `Name` against the AWS regex
    `[a-zA-Z0-9_.\-]{1,256}`.

  ## Tests

  All in `SnsMobilePushTest` — updated stale assertions to the corrected error
  codes and behavior, added regression tests for the Token-rotation fix and the
  `Name` regex.
  
  ## References

  - [SNS Publish API](https://docs.aws.amazon.com/sns/latest/api/API_Publish.html) — `EndpointDisabled`, `PlatformApplicationDisabled` wire codes
  - [SNS mobile-push guide](https://docs.aws.amazon.com/sns/latest/dg/sns-send-custom-platform-specific-payloads-mobile-devices.html) — `{"APNS":"..."}` examples
  without `default`
  - [GetEndpointAttributes](https://docs.aws.amazon.com/sns/latest/api/API_GetEndpointAttributes.html) — Token rotation flow
  - [CreatePlatformApplication](https://docs.aws.amazon.com/sns/latest/api/API_CreatePlatformApplication.html) — Name regex

  ## Test plan

  - [x] `./mvnw test -Dtest=SnsMobilePushTest`
  - [x] `./mvnw test`