### PR TITLE
docs(ses): list v1 ConfigurationSetEventDestination actions

### DIFF
--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -42,6 +42,9 @@ Floci exposes the classic Amazon SES Query API used by `aws ses ...` commands an
 | `DescribeConfigurationSet`          | Read a configuration set                                  |
 | `ListConfigurationSets`             | List configuration sets                                   |
 | `DeleteConfigurationSet`            | Delete a configuration set                                |
+| `CreateConfigurationSetEventDestination` | Attach an event destination to a configuration set        |
+| `UpdateConfigurationSetEventDestination` | Update an existing event destination on a configuration set |
+| `DeleteConfigurationSetEventDestination` | Remove an event destination from a configuration set      |
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

The v1 Query handler dispatches `CreateConfigurationSetEventDestination`, `UpdateConfigurationSetEventDestination`, and `DeleteConfigurationSetEventDestination` at `SesQueryHandler.java:85-90` but the Supported Actions table in `docs/services/ses.md` did not list them, leaving the v1 surface under-documented compared to v2 (whose equivalent REST endpoints are already in the table).

Add the three actions to the v1 table immediately after `DeleteConfigurationSet`, in the order they appear in the handler.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

Documentation-only update of the v1 Query action table. No code, wire-protocol, or runtime behavior change. The handler dispatch entries the table now describes were already in place — this PR just makes the surface visible to users browsing the doc.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)