### PR TITLE
fix: preserve Glue column parameters

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/glue-catalog.bats
+++ b/compatibility-tests/sdk-test-awscli/test/glue-catalog.bats
@@ -48,7 +48,10 @@ table_input() {
                 Columns: [
                     {
                         Name: "id",
-                        Type: "int"
+                        Type: "int",
+                        Parameters: {
+                            comment: "identifier"
+                        }
                     }
                 ]
             }
@@ -114,8 +117,10 @@ function_input() {
     assert_success
     name=$(json_get "$output" '.Table.Name')
     version_id=$(json_get "$output" '.Table.VersionId')
+    column_comment=$(json_get "$output" '.Table.StorageDescriptor.Columns[0].Parameters.comment')
     [ "$name" = "$TABLE_NAME" ]
     [ "$version_id" = "0" ]
+    [ "$column_comment" = "identifier" ]
 
     run aws_cmd glue get-tables --database-name "$DB_NAME"
     assert_success

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/GlueCatalogTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/GlueCatalogTest.java
@@ -110,6 +110,10 @@ class GlueCatalogTest {
         assertThat(createdTable.databaseName()).isEqualTo(DATABASE_NAME);
         assertThat(createdTable.name()).isEqualTo(TABLE_NAME);
         assertThat(createdTable.versionId()).isEqualTo("0");
+        assertThat(createdTable.storageDescriptor().columns())
+                .singleElement()
+                .satisfies(column -> assertThat(column.parameters())
+                        .containsEntry("comment", "identifier"));
         assertThat(glue.getTables(GetTablesRequest.builder()
                 .databaseName(DATABASE_NAME)
                 .build()).tableList())
@@ -220,6 +224,7 @@ class GlueCatalogTest {
                         .columns(Column.builder()
                                 .name("id")
                                 .type("int")
+                                .parameters(Map.of("comment", "identifier"))
                                 .build())
                         .build())
                 .build();

--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
@@ -422,6 +422,7 @@ public class GlueService {
             columnCopy.setName(column.getName());
             columnCopy.setType(column.getType());
             columnCopy.setComment(column.getComment());
+            columnCopy.setParameters(copyMap(column.getParameters()));
             copy.add(columnCopy);
         }
         return copy;

--- a/src/main/java/io/github/hectorvent/floci/services/glue/model/Column.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/model/Column.java
@@ -3,6 +3,9 @@ package io.github.hectorvent.floci.services.glue.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 @RegisterForReflection
 public class Column {
     @JsonProperty("Name")
@@ -11,6 +14,8 @@ public class Column {
     private String type;
     @JsonProperty("Comment")
     private String comment;
+    @JsonProperty("Parameters")
+    private Map<String, String> parameters;
 
     public Column() {}
     public Column(String name, String type) {
@@ -24,4 +29,6 @@ public class Column {
     public void setType(String type) { this.type = type; }
     public String getComment() { return comment; }
     public void setComment(String comment) { this.comment = comment; }
+    public Map<String, String> getParameters() { return parameters == null ? null : new LinkedHashMap<>(parameters); }
+    public void setParameters(Map<String, String> parameters) { this.parameters = parameters == null ? null : new LinkedHashMap<>(parameters); }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
@@ -69,7 +69,9 @@ class GlueServiceTest {
         Table table = new Table();
         table.setName("plain");
         StorageDescriptor sd = new StorageDescriptor();
-        sd.setColumns(java.util.List.of(new Column("a", "string")));
+        Column column = new Column("a", "string");
+        column.setParameters(Map.of("trino_type_id", "varchar"));
+        sd.setColumns(java.util.List.of(column));
         table.setStorageDescriptor(sd);
         glueService.createTable("db1", table);
 
@@ -78,6 +80,7 @@ class GlueServiceTest {
         assertEquals(1, fetched.getStorageDescriptor().getColumns().size());
         assertEquals("a", fetched.getStorageDescriptor().getColumns().get(0).getName());
         assertEquals("0", fetched.getVersionId());
+        assertEquals("varchar", fetched.getStorageDescriptor().getColumns().get(0).getParameters().get("trino_type_id"));
         assertNull(fetched.getStorageDescriptor().getSchemaReference());
     }
 


### PR DESCRIPTION
Glue table columns now retain Parameters in table responses like AWS.

Fixes #1204
