### PR TITLE
fix(cloudformation): poll for CREATE_COMPLETE in SAM changeset test

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/SamTransformIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/SamTransformIntegrationTest.java
@@ -521,7 +521,7 @@ class SamTransformIntegrationTest {
     }
 
     @Test
-    void samFunction_viaChangeSet_createsLambda() {
+    void samFunction_viaChangeSet_createsLambda() throws Exception {
         String stackName = "sam-changeset-stack";
         stacksToDelete.add(stackName);
 
@@ -562,15 +562,23 @@ class SamTransformIntegrationTest {
         .then()
             .statusCode(200);
 
-        given()
-            .contentType("application/x-www-form-urlencoded")
-            .formParam("Action", "DescribeStacks")
-            .formParam("StackName", stackName)
-        .when()
-            .post("/")
-        .then()
-            .statusCode(200)
-            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+        String describeBody = null;
+        for (int attempt = 0; attempt < 50; attempt++) {
+            describeBody = given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "DescribeStacks")
+                .formParam("StackName", stackName)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract().asString();
+            if (describeBody.contains("<StackStatus>CREATE_COMPLETE</StackStatus>")) {
+                break;
+            }
+            Thread.sleep(100);
+        }
+        assertThat(describeBody, containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
 
         given()
         .when()


### PR DESCRIPTION
## Summary

`SamTransformIntegrationTest.samFunction_viaChangeSet_createsLambda` asserted `CREATE_COMPLETE` immediately after `ExecuteChangeSet`, which provisions the stack asynchronously. On slower/variable runners the assertion raced the async work and intermittently observed `CREATE_IN_PROGRESS`, failing **unrelated** PRs' CI (e.g. [run 26976671226](https://github.com/floci-io/floci/actions/runs/26976671226) failed on this test, then the same change passed on `main` in [run 27052779758](https://github.com/floci-io/floci/actions/runs/27052779758)).

This polls `DescribeStacks` until the stack reaches `CREATE_COMPLETE` (bounded to ~5s) before asserting. Test-only change — no production code touched.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The incorrect behavior was in the **test**, not the emulator. The test assumed `ExecuteChangeSet` completed synchronously. Real AWS `ExecuteChangeSet` returns immediately and provisions asynchronously — which the emulator already models correctly — so the test now polls `DescribeStacks` for the terminal status the way an AWS client would. No wire-protocol or production behavior change.

## Checklist

- [x] `./mvnw test` passes locally (`Tests run: 5436, Failures: 0, Errors: 0, Skipped: 8`)
- [x] New or updated integration test added (updated existing `SamTransformIntegrationTest`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)