### PR TITLE
feat: support Glue DeleteDatabase

### DIFF
--- a/docs/services/glue.md
+++ b/docs/services/glue.md
@@ -11,7 +11,7 @@ Floci emulates the AWS Glue Data Catalog and Glue Schema Registry, allowing you 
 
 | Area | Actions |
 |---|---|
-| Databases | `CreateDatabase` · `GetDatabase` · `GetDatabases` |
+| Databases | `CreateDatabase` · `GetDatabase` · `GetDatabases` · `DeleteDatabase` |
 | Tables | `CreateTable` · `GetTable` · `GetTables` · `DeleteTable` |
 | Partitions | `CreatePartition` · `GetPartitions` |
 | User-defined functions | `CreateUserDefinedFunction` · `GetUserDefinedFunction` · `GetUserDefinedFunctions` · `UpdateUserDefinedFunction` · `DeleteUserDefinedFunction` |

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -36,7 +36,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [RDS](rds.md) | `POST /` with `Action=` param + TCP proxy | Query + wire | 14 |
 | [MSK](msk.md) | `/v1/clusters/...`, `/api/v2/clusters/...` + Redpanda broker | REST JSON + Kafka | 8 |
 | [Athena](athena.md) | `POST /` + `X-Amz-Target: AmazonAthena.*` | JSON 1.1 | 4 |
-| [Glue](glue.md) | `POST /` + `X-Amz-Target: AWSGlue.*` | JSON 1.1 | 37 |
+| [Glue](glue.md) | `POST /` + `X-Amz-Target: AWSGlue.*` | JSON 1.1 | 38 |
 | [Neptune](neptune.md) | `POST /` with `Action=` param + Gremlin TCP proxy | Query + WebSocket | 8 |
 | [Data Firehose](firehose.md) | `POST /` + `X-Amz-Target: Firehose_20150804.*` | JSON 1.1 | 6 |
 | [ECS](ecs.md) | `POST /` + `X-Amz-Target: AmazonEC2ContainerServiceV20141113.*` | JSON 1.1 | 58 |

