### PR TITLE
fix: enforce Glue table version checks

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueJsonHandler.java
@@ -79,8 +79,7 @@ public class GlueJsonHandler {
             case "UpdateTable" -> {
                 String dbName = request.get("DatabaseName").asText();
                 Table table = mapper.treeToValue(request.get("TableInput"), Table.class);
-                String versionId = request.path("VersionId").asText(null);
-                glueService.updateTable(dbName, table, versionId);
+                glueService.updateTable(dbName, table, request.path("VersionId").asText(null));
                 yield Response.ok().build();
             }
             case "GetTableVersions" -> {

--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
@@ -141,7 +141,7 @@ public class GlueService {
                         "Table not found: " + databaseName + "." + table.getName(), 400));
         if (versionId != null && !versionId.equals(existing.getVersionId())) {
             throw new AwsException("ConcurrentModificationException",
-                    "Table was modified concurrently: " + databaseName + "." + table.getName(), 400);
+                    "Update table failed due to concurrent modifications.", 400);
         }
         validateSchemaReference(table);
         table.setDatabaseName(databaseName);
@@ -418,4 +418,5 @@ public class GlueService {
     private static Map<String, String> copyMap(Map<String, String> source) {
         return source != null ? new LinkedHashMap<>(source) : null;
     }
+
 }

--- a/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
@@ -214,6 +214,56 @@ class GlueServiceTest {
     }
 
     @Test
+    void updateTableChecksVersionId() {
+        Table table = new Table();
+        table.setName("plain");
+        glueService.createTable("db1", table);
+        assertEquals("0", glueService.getTable("db1", "plain").getVersionId());
+
+        Table nonCanonicalVersionReplacement = new Table();
+        nonCanonicalVersionReplacement.setName("plain");
+        AwsException nonCanonicalVersionEx = assertThrows(AwsException.class,
+                () -> glueService.updateTable("db1", nonCanonicalVersionReplacement, "00"));
+        assertEquals("ConcurrentModificationException", nonCanonicalVersionEx.getErrorCode());
+        assertEquals("0", glueService.getTable("db1", "plain").getVersionId());
+
+        Table nonNumericVersionReplacement = new Table();
+        nonNumericVersionReplacement.setName("plain");
+        AwsException nonNumericVersionEx = assertThrows(AwsException.class,
+                () -> glueService.updateTable("db1", nonNumericVersionReplacement, "invalid"));
+        assertEquals("ConcurrentModificationException", nonNumericVersionEx.getErrorCode());
+        assertEquals("0", glueService.getTable("db1", "plain").getVersionId());
+
+        Table firstReplacement = new Table();
+        firstReplacement.setName("plain");
+        firstReplacement.setDescription("first");
+        glueService.updateTable("db1", firstReplacement, "0");
+        assertEquals("1", glueService.getTable("db1", "plain").getVersionId());
+
+        Table staleReplacement = new Table();
+        staleReplacement.setName("plain");
+        AwsException ex = assertThrows(AwsException.class,
+                () -> glueService.updateTable("db1", staleReplacement, "0"));
+
+        assertEquals("ConcurrentModificationException", ex.getErrorCode());
+        assertEquals("Update table failed due to concurrent modifications.", ex.getMessage());
+    }
+
+    @Test
+    void updateTableIncrementsMissingVersionId() {
+        Table existing = new Table();
+        existing.setName("plain");
+        existing.setDatabaseName("db1");
+        tableStore.put("db1:plain", existing);
+
+        Table replacement = new Table();
+        replacement.setName("plain");
+        glueService.updateTable("db1", replacement);
+
+        assertEquals("1", glueService.getTable("db1", "plain").getVersionId());
+    }
+
+    @Test
     void getTableReturnsViewFieldsUnchanged() {
         Table table = new Table();
         table.setName("view");


### PR DESCRIPTION
Glue tables now expose VersionId and reject stale UpdateTable requests like AWS.

Fixes #1205
