### PR TITLE
fix(elbv2): align DeleteTargetGroup with AWS Query response

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2QueryHandler.java
@@ -339,7 +339,8 @@ public class ElbV2QueryHandler {
     private Response handleDeleteTargetGroup(MultivaluedMap<String, String> p, String region) {
         String arn = p.getFirst("TargetGroupArn");
         service.deleteTargetGroup(region, arn);
-        return voidResponse("DeleteTargetGroupResponse");
+        String xml = AwsQueryResponse.envelopeEmptyResult("DeleteTargetGroup", AwsNamespaces.ELB_V2);
+        return Response.ok(xml).type(MediaType.APPLICATION_XML).build();
     }
 
     private Response handleModifyTargetGroup(MultivaluedMap<String, String> p, String region) {

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
@@ -662,6 +662,21 @@ class ElbV2IntegrationTest {
 
     @Test
     @Order(72)
+    void deleteTargetGroupIncludesEmptyResult() {
+        given()
+                .formParam("Action", "DeleteTargetGroup")
+                .formParam("TargetGroupArn", tgArn)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<DeleteTargetGroupResult"))
+                .body("DeleteTargetGroupResponse.ResponseMetadata.RequestId", not(isEmptyOrNullString()));
+    }
+
+    @Test
+    @Order(73)
     void deleteLoadBalancerCascades() {
         given()
                 .formParam("Action", "DeleteLoadBalancer")


### PR DESCRIPTION
## Summary

Fixes the ELBv2 `DeleteTargetGroup` Query response shape to align with AWS client expectations. Floci previously returned `DeleteTargetGroupResponse` without a `DeleteTargetGroupResult` element, which caused AWS CLI / botocore to fail during XML parsing with `KeyError: 'DeleteTargetGroupResult'`.

This PR adds a regression integration test for the response shape and updates `DeleteTargetGroup` to return an empty AWS Query result wrapper.

Closes #1064

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

For this bug fix, the incorrect behavior was that `DeleteTargetGroup` returned:

```xml
<DeleteTargetGroupResponse ...>
  <ResponseMetadata>...</ResponseMetadata>
</DeleteTargetGroupResponse>
```

AWS clients expect an empty result wrapper for this operation, so the response now includes:

```xml
<DeleteTargetGroupResponse ...>
  <DeleteTargetGroupResult/>
  <ResponseMetadata>...</ResponseMetadata>
</DeleteTargetGroupResponse>
```

Verified by adding an ELBv2 integration test that reproduces the missing `DeleteTargetGroupResult` case and passes after the fix.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

`./mvnw -Dtest=ElbV2IntegrationTest test` passed; full `./mvnw test` currently hits unrelated existing `ElastiCacheMemcachedIntegrationTest` connection-refused errors.