### PR TITLE
feat(iam): seed standard EKS cluster and node group managed policies

### DIFF
--- a/docs/services/iam.md
+++ b/docs/services/iam.md
@@ -51,6 +51,9 @@ Floci seeds a catalog of commonly-used AWS managed policies at startup. These ar
 **ECS / EKS execution roles**
 `AmazonECSTaskExecutionRolePolicy` · `AmazonEKSFargatePodExecutionRolePolicy`
 
+**EKS cluster & node groups**
+`AmazonEKSClusterPolicy` · `AmazonEKSServicePolicy` · `AmazonEKSVPCResourceController` · `AmazonEKSWorkerNodePolicy` · `AmazonEKS_CNI_Policy`
+
 **Other execution roles**
 `AmazonS3ObjectLambdaExecutionRolePolicy` · `CloudWatchLambdaInsightsExecutionRolePolicy` · `CloudWatchLambdaApplicationSignalsExecutionRolePolicy` · `AWSConfigRulesExecutionRole` · `AWSMSKReplicatorExecutionRole` · `AWS-SSM-DiagnosisAutomation-ExecutionRolePolicy` · `AWS-SSM-RemediationAutomation-ExecutionRolePolicy` · `AmazonSageMakerGeospatialExecutionRole` · `AmazonSageMakerCanvasEMRServerlessExecutionRolePolicy` · `SageMakerStudioBedrockFunctionExecutionRolePolicy` · `SageMakerStudioDomainExecutionRolePolicy` · `SageMakerStudioQueryExecutionRolePolicy` · `AmazonDataZoneDomainExecutionRolePolicy` · `AmazonBedrockAgentCoreMemoryBedrockModelInferenceExecutionRolePolicy` · `AWSPartnerCentralSellingResourceSnapshotJobExecutionRolePolicy`
 

--- a/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
@@ -72,6 +72,19 @@ final class AwsManagedPolicies {
         new ManagedPolicyDef("AmazonEKSFargatePodExecutionRolePolicy", "/",
                 "Provides access to other AWS service resources required to run Amazon EKS pods on AWS Fargate."),
 
+        // EKS cluster and node group policies (required by the EKS console/SDK and
+        // the terraform-aws-modules/eks module — see #1092).
+        new ManagedPolicyDef("AmazonEKSClusterPolicy", "/",
+                "Provides Kubernetes the permissions it requires to manage resources on your behalf."),
+        new ManagedPolicyDef("AmazonEKSServicePolicy", "/",
+                "This policy allows Amazon Elastic Container Service for Kubernetes to create and manage the necessary resources to operate EKS Clusters."),
+        new ManagedPolicyDef("AmazonEKSVPCResourceController", "/",
+                "Policy used by VPC Resource Controller to manage ENI and IPs for worker nodes."),
+        new ManagedPolicyDef("AmazonEKSWorkerNodePolicy", "/",
+                "This policy allows Amazon EKS worker nodes to connect to Amazon EKS Clusters."),
+        new ManagedPolicyDef("AmazonEKS_CNI_Policy", "/",
+                "Provides the Amazon VPC CNI Plugin the permissions it requires to modify the IP address configuration on your EKS worker nodes."),
+
         // S3 Object Lambda execution role policy
         new ManagedPolicyDef("AmazonS3ObjectLambdaExecutionRolePolicy", "/service-role/",
                 "Provides write permissions to CloudWatch Logs for S3 Object Lambda access points."),

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
@@ -147,6 +149,32 @@ class IamIntegrationTest {
                     equalTo("AWSLambdaBasicExecutionRole"))
             .body("GetPolicyResponse.GetPolicyResult.Policy.Arn",
                     equalTo("arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"));
+    }
+
+    // The standard EKS managed policies the EKS console/SDK and the
+    // terraform-aws-modules/eks module attach to cluster and node roles (#1092).
+    @ParameterizedTest
+    @Order(6)
+    @ValueSource(strings = {
+            "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy",
+            "arn:aws:iam::aws:policy/AmazonEKSServicePolicy",
+            "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController",
+            "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+            "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+    })
+    void getEksManagedPolicy(String arn) {
+        String expectedName = arn.substring(arn.lastIndexOf('/') + 1);
+        given()
+            .formParam("Action", "GetPolicy")
+            .formParam("PolicyArn", arn)
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=test/20260227/us-east-1/iam/aws4_request")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("GetPolicyResponse.GetPolicyResult.Policy.PolicyName", equalTo(expectedName))
+            .body("GetPolicyResponse.GetPolicyResult.Policy.Arn", equalTo(arn));
     }
 
     @Test


### PR DESCRIPTION
## Summary

EKS cluster creation and managed node groups attach a set of AWS managed policies that floci did not seed in its IAM catalog. `GetPolicy` / `AttachRolePolicy` for these therefore returned `NoSuchEntity`:

```
NoSuchEntity: Policy arn:aws:iam::aws:policy/AmazonEKSClusterPolicy does not exist.
NoSuchEntity: Policy arn:aws:iam::aws:policy/AmazonEKSVPCResourceController does not exist.
```

…which breaks the `terraform-aws-modules/eks` module and the EKS console flow.

This seeds the standard EKS set into the startup catalog (all path `/`):
`AmazonEKSClusterPolicy`, `AmazonEKSServicePolicy`, `AmazonEKSVPCResourceController`, `AmazonEKSWorkerNodePolicy`, `AmazonEKS_CNI_Policy`. As with the rest of the catalog they use the permissive wildcard document (floci does not enforce IAM evaluation by default).

Closes #1092

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

These are real AWS managed-policy ARNs/names verified against the IAM console; all use path `/` (not `/service-role/`). Behavior matches real AWS: `GetPolicy` on each ARN now returns the policy, and `AttachRolePolicy` succeeds, so EKS IaC that references them provisions instead of failing with `NoSuchEntity`.

## Test verification (RED → GREEN)

The parameterized `getEksManagedPolicy` test was run locally with the catalog additions and again with them reverted, to confirm it catches the missing policies (CI only proves the with-fix case).

**RED** — EKS entries removed from `AwsManagedPolicies`, test kept (`mvn test -Dtest=IamIntegrationTest`):
```
[ERROR] IamIntegrationTest.getEksManagedPolicy(String)[1..5] <<< FAILURE!
[ERROR] Tests run: 32, Failures: 5, Errors: 0, Skipped: 0
[INFO] BUILD FAILURE
```
Exactly the 5 EKS ARNs fail (GetPolicy → not 200); the other 27 IAM cases stay green.

**GREEN** — with the seeded policies:
```
[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (`IamIntegrationTest.getEksManagedPolicy`, parameterized over the 5 ARNs)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Doc-sync: managed-policy catalog in `docs/services/iam.md` updated
