### PR TITLE
fix(stepfunctions): honor catch on lambda task failures

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -140,14 +140,15 @@ public class AslExecutor {
                         currentStateName = null;
                     }
                 } catch (FailStateException e) {
-                    exec.setStatus("FAILED");
-                    exec.setStopDate(System.currentTimeMillis() / 1000.0);
-                    String failError = e.error != null ? e.error : "States.Runtime";
-                    String failCause = e.cause != null ? e.cause : "";
-                    exec.setError(failError);
-                    exec.setCause(failCause);
-                    addEvent(history, eventId, "ExecutionFailed", null,
-                            Map.of("error", failError, "cause", failCause));
+                    StateResult caught = handleCatch(stateDef, currentInput, e);
+                    if (caught != null) {
+                        addEvent(history, eventId, stateExitedEventType(type), eventId.get() - 1,
+                                Map.of("name", currentStateName, "output", caught.output().toString()));
+                        currentInput = caught.output();
+                        currentStateName = caught.nextState();
+                        continue;
+                    }
+                    failExecution(exec, history, eventId, e);
                     onUpdate.accept(exec, history);
                     return;
                 } catch (Exception e) {
@@ -938,8 +939,17 @@ public class AslExecutor {
             }
             String type = stateDef.path("Type").asText();
             boolean stateJsonata = isJsonata(stateDef, topLevelQueryLanguage);
-            StateResult result = executeState(currentState, type, stateDef, currentInput, ignored, eventId, sm,
-                    stateJsonata, topLevelQueryLanguage, context);
+            StateResult result;
+            try {
+                result = executeState(currentState, type, stateDef, currentInput, ignored, eventId, sm,
+                        stateJsonata, topLevelQueryLanguage, context);
+            } catch (FailStateException e) {
+                StateResult caught = handleCatch(stateDef, currentInput, e);
+                if (caught == null) {
+                    throw e;
+                }
+                result = caught;
+            }
             currentInput = result.output();
             currentState = result.nextState();
             if ("Succeed".equals(type) || stateDef.path("End").asBoolean(false)) {
@@ -1309,6 +1319,64 @@ public class AslExecutor {
         event.setPreviousEventId(prevId);
         event.setDetails(details);
         history.add(event);
+    }
+
+    private void failExecution(Execution exec, List<HistoryEvent> history, AtomicLong eventId, FailStateException e) {
+        exec.setStatus("FAILED");
+        exec.setStopDate(System.currentTimeMillis() / 1000.0);
+        String failError = e.error != null ? e.error : "States.Runtime";
+        String failCause = e.cause != null ? e.cause : "";
+        exec.setError(failError);
+        exec.setCause(failCause);
+        addEvent(history, eventId, "ExecutionFailed", null,
+                Map.of("error", failError, "cause", failCause));
+    }
+
+    private StateResult handleCatch(JsonNode stateDef, JsonNode input, FailStateException failure) throws Exception {
+        JsonNode catchers = stateDef.path("Catch");
+        if (!catchers.isArray()) {
+            return null;
+        }
+        String error = failure.error != null ? failure.error : "States.Runtime";
+        String cause = failure.cause != null ? failure.cause : "";
+        for (JsonNode catcher : catchers) {
+            if (!catchMatches(catcher, error)) {
+                continue;
+            }
+            String next = catcher.path("Next").asText(null);
+            if (next == null || next.isBlank()) {
+                return null;
+            }
+            ObjectNode errorOutput = objectMapper.createObjectNode();
+            errorOutput.put("Error", error);
+            errorOutput.put("Cause", cause);
+            return new StateResult(mergeResult(catcher, input, errorOutput), next);
+        }
+        return null;
+    }
+
+    private boolean catchMatches(JsonNode catcher, String error) {
+        JsonNode errors = catcher.path("ErrorEquals");
+        if (!errors.isArray()) {
+            return false;
+        }
+        for (JsonNode candidate : errors) {
+            String expected = candidate.asText();
+            if (expected.equals(error)) {
+                return true;
+            }
+            if ("States.TaskFailed".equals(expected)
+                    && !"States.Timeout".equals(error)
+                    && !"States.Runtime".equals(error)) {
+                return true;
+            }
+            if ("States.ALL".equals(expected)
+                    && !"States.Runtime".equals(error)
+                    && !"States.DataLimitExceeded".equals(error)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private String stateEnteredEventType(String stateType) {

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorCatchTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorCatchTest.java
@@ -1,0 +1,176 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbJsonHandler;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
+import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
+import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
+import io.github.hectorvent.floci.services.lambda.model.InvocationType;
+import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
+import io.github.hectorvent.floci.services.lambda.model.LambdaFunction;
+import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
+import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
+import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
+import io.github.hectorvent.floci.services.stepfunctions.model.StateMachine;
+import jakarta.enterprise.inject.Instance;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AslExecutorCatchTest {
+
+    private static final String REGION = "us-east-2";
+    private static final String ACCOUNT = "000000000000";
+    private static final String FAILING_FUNCTION_NAME = "failing-lambda";
+    private static final String CLEANUP_FUNCTION_NAME = "cleanup-lambda";
+    private static final String FAILING_FUNCTION_ARN = lambdaArn(FAILING_FUNCTION_NAME);
+    private static final String CLEANUP_FUNCTION_ARN = lambdaArn(CLEANUP_FUNCTION_NAME);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private LambdaExecutorService lambdaExecutor;
+    private LambdaFunctionStore functionStore;
+    private LambdaFunction failingFunction;
+    private LambdaFunction cleanupFunction;
+    private AslExecutor executor;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        lambdaExecutor = mock(LambdaExecutorService.class);
+        functionStore = mock(LambdaFunctionStore.class);
+        failingFunction = lambdaFunction(FAILING_FUNCTION_NAME, FAILING_FUNCTION_ARN);
+        cleanupFunction = lambdaFunction(CLEANUP_FUNCTION_NAME, CLEANUP_FUNCTION_ARN);
+
+        when(functionStore.get(REGION, FAILING_FUNCTION_NAME)).thenReturn(Optional.of(failingFunction));
+        when(functionStore.get(REGION, CLEANUP_FUNCTION_NAME)).thenReturn(Optional.of(cleanupFunction));
+        when(lambdaExecutor.invoke(eq(failingFunction), any(byte[].class), eq(InvocationType.RequestResponse)))
+                .thenReturn(new InvokeResult(200, "Handled", errorPayload(), null, "fail-request"));
+        when(lambdaExecutor.invoke(eq(cleanupFunction), any(byte[].class), eq(InvocationType.RequestResponse)))
+                .thenAnswer(invocation -> {
+                    byte[] payload = invocation.getArgument(1);
+                    JsonNode input = objectMapper.readTree(payload);
+                    byte[] output = objectMapper.writeValueAsBytes(objectMapper.createObjectNode()
+                            .put("cleanup", true)
+                            .set("input", input));
+                    return new InvokeResult(200, null, output, null, "cleanup-request");
+                });
+
+        executor = new AslExecutor(
+                lambdaExecutor,
+                functionStore,
+                mock(DynamoDbService.class),
+                mock(DynamoDbJsonHandler.class),
+                mock(SqsJsonHandler.class),
+                objectMapper,
+                new JsonataEvaluator(objectMapper),
+                mock(Instance.class));
+    }
+
+    @Test
+    void lambdaTaskFailureWithStatesAllCatchTransitionsToCleanupWithOriginalInput() throws Exception {
+        Execution execution = run("""
+                {
+                  "StartAt": "FailingLambdaTask",
+                  "States": {
+                    "FailingLambdaTask": {
+                      "Type": "Task",
+                      "Resource": "%s",
+                      "Next": "UnexpectedSuccess",
+                      "Catch": [{
+                        "ErrorEquals": ["States.ALL"],
+                        "Next": "CleanupLambdaTask",
+                        "ResultPath": null
+                      }]
+                    },
+                    "UnexpectedSuccess": {
+                      "Type": "Fail",
+                      "Cause": "failing Lambda unexpectedly succeeded"
+                    },
+                    "CleanupLambdaTask": {
+                      "Type": "Task",
+                      "Resource": "%s",
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(FAILING_FUNCTION_ARN, CLEANUP_FUNCTION_ARN));
+
+        assertEquals("SUCCEEDED", execution.getStatus());
+        JsonNode output = objectMapper.readTree(execution.getOutput());
+        assertTrue(output.path("cleanup").asBoolean());
+        assertEquals("token-1", output.path("input").path("cleanupToken").asText());
+        assertTrue(output.path("input").path("fail").asBoolean());
+
+        verify(lambdaExecutor).invoke(eq(failingFunction), any(byte[].class), eq(InvocationType.RequestResponse));
+        verify(lambdaExecutor).invoke(eq(cleanupFunction), any(byte[].class), eq(InvocationType.RequestResponse));
+    }
+
+    @Test
+    void lambdaTaskFailureWithoutCatchStillFailsExecution() throws Exception {
+        Execution execution = run("""
+                {
+                  "StartAt": "FailingLambdaTask",
+                  "States": {
+                    "FailingLambdaTask": {
+                      "Type": "Task",
+                      "Resource": "%s",
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(FAILING_FUNCTION_ARN));
+
+        assertEquals("FAILED", execution.getStatus());
+        assertEquals("Lambda.AWSLambdaException", execution.getError());
+        assertEquals("Handled", execution.getCause());
+        verify(lambdaExecutor).invoke(eq(failingFunction), any(byte[].class), eq(InvocationType.RequestResponse));
+        verify(lambdaExecutor, never()).invoke(eq(cleanupFunction), any(byte[].class), eq(InvocationType.RequestResponse));
+    }
+
+    private Execution run(String definition) {
+        StateMachine stateMachine = new StateMachine();
+        stateMachine.setName("catch-test");
+        stateMachine.setStateMachineArn("arn:aws:states:%s:%s:stateMachine:catch-test".formatted(REGION, ACCOUNT));
+        stateMachine.setRoleArn("arn:aws:iam::%s:role/test-role".formatted(ACCOUNT));
+        stateMachine.setDefinition(definition);
+
+        Execution execution = new Execution();
+        execution.setName("catch-test-execution");
+        execution.setExecutionArn("arn:aws:states:%s:%s:execution:catch-test:catch-test-execution".formatted(REGION, ACCOUNT));
+        execution.setStateMachineArn(stateMachine.getStateMachineArn());
+        execution.setInput("{\"fail\":true,\"cleanupToken\":\"token-1\"}");
+
+        List<HistoryEvent> history = new ArrayList<>();
+        executor.executeSync(stateMachine, execution, history, (updated, events) -> {
+        });
+        return execution;
+    }
+
+    private byte[] errorPayload() {
+        return "{\"errorType\":\"ContractFailure\",\"errorMessage\":\"forced failure\"}".getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static LambdaFunction lambdaFunction(String name, String arn) {
+        LambdaFunction function = new LambdaFunction();
+        function.setFunctionName(name);
+        function.setFunctionArn(arn);
+        return function;
+    }
+
+    private static String lambdaArn(String name) {
+        return "arn:aws:lambda:%s:%s:function:%s".formatted(REGION, ACCOUNT, name);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1195

- route Lambda Task function failures through ASL `Catch` before marking the execution failed
- preserve the existing terminal `FAILED` behavior when no catcher matches
- add a focused Step Functions regression test for `Catch: States.ALL` with `ResultPath: null`, plus the no-catcher failure path

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

AWS Step Functions evaluates `Catch` handlers for Task state errors before failing the overall execution. A matched catcher transitions to its configured `Next` state and applies the catcher's `ResultPath`; `ResultPath: null` preserves the original input for the recovery state.

This PR aligns Floci's Lambda Task failure handling with those Amazon States Language semantics. Previously, a Lambda function error caused Floci to immediately mark the execution `FAILED`, so a matching `States.ALL` catcher was never reached.

Reference docs:

- AWS Step Functions error handling: https://docs.aws.amazon.com/step-functions/latest/dg/concepts-error-handling.html
- Catch `ResultPath` behavior: https://docs.aws.amazon.com/step-functions/latest/dg/input-output-resultpath.html
- Amazon States Language specification: https://states-language.net/spec.html
- Lambda synchronous invoke `FunctionError`: https://docs.aws.amazon.com/lambda/latest/api/API_Invoke.html

Validation run locally:

```bash
./mvnw test
./mvnw test -Dtest=AslExecutorCatchTest
./mvnw test -Dtest=AslExecutorCatchTest,StepFunctionsSqsIntegrationTest,StepFunctionsDynamoDbIntegrationTest
./mvnw test -Dtest='*StepFunctions*Test,AslExecutorCatchTest'
git diff --check
```

Full local `./mvnw test` result: `5438` tests run, `0` failures, `0` errors, `8` skipped.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)