### PR TITLE
feat(ecs): honour task-definition volumes + container mountPoints

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
@@ -15,6 +15,7 @@ import io.github.hectorvent.floci.services.ecs.model.EcsServiceModel;
 import io.github.hectorvent.floci.services.ecs.model.EcsTask;
 import io.github.hectorvent.floci.services.ecs.model.KeyValuePair;
 import io.github.hectorvent.floci.services.ecs.model.LaunchType;
+import io.github.hectorvent.floci.services.ecs.model.MountPoint;
 import io.github.hectorvent.floci.services.ecs.model.NetworkBinding;
 import io.github.hectorvent.floci.services.ecs.model.NetworkConfiguration;
 import io.github.hectorvent.floci.services.ecs.model.NetworkMode;
@@ -24,6 +25,7 @@ import io.github.hectorvent.floci.services.ecs.model.ServiceDeployment;
 import io.github.hectorvent.floci.services.ecs.model.ServiceRevision;
 import io.github.hectorvent.floci.services.ecs.model.TaskDefinition;
 import io.github.hectorvent.floci.services.ecs.model.TaskSet;
+import io.github.hectorvent.floci.services.ecs.model.Volume;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -209,6 +211,9 @@ public class EcsJsonHandler {
 
         TaskDefinition td = service.registerTaskDefinition(family, containerDefs, networkMode, cpu, memory,
                 taskRoleArn, executionRoleArn, tags, region);
+        // Task-level volumes are not part of registerTaskDefinition's signature; set them on the
+        // returned (and stored) task definition so they round-trip and reach RunTask launches.
+        td.setVolumes(parseVolumes(req.path("volumes")));
 
         ObjectNode resp = objectMapper.createObjectNode();
         resp.set("taskDefinition", taskDefinitionNode(td));
@@ -925,6 +930,20 @@ public class EcsJsonHandler {
             }
         }
         n.set("containerDefinitions", containers);
+        if (td.getVolumes() != null && !td.getVolumes().isEmpty()) {
+            ArrayNode vols = objectMapper.createArrayNode();
+            for (Volume v : td.getVolumes()) {
+                ObjectNode vNode = objectMapper.createObjectNode();
+                vNode.put("name", v.name());
+                if (v.hostSourcePath() != null) {
+                    ObjectNode host = objectMapper.createObjectNode();
+                    host.put("sourcePath", v.hostSourcePath());
+                    vNode.set("host", host);
+                }
+                vols.add(vNode);
+            }
+            n.set("volumes", vols);
+        }
         if (td.getTags() != null && !td.getTags().isEmpty()) {
             n.set("tags", tagsNode(td.getTags()));
         }
@@ -960,6 +979,18 @@ public class EcsJsonHandler {
                 envArr.add(kvNode);
             }
             n.set("environment", envArr);
+        }
+
+        if (def.getMountPoints() != null && !def.getMountPoints().isEmpty()) {
+            ArrayNode mps = objectMapper.createArrayNode();
+            for (MountPoint mp : def.getMountPoints()) {
+                ObjectNode mpNode = objectMapper.createObjectNode();
+                mpNode.put("sourceVolume", mp.sourceVolume());
+                mpNode.put("containerPath", mp.containerPath());
+                mpNode.put("readOnly", mp.readOnly());
+                mps.add(mpNode);
+            }
+            n.set("mountPoints", mps);
         }
 
         return n;
@@ -1200,6 +1231,7 @@ public class EcsJsonHandler {
 
             def.setPortMappings(parsePortMappings(item.path("portMappings")));
             def.setEnvironment(parseKeyValuePairs(item.path("environment")));
+            def.setMountPoints(parseMountPoints(item.path("mountPoints")));
 
             if (item.has("command") && item.path("command").isArray()) {
                 List<String> cmd = new ArrayList<>();
@@ -1238,6 +1270,32 @@ public class EcsJsonHandler {
         }
         for (JsonNode item : node) {
             result.add(new KeyValuePair(item.path("name").asText(), item.path("value").asText()));
+        }
+        return result;
+    }
+
+    private List<Volume> parseVolumes(JsonNode node) {
+        List<Volume> result = new ArrayList<>();
+        if (!node.isArray()) {
+            return result;
+        }
+        for (JsonNode item : node) {
+            String hostSourcePath = item.path("host").path("sourcePath").asText(null);
+            result.add(new Volume(item.path("name").asText(), hostSourcePath));
+        }
+        return result;
+    }
+
+    private List<MountPoint> parseMountPoints(JsonNode node) {
+        List<MountPoint> result = new ArrayList<>();
+        if (!node.isArray()) {
+            return result;
+        }
+        for (JsonNode item : node) {
+            result.add(new MountPoint(
+                    item.path("sourceVolume").asText(),
+                    item.path("containerPath").asText(),
+                    item.path("readOnly").asBoolean(false)));
         }
         return result;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
@@ -292,6 +292,14 @@ public class EcsService {
                                        LaunchType launchType, String group, String startedBy,
                                        String containerInstanceArn,
                                        List<ContainerOverride> containerOverrides, String region) {
+        // Fail loudly instead of silently launching zero containers and leaving
+        // a task that looks RUNNING with nothing behind it.
+        if (taskDef.getContainerDefinitions() == null || taskDef.getContainerDefinitions().isEmpty()) {
+            LOG.warnv("Task definition {0} has no container definitions; refusing to launch tasks",
+                    taskDef.getTaskDefinitionArn());
+            throw new AwsException("ClientException",
+                    "Task definition " + taskDef.getTaskDefinitionArn() + " has no container definitions.", 400);
+        }
         List<EcsTask> launched = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             String taskId = UUID.randomUUID().toString().replace("-", "");

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManager.java
@@ -12,9 +12,11 @@ import io.github.hectorvent.floci.services.ecs.model.Container;
 import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
 import io.github.hectorvent.floci.services.ecs.model.ContainerOverride;
 import io.github.hectorvent.floci.services.ecs.model.EcsTask;
+import io.github.hectorvent.floci.services.ecs.model.MountPoint;
 import io.github.hectorvent.floci.services.ecs.model.NetworkBinding;
 import io.github.hectorvent.floci.services.ecs.model.PortMapping;
 import io.github.hectorvent.floci.services.ecs.model.TaskDefinition;
+import io.github.hectorvent.floci.services.ecs.model.Volume;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.ExposedPort;
@@ -72,6 +74,16 @@ public class EcsContainerManager {
         List<Closeable> logStreams = new ArrayList<>();
         List<Container> runtimeContainers = new ArrayList<>();
 
+        // Task-level volumes: map volume name -> host source path, consumed by per-container mountPoints.
+        Map<String, String> volumeSourcePaths = new LinkedHashMap<>();
+        if (taskDef.getVolumes() != null) {
+            for (Volume v : taskDef.getVolumes()) {
+                if (v.name() != null && v.hostSourcePath() != null) {
+                    volumeSourcePaths.put(v.name(), v.hostSourcePath());
+                }
+            }
+        }
+
         for (ContainerDefinition def : taskDef.getContainerDefinitions()) {
             String containerName = "floci-ecs-" + taskId + "-" + def.getName();
 
@@ -123,6 +135,25 @@ public class EcsContainerManager {
             }
             if (def.getEntryPoint() != null && !def.getEntryPoint().isEmpty()) {
                 specBuilder.withEntrypoint(def.getEntryPoint());
+            }
+
+            // Bind-mount task-level volumes referenced by this container's mountPoints.
+            // The host source path resolves on the Docker daemon (sibling-container launch),
+            // so it must be an absolute host path. Unresolved volume references are skipped.
+            if (def.getMountPoints() != null) {
+                for (MountPoint mp : def.getMountPoints()) {
+                    String sourcePath = volumeSourcePaths.get(mp.sourceVolume());
+                    if (sourcePath == null || mp.containerPath() == null) {
+                        LOG.warnv("Skipping mountPoint with unresolved volume {0} on container {1}",
+                                mp.sourceVolume(), def.getName());
+                        continue;
+                    }
+                    if (mp.readOnly()) {
+                        specBuilder.withReadOnlyBind(sourcePath, mp.containerPath());
+                    } else {
+                        specBuilder.withBind(sourcePath, mp.containerPath());
+                    }
+                }
             }
 
             ContainerSpec spec = specBuilder.build();

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/ContainerDefinition.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/ContainerDefinition.java
@@ -17,6 +17,7 @@ public class ContainerDefinition {
     private List<KeyValuePair> environment;
     private List<String> command;
     private List<String> entryPoint;
+    private List<MountPoint> mountPoints;
 
     public String getName() { return name; }
     public void setName(String name) { this.name = name; }
@@ -47,4 +48,7 @@ public class ContainerDefinition {
 
     public List<String> getEntryPoint() { return entryPoint; }
     public void setEntryPoint(List<String> entryPoint) { this.entryPoint = entryPoint; }
+
+    public List<MountPoint> getMountPoints() { return mountPoints; }
+    public void setMountPoints(List<MountPoint> mountPoints) { this.mountPoints = mountPoints; }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/MountPoint.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/MountPoint.java
@@ -1,0 +1,10 @@
+package io.github.hectorvent.floci.services.ecs.model;
+
+/**
+ * A container mount point in an ECS container definition:
+ * {@code {"sourceVolume": ..., "containerPath": ..., "readOnly": ...}}.
+ * {@code sourceVolume} references a task-level {@link Volume} by name; the volume's
+ * host source path is bind-mounted into the container at {@code containerPath}.
+ */
+public record MountPoint(String sourceVolume, String containerPath, boolean readOnly) {
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/TaskDefinition.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/TaskDefinition.java
@@ -19,6 +19,7 @@ public class TaskDefinition {
     private String taskRoleArn;
     private String executionRoleArn;
     private List<ContainerDefinition> containerDefinitions;
+    private List<Volume> volumes;
     private Map<String, String> tags = new HashMap<>();
 
     public String getTaskDefinitionArn() { return taskDefinitionArn; }
@@ -52,6 +53,9 @@ public class TaskDefinition {
     public void setContainerDefinitions(List<ContainerDefinition> containerDefinitions) {
         this.containerDefinitions = containerDefinitions;
     }
+
+    public List<Volume> getVolumes() { return volumes; }
+    public void setVolumes(List<Volume> volumes) { this.volumes = volumes; }
 
     public Map<String, String> getTags() { return tags; }
     public void setTags(Map<String, String> tags) { this.tags = tags; }

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/Volume.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/Volume.java
@@ -1,0 +1,10 @@
+package io.github.hectorvent.floci.services.ecs.model;
+
+/**
+ * A task-level volume in an ECS task definition. Only the EC2-launch-type
+ * {@code host} volume shape is modelled: {@code {"name": ..., "host": {"sourcePath": ...}}}.
+ * {@code hostSourcePath} is the absolute path on the Docker host that the volume
+ * binds to; a container references this volume by {@code name} via a {@link MountPoint}.
+ */
+public record Volume(String name, String hostSourcePath) {
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/EcsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/EcsIntegrationTest.java
@@ -323,6 +323,49 @@ class EcsIntegrationTest {
             .body("task.lastStatus", equalTo("STOPPED"));
     }
 
+    @Test
+    @Order(24)
+    void runTaskWithEmptyContainerDefinitionsFailsLoudly() {
+        ecs("RegisterTaskDefinition")
+            .body("""
+                {
+                    "family": "empty-containers-task",
+                    "containerDefinitions": []
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        ecs("RunTask")
+            .body("""
+                {
+                    "cluster": "%s",
+                    "taskDefinition": "empty-containers-task",
+                    "launchType": "FARGATE",
+                    "count": 1
+                }
+                """.formatted(CLUSTER_NAME))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ClientException"))
+            .body("message", containsString("no container definitions"));
+
+        // The failed launch must not leave a phantom task behind.
+        ecs("ListTasks")
+            .body("""
+                {"cluster": "%s", "family": "empty-containers-task"}
+                """.formatted(CLUSTER_NAME))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("taskArns", empty());
+    }
+
     // ── Services ──────────────────────────────────────────────────────────────
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandlerVolumesTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandlerVolumesTest.java
@@ -1,0 +1,99 @@
+package io.github.hectorvent.floci.services.ecs;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
+import io.github.hectorvent.floci.services.ecs.model.TaskDefinition;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the RegisterTaskDefinition JSON wire path in {@link EcsJsonHandler}:
+ * task-level {@code volumes} and per-container {@code mountPoints} must be parsed from the
+ * request, stored on the task definition, and serialized back in the response (round-trip
+ * fidelity, faithful to the EC2-launch-type ECS shape {@code volumes[].host.sourcePath}).
+ *
+ * <p>{@link EcsService} is mocked to echo the parsed container definitions back inside a
+ * task definition, so the test exercises parse + serialize without any Docker/Quarkus context.
+ */
+class EcsJsonHandlerVolumesTest {
+
+    private EcsService service;
+    private ObjectMapper objectMapper;
+    private EcsJsonHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        service = mock(EcsService.class);
+        // Echo the parsed container definitions (arg index 1) back inside a task definition.
+        when(service.registerTaskDefinition(anyString(), any(), any(), any(), any(), any(), any(), any(), anyString()))
+                .thenAnswer(inv -> {
+                    TaskDefinition td = new TaskDefinition();
+                    td.setFamily(inv.getArgument(0));
+                    td.setRevision(1);
+                    td.setStatus("ACTIVE");
+                    td.setContainerDefinitions(inv.getArgument(1, List.class));
+                    return td;
+                });
+
+        handler = new EcsJsonHandler(service, objectMapper);
+    }
+
+    @Test
+    void registerTaskDefinitionRoundTripsVolumesAndMountPoints() throws Exception {
+        String requestJson = """
+                {
+                  "family": "volumes-family",
+                  "containerDefinitions": [
+                    {
+                      "name": "app",
+                      "image": "alpine:latest",
+                      "mountPoints": [
+                        {"sourceVolume": "config-vol", "containerPath": "/app/config.yml", "readOnly": true},
+                        {"sourceVolume": "aws-vol", "containerPath": "/root/.aws", "readOnly": false}
+                      ]
+                    }
+                  ],
+                  "volumes": [
+                    {"name": "config-vol", "host": {"sourcePath": "/host/abs/config.yml"}},
+                    {"name": "aws-vol", "host": {"sourcePath": "/host/abs/.aws"}}
+                  ]
+                }
+                """;
+        JsonNode request = objectMapper.readTree(requestJson);
+
+        Response response = handler.handle("RegisterTaskDefinition", request, "us-east-1");
+        JsonNode td = objectMapper.valueToTree(response.getEntity()).path("taskDefinition");
+
+        // Task-level volumes round-trip with the EC2 host.sourcePath shape.
+        JsonNode volumes = td.path("volumes");
+        assertTrue(volumes.isArray() && volumes.size() == 2, "two volumes expected");
+        assertEquals("config-vol", volumes.get(0).path("name").asText());
+        assertEquals("/host/abs/config.yml", volumes.get(0).path("host").path("sourcePath").asText());
+        assertEquals("aws-vol", volumes.get(1).path("name").asText());
+        assertEquals("/host/abs/.aws", volumes.get(1).path("host").path("sourcePath").asText());
+
+        // Per-container mountPoints round-trip with sourceVolume/containerPath/readOnly.
+        JsonNode mps = td.path("containerDefinitions").get(0).path("mountPoints");
+        assertTrue(mps.isArray() && mps.size() == 2, "two mountPoints expected");
+        assertEquals("config-vol", mps.get(0).path("sourceVolume").asText());
+        assertEquals("/app/config.yml", mps.get(0).path("containerPath").asText());
+        assertTrue(mps.get(0).path("readOnly").asBoolean(), "config mount is read-only");
+        assertEquals("aws-vol", mps.get(1).path("sourceVolume").asText());
+        assertEquals("/root/.aws", mps.get(1).path("containerPath").asText());
+        assertFalse(mps.get(1).path("readOnly").asBoolean(), "aws mount is read-write");
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerVolumesTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerVolumesTest.java
@@ -1,0 +1,109 @@
+package io.github.hectorvent.floci.services.ecs.container;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
+import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
+import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
+import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
+import io.github.hectorvent.floci.services.ecs.model.EcsTask;
+import io.github.hectorvent.floci.services.ecs.model.MountPoint;
+import io.github.hectorvent.floci.services.ecs.model.TaskDefinition;
+import io.github.hectorvent.floci.services.ecs.model.Volume;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for task-definition {@code volumes} + container {@code mountPoints} handling in
+ * {@link EcsContainerManager#startTask}: a container mountPoint resolves its source volume to
+ * the task-level volume's host source path and bind-mounts it at the container path —
+ * read-only via {@code withReadOnlyBind}, read-write via {@code withBind}. A mountPoint whose
+ * source volume is not declared in the task definition is skipped (no bind).
+ *
+ * <p>The container builder and lifecycle manager are mocked, so the test asserts the bind
+ * arguments that <em>would</em> be handed to Docker without launching one — runnable under
+ * {@code mvn test} (CI) with no Docker daemon.
+ */
+class EcsContainerManagerVolumesTest {
+
+    private ContainerBuilder containerBuilder;
+    private ContainerBuilder.Builder builder;
+    private ContainerLifecycleManager lifecycleManager;
+    private EcsContainerManager manager;
+
+    @BeforeEach
+    void setUp() {
+        builder = mock(ContainerBuilder.Builder.class, RETURNS_SELF);
+        containerBuilder = mock(ContainerBuilder.class);
+        when(containerBuilder.newContainer(anyString())).thenReturn(builder);
+
+        lifecycleManager = mock(ContainerLifecycleManager.class);
+        when(lifecycleManager.createAndStart(any()))
+                .thenReturn(new ContainerInfo("docker-id", Map.of()));
+
+        ContainerLogStreamer logStreamer = mock(ContainerLogStreamer.class);
+        ContainerDetector containerDetector = mock(ContainerDetector.class);
+        EmulatorConfig config = mock(EmulatorConfig.class, RETURNS_DEEP_STUBS);
+        RegionResolver regionResolver = mock(RegionResolver.class);
+
+        manager = new EcsContainerManager(containerBuilder, lifecycleManager, logStreamer,
+                containerDetector, config, regionResolver);
+    }
+
+    @Test
+    void mountPointsResolveTaskVolumesToHostBindsByAccessMode() {
+        ContainerDefinition app = new ContainerDefinition();
+        app.setName("app");
+        app.setImage("app:latest");
+        app.setMountPoints(List.of(
+                new MountPoint("config-vol", "/app/config.yml", true),    // read-only
+                new MountPoint("aws-vol", "/root/.aws", false),           // read-write
+                new MountPoint("missing-vol", "/app/nope", true)));       // unresolved -> skipped
+
+        TaskDefinition taskDef = new TaskDefinition();
+        taskDef.setFamily("test-family");
+        taskDef.setContainerDefinitions(List.of(app));
+        taskDef.setVolumes(List.of(
+                new Volume("config-vol", "/host/abs/app/config.yml"),
+                new Volume("aws-vol", "/host/abs/home/.aws")));
+
+        EcsTask task = new EcsTask();
+        task.setTaskArn("arn:aws:ecs:us-east-1:000000000000:task/test-cluster/abc123");
+
+        manager.startTask(task, taskDef, List.of(), "us-east-1");
+
+        // Read-only mountPoint -> withReadOnlyBind(hostSourcePath, containerPath).
+        ArgumentCaptor<String> roHost = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> roPath = ArgumentCaptor.forClass(String.class);
+        verify(builder, times(1)).withReadOnlyBind(roHost.capture(), roPath.capture());
+        assertEquals("/host/abs/app/config.yml", roHost.getValue());
+        assertEquals("/app/config.yml", roPath.getValue());
+
+        // Read-write mountPoint -> withBind(hostSourcePath, containerPath).
+        ArgumentCaptor<String> rwHost = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> rwPath = ArgumentCaptor.forClass(String.class);
+        verify(builder, times(1)).withBind(rwHost.capture(), rwPath.capture());
+        assertEquals("/host/abs/home/.aws", rwHost.getValue());
+        assertEquals("/root/.aws", rwPath.getValue());
+
+        // The unresolved "missing-vol" mountPoint contributes no bind beyond the two above.
+        verify(builder, never()).withBind("/app/nope", "/app/nope");
+    }
+}


### PR DESCRIPTION
## What

floci parses RegisterTaskDefinition but drops task-level `volumes[]` and per-container
`mountPoints[]` — they don't round-trip through Describe, and RunTask launches the
container without any of the declared binds.

This implements the EC2-launch-type host-bind semantics: a task definition may declare
task-level volumes (`{name, host.sourcePath}`), each container definition may reference
them via mountPoints (`{sourceVolume, containerPath, readOnly}`), and at RunTask launch
each mountPoint resolves its source volume to the host source path and bind-mounts it
into the container — read-only or read-write per the mountPoint. A mountPoint whose
`sourceVolume` is not declared in the task definition is skipped with a warning.

It also fixes a silent-failure path found while testing: RunTask on a task definition
with zero container definitions used to launch nothing, log nothing, and still leave a
task progressing towards RUNNING — callers polling DescribeTasks waited forever. It now
fails loudly with a `ClientException` (HTTP 400) before any task is created.

## Why

`volumes` + `mountPoints` are the standard ECS way to hand per-task config/state to a
container — the common local-dev pattern is a stock image launched with a host file
bind-mounted at a fixed container path, instead of baking config into per-image
wrappers.

## Changes

- new `model/Volume` (`name`, `host.sourcePath`) and `model/MountPoint`
  (`sourceVolume`, `containerPath`, `readOnly`) records; `volumes` on
  `TaskDefinition`, `mountPoints` on `ContainerDefinition`
- `EcsJsonHandler`: parse + serialize round-trip for both
- `EcsContainerManager.startTask`: resolve each mountPoint against the task-level
  volumes and wire the binds (`withReadOnlyBind` / `withBind`)
- `EcsService.launchTasks`: WARN + throw `ClientException` when the resolved task
  definition has no container definitions (covers RunTask and StartTask, docker and
  mock mode)

## Testing

- `mvn test -B` passes on Java 25 (Temurin); the existing ECS suite is green.
- `EcsJsonHandlerVolumesTest` — RegisterTaskDefinition wire path: `volumes[].host.sourcePath`
  and `mountPoints[]` parse from the request and serialize back in the response.
- `EcsContainerManagerVolumesTest` — `startTask` resolves mountPoints to binds by access
  mode (read-only vs read-write) and skips a mountPoint referencing an undeclared volume.
  Builder/lifecycle are mocked, so it runs under `mvn test` with no Docker daemon, same
  approach as `EcsContainerManagerOverridesTest`.
- `EcsIntegrationTest.runTaskWithEmptyContainerDefinitionsFailsLoudly` — RunTask on a
  family registered with `"containerDefinitions": []` returns 400 `ClientException` and
  leaves no phantom task behind.
- Exercised end-to-end against the built docker image with the AWS CLI:
  RegisterTaskDefinition with a host volume + mountPoint, RunTask, and `docker inspect`
  on the launched container shows the expected bind; RunTask on an empty-container
  family returns the error response instead of a silently RUNNING task.