--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueJsonHandler.java
@@ -55,6 +55,11 @@ public class GlueJsonHandler {
             case "GetDatabases" -> {
                 yield Response.ok(Map.of("DatabaseList", glueService.getDatabases())).build();
             }
+            case "DeleteDatabase" -> {
+                String name = request.get("Name").asText();
+                glueService.deleteDatabase(name);
+                yield Response.ok().build();
+            }
             case "CreateTable" -> {
                 String dbName = request.get("DatabaseName").asText();
                 Table table = mapper.treeToValue(request.get("TableInput"), Table.class);

--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
@@ -86,6 +86,17 @@ public class GlueService {
         return databaseStore.scan(k -> true);
     }
 
+    public void deleteDatabase(String name) {
+        getDatabase(name);
+        List<String> tableNames = tableStore.scan(k -> true).stream()
+                .filter(table -> name.equals(table.getDatabaseName()))
+                .map(Table::getName)
+                .toList();
+        tableNames.forEach(tableName -> deleteTable(name, tableName));
+        databaseStore.delete(name);
+        LOG.infov("Deleted Glue Database: {0}", name);
+    }
+
     public void createTable(String databaseName, Table table) {
         getDatabase(databaseName);
         String key = databaseName + ":" + table.getName();

--- a/src/test/java/io/github/hectorvent/floci/services/glue/GlueCatalogSchemaBindingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/GlueCatalogSchemaBindingIntegrationTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -342,5 +344,43 @@ class GlueCatalogSchemaBindingIntegrationTest {
         .when().post("/").then()
             .statusCode(400)
             .body("__type", equalTo("EntityNotFoundException"));
+    }
+
+    @Test
+    @Order(9)
+    void deleteDatabaseRemovesCatalogDatabase() {
+        String database = "database-to-delete";
+
+        given().contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSGlue.CreateDatabase")
+            .body("{ \"DatabaseInput\": { \"Name\": \"" + database + "\" } }")
+        .when().post("/").then().statusCode(200);
+
+        given().contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSGlue.CreateTable")
+            .body("""
+                  {
+                    "DatabaseName": "%s",
+                    "TableInput": {
+                      "Name": "table_to_delete",
+                      "StorageDescriptor": {
+                        "Location": "s3://bucket/delete/"
+                      }
+                    }
+                  }
+                  """.formatted(database))
+        .when().post("/").then().statusCode(200);
+
+        given().contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSGlue.DeleteDatabase")
+            .body("{ \"Name\": \"" + database + "\" }")
+        .when().post("/").then().statusCode(200);
+
+        given().contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSGlue.GetDatabases")
+            .body("{}")
+        .when().post("/").then()
+            .statusCode(200)
+            .body("DatabaseList.Name", not(hasItem(database)));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
@@ -44,16 +44,20 @@ class GlueServiceTest {
 
     private GlueService glueService;
     private GlueSchemaRegistryService schemaRegistryService;
+    private StorageBackend<String, Table> tableStore;
+    private StorageBackend<String, Partition> partitionStore;
 
     @BeforeEach
     void setUp() {
         RegionResolver regionResolver = new RegionResolver(REGION, ACCOUNT_ID);
         StorageFactory storageFactory = new InMemoryStorageFactory();
         schemaRegistryService = new GlueSchemaRegistryService(storageFactory, regionResolver);
+        tableStore = new InMemoryStorage<>();
+        partitionStore = new InMemoryStorage<>();
         glueService = new GlueService(
                 new InMemoryStorage<String, Database>(),
-                new InMemoryStorage<String, Table>(),
-                new InMemoryStorage<String, Partition>(),
+                tableStore,
+                partitionStore,
                 new InMemoryStorage<String, UserDefinedFunction>(),
                 schemaRegistryService, regionResolver);
         glueService.createDatabase(new Database("db1"));
@@ -228,6 +232,45 @@ class GlueServiceTest {
         assertEquals("SELECT 1 AS x", fetched.getViewOriginalText());
         assertEquals("SELECT 1 AS x", fetched.getViewExpandedText());
         assertEquals("true", fetched.getParameters().get("presto_view"));
+    }
+
+    @Test
+    void deleteDatabaseDeletesDatabaseTablesAndPartitions() {
+        Table table = new Table();
+        table.setName("plain");
+        glueService.createTable("db1", table);
+
+        Partition partition = new Partition();
+        partition.setValues(java.util.List.of("2026"));
+        glueService.createPartition("db1", "plain", partition);
+
+        glueService.deleteDatabase("db1");
+
+        assertThrows(AwsException.class, () -> glueService.getDatabase("db1"));
+        assertThrows(AwsException.class, () -> glueService.getTable("db1", "plain"));
+        assertTrue(tableStore.scan(k -> true).isEmpty());
+        assertTrue(partitionStore.scan(k -> true).isEmpty());
+    }
+
+    @Test
+    void deleteDatabaseDoesNotDeleteSimilarDatabaseNames() {
+        glueService.createDatabase(new Database("a"));
+        glueService.createDatabase(new Database("a:b"));
+        Table similarDatabaseTable = new Table();
+        similarDatabaseTable.setName("t");
+        glueService.createTable("a:b", similarDatabaseTable);
+
+        glueService.deleteDatabase("a");
+
+        assertEquals("t", glueService.getTable("a:b", "t").getName());
+    }
+
+    @Test
+    void deleteDatabaseForMissingDatabaseThrows() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> glueService.deleteDatabase("missing"));
+
+        assertEquals("EntityNotFoundException", ex.getErrorCode());
     }
 
     @Test


### PR DESCRIPTION
Adds Glue DeleteDatabase support so SDK clients can remove catalog databases during cleanup.

Closes #1179
