### PR TITLE
feat(ses): per-configuration-set sending toggle (v1 + v2)

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesConfigurationSetSendingTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesConfigurationSetSendingTest.java
@@ -1,0 +1,214 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import software.amazon.awssdk.services.ses.SesClient;
+import software.amazon.awssdk.services.ses.model.ConfigurationSetAttribute;
+import software.amazon.awssdk.services.ses.model.DescribeConfigurationSetRequest;
+import software.amazon.awssdk.services.ses.model.DescribeConfigurationSetResponse;
+import software.amazon.awssdk.services.ses.model.UpdateConfigurationSetSendingEnabledRequest;
+
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.Body;
+import software.amazon.awssdk.services.sesv2.model.Content;
+import software.amazon.awssdk.services.sesv2.model.CreateConfigurationSetRequest;
+import software.amazon.awssdk.services.sesv2.model.DeleteConfigurationSetRequest;
+import software.amazon.awssdk.services.sesv2.model.Destination;
+import software.amazon.awssdk.services.sesv2.model.EmailContent;
+import software.amazon.awssdk.services.sesv2.model.GetConfigurationSetRequest;
+import software.amazon.awssdk.services.sesv2.model.GetConfigurationSetResponse;
+import software.amazon.awssdk.services.sesv2.model.Message;
+import software.amazon.awssdk.services.sesv2.model.NotFoundException;
+import software.amazon.awssdk.services.sesv2.model.PutConfigurationSetSendingOptionsRequest;
+import software.amazon.awssdk.services.sesv2.model.SendEmailRequest;
+import software.amazon.awssdk.services.sesv2.model.SendEmailResponse;
+import software.amazon.awssdk.services.sesv2.model.SendingPausedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * SDK compatibility test for the per-configuration-set sending toggle. Verifies
+ * the AWS Java SDK v2 marshalling of:
+ *   - {@code sesv2.putConfigurationSetSendingOptions(SendingEnabled=...)}
+ *   - {@code sesv2.getConfigurationSet(...)} response carrying the
+ *     {@code SendingOptions.SendingEnabled} block
+ *   - {@code ses.updateConfigurationSetSendingEnabled(...)}  (v1 Query)
+ *   - {@code ses.describeConfigurationSet(...)} with the
+ *     {@code reputationOptions} attribute returning
+ *     {@code ReputationOptions.SendingEnabled}
+ *   - Cross-API state sharing (v1 and v2 read/write the same flag)
+ *   - {@code sesv2.sendEmail(...)} rejected with {@link SendingPausedException}
+ *     when the configured set is disabled
+ */
+@DisplayName("SES Per-Configuration-Set Sending Toggle (v1 + v2)")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesConfigurationSetSendingTest {
+
+    private static final String CS_NAME = "compat-cs-sending";
+    private static final String FROM = "sender@example.com";
+    private static final String TO = "recipient@example.com";
+
+    private static SesClient sesV1;
+    private static SesV2Client sesV2;
+
+    @BeforeAll
+    static void setup() {
+        sesV1 = TestFixtures.sesClient();
+        sesV2 = TestFixtures.sesV2Client();
+        // Start clean — drop any leftover CS from a previous run.
+        try {
+            sesV2.deleteConfigurationSet(DeleteConfigurationSetRequest.builder()
+                    .configurationSetName(CS_NAME).build());
+        } catch (Exception ignored) {}
+        sesV2.createConfigurationSet(CreateConfigurationSetRequest.builder()
+                .configurationSetName(CS_NAME).build());
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (sesV2 != null) {
+            try {
+                sesV2.deleteConfigurationSet(DeleteConfigurationSetRequest.builder()
+                        .configurationSetName(CS_NAME).build());
+            } catch (Exception ignored) {}
+            sesV2.close();
+        }
+        if (sesV1 != null) {
+            sesV1.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void v2GetConfigurationSet_defaultsToSendingEnabledTrue() {
+        GetConfigurationSetResponse response = sesV2.getConfigurationSet(
+                GetConfigurationSetRequest.builder().configurationSetName(CS_NAME).build());
+
+        assertThat(response.sendingOptions()).isNotNull();
+        assertThat(response.sendingOptions().sendingEnabled()).isTrue();
+    }
+
+    @Test
+    @Order(2)
+    void v2SendEmail_defaultEnabled_succeeds() {
+        SendEmailResponse response = sesV2.sendEmail(buildSimpleSend(CS_NAME));
+        assertThat(response.messageId()).isNotBlank();
+    }
+
+    @Test
+    @Order(3)
+    void v2PutConfigurationSetSendingOptions_disables() {
+        sesV2.putConfigurationSetSendingOptions(PutConfigurationSetSendingOptionsRequest.builder()
+                .configurationSetName(CS_NAME)
+                .sendingEnabled(false)
+                .build());
+
+        GetConfigurationSetResponse response = sesV2.getConfigurationSet(
+                GetConfigurationSetRequest.builder().configurationSetName(CS_NAME).build());
+        assertThat(response.sendingOptions().sendingEnabled()).isFalse();
+    }
+
+    @Test
+    @Order(4)
+    void v1DescribeConfigurationSet_reputationOptions_reflectsDisabled() {
+        DescribeConfigurationSetResponse response = sesV1.describeConfigurationSet(
+                DescribeConfigurationSetRequest.builder()
+                        .configurationSetName(CS_NAME)
+                        .configurationSetAttributeNames(ConfigurationSetAttribute.REPUTATION_OPTIONS)
+                        .build());
+
+        assertThat(response.reputationOptions()).isNotNull();
+        assertThat(response.reputationOptions().sendingEnabled()).isFalse();
+    }
+
+    @Test
+    @Order(5)
+    void v2SendEmail_whenDisabled_isRejectedWithSendingPausedException() {
+        assertThatThrownBy(() -> sesV2.sendEmail(buildSimpleSend(CS_NAME)))
+                .isInstanceOf(SendingPausedException.class);
+    }
+
+    @Test
+    @Order(6)
+    void v1UpdateConfigurationSetSendingEnabled_reEnables() {
+        sesV1.updateConfigurationSetSendingEnabled(
+                UpdateConfigurationSetSendingEnabledRequest.builder()
+                        .configurationSetName(CS_NAME)
+                        .enabled(true)
+                        .build());
+
+        // Visible via v2 GetConfigurationSet
+        GetConfigurationSetResponse v2Response = sesV2.getConfigurationSet(
+                GetConfigurationSetRequest.builder().configurationSetName(CS_NAME).build());
+        assertThat(v2Response.sendingOptions().sendingEnabled()).isTrue();
+
+        // Visible via v1 DescribeConfigurationSet
+        DescribeConfigurationSetResponse v1Response = sesV1.describeConfigurationSet(
+                DescribeConfigurationSetRequest.builder()
+                        .configurationSetName(CS_NAME)
+                        .configurationSetAttributeNames(ConfigurationSetAttribute.REPUTATION_OPTIONS)
+                        .build());
+        assertThat(v1Response.reputationOptions().sendingEnabled()).isTrue();
+    }
+
+    @Test
+    @Order(7)
+    void v2SendEmail_afterReEnable_succeeds() {
+        SendEmailResponse response = sesV2.sendEmail(buildSimpleSend(CS_NAME));
+        assertThat(response.messageId()).isNotBlank();
+    }
+
+    @Test
+    @Order(8)
+    void v1DisableAndV2GetConfigurationSet_share_state() {
+        sesV1.updateConfigurationSetSendingEnabled(
+                UpdateConfigurationSetSendingEnabledRequest.builder()
+                        .configurationSetName(CS_NAME)
+                        .enabled(false)
+                        .build());
+
+        GetConfigurationSetResponse response = sesV2.getConfigurationSet(
+                GetConfigurationSetRequest.builder().configurationSetName(CS_NAME).build());
+        assertThat(response.sendingOptions().sendingEnabled()).isFalse();
+
+        // Restore for the unknown-CS test below.
+        sesV2.putConfigurationSetSendingOptions(PutConfigurationSetSendingOptionsRequest.builder()
+                .configurationSetName(CS_NAME)
+                .sendingEnabled(true)
+                .build());
+    }
+
+    @Test
+    @Order(9)
+    void v2PutConfigurationSetSendingOptions_unknownCS_throwsNotFound() {
+        assertThatThrownBy(() -> sesV2.putConfigurationSetSendingOptions(
+                PutConfigurationSetSendingOptionsRequest.builder()
+                        .configurationSetName("does-not-exist-cs")
+                        .sendingEnabled(false)
+                        .build()))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    private static SendEmailRequest buildSimpleSend(String configSet) {
+        return SendEmailRequest.builder()
+                .fromEmailAddress(FROM)
+                .destination(Destination.builder().toAddresses(TO).build())
+                .configurationSetName(configSet)
+                .content(EmailContent.builder()
+                        .simple(Message.builder()
+                                .subject(Content.builder().data("compat-send-toggle").build())
+                                .body(Body.builder()
+                                        .text(Content.builder().data("hi").build())
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+    }
+}

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -45,6 +45,7 @@ Floci exposes the classic Amazon SES Query API used by `aws ses ...` commands an
 | `CreateConfigurationSetEventDestination` | Attach an event destination to a configuration set        |
 | `UpdateConfigurationSetEventDestination` | Update an existing event destination on a configuration set |
 | `DeleteConfigurationSetEventDestination` | Remove an event destination from a configuration set      |
+| `UpdateConfigurationSetSendingEnabled`   | Enable or disable email sending through a configuration set |
 
 ## Configuration
 
@@ -191,6 +192,7 @@ Alongside the classic Query API, Floci implements a subset of the SES v2 REST JS
 | `PUT` | `/v2/email/configuration-sets/{name}/event-destinations/{eventDestinationName}` | `UpdateConfigurationSetEventDestination` |
 | `DELETE` | `/v2/email/configuration-sets/{name}/event-destinations/{eventDestinationName}` | `DeleteConfigurationSetEventDestination` |
 | `PUT` | `/v2/email/configuration-sets/{name}/suppression-options` | `PutConfigurationSetSuppressionOptions` |
+| `PUT` | `/v2/email/configuration-sets/{name}/sending` | `PutConfigurationSetSendingOptions` |
 | `PUT` | `/v2/email/suppression/addresses` | `PutSuppressedDestination` |
 | `GET` | `/v2/email/suppression/addresses/{EmailAddress}` | `GetSuppressedDestination` |
 | `DELETE` | `/v2/email/suppression/addresses/{EmailAddress}` | `DeleteSuppressedDestination` |

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -335,7 +335,8 @@ public class AwsQueryController {
             "ListConfigurationSets", "DeleteConfigurationSet",
             "CreateConfigurationSetEventDestination",
             "UpdateConfigurationSetEventDestination",
-            "DeleteConfigurationSetEventDestination"
+            "DeleteConfigurationSetEventDestination",
+            "UpdateConfigurationSetSendingEnabled"
     );
 
     private static final Set<String> COGNITO_ACTIONS = Set.of(

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -655,6 +655,8 @@ public class SesController {
                     reasons.add(r);
                 }
             }
+            ObjectNode sendingNode = result.putObject("SendingOptions");
+            sendingNode.put("SendingEnabled", cs.isSendingEnabledEffective());
             return Response.ok(result).build();
         } catch (AwsException e) {
             throw remapV1Exception(e);
@@ -689,6 +691,33 @@ public class SesController {
             }
             sesService.putConfigurationSetSuppressionOptions(name, reasons, region);
             LOG.infov("SES V2 PutConfigurationSetSuppressionOptions: {0} on {1}", reasons, name);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @PUT
+    @Path("/configuration-sets/{configurationSetName}/sending")
+    public Response putConfigurationSetSendingOptions(@Context HttpHeaders headers,
+                                                       @PathParam("configurationSetName") String name,
+                                                       String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode request = (body == null || body.isBlank())
+                    ? objectMapper.createObjectNode()
+                    : objectMapper.readTree(body);
+            requireJsonObject(request);
+            JsonNode enabledNode = request.path("SendingEnabled");
+            if (enabledNode.isMissingNode() || enabledNode.isNull() || !enabledNode.isBoolean()) {
+                throw new AwsException("BadRequestException",
+                        "SendingEnabled must be present and must be a boolean.", 400);
+            }
+            sesService.setConfigurationSetSendingEnabled(name, enabledNode.booleanValue(), region);
+            LOG.infov("SES V2 PutConfigurationSetSendingOptions: {0} on {1}",
+                    enabledNode.booleanValue(), name);
             return Response.ok(objectMapper.createObjectNode()).build();
         } catch (AwsException e) {
             throw remapV1Exception(e);
@@ -1310,6 +1339,8 @@ public class SesController {
                     new AwsException("NotFoundException", e.getMessage(), 404);
             case "AlreadyExists", "ConfigurationSetAlreadyExists" ->
                     new AwsException("AlreadyExistsException", e.getMessage(), 400);
+            case "ConfigurationSetSendingPausedException" ->
+                    new AwsException("SendingPausedException", e.getMessage(), 400);
             default -> e;
         };
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
@@ -88,6 +88,8 @@ public class SesQueryHandler {
                         handleUpdateConfigurationSetEventDestination(params, region);
                 case "DeleteConfigurationSetEventDestination" ->
                         handleDeleteConfigurationSetEventDestination(params, region);
+                case "UpdateConfigurationSetSendingEnabled" ->
+                        handleUpdateConfigurationSetSendingEnabled(params, region);
                 default -> AwsQueryResponse.error("UnsupportedOperation",
                         "Operation " + action + " is not supported by SES.", AwsNamespaces.SES, 400);
             };
@@ -573,6 +575,11 @@ public class SesQueryHandler {
             }
             xml.end("EventDestinations");
         }
+        if (attrs.contains("reputationOptions")) {
+            xml.start("ReputationOptions")
+                .elem("SendingEnabled", String.valueOf(cs.isSendingEnabledEffective()))
+               .end("ReputationOptions");
+        }
         return Response.ok(AwsQueryResponse.envelope("DescribeConfigurationSet",
                 AwsNamespaces.SES, xml.build())).build();
     }
@@ -682,6 +689,15 @@ public class SesQueryHandler {
         sesService.deleteConfigurationSetEventDestination(configSet, edName, region);
         return Response.ok(AwsQueryResponse.envelopeEmptyResult(
                 "DeleteConfigurationSetEventDestination", AwsNamespaces.SES)).build();
+    }
+
+    private Response handleUpdateConfigurationSetSendingEnabled(MultivaluedMap<String, String> params,
+                                                                String region) {
+        String configSet = requireParam(params, "ConfigurationSetName");
+        boolean enabled = parseRequiredBoolean(params, "Enabled");
+        sesService.setConfigurationSetSendingEnabled(configSet, enabled, region);
+        return Response.ok(AwsQueryResponse.envelopeEmptyResult(
+                "UpdateConfigurationSetSendingEnabled", AwsNamespaces.SES)).build();
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -285,20 +285,30 @@ public class SesService {
     }
 
     /**
-     * Validate that a non-blank {@code ConfigurationSetName} refers to a configuration set
-     * that exists in the given region. Always raises {@code ConfigurationSetDoesNotExist}
-     * with {@code httpStatus = 400}; the V2 REST controller's {@code remapV1Exception}
-     * then translates that into a {@code NotFoundException 404}, while V1 Query keeps the
-     * original code/status. Mirrors AWS SES behaviour: invalid set name fails fast instead
-     * of silently storing/relaying the message and skipping event publishing later.
+     * Validate that a non-blank {@code ConfigurationSetName} is usable for a send. Performs
+     * two gates:
+     *   1. Existence — raises {@code ConfigurationSetDoesNotExist} (400) when the set is
+     *      missing in the given region. The V2 REST controller's {@code remapV1Exception}
+     *      translates that into {@code NotFoundException 404}; V1 Query keeps the original.
+     *   2. Sending-enabled — raises {@code ConfigurationSetSendingPausedException} (400)
+     *      when the set's {@code SendingEnabled} flag has been turned off via
+     *      {@code UpdateConfigurationSetSendingEnabled} (v1) /
+     *      {@code PutConfigurationSetSendingOptions} (v2). The V2 controller narrows that
+     *      code to {@code SendingPausedException}; V1 keeps the longer form, matching the
+     *      exact wire shape AWS returns on each surface.
+     * Mirrors AWS SES behaviour: invalid or paused set fails fast instead of silently
+     * storing/relaying the message and skipping event publishing later.
      */
     private void validateConfigurationSet(String configurationSetName, String region) {
         if (configurationSetName == null || configurationSetName.isBlank()) {
             return;
         }
-        if (configSetStore.get(configSetKey(region, configurationSetName)).isEmpty()) {
-            throw new AwsException("ConfigurationSetDoesNotExist",
-                    "Configuration set <" + configurationSetName + "> does not exist.", 400);
+        ConfigurationSet cs = configSetStore.get(configSetKey(region, configurationSetName))
+                .orElseThrow(() -> new AwsException("ConfigurationSetDoesNotExist",
+                        "Configuration set <" + configurationSetName + "> does not exist.", 400));
+        if (cs.getSendingEnabled() != null && !cs.getSendingEnabled()) {
+            throw new AwsException("ConfigurationSetSendingPausedException",
+                    "Sending is paused for configuration set " + configurationSetName, 400);
         }
     }
 
@@ -532,6 +542,14 @@ public class SesService {
     public void setAccountSendingEnabled(String region, boolean enabled) {
         accountSettingsStore.put("sending::" + region, enabled);
         LOG.infov("Updated account sending enabled for region {0}: {1}", region, enabled);
+    }
+
+    public void setConfigurationSetSendingEnabled(String configSetName, boolean enabled, String region) {
+        ConfigurationSet cs = getConfigurationSet(configSetName, region);
+        cs.setSendingEnabled(enabled);
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Updated SendingEnabled on configuration set {0} in region {1}: {2}",
+                configSetName, region, enabled);
     }
 
     // ──────────────────────────── Templates ────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/ConfigurationSet.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/ConfigurationSet.java
@@ -27,6 +27,9 @@ public class ConfigurationSet {
     @JsonProperty("SuppressionOptions")
     private SuppressionOptions suppressionOptions;
 
+    @JsonProperty("SendingEnabled")
+    private Boolean sendingEnabled;
+
     public ConfigurationSet() {}
 
     public ConfigurationSet(String name) {
@@ -51,5 +54,20 @@ public class ConfigurationSet {
     public SuppressionOptions getSuppressionOptions() { return suppressionOptions; }
     public void setSuppressionOptions(SuppressionOptions suppressionOptions) {
         this.suppressionOptions = suppressionOptions;
+    }
+
+    public Boolean getSendingEnabled() { return sendingEnabled; }
+    public void setSendingEnabled(Boolean sendingEnabled) { this.sendingEnabled = sendingEnabled; }
+
+    /**
+     * Effective sending-enabled flag with the AWS default applied — an unset
+     * (null) field is treated as enabled, matching the AWS behaviour where a
+     * configuration set without an explicit {@code SendingEnabled} state is
+     * implicitly enabled. Use this anywhere v1/v2 read or enforce the toggle
+     * so the default rule stays consistent across surfaces.
+     */
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    public boolean isSendingEnabledEffective() {
+        return sendingEnabled == null || sendingEnabled;
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetSendingOptionsV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetSendingOptionsV2IntegrationTest.java
@@ -1,0 +1,254 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Integration test for SES per-configuration-set Sending toggle. Covers both:
+ *   - v2 PUT /v2/email/configuration-sets/{name}/sending (PutConfigurationSetSendingOptions)
+ *   - v1 Query Action=UpdateConfigurationSetSendingEnabled
+ * and verifies the toggle is enforced by SendEmail (v2 outbound-emails) with a
+ * SendingPausedException response, and that the state is visible on both
+ *   - v2 GetConfigurationSet (SendingOptions block)
+ *   - v1 DescribeConfigurationSet (ReputationOptions block, reputationOptions attribute)
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesConfigurationSetSendingOptionsV2IntegrationTest {
+
+    private static final String SES_AUTH =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/ses/aws4_request";
+    private static final String CS = "cs-sending-options";
+    private static final String SENDER = "sender@example.com";
+
+    @Test
+    @Order(1)
+    void createConfigurationSet() {
+        given()
+                .contentType("application/json")
+                .header("Authorization", SES_AUTH)
+                .body("{\"ConfigurationSetName\":\"" + CS + "\"}")
+        .when()
+                .post("/v2/email/configuration-sets")
+        .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void getConfigurationSet_defaultSendingEnabledTrue() {
+        given()
+                .header("Authorization", SES_AUTH)
+        .when()
+                .get("/v2/email/configuration-sets/" + CS)
+        .then()
+                .statusCode(200)
+                .body("ConfigurationSetName", equalTo(CS))
+                .body("SendingOptions.SendingEnabled", equalTo(true));
+    }
+
+    @Test
+    @Order(3)
+    void sendEmail_defaultEnabled_succeeds() {
+        sendEmail(CS).then().statusCode(200);
+    }
+
+    @Test
+    @Order(4)
+    void putSendingOptions_disableViaV2() {
+        given()
+                .contentType("application/json")
+                .header("Authorization", SES_AUTH)
+                .body("{\"SendingEnabled\":false}")
+        .when()
+                .put("/v2/email/configuration-sets/" + CS + "/sending")
+        .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @Order(5)
+    void getConfigurationSet_reflectsDisabled() {
+        given()
+                .header("Authorization", SES_AUTH)
+        .when()
+                .get("/v2/email/configuration-sets/" + CS)
+        .then()
+                .statusCode(200)
+                .body("SendingOptions.SendingEnabled", equalTo(false));
+    }
+
+    @Test
+    @Order(6)
+    void v2SendEmail_whenDisabled_isRejectedWithSendingPausedException() {
+        sendEmail(CS)
+        .then()
+                .statusCode(400)
+                .body("__type", equalTo("SendingPausedException"))
+                .body("message", equalTo("Sending is paused for configuration set " + CS));
+    }
+
+    @Test
+    @Order(7)
+    void v1SendEmail_whenDisabled_isRejectedWithConfigurationSetSendingPausedException() {
+        // v1 Query API returns the longer ConfigurationSetSendingPausedException error code
+        // (matching the AWS v1 SES wire contract). The v2 controller's remapV1Exception
+        // narrows this to SendingPausedException for v2 callers only.
+        given()
+                .contentType("application/x-www-form-urlencoded")
+                .header("Authorization", SES_AUTH)
+                .formParam("Action", "SendEmail")
+                .formParam("Source", SENDER)
+                .formParam("Destination.ToAddresses.member.1", "recipient@example.com")
+                .formParam("Message.Subject.Data", "v1-disabled")
+                .formParam("Message.Body.Text.Data", "hi")
+                .formParam("ConfigurationSetName", CS)
+        .when()
+                .post("/")
+        .then()
+                .statusCode(400)
+                .body(containsString("<Code>ConfigurationSetSendingPausedException</Code>"))
+                .body(containsString(
+                        "<Message>Sending is paused for configuration set " + CS + "</Message>"));
+    }
+
+    @Test
+    @Order(8)
+    void v1_describeConfigurationSet_reputationOptions_reflectsDisabled() {
+        given()
+                .contentType("application/x-www-form-urlencoded")
+                .header("Authorization", SES_AUTH)
+                .formParam("Action", "DescribeConfigurationSet")
+                .formParam("ConfigurationSetName", CS)
+                .formParam("ConfigurationSetAttributeNames.member.1", "reputationOptions")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200)
+                .body(containsString("<SendingEnabled>false</SendingEnabled>"));
+    }
+
+    @Test
+    @Order(9)
+    void v1_updateConfigurationSetSendingEnabled_reEnables() {
+        given()
+                .contentType("application/x-www-form-urlencoded")
+                .header("Authorization", SES_AUTH)
+                .formParam("Action", "UpdateConfigurationSetSendingEnabled")
+                .formParam("ConfigurationSetName", CS)
+                .formParam("Enabled", "true")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @Order(10)
+    void sendEmail_afterReEnable_succeeds() {
+        sendEmail(CS).then().statusCode(200);
+    }
+
+    @Test
+    @Order(11)
+    void getConfigurationSet_reflectsReEnabled() {
+        given()
+                .header("Authorization", SES_AUTH)
+        .when()
+                .get("/v2/email/configuration-sets/" + CS)
+        .then()
+                .statusCode(200)
+                .body("SendingOptions.SendingEnabled", equalTo(true));
+    }
+
+    @Test
+    @Order(12)
+    void putSendingOptions_missingSendingEnabled_returns400() {
+        given()
+                .contentType("application/json")
+                .header("Authorization", SES_AUTH)
+                .body("{}")
+        .when()
+                .put("/v2/email/configuration-sets/" + CS + "/sending")
+        .then()
+                .statusCode(400)
+                .body("message", containsString("SendingEnabled"));
+    }
+
+    @Test
+    @Order(13)
+    void putSendingOptions_nonBooleanSendingEnabled_returns400() {
+        given()
+                .contentType("application/json")
+                .header("Authorization", SES_AUTH)
+                .body("{\"SendingEnabled\":\"yes\"}")
+        .when()
+                .put("/v2/email/configuration-sets/" + CS + "/sending")
+        .then()
+                .statusCode(400)
+                .body("message", containsString("SendingEnabled"));
+    }
+
+    @Test
+    @Order(14)
+    void putSendingOptions_unknownConfigSet_returns404_NotFoundException() {
+        given()
+                .contentType("application/json")
+                .header("Authorization", SES_AUTH)
+                .body("{\"SendingEnabled\":false}")
+        .when()
+                .put("/v2/email/configuration-sets/does-not-exist/sending")
+        .then()
+                .statusCode(404)
+                .body("__type", equalTo("NotFoundException"))
+                .body("message", equalTo("Configuration set <does-not-exist> does not exist."));
+    }
+
+    @Test
+    @Order(15)
+    void v1_updateConfigurationSetSendingEnabled_nonBooleanEnabled_returnsInvalidParameterValue() {
+        // parseRequiredBoolean enforces AWS-style "true"|"false". Anything else (e.g.
+        // "yes") must surface as InvalidParameterValue instead of being silently
+        // coerced to false (which would disable sending without the caller realizing).
+        given()
+                .contentType("application/x-www-form-urlencoded")
+                .header("Authorization", SES_AUTH)
+                .formParam("Action", "UpdateConfigurationSetSendingEnabled")
+                .formParam("ConfigurationSetName", CS)
+                .formParam("Enabled", "yes")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(400)
+                .body(containsString("<Code>InvalidParameterValue</Code>"))
+                .body(containsString("Enabled"));
+    }
+
+    private static io.restassured.response.Response sendEmail(String configSet) {
+        return given()
+                .contentType("application/json")
+                .header("Authorization", SES_AUTH)
+                .body("""
+                    {
+                      "FromEmailAddress": "%s",
+                      "Destination": {"ToAddresses": ["recipient@example.com"]},
+                      "ConfigurationSetName": "%s",
+                      "Content": {
+                        "Simple": {
+                          "Subject": {"Data": "send-toggle"},
+                          "Body": {"Text": {"Data": "hi"}}
+                        }
+                      }
+                    }
+                    """.formatted(SENDER, configSet))
+        .when()
+                .post("/v2/email/outbound-emails");
+    }
+}


### PR DESCRIPTION
## Summary

Add `UpdateConfigurationSetSendingEnabled` (SES v1 Query) and `PutConfigurationSetSendingOptions` (SES v2 REST, `PUT /v2/email/configuration-sets/{name}/sending`) to toggle email sending on a single configuration set, complementing the existing account-level `UpdateAccountSendingEnabled` / `PutAccountSendingAttributes` toggle. Both APIs share state — they read/write the same `ConfigurationSet.sendingEnabled` flag (null/true = enabled), matching the AWS contract where v1 and v2 are two surfaces over the same backend.

Enforcement is centralized in `SesService.validateConfigurationSet`, which is called by `SendEmail`, `SendRawEmail`, and `SendBulkTemplatedEmail` (v1 and v2 paths). When the CS's `sendingEnabled` is `false`, the send is rejected. The error code differs per surface, matching exactly what AWS returns in production:
- v1 `SendEmail` → `ConfigurationSetSendingPausedException`
- v2 `SendEmail` → `SendingPausedException`
Message on both: `Sending is paused for configuration set <name>`. The service throws the v1 form; `SesController.remapV1Exception` narrows it for v2 callers, following the same pattern as `ConfigurationSetDoesNotExist` → `NotFoundException`.

Read-back paths:
- v2 `GetConfigurationSet` returns `SendingOptions: {SendingEnabled}`
- v1 `DescribeConfigurationSet` with `reputationOptions` attribute returns `ReputationOptions/SendingEnabled` (matches the AWS v1 wire contract where `SendingEnabled` lives under `ReputationOptions`)

The v1 action is also added to `AwsQueryController.SES_ACTIONS` so that action-name-based service routing recognizes it.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Wire shapes verified against real AWS:
- `aws sesv2 send-email` against a CS with `SendingEnabled=false` → `SendingPausedException` + `Sending is paused for configuration set <name>` (no angle brackets around the name in this specific message — Floci reproduces this byte-for-byte).
- `aws ses send-email` (v1) against the same CS → `ConfigurationSetSendingPausedException` + the same message body. Floci matches.
- `aws sesv2 put-configuration-set-sending-options` on an unknown CS → `NotFoundException` + `Configuration set <name> does not exist.` (angle brackets included on this AWS error). Floci matches.

Verified against the AWS Java SDK v2 (`sesv2` + `ses` clients) via the SDK compatibility suite added in this branch — 9 cases covering both APIs, cross-API state sharing, `SendingPausedException` on disabled-CS sends, `NotFoundException` on unknown CS, and read-back through both `GetConfigurationSet` and `DescribeConfigurationSet(reputationOptions)`.

Note on v1 read-back: AWS keeps `SendingEnabled` under `ReputationOptions` in `DescribeConfigurationSet` even though the toggle action is named `UpdateConfigurationSetSendingEnabled` — Floci preserves this v1 quirk.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)