### PR TITLE
feat(elbv2): align DescribeLoadBalancers availability zones with AWS behavior

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -96,7 +96,7 @@ public class Ec2Service {
 
     // ─── Default resource seeding ──────────────────────────────────────────────
 
-    void ensureDefaultResources(String region) {
+    public void ensureDefaultResources(String region) {
         if (!seededRegions.add(region)) {
             return;
         }
@@ -204,7 +204,7 @@ public class Ec2Service {
         // Resolve subnet
         Subnet subnet = null;
         if (subnetId != null && !subnetId.isEmpty()) {
-            subnet = getRequiredSubnet(region, subnetId);
+            subnet = requireSubnet(region, subnetId);
         } else {
             // Pick first default subnet
             subnet = subnets.values().stream()
@@ -319,7 +319,8 @@ public class Ec2Service {
         return reservation;
     }
     
-    private Subnet getRequiredSubnet(String region, String subnetId) {
+    public Subnet requireSubnet(String region, String subnetId) {
+        ensureDefaultResources(region);
         Subnet subnet = subnets.get(key(region, subnetId));
         if (subnet == null) 
             throw new AwsException("InvalidSubnetID.NotFound", "The subnet ID '" + subnetId + "' does not exist", 400);
@@ -649,7 +650,7 @@ public class Ec2Service {
 
     public void modifySubnetAttribute(String region, String subnetId, String attribute, String value) {
         ensureDefaultResources(region);
-        Subnet subnet = getRequiredSubnet(region, subnetId);
+        Subnet subnet = requireSubnet(region, subnetId);
         switch (attribute) {
             case "mapPublicIpOnLaunch"           -> subnet.setMapPublicIpOnLaunch(Boolean.parseBoolean(value));
             case "assignIpv6AddressOnCreation"   -> subnet.setAssignIpv6AddressOnCreation(Boolean.parseBoolean(value));

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2QueryHandler.java
@@ -829,8 +829,11 @@ public class ElbV2QueryHandler {
         xml.start("State").elem("Code", safe(lb.getState())).end("State");
         xml.elem("Type", safe(lb.getType()));
         xml.start("AvailabilityZones");
-        for (String az : lb.getAvailabilityZones()) {
-            xml.start("member").elem("ZoneName", az).end("member");
+        for (AvailabilityZone az : lb.getAvailabilityZones()) {
+            xml.start("member")
+                    .elem("SubnetId", safe(az.getSubnetId()))
+                    .elem("ZoneName", safe(az.getZoneName()))
+                    .end("member");
         }
         xml.end("AvailabilityZones");
         xml.start("SecurityGroups");

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
@@ -684,7 +684,16 @@ public class ElbV2Service {
     private List<AvailabilityZone> resolveAvailabilityZones(String region, List<String> subnetIds) {
         List<AvailabilityZone> availabilityZones = new ArrayList<>();
         for (String subnetId : subnetIds) {
-            Subnet subnet = ec2Service.requireSubnet(region, subnetId);
+            Subnet subnet;
+            try {
+                subnet = ec2Service.requireSubnet(region, subnetId);
+            } catch (AwsException e) {
+                if ("InvalidSubnetID.NotFound".equals(e.getErrorCode())) {
+                    throw new AwsException("SubnetNotFound",
+                            "Subnet '" + subnetId + "' not found", 400);
+                }
+                throw e;
+            }
             AvailabilityZone availabilityZone = new AvailabilityZone();
             availabilityZone.setSubnetId(subnet.getSubnetId());
             availabilityZone.setZoneName(subnet.getAvailabilityZone());

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
@@ -3,6 +3,8 @@ package io.github.hectorvent.floci.services.elbv2;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.model.Subnet;
 import io.github.hectorvent.floci.services.elbv2.model.*;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -23,6 +25,9 @@ public class ElbV2Service {
 
     @Inject
     RegionResolver regionResolver;
+
+    @Inject
+    Ec2Service ec2Service;
 
     private static final String CANONICAL_HOSTED_ZONE_ID = "Z35SXDOTRQ7X7K";
 
@@ -75,7 +80,7 @@ public class ElbV2Service {
         lb.setType(lbType);
         lb.setIpAddressType(ipType);
         lb.setRegion(region);
-        if (subnets != null) lb.setAvailabilityZones(new ArrayList<>(subnets));
+        if (subnets != null) lb.setAvailabilityZones(resolveAvailabilityZones(region, subnets));
         if (securityGroups != null) lb.setSecurityGroups(new ArrayList<>(securityGroups));
 
         regionLbs.put(arn, lb);
@@ -164,7 +169,7 @@ public class ElbV2Service {
 
     public void setSubnets(String region, String arn, List<String> subnets) {
         LoadBalancer lb = requireLoadBalancer(region, arn);
-        lb.setAvailabilityZones(new ArrayList<>(subnets));
+        lb.setAvailabilityZones(resolveAvailabilityZones(region, subnets));
     }
 
     public void setIpAddressType(String region, String arn, String ipAddressType) {
@@ -674,6 +679,18 @@ public class ElbV2Service {
                     "One or more load balancers not found.", 400);
         }
         return lb;
+    }
+
+    private List<AvailabilityZone> resolveAvailabilityZones(String region, List<String> subnetIds) {
+        List<AvailabilityZone> availabilityZones = new ArrayList<>();
+        for (String subnetId : subnetIds) {
+            Subnet subnet = ec2Service.requireSubnet(region, subnetId);
+            AvailabilityZone availabilityZone = new AvailabilityZone();
+            availabilityZone.setSubnetId(subnet.getSubnetId());
+            availabilityZone.setZoneName(subnet.getAvailabilityZone());
+            availabilityZones.add(availabilityZone);
+        }
+        return availabilityZones;
     }
 
     private TargetGroup requireTargetGroup(String region, String arn) {

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/model/AvailabilityZone.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/model/AvailabilityZone.java
@@ -1,0 +1,20 @@
+package io.github.hectorvent.floci.services.elbv2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AvailabilityZone {
+
+    private String subnetId;
+    private String zoneName;
+
+    public AvailabilityZone() {}
+
+    public String getSubnetId() { return subnetId; }
+    public void setSubnetId(String subnetId) { this.subnetId = subnetId; }
+
+    public String getZoneName() { return zoneName; }
+    public void setZoneName(String zoneName) { this.zoneName = zoneName; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/model/LoadBalancer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/model/LoadBalancer.java
@@ -22,7 +22,7 @@ public class LoadBalancer {
     private String vpcId;
     private String state;
     private String type;
-    private List<String> availabilityZones = new ArrayList<>();
+    private List<AvailabilityZone> availabilityZones = new ArrayList<>();
     private List<String> securityGroups = new ArrayList<>();
     private String ipAddressType;
     private String region;
@@ -57,8 +57,8 @@ public class LoadBalancer {
     public String getType() { return type; }
     public void setType(String type) { this.type = type; }
 
-    public List<String> getAvailabilityZones() { return availabilityZones; }
-    public void setAvailabilityZones(List<String> availabilityZones) { this.availabilityZones = availabilityZones; }
+    public List<AvailabilityZone> getAvailabilityZones() { return availabilityZones; }
+    public void setAvailabilityZones(List<AvailabilityZone> availabilityZones) { this.availabilityZones = availabilityZones; }
 
     public List<String> getSecurityGroups() { return securityGroups; }
     public void setSecurityGroups(List<String> securityGroups) { this.securityGroups = securityGroups; }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -5117,7 +5117,7 @@ class CloudFormationIntegrationTest {
                     "Name": "cfn-alb",
                     "Type": "application",
                     "Scheme": "internet-facing",
-                    "Subnets": ["subnet-aaa", "subnet-bbb"],
+                    "Subnets": ["subnet-default-a", "subnet-default-b"],
                     "SecurityGroups": ["sg-123"]
                   }
                 },

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
@@ -730,4 +730,47 @@ class ElbV2IntegrationTest {
                 .statusCode(400)
                 .body("ErrorResponse.Error.Code", equalTo("LoadBalancerNotFound"));
     }
+
+    @Test
+    @Order(73)
+    void createLoadBalancerWithMissingSubnetReturnsSubnetNotFound() {
+        given()
+                .formParam("Action", "CreateLoadBalancer")
+                .formParam("Name", "lb-missing-subnet")
+                .formParam("Type", "application")
+                .formParam("Subnets.member.1", "subnet-does-not-exist")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(400)
+                .body("ErrorResponse.Error.Code", equalTo("SubnetNotFound"));
+    }
+
+    @Test
+    @Order(74)
+    void setSubnetsWithMissingSubnetReturnsSubnetNotFound() {
+        String setSubnetsLbArn = given()
+                .formParam("Action", "CreateLoadBalancer")
+                .formParam("Name", "lb-set-subnets")
+                .formParam("Type", "application")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.LoadBalancerArn");
+
+        given()
+                .formParam("Action", "SetSubnets")
+                .formParam("LoadBalancerArn", setSubnetsLbArn)
+                .formParam("Subnets.member.1", "subnet-does-not-exist")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(400)
+                .body("ErrorResponse.Error.Code", equalTo("SubnetNotFound"));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
@@ -167,6 +167,54 @@ class ElbV2IntegrationTest {
                 .body("ErrorResponse.Error.Code", equalTo("LoadBalancerNotFound"));
     }
 
+    @Test
+    @Order(9)
+    void createAndDescribeLoadBalancerWithSubnetsExposeSubnetAndZoneName() {
+        String subnetAwareLbArn = given()
+                .formParam("Action", "CreateLoadBalancer")
+                .formParam("Name", "lb-with-subnets")
+                .formParam("Type", "application")
+                .formParam("Subnets.member.1", "subnet-default-a")
+                .formParam("Subnets.member.2", "subnet-default-b")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .contentType("application/xml")
+                .body("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.AvailabilityZones.member.size()",
+                        equalTo(2))
+                .body("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.AvailabilityZones.member[0].SubnetId",
+                        equalTo("subnet-default-a"))
+                .body("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.AvailabilityZones.member[0].ZoneName",
+                        equalTo("us-east-1a"))
+                .body("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.AvailabilityZones.member[1].SubnetId",
+                        equalTo("subnet-default-b"))
+                .body("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.AvailabilityZones.member[1].ZoneName",
+                        equalTo("us-east-1b"))
+                .extract()
+                .path("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.LoadBalancerArn");
+
+        given()
+                .formParam("Action", "DescribeLoadBalancers")
+                .formParam("LoadBalancerArns.member.1", subnetAwareLbArn)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body("DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancers.member.AvailabilityZones.member.size()",
+                        equalTo(2))
+                .body("DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancers.member.AvailabilityZones.member[0].SubnetId",
+                        equalTo("subnet-default-a"))
+                .body("DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancers.member.AvailabilityZones.member[0].ZoneName",
+                        equalTo("us-east-1a"))
+                .body("DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancers.member.AvailabilityZones.member[1].SubnetId",
+                        equalTo("subnet-default-b"))
+                .body("DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancers.member.AvailabilityZones.member[1].ZoneName",
+                        equalTo("us-east-1b"));
+    }
+
     // ── Target Groups ─────────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

Align `CreateLoadBalancer` / `DescribeLoadBalancers` availability zone output with AWS-compatible ELBv2 behavior.

This PR:
- adds an ELBv2 `AvailabilityZone` model with `SubnetId` and `ZoneName`
- changes load balancers to store structured availability zone data instead of raw subnet ID strings
- resolves `subnetId -> subnet -> availabilityZone` via EC2 when creating/updating load balancers
- returns `AvailabilityZones.member.SubnetId` and `AvailabilityZones.member.ZoneName` in the ELBv2 XML response shape
- adds an integration test covering subnet-aware load balancer creation and describe behavior

Closes #1076

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Bug fix.

Previous behavior:
- ELBv2 `LoadBalancer.availabilityZones` stored subnet IDs as `List<String>`
- `DescribeLoadBalancers` returned subnet IDs in `AvailabilityZones.member.ZoneName`
- `AvailabilityZones.member.SubnetId` was missing entirely

Fixed behavior:
- ELBv2 now stores structured availability zone data
- `CreateLoadBalancer` / `DescribeLoadBalancers` return AWS-compatible `SubnetId` and `ZoneName` fields for each availability zone entry

Verified with:
- integration test for subnet-based load balancer create/describe flow in `ElbV2IntegrationTest`

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

`./mvnw -Dtest=ElbV2IntegrationTest test` passed; full `./mvnw test` currently hits unrelated existing `ElastiCacheMemcachedIntegrationTest` connection-refused errors.