### PR TITLE
feat(cloudwatch): accept log group ARN via logGroupIdentifier

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
@@ -110,15 +110,17 @@ public class CloudWatchLogsHandler {
     }
 
     private Response handleDescribeLogStreams(JsonNode request, String region) {
-        String groupName = request.path("logGroupName").asText();
+        String groupName = resolveLogGroupName(request);
         String prefix = request.path("logStreamNamePrefix").asText(null);
         List<LogStream> streams = logsService.describeLogStreams(groupName, prefix, region);
 
+        String logGroupArn = logsService.buildArn(groupName, region);
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode streamsArray = objectMapper.createArrayNode();
         for (LogStream s : streams) {
             ObjectNode node = objectMapper.createObjectNode();
             node.put("logStreamName", s.getLogStreamName());
+            node.put("arn", logGroupArn + ":log-stream:" + s.getLogStreamName());
             node.put("createdTime", s.getCreatedTime());
             node.put("lastIngestionTime", s.getLastIngestionTime());
             node.put("uploadSequenceToken", s.getUploadSequenceToken());
@@ -136,7 +138,7 @@ public class CloudWatchLogsHandler {
     }
 
     private Response handlePutLogEvents(JsonNode request, String region) {
-        String groupName = request.path("logGroupName").asText();
+        String groupName = resolveLogGroupName(request);
         String streamName = request.path("logStreamName").asText();
 
         List<Map<String, Object>> events = new ArrayList<>();
@@ -154,8 +156,8 @@ public class CloudWatchLogsHandler {
     }
 
     private Response handleGetLogEvents(JsonNode request, String region) {
-        String groupName = request.path("logGroupName").asText();
-        String streamName = request.path("logStreamName").asText();
+        String groupName = resolveLogGroupName(request);
+        String streamName = resolveLogStreamName(request.path("logStreamName").asText(null));
         Long startTime = request.has("startTime") ? request.path("startTime").asLong() : null;
         Long endTime = request.has("endTime") ? request.path("endTime").asLong() : null;
         int limit = request.path("limit").asInt(0);
@@ -173,14 +175,14 @@ public class CloudWatchLogsHandler {
     }
 
     private Response handleFilterLogEvents(JsonNode request, String region) {
-        String groupName = request.path("logGroupName").asText();
+        String groupName = resolveLogGroupName(request);
         Long startTime = request.has("startTime") ? request.path("startTime").asLong() : null;
         Long endTime = request.has("endTime") ? request.path("endTime").asLong() : null;
         String filterPattern = request.path("filterPattern").asText(null);
         int limit = request.path("limit").asInt(0);
 
         List<String> streamNames = new ArrayList<>();
-        request.path("logStreamNames").forEach(n -> streamNames.add(n.asText()));
+        request.path("logStreamNames").forEach(n -> streamNames.add(resolveLogStreamName(n.asText(null))));
 
         CloudWatchLogsService.FilteredLogEventsResult result =
                 logsService.filterLogEvents(groupName, streamNames, startTime, endTime, filterPattern, limit, region);
@@ -307,6 +309,21 @@ public class CloudWatchLogsHandler {
         String filterName = request.path("filterName").asText();
         logsService.deleteSubscriptionFilter(logGroupName, filterName, region);
         return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private String resolveLogGroupName(JsonNode request) {
+        String name = request.path("logGroupName").asText(null);
+        if (name == null || name.isBlank()) {
+            name = request.path("logGroupIdentifier").asText(null);
+        }
+        return extractLogGroupNameFromArn(name);
+    }
+
+    private String resolveLogStreamName(String name) {
+        if (name != null && name.contains(":log-stream:")) {
+            return name.substring(name.indexOf(":log-stream:") + ":log-stream:".length());
+        }
+        return name;
     }
 
     private String extractLogGroupNameFromArn(String arn) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandlerTest.java
@@ -1,0 +1,229 @@
+package io.github.hectorvent.floci.services.cloudwatch.logs;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Handler-level tests for ARN-based log group/stream resolution (issue #1164).
+ *
+ * <p>Verifies that CloudWatch Logs APIs accept either a name or an ARN via
+ * {@code logGroupIdentifier} / {@code logStreamName}, mirroring real AWS behavior
+ * so SDK clients that pass {@code --log-group-identifier} work against floci.
+ */
+class CloudWatchLogsHandlerTest {
+
+    private static final String REGION = "us-east-1";
+    private static final String ACCOUNT = "000000000000";
+    private static final String GROUP = "/aws/rds/instance/mypostgres-dsf/postgresql";
+    private static final String STREAM = "postgresql.log.2026-06-04";
+    private static final String GROUP_ARN =
+            "arn:aws:logs:" + REGION + ":" + ACCOUNT + ":log-group:" + GROUP;
+    private static final String GROUP_ARN_WILDCARD = GROUP_ARN + ":*";
+    private static final String STREAM_ARN = GROUP_ARN + ":log-stream:" + STREAM;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private CloudWatchLogsService service;
+    private CloudWatchLogsHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        service = new CloudWatchLogsService(
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                10_000,
+                new RegionResolver(REGION, ACCOUNT)
+        );
+        handler = new CloudWatchLogsHandler(service, MAPPER);
+
+        service.createLogGroup(GROUP, null, null, REGION);
+        service.createLogStream(GROUP, STREAM, REGION);
+    }
+
+    // ──────────────────────────── DescribeLogStreams ────────────────────────────
+
+    @Test
+    void describeLogStreamsByLogGroupIdentifierArnResolvesToGroup() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("logGroupIdentifier", GROUP_ARN);
+
+        Response response = handler.handle("DescribeLogStreams", request, REGION);
+
+        assertEquals(200, response.getStatus());
+        JsonNode streams = ((ObjectNode) response.getEntity()).path("logStreams");
+        assertEquals(1, streams.size());
+        assertEquals(STREAM, streams.get(0).path("logStreamName").asText());
+    }
+
+    @Test
+    void describeLogStreamsByLogGroupIdentifierArnWithWildcardSuffix() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("logGroupIdentifier", GROUP_ARN_WILDCARD);
+
+        Response response = handler.handle("DescribeLogStreams", request, REGION);
+
+        assertEquals(200, response.getStatus());
+        assertEquals(1, ((ObjectNode) response.getEntity()).path("logStreams").size());
+    }
+
+    @Test
+    void describeLogStreamsByNameStillWorks() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("logGroupName", GROUP);
+
+        Response response = handler.handle("DescribeLogStreams", request, REGION);
+
+        assertEquals(200, response.getStatus());
+        assertEquals(1, ((ObjectNode) response.getEntity()).path("logStreams").size());
+    }
+
+    @Test
+    void describeLogStreamsResponseIncludesPerStreamArn() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("logGroupName", GROUP);
+
+        Response response = handler.handle("DescribeLogStreams", request, REGION);
+
+        JsonNode stream = ((ObjectNode) response.getEntity()).path("logStreams").get(0);
+        assertEquals(STREAM_ARN, stream.path("arn").asText());
+    }
+
+    @Test
+    void describeLogStreamsPrefersLogGroupNameWhenBothProvided() {
+        // logGroupName is the canonical field — if both are present, name wins
+        // so a mistyped identifier doesn't silently override the explicit name.
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("logGroupName", GROUP);
+        request.put("logGroupIdentifier", "arn:aws:logs:us-east-1:000000000000:log-group:/does/not/exist");
+
+        Response response = handler.handle("DescribeLogStreams", request, REGION);
+
+        assertEquals(200, response.getStatus());
+        assertEquals(1, ((ObjectNode) response.getEntity()).path("logStreams").size());
+    }
+
+    // ──────────────────────────── PutLogEvents ────────────────────────────
+
+    @Test
+    void putLogEventsByLogGroupIdentifierArn() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("logGroupIdentifier", GROUP_ARN);
+        request.put("logStreamName", STREAM);
+        ArrayNode events = request.putArray("logEvents");
+        ObjectNode event = events.addObject();
+        event.put("timestamp", System.currentTimeMillis());
+        event.put("message", "hello via ARN");
+
+        Response response = handler.handle("PutLogEvents", request, REGION);
+
+        assertEquals(200, response.getStatus());
+        var stored = service.getLogEvents(GROUP, STREAM, null, null, 100, true, null, REGION);
+        assertEquals(1, stored.events().size());
+        assertEquals("hello via ARN", stored.events().getFirst().getMessage());
+    }
+
+    // ──────────────────────────── GetLogEvents ────────────────────────────
+
+    @Test
+    void getLogEventsByLogGroupIdentifierArnAndLogStreamArn() {
+        long now = System.currentTimeMillis();
+        service.putLogEvents(GROUP, STREAM,
+                java.util.List.of(java.util.Map.of("timestamp", now, "message", "via arn")),
+                REGION);
+
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("logGroupIdentifier", GROUP_ARN);
+        request.put("logStreamName", STREAM_ARN);
+
+        Response response = handler.handle("GetLogEvents", request, REGION);
+
+        assertEquals(200, response.getStatus());
+        JsonNode events = ((ObjectNode) response.getEntity()).path("events");
+        assertEquals(1, events.size());
+        assertEquals("via arn", events.get(0).path("message").asText());
+    }
+
+    // ──────────────────────────── FilterLogEvents ────────────────────────────
+
+    @Test
+    void filterLogEventsByLogGroupIdentifierArnAndStreamArns() {
+        long now = System.currentTimeMillis();
+        service.putLogEvents(GROUP, STREAM, java.util.List.of(
+                java.util.Map.of("timestamp", now, "message", "ERROR: kaboom"),
+                java.util.Map.of("timestamp", now + 1, "message", "INFO: fine")
+        ), REGION);
+
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("logGroupIdentifier", GROUP_ARN);
+        ArrayNode streamArns = request.putArray("logStreamNames");
+        streamArns.add(STREAM_ARN);
+        request.put("filterPattern", "ERROR");
+
+        Response response = handler.handle("FilterLogEvents", request, REGION);
+
+        assertEquals(200, response.getStatus());
+        JsonNode events = ((ObjectNode) response.getEntity()).path("events");
+        assertEquals(1, events.size());
+        assertThat(events.get(0).path("message").asText(), containsString("ERROR"));
+    }
+
+    @Test
+    void filterLogEventsByLogGroupIdentifierArnWithoutStreamFilter() {
+        long now = System.currentTimeMillis();
+        service.putLogEvents(GROUP, STREAM, java.util.List.of(
+                java.util.Map.of("timestamp", now, "message", "a"),
+                java.util.Map.of("timestamp", now + 1, "message", "b")
+        ), REGION);
+
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("logGroupIdentifier", GROUP_ARN);
+
+        Response response = handler.handle("FilterLogEvents", request, REGION);
+
+        assertEquals(200, response.getStatus());
+        assertEquals(2, ((ObjectNode) response.getEntity()).path("events").size());
+    }
+
+    // ──────────────────────────── Resilience ────────────────────────────
+
+    @Test
+    void describeLogStreamsByPlainNamePassedAsIdentifier() {
+        // Some callers pass the plain name through --log-group-identifier rather than
+        // the ARN. The resolver must accept both forms.
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("logGroupIdentifier", GROUP);
+
+        Response response = handler.handle("DescribeLogStreams", request, REGION);
+
+        assertEquals(200, response.getStatus());
+        assertEquals(1, ((ObjectNode) response.getEntity()).path("logStreams").size());
+    }
+
+    @Test
+    void perStreamArnDoesNotEndWithWildcard() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("logGroupName", GROUP);
+
+        Response response = handler.handle("DescribeLogStreams", request, REGION);
+
+        String arn = ((ObjectNode) response.getEntity())
+                .path("logStreams").get(0).path("arn").asText();
+        assertTrue(arn.contains(":log-stream:" + STREAM));
+        assertThat(arn, not(containsString(":*")));
+    }
+}


### PR DESCRIPTION
## Summary

CloudWatch Logs APIs that take a log group reference now accept either
`logGroupName` or `logGroupIdentifier`. When an ARN is provided, the
log-group name is extracted from the `:log-group:` segment (trailing
`:*` tolerated). Log-stream identifiers passed as ARNs have their
`:log-stream:` prefix stripped, so SDK responses round-trip cleanly.

`DescribeLogStreams` responses now also include a per-stream `arn` field,
matching real CloudWatch.

Closes #1164

Affected actions: `DescribeLogStreams`, `PutLogEvents`, `GetLogEvents`, `FilterLogEvents`.

## Type of change

- [x] New feature (`feat:`)

## AWS Compatibility

Verified against AWS CLI `aws-cli/2.34.58 Python/3.14.5 Darwin/24.6.0 source/arm64` reproducing the failure
described in #1164:

- ❌ before: `aws logs describe-log-streams --log-group-identifier "arn:aws:logs:us-east-1:000000000000:log-group:/aws/rds/instance/mypostgres-dsf/postgresql"` returned `ResourceNotFoundException`
- ✅ after: same command returns the expected log stream list

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (`CloudWatchLogsHandlerTest`, 11 tests covering ARN, ARN+wildcard, plain name, mixed identifier/name precedence, and per-stream ARN response field)
- [x] Commit messages follow Conventional Commits
