### PR TITLE
fix: normalize Glue catalog names

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -70,15 +71,17 @@ public class GlueService {
     }
 
     public void createDatabase(Database database) {
-        if (databaseStore.get(database.getName()).isPresent()) {
+        String databaseName = normalizeName(database.getName());
+        if (databaseStore.get(databaseName).isPresent()) {
             throw new AwsException("AlreadyExistsException", "Database already exists: " + database.getName(), 400);
         }
-        databaseStore.put(database.getName(), database);
+        database.setName(databaseName);
+        databaseStore.put(databaseName, database);
         LOG.infov("Created Glue Database: {0}", database.getName());
     }
 
     public Database getDatabase(String name) {
-        return databaseStore.get(name)
+        return databaseStore.get(normalizeName(name))
                 .orElseThrow(() -> new AwsException("EntityNotFoundException", "Database not found: " + name, 400));
     }
 
@@ -87,24 +90,25 @@ public class GlueService {
     }
 
     public void deleteDatabase(String name) {
-        getDatabase(name);
+        String databaseName = getDatabase(name).getName();
         List<String> tableNames = tableStore.scan(k -> true).stream()
-                .filter(table -> name.equals(table.getDatabaseName()))
+                .filter(table -> databaseName.equals(table.getDatabaseName()))
                 .map(Table::getName)
                 .toList();
         tableNames.forEach(tableName -> deleteTable(name, tableName));
-        databaseStore.delete(name);
+        databaseStore.delete(databaseName);
         LOG.infov("Deleted Glue Database: {0}", name);
     }
 
     public void createTable(String databaseName, Table table) {
-        getDatabase(databaseName);
-        String key = databaseName + ":" + table.getName();
+        Database database = getDatabase(databaseName);
+        String key = tableKey(databaseName, table.getName());
         if (tableStore.get(key).isPresent()) {
             throw new AwsException("AlreadyExistsException", "Table already exists: " + table.getName(), 400);
         }
         validateSchemaReference(table);
-        table.setDatabaseName(databaseName);
+        table.setName(normalizeName(table.getName()));
+        table.setDatabaseName(database.getName());
         if (table.getCreateTime() == null) {
             table.setCreateTime(Instant.now());
         }
@@ -114,14 +118,14 @@ public class GlueService {
     }
 
     public Table getTable(String databaseName, String tableName) {
-        String key = databaseName + ":" + tableName;
-        Table table = tableStore.get(key)
+        Table table = tableStore.get(tableKey(databaseName, tableName))
                 .orElseThrow(() -> new AwsException("EntityNotFoundException", "Table not found: " + databaseName + "." + tableName, 400));
         return withResolvedSchemaReference(table);
     }
 
     public List<Table> getTables(String databaseName) {
-        List<Table> tables = tableStore.scan(k -> k.startsWith(databaseName + ":"));
+        String prefix = normalizeName(databaseName) + ":";
+        List<Table> tables = tableStore.scan(k -> k.startsWith(prefix));
         List<Table> resolved = new ArrayList<>(tables.size());
         for (Table table : tables) {
             resolved.add(withResolvedSchemaReference(table));
@@ -134,8 +138,8 @@ public class GlueService {
     }
 
     public synchronized void updateTable(String databaseName, Table table, String versionId) {
-        getDatabase(databaseName);
-        String key = databaseName + ":" + table.getName();
+        Database database = getDatabase(databaseName);
+        String key = tableKey(databaseName, table.getName());
         Table existing = tableStore.get(key)
                 .orElseThrow(() -> new AwsException("EntityNotFoundException",
                         "Table not found: " + databaseName + "." + table.getName(), 400));
@@ -144,7 +148,8 @@ public class GlueService {
                     "Update table failed due to concurrent modifications.", 400);
         }
         validateSchemaReference(table);
-        table.setDatabaseName(databaseName);
+        table.setName(normalizeName(table.getName()));
+        table.setDatabaseName(database.getName());
         table.setCreateTime(existing.getCreateTime());
         table.setUpdateTime(Instant.now());
         table.setVersionId(nextVersionId(existing.getVersionId()));
@@ -157,35 +162,36 @@ public class GlueService {
     }
 
     public void deleteTable(String databaseName, String tableName) {
-        String key = databaseName + ":" + tableName;
+        String key = tableKey(databaseName, tableName);
         tableStore.delete(key);
         partitionStore.scan(k -> k.startsWith(key + ":")).forEach(p -> {
-            partitionStore.delete(databaseName + ":" + tableName + ":" + String.join(",", p.getValues()));
+            partitionStore.delete(key + ":" + String.join(",", p.getValues()));
         });
         LOG.infov("Deleted Glue Table: {0}.{1}", databaseName, tableName);
     }
 
     public void createPartition(String databaseName, String tableName, Partition partition) {
-        getTable(databaseName, tableName);
-        String key = databaseName + ":" + tableName + ":" + String.join(",", partition.getValues());
-        partition.setDatabaseName(databaseName);
-        partition.setTableName(tableName);
+        Table table = getTable(databaseName, tableName);
+        String key = tableKey(databaseName, tableName) + ":" + String.join(",", partition.getValues());
+        partition.setDatabaseName(table.getDatabaseName());
+        partition.setTableName(table.getName());
         partitionStore.put(key, partition);
     }
 
     public List<Partition> getPartitions(String databaseName, String tableName) {
-        String prefix = databaseName + ":" + tableName + ":";
+        String prefix = tableKey(databaseName, tableName) + ":";
         return partitionStore.scan(k -> k.startsWith(prefix));
     }
 
     public void createUserDefinedFunction(String databaseName, UserDefinedFunction function) {
-        getDatabase(databaseName);
+        Database database = getDatabase(databaseName);
         String key = functionKey(databaseName, function.getFunctionName());
         if (functionStore.get(key).isPresent()) {
             throw new AwsException("AlreadyExistsException",
                     "Function already exists: " + databaseName + "." + function.getFunctionName(), 400);
         }
-        function.setDatabaseName(databaseName);
+        function.setDatabaseName(database.getName());
+        function.setFunctionName(normalizeName(function.getFunctionName()));
         function.setCreateTime(Instant.now());
         functionStore.put(key, function);
     }
@@ -207,16 +213,14 @@ public class GlueService {
             String functionType,
             Integer maxResults,
             String nextToken) {
-        if (databaseName != null) {
-            getDatabase(databaseName);
-        }
+        String databaseNameFilter = databaseName == null ? null : getDatabase(databaseName).getName();
         Pattern compiledPattern = compileFunctionPattern(pattern);
         int offset = decodeFunctionNextToken(nextToken);
         if (maxResults != null && (maxResults < 1 || maxResults > MAX_FUNCTION_RESULTS)) {
             throw new AwsException("InvalidInputException", "MaxResults must be between 1 and 100", 400);
         }
         List<UserDefinedFunction> functions = functionStore.scan(k -> true).stream()
-                .filter(function -> databaseName == null || databaseName.equals(function.getDatabaseName()))
+                .filter(function -> databaseNameFilter == null || databaseNameFilter.equals(function.getDatabaseName()))
                 .filter(function -> functionType == null || functionType.equals(function.getFunctionType()))
                 .filter(function -> function.getFunctionName() != null)
                 .filter(function -> compiledPattern.matcher(function.getFunctionName()).matches())
@@ -236,8 +240,8 @@ public class GlueService {
 
     public void updateUserDefinedFunction(String databaseName, String functionName, UserDefinedFunction function) {
         UserDefinedFunction existing = getUserDefinedFunction(databaseName, functionName);
-        function.setDatabaseName(databaseName);
-        function.setFunctionName(functionName);
+        function.setDatabaseName(existing.getDatabaseName());
+        function.setFunctionName(existing.getFunctionName());
         function.setCreateTime(existing.getCreateTime());
         functionStore.put(functionKey(databaseName, functionName), function);
     }
@@ -290,7 +294,15 @@ public class GlueService {
     }
 
     private static String functionKey(String databaseName, String functionName) {
-        return databaseName + ":" + functionName;
+        return normalizeName(databaseName) + ":" + normalizeName(functionName);
+    }
+
+    private static String tableKey(String databaseName, String tableName) {
+        return normalizeName(databaseName) + ":" + normalizeName(tableName);
+    }
+
+    private static String normalizeName(String name) {
+        return name.toLowerCase(Locale.ROOT);
     }
 
     private static Pattern compileFunctionPattern(String pattern) {

--- a/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
@@ -402,6 +402,87 @@ class GlueServiceTest {
     }
 
     @Test
+    void catalogNamesAreCaseInsensitiveAcrossApis() {
+        glueService.createDatabase(new Database("MixedCaseDatabase"));
+
+        assertEquals("mixedcasedatabase", glueService.getDatabase("MixedCaseDatabase").getName());
+        assertEquals("mixedcasedatabase", glueService.getDatabase("mixedcasedatabase").getName());
+        assertTrue(glueService.getDatabases().stream()
+                .map(Database::getName)
+                .toList()
+                .contains("mixedcasedatabase"));
+        AwsException databaseExists = assertThrows(AwsException.class,
+                () -> glueService.createDatabase(new Database("MIXEDCASEDATABASE")));
+        assertEquals("AlreadyExistsException", databaseExists.getErrorCode());
+
+        Table table = new Table();
+        table.setName("MixedCaseTable");
+        glueService.createTable("MixedCaseDatabase", table);
+        Table duplicateTable = new Table();
+        duplicateTable.setName("MIXEDCASETABLE");
+        AwsException tableExists = assertThrows(AwsException.class,
+                () -> glueService.createTable("MIXEDCASEDATABASE", duplicateTable));
+        assertEquals("AlreadyExistsException", tableExists.getErrorCode());
+        Table fetchedTable = glueService.getTable("mixedcasedatabase", "MIXEDCASETABLE");
+        assertEquals("mixedcasedatabase", fetchedTable.getDatabaseName());
+        assertEquals("mixedcasetable", fetchedTable.getName());
+        assertEquals(List.of("mixedcasetable"), glueService.getTables("MIXEDCASEDATABASE").stream()
+                .map(Table::getName)
+                .toList());
+
+        Table replacement = new Table();
+        replacement.setName("MIXEDCASETABLE");
+        replacement.setDescription("updated");
+        glueService.updateTable("MIXEDCASEDATABASE", replacement, fetchedTable.getVersionId());
+        assertEquals("updated", glueService.getTable("mixedcasedatabase", "mixedcasetable").getDescription());
+
+        Partition partition = new Partition();
+        partition.setValues(List.of("2026"));
+        glueService.createPartition("MIXEDCASEDATABASE", "MIXEDCASETABLE", partition);
+        Partition fetchedPartition = glueService.getPartitions("mixedcasedatabase", "mixedcasetable").get(0);
+        assertEquals("mixedcasedatabase", fetchedPartition.getDatabaseName());
+        assertEquals("mixedcasetable", fetchedPartition.getTableName());
+
+        UserDefinedFunction function = new UserDefinedFunction();
+        function.setFunctionName("MixedCaseFunction");
+        glueService.createUserDefinedFunction("mixedcasedatabase", function);
+        UserDefinedFunction duplicateFunction = new UserDefinedFunction();
+        duplicateFunction.setFunctionName("MIXEDCASEFUNCTION");
+        AwsException functionExists = assertThrows(AwsException.class,
+                () -> glueService.createUserDefinedFunction("MIXEDCASEDATABASE", duplicateFunction));
+        assertEquals("AlreadyExistsException", functionExists.getErrorCode());
+        UserDefinedFunction fetchedFunction = glueService.getUserDefinedFunction("MixedCaseDatabase", "MIXEDCASEFUNCTION");
+        assertEquals("mixedcasedatabase", fetchedFunction.getDatabaseName());
+        assertEquals("mixedcasefunction", fetchedFunction.getFunctionName());
+        GlueService.UserDefinedFunctionPage functions = glueService.getUserDefinedFunctions(
+                "MIXEDCASEDATABASE", "mixedcase.*", null, 1, null);
+        assertEquals(1, functions.functions().size());
+        assertNull(functions.nextToken());
+
+        UserDefinedFunction replacementFunction = new UserDefinedFunction();
+        replacementFunction.setFunctionName("ignored-name");
+        replacementFunction.setOwnerName("new-owner");
+        glueService.updateUserDefinedFunction("MIXEDCASEDATABASE", "MIXEDCASEFUNCTION", replacementFunction);
+        assertEquals("new-owner", glueService.getUserDefinedFunction("mixedcasedatabase", "mixedcasefunction").getOwnerName());
+
+        glueService.deleteUserDefinedFunction("MIXEDCASEDATABASE", "MIXEDCASEFUNCTION");
+        assertThrows(AwsException.class,
+                () -> glueService.getUserDefinedFunction("mixedcasedatabase", "mixedcasefunction"));
+
+        glueService.deleteTable("MIXEDCASEDATABASE", "MIXEDCASETABLE");
+        assertThrows(AwsException.class,
+                () -> glueService.getTable("mixedcasedatabase", "mixedcasetable"));
+
+        Table tableDeletedWithDatabase = new Table();
+        tableDeletedWithDatabase.setName("MixedCaseTableDeletedWithDatabase");
+        glueService.createTable("mixedcasedatabase", tableDeletedWithDatabase);
+        glueService.deleteDatabase("MIXEDCASEDATABASE");
+        assertThrows(AwsException.class, () -> glueService.getDatabase("mixedcasedatabase"));
+        assertThrows(AwsException.class,
+                () -> glueService.getTable("mixedcasedatabase", "mixedcasetabledeletedwithdatabase"));
+    }
+
+    @Test
     void getTableVersionsReturnsEmptyListForAthenaCompatibility() {
         assertTrue(glueService.getTableVersions().isEmpty());
     }


### PR DESCRIPTION
Glue catalog names now match AWS behavior by normalizing created database, table, and function names to lowercase and allowing case-insensitive lookup.

Fixes #1202
