### PR TITLE
fix: wrap ELBv2 void query responses in their Result envelope

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2QueryHandler.java
@@ -1233,8 +1233,12 @@ public class ElbV2QueryHandler {
     // ── Misc helpers ─────────────────────────────────────────────────────────
 
     private Response voidResponse(String responseName) {
+        String actionName = responseName.substring(0, responseName.length() - "Response".length());
+        String resultName = actionName + "Result";
         String xml = new XmlBuilder()
                 .start(responseName, AwsNamespaces.ELB_V2)
+                .start(resultName)
+                .end(resultName)
                 .raw(AwsQueryResponse.responseMetadata())
                 .end(responseName)
                 .build();

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
@@ -20,6 +20,8 @@ class ElbV2IntegrationTest {
             "AWS4-HMAC-SHA256 Credential=test/20260427/us-east-1/elasticloadbalancing/aws4_request";
     private static final String EC2_AUTH =
             "AWS4-HMAC-SHA256 Credential=test/20260427/us-east-1/ec2/aws4_request";
+    private static final String ELB_V2_XMLNS =
+            "https://elasticloadbalancing.amazonaws.com/doc/2015-12-01/";
 
     private static String lbArn;
     private static String tgArn;
@@ -222,6 +224,38 @@ class ElbV2IntegrationTest {
                 .body("DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancers.member.AvailabilityZones.member[1].ZoneName",
                         equalTo("us-east-1b"));
     }
+
+    @Test
+    @Order(9)
+    void setSubnetsReturnsEmptyResultEnvelope() {
+        given()
+                .formParam("Action", "SetSubnets")
+                .formParam("LoadBalancerArn", lbArn)
+                .formParam("Subnets.member.1", "subnet-default-b")
+                .formParam("Subnets.member.2", "subnet-default-c")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .contentType("application/xml")
+                .body(containsString("<SetSubnetsResponse xmlns=\"" + ELB_V2_XMLNS + "\">"))
+                .body(containsString("<SetSubnetsResult></SetSubnetsResult>"))
+                .body("SetSubnetsResponse.ResponseMetadata.RequestId", not(emptyOrNullString()));
+
+        given()
+                .formParam("Action", "DescribeLoadBalancers")
+                .formParam("LoadBalancerArns.member.1", lbArn)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body("DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancers.member.AvailabilityZones.member.SubnetId",
+                        hasItems("subnet-default-b", "subnet-default-c"));
+    }
+
+    // ── Target Groups ─────────────────────────────────────────────────────────
 
     @Test
     @Order(10)
@@ -979,7 +1013,11 @@ class ElbV2IntegrationTest {
             .when()
                 .post("/")
             .then()
-                .statusCode(200);
+                .statusCode(200)
+                .contentType("application/xml")
+                .body(containsString("<DeleteListenerResponse xmlns=\"" + ELB_V2_XMLNS + "\">"))
+                .body(containsString("<DeleteListenerResult></DeleteListenerResult>"))
+                .body("DeleteListenerResponse.ResponseMetadata.RequestId", not(emptyOrNullString()));
 
         given()
                 .formParam("Action", "DescribeListeners")
@@ -990,6 +1028,20 @@ class ElbV2IntegrationTest {
             .then()
                 .statusCode(200)
                 .body("DescribeListenersResponse.DescribeListenersResult.Listeners.member.size()", equalTo(0));
+
+        given()
+                .formParam("Action", "DeleteTargetGroup")
+                .formParam("TargetGroupArn", tgArn)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .contentType("application/xml")
+                .body(containsString("<DeleteTargetGroupResponse xmlns=\"" + ELB_V2_XMLNS + "\">"))
+                .body(containsString("<DeleteTargetGroupResult></DeleteTargetGroupResult>"))
+                .body("DeleteTargetGroupResponse.ResponseMetadata.RequestId", not(emptyOrNullString()));
+        tgArn = null;
     }
 
     @Test
@@ -1017,7 +1069,11 @@ class ElbV2IntegrationTest {
             .when()
                 .post("/")
             .then()
-                .statusCode(200);
+                .statusCode(200)
+                .contentType("application/xml")
+                .body(containsString("<DeleteLoadBalancerResponse xmlns=\"" + ELB_V2_XMLNS + "\">"))
+                .body(containsString("<DeleteLoadBalancerResult></DeleteLoadBalancerResult>"))
+                .body("DeleteLoadBalancerResponse.ResponseMetadata.RequestId", not(emptyOrNullString()));
 
         given()
                 .formParam("Action", "DescribeLoadBalancers")


### PR DESCRIPTION
## Summary

ELBv2 void query actions (`DeleteTargetGroup`, `DeleteListener`, `DeleteLoadBalancer`, `SetSubnets`) return their response without the `<XResult>` wrapper element. The AWS query protocol always nests an empty Result element inside the Response, and SDK/Terraform deserializers expect it - against floci, `terraform destroy` and the AWS CLI fail to parse these responses. This adds the `<{Action}Result></{Action}Result>` element in `ElbV2QueryHandler.voidResponse()`, deriving the name from the response name. Closes #1096.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: real ELBv2 returns e.g. `<DeleteTargetGroupResponse xmlns=...><DeleteTargetGroupResult/><ResponseMetadata>...</ResponseMetadata></DeleteTargetGroupResponse>`; floci omitted the `<DeleteTargetGroupResult/>` element, so query-protocol deserializers (AWS CLI, Terraform AWS provider) rejected the response. The wrapper shape matches the ELBv2 2015-12-01 API reference response examples for all four void actions.

## Checklist

- [x] `./mvnw test` passes locally (`ElbV2IntegrationTest`: 35/35)
- [x] New or updated integration test added (Result-envelope assertions for all four void actions, plus a SetSubnets round-trip)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
