### PR TITLE
fix(lambda): normalize backslash ZIP path separators on extraction

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractor.java
@@ -20,13 +20,7 @@ public class ZipExtractor {
 
     private static final Logger LOG = Logger.getLogger(ZipExtractor.class);
 
-    // The ZIP spec (APPNOTE.TXT 4.4.17) mandates '/' as the entry path separator.
-    // PowerShell's Compress-Archive instead writes '\', which on Linux is a literal
-    // filename character — so "wwwroot\app.css" would become a single flat file
-    // instead of a nested path. Normalize '\' -> '/' so such archives extract
-    // correctly (matching how real AWS Lambda unpacks them).
-    private static final char WINDOWS_SEPARATOR = '\\';
-    private static final char UNIX_SEPARATOR = '/';
+    private static final char BACKSLASH = '\\';
 
     public void extractTo(byte[] zipBytes, Path targetDir) throws IOException {
         // Resolve to absolute path so that normalize() on entry paths stays comparable
@@ -36,9 +30,17 @@ public class ZipExtractor {
         try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
             ZipEntry entry;
             while ((entry = zis.getNextEntry()) != null) {
-                // Normalize Windows-style separators before any path handling so the
-                // traversal guard and resolution below operate on canonical names.
-                String entryName = entry.getName().replace(WINDOWS_SEPARATOR, UNIX_SEPARATOR);
+                String entryName = entry.getName();
+
+                // PowerShell 5 Compress-Archive writes '\' as a literal filename byte on
+                // Linux. Real AWS Lambda does NOT normalize this (the archive extracts to
+                // a flat "wwwroot\app.css" file), so neither do we; masking it would let
+                // a broken package pass locally and then fail on deploy.
+                if (entryName.indexOf(BACKSLASH) >= 0) {
+                    LOG.warnv("ZIP entry \"{0}\" uses backslash separators (PowerShell Compress-Archive). "
+                            + "It extracts as a literal filename and will also fail on real AWS Lambda. "
+                            + "Repackage with tar, PowerShell Core (pwsh), or the dotnet lambda CLI.", entryName);
+                }
 
                 // Security: prevent path traversal
                 if (entryName.contains("..") || entryName.startsWith("/")) {
@@ -47,10 +49,6 @@ public class ZipExtractor {
                     continue;
                 }
 
-                // A trailing separator marks a directory entry; Compress-Archive's
-                // backslash form would otherwise slip past ZipEntry.isDirectory().
-                boolean isDirectory = entry.isDirectory() || entryName.endsWith(String.valueOf(UNIX_SEPARATOR));
-
                 Path targetPath = absTarget.resolve(entryName).normalize();
                 if (!targetPath.startsWith(absTarget)) {
                     LOG.warnv("Skipping out-of-bounds ZIP entry: {0}", entryName);
@@ -58,7 +56,7 @@ public class ZipExtractor {
                     continue;
                 }
 
-                if (isDirectory) {
+                if (entry.isDirectory()) {
                     Files.createDirectories(targetPath);
                 } else {
                     Files.createDirectories(targetPath.getParent());

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractor.java
@@ -20,6 +20,14 @@ public class ZipExtractor {
 
     private static final Logger LOG = Logger.getLogger(ZipExtractor.class);
 
+    // The ZIP spec (APPNOTE.TXT 4.4.17) mandates '/' as the entry path separator.
+    // PowerShell's Compress-Archive instead writes '\', which on Linux is a literal
+    // filename character — so "wwwroot\app.css" would become a single flat file
+    // instead of a nested path. Normalize '\' -> '/' so such archives extract
+    // correctly (matching how real AWS Lambda unpacks them).
+    private static final char WINDOWS_SEPARATOR = '\\';
+    private static final char UNIX_SEPARATOR = '/';
+
     public void extractTo(byte[] zipBytes, Path targetDir) throws IOException {
         // Resolve to absolute path so that normalize() on entry paths stays comparable
         Path absTarget = targetDir.toAbsolutePath().normalize();
@@ -28,7 +36,9 @@ public class ZipExtractor {
         try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
             ZipEntry entry;
             while ((entry = zis.getNextEntry()) != null) {
-                String entryName = entry.getName();
+                // Normalize Windows-style separators before any path handling so the
+                // traversal guard and resolution below operate on canonical names.
+                String entryName = entry.getName().replace(WINDOWS_SEPARATOR, UNIX_SEPARATOR);
 
                 // Security: prevent path traversal
                 if (entryName.contains("..") || entryName.startsWith("/")) {
@@ -37,6 +47,10 @@ public class ZipExtractor {
                     continue;
                 }
 
+                // A trailing separator marks a directory entry; Compress-Archive's
+                // backslash form would otherwise slip past ZipEntry.isDirectory().
+                boolean isDirectory = entry.isDirectory() || entryName.endsWith(String.valueOf(UNIX_SEPARATOR));
+
                 Path targetPath = absTarget.resolve(entryName).normalize();
                 if (!targetPath.startsWith(absTarget)) {
                     LOG.warnv("Skipping out-of-bounds ZIP entry: {0}", entryName);
@@ -44,7 +58,7 @@ public class ZipExtractor {
                     continue;
                 }
 
-                if (entry.isDirectory()) {
+                if (isDirectory) {
                     Files.createDirectories(targetPath);
                 } else {
                     Files.createDirectories(targetPath.getParent());

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
@@ -29,19 +29,23 @@ class ZipExtractorTest {
     }
 
     @Test
-    void extractsBackslashEntriesAsNestedPaths(@TempDir Path target) throws IOException {
-        // PowerShell Compress-Archive writes '\' separators (issue #1198).
+    void extractsBackslashEntriesAsLiteralFilename(@TempDir Path target) throws IOException {
+        // PowerShell 5 Compress-Archive writes '\' separators (issue #1198).
+        // Real AWS Lambda does NOT normalize these — the entry extracts as a single
+        // literal-named file. Floci must match AWS, not silently fix broken packages.
         byte[] zip = zipWith("wwwroot\\_framework\\blazor.web.js", "// js");
 
         extractor.extractTo(zip, target);
 
-        // The fix: the file lands at a real nested path, not a single flat file.
+        // AWS-congruent: the backslashed entry lands as a literal filename, not nested.
+        Path flat = target.resolve("wwwroot\\_framework\\blazor.web.js");
+        assertTrue(Files.isRegularFile(flat),
+                "backslashed entry must extract as a literal filename (matching AWS Lambda)");
+        assertEquals("// js", Files.readString(flat));
+        // It must NOT create a nested path.
         Path nested = target.resolve("wwwroot").resolve("_framework").resolve("blazor.web.js");
-        assertTrue(Files.isRegularFile(nested), "nested path should exist after extraction");
-        assertEquals("// js", Files.readString(nested));
-        // And NOT as a literal file named with backslashes.
-        assertFalse(Files.exists(target.resolve("wwwroot\\_framework\\blazor.web.js")),
-                "backslashed flat file must not be created");
+        assertFalse(Files.exists(nested),
+                "backslashed entry must NOT create a nested path (AWS does not normalize)");
     }
 
     @Test
@@ -57,7 +61,8 @@ class ZipExtractorTest {
 
     @Test
     void rejectsBackslashTraversalEntries(@TempDir Path target) throws IOException {
-        // "..\..\evil" normalizes to "../../evil" and must be skipped, not written.
+        // "..\..\evil" contains ".." in the original entry name, so the traversal
+        // guard catches it even without normalization.
         byte[] zip = zipWith("..\\..\\evil.sh", "rm -rf");
 
         extractor.extractTo(zip, target);

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
@@ -1,0 +1,68 @@
+package io.github.hectorvent.floci.services.lambda.zip;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ZipExtractorTest {
+
+    private final ZipExtractor extractor = new ZipExtractor();
+
+    /** Build a ZIP whose entry names use the given separator, as PowerShell does. */
+    private static byte[] zipWith(String entryName, String content) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry(entryName));
+            zos.write(content.getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+        return baos.toByteArray();
+    }
+
+    @Test
+    void extractsBackslashEntriesAsNestedPaths(@TempDir Path target) throws IOException {
+        // PowerShell Compress-Archive writes '\' separators (issue #1198).
+        byte[] zip = zipWith("wwwroot\\_framework\\blazor.web.js", "// js");
+
+        extractor.extractTo(zip, target);
+
+        // The fix: the file lands at a real nested path, not a single flat file.
+        Path nested = target.resolve("wwwroot").resolve("_framework").resolve("blazor.web.js");
+        assertTrue(Files.isRegularFile(nested), "nested path should exist after extraction");
+        assertEquals("// js", Files.readString(nested));
+        // And NOT as a literal file named with backslashes.
+        assertFalse(Files.exists(target.resolve("wwwroot\\_framework\\blazor.web.js")),
+                "backslashed flat file must not be created");
+    }
+
+    @Test
+    void stillExtractsStandardForwardSlashEntries(@TempDir Path target) throws IOException {
+        byte[] zip = zipWith("conf/app.css", "body{}");
+
+        extractor.extractTo(zip, target);
+
+        Path nested = target.resolve("conf").resolve("app.css");
+        assertTrue(Files.isRegularFile(nested));
+        assertEquals("body{}", Files.readString(nested));
+    }
+
+    @Test
+    void rejectsBackslashTraversalEntries(@TempDir Path target) throws IOException {
+        // "..\..\evil" normalizes to "../../evil" and must be skipped, not written.
+        byte[] zip = zipWith("..\\..\\evil.sh", "rm -rf");
+
+        extractor.extractTo(zip, target);
+
+        assertFalse(Files.exists(target.getParent().getParent().resolve("evil.sh")),
+                "traversal entry must not escape the target dir");
+    }
+}


### PR DESCRIPTION
## Summary

Lambda ZIPs created on Windows with PowerShell `Compress-Archive` store entry names with backslash (`\`) path separators. The ZIP spec (APPNOTE.TXT 4.4.17) mandates `/`, and on Linux `\` is a literal filename character — so `ZipExtractor` wrote a single flat file named `wwwroot\app.css` instead of creating the nested `wwwroot/app.css` path.

**However**, real AWS Lambda does NOT normalize `\` to `/` — a PowerShell 5 `Compress-Archive` zip extracts as a literal-named file on Lambda, identical to what Floci does today. AWS recommends building on a POSIX OS (or WSL), and the C# guide steers you to `dotnet lambda` / SAM / CDK, all of which emit forward-slash zips. The fix lives on the packaging side, not the consumer side.

So this PR now:
- Keeps backslash separators literal (matching AWS Lambda exactly)
- Emits a clear `LOG.warnv` when backslashes are detected, telling the developer how to repackage correctly (`tar`, `pwsh`, or `dotnet lambda` CLI)
- Keeps the traversal guard and containment check (defense-in-depth)

Floci behaves exactly like AWS, and the developer gets an actionable signal instead of a silent local-only success that breaks on deploy.

## Type of change

- [x] Bug fix (AWS compatibility — Floci now matches real Lambda behavior)

## RED → GREEN verification (real `./mvnw test` run, not simulated)

**RED** — old normalization code vs new test:

```
Tests run: 3, Failures: 1, Errors: 0, Skipped: 0 <<< FAILURE!

ZipExtractorTest.extractsBackslashEntriesAsLiteralFilename FAILED
  backslashed entry must extract as a literal filename (matching AWS Lambda)
  ==> expected: <true> but was: <false>
```

The normalization code creates nested paths, but the new test asserts literal filenames (AWS-congruent). The test catches the fidelity mismatch.

**GREEN** — warning code:

```
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS

WARN ZIP entry "wwwroot\_framework\blazor.web.js" uses backslash separators (PowerShell Compress-Archive).
  It extracts as a literal filename and will also fail on real AWS Lambda.
  Repackage with tar, PowerShell Core (pwsh), or the dotnet lambda CLI.

WARN ZIP entry "..\..\evil.sh" uses backslash separators ...
WARN Skipping suspicious ZIP entry: ..\..\evil.sh
```

New tests:
- `extractsBackslashEntriesAsLiteralFilename` — backslashed entry creates a literal flat file, not nested
- `stillExtractsStandardForwardSlashEntries` — forward-slash entries unchanged
- `rejectsBackslashTraversalEntries` — `..\..\evil.sh` still caught by traversal guard
