### PR TITLE
fix(ecs): retain inactive services for terraform draining and recreation with correct idempotency 

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
@@ -31,11 +31,7 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -484,8 +480,40 @@ public class EcsService {
 
         String key = serviceKey(region, cluster.getClusterName(), serviceName);
         if (services.containsKey(key)) {
-            throw new AwsException("InvalidParameterException",
-                    "Creation of service was not idempotent.", 400);
+            EcsServiceModel existingSvc = services.get(key);
+
+            if ("ACTIVE".equals(existingSvc.getStatus())) {
+                LaunchType incomingLaunchType = launchType != null ? launchType : LaunchType.FARGATE;
+
+                boolean networkMatches = false;
+                if (existingSvc.getNetworkConfiguration() == null && networkConfiguration == null) {
+                    networkMatches = true;
+                } else if (existingSvc.getNetworkConfiguration() != null && networkConfiguration != null) {
+                    var existingVpc = existingSvc.getNetworkConfiguration().getAwsvpcConfiguration();
+                    var incomingVpc = networkConfiguration.getAwsvpcConfiguration();
+
+                    if (existingVpc == null && incomingVpc == null) {
+                        networkMatches = true;
+                    } else if (existingVpc != null && incomingVpc != null) {
+                        networkMatches = Objects.equals(existingVpc.getSubnets(), incomingVpc.getSubnets())
+                                && Objects.equals(existingVpc.getSecurityGroups(), incomingVpc.getSecurityGroups())
+                                && Objects.equals(existingVpc.getAssignPublicIp(), incomingVpc.getAssignPublicIp());
+                    }
+                }
+
+                boolean isIdempotent = Objects.equals(existingSvc.getTaskDefinition(), taskDefinition)
+                        && existingSvc.getDesiredCount() == desiredCount
+                        && Objects.equals(existingSvc.getLaunchType(), incomingLaunchType)
+                        && networkMatches;
+
+                if (isIdempotent) {
+                    LOG.infov("Service {0} already exists with identical configuration. Returning existing instance (Idempotent).", serviceName);
+                    return existingSvc;
+                } else {
+                    throw new AwsException("InvalidParameterException",
+                            "Creation of service was not idempotent.", 400);
+                }
+            }
         }
 
         EcsServiceModel svc = new EcsServiceModel();
@@ -515,10 +543,18 @@ public class EcsService {
                                           Integer desiredCount, NetworkConfiguration networkConfiguration,
                                           String region) {
         EcsCluster cluster = resolveClusterOrDefault(clusterRef, region);
+
+        if (serviceName != null && serviceName.contains("/")) {
+            serviceName = serviceName.substring(serviceName.lastIndexOf("/") + 1);
+        }
+
         String key = serviceKey(region, cluster.getClusterName(), serviceName);
         EcsServiceModel svc = services.get(key);
         if (svc == null) {
             throw new AwsException("ServiceNotFoundException", "Service " + serviceName + " not found.", 404);
+        }
+        if ("INACTIVE".equals(svc.getStatus())) {
+            return svc;
         }
         if (desiredCount != null) {
             svc.setDesiredCount(desiredCount);
@@ -536,10 +572,18 @@ public class EcsService {
 
     public EcsServiceModel deleteService(String clusterRef, String serviceName, boolean force, String region) {
         EcsCluster cluster = resolveClusterOrDefault(clusterRef, region);
+
+        if (serviceName != null && serviceName.contains("/")) {
+            serviceName = serviceName.substring(serviceName.lastIndexOf("/") + 1);
+        }
+
         String key = serviceKey(region, cluster.getClusterName(), serviceName);
         EcsServiceModel svc = services.get(key);
         if (svc == null) {
             throw new AwsException("ServiceNotFoundException", "Service " + serviceName + " not found.", 404);
+        }
+        if("INACTIVE".equals(svc.getStatus())) {
+            return svc;
         }
         if (!force && svc.getDesiredCount() > 0) {
             throw new AwsException("InvalidParameterException",
@@ -563,7 +607,6 @@ public class EcsService {
                                 t.getTaskArn(), e.getMessage());
                     }
                 });
-        services.remove(key);
         return svc;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
@@ -31,7 +31,13 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
-import java.util.*;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -483,36 +489,8 @@ public class EcsService {
             EcsServiceModel existingSvc = services.get(key);
 
             if ("ACTIVE".equals(existingSvc.getStatus())) {
-                LaunchType incomingLaunchType = launchType != null ? launchType : LaunchType.FARGATE;
-
-                boolean networkMatches = false;
-                if (existingSvc.getNetworkConfiguration() == null && networkConfiguration == null) {
-                    networkMatches = true;
-                } else if (existingSvc.getNetworkConfiguration() != null && networkConfiguration != null) {
-                    var existingVpc = existingSvc.getNetworkConfiguration().getAwsvpcConfiguration();
-                    var incomingVpc = networkConfiguration.getAwsvpcConfiguration();
-
-                    if (existingVpc == null && incomingVpc == null) {
-                        networkMatches = true;
-                    } else if (existingVpc != null && incomingVpc != null) {
-                        networkMatches = Objects.equals(existingVpc.getSubnets(), incomingVpc.getSubnets())
-                                && Objects.equals(existingVpc.getSecurityGroups(), incomingVpc.getSecurityGroups())
-                                && Objects.equals(existingVpc.getAssignPublicIp(), incomingVpc.getAssignPublicIp());
-                    }
-                }
-
-                boolean isIdempotent = Objects.equals(existingSvc.getTaskDefinition(), taskDefinition)
-                        && existingSvc.getDesiredCount() == desiredCount
-                        && Objects.equals(existingSvc.getLaunchType(), incomingLaunchType)
-                        && networkMatches;
-
-                if (isIdempotent) {
-                    LOG.infov("Service {0} already exists with identical configuration. Returning existing instance (Idempotent).", serviceName);
-                    return existingSvc;
-                } else {
-                    throw new AwsException("InvalidParameterException",
-                            "Creation of service was not idempotent.", 400);
-                }
+                throw new AwsException("InvalidParameterException",
+                        "Creation of service was not idempotent.", 400);
             }
         }
 
@@ -544,9 +522,7 @@ public class EcsService {
                                           String region) {
         EcsCluster cluster = resolveClusterOrDefault(clusterRef, region);
 
-        if (serviceName != null && serviceName.contains("/")) {
-            serviceName = serviceName.substring(serviceName.lastIndexOf("/") + 1);
-        }
+        serviceName = extractServiceName(serviceName);
 
         String key = serviceKey(region, cluster.getClusterName(), serviceName);
         EcsServiceModel svc = services.get(key);
@@ -554,7 +530,8 @@ public class EcsService {
             throw new AwsException("ServiceNotFoundException", "Service " + serviceName + " not found.", 404);
         }
         if ("INACTIVE".equals(svc.getStatus())) {
-            return svc;
+            throw new AwsException("ServiceNotActiveException",
+                    "Service " + serviceName + " is not active.", 400);
         }
         if (desiredCount != null) {
             svc.setDesiredCount(desiredCount);
@@ -573,16 +550,14 @@ public class EcsService {
     public EcsServiceModel deleteService(String clusterRef, String serviceName, boolean force, String region) {
         EcsCluster cluster = resolveClusterOrDefault(clusterRef, region);
 
-        if (serviceName != null && serviceName.contains("/")) {
-            serviceName = serviceName.substring(serviceName.lastIndexOf("/") + 1);
-        }
+        serviceName = extractServiceName(serviceName);
 
         String key = serviceKey(region, cluster.getClusterName(), serviceName);
         EcsServiceModel svc = services.get(key);
         if (svc == null) {
             throw new AwsException("ServiceNotFoundException", "Service " + serviceName + " not found.", 404);
         }
-        if("INACTIVE".equals(svc.getStatus())) {
+        if ("INACTIVE".equals(svc.getStatus())) {
             return svc;
         }
         if (!force && svc.getDesiredCount() > 0) {
@@ -627,6 +602,7 @@ public class EcsService {
         String prefix = serviceKeyPrefix(region, cluster.getClusterName());
         return services.entrySet().stream()
                 .filter(e -> e.getKey().startsWith(prefix))
+                .filter(e -> !"INACTIVE".equals(e.getValue().getStatus()))
                 .map(e -> e.getValue().getServiceArn())
                 .toList();
     }
@@ -634,6 +610,7 @@ public class EcsService {
     public List<String> listServicesByNamespace(String namespace, String region) {
         return services.values().stream()
                 .filter(s -> namespace.equals(s.getNamespace()))
+                .filter(s -> !"INACTIVE".equals(s.getStatus()))
                 .map(EcsServiceModel::getServiceArn)
                 .toList();
     }
@@ -1385,6 +1362,13 @@ public class EcsService {
 
     private static String extractRegionFromServiceKey(String key) {
         return key.substring(0, key.indexOf("::"));
+    }
+
+    private static String extractServiceName(String serviceName) {
+        if (serviceName != null && serviceName.contains("/")) {
+            return serviceName.substring(serviceName.lastIndexOf("/") + 1);
+        }
+        return serviceName;
     }
 
     private static String extractClusterNameFromServiceKey(String key) {

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/EcsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/EcsIntegrationTest.java
@@ -37,6 +37,10 @@ class EcsIntegrationTest {
     private static final String TASK_DEF_FAMILY = "test-task";
     private static final String SERVICE_NAME = "test-service";
 
+    private static final String REVIEW_CLUSTER = "review-cluster";
+    private static final String REVIEW_SERVICE = "review-svc";
+    private static final String REVIEW_LB_SERVICE = "review-lb-svc";
+
     private static final String CONTENT_TYPE = "application/x-amz-json-1.1";
 
     private static String taskArn;
@@ -421,7 +425,7 @@ class EcsIntegrationTest {
 
     @Test
     @Order(34)
-    void createServiceIdempotentWithSameParameters() {
+    void createServiceDuplicateActiveNameAlwaysFails() {
         ecs("CreateService")
                 .body("""
                 {
@@ -435,9 +439,9 @@ class EcsIntegrationTest {
                 .when()
                 .post("/")
                 .then()
-                .statusCode(200)
-                .body("service.serviceName", equalTo(SERVICE_NAME))
-                .body("service.status", equalTo("ACTIVE"));
+                .statusCode(400)
+                .body("__type", containsString("InvalidParameterException"))
+                .body("message", containsString("Creation of service was not idempotent."));
     }
 
     @Test
@@ -548,7 +552,7 @@ class EcsIntegrationTest {
 
     @Test
     @Order(51)
-    void updateInactiveServiceHandlesDrainGracefully() {
+    void updateInactiveServiceReturnsServiceNotActiveException() {
         String fullServiceArn = "arn:aws:ecs:" + REGION + ":" + ACCOUNT + ":service/" + CLUSTER_NAME + "/" + SERVICE_NAME;
 
         ecs("UpdateService")
@@ -562,9 +566,8 @@ class EcsIntegrationTest {
                 .when()
                 .post("/")
                 .then()
-                .statusCode(200)
-                .body("service.serviceName", equalTo(SERVICE_NAME))
-                .body("service.status", equalTo("INACTIVE"));
+                .statusCode(400)
+                .body("__type", containsString("ServiceNotActiveException"));
     }
 
     @Test
@@ -607,5 +610,204 @@ class EcsIntegrationTest {
             .post("/")
         .then()
             .statusCode(400);
+    }
+
+    @Test
+    @Order(60)
+    void reviewSetup_createClusterAndService() {
+        ecs("CreateCluster")
+            .body("""
+                {"clusterName": "%s"}
+                """.formatted(REVIEW_CLUSTER))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        ecs("RegisterTaskDefinition")
+            .body("""
+                {
+                    "family": "review-td",
+                    "containerDefinitions": [
+                        {
+                            "name": "app",
+                            "image": "nginx:latest",
+                            "cpu": 256,
+                            "memory": 512,
+                            "essential": true,
+                            "portMappings": [{"containerPort": 80, "protocol": "tcp"}]
+                        }
+                    ],
+                    "requiresCompatibilities": ["FARGATE"],
+                    "cpu": "256",
+                    "memory": "512",
+                    "networkMode": "awsvpc"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        ecs("CreateService")
+            .body("""
+                {
+                    "cluster": "%s",
+                    "serviceName": "%s",
+                    "taskDefinition": "review-td",
+                    "desiredCount": 1,
+                    "launchType": "FARGATE"
+                }
+                """.formatted(REVIEW_CLUSTER, REVIEW_SERVICE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("service.status", equalTo("ACTIVE"));
+    }
+
+    @Test
+    @Order(61)
+    void deleteServiceHidesFromListServices() {
+        ecs("DeleteService")
+            .body("""
+                {
+                    "cluster": "%s",
+                    "service": "%s",
+                    "force": true
+                }
+                """.formatted(REVIEW_CLUSTER, REVIEW_SERVICE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("service.status", equalTo("INACTIVE"));
+
+        ecs("ListServices")
+            .body("""
+                {"cluster": "%s"}
+                """.formatted(REVIEW_CLUSTER))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("serviceArns", not(hasItem(containsString(REVIEW_SERVICE))));
+    }
+
+    @Test
+    @Order(62)
+    void deleteServiceStillDescribableAsInactive() {
+        ecs("DescribeServices")
+            .body("""
+                {
+                    "cluster": "%s",
+                    "services": ["%s"]
+                }
+                """.formatted(REVIEW_CLUSTER, REVIEW_SERVICE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("services", hasSize(1))
+            .body("services[0].serviceName", equalTo(REVIEW_SERVICE))
+            .body("services[0].status", equalTo("INACTIVE"));
+    }
+
+    @Test
+    @Order(63)
+    void updateInactiveServiceShouldReturnError() {
+        ecs("UpdateService")
+            .body("""
+                {
+                    "cluster": "%s",
+                    "service": "%s",
+                    "desiredCount": 5
+                }
+                """.formatted(REVIEW_CLUSTER, REVIEW_SERVICE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ServiceNotActiveException"));
+    }
+
+    @Test
+    @Order(64)
+    void createServiceIgnoresLoadBalancersInIdempotencyCheck() {
+        ecs("CreateService")
+            .body("""
+                {
+                    "cluster": "%s",
+                    "serviceName": "%s",
+                    "taskDefinition": "review-td",
+                    "desiredCount": 1,
+                    "launchType": "FARGATE",
+                    "loadBalancers": [
+                        {
+                            "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/tg-a/1234",
+                            "containerName": "app",
+                            "containerPort": 80
+                        }
+                    ]
+                }
+                """.formatted(REVIEW_CLUSTER, REVIEW_LB_SERVICE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("service.serviceName", equalTo(REVIEW_LB_SERVICE))
+            .body("service.status", equalTo("ACTIVE"));
+
+        ecs("CreateService")
+            .body("""
+                {
+                    "cluster": "%s",
+                    "serviceName": "%s",
+                    "taskDefinition": "review-td",
+                    "desiredCount": 1,
+                    "launchType": "FARGATE",
+                    "loadBalancers": [
+                        {
+                            "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/tg-DIFFERENT/9999",
+                            "containerName": "app",
+                            "containerPort": 8080
+                        }
+                    ]
+                }
+                """.formatted(REVIEW_CLUSTER, REVIEW_LB_SERVICE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("InvalidParameterException"))
+            .body("message", containsString("Creation of service was not idempotent."));
+    }
+
+    // ── PR Review: Cleanup ───────────────────────────────────────────────────
+
+    @Test
+    @Order(69)
+    void reviewCleanup() {
+        ecs("DeleteService")
+            .body("""
+                {
+                    "cluster": "%s",
+                    "service": "%s",
+                    "force": true
+                }
+                """.formatted(REVIEW_CLUSTER, REVIEW_LB_SERVICE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        ecs("DeleteCluster")
+            .body("""
+                {"cluster": "%s"}
+                """.formatted(REVIEW_CLUSTER))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/EcsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/EcsIntegrationTest.java
@@ -419,6 +419,48 @@ class EcsIntegrationTest {
             .body("service.desiredCount", equalTo(2));
     }
 
+    @Test
+    @Order(34)
+    void createServiceIdempotentWithSameParameters() {
+        ecs("CreateService")
+                .body("""
+                {
+                    "cluster": "%s",
+                    "serviceName": "%s",
+                    "taskDefinition": "%s",
+                    "desiredCount": 2,
+                    "launchType": "FARGATE"
+                }
+                """.formatted(CLUSTER_NAME, SERVICE_NAME, TASK_DEF_FAMILY))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .body("service.serviceName", equalTo(SERVICE_NAME))
+                .body("service.status", equalTo("ACTIVE"));
+    }
+
+    @Test
+    @Order(35)
+    void createServiceWithDifferentParametersFailsIdempotency() {
+        ecs("CreateService")
+                .body("""
+                {
+                    "cluster": "%s",
+                    "serviceName": "%s",
+                    "taskDefinition": "%s",
+                    "desiredCount": 99,
+                    "launchType": "FARGATE"
+                }
+                """.formatted(CLUSTER_NAME, SERVICE_NAME, TASK_DEF_FAMILY))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("InvalidParameterException"))
+                .body("message", containsString("Creation of service was not idempotent."));
+    }
+
     // ── Tags ─────────────────────────────────────────────────────────────────
 
     @Test
@@ -506,6 +548,27 @@ class EcsIntegrationTest {
 
     @Test
     @Order(51)
+    void updateInactiveServiceHandlesDrainGracefully() {
+        String fullServiceArn = "arn:aws:ecs:" + REGION + ":" + ACCOUNT + ":service/" + CLUSTER_NAME + "/" + SERVICE_NAME;
+
+        ecs("UpdateService")
+                .body("""
+                {
+                    "cluster": "%s",
+                    "service": "%s",
+                    "desiredCount": 0
+                }
+                """.formatted(CLUSTER_NAME, fullServiceArn))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .body("service.serviceName", equalTo(SERVICE_NAME))
+                .body("service.status", equalTo("INACTIVE"));
+    }
+
+    @Test
+    @Order(52)
     void deregisterTaskDefinition() {
         ecs("DeregisterTaskDefinition")
             .body("""
@@ -519,7 +582,7 @@ class EcsIntegrationTest {
     }
 
     @Test
-    @Order(52)
+    @Order(53)
     void deleteCluster() {
         ecs("DeleteCluster")
             .body("""
@@ -534,7 +597,7 @@ class EcsIntegrationTest {
     }
 
     @Test
-    @Order(53)
+    @Order(54)
     void deleteClusterNotFound() {
         ecs("DeleteCluster")
             .body("""


### PR DESCRIPTION
## Summary

Fixes ECS service lifecycle handling during Terraform destroy then recreate sequences, resolving both an internal map desynchronization bug and an unhandled ARN string format parsing error.

- Retain inactive services: 'DeleteService'  removed the service from memory and when terraform followed with 'UpdateService' to drain task it threw 404 'ServiceNotFoundException'. We now update the status to INACTIVE and keep entry in memory
- Idempotency: modified 'CreateService' to ensure deep structural equality verification on incoming paramters instead of references ('==') which failed idempotent REST requests

Closes #1095

## Type of change

- [X] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore


## AWS Compatibility
- 'DeleteService' completely dropped the key from the map, when terraform performed update for task draining it threw 404 ServiceNotFoundException
- Re-running `CreateService` on existing service name failed blindly with a `400 InvalidParameterException` (idempotency error) even if the existing service was `INACTIVE` or if the duplicate parameters matched the `ACTIVE` deployment exactly.

## Checklist

- [X] `./mvnw test` passes locally
- [X] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)


Local test note: All targeted `EcsIntegrationTest` assertions pass cleanly. general suite testing was paused at docker task scheduling loops (`java.net.SocketException`) due to an isolated local daemon socket configuration (`unix://localhost:2375`)