### PR TITLE
fix: enforce Glue table version checks

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueJsonHandler.java
@@ -79,7 +79,8 @@ public class GlueJsonHandler {
             case "UpdateTable" -> {
                 String dbName = request.get("DatabaseName").asText();
                 Table table = mapper.treeToValue(request.get("TableInput"), Table.class);
-                glueService.updateTable(dbName, table);
+                String versionId = request.path("VersionId").asText(null);
+                glueService.updateTable(dbName, table, versionId);
                 yield Response.ok().build();
             }
             case "GetTableVersions" -> {

--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
@@ -108,6 +108,7 @@ public class GlueService {
         if (table.getCreateTime() == null) {
             table.setCreateTime(Instant.now());
         }
+        table.setVersionId("0");
         tableStore.put(key, table);
         LOG.infov("Created Glue Table: {0}.{1}", databaseName, table.getName());
     }
@@ -129,15 +130,24 @@ public class GlueService {
     }
 
     public void updateTable(String databaseName, Table table) {
+        updateTable(databaseName, table, null);
+    }
+
+    public synchronized void updateTable(String databaseName, Table table, String versionId) {
         getDatabase(databaseName);
         String key = databaseName + ":" + table.getName();
         Table existing = tableStore.get(key)
                 .orElseThrow(() -> new AwsException("EntityNotFoundException",
                         "Table not found: " + databaseName + "." + table.getName(), 400));
+        if (versionId != null && !versionId.equals(existing.getVersionId())) {
+            throw new AwsException("ConcurrentModificationException",
+                    "Table was modified concurrently: " + databaseName + "." + table.getName(), 400);
+        }
         validateSchemaReference(table);
         table.setDatabaseName(databaseName);
         table.setCreateTime(existing.getCreateTime());
         table.setUpdateTime(Instant.now());
+        table.setVersionId(nextVersionId(existing.getVersionId()));
         tableStore.put(key, table);
         LOG.infov("Updated Glue Table: {0}.{1}", databaseName, table.getName());
     }
@@ -330,8 +340,21 @@ public class GlueService {
         copy.setTableType(source.getTableType());
         copy.setViewOriginalText(source.getViewOriginalText());
         copy.setViewExpandedText(source.getViewExpandedText());
+        copy.setVersionId(source.getVersionId());
         copy.setParameters(copyMap(source.getParameters()));
         return copy;
+    }
+
+    private static String nextVersionId(String versionId) {
+        if (versionId == null) {
+            return "1";
+        }
+        try {
+            return Long.toString(Math.addExact(Long.parseLong(versionId), 1));
+        }
+        catch (ArithmeticException | NumberFormatException e) {
+            throw new AwsException("InvalidInputException", "Invalid table VersionId: " + versionId, 400);
+        }
     }
 
     private static StorageDescriptor copyStorageDescriptor(StorageDescriptor source) {

--- a/src/main/java/io/github/hectorvent/floci/services/glue/model/Table.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/model/Table.java
@@ -36,6 +36,8 @@ public class Table {
     private String viewOriginalText;
     @JsonProperty("ViewExpandedText")
     private String viewExpandedText;
+    @JsonProperty("VersionId")
+    private String versionId;
     @JsonProperty("Parameters")
     private Map<String, String> parameters;
 
@@ -65,6 +67,8 @@ public class Table {
     public void setViewOriginalText(String viewOriginalText) { this.viewOriginalText = viewOriginalText; }
     public String getViewExpandedText() { return viewExpandedText; }
     public void setViewExpandedText(String viewExpandedText) { this.viewExpandedText = viewExpandedText; }
+    public String getVersionId() { return versionId; }
+    public void setVersionId(String versionId) { this.versionId = versionId; }
     public Map<String, String> getParameters() { return parameters; }
     public void setParameters(Map<String, String> parameters) { this.parameters = parameters; }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/glue/GlueCatalogSchemaBindingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/GlueCatalogSchemaBindingIntegrationTest.java
@@ -101,6 +101,7 @@ class GlueCatalogSchemaBindingIntegrationTest {
             .body("Table.StorageDescriptor.Columns[0].Type", equalTo("bigint"))
             .body("Table.StorageDescriptor.Columns[1].Name", equalTo("name"))
             .body("Table.StorageDescriptor.Columns[1].Type", equalTo("string"))
+            .body("Table.VersionId", equalTo("0"))
             .body("Table.StorageDescriptor.SchemaReference", notNullValue());
     }
 
@@ -119,6 +120,7 @@ class GlueCatalogSchemaBindingIntegrationTest {
         .when().post("/").then()
             .statusCode(200)
             .body("Table.StorageDescriptor.Columns", hasSize(3))
+            .body("Table.VersionId", equalTo("0"))
             .body("Table.StorageDescriptor.Columns[2].Name", equalTo("email"))
             .body("Table.StorageDescriptor.Columns[2].Type", equalTo("string"));
     }
@@ -382,5 +384,55 @@ class GlueCatalogSchemaBindingIntegrationTest {
         .when().post("/").then()
             .statusCode(200)
             .body("DatabaseList.Name", not(hasItem(database)));
+    }
+
+    @Test
+    @Order(10)
+    void updateTableRejectsStaleVersionId() {
+        String versionId = given().contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSGlue.GetTable")
+            .body("""
+                  {
+                    "DatabaseName": "%s",
+                    "Name": "%s"
+                  }
+                  """.formatted(DATABASE, TABLE))
+        .when().post().then()
+            .statusCode(200)
+            .extract().path("Table.VersionId");
+
+        given().contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSGlue.UpdateTable")
+            .body("""
+                  {
+                    "DatabaseName": "%s",
+                    "VersionId": "stale-version",
+                    "TableInput": {
+                      "Name": "%s",
+                      "StorageDescriptor": {
+                        "Location": "s3://bucket/users/",
+                        "Columns": []
+                      },
+                      "Parameters": {
+                        "metadata_location": "s3://bucket/v2.metadata.json"
+                      }
+                    }
+                  }
+                  """.formatted(DATABASE, TABLE))
+        .when().post("/").then()
+            .statusCode(400)
+            .body("__type", equalTo("ConcurrentModificationException"));
+
+        given().contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AWSGlue.GetTable")
+            .body("""
+                  {
+                    "DatabaseName": "%s",
+                    "Name": "%s"
+                  }
+                  """.formatted(DATABASE, TABLE))
+        .when().post("/").then()
+            .statusCode(200)
+            .body("Table.VersionId", equalTo(versionId));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -76,6 +77,7 @@ class GlueServiceTest {
 
         assertEquals(1, fetched.getStorageDescriptor().getColumns().size());
         assertEquals("a", fetched.getStorageDescriptor().getColumns().get(0).getName());
+        assertEquals("0", fetched.getVersionId());
         assertNull(fetched.getStorageDescriptor().getSchemaReference());
     }
 
@@ -206,6 +208,7 @@ class GlueServiceTest {
         Table fetched = glueService.getTable("db1", "plain");
         assertEquals(created.getCreateTime(), fetched.getCreateTime());
         assertNotNull(fetched.getUpdateTime());
+        assertEquals("1", fetched.getVersionId());
         assertEquals(1, fetched.getStorageDescriptor().getColumns().size());
         assertEquals("b", fetched.getStorageDescriptor().getColumns().get(0).getName());
     }
@@ -271,6 +274,81 @@ class GlueServiceTest {
                 () -> glueService.deleteDatabase("missing"));
 
         assertEquals("EntityNotFoundException", ex.getErrorCode());
+    }
+
+    @Test
+    void updateTableWithCurrentVersionIdSucceedsAndIncrementsVersionId() {
+        Table table = new Table();
+        table.setName("plain");
+        table.setParameters(Map.of("metadata_location", "s3://bucket/v1.metadata.json"));
+        glueService.createTable("db1", table);
+
+        Table created = glueService.getTable("db1", "plain");
+        Table replacement = new Table();
+        replacement.setName("plain");
+        replacement.setParameters(Map.of("metadata_location", "s3://bucket/v2.metadata.json"));
+
+        glueService.updateTable("db1", replacement, created.getVersionId());
+
+        Table fetched = glueService.getTable("db1", "plain");
+        assertEquals("1", fetched.getVersionId());
+        assertEquals("s3://bucket/v2.metadata.json", fetched.getParameters().get("metadata_location"));
+    }
+
+    @Test
+    void updateTableWithStaleVersionIdThrowsAndDoesNotOverwrite() {
+        Table table = new Table();
+        table.setName("plain");
+        table.setParameters(Map.of("metadata_location", "s3://bucket/v1.metadata.json"));
+        glueService.createTable("db1", table);
+
+        Table replacement = new Table();
+        replacement.setName("plain");
+        replacement.setParameters(Map.of("metadata_location", "s3://bucket/v2.metadata.json"));
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> glueService.updateTable("db1", replacement, "stale-version"));
+
+        assertEquals("ConcurrentModificationException", ex.getErrorCode());
+        Table fetched = glueService.getTable("db1", "plain");
+        assertEquals("0", fetched.getVersionId());
+        assertEquals("s3://bucket/v1.metadata.json", fetched.getParameters().get("metadata_location"));
+    }
+
+    @Test
+    void createTableIgnoresProvidedVersionId() {
+        Table table = new Table();
+        table.setName("plain");
+        table.setVersionId("7");
+
+        glueService.createTable("db1", table);
+
+        assertEquals("0", glueService.getTable("db1", "plain").getVersionId());
+    }
+
+    @Test
+    void updateTableWithSameVersionIdRejectsSecondUpdate() {
+        Table table = new Table();
+        table.setName("plain");
+        table.setParameters(Map.of("metadata_location", "s3://bucket/v1.metadata.json"));
+        glueService.createTable("db1", table);
+        String versionId = glueService.getTable("db1", "plain").getVersionId();
+
+        Table firstReplacement = new Table();
+        firstReplacement.setName("plain");
+        firstReplacement.setParameters(Map.of("metadata_location", "s3://bucket/v2a.metadata.json"));
+        glueService.updateTable("db1", firstReplacement, versionId);
+
+        Table secondReplacement = new Table();
+        secondReplacement.setName("plain");
+        secondReplacement.setParameters(Map.of("metadata_location", "s3://bucket/v2b.metadata.json"));
+        AwsException ex = assertThrows(AwsException.class,
+                () -> glueService.updateTable("db1", secondReplacement, versionId));
+
+        assertEquals("ConcurrentModificationException", ex.getErrorCode());
+        Table fetched = glueService.getTable("db1", "plain");
+        assertEquals("1", fetched.getVersionId());
+        assertEquals("s3://bucket/v2a.metadata.json", fetched.getParameters().get("metadata_location"));
     }
 
     @Test


### PR DESCRIPTION
Adds Glue table VersionId handling so stale table updates fail instead of overwriting newer catalog state.

Closes #1183
