### PR TITLE
fix: persist SSE specification and return SSEDescription for encrypted tables

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.dynamodb;
 
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsErrorResponse;
 import io.github.hectorvent.floci.core.common.AwsException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -22,6 +23,9 @@ import java.util.*;
  */
 @ApplicationScoped
 public class DynamoDbJsonHandler {
+
+    private static final String DEFAULT_ACCOUNT_ID = "000000000000";
+    private static final String SSE_TYPE_KMS = "KMS";
 
     private final DynamoDbService dynamoDbService;
     private final DynamoDbStreamService dynamoDbStreamService;
@@ -187,6 +191,13 @@ public class DynamoDbJsonHandler {
             table.setStreamEnabled(true);
             table.setStreamArn(sd.getStreamArn());
             table.setStreamViewType(viewType);
+        }
+
+        JsonNode sseSpec = request.path("SSESpecification");
+        if (!sseSpec.isMissingNode() && sseSpec.path("Enabled").asBoolean(false)) {
+            table.setSseEnabled(true);
+            table.setSseType(SSE_TYPE_KMS);
+            table.setKmsMasterKeyArn(defaultKmsMasterKeyArn(region));
         }
 
         ObjectNode response = objectMapper.createObjectNode();
@@ -1771,6 +1782,16 @@ public class DynamoDbJsonHandler {
         ptNode.put("NumberOfDecreasesToday", table.getProvisionedThroughput().getNumberOfDecreasesToday());
         node.set("ProvisionedThroughput", ptNode);
 
+        if (table.isSseEnabled()) {
+            ObjectNode sseDescription = objectMapper.createObjectNode();
+            sseDescription.put("Status", "ENABLED");
+            sseDescription.put("SSEType", table.getSseType() != null ? table.getSseType() : SSE_TYPE_KMS);
+            sseDescription.put("KMSMasterKeyArn", table.getKmsMasterKeyArn() != null
+                    ? table.getKmsMasterKeyArn()
+                    : defaultKmsMasterKeyArn(AwsArnUtils.regionOrDefault(table.getTableArn(), "us-east-1")));
+            node.set("SSEDescription", sseDescription);
+        }
+
         List<GlobalSecondaryIndex> gsis = table.getGlobalSecondaryIndexes();
         if (gsis != null && !gsis.isEmpty()) {
             ArrayNode gsiArray = objectMapper.createArrayNode();
@@ -1857,6 +1878,11 @@ public class DynamoDbJsonHandler {
         }
 
         return node;
+    }
+
+    private String defaultKmsMasterKeyArn(String region) {
+        return AwsArnUtils.Arn.of("kms", region, DEFAULT_ACCOUNT_ID,
+                "key/aws-managed-dynamodb").toString();
     }
 
     private ObjectNode continuousBackupsDescriptionNode(TableDefinition table) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
@@ -39,6 +39,9 @@ public class TableDefinition {
     private boolean streamEnabled;
     private String streamArn;
     private String streamViewType;
+    private boolean sseEnabled;
+    private String sseType;
+    private String kmsMasterKeyArn;
     private List<KinesisStreamingDestination> kinesisStreamingDestinations;
 
     public TableDefinition() {
@@ -147,6 +150,15 @@ public class TableDefinition {
 
     public String getStreamViewType() { return streamViewType; }
     public void setStreamViewType(String streamViewType) { this.streamViewType = streamViewType; }
+
+    public boolean isSseEnabled() { return sseEnabled; }
+    public void setSseEnabled(boolean sseEnabled) { this.sseEnabled = sseEnabled; }
+
+    public String getSseType() { return sseType; }
+    public void setSseType(String sseType) { this.sseType = sseType; }
+
+    public String getKmsMasterKeyArn() { return kmsMasterKeyArn; }
+    public void setKmsMasterKeyArn(String kmsMasterKeyArn) { this.kmsMasterKeyArn = kmsMasterKeyArn; }
 
     public List<KinesisStreamingDestination> getKinesisStreamingDestinations() {
         return kinesisStreamingDestinations != null ? kinesisStreamingDestinations : new ArrayList<>();

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -62,7 +62,8 @@ class DynamoDbIntegrationTest {
             .statusCode(200)
             .body("TableDescription.TableName", equalTo("TestTable"))
             .body("TableDescription.TableStatus", equalTo("ACTIVE"))
-            .body("TableDescription.KeySchema.size()", equalTo(2));
+            .body("TableDescription.KeySchema.size()", equalTo(2))
+            .body("TableDescription.SSEDescription", nullValue());
     }
 
     @Test
@@ -83,6 +84,83 @@ class DynamoDbIntegrationTest {
         .then()
             .statusCode(400)
             .body("__type", equalTo("ResourceInUseException"));
+    }
+
+    @Test
+    void createTableWithEnabledSseReturnsStableDescription() throws Exception {
+        Response createResponse = given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "SseTable",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST",
+                    "SSESpecification": {"Enabled": true}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TableDescription.SSEDescription.Status", equalTo("ENABLED"))
+            .body("TableDescription.SSEDescription.SSEType", equalTo("KMS"))
+            .body("TableDescription.SSEDescription.KMSMasterKeyArn",
+                    startsWith("arn:aws:kms:us-east-1:000000000000:key/"))
+            .extract()
+            .response();
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode createSseDescription = mapper.readTree(createResponse.asString())
+                .path("TableDescription").path("SSEDescription");
+
+        Response firstDescribeResponse = given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DescribeTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "SseTable"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Table.SSEDescription.Status", equalTo("ENABLED"))
+            .body("Table.SSEDescription.SSEType", equalTo("KMS"))
+            .extract()
+            .response();
+
+        JsonNode firstDescribeSseDescription = mapper.readTree(firstDescribeResponse.asString())
+                .path("Table").path("SSEDescription");
+        assertEquals(createSseDescription, firstDescribeSseDescription);
+
+        Response secondDescribeResponse = given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DescribeTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "SseTable"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract()
+            .response();
+
+        JsonNode secondDescribeSseDescription = mapper.readTree(secondDescribeResponse.asString())
+                .path("Table").path("SSEDescription");
+        assertEquals(firstDescribeSseDescription, secondDescribeSseDescription);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "SseTable"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
     }
 
     @Test


### PR DESCRIPTION
## Summary

CreateTable with `SSESpecification.Enabled=true` silently drops the encryption setting: DescribeTable never returns an `SSEDescription`, so Terraform sees permanent drift on `server_side_encryption` and re-applies it forever. This persists the SSE settings on `TableDefinition` and emits `SSEDescription` (Status/SSEType/KMSMasterKeyArn) from the shared `tableToNode` serializer, mirroring how `StreamSpecification` is already captured. Closes #1080.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: real DynamoDB returns `"SSEDescription": {"Status": "ENABLED", "SSEType": "KMS", "KMSMasterKeyArn": "..."}` from CreateTable/DescribeTable for SSE-enabled tables; floci omitted it entirely, so the Terraform AWS provider detected drift on every plan. Tables without SSESpecification still return no SSEDescription (matching real DynamoDB's owned-key default representation). The KMS ARN uses the emulator's default account id, consistent with other emulated ARNs.

## Checklist

- [x] `./mvnw test` passes locally (full DynamoDB suite; the one pre-existing `DynamoDbProjectionIntegrationTest` failure reproduces on a clean checkout without this change)
- [x] New or updated integration test added (SSE-enabled CreateTable/DescribeTable round-trip + no-SSE table omits SSEDescription)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
