### PR TITLE
fix: accept AttributesToGet with Select=SPECIFIC_ATTRIBUTES in Query

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -680,6 +680,11 @@ public class DynamoDbJsonHandler {
                     "Can not use both expression and non-expression parameters in the same request: "
                     + "Non-expression parameters: {QueryFilter} Expression parameters: {FilterExpression}", 400);
         }
+        if (attributesToGet != null && projectionExpression != null) {
+            throw new AwsException("ValidationException",
+                    "Can not use both expression and non-expression parameters in the same request: "
+                    + "Non-expression parameters: {AttributesToGet} Expression parameters: {ProjectionExpression}", 400);
+        }
 
         if (keyConditionExpr == null && keyConditions == null) {
             throw new AwsException("ValidationException",
@@ -698,7 +703,8 @@ public class DynamoDbJsonHandler {
                     + "Member must satisfy enum value set: [SPECIFIC_ATTRIBUTES, COUNT, ALL_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES]", 400);
         }
 
-        if ("SPECIFIC_ATTRIBUTES".equals(select) && projectionExpression == null) {
+        boolean hasAttributesToGet = attributesToGet != null && attributesToGet.size() > 0;
+        if ("SPECIFIC_ATTRIBUTES".equals(select) && projectionExpression == null && !hasAttributesToGet) {
             throw new AwsException("ValidationException",
                     "Select type SPECIFIC_ATTRIBUTES requires the ProjectionExpression to be provided.", 400);
         }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -295,6 +295,126 @@ class DynamoDbIntegrationTest {
 
     @Test
     @Order(10)
+    void queryWithSelectSpecificAttributesAndAttributesToGet() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "TestTable",
+                    "KeyConditionExpression": "pk = :pk",
+                    "ExpressionAttributeValues": {
+                        ":pk": {"S": "user-1"}
+                    },
+                    "Select": "SPECIFIC_ATTRIBUTES",
+                    "AttributesToGet": ["pk", "sk"]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Count", equalTo(3))
+            .body("Items[0].size()", equalTo(2))
+            .body("Items[0].pk.S", equalTo("user-1"))
+            .body("Items[0].sk.S", equalTo("order-001"))
+            .body("Items[0].name", nullValue())
+            .body("Items[0].age", nullValue())
+            .body("Items[0].total", nullValue())
+            .body("Items[1].size()", equalTo(2))
+            .body("Items[1].pk.S", equalTo("user-1"))
+            .body("Items[1].sk.S", equalTo("order-002"))
+            .body("Items[1].total", nullValue())
+            .body("Items[2].size()", equalTo(2))
+            .body("Items[2].pk.S", equalTo("user-1"))
+            .body("Items[2].sk.S", equalTo("profile"))
+            .body("Items[2].name", nullValue())
+            .body("Items[2].age", nullValue());
+    }
+
+    @Test
+    @Order(10)
+    void queryWithSelectSpecificAttributesAndProjectionExpression() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "TestTable",
+                    "KeyConditionExpression": "pk = :pk",
+                    "ExpressionAttributeValues": {
+                        ":pk": {"S": "user-1"}
+                    },
+                    "Select": "SPECIFIC_ATTRIBUTES",
+                    "ProjectionExpression": "pk, sk"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Count", equalTo(3))
+            .body("Items[0].size()", equalTo(2))
+            .body("Items[0].pk.S", equalTo("user-1"))
+            .body("Items[0].sk.S", equalTo("order-001"))
+            .body("Items[0].name", nullValue())
+            .body("Items[0].age", nullValue())
+            .body("Items[0].total", nullValue());
+    }
+
+    @Test
+    @Order(10)
+    void queryWithSelectSpecificAttributesRequiresProjectionParameters() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "TestTable",
+                    "KeyConditionExpression": "pk = :pk",
+                    "ExpressionAttributeValues": {
+                        ":pk": {"S": "user-1"}
+                    },
+                    "Select": "SPECIFIC_ATTRIBUTES"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", equalTo("Select type SPECIFIC_ATTRIBUTES requires the ProjectionExpression to be provided."));
+    }
+
+    @Test
+    @Order(10)
+    void queryWithProjectionExpressionAndAttributesToGetFails() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "TestTable",
+                    "KeyConditionExpression": "pk = :pk",
+                    "ExpressionAttributeValues": {
+                        ":pk": {"S": "user-1"}
+                    },
+                    "Select": "SPECIFIC_ATTRIBUTES",
+                    "ProjectionExpression": "pk, sk",
+                    "AttributesToGet": ["pk", "sk"]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", equalTo("Can not use both expression and non-expression parameters in the same request: "
+                    + "Non-expression parameters: {AttributesToGet} Expression parameters: {ProjectionExpression}"));
+    }
+
+    @Test
+    @Order(10)
     void queryWithBeginsWith() {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.Query")


### PR DESCRIPTION
## Summary

Query with `Select=SPECIFIC_ATTRIBUTES` plus the legacy `AttributesToGet` parameter is wrongly rejected with `Select type SPECIFIC_ATTRIBUTES requires the ProjectionExpression to be provided.` Real DynamoDB accepts either `ProjectionExpression` or `AttributesToGet` to satisfy `SPECIFIC_ATTRIBUTES`; this regressed after 1.5.15. The validation in `DynamoDbJsonHandler` now also accepts a non-empty `AttributesToGet`, and combining `AttributesToGet` with `ProjectionExpression` returns the same `ValidationException` real DynamoDB raises for mixed expression/non-expression parameters. Closes #1046.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: legacy-parameter Queries (`Select=SPECIFIC_ATTRIBUTES` + `AttributesToGet`) returned a 400 `ValidationException` demanding `ProjectionExpression`, breaking older SDK clients that still use the legacy projection parameter. Real DynamoDB documents `AttributesToGet` as the legacy equivalent of `ProjectionExpression` and accepts this combination; it only rejects mixing the two ("Can not use both expression and non-expression parameters in the same request"), which this change also emulates.

## Checklist

- [x] `./mvnw test` passes locally (full DynamoDB suite; the one pre-existing `DynamoDbProjectionIntegrationTest` failure reproduces on a clean checkout without this change)
- [x] New or updated integration test added (SPECIFIC_ATTRIBUTES + AttributesToGet projection, plus the mixed-parameters rejection case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
