### PR TITLE
fix: preserve Glue view table fields

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
@@ -194,12 +194,15 @@ public class GlueService {
         copy.setName(source.getName());
         copy.setDatabaseName(source.getDatabaseName());
         copy.setDescription(source.getDescription());
+        copy.setOwner(source.getOwner());
         copy.setCreateTime(source.getCreateTime());
         copy.setUpdateTime(source.getUpdateTime());
         copy.setLastAccessTime(source.getLastAccessTime());
         copy.setPartitionKeys(copyColumns(source.getPartitionKeys()));
         copy.setStorageDescriptor(copyStorageDescriptor(source.getStorageDescriptor()));
         copy.setTableType(source.getTableType());
+        copy.setViewOriginalText(source.getViewOriginalText());
+        copy.setViewExpandedText(source.getViewExpandedText());
         copy.setParameters(copyMap(source.getParameters()));
         return copy;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/glue/model/Table.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/model/Table.java
@@ -15,6 +15,8 @@ public class Table {
     private String databaseName;
     @JsonProperty("Description")
     private String description;
+    @JsonProperty("Owner")
+    private String owner;
     @JsonProperty("CreateTime")
     @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Instant createTime;
@@ -30,6 +32,10 @@ public class Table {
     private StorageDescriptor storageDescriptor;
     @JsonProperty("TableType")
     private String tableType;
+    @JsonProperty("ViewOriginalText")
+    private String viewOriginalText;
+    @JsonProperty("ViewExpandedText")
+    private String viewExpandedText;
     @JsonProperty("Parameters")
     private Map<String, String> parameters;
 
@@ -41,6 +47,8 @@ public class Table {
     public void setDatabaseName(String databaseName) { this.databaseName = databaseName; }
     public String getDescription() { return description; }
     public void setDescription(String description) { this.description = description; }
+    public String getOwner() { return owner; }
+    public void setOwner(String owner) { this.owner = owner; }
     public Instant getCreateTime() { return createTime; }
     public void setCreateTime(Instant createTime) { this.createTime = createTime; }
     public Instant getUpdateTime() { return updateTime; }
@@ -53,6 +61,10 @@ public class Table {
     public void setStorageDescriptor(StorageDescriptor storageDescriptor) { this.storageDescriptor = storageDescriptor; }
     public String getTableType() { return tableType; }
     public void setTableType(String tableType) { this.tableType = tableType; }
+    public String getViewOriginalText() { return viewOriginalText; }
+    public void setViewOriginalText(String viewOriginalText) { this.viewOriginalText = viewOriginalText; }
+    public String getViewExpandedText() { return viewExpandedText; }
+    public void setViewExpandedText(String viewExpandedText) { this.viewExpandedText = viewExpandedText; }
     public Map<String, String> getParameters() { return parameters; }
     public void setParameters(Map<String, String> parameters) { this.parameters = parameters; }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/glue/GlueCatalogSchemaBindingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/GlueCatalogSchemaBindingIntegrationTest.java
@@ -151,4 +151,40 @@ class GlueCatalogSchemaBindingIntegrationTest {
             .statusCode(200)
             .body("TableList[0].StorageDescriptor.Columns", hasSize(3));
     }
+
+    @Test
+    @Order(7)
+    void createTableRoundTripsViewFields() {
+        given().contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSGlue.CreateTable")
+            .body("""
+                    {
+                      "DatabaseName": "%s",
+                      "TableInput": {
+                        "Name": "view_table",
+                        "Owner": "test-owner",
+                        "TableType": "VIRTUAL_VIEW",
+                        "StorageDescriptor": {
+                          "Columns": [{"Name":"x", "Type":"int"}]
+                        },
+                        "ViewOriginalText": "SELECT 1 AS x",
+                        "ViewExpandedText": "SELECT 1 AS x",
+                        "Parameters": {"presto_view":"true"}
+                      }
+                    }
+                    """.formatted(DATABASE))
+        .when().post("/").then().statusCode(200);
+
+        given().contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSGlue.GetTable")
+            .body("{ \"DatabaseName\": \"" + DATABASE + "\", \"Name\": \"view_table\" }")
+        .when().post("/").then()
+            .statusCode(200)
+            .body("Table.Name", equalTo("view_table"))
+            .body("Table.Owner", equalTo("test-owner"))
+            .body("Table.TableType", equalTo("VIRTUAL_VIEW"))
+            .body("Table.ViewOriginalText", equalTo("SELECT 1 AS x"))
+            .body("Table.ViewExpandedText", equalTo("SELECT 1 AS x"))
+            .body("Table.Parameters.presto_view", equalTo("true"));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
@@ -204,6 +204,30 @@ class GlueServiceTest {
     }
 
     @Test
+    void getTableReturnsViewFieldsUnchanged() {
+        Table table = new Table();
+        table.setName("view");
+        table.setOwner("test-owner");
+        table.setTableType("VIRTUAL_VIEW");
+        table.setViewOriginalText("SELECT 1 AS x");
+        table.setViewExpandedText("SELECT 1 AS x");
+        table.setParameters(Map.of("presto_view", "true"));
+        StorageDescriptor storageDescriptor = new StorageDescriptor();
+        storageDescriptor.setColumns(java.util.List.of(new Column("x", "int")));
+        table.setStorageDescriptor(storageDescriptor);
+
+        glueService.createTable("db1", table);
+
+        Table fetched = glueService.getTable("db1", "view");
+
+        assertEquals("test-owner", fetched.getOwner());
+        assertEquals("VIRTUAL_VIEW", fetched.getTableType());
+        assertEquals("SELECT 1 AS x", fetched.getViewOriginalText());
+        assertEquals("SELECT 1 AS x", fetched.getViewExpandedText());
+        assertEquals("true", fetched.getParameters().get("presto_view"));
+    }
+
+    @Test
     void getTableVersionsReturnsEmptyListForAthenaCompatibility() {
         assertTrue(glueService.getTableVersions().isEmpty());
     }


### PR DESCRIPTION
Preserves Glue view table fields so SDK clients can read view metadata after creating catalog views.

Closes #1180
