### PR TITLE
fix(dynamodb): remove 'metadata' from reserved words list

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbReservedWords.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbReservedWords.java
@@ -64,7 +64,7 @@ final class DynamoDbReservedWords {
         "LEFT", "LENGTH", "LESS", "LEVEL", "LIKE", "LIMIT", "LIMITED", "LINES",
         "LIST", "LOAD", "LOCAL", "LOCALTIME", "LOCALTIMESTAMP", "LOCATION", "LOCATOR",
         "LOCK", "LOCKS", "LOG", "LOGED", "LONG", "LOOP", "LOWER",
-        "MAP", "MATCH", "MATERIALIZED", "MAX", "MAXLEN", "MERGE", "METADATA", "MIN",
+        "MAP", "MATCH", "MATERIALIZED", "MAX", "MAXLEN", "MERGE", "MIN",
         "MINUS", "MODIFIES", "MODIFY", "MODULE", "MONTH", "MULTI", "MULTISET",
         "NAME", "NAMES", "NATIONAL", "NATURAL", "NCHAR", "NCLOB", "NEW", "NEXT",
         "NO", "NONE", "NOT", "NULL", "NULLIF", "NUMBER", "NUMERIC",

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbReservedWordsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbReservedWordsTest.java
@@ -1,0 +1,49 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers issue #1169: {@code metadata} is not an official DynamoDB reserved
+ * word (the AWS list goes MERGE -> METHOD -> METRICS -> MIN), so {@code check}
+ * must accept it as a bare attribute name.
+ *
+ * <p>RED/GREEN: re-adding {@code "METADATA"} to the {@code RESERVED} set makes
+ * {@link #metadataIsNotReserved} fail (check throws). The two regression tests
+ * guard that the validation mechanism itself is untouched.
+ */
+class DynamoDbReservedWordsTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "UpdateExpression", "FilterExpression", "ConditionExpression", "ProjectionExpression"
+    })
+    void metadataIsNotReserved(String expressionType) {
+        // Bare `metadata` attribute name, no `#` alias — must be accepted.
+        assertDoesNotThrow(() -> DynamoDbReservedWords.check("SET metadata = :v", expressionType));
+    }
+
+    @Test
+    void stillRejectsGenuineReservedWord() {
+        // `NAME` remains an official reserved word — the check must still fire.
+        AwsException ex = assertThrows(AwsException.class,
+                () -> DynamoDbReservedWords.check("SET name = :v", "UpdateExpression"));
+        assertEquals("ValidationException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+        assertTrue(ex.getMessage().contains("name"),
+                "message should name the offending reserved word, got: " + ex.getMessage());
+    }
+
+    @Test
+    void aliasedAttributeIsNeverReserved() {
+        // A `#`-aliased name is opaque to the reserved-word check.
+        assertDoesNotThrow(() -> DynamoDbReservedWords.check("SET #m = :v", "UpdateExpression"));
+    }
+}


### PR DESCRIPTION
## Summary

`metadata` is not an official DynamoDB reserved word per the [AWS docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html) — the list goes `MERGE → METHOD → METRICS → MIN`, with no `METADATA`.

Having it in the reserved set made `DynamoDbReservedWords.check` reject bare `metadata` attribute names:

```
Invalid UpdateExpression: Attribute name is a reserved keyword; reserved word: metadata
```

## Changes

- Removed `"METADATA"` from the `RESERVED` set in `DynamoDbReservedWords.java`.
- **Added a regression test** (`DynamoDbReservedWordsTest`) — the first revision shipped with none.

## Testing — real RED → GREEN

`./mvnw -Dtest=DynamoDbReservedWordsTest test`

**GREEN (fix in place):**
```
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
```

**RED (revert: `"METADATA"` re-added to RESERVED):**
```
Tests run: 6, Failures: 4, Errors: 0
metadataIsNotReserved(String)[1] <<< FAILURE!
  Unexpected exception thrown: AwsException: Invalid UpdateExpression:
  Attribute name is a reserved keyword; reserved word: metadata
```
The 4 parameterized cases (`UpdateExpression`/`FilterExpression`/`ConditionExpression`/`ProjectionExpression`) fail when the word is reserved; the two regression cases (`name` still rejected, `#m` alias accepted) stay green, proving the validation mechanism is otherwise untouched.

Closes #1169
