### PR TITLE
feat(appsync): Phase 3 — $util runtime library for VTL resolvers

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
@@ -875,6 +875,76 @@ class AppSyncTest {
                 .build());
     }
 
+    // ── SDK Coverage Gaps ─────────────────────────────────────────────
+
+    @Test
+    @Order(116)
+    void getIntrospectionSchema() {
+        GetIntrospectionSchemaResponse resp = client.getIntrospectionSchema(
+                GetIntrospectionSchemaRequest.builder()
+                        .apiId(apiId)
+                        .format("SDL")
+                        .build());
+
+        assertThat(resp.schema()).isNotNull();
+        String schema = resp.schema().asUtf8String();
+        assertThat(schema).contains("type Query");
+    }
+
+    @Test
+    @Order(117)
+    void listDomainNames() {
+        CreateDomainNameResponse created = client.createDomainName(
+                CreateDomainNameRequest.builder()
+                        .domainName("list-test-" + java.util.UUID.randomUUID().toString().substring(0, 8) + ".example.com")
+                        .certificateArn("arn:aws:acm:us-east-1:000000000000:certificate/test")
+                        .build());
+
+        ListDomainNamesResponse resp = client.listDomainNames(
+                ListDomainNamesRequest.builder()
+                        .build());
+
+        assertThat(resp.domainNameConfigs()).isNotEmpty();
+
+        client.deleteDomainName(DeleteDomainNameRequest.builder()
+                .domainName(created.domainNameConfig().domainName())
+                .build());
+    }
+
+    @Test
+    @Order(118)
+    void getFunction() {
+        String fnId = client.listFunctions(ListFunctionsRequest.builder()
+                .apiId(apiId)
+                .build())
+                .functions().get(0).functionId();
+
+        GetFunctionResponse resp = client.getFunction(GetFunctionRequest.builder()
+                .apiId(apiId)
+                .functionId(fnId)
+                .build());
+
+        assertThat(resp.functionConfiguration()).isNotNull();
+        assertThat(resp.functionConfiguration().functionId()).isEqualTo(fnId);
+    }
+
+    @Test
+    @Order(119)
+    void listResolversByFunction() {
+        String fnId = client.listFunctions(ListFunctionsRequest.builder()
+                .apiId(apiId)
+                .build())
+                .functions().get(0).functionId();
+
+        ListResolversByFunctionResponse resp = client.listResolversByFunction(
+                ListResolversByFunctionRequest.builder()
+                        .apiId(apiId)
+                        .functionId(fnId)
+                        .build());
+
+        assertThat(resp).isNotNull();
+    }
+
     // ── Error Handling ─────────────────────────────────────────────────
 
     @Test

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncController.java
@@ -572,7 +572,7 @@ public class AppSyncController {
                                     @QueryParam("nextToken") String nextToken) {
         var page = service.listDomainNames(maxResults, nextToken);
         ObjectNode root = objectMapper.createObjectNode();
-        ArrayNode items = root.putArray("domainNames");
+        ArrayNode items = root.putArray("domainNameConfigs");
         page.items().forEach(items::addPOJO);
         if (page.nextToken() != null) {
             root.put("nextToken", page.nextToken());

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/AppSyncUtil.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/AppSyncUtil.java
@@ -167,16 +167,13 @@ public class AppSyncUtil {
     }
 
     public String typeOf(Object value) {
-        if (value == null) return "null";
+        if (value == null) return "Null";
         if (value instanceof String) return "String";
         if (value instanceof Boolean) return "Boolean";
-        if (value instanceof Integer) return "Integer";
-        if (value instanceof Long) return "Long";
-        if (value instanceof Double) return "Double";
-        if (value instanceof Float) return "Float";
+        if (value instanceof Number) return "Number";
         if (value instanceof List<?>) return "List";
         if (value instanceof Map<?, ?>) return "Map";
-        return value.getClass().getSimpleName();
+        return "Object";
     }
 
     public String authType() {
@@ -217,7 +214,7 @@ public class AppSyncUtil {
     }
 
     public void unauthorized() {
-        throw new VtlErrorSignal("Not Authorized", "UnauthorizedException", null, null);
+        throw new VtlErrorSignal("Not Authorized", "Unauthorized", null, null);
     }
 
     public void validate(boolean condition, String message) {

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/AppSyncUtil.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/AppSyncUtil.java
@@ -181,7 +181,7 @@ public class AppSyncUtil {
     }
 
     public void error(String message) {
-        throw new VtlErrorSignal(message, "UnknownError", null, null);
+        throw new VtlErrorSignal(message, "Unknown", null, null);
     }
 
     public void error(String message, String errorType) {
@@ -218,7 +218,7 @@ public class AppSyncUtil {
     }
 
     public void validate(boolean condition, String message) {
-        validate(condition, message, "UnknownError");
+        validate(condition, message, "Unknown");
     }
 
     public void validate(boolean condition, String message, String errorType) {

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/AppSyncUtil.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/AppSyncUtil.java
@@ -1,0 +1,240 @@
+package io.github.hectorvent.floci.services.appsync.graphql.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.regex.Pattern;
+
+public class AppSyncUtil {
+
+    private final ObjectMapper objectMapper;
+    private final StrUtil strUtil;
+    private final TimeUtil timeUtil;
+    private final MathUtil mathUtil;
+    private final DynamoDbUtil dynamoDbUtil;
+    private final TransformUtil transformUtil;
+    private final ListUtil listUtil;
+    private final MapUtil mapUtil;
+
+    public AppSyncUtil(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        this.strUtil = new StrUtil();
+        this.timeUtil = new TimeUtil();
+        this.mathUtil = new MathUtil();
+        this.dynamoDbUtil = new DynamoDbUtil(objectMapper);
+        this.transformUtil = new TransformUtil(objectMapper);
+        this.listUtil = new ListUtil();
+        this.mapUtil = new MapUtil();
+    }
+
+    public StrUtil getStr() { return strUtil; }
+    public TimeUtil getTime() { return timeUtil; }
+    public MathUtil getMath() { return mathUtil; }
+    public DynamoDbUtil getDynamodb() { return dynamoDbUtil; }
+    public TransformUtil getTransform() { return transformUtil; }
+    public ListUtil getList() { return listUtil; }
+    public MapUtil getMap() { return mapUtil; }
+
+    public String escapeJavaScript(String s) {
+        if (s == null) return "";
+        StringBuilder sb = new StringBuilder(s.length() + 16);
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\' -> sb.append("\\\\");
+                case '"' -> sb.append("\\\"");
+                case '\'' -> sb.append("\\'");
+                case '/' -> sb.append("\\/");
+                case '\b' -> sb.append("\\b");
+                case '\t' -> sb.append("\\t");
+                case '\n' -> sb.append("\\n");
+                case '\f' -> sb.append("\\f");
+                case '\r' -> sb.append("\\r");
+                default -> {
+                    if (c < 0x20 || c > 0x7E) {
+                        sb.append("\\u").append(String.format("%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    public String urlEncode(String s) {
+        if (s == null) return "";
+        return URLEncoder.encode(s, StandardCharsets.UTF_8);
+    }
+
+    public String urlDecode(String s) {
+        if (s == null) return "";
+        return URLDecoder.decode(s, StandardCharsets.UTF_8);
+    }
+
+    public String base64Encode(byte[] data) {
+        if (data == null) return "";
+        return Base64.getEncoder().encodeToString(data);
+    }
+
+    public String base64Decode(String s) {
+        if (s == null) return "";
+        return new String(Base64.getDecoder().decode(s), StandardCharsets.UTF_8);
+    }
+
+    public Object parseJson(String s) {
+        if (s == null || s.isEmpty()) return Map.of();
+        try {
+            return objectMapper.readValue(s, Object.class);
+        } catch (JsonProcessingException e) {
+            return Map.of();
+        }
+    }
+
+    public String toJson(Object o) {
+        try {
+            return objectMapper.writeValueAsString(o);
+        } catch (JsonProcessingException e) {
+            return "null";
+        }
+    }
+
+    public String autoId() {
+        return UUID.randomUUID().toString();
+    }
+
+    public String quiet(String s) {
+        return "";
+    }
+
+    public String qr(String s) {
+        return "";
+    }
+
+    public boolean matches(String pattern, String value) {
+        if (pattern == null || value == null) return false;
+        return Pattern.matches(pattern, value);
+    }
+
+    public Object defaultIfNull(Object value, Object defaultValue) {
+        return value != null ? value : defaultValue;
+    }
+
+    public String defaultIfNullOrEmpty(String value, String defaultValue) {
+        if (value == null || value.isEmpty()) return defaultValue;
+        return value;
+    }
+
+    public String defaultIfNullOrBlank(String value, String defaultValue) {
+        if (value == null || value.isBlank()) return defaultValue;
+        return value;
+    }
+
+    public boolean isNull(Object value) {
+        return value == null;
+    }
+
+    public boolean isNullOrEmpty(String value) {
+        return value == null || value.isEmpty();
+    }
+
+    public boolean isNullOrBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    public boolean isString(Object value) {
+        return value instanceof String;
+    }
+
+    public boolean isNumber(Object value) {
+        return value instanceof Number;
+    }
+
+    public boolean isBoolean(Object value) {
+        return value instanceof Boolean;
+    }
+
+    public boolean isList(Object value) {
+        return value instanceof List<?>;
+    }
+
+    public boolean isMap(Object value) {
+        return value instanceof Map<?, ?>;
+    }
+
+    public String typeOf(Object value) {
+        if (value == null) return "null";
+        if (value instanceof String) return "String";
+        if (value instanceof Boolean) return "Boolean";
+        if (value instanceof Integer) return "Integer";
+        if (value instanceof Long) return "Long";
+        if (value instanceof Double) return "Double";
+        if (value instanceof Float) return "Float";
+        if (value instanceof List<?>) return "List";
+        if (value instanceof Map<?, ?>) return "Map";
+        return value.getClass().getSimpleName();
+    }
+
+    public String authType() {
+        return null;
+    }
+
+    public void error(String message) {
+        throw new VtlErrorSignal(message, "UnknownError", null, null);
+    }
+
+    public void error(String message, String errorType) {
+        throw new VtlErrorSignal(message, errorType, null, null);
+    }
+
+    public void error(String message, String errorType, Object data) {
+        throw new VtlErrorSignal(message, errorType, data, null);
+    }
+
+    public void error(String message, String errorType, Object data, Object errorInfo) {
+        throw new VtlErrorSignal(message, errorType, data, errorInfo);
+    }
+
+    public void appendError(String message) {
+        // In VTL context, this adds to $context.error without halting
+        // For standalone usage, this is a no-op
+    }
+
+    public void appendError(String message, String errorType) {
+        // No-op for standalone usage
+    }
+
+    public void appendError(String message, String errorType, Object data) {
+        // No-op for standalone usage
+    }
+
+    public void appendError(String message, String errorType, Object data, Object errorInfo) {
+        // No-op for standalone usage
+    }
+
+    public void unauthorized() {
+        throw new VtlErrorSignal("Not Authorized", "UnauthorizedException", null, null);
+    }
+
+    public void validate(boolean condition, String message) {
+        if (!condition) {
+            throw new VtlErrorSignal(message, "UnknownError", null, null);
+        }
+    }
+
+    public void validate(boolean condition, String message, String errorType) {
+        if (!condition) {
+            throw new VtlErrorSignal(message, errorType, null, null);
+        }
+    }
+
+    public void validate(boolean condition, String message, String errorType, Object data) {
+        if (!condition) {
+            throw new VtlErrorSignal(message, errorType, data, null);
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/AppSyncUtil.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/AppSyncUtil.java
@@ -112,7 +112,7 @@ public class AppSyncUtil {
     }
 
     public String qr(String s) {
-        return "";
+        return quiet(s);
     }
 
     public boolean matches(String pattern, String value) {
@@ -221,15 +221,11 @@ public class AppSyncUtil {
     }
 
     public void validate(boolean condition, String message) {
-        if (!condition) {
-            throw new VtlErrorSignal(message, "UnknownError", null, null);
-        }
+        validate(condition, message, "UnknownError");
     }
 
     public void validate(boolean condition, String message, String errorType) {
-        if (!condition) {
-            throw new VtlErrorSignal(message, errorType, null, null);
-        }
+        validate(condition, message, errorType, null);
     }
 
     public void validate(boolean condition, String message, String errorType, Object data) {

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/DynamoDbUtil.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/DynamoDbUtil.java
@@ -65,7 +65,7 @@ public class DynamoDbUtil {
     }
 
     public Map<String, Object> toBinary(String value) {
-        return Collections.singletonMap("B", base64Encode(value));
+        return Collections.singletonMap("B", value);
     }
 
     public String toBinaryJson(String value) {
@@ -113,7 +113,11 @@ public class DynamoDbUtil {
     }
 
     public Map<String, Object> toMapValues(Map<String, Object> value) {
-        return toMap(value);
+        Map<String, Object> converted = new LinkedHashMap<>(value.size());
+        for (Map.Entry<String, Object> entry : value.entrySet()) {
+            converted.put(entry.getKey(), toDynamoDB(entry.getValue()));
+        }
+        return converted;
     }
 
     public String toMapValuesJson(Map<String, Object> value) {
@@ -141,11 +145,7 @@ public class DynamoDbUtil {
     }
 
     public Map<String, Object> toBinarySet(List<String> value) {
-        List<String> encoded = new ArrayList<>(value.size());
-        for (String s : value) {
-            encoded.add(base64Encode(s));
-        }
-        return Collections.singletonMap("BS", encoded);
+        return Collections.singletonMap("BS", new ArrayList<>(value));
     }
 
     public String toBinarySetJson(List<String> value) {

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/DynamoDbUtil.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/DynamoDbUtil.java
@@ -3,7 +3,6 @@ package io.github.hectorvent.floci.services.appsync.graphql.util;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 public class DynamoDbUtil {
@@ -150,10 +149,6 @@ public class DynamoDbUtil {
 
     public String toBinarySetJson(List<String> value) {
         return toJson(toBinarySet(value));
-    }
-
-    private String base64Encode(String value) {
-        return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
     }
 
     private String toJson(Map<String, Object> map) {

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/DynamoDbUtil.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/DynamoDbUtil.java
@@ -45,53 +45,47 @@ public class DynamoDbUtil {
     }
 
     public String toDynamoDBJson(Object value) {
-        try {
-            return objectMapper.writeValueAsString(toDynamoDB(value));
-        } catch (JsonProcessingException e) {
-            return "{}";
-        }
+        return toJson(toDynamoDB(value));
     }
 
     public Map<String, Object> toString(String value) {
         return Collections.singletonMap("S", value);
     }
 
-    public Map<String, String> toStringJson(String value) {
-        return Collections.singletonMap("S", value);
+    public String toStringJson(String value) {
+        return toJson(toString(value));
     }
 
     public Map<String, Object> toNumber(Number value) {
         return Collections.singletonMap("N", value.toString());
     }
 
-    public Map<String, String> toNumberJson(Number value) {
-        return Collections.singletonMap("N", value.toString());
+    public String toNumberJson(Number value) {
+        return toJson(toNumber(value));
     }
 
     public Map<String, Object> toBinary(String value) {
-        String encoded = Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
-        return Collections.singletonMap("B", encoded);
+        return Collections.singletonMap("B", base64Encode(value));
     }
 
-    public Map<String, String> toBinaryJson(String value) {
-        String encoded = Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
-        return Collections.singletonMap("B", encoded);
+    public String toBinaryJson(String value) {
+        return toJson(toBinary(value));
     }
 
     public Map<String, Object> toBoolean(Boolean value) {
         return Collections.singletonMap("BOOL", value);
     }
 
-    public Map<String, String> toBooleanJson(Boolean value) {
-        return Collections.singletonMap("BOOL", value.toString());
+    public String toBooleanJson(Boolean value) {
+        return toJson(toBoolean(value));
     }
 
     public Map<String, Object> toNull() {
         return Collections.singletonMap("NULL", true);
     }
 
-    public Map<String, String> toNullJson() {
-        return Collections.singletonMap("NULL", "true");
+    public String toNullJson() {
+        return toJson(toNull());
     }
 
     public Map<String, Object> toList(List<?> value) {
@@ -102,8 +96,8 @@ public class DynamoDbUtil {
         return Collections.singletonMap("L", converted);
     }
 
-    public Map<String, Object> toListJson(List<?> value) {
-        return toList(value);
+    public String toListJson(List<?> value) {
+        return toJson(toList(value));
     }
 
     public Map<String, Object> toMap(Map<String, Object> value) {
@@ -114,24 +108,24 @@ public class DynamoDbUtil {
         return Collections.singletonMap("M", converted);
     }
 
-    public Map<String, Object> toMapJson(Map<String, Object> value) {
-        return toMap(value);
+    public String toMapJson(Map<String, Object> value) {
+        return toJson(toMap(value));
     }
 
     public Map<String, Object> toMapValues(Map<String, Object> value) {
         return toMap(value);
     }
 
-    public Map<String, Object> toMapValuesJson(Map<String, Object> value) {
-        return toMap(value);
+    public String toMapValuesJson(Map<String, Object> value) {
+        return toJson(toMapValues(value));
     }
 
     public Map<String, Object> toStringSet(List<String> value) {
         return Collections.singletonMap("SS", new ArrayList<>(value));
     }
 
-    public Map<String, Object> toStringSetJson(List<String> value) {
-        return toStringSet(value);
+    public String toStringSetJson(List<String> value) {
+        return toJson(toStringSet(value));
     }
 
     public Map<String, Object> toNumberSet(List<? extends Number> value) {
@@ -142,19 +136,31 @@ public class DynamoDbUtil {
         return Collections.singletonMap("NS", strings);
     }
 
-    public Map<String, Object> toNumberSetJson(List<? extends Number> value) {
-        return toNumberSet(value);
+    public String toNumberSetJson(List<? extends Number> value) {
+        return toJson(toNumberSet(value));
     }
 
     public Map<String, Object> toBinarySet(List<String> value) {
         List<String> encoded = new ArrayList<>(value.size());
         for (String s : value) {
-            encoded.add(Base64.getEncoder().encodeToString(s.getBytes(StandardCharsets.UTF_8)));
+            encoded.add(base64Encode(s));
         }
         return Collections.singletonMap("BS", encoded);
     }
 
-    public Map<String, Object> toBinarySetJson(List<String> value) {
-        return toBinarySet(value);
+    public String toBinarySetJson(List<String> value) {
+        return toJson(toBinarySet(value));
+    }
+
+    private String base64Encode(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String toJson(Map<String, Object> map) {
+        try {
+            return objectMapper.writeValueAsString(map);
+        } catch (JsonProcessingException e) {
+            return "{}";
+        }
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/DynamoDbUtil.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/DynamoDbUtil.java
@@ -1,0 +1,160 @@
+package io.github.hectorvent.floci.services.appsync.graphql.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+public class DynamoDbUtil {
+
+    private final ObjectMapper objectMapper;
+
+    public DynamoDbUtil(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public Map<String, Object> toDynamoDB(Object value) {
+        if (value == null) {
+            return Collections.singletonMap("NULL", true);
+        }
+        if (value instanceof String s) {
+            return Collections.singletonMap("S", s);
+        }
+        if (value instanceof Boolean b) {
+            return Collections.singletonMap("BOOL", b);
+        }
+        if (value instanceof Number n) {
+            return Collections.singletonMap("N", n.toString());
+        }
+        if (value instanceof List<?> list) {
+            List<Object> converted = new ArrayList<>(list.size());
+            for (Object item : list) {
+                converted.add(toDynamoDB(item));
+            }
+            return Collections.singletonMap("L", converted);
+        }
+        if (value instanceof Map<?, ?> map) {
+            Map<String, Object> converted = new LinkedHashMap<>(map.size());
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                converted.put(entry.getKey().toString(), toDynamoDB(entry.getValue()));
+            }
+            return Collections.singletonMap("M", converted);
+        }
+        return Collections.singletonMap("S", value.toString());
+    }
+
+    public String toDynamoDBJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(toDynamoDB(value));
+        } catch (JsonProcessingException e) {
+            return "{}";
+        }
+    }
+
+    public Map<String, Object> toString(String value) {
+        return Collections.singletonMap("S", value);
+    }
+
+    public Map<String, String> toStringJson(String value) {
+        return Collections.singletonMap("S", value);
+    }
+
+    public Map<String, Object> toNumber(Number value) {
+        return Collections.singletonMap("N", value.toString());
+    }
+
+    public Map<String, String> toNumberJson(Number value) {
+        return Collections.singletonMap("N", value.toString());
+    }
+
+    public Map<String, Object> toBinary(String value) {
+        String encoded = Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+        return Collections.singletonMap("B", encoded);
+    }
+
+    public Map<String, String> toBinaryJson(String value) {
+        String encoded = Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+        return Collections.singletonMap("B", encoded);
+    }
+
+    public Map<String, Object> toBoolean(Boolean value) {
+        return Collections.singletonMap("BOOL", value);
+    }
+
+    public Map<String, String> toBooleanJson(Boolean value) {
+        return Collections.singletonMap("BOOL", value.toString());
+    }
+
+    public Map<String, Object> toNull() {
+        return Collections.singletonMap("NULL", true);
+    }
+
+    public Map<String, String> toNullJson() {
+        return Collections.singletonMap("NULL", "true");
+    }
+
+    public Map<String, Object> toList(List<?> value) {
+        List<Object> converted = new ArrayList<>(value.size());
+        for (Object item : value) {
+            converted.add(toDynamoDB(item));
+        }
+        return Collections.singletonMap("L", converted);
+    }
+
+    public Map<String, Object> toListJson(List<?> value) {
+        return toList(value);
+    }
+
+    public Map<String, Object> toMap(Map<String, Object> value) {
+        Map<String, Object> converted = new LinkedHashMap<>(value.size());
+        for (Map.Entry<String, Object> entry : value.entrySet()) {
+            converted.put(entry.getKey(), toDynamoDB(entry.getValue()));
+        }
+        return Collections.singletonMap("M", converted);
+    }
+
+    public Map<String, Object> toMapJson(Map<String, Object> value) {
+        return toMap(value);
+    }
+
+    public Map<String, Object> toMapValues(Map<String, Object> value) {
+        return toMap(value);
+    }
+
+    public Map<String, Object> toMapValuesJson(Map<String, Object> value) {
+        return toMap(value);
+    }
+
+    public Map<String, Object> toStringSet(List<String> value) {
+        return Collections.singletonMap("SS", new ArrayList<>(value));
+    }
+
+    public Map<String, Object> toStringSetJson(List<String> value) {
+        return toStringSet(value);
+    }
+
+    public Map<String, Object> toNumberSet(List<? extends Number> value) {
+        List<String> strings = new ArrayList<>(value.size());
+        for (Number n : value) {
+            strings.add(n.toString());
+        }
+        return Collections.singletonMap("NS", strings);
+    }
+
+    public Map<String, Object> toNumberSetJson(List<? extends Number> value) {
+        return toNumberSet(value);
+    }
+
+    public Map<String, Object> toBinarySet(List<String> value) {
+        List<String> encoded = new ArrayList<>(value.size());
+        for (String s : value) {
+            encoded.add(Base64.getEncoder().encodeToString(s.getBytes(StandardCharsets.UTF_8)));
+        }
+        return Collections.singletonMap("BS", encoded);
+    }
+
+    public Map<String, Object> toBinarySetJson(List<String> value) {
+        return toBinarySet(value);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/ListUtil.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/ListUtil.java
@@ -1,0 +1,71 @@
+package io.github.hectorvent.floci.services.appsync.graphql.util;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class ListUtil {
+
+    public List<Object> copyAndRetainAll(List<?> list, List<?> keep) {
+        if (list == null || keep == null) {
+            return list != null ? new ArrayList<>(list) : new ArrayList<>();
+        }
+        Set<Object> keepSet = new HashSet<>(keep);
+        return list.stream()
+                .filter(keepSet::contains)
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    public List<Object> copyAndRemoveAll(List<?> list, List<?> remove) {
+        if (list == null) {
+            return new ArrayList<>();
+        }
+        if (remove == null) {
+            return new ArrayList<>(list);
+        }
+        Set<Object> removeSet = new HashSet<>(remove);
+        return list.stream()
+                .filter(item -> !removeSet.contains(item))
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<Object> sortList(List<?> list, boolean descending, String fieldName) {
+        if (list == null || list.isEmpty()) {
+            return new ArrayList<>();
+        }
+        List<Object> sorted = new ArrayList<>(list);
+        if (fieldName == null || fieldName.isEmpty()) {
+            sorted.sort((a, b) -> compareObjects(a, b, descending));
+        } else {
+            sorted.sort((a, b) -> {
+                Object valA = getFieldValue(a, fieldName);
+                Object valB = getFieldValue(b, fieldName);
+                return compareObjects(valA, valB, descending);
+            });
+        }
+        return sorted;
+    }
+
+    private int compareObjects(Object a, Object b, boolean descending) {
+        int result;
+        if (a == null && b == null) {
+            result = 0;
+        } else if (a == null) {
+            result = -1;
+        } else if (b == null) {
+            result = 1;
+        } else if (a instanceof Comparable<?> && b.getClass().isAssignableFrom(a.getClass())) {
+            result = ((Comparable<Object>) a).compareTo(b);
+        } else {
+            result = a.toString().compareTo(b.toString());
+        }
+        return descending ? -result : result;
+    }
+
+    private Object getFieldValue(Object obj, String fieldName) {
+        if (obj instanceof Map<?, ?> map) {
+            return map.get(fieldName);
+        }
+        return null;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/MapUtil.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/MapUtil.java
@@ -1,0 +1,38 @@
+package io.github.hectorvent.floci.services.appsync.graphql.util;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class MapUtil {
+
+    public Map<String, Object> copyAndRetainAllKeys(Map<String, Object> map, List<?> keys) {
+        if (map == null || keys == null) {
+            return map != null ? new LinkedHashMap<>(map) : new LinkedHashMap<>();
+        }
+        Set<Object> keySet = new HashSet<>(keys);
+        return map.entrySet().stream()
+                .filter(entry -> keySet.contains(entry.getKey()))
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue,
+                        (a, b) -> a,
+                        LinkedHashMap::new));
+    }
+
+    public Map<String, Object> copyAndRemoveAllKeys(Map<String, Object> map, List<?> keys) {
+        if (map == null) {
+            return new LinkedHashMap<>();
+        }
+        if (keys == null) {
+            return new LinkedHashMap<>(map);
+        }
+        Set<Object> keySet = new HashSet<>(keys);
+        return map.entrySet().stream()
+                .filter(entry -> !keySet.contains(entry.getKey()))
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue,
+                        (a, b) -> a,
+                        LinkedHashMap::new));
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/MathUtil.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/MathUtil.java
@@ -1,0 +1,34 @@
+package io.github.hectorvent.floci.services.appsync.graphql.util;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class MathUtil {
+
+    public Integer roundNum(Double value) {
+        if (value == null) return 0;
+        return BigDecimal.valueOf(value).setScale(0, RoundingMode.HALF_UP).intValue();
+    }
+
+    public Double minVal(Double a, Double b) {
+        if (a == null) return b != null ? b : 0.0;
+        if (b == null) return a;
+        return Math.min(a, b);
+    }
+
+    public Double maxVal(Double a, Double b) {
+        if (a == null) return b != null ? b : 0.0;
+        if (b == null) return a;
+        return Math.max(a, b);
+    }
+
+    public Double randomDouble() {
+        return ThreadLocalRandom.current().nextDouble();
+    }
+
+    public Integer randomWithinRange(Integer min, Integer max) {
+        if (min == null || max == null) return 0;
+        return ThreadLocalRandom.current().nextInt(min, max + 1);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/StrUtil.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/StrUtil.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.services.appsync.graphql.util;
 
+import java.text.Normalizer;
+
 public class StrUtil {
 
     public String toUpper(String s) {
@@ -17,9 +19,9 @@ public class StrUtil {
         return s.replace(target, replacement);
     }
 
-    public String normalize(String s, String replacement) {
+    public String normalize(String s, String form) {
         if (s == null) return "";
-        if (replacement == null) replacement = " ";
-        return s.replaceAll("\\s+", replacement);
+        if (form == null) form = "nfc";
+        return Normalizer.normalize(s, Normalizer.Form.valueOf(form.toUpperCase()));
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/StrUtil.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/StrUtil.java
@@ -1,0 +1,25 @@
+package io.github.hectorvent.floci.services.appsync.graphql.util;
+
+public class StrUtil {
+
+    public String toUpper(String s) {
+        if (s == null) return "";
+        return s.toUpperCase();
+    }
+
+    public String toLower(String s) {
+        if (s == null) return "";
+        return s.toLowerCase();
+    }
+
+    public String toReplace(String s, String target, String replacement) {
+        if (s == null || target == null || replacement == null) return s != null ? s : "";
+        return s.replace(target, replacement);
+    }
+
+    public String normalize(String s, String replacement) {
+        if (s == null) return "";
+        if (replacement == null) replacement = " ";
+        return s.replaceAll("\\s+", replacement);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/TimeUtil.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/TimeUtil.java
@@ -9,7 +9,12 @@ import java.time.temporal.ChronoField;
 
 public class TimeUtil {
 
-    private static final DateTimeFormatter ISO_FORMATTER = DateTimeFormatter.ISO_INSTANT;
+    private static final DateTimeFormatter ISO_FORMATTER = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
+            .appendFraction(ChronoField.MILLI_OF_SECOND, 3, 3, true)
+            .appendOffsetId()
+            .toFormatter()
+            .withZone(ZoneOffset.UTC);
 
     public String nowISO8601() {
         return ISO_FORMATTER.format(Instant.now());

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/TimeUtil.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/TimeUtil.java
@@ -1,0 +1,74 @@
+package io.github.hectorvent.floci.services.appsync.graphql.util;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+
+public class TimeUtil {
+
+    private static final DateTimeFormatter ISO_FORMATTER = DateTimeFormatter.ISO_INSTANT;
+
+    public String nowISO8601() {
+        return ISO_FORMATTER.format(Instant.now());
+    }
+
+    public long nowEpochSeconds() {
+        return Instant.now().getEpochSecond();
+    }
+
+    public long nowEpochMilliSeconds() {
+        return System.currentTimeMillis();
+    }
+
+    public String nowFormatted(String format) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format);
+        return formatter.format(ZonedDateTime.now(ZoneOffset.UTC));
+    }
+
+    public String nowFormatted(String format, String offset) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format);
+        ZoneOffset zoneOffset = ZoneOffset.of(offset);
+        return formatter.format(ZonedDateTime.now(zoneOffset));
+    }
+
+    public long parseFormattedToEpochMilliSeconds(String timestamp, String format) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format);
+        var parsed = java.time.LocalDateTime.parse(timestamp, formatter);
+        return parsed.toInstant(ZoneOffset.UTC).toEpochMilli();
+    }
+
+    public long parseFormattedToEpochMilliSeconds(String timestamp, String format, String timezone) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format);
+        ZoneOffset zoneOffset = ZoneOffset.of(timezone);
+        var parsed = java.time.LocalDateTime.parse(timestamp, formatter);
+        return parsed.toInstant(zoneOffset).toEpochMilli();
+    }
+
+    public long parseISO8601ToEpochMilliSeconds(String timestamp) {
+        return Instant.parse(timestamp).toEpochMilli();
+    }
+
+    public long epochMilliSecondsToSeconds(long epochMilliSeconds) {
+        return epochMilliSeconds / 1000;
+    }
+
+    public String epochMilliSecondsToISO8601(long epochMilliSeconds) {
+        return ISO_FORMATTER.format(Instant.ofEpochMilli(epochMilliSeconds));
+    }
+
+    public String epochMilliSecondsToFormatted(long epochMilliSeconds, String format) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format);
+        ZonedDateTime zdt = Instant.ofEpochMilli(epochMilliSeconds).atZone(ZoneOffset.UTC);
+        return formatter.format(zdt);
+    }
+
+    public String epochMilliSecondsToFormatted(long epochMilliSeconds, String format, String offset) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format);
+        ZoneOffset zoneOffset = ZoneOffset.of(offset);
+        ZonedDateTime zdt = Instant.ofEpochMilli(epochMilliSeconds).atZone(zoneOffset);
+        return formatter.format(zdt);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/TransformUtil.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/TransformUtil.java
@@ -15,21 +15,9 @@ public class TransformUtil {
         this.objectMapper = objectMapper;
     }
 
-    @SuppressWarnings("unchecked")
     public Map<String, Object> toDynamoDBFilterExpression(Object input) {
-        if (input == null) {
-            return Collections.emptyMap();
-        }
-        Map<String, Object> source;
-        if (input instanceof Map<?, ?> map) {
-            source = (Map<String, Object>) map;
-        } else if (input instanceof String s) {
-            try {
-                source = objectMapper.readValue(s, Map.class);
-            } catch (Exception e) {
-                return Collections.emptyMap();
-            }
-        } else {
+        Map<String, Object> source = parseInput(input);
+        if (source.isEmpty()) {
             return Collections.emptyMap();
         }
 
@@ -46,60 +34,46 @@ public class TransformUtil {
         return result;
     }
 
-    @SuppressWarnings("unchecked")
     public Map<String, Object> toElasticsearchQueryDSL(Object input) {
-        if (input == null) {
-            return Collections.emptyMap();
-        }
-        if (input instanceof Map<?, ?> map) {
-            return (Map<String, Object>) map;
-        }
-        if (input instanceof String s) {
-            try {
-                return objectMapper.readValue(s, Map.class);
-            } catch (Exception e) {
-                return Collections.emptyMap();
-            }
-        }
-        return Collections.emptyMap();
+        return parseInput(input);
     }
 
-    @SuppressWarnings("unchecked")
     public Map<String, Object> toSubscriptionFilter(Object input) {
-        if (input == null) {
-            return Collections.emptyMap();
-        }
-        if (input instanceof Map<?, ?> map) {
-            return (Map<String, Object>) map;
-        }
-        if (input instanceof String s) {
-            try {
-                return objectMapper.readValue(s, Map.class);
-            } catch (Exception e) {
-                return Collections.emptyMap();
-            }
-        }
-        return Collections.emptyMap();
+        return parseInput(input);
     }
 
-    @SuppressWarnings("unchecked")
     public Map<String, Object> toSubscriptionFilter(Object input, List<String> filterKeys) {
-        Map<String, Object> result = toSubscriptionFilter(input);
-        Map<String, Object> mutableResult = new HashMap<>(result);
+        Map<String, Object> result = new HashMap<>(toSubscriptionFilter(input));
         if (filterKeys != null && !filterKeys.isEmpty()) {
-            mutableResult.put("filterKeys", filterKeys);
+            result.put("filterKeys", filterKeys);
         }
-        return mutableResult;
+        return result;
     }
 
-    @SuppressWarnings("unchecked")
     public Map<String, Object> toSubscriptionFilter(Object input, List<String> filterKeys,
                                                      Map<String, String> headerOverrides) {
-        Map<String, Object> result = toSubscriptionFilter(input, filterKeys);
-        Map<String, Object> mutableResult = new HashMap<>(result);
+        Map<String, Object> result = new HashMap<>(toSubscriptionFilter(input, filterKeys));
         if (headerOverrides != null && !headerOverrides.isEmpty()) {
-            mutableResult.put("headerOverrides", headerOverrides);
+            result.put("headerOverrides", headerOverrides);
         }
-        return mutableResult;
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> parseInput(Object input) {
+        if (input == null) {
+            return Collections.emptyMap();
+        }
+        if (input instanceof Map<?, ?> map) {
+            return (Map<String, Object>) map;
+        }
+        if (input instanceof String s) {
+            try {
+                return objectMapper.readValue(s, Map.class);
+            } catch (Exception e) {
+                return Collections.emptyMap();
+            }
+        }
+        return Collections.emptyMap();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/TransformUtil.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/TransformUtil.java
@@ -1,0 +1,105 @@
+package io.github.hectorvent.floci.services.appsync.graphql.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TransformUtil {
+
+    private final ObjectMapper objectMapper;
+
+    public TransformUtil(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> toDynamoDBFilterExpression(Object input) {
+        if (input == null) {
+            return Collections.emptyMap();
+        }
+        Map<String, Object> source;
+        if (input instanceof Map<?, ?> map) {
+            source = (Map<String, Object>) map;
+        } else if (input instanceof String s) {
+            try {
+                source = objectMapper.readValue(s, Map.class);
+            } catch (Exception e) {
+                return Collections.emptyMap();
+            }
+        } else {
+            return Collections.emptyMap();
+        }
+
+        Map<String, Object> result = new HashMap<>();
+        if (source.containsKey("expression")) {
+            result.put("FilterExpression", source.get("expression"));
+        }
+        if (source.containsKey("expressionNames")) {
+            result.put("ExpressionAttributeNames", source.get("expressionNames"));
+        }
+        if (source.containsKey("expressionValues")) {
+            result.put("ExpressionAttributeValues", source.get("expressionValues"));
+        }
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> toElasticsearchQueryDSL(Object input) {
+        if (input == null) {
+            return Collections.emptyMap();
+        }
+        if (input instanceof Map<?, ?> map) {
+            return (Map<String, Object>) map;
+        }
+        if (input instanceof String s) {
+            try {
+                return objectMapper.readValue(s, Map.class);
+            } catch (Exception e) {
+                return Collections.emptyMap();
+            }
+        }
+        return Collections.emptyMap();
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> toSubscriptionFilter(Object input) {
+        if (input == null) {
+            return Collections.emptyMap();
+        }
+        if (input instanceof Map<?, ?> map) {
+            return (Map<String, Object>) map;
+        }
+        if (input instanceof String s) {
+            try {
+                return objectMapper.readValue(s, Map.class);
+            } catch (Exception e) {
+                return Collections.emptyMap();
+            }
+        }
+        return Collections.emptyMap();
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> toSubscriptionFilter(Object input, List<String> filterKeys) {
+        Map<String, Object> result = toSubscriptionFilter(input);
+        Map<String, Object> mutableResult = new HashMap<>(result);
+        if (filterKeys != null && !filterKeys.isEmpty()) {
+            mutableResult.put("filterKeys", filterKeys);
+        }
+        return mutableResult;
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> toSubscriptionFilter(Object input, List<String> filterKeys,
+                                                     Map<String, String> headerOverrides) {
+        Map<String, Object> result = toSubscriptionFilter(input, filterKeys);
+        Map<String, Object> mutableResult = new HashMap<>(result);
+        if (headerOverrides != null && !headerOverrides.isEmpty()) {
+            mutableResult.put("headerOverrides", headerOverrides);
+        }
+        return mutableResult;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/VtlErrorSignal.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/util/VtlErrorSignal.java
@@ -1,0 +1,27 @@
+package io.github.hectorvent.floci.services.appsync.graphql.util;
+
+public class VtlErrorSignal extends RuntimeException {
+
+    private final String errorType;
+    private final Object data;
+    private final Object errorInfo;
+
+    public VtlErrorSignal(String message, String errorType, Object data, Object errorInfo) {
+        super(message);
+        this.errorType = errorType;
+        this.data = data;
+        this.errorInfo = errorInfo;
+    }
+
+    public String getErrorType() {
+        return errorType;
+    }
+
+    public Object getData() {
+        return data;
+    }
+
+    public Object getErrorInfo() {
+        return errorInfo;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
@@ -1653,7 +1653,7 @@ class AppSyncIntegrationTest {
             .get("/v1/domainnames")
         .then()
             .statusCode(200)
-            .body("domainNames", hasSize(greaterThanOrEqualTo(1)));
+            .body("domainNameConfigs", hasSize(greaterThanOrEqualTo(1)));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/AppSyncUtilTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/AppSyncUtilTest.java
@@ -431,7 +431,7 @@ class AppSyncUtilTest {
     void error_singleArg() {
         VtlErrorSignal ex = assertThrows(VtlErrorSignal.class, () -> util.error("msg"));
         assertThat(ex.getMessage(), is("msg"));
-        assertThat(ex.getErrorType(), is("UnknownError"));
+        assertThat(ex.getErrorType(), is("Unknown"));
         assertThat(ex.getData(), is(nullValue()));
         assertThat(ex.getErrorInfo(), is(nullValue()));
     }
@@ -476,7 +476,7 @@ class AppSyncUtilTest {
     void validate_false() {
         VtlErrorSignal ex = assertThrows(VtlErrorSignal.class, () -> util.validate(false, "msg"));
         assertThat(ex.getMessage(), is("msg"));
-        assertThat(ex.getErrorType(), is("UnknownError"));
+        assertThat(ex.getErrorType(), is("Unknown"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/AppSyncUtilTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/AppSyncUtilTest.java
@@ -392,7 +392,7 @@ class AppSyncUtilTest {
 
     @Test
     void typeOf_null() {
-        assertThat(util.typeOf(null), is("null"));
+        assertThat(util.typeOf(null), is("Null"));
     }
 
     @Test
@@ -401,8 +401,10 @@ class AppSyncUtilTest {
     }
 
     @Test
-    void typeOf_integer() {
-        assertThat(util.typeOf(42), is("Integer"));
+    void typeOf_number() {
+        assertThat(util.typeOf(42), is("Number"));
+        assertThat(util.typeOf(3.14), is("Number"));
+        assertThat(util.typeOf(123L), is("Number"));
     }
 
     @Test
@@ -418,6 +420,11 @@ class AppSyncUtilTest {
     @Test
     void typeOf_map() {
         assertThat(util.typeOf(Map.of()), is("Map"));
+    }
+
+    @Test
+    void typeOf_unknown() {
+        assertThat(util.typeOf(new Object()), is("Object"));
     }
 
     @Test
@@ -457,7 +464,7 @@ class AppSyncUtilTest {
     void unauthorized() {
         VtlErrorSignal ex = assertThrows(VtlErrorSignal.class, util::unauthorized);
         assertThat(ex.getMessage(), is("Not Authorized"));
-        assertThat(ex.getErrorType(), is("UnauthorizedException"));
+        assertThat(ex.getErrorType(), is("Unauthorized"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/AppSyncUtilTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/AppSyncUtilTest.java
@@ -1,0 +1,495 @@
+package io.github.hectorvent.floci.services.appsync.graphql.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AppSyncUtilTest {
+
+    private final AppSyncUtil util = new AppSyncUtil(new com.fasterxml.jackson.databind.ObjectMapper());
+
+    @Test
+    void escapeJavaScript_null() {
+        assertThat(util.escapeJavaScript(null), is(""));
+    }
+
+    @Test
+    void escapeJavaScript_empty() {
+        assertThat(util.escapeJavaScript(""), is(""));
+    }
+
+    @Test
+    void escapeJavaScript_plain() {
+        assertThat(util.escapeJavaScript("hello"), is("hello"));
+    }
+
+    @Test
+    void escapeJavaScript_quotes() {
+        assertThat(util.escapeJavaScript("a\"b"), is("a\\\"b"));
+        assertThat(util.escapeJavaScript("a'b"), is("a\\'b"));
+    }
+
+    @Test
+    void escapeJavaScript_backslash() {
+        assertThat(util.escapeJavaScript("a\\b"), is("a\\\\b"));
+    }
+
+    @Test
+    void escapeJavaScript_controlChars() {
+        assertThat(util.escapeJavaScript("a\tb"), is("a\\tb"));
+        assertThat(util.escapeJavaScript("a\nb"), is("a\\nb"));
+        assertThat(util.escapeJavaScript("a\rb"), is("a\\rb"));
+        assertThat(util.escapeJavaScript("a\bb"), is("a\\bb"));
+        assertThat(util.escapeJavaScript("a\fb"), is("a\\fb"));
+    }
+
+    @Test
+    void escapeJavaScript_unicode() {
+        assertThat(util.escapeJavaScript("caf\u00e9"), containsString("\\u"));
+    }
+
+    @Test
+    void escapeJavaScript_slash() {
+        assertThat(util.escapeJavaScript("a/b"), is("a\\/b"));
+    }
+
+    @Test
+    void urlEncode_null() {
+        assertThat(util.urlEncode(null), is(""));
+    }
+
+    @Test
+    void urlEncode_empty() {
+        assertThat(util.urlEncode(""), is(""));
+    }
+
+    @Test
+    void urlEncode_spaces() {
+        assertThat(util.urlEncode("hello world"), is("hello+world"));
+    }
+
+    @Test
+    void urlEncode_specialChars() {
+        assertThat(util.urlEncode("a&b=c"), is("a%26b%3Dc"));
+    }
+
+    @Test
+    void urlDecode_null() {
+        assertThat(util.urlDecode(null), is(""));
+    }
+
+    @Test
+    void urlDecode_empty() {
+        assertThat(util.urlDecode(""), is(""));
+    }
+
+    @Test
+    void urlDecode_spaces() {
+        assertThat(util.urlDecode("hello+world"), is("hello world"));
+    }
+
+    @Test
+    void urlDecode_percentEncoded() {
+        assertThat(util.urlDecode("a%26b"), is("a&b"));
+    }
+
+    @Test
+    void urlEncode_roundtrip() {
+        String original = "hello world! @#$%";
+        assertThat(util.urlDecode(util.urlEncode(original)), is(original));
+    }
+
+    @Test
+    void base64Encode_null() {
+        assertThat(util.base64Encode(null), is(""));
+    }
+
+    @Test
+    void base64Encode_hello() {
+        assertThat(util.base64Encode("hello".getBytes(StandardCharsets.UTF_8)), is("aGVsbG8="));
+    }
+
+    @Test
+    void base64Decode_null() {
+        assertThat(util.base64Decode(null), is(""));
+    }
+
+    @Test
+    void base64Decode_hello() {
+        assertThat(util.base64Decode("aGVsbG8="), is("hello"));
+    }
+
+    @Test
+    void base64_roundtrip() {
+        String original = "test string with unicode: \u00e9";
+        assertThat(util.base64Decode(util.base64Encode(original.getBytes(StandardCharsets.UTF_8))), is(original));
+    }
+
+    @Test
+    void parseJson_null() {
+        Object result = util.parseJson(null);
+        assertThat(result, instanceOf(Map.class));
+        assertThat(((Map<?, ?>) result).isEmpty(), is(true));
+    }
+
+    @Test
+    void parseJson_empty() {
+        Object result = util.parseJson("");
+        assertThat(result, instanceOf(Map.class));
+        assertThat(((Map<?, ?>) result).isEmpty(), is(true));
+    }
+
+    @Test
+    void parseJson_invalid() {
+        Object result = util.parseJson("not json");
+        assertThat(result, instanceOf(Map.class));
+        assertThat(((Map<?, ?>) result).isEmpty(), is(true));
+    }
+
+    @Test
+    void parseJson_object() {
+        Object result = util.parseJson("{\"a\":1,\"b\":\"hello\"}");
+        assertThat(result, instanceOf(Map.class));
+        Map<?, ?> map = (Map<?, ?>) result;
+        assertThat(map.get("a"), is(1));
+        assertThat(map.get("b"), is("hello"));
+    }
+
+    @Test
+    void parseJson_array() {
+        Object result = util.parseJson("[1,2,3]");
+        assertThat(result, instanceOf(List.class));
+        List<?> list = (List<?>) result;
+        assertThat(list, hasSize(3));
+    }
+
+    @Test
+    void toJson_null() {
+        assertThat(util.toJson(null), is("null"));
+    }
+
+    @Test
+    void toJson_string() {
+        assertThat(util.toJson("hello"), is("\"hello\""));
+    }
+
+    @Test
+    void toJson_map() {
+        String json = util.toJson(Map.of("a", 1));
+        assertThat(json, containsString("\"a\""));
+        assertThat(json, containsString("1"));
+    }
+
+    @Test
+    void toJson_list() {
+        String json = util.toJson(List.of(1, 2, 3));
+        assertThat(json, is("[1,2,3]"));
+    }
+
+    @Test
+    void autoId_format() {
+        String id = util.autoId();
+        assertThat(id, matchesPattern("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"));
+    }
+
+    @Test
+    void autoId_uniqueness() {
+        String id1 = util.autoId();
+        String id2 = util.autoId();
+        assertThat(id1, is(not(id2)));
+    }
+
+    @Test
+    void quiet_any() {
+        assertThat(util.quiet("hello"), is(""));
+        assertThat(util.quiet(null), is(""));
+        assertThat(util.quiet(""), is(""));
+    }
+
+    @Test
+    void qr_any() {
+        assertThat(util.qr("hello"), is(""));
+        assertThat(util.qr(null), is(""));
+        assertThat(util.qr(""), is(""));
+    }
+
+    @Test
+    void matches_match() {
+        assertThat(util.matches("[a-z]+", "hello"), is(true));
+    }
+
+    @Test
+    void matches_noMatch() {
+        assertThat(util.matches("[a-z]+", "HELLO"), is(false));
+    }
+
+    @Test
+    void matches_nullPattern() {
+        assertThat(util.matches(null, "hello"), is(false));
+    }
+
+    @Test
+    void matches_nullValue() {
+        assertThat(util.matches("[a-z]+", null), is(false));
+    }
+
+    @Test
+    void defaultIfNull_null() {
+        assertThat(util.defaultIfNull(null, "default"), is("default"));
+    }
+
+    @Test
+    void defaultIfNull_nonNull() {
+        assertThat(util.defaultIfNull("value", "default"), is("value"));
+    }
+
+    @Test
+    void defaultIfNull_bothNull() {
+        assertThat(util.defaultIfNull(null, null), is(nullValue()));
+    }
+
+    @Test
+    void defaultIfNullOrEmpty_null() {
+        assertThat(util.defaultIfNullOrEmpty(null, "default"), is("default"));
+    }
+
+    @Test
+    void defaultIfNullOrEmpty_empty() {
+        assertThat(util.defaultIfNullOrEmpty("", "default"), is("default"));
+    }
+
+    @Test
+    void defaultIfNullOrEmpty_nonEmpty() {
+        assertThat(util.defaultIfNullOrEmpty("value", "default"), is("value"));
+    }
+
+    @Test
+    void defaultIfNullOrEmpty_whitespace() {
+        assertThat(util.defaultIfNullOrEmpty(" ", "default"), is(" "));
+    }
+
+    @Test
+    void defaultIfNullOrBlank_null() {
+        assertThat(util.defaultIfNullOrBlank(null, "default"), is("default"));
+    }
+
+    @Test
+    void defaultIfNullOrBlank_empty() {
+        assertThat(util.defaultIfNullOrBlank("", "default"), is("default"));
+    }
+
+    @Test
+    void defaultIfNullOrBlank_whitespace() {
+        assertThat(util.defaultIfNullOrBlank("  ", "default"), is("default"));
+    }
+
+    @Test
+    void defaultIfNullOrBlank_nonBlank() {
+        assertThat(util.defaultIfNullOrBlank("value", "default"), is("value"));
+    }
+
+    @Test
+    void isNull_null() {
+        assertThat(util.isNull(null), is(true));
+    }
+
+    @Test
+    void isNull_nonNull() {
+        assertThat(util.isNull("value"), is(false));
+    }
+
+    @Test
+    void isNullOrEmpty_null() {
+        assertThat(util.isNullOrEmpty(null), is(true));
+    }
+
+    @Test
+    void isNullOrEmpty_empty() {
+        assertThat(util.isNullOrEmpty(""), is(true));
+    }
+
+    @Test
+    void isNullOrEmpty_nonEmpty() {
+        assertThat(util.isNullOrEmpty("a"), is(false));
+    }
+
+    @Test
+    void isNullOrBlank_null() {
+        assertThat(util.isNullOrBlank(null), is(true));
+    }
+
+    @Test
+    void isNullOrBlank_empty() {
+        assertThat(util.isNullOrBlank(""), is(true));
+    }
+
+    @Test
+    void isNullOrBlank_whitespace() {
+        assertThat(util.isNullOrBlank("  "), is(true));
+    }
+
+    @Test
+    void isNullOrBlank_nonBlank() {
+        assertThat(util.isNullOrBlank("a"), is(false));
+    }
+
+    @Test
+    void isString_string() {
+        assertThat(util.isString("hello"), is(true));
+    }
+
+    @Test
+    void isString_nonString() {
+        assertThat(util.isString(123), is(false));
+    }
+
+    @Test
+    void isNumber_number() {
+        assertThat(util.isNumber(123), is(true));
+        assertThat(util.isNumber(1.5), is(true));
+    }
+
+    @Test
+    void isNumber_nonNumber() {
+        assertThat(util.isNumber("hello"), is(false));
+    }
+
+    @Test
+    void isBoolean_boolean() {
+        assertThat(util.isBoolean(true), is(true));
+    }
+
+    @Test
+    void isBoolean_nonBoolean() {
+        assertThat(util.isBoolean("true"), is(false));
+    }
+
+    @Test
+    void isList_list() {
+        assertThat(util.isList(List.of()), is(true));
+    }
+
+    @Test
+    void isList_nonList() {
+        assertThat(util.isList("[]"), is(false));
+    }
+
+    @Test
+    void isMap_map() {
+        assertThat(util.isMap(Map.of()), is(true));
+    }
+
+    @Test
+    void isMap_nonMap() {
+        assertThat(util.isMap("{}"), is(false));
+    }
+
+    @Test
+    void typeOf_null() {
+        assertThat(util.typeOf(null), is("null"));
+    }
+
+    @Test
+    void typeOf_string() {
+        assertThat(util.typeOf("hello"), is("String"));
+    }
+
+    @Test
+    void typeOf_integer() {
+        assertThat(util.typeOf(42), is("Integer"));
+    }
+
+    @Test
+    void typeOf_boolean() {
+        assertThat(util.typeOf(true), is("Boolean"));
+    }
+
+    @Test
+    void typeOf_list() {
+        assertThat(util.typeOf(List.of()), is("List"));
+    }
+
+    @Test
+    void typeOf_map() {
+        assertThat(util.typeOf(Map.of()), is("Map"));
+    }
+
+    @Test
+    void error_singleArg() {
+        VtlErrorSignal ex = assertThrows(VtlErrorSignal.class, () -> util.error("msg"));
+        assertThat(ex.getMessage(), is("msg"));
+        assertThat(ex.getErrorType(), is("UnknownError"));
+        assertThat(ex.getData(), is(nullValue()));
+        assertThat(ex.getErrorInfo(), is(nullValue()));
+    }
+
+    @Test
+    void error_twoArgs() {
+        VtlErrorSignal ex = assertThrows(VtlErrorSignal.class, () -> util.error("msg", "Custom"));
+        assertThat(ex.getMessage(), is("msg"));
+        assertThat(ex.getErrorType(), is("Custom"));
+    }
+
+    @Test
+    void error_threeArgs() {
+        Object data = Map.of("key", "value");
+        VtlErrorSignal ex = assertThrows(VtlErrorSignal.class, () -> util.error("msg", "Type", data));
+        assertThat(ex.getData(), is(data));
+        assertThat(ex.getErrorInfo(), is(nullValue()));
+    }
+
+    @Test
+    void error_fourArgs() {
+        Object data = Map.of("key", "value");
+        Object info = Map.of("info", "detail");
+        VtlErrorSignal ex = assertThrows(VtlErrorSignal.class, () -> util.error("msg", "Type", data, info));
+        assertThat(ex.getData(), is(data));
+        assertThat(ex.getErrorInfo(), is(info));
+    }
+
+    @Test
+    void unauthorized() {
+        VtlErrorSignal ex = assertThrows(VtlErrorSignal.class, util::unauthorized);
+        assertThat(ex.getMessage(), is("Not Authorized"));
+        assertThat(ex.getErrorType(), is("UnauthorizedException"));
+    }
+
+    @Test
+    void validate_true() {
+        assertDoesNotThrow(() -> util.validate(true, "msg"));
+    }
+
+    @Test
+    void validate_false() {
+        VtlErrorSignal ex = assertThrows(VtlErrorSignal.class, () -> util.validate(false, "msg"));
+        assertThat(ex.getMessage(), is("msg"));
+        assertThat(ex.getErrorType(), is("UnknownError"));
+    }
+
+    @Test
+    void validate_false_withType() {
+        VtlErrorSignal ex = assertThrows(VtlErrorSignal.class, () -> util.validate(false, "msg", "Custom"));
+        assertThat(ex.getErrorType(), is("Custom"));
+    }
+
+    @Test
+    void validate_false_withData() {
+        Object data = Map.of("k", "v");
+        VtlErrorSignal ex = assertThrows(VtlErrorSignal.class, () -> util.validate(false, "msg", "Type", data));
+        assertThat(ex.getData(), is(data));
+    }
+
+    @Test
+    void appendError_noException() {
+        assertDoesNotThrow(() -> util.appendError("msg"));
+        assertDoesNotThrow(() -> util.appendError("msg", "Type"));
+        assertDoesNotThrow(() -> util.appendError("msg", "Type", Map.of()));
+        assertDoesNotThrow(() -> util.appendError("msg", "Type", Map.of(), Map.of()));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/DynamoDbUtilTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/DynamoDbUtilTest.java
@@ -308,13 +308,15 @@ class DynamoDbUtilTest {
     @Test
     void toMapValues() {
         Map<String, Object> result = dynamoDb.toMapValues(Map.of("k", "v"));
-        assertThat(result, hasKey("M"));
+        assertThat(result, hasKey("k"));
+        assertThat((Map<?, ?>) result.get("k"), hasEntry("S", "v"));
     }
 
     @Test
     void toMapValuesJson() {
         String result = dynamoDb.toMapValuesJson(Map.of("k", "v"));
-        assertThat(result, containsString("\"M\""));
+        assertThat(result, containsString("k"));
+        assertThat(result, containsString("\"S\""));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/DynamoDbUtilTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/DynamoDbUtilTest.java
@@ -1,0 +1,332 @@
+package io.github.hectorvent.floci.services.appsync.graphql.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DynamoDbUtilTest {
+
+    private final DynamoDbUtil dynamoDb = new DynamoDbUtil(new ObjectMapper());
+
+    @Test
+    void toDynamoDB_string() {
+        Map<String, Object> result = dynamoDb.toDynamoDB("hello");
+        assertThat(result, hasEntry("S", "hello"));
+    }
+
+    @Test
+    void toDynamoDB_number() {
+        Map<String, Object> result = dynamoDb.toDynamoDB(42);
+        assertThat(result, hasEntry("N", "42"));
+    }
+
+    @Test
+    void toDynamoDB_long() {
+        Map<String, Object> result = dynamoDb.toDynamoDB(123456789L);
+        assertThat(result, hasEntry("N", "123456789"));
+    }
+
+    @Test
+    void toDynamoDB_double() {
+        Map<String, Object> result = dynamoDb.toDynamoDB(3.14);
+        assertThat(result, hasEntry("N", "3.14"));
+    }
+
+    @Test
+    void toDynamoDB_boolean_true() {
+        Map<String, Object> result = dynamoDb.toDynamoDB(true);
+        assertThat(result, hasEntry("BOOL", true));
+    }
+
+    @Test
+    void toDynamoDB_boolean_false() {
+        Map<String, Object> result = dynamoDb.toDynamoDB(false);
+        assertThat(result, hasEntry("BOOL", false));
+    }
+
+    @Test
+    void toDynamoDB_null() {
+        Map<String, Object> result = dynamoDb.toDynamoDB(null);
+        assertThat(result, hasEntry("NULL", true));
+    }
+
+    @Test
+    void toDynamoDB_list() {
+        Map<String, Object> result = dynamoDb.toDynamoDB(List.of("a", "b"));
+        assertThat(result, hasKey("L"));
+        List<?> l = (List<?>) result.get("L");
+        assertThat(l, hasSize(2));
+        assertThat((Map<?, ?>) l.get(0), hasEntry("S", "a"));
+        assertThat((Map<?, ?>) l.get(1), hasEntry("S", "b"));
+    }
+
+    @Test
+    void toDynamoDB_map() {
+        Map<String, Object> result = dynamoDb.toDynamoDB(Map.of("key", "value"));
+        assertThat(result, hasKey("M"));
+        Map<?, ?> m = (Map<?, ?>) result.get("M");
+        assertThat((Map<?, ?>) m.get("key"), hasEntry("S", "value"));
+    }
+
+    @Test
+    void toDynamoDB_nestedMap() {
+        Map<String, Object> inner = Map.of("b", "c");
+        Map<String, Object> outer = Map.of("a", inner);
+        Map<String, Object> result = dynamoDb.toDynamoDB(outer);
+        assertThat(result, hasKey("M"));
+        Map<?, ?> m = (Map<?, ?>) result.get("M");
+        assertThat(m, hasKey("a"));
+        Map<?, ?> innerResult = (Map<?, ?>) ((Map<?, ?>) m.get("a")).get("M");
+        Map<?, ?> bResult = (Map<?, ?>) innerResult.get("b");
+        assertThat((String) bResult.get("S"), is("c"));
+    }
+
+    @Test
+    void toDynamoDB_listOfMaps() {
+        List<Map<String, Object>> list = List.of(Map.of("k", "v"));
+        Map<String, Object> result = dynamoDb.toDynamoDB(list);
+        assertThat(result, hasKey("L"));
+        List<?> l = (List<?>) result.get("L");
+        assertThat(l, hasSize(1));
+        assertThat((Map<?, ?>) ((Map<?, ?>) l.get(0)).get("M"), hasKey("k"));
+    }
+
+    @Test
+    void toDynamoDB_unknownType() {
+        Map<String, Object> result = dynamoDb.toDynamoDB(new Object());
+        assertThat((String) result.get("S"), startsWith("java.lang.Object"));
+    }
+
+    @Test
+    void toString_basic() {
+        Map<String, Object> result = dynamoDb.toString("hello");
+        assertThat(result, hasEntry("S", "hello"));
+    }
+
+    @Test
+    void toString_empty() {
+        Map<String, Object> result = dynamoDb.toString("");
+        assertThat(result, hasEntry("S", ""));
+    }
+
+    @Test
+    void toString_null() {
+        Map<String, Object> result = dynamoDb.toString(null);
+        assertThat(result, hasKey("S"));
+        assertThat(result.get("S"), is(nullValue()));
+    }
+
+    @Test
+    void toNumber_int() {
+        Map<String, Object> result = dynamoDb.toNumber(42);
+        assertThat(result, hasEntry("N", "42"));
+    }
+
+    @Test
+    void toNumber_long() {
+        Map<String, Object> result = dynamoDb.toNumber(123456789L);
+        assertThat(result, hasEntry("N", "123456789"));
+    }
+
+    @Test
+    void toNumber_double() {
+        Map<String, Object> result = dynamoDb.toNumber(3.14);
+        assertThat(result, hasEntry("N", "3.14"));
+    }
+
+    @Test
+    void toBoolean_true() {
+        Map<String, Object> result = dynamoDb.toBoolean(true);
+        assertThat(result, hasEntry("BOOL", true));
+    }
+
+    @Test
+    void toBoolean_false() {
+        Map<String, Object> result = dynamoDb.toBoolean(false);
+        assertThat(result, hasEntry("BOOL", false));
+    }
+
+    @Test
+    void toNull() {
+        Map<String, Object> result = dynamoDb.toNull();
+        assertThat(result, hasEntry("NULL", true));
+    }
+
+    @Test
+    void toList_strings() {
+        Map<String, Object> result = dynamoDb.toList(List.of("a", "b"));
+        assertThat(result, hasKey("L"));
+        List<?> l = (List<?>) result.get("L");
+        assertThat(l, hasSize(2));
+    }
+
+    @Test
+    void toList_numbers() {
+        Map<String, Object> result = dynamoDb.toList(List.of(1, 2, 3));
+        assertThat(result, hasKey("L"));
+        List<?> l = (List<?>) result.get("L");
+        assertThat(l, hasSize(3));
+    }
+
+    @Test
+    void toList_empty() {
+        Map<String, Object> result = dynamoDb.toList(List.of());
+        assertThat(result, hasKey("L"));
+        List<?> l = (List<?>) result.get("L");
+        assertThat(l, empty());
+    }
+
+    @Test
+    void toMap_flat() {
+        Map<String, Object> result = dynamoDb.toMap(Map.of("k", "v"));
+        assertThat(result, hasKey("M"));
+        Map<?, ?> m = (Map<?, ?>) result.get("M");
+        assertThat((String) ((Map<?, ?>) m.get("k")).get("S"), is("v"));
+    }
+
+    @Test
+    void toMap_empty() {
+        Map<String, Object> result = dynamoDb.toMap(Map.of());
+        assertThat(result, hasKey("M"));
+        Map<?, ?> m = (Map<?, ?>) result.get("M");
+        assertThat(m, anEmptyMap());
+    }
+
+    @Test
+    void toStringSet() {
+        Map<String, Object> result = dynamoDb.toStringSet(List.of("a", "b"));
+        assertThat(result, hasEntry("SS", List.of("a", "b")));
+    }
+
+    @Test
+    void toStringSet_empty() {
+        Map<String, Object> result = dynamoDb.toStringSet(List.of());
+        assertThat(result, hasEntry("SS", List.of()));
+    }
+
+    @Test
+    void toNumberSet() {
+        Map<String, Object> result = dynamoDb.toNumberSet(List.of(1, 2, 3));
+        assertThat(result, hasKey("NS"));
+        List<?> ns = (List<?>) result.get("NS");
+        assertThat(ns, hasSize(3));
+        assertThat(ns, contains("1", "2", "3"));
+    }
+
+    @Test
+    void toNumberSet_empty() {
+        Map<String, Object> result = dynamoDb.toNumberSet(List.of());
+        assertThat(result, hasEntry("NS", List.of()));
+    }
+
+    @Test
+    void toBinary() {
+        Map<String, Object> result = dynamoDb.toBinary("hello");
+        assertThat(result, hasKey("B"));
+    }
+
+    @Test
+    void toBinary_empty() {
+        Map<String, Object> result = dynamoDb.toBinary("");
+        assertThat(result, hasKey("B"));
+    }
+
+    @Test
+    void toBinarySet() {
+        Map<String, Object> result = dynamoDb.toBinarySet(List.of("a", "b"));
+        assertThat(result, hasKey("BS"));
+        List<?> bs = (List<?>) result.get("BS");
+        assertThat(bs, hasSize(2));
+    }
+
+    @Test
+    void toBinarySet_empty() {
+        Map<String, Object> result = dynamoDb.toBinarySet(List.of());
+        assertThat(result, hasEntry("BS", List.of()));
+    }
+
+    @Test
+    void toDynamoDBJson_valid() {
+        String json = dynamoDb.toDynamoDBJson("hello");
+        assertThat(json, containsString("\"S\""));
+        assertThat(json, containsString("hello"));
+    }
+
+    @Test
+    void toDynamoDBJson_map() {
+        String json = dynamoDb.toDynamoDBJson(Map.of("key", "value"));
+        assertThat(json, containsString("\"M\""));
+        assertThat(json, containsString("key"));
+    }
+
+    @Test
+    void toStringJson() {
+        Map<String, String> result = dynamoDb.toStringJson("hello");
+        assertThat(result, hasEntry("S", "hello"));
+    }
+
+    @Test
+    void toNumberJson() {
+        Map<String, String> result = dynamoDb.toNumberJson(42);
+        assertThat(result, hasEntry("N", "42"));
+    }
+
+    @Test
+    void toBooleanJson() {
+        Map<String, String> result = dynamoDb.toBooleanJson(true);
+        assertThat(result, hasEntry("BOOL", "true"));
+    }
+
+    @Test
+    void toNullJson() {
+        Map<String, String> result = dynamoDb.toNullJson();
+        assertThat(result, hasEntry("NULL", "true"));
+    }
+
+    @Test
+    void toListJson() {
+        Map<String, Object> result = dynamoDb.toListJson(List.of("a"));
+        assertThat(result, hasKey("L"));
+    }
+
+    @Test
+    void toMapJson() {
+        Map<String, Object> result = dynamoDb.toMapJson(Map.of("k", "v"));
+        assertThat(result, hasKey("M"));
+    }
+
+    @Test
+    void toMapValues() {
+        Map<String, Object> result = dynamoDb.toMapValues(Map.of("k", "v"));
+        assertThat(result, hasKey("M"));
+    }
+
+    @Test
+    void toMapValuesJson() {
+        Map<String, Object> result = dynamoDb.toMapValuesJson(Map.of("k", "v"));
+        assertThat(result, hasKey("M"));
+    }
+
+    @Test
+    void toStringSetJson() {
+        Map<String, Object> result = dynamoDb.toStringSetJson(List.of("a"));
+        assertThat(result, hasKey("SS"));
+    }
+
+    @Test
+    void toNumberSetJson() {
+        Map<String, Object> result = dynamoDb.toNumberSetJson(List.of(1));
+        assertThat(result, hasKey("NS"));
+    }
+
+    @Test
+    void toBinarySetJson() {
+        Map<String, Object> result = dynamoDb.toBinarySetJson(List.of("a"));
+        assertThat(result, hasKey("BS"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/DynamoDbUtilTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/DynamoDbUtilTest.java
@@ -266,38 +266,43 @@ class DynamoDbUtilTest {
 
     @Test
     void toStringJson() {
-        Map<String, String> result = dynamoDb.toStringJson("hello");
-        assertThat(result, hasEntry("S", "hello"));
+        String result = dynamoDb.toStringJson("hello");
+        assertThat(result, containsString("\"S\""));
+        assertThat(result, containsString("hello"));
     }
 
     @Test
     void toNumberJson() {
-        Map<String, String> result = dynamoDb.toNumberJson(42);
-        assertThat(result, hasEntry("N", "42"));
+        String result = dynamoDb.toNumberJson(42);
+        assertThat(result, containsString("\"N\""));
+        assertThat(result, containsString("42"));
     }
 
     @Test
     void toBooleanJson() {
-        Map<String, String> result = dynamoDb.toBooleanJson(true);
-        assertThat(result, hasEntry("BOOL", "true"));
+        String result = dynamoDb.toBooleanJson(true);
+        assertThat(result, containsString("\"BOOL\""));
+        assertThat(result, containsString("true"));
     }
 
     @Test
     void toNullJson() {
-        Map<String, String> result = dynamoDb.toNullJson();
-        assertThat(result, hasEntry("NULL", "true"));
+        String result = dynamoDb.toNullJson();
+        assertThat(result, containsString("\"NULL\""));
+        assertThat(result, containsString("true"));
     }
 
     @Test
     void toListJson() {
-        Map<String, Object> result = dynamoDb.toListJson(List.of("a"));
-        assertThat(result, hasKey("L"));
+        String result = dynamoDb.toListJson(List.of("a"));
+        assertThat(result, containsString("\"L\""));
     }
 
     @Test
     void toMapJson() {
-        Map<String, Object> result = dynamoDb.toMapJson(Map.of("k", "v"));
-        assertThat(result, hasKey("M"));
+        String result = dynamoDb.toMapJson(Map.of("k", "v"));
+        assertThat(result, containsString("\"M\""));
+        assertThat(result, containsString("k"));
     }
 
     @Test
@@ -308,25 +313,25 @@ class DynamoDbUtilTest {
 
     @Test
     void toMapValuesJson() {
-        Map<String, Object> result = dynamoDb.toMapValuesJson(Map.of("k", "v"));
-        assertThat(result, hasKey("M"));
+        String result = dynamoDb.toMapValuesJson(Map.of("k", "v"));
+        assertThat(result, containsString("\"M\""));
     }
 
     @Test
     void toStringSetJson() {
-        Map<String, Object> result = dynamoDb.toStringSetJson(List.of("a"));
-        assertThat(result, hasKey("SS"));
+        String result = dynamoDb.toStringSetJson(List.of("a"));
+        assertThat(result, containsString("\"SS\""));
     }
 
     @Test
     void toNumberSetJson() {
-        Map<String, Object> result = dynamoDb.toNumberSetJson(List.of(1));
-        assertThat(result, hasKey("NS"));
+        String result = dynamoDb.toNumberSetJson(List.of(1));
+        assertThat(result, containsString("\"NS\""));
     }
 
     @Test
     void toBinarySetJson() {
-        Map<String, Object> result = dynamoDb.toBinarySetJson(List.of("a"));
-        assertThat(result, hasKey("BS"));
+        String result = dynamoDb.toBinarySetJson(List.of("a"));
+        assertThat(result, containsString("\"BS\""));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/ListUtilTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/ListUtilTest.java
@@ -1,0 +1,127 @@
+package io.github.hectorvent.floci.services.appsync.graphql.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ListUtilTest {
+
+    private final ListUtil listUtil = new ListUtil();
+
+    @Test
+    void copyAndRetainAll_basic() {
+        List<Object> result = listUtil.copyAndRetainAll(List.of(1, 2, 3), List.of(2, 3, 4));
+        assertThat(result, containsInAnyOrder(2, 3));
+    }
+
+    @Test
+    void copyAndRetainAll_noOverlap() {
+        List<Object> result = listUtil.copyAndRetainAll(List.of(1, 2, 3), List.of(4, 5));
+        assertThat(result, empty());
+    }
+
+    @Test
+    void copyAndRetainAll_allRetained() {
+        List<Object> result = listUtil.copyAndRetainAll(List.of(1, 2, 3), List.of(1, 2, 3));
+        assertThat(result, containsInAnyOrder(1, 2, 3));
+    }
+
+    @Test
+    void copyAndRetainAll_emptyKeep() {
+        List<Object> result = listUtil.copyAndRetainAll(List.of(1, 2, 3), List.of());
+        assertThat(result, empty());
+    }
+
+    @Test
+    void copyAndRetainAll_nullList() {
+        List<Object> result = listUtil.copyAndRetainAll(null, List.of(1));
+        assertThat(result, empty());
+    }
+
+    @Test
+    void copyAndRetainAll_nullKeep() {
+        List<Object> result = listUtil.copyAndRetainAll(List.of(1, 2, 3), null);
+        assertThat(result, containsInAnyOrder(1, 2, 3));
+    }
+
+    @Test
+    void copyAndRemoveAll_basic() {
+        List<Object> result = listUtil.copyAndRemoveAll(List.of(1, 2, 3), List.of(2));
+        assertThat(result, containsInAnyOrder(1, 3));
+    }
+
+    @Test
+    void copyAndRemoveAll_noOverlap() {
+        List<Object> result = listUtil.copyAndRemoveAll(List.of(1, 2, 3), List.of(4, 5));
+        assertThat(result, containsInAnyOrder(1, 2, 3));
+    }
+
+    @Test
+    void copyAndRemoveAll_allRemoved() {
+        List<Object> result = listUtil.copyAndRemoveAll(List.of(1, 2, 3), List.of(1, 2, 3));
+        assertThat(result, empty());
+    }
+
+    @Test
+    void copyAndRemoveAll_emptyRemove() {
+        List<Object> result = listUtil.copyAndRemoveAll(List.of(1, 2, 3), List.of());
+        assertThat(result, containsInAnyOrder(1, 2, 3));
+    }
+
+    @Test
+    void copyAndRemoveAll_nullList() {
+        List<Object> result = listUtil.copyAndRemoveAll(null, List.of(1));
+        assertThat(result, empty());
+    }
+
+    @Test
+    void copyAndRemoveAll_nullRemove() {
+        List<Object> result = listUtil.copyAndRemoveAll(List.of(1, 2, 3), null);
+        assertThat(result, containsInAnyOrder(1, 2, 3));
+    }
+
+    @Test
+    void sortList_basic() {
+        List<Object> result = listUtil.sortList(List.of(3, 1, 2), false, null);
+        assertThat(result, contains(1, 2, 3));
+    }
+
+    @Test
+    void sortList_descending() {
+        List<Object> result = listUtil.sortList(List.of(3, 1, 2), true, null);
+        assertThat(result, contains(3, 2, 1));
+    }
+
+    @Test
+    void sortList_withFieldName() {
+        var map1 = new java.util.HashMap<String, Object>();
+        map1.put("name", "Charlie");
+        var map2 = new java.util.HashMap<String, Object>();
+        map2.put("name", "Alice");
+        var map3 = new java.util.HashMap<String, Object>();
+        map3.put("name", "Bob");
+        List<Object> input = List.of(map1, map2, map3);
+        List<Object> result = listUtil.sortList(input, false, "name");
+        assertThat(((Map<?, ?>) result.get(0)).get("name"), is("Alice"));
+        assertThat(((Map<?, ?>) result.get(1)).get("name"), is("Bob"));
+        assertThat(((Map<?, ?>) result.get(2)).get("name"), is("Charlie"));
+    }
+
+    @Test
+    void sortList_null() {
+        List<Object> result = listUtil.sortList(null, false, null);
+        assertThat(result, empty());
+    }
+
+    @Test
+    void sortList_empty() {
+        List<Object> result = listUtil.sortList(List.of(), false, null);
+        assertThat(result, empty());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/MapUtilTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/MapUtilTest.java
@@ -1,0 +1,110 @@
+package io.github.hectorvent.floci.services.appsync.graphql.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MapUtilTest {
+
+    private final MapUtil mapUtil = new MapUtil();
+
+    @Test
+    void copyAndRetainAllKeys_basic() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("a", 1);
+        map.put("b", 2);
+        map.put("c", 3);
+        Map<String, Object> result = mapUtil.copyAndRetainAllKeys(map, List.of("a", "c"));
+        assertThat(result, hasEntry("a", 1));
+        assertThat(result, hasEntry("c", 3));
+        assertThat(result, not(hasKey("b")));
+    }
+
+    @Test
+    void copyAndRetainAllKeys_noOverlap() {
+        Map<String, Object> map = Map.of("a", 1, "b", 2);
+        Map<String, Object> result = mapUtil.copyAndRetainAllKeys(map, List.of("x", "y"));
+        assertThat(result, anEmptyMap());
+    }
+
+    @Test
+    void copyAndRetainAllKeys_allRetained() {
+        Map<String, Object> map = Map.of("a", 1, "b", 2);
+        Map<String, Object> result = mapUtil.copyAndRetainAllKeys(map, List.of("a", "b"));
+        assertThat(result, hasEntry("a", 1));
+        assertThat(result, hasEntry("b", 2));
+    }
+
+    @Test
+    void copyAndRetainAllKeys_emptyKeys() {
+        Map<String, Object> map = Map.of("a", 1);
+        Map<String, Object> result = mapUtil.copyAndRetainAllKeys(map, List.of());
+        assertThat(result, anEmptyMap());
+    }
+
+    @Test
+    void copyAndRetainAllKeys_nullMap() {
+        Map<String, Object> result = mapUtil.copyAndRetainAllKeys(null, List.of("a"));
+        assertThat(result, anEmptyMap());
+    }
+
+    @Test
+    void copyAndRetainAllKeys_nullKeys() {
+        Map<String, Object> map = Map.of("a", 1);
+        Map<String, Object> result = mapUtil.copyAndRetainAllKeys(map, null);
+        assertThat(result, hasEntry("a", 1));
+    }
+
+    @Test
+    void copyAndRemoveAllKeys_basic() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("a", 1);
+        map.put("b", 2);
+        map.put("c", 3);
+        Map<String, Object> result = mapUtil.copyAndRemoveAllKeys(map, List.of("b"));
+        assertThat(result, hasEntry("a", 1));
+        assertThat(result, hasEntry("c", 3));
+        assertThat(result, not(hasKey("b")));
+    }
+
+    @Test
+    void copyAndRemoveAllKeys_noOverlap() {
+        Map<String, Object> map = Map.of("a", 1, "b", 2);
+        Map<String, Object> result = mapUtil.copyAndRemoveAllKeys(map, List.of("x", "y"));
+        assertThat(result, hasEntry("a", 1));
+        assertThat(result, hasEntry("b", 2));
+    }
+
+    @Test
+    void copyAndRemoveAllKeys_allRemoved() {
+        Map<String, Object> map = Map.of("a", 1, "b", 2);
+        Map<String, Object> result = mapUtil.copyAndRemoveAllKeys(map, List.of("a", "b"));
+        assertThat(result, anEmptyMap());
+    }
+
+    @Test
+    void copyAndRemoveAllKeys_emptyKeys() {
+        Map<String, Object> map = Map.of("a", 1);
+        Map<String, Object> result = mapUtil.copyAndRemoveAllKeys(map, List.of());
+        assertThat(result, hasEntry("a", 1));
+    }
+
+    @Test
+    void copyAndRemoveAllKeys_nullMap() {
+        Map<String, Object> result = mapUtil.copyAndRemoveAllKeys(null, List.of("a"));
+        assertThat(result, anEmptyMap());
+    }
+
+    @Test
+    void copyAndRemoveAllKeys_nullKeys() {
+        Map<String, Object> map = Map.of("a", 1);
+        Map<String, Object> result = mapUtil.copyAndRemoveAllKeys(map, null);
+        assertThat(result, hasEntry("a", 1));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/MathUtilTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/MathUtilTest.java
@@ -1,0 +1,119 @@
+package io.github.hectorvent.floci.services.appsync.graphql.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MathUtilTest {
+
+    private final MathUtil math = new MathUtil();
+
+    @Test
+    void roundNum_basic() {
+        assertThat(math.roundNum(2.3), is(2));
+        assertThat(math.roundNum(2.5), is(3));
+        assertThat(math.roundNum(2.7), is(3));
+    }
+
+    @Test
+    void roundNum_negative() {
+        assertThat(math.roundNum(-2.3), is(-2));
+        assertThat(math.roundNum(-2.5), is(-3));
+    }
+
+    @Test
+    void roundNum_null() {
+        assertThat(math.roundNum(null), is(0));
+    }
+
+    @Test
+    void roundNum_integer() {
+        assertThat(math.roundNum(3.0), is(3));
+    }
+
+    @Test
+    void minVal_basic() {
+        assertThat(math.minVal(3.0, 1.0), is(1.0));
+        assertThat(math.minVal(1.0, 3.0), is(1.0));
+    }
+
+    @Test
+    void minVal_equal() {
+        assertThat(math.minVal(2.0, 2.0), is(2.0));
+    }
+
+    @Test
+    void minVal_negative() {
+        assertThat(math.minVal(-1.0, -3.0), is(-3.0));
+    }
+
+    @Test
+    void minVal_nullFirst() {
+        assertThat(math.minVal(null, 5.0), is(5.0));
+    }
+
+    @Test
+    void minVal_nullSecond() {
+        assertThat(math.minVal(5.0, null), is(5.0));
+    }
+
+    @Test
+    void minVal_bothNull() {
+        assertThat(math.minVal(null, null), is(0.0));
+    }
+
+    @Test
+    void maxVal_basic() {
+        assertThat(math.maxVal(3.0, 1.0), is(3.0));
+        assertThat(math.maxVal(1.0, 3.0), is(3.0));
+    }
+
+    @Test
+    void maxVal_equal() {
+        assertThat(math.maxVal(2.0, 2.0), is(2.0));
+    }
+
+    @Test
+    void maxVal_negative() {
+        assertThat(math.maxVal(-1.0, -3.0), is(-1.0));
+    }
+
+    @Test
+    void maxVal_nullFirst() {
+        assertThat(math.maxVal(null, 5.0), is(5.0));
+    }
+
+    @Test
+    void maxVal_nullSecond() {
+        assertThat(math.maxVal(5.0, null), is(5.0));
+    }
+
+    @Test
+    void maxVal_bothNull() {
+        assertThat(math.maxVal(null, null), is(0.0));
+    }
+
+    @Test
+    void randomDouble_range() {
+        double result = math.randomDouble();
+        assertThat(result, greaterThanOrEqualTo(0.0));
+        assertThat(result, lessThan(1.0));
+    }
+
+    @Test
+    void randomWithinRange_range() {
+        for (int i = 0; i < 100; i++) {
+            int result = math.randomWithinRange(5, 10);
+            assertThat(result, greaterThanOrEqualTo(5));
+            assertThat(result, lessThanOrEqualTo(10));
+        }
+    }
+
+    @Test
+    void randomWithinRange_null() {
+        assertThat(math.randomWithinRange(null, 10), is(0));
+        assertThat(math.randomWithinRange(5, null), is(0));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/StrUtilTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/StrUtilTest.java
@@ -81,37 +81,51 @@ class StrUtilTest {
     }
 
     @Test
-    void normalize_basic() {
-        assertThat(str.normalize("hello   world", " "), is("hello world"));
+    void normalize_nfc() {
+        // e + combining acute accent → precomposed é
+        String input = "e\u0301";
+        assertThat(str.normalize(input, "nfc"), is("\u00e9"));
     }
 
     @Test
-    void normalize_tabs() {
-        assertThat(str.normalize("hello\tworld", " "), is("hello world"));
+    void normalize_nfd() {
+        // precomposed é → e + combining acute accent
+        String input = "\u00e9";
+        assertThat(str.normalize(input, "nfd"), is("e\u0301"));
     }
 
     @Test
-    void normalize_mixed() {
-        assertThat(str.normalize("hello \t\n world", " "), is("hello world"));
+    void normalize_nfkc() {
+        // fullwidth Latin small letter e → normal e
+        String input = "\uff45";
+        assertThat(str.normalize(input, "nfkc"), is("e"));
     }
 
     @Test
-    void normalize_customReplacement() {
-        assertThat(str.normalize("hello   world", "-"), is("hello-world"));
+    void normalize_nfkd() {
+        // fullwidth Latin small letter e → normal e
+        String input = "\uff45";
+        assertThat(str.normalize(input, "nfkd"), is("e"));
+    }
+
+    @Test
+    void normalize_caseInsensitive() {
+        String input = "e\u0301";
+        assertThat(str.normalize(input, "NFC"), is("\u00e9"));
     }
 
     @Test
     void normalize_null() {
-        assertThat(str.normalize(null, " "), is(""));
+        assertThat(str.normalize(null, "nfc"), is(""));
     }
 
     @Test
-    void normalize_nullReplacement() {
-        assertThat(str.normalize("hello   world", null), is("hello world"));
+    void normalize_nullForm() {
+        assertThat(str.normalize("hello", null), is("hello"));
     }
 
     @Test
-    void normalize_noWhitespace() {
-        assertThat(str.normalize("hello", " "), is("hello"));
+    void normalize_alreadyNormalized() {
+        assertThat(str.normalize("hello", "nfc"), is("hello"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/StrUtilTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/StrUtilTest.java
@@ -1,0 +1,117 @@
+package io.github.hectorvent.floci.services.appsync.graphql.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class StrUtilTest {
+
+    private final StrUtil str = new StrUtil();
+
+    @Test
+    void toUpper_basic() {
+        assertThat(str.toUpper("hello"), is("HELLO"));
+    }
+
+    @Test
+    void toUpper_mixed() {
+        assertThat(str.toUpper("Hello World"), is("HELLO WORLD"));
+    }
+
+    @Test
+    void toUpper_null() {
+        assertThat(str.toUpper(null), is(""));
+    }
+
+    @Test
+    void toUpper_empty() {
+        assertThat(str.toUpper(""), is(""));
+    }
+
+    @Test
+    void toLower_basic() {
+        assertThat(str.toLower("HELLO"), is("hello"));
+    }
+
+    @Test
+    void toLower_mixed() {
+        assertThat(str.toLower("Hello World"), is("hello world"));
+    }
+
+    @Test
+    void toLower_null() {
+        assertThat(str.toLower(null), is(""));
+    }
+
+    @Test
+    void toLower_empty() {
+        assertThat(str.toLower(""), is(""));
+    }
+
+    @Test
+    void toReplace_basic() {
+        assertThat(str.toReplace("hello world", "world", "there"), is("hello there"));
+    }
+
+    @Test
+    void toReplace_multiple() {
+        assertThat(str.toReplace("aabbcc", "bb", "xx"), is("aaxxcc"));
+    }
+
+    @Test
+    void toReplace_noMatch() {
+        assertThat(str.toReplace("hello", "xyz", "abc"), is("hello"));
+    }
+
+    @Test
+    void toReplace_nullString() {
+        assertThat(str.toReplace(null, "a", "b"), is(""));
+    }
+
+    @Test
+    void toReplace_nullTarget() {
+        assertThat(str.toReplace("hello", null, "b"), is("hello"));
+    }
+
+    @Test
+    void toReplace_nullReplacement() {
+        assertThat(str.toReplace("hello", "l", null), is("hello"));
+    }
+
+    @Test
+    void normalize_basic() {
+        assertThat(str.normalize("hello   world", " "), is("hello world"));
+    }
+
+    @Test
+    void normalize_tabs() {
+        assertThat(str.normalize("hello\tworld", " "), is("hello world"));
+    }
+
+    @Test
+    void normalize_mixed() {
+        assertThat(str.normalize("hello \t\n world", " "), is("hello world"));
+    }
+
+    @Test
+    void normalize_customReplacement() {
+        assertThat(str.normalize("hello   world", "-"), is("hello-world"));
+    }
+
+    @Test
+    void normalize_null() {
+        assertThat(str.normalize(null, " "), is(""));
+    }
+
+    @Test
+    void normalize_nullReplacement() {
+        assertThat(str.normalize("hello   world", null), is("hello world"));
+    }
+
+    @Test
+    void normalize_noWhitespace() {
+        assertThat(str.normalize("hello", " "), is("hello"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/TimeUtilTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/TimeUtilTest.java
@@ -1,0 +1,150 @@
+package io.github.hectorvent.floci.services.appsync.graphql.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class TimeUtilTest {
+
+    private final TimeUtil time = new TimeUtil();
+
+    @Test
+    void nowISO8601_format() {
+        String result = time.nowISO8601();
+        assertThat(result, matchesPattern("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+Z"));
+    }
+
+    @Test
+    void nowISO8601_currentDate() {
+        String result = time.nowISO8601();
+        String today = DateTimeFormatter.ofPattern("yyyy-MM-dd").format(ZonedDateTime.now(ZoneOffset.UTC));
+        assertThat(result, startsWith(today));
+    }
+
+    @Test
+    void nowEpochSeconds_positive() {
+        long result = time.nowEpochSeconds();
+        assertThat(result, greaterThan(0L));
+    }
+
+    @Test
+    void nowEpochSeconds_withinRange() {
+        long expected = System.currentTimeMillis() / 1000;
+        long result = time.nowEpochSeconds();
+        assertThat(Math.abs(result - expected), is(lessThanOrEqualTo(1L)));
+    }
+
+    @Test
+    void nowEpochMilliSeconds_positive() {
+        long result = time.nowEpochMilliSeconds();
+        assertThat(result, greaterThan(0L));
+    }
+
+    @Test
+    void nowEpochMilliSeconds_withinRange() {
+        long expected = System.currentTimeMillis();
+        long result = time.nowEpochMilliSeconds();
+        assertThat(Math.abs(result - expected), is(lessThanOrEqualTo(100L)));
+    }
+
+    @Test
+    void nowFormatted_utc() {
+        String result = time.nowFormatted("yyyy-MM-dd");
+        String today = DateTimeFormatter.ofPattern("yyyy-MM-dd").format(ZonedDateTime.now(ZoneOffset.UTC));
+        assertThat(result, is(today));
+    }
+
+    @Test
+    void nowFormatted_withOffset() {
+        String result = time.nowFormatted("HH", "+05:30");
+        assertThat(result, matchesPattern("\\d{2}"));
+    }
+
+    @Test
+    void nowFormatted_invalidFormat() {
+        assertThrows(Exception.class, () -> time.nowFormatted("INVALID"));
+    }
+
+    @Test
+    void parseISO8601ToEpochMilliSeconds_valid() {
+        long result = time.parseISO8601ToEpochMilliSeconds("2024-01-15T12:00:00Z");
+        Instant instant = Instant.parse("2024-01-15T12:00:00Z");
+        assertThat(result, is(instant.toEpochMilli()));
+    }
+
+    @Test
+    void parseISO8601ToEpochMilliSeconds_epoch0() {
+        long result = time.parseISO8601ToEpochMilliSeconds("1970-01-01T00:00:00Z");
+        assertThat(result, is(0L));
+    }
+
+    @Test
+    void parseISO8601ToEpochMilliSeconds_invalid() {
+        assertThrows(Exception.class, () -> time.parseISO8601ToEpochMilliSeconds("not-a-date"));
+    }
+
+    @Test
+    void parseFormattedToEpochMilliSeconds_valid() {
+        long result = time.parseFormattedToEpochMilliSeconds("2024-01-15 12:00:00", "yyyy-MM-dd HH:mm:ss");
+        Instant expected = Instant.parse("2024-01-15T12:00:00Z");
+        assertThat(result, is(expected.toEpochMilli()));
+    }
+
+    @Test
+    void parseFormattedToEpochMilliSeconds_withTimezone() {
+        long result = time.parseFormattedToEpochMilliSeconds("2024-01-15 12:00:00", "yyyy-MM-dd HH:mm:ss", "+00:00");
+        Instant expected = Instant.parse("2024-01-15T12:00:00Z");
+        assertThat(result, is(expected.toEpochMilli()));
+    }
+
+    @Test
+    void parseFormattedToEpochMilliSeconds_invalid() {
+        assertThrows(Exception.class, () -> time.parseFormattedToEpochMilliSeconds("invalid", "yyyy-MM-dd"));
+    }
+
+    @Test
+    void epochMilliSecondsToISO8601_valid() {
+        Instant instant = Instant.parse("2024-01-15T12:00:00Z");
+        String result = time.epochMilliSecondsToISO8601(instant.toEpochMilli());
+        assertThat(result, is("2024-01-15T12:00:00Z"));
+    }
+
+    @Test
+    void epochMilliSecondsToISO8601_epoch0() {
+        String result = time.epochMilliSecondsToISO8601(0L);
+        assertThat(result, is("1970-01-01T00:00:00Z"));
+    }
+
+    @Test
+    void epochMilliSecondsToSeconds_valid() {
+        long result = time.epochMilliSecondsToSeconds(1705310400000L);
+        assertThat(result, is(1705310400L));
+    }
+
+    @Test
+    void epochMilliSecondsToSeconds_epoch0() {
+        long result = time.epochMilliSecondsToSeconds(0L);
+        assertThat(result, is(0L));
+    }
+
+    @Test
+    void epochMilliSecondsToFormatted_valid() {
+        Instant instant = Instant.parse("2024-01-15T12:00:00Z");
+        String result = time.epochMilliSecondsToFormatted(instant.toEpochMilli(), "yyyy-MM-dd");
+        assertThat(result, is("2024-01-15"));
+    }
+
+    @Test
+    void epochMilliSecondsToFormatted_withOffset() {
+        Instant instant = Instant.parse("2024-01-15T12:00:00Z");
+        String result = time.epochMilliSecondsToFormatted(instant.toEpochMilli(), "yyyy-MM-dd", "+00:00");
+        assertThat(result, is("2024-01-15"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/TimeUtilTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/TimeUtilTest.java
@@ -113,13 +113,13 @@ class TimeUtilTest {
     void epochMilliSecondsToISO8601_valid() {
         Instant instant = Instant.parse("2024-01-15T12:00:00Z");
         String result = time.epochMilliSecondsToISO8601(instant.toEpochMilli());
-        assertThat(result, is("2024-01-15T12:00:00Z"));
+        assertThat(result, is("2024-01-15T12:00:00.000Z"));
     }
 
     @Test
     void epochMilliSecondsToISO8601_epoch0() {
         String result = time.epochMilliSecondsToISO8601(0L);
-        assertThat(result, is("1970-01-01T00:00:00Z"));
+        assertThat(result, is("1970-01-01T00:00:00.000Z"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/TransformUtilTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/util/TransformUtilTest.java
@@ -1,0 +1,103 @@
+package io.github.hectorvent.floci.services.appsync.graphql.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class TransformUtilTest {
+
+    private final TransformUtil transform = new TransformUtil(new ObjectMapper());
+
+    @Test
+    void toDynamoDBFilterExpression_null() {
+        Map<String, Object> result = transform.toDynamoDBFilterExpression(null);
+        assertThat(result, anEmptyMap());
+    }
+
+    @Test
+    void toDynamoDBFilterExpression_simple() {
+        Map<String, Object> input = new HashMap<>();
+        input.put("expression", "#pk = :pk");
+        input.put("expressionNames", Map.of("#pk", "id"));
+        input.put("expressionValues", Map.of(":pk", Map.of("S", "123")));
+
+        Map<String, Object> result = transform.toDynamoDBFilterExpression(input);
+        assertThat(result, hasEntry("FilterExpression", "#pk = :pk"));
+        assertThat(result, hasKey("ExpressionAttributeNames"));
+        assertThat(result, hasKey("ExpressionAttributeValues"));
+    }
+
+    @Test
+    void toDynamoDBFilterExpression_jsonString() {
+        String json = "{\"expression\":\"#pk = :pk\"}";
+        Map<String, Object> result = transform.toDynamoDBFilterExpression(json);
+        assertThat(result, hasEntry("FilterExpression", "#pk = :pk"));
+    }
+
+    @Test
+    void toDynamoDBFilterExpression_emptyMap() {
+        Map<String, Object> result = transform.toDynamoDBFilterExpression(Map.of());
+        assertThat(result, anEmptyMap());
+    }
+
+    @Test
+    void toElasticsearchQueryDSL_null() {
+        Map<String, Object> result = transform.toElasticsearchQueryDSL(null);
+        assertThat(result, anEmptyMap());
+    }
+
+    @Test
+    void toElasticsearchQueryDSL_map() {
+        Map<String, Object> input = Map.of("query", Map.of("match_all", Map.of()));
+        Map<String, Object> result = transform.toElasticsearchQueryDSL(input);
+        assertThat(result, is(input));
+    }
+
+    @Test
+    void toElasticsearchQueryDSL_jsonString() {
+        String json = "{\"query\":{\"match_all\":{}}}";
+        Map<String, Object> result = transform.toElasticsearchQueryDSL(json);
+        assertThat(result, hasKey("query"));
+    }
+
+    @Test
+    void toSubscriptionFilter_null() {
+        Map<String, Object> result = transform.toSubscriptionFilter(null);
+        assertThat(result, anEmptyMap());
+    }
+
+    @Test
+    void toSubscriptionFilter_map() {
+        Map<String, Object> input = Map.of("filter", Map.of("field", "value"));
+        Map<String, Object> result = transform.toSubscriptionFilter(input);
+        assertThat(result, is(input));
+    }
+
+    @Test
+    void toSubscriptionFilter_jsonString() {
+        String json = "{\"filter\":{\"field\":\"value\"}}";
+        Map<String, Object> result = transform.toSubscriptionFilter(json);
+        assertThat(result, hasKey("filter"));
+    }
+
+    @Test
+    void toSubscriptionFilter_withFilterKeys() {
+        Map<String, Object> input = Map.of("filter", Map.of("field", "value"));
+        Map<String, Object> result = transform.toSubscriptionFilter(input, java.util.List.of("key1"));
+        assertThat(result, hasKey("filterKeys"));
+    }
+
+    @Test
+    void toSubscriptionFilter_withHeaderOverrides() {
+        Map<String, Object> input = Map.of("filter", Map.of("field", "value"));
+        Map<String, Object> result = transform.toSubscriptionFilter(
+                input, java.util.List.of("key1"), Map.of("header", "value"));
+        assertThat(result, hasKey("headerOverrides"));
+    }
+}


### PR DESCRIPTION
## Summary

Refs #1085 (Phase 3 implementation)

Phase 3 adds the AppSync **utility runtime** (`$util.*` namespace) as a standalone Java library, prerequisite for VTL template evaluation in Phase 4. Also applies Phase 2 test additions.

## Changes

### Part A: Phase 2 Test Additions
- Add 4 SDK tests: `getIntrospectionSchema`, `listDomainNames`, `getFunction`, `listResolversByFunction`
- Fix `listDomainNames` response field from `"domainNames"` to `"domainNameConfigs"` (AWS SDK v2 compatibility)

### Part B: `$util` Runtime Library

Standalone utility classes matching AWS AppSync `$util` namespace, validated against official documentation. No VTL/Velocity dependency — integrated in Phase 4.

| Class | Namespace | Methods |
|-------|-----------|---------|
| `VtlErrorSignal` | — | Exception for `$util.error()` / `$util.unauthorized()` |
| `AppSyncUtil` | `$util` | Root methods + error/validate/appendError/type checks |
| `StrUtil` | `$util.str` | `toUpper`, `toLower`, `toReplace`, `normalize` |
| `TimeUtil` | `$util.time` | 12 methods (epochMilliSeconds-based per AWS) |
| `MathUtil` | `$util.math` | `roundNum`, `minVal`, `maxVal`, `randomDouble`, `randomWithinRange` |
| `DynamoDbUtil` | `$util.dynamodb` | 24 methods (12 value + 12 JSON variants) |
| `TransformUtil` | `$util.transform` | `toDynamoDBFilterExpression`, `toElasticsearchQueryDSL`, `toSubscriptionFilter` |
| `ListUtil` | `$util.list` | `copyAndRetainAll`, `copyAndRemoveAll`, `sortList` |
| `MapUtil` | `$util.map` | `copyAndRetainAllKeys`, `copyAndRemoveAllKeys` |

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Methods in `$util.str`, `$util.time`, `$util.math`, `$util.dynamodb`, `$util.list`, `$util.map`, and root `$util` methods (`error`, `validate`, `unauthorized`, `typeOf`, etc.) match real AWS AppSync behavior. Key corrections applied after review:

- `$util.dynamodb.toMapValues` returns inner map (not wrapped in `{"M": ...}`)
- `$util.dynamodb.toBinary`/`toBinarySet` wrap input as-is (no base64 re-encoding)
- `$util.str.normalize` uses Unicode normalization (NFC/NFD/NFKC/NFKD)
- `$util.typeOf` returns exact AWS values: `Null`, `Number`, `String`, `Map`, `List`, `Boolean`, `Object`
- `$util.unauthorized()` errorType is `Unauthorized` (not `UnauthorizedException`)
- `$util.time.nowISO8601()` always includes 3 fractional digits

## Test Verification

```
Phase 3 utility tests:    234 passed ✅
AppSync integration tests: 117 passed ✅
AppSync SDK tests:          65 passed ✅
```

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (Phase 2 SDK tests + 234 unit tests for $util)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Not Yet Implemented

| Method | Status | Phase |
|--------|--------|-------|
| `$util.authType()` | Stub — returns null, needs `$context.identity` | Phase 4 |
| `$util.appendError()` × 4 | Stub — no-ops, needs `$context.error` list | Phase 4 |
| `$util.transform.toElasticsearchQueryDSL()` | Passthrough — needs ES query DSL construction | Phase 8 |
| `$util.transform.toSubscriptionFilter()` | Passthrough — needs filterGroup expansion | Phase 10 |

`$util.transform.toDynamoDBFilterExpression()` is partially implemented (maps field names) but may need edge case handling.

