### PR TITLE
chore(deps): bump quarkus to 3.36.0 and patch build dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <quarkus.platform.version>3.34.6</quarkus.platform.version>
+        <quarkus.platform.version>3.36.0</quarkus.platform.version>
         <apicurio.version>2.6.9.Final</apicurio.version>
     </properties>
 
@@ -152,7 +152,7 @@
         <dependency>
             <groupId>com.dashjoin</groupId>
             <artifactId>jsonata</artifactId>
-            <version>0.9.9</version>
+            <version>0.9.10</version>
         </dependency>
 
         <!-- Apache Velocity Template Engine (API Gateway VTL mapping templates) -->
@@ -173,7 +173,7 @@
         <dependency>
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser</artifactId>
-            <version>2.1.41</version>
+            <version>2.1.43</version>
         </dependency>
 
         <!-- Glue Schema Registry: Apicurio format utilities (parsing, canonicalization, compatibility) -->
@@ -252,7 +252,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.5</version>
+                <version>3.5.6</version>
                 <configuration>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
@@ -262,7 +262,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.6.2</version>
+                <version>3.6.3</version>
                 <executions>
                     <execution>
                         <id>enforce-java</id>


### PR DESCRIPTION
## Summary

Applies the native-safe subset of Dependabot's dependency updates:

- io.quarkus.platform            3.34.6 -> 3.36.0
- com.dashjoin:jsonata          0.9.9  -> 0.9.10
- io.swagger.parser.v3:swagger-parser  2.1.41 -> 2.1.43
- maven-surefire-plugin         3.5.5  -> 3.5.6
- maven-enforcer-plugin         3.6.2  -> 3.6.3

Excludes the coupled protobuf 4.x / apicurio 3.x chain (proto-google-common-protos 2.71.0, protobuf-java(+util) 4.34.1, apicurio 3.2.3). Those cannot be applied piecemeal: apicurio 3.x breaks compilation (renamed packages, ContentHandle -> TypedContent) and protobuf 4.x breaks the GraalVM native image because apicurio 2.6.9 references protobuf-3-only symbols (setPhpGenericServices, GeneratedFile) removed in 4.x. They require a coordinated upgrade with source migration.

Verified: ./mvnw test, native image build, and native boot + smoke test.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
