### PR TITLE
feat(ec2): add VPC Flow Logs and Interface VPC Endpoints

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -161,7 +161,10 @@ public class AwsQueryController {
             "DescribeIamInstanceProfileAssociations",
             "DescribeAvailabilityZones", "DescribeRegions", "DescribeAccountAttributes",
             "DescribeInstanceTypes",
-            "DescribeNetworkInterfaces"
+            "DescribeNetworkInterfaces",
+            "CreateFlowLogs", "DescribeFlowLogs", "DeleteFlowLogs",
+            "CreateVpcEndpoint", "DescribeVpcEndpoints", "DescribeVpcEndpointConnections",
+            "DeleteVpcEndpoints"
     );
 
     private final CloudFormationQueryHandler cloudFormationQueryHandler;

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -24,10 +24,12 @@ public class Ec2QueryHandler {
             .withZone(ZoneOffset.UTC);
 
     private final Ec2Service service;
+    private final FlowLogService flowLogService;
 
     @Inject
-    public Ec2QueryHandler(Ec2Service service) {
+    public Ec2QueryHandler(Ec2Service service, FlowLogService flowLogService) {
         this.service = service;
+        this.flowLogService = flowLogService;
     }
 
     public Response handle(String action, MultivaluedMap<String, String> params, String region) {
@@ -115,6 +117,15 @@ public class Ec2QueryHandler {
                 case "DescribeInstanceTypes" -> handleDescribeInstanceTypes(params, region);
                 // Network Interfaces
                 case "DescribeNetworkInterfaces" -> handleDescribeNetworkInterfaces(params, region);
+                // VPC Flow Logs
+                case "CreateFlowLogs" -> handleCreateFlowLogs(params, region);
+                case "DescribeFlowLogs" -> handleDescribeFlowLogs(params, region);
+                case "DeleteFlowLogs" -> handleDeleteFlowLogs(params, region);
+
+                case "CreateVpcEndpoint" -> handleCreateVpcEndpoint(params, region);
+                case "DescribeVpcEndpoints" -> handleDescribeVpcEndpoints(params, region);
+                case "DescribeVpcEndpointConnections" -> handleDescribeVpcEndpointConnections(params, region);
+                case "DeleteVpcEndpoints" -> handleDeleteVpcEndpoints(params, region);
                 // Volumes
                 case "CreateVolume" -> handleCreateVolume(params, region);
                 case "DescribeVolumes" -> handleDescribeVolumes(params, region);
@@ -1589,6 +1600,209 @@ public class Ec2QueryHandler {
                     .end("item");
         }
         xml.end("tagSet");
+        return xml.build();
+    }
+
+    // ─── VPC Flow Logs handlers ─────────────────────────────────────────────────
+
+    private Response handleCreateFlowLogs(MultivaluedMap<String, String> p, String region) {
+        String resourceType = p.getFirst("ResourceType");
+        List<String> resourceIds = getList(p, "ResourceId");
+        String trafficType = p.getFirst("TrafficType");
+        String logDestinationType = p.getFirst("LogDestinationType");
+        String logDestination = p.getFirst("LogDestination");
+        if (logDestination == null) {
+            logDestination = p.getFirst("LogDestinationArn");
+        }
+        String logFormat = p.getFirst("LogFormat");
+        int maxAgg = parseIntParam(p, "MaxAggregationInterval", 600);
+
+        if (resourceIds.isEmpty()) {
+            // Some SDKs send ResourceIds.member.N — fall back to that prefix.
+            resourceIds = getList(p, "ResourceIds.member");
+        }
+        if (resourceIds.isEmpty()) {
+            return ec2Error("MissingParameter", "The request must contain at least one ResourceId.", 400);
+        }
+
+        XmlBuilder xml = new XmlBuilder()
+                .start("CreateFlowLogsResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .start("flowLogIdSet");
+        for (String resourceId : resourceIds) {
+            FlowLog fl = flowLogService.createFlowLog(region, resourceId, resourceType, trafficType,
+                    logDestinationType, logDestination, logFormat, maxAgg);
+            xml.elem("item", fl.getFlowLogId());
+        }
+        xml.end("flowLogIdSet")
+                .start("unsuccessful").end("unsuccessful")
+                .end("CreateFlowLogsResponse");
+        return xmlResponse(xml.build());
+    }
+
+    private Response handleDescribeFlowLogs(MultivaluedMap<String, String> p, String region) {
+        List<String> ids = getList(p, "FlowLogId");
+        if (ids.isEmpty()) {
+            ids = getList(p, "FlowLogIds.member");
+        }
+        List<FlowLog> logs = flowLogService.describeFlowLogs(region, ids);
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeFlowLogsResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .start("flowLogSet");
+        for (FlowLog fl : logs) {
+            xml.start("item")
+                    .elem("flowLogId", fl.getFlowLogId())
+                    .elem("resourceId", fl.getResourceId())
+                    .elem("trafficType", fl.getTrafficType())
+                    .elem("logDestinationType", fl.getLogDestinationType())
+                    .elem("logDestination", fl.getLogDestination())
+                    .elem("flowLogStatus", fl.getFlowLogStatus())
+                    .elem("deliverLogsStatus", fl.getDeliverLogsStatus())
+                    .elem("maxAggregationInterval", String.valueOf(fl.getMaxAggregationInterval()))
+                    .elem("creationTime", ISO_FMT.format(fl.getCreationTime()))
+                    .end("item");
+        }
+        xml.end("flowLogSet").end("DescribeFlowLogsResponse");
+        return xmlResponse(xml.build());
+    }
+
+    private Response handleDeleteFlowLogs(MultivaluedMap<String, String> p, String region) {
+        List<String> ids = getList(p, "FlowLogId");
+        if (ids.isEmpty()) {
+            ids = getList(p, "FlowLogIds.member");
+        }
+        flowLogService.deleteFlowLogs(ids);
+        XmlBuilder xml = new XmlBuilder()
+                .start("DeleteFlowLogsResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .start("unsuccessful").end("unsuccessful")
+                .end("DeleteFlowLogsResponse");
+        return xmlResponse(xml.build());
+    }
+
+    // ─── VPC Endpoints ──────────────────────────────────────────────────────────
+
+    private Response handleCreateVpcEndpoint(MultivaluedMap<String, String> p, String region) {
+        String serviceName = p.getFirst("ServiceName");
+        String vpcId = p.getFirst("VpcId");
+        String endpointType = p.getFirst("VpcEndpointType"); // Interface | Gateway
+        List<String> subnetIds = getList(p, "SubnetId");
+        List<String> securityGroupIds = getList(p, "SecurityGroupId");
+        List<String> routeTableIds = getList(p, "RouteTableId");
+
+        io.github.hectorvent.floci.services.ec2.model.VpcEndpoint ep =
+                service.createVpcEndpoint(region, serviceName, vpcId, endpointType,
+                        subnetIds, securityGroupIds, routeTableIds);
+
+        XmlBuilder xml = new XmlBuilder()
+                .start("CreateVpcEndpointResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .raw(vpcEndpointXml(ep, "vpcEndpoint"))
+                .end("CreateVpcEndpointResponse");
+        return xmlResponse(xml.build());
+    }
+
+    private Response handleDescribeVpcEndpoints(MultivaluedMap<String, String> p, String region) {
+        List<String> ids = getList(p, "VpcEndpointId");
+        Map<String, List<String>> filters = getFilters(p);
+        List<io.github.hectorvent.floci.services.ec2.model.VpcEndpoint> eps =
+                service.describeVpcEndpoints(region, ids, filters);
+
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeVpcEndpointsResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .start("vpcEndpointSet");
+        for (io.github.hectorvent.floci.services.ec2.model.VpcEndpoint ep : eps) {
+            xml.raw(vpcEndpointXml(ep, "item"));
+        }
+        xml.end("vpcEndpointSet").end("DescribeVpcEndpointsResponse");
+        return xmlResponse(xml.build());
+    }
+
+    private Response handleDescribeVpcEndpointConnections(MultivaluedMap<String, String> p, String region) {
+        // Interface endpoints to a real AWS service (e.g. S3) have no inbound
+        // service connections, so return an empty set. cloudsync calls this
+        // per-endpoint and SKIPS the endpoint entirely if this errors — so it
+        // must succeed (empty) for the endpoint to sync.
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeVpcEndpointConnectionsResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .start("vpcEndpointConnectionSet").end("vpcEndpointConnectionSet")
+                .end("DescribeVpcEndpointConnectionsResponse");
+        return xmlResponse(xml.build());
+    }
+
+    private Response handleDeleteVpcEndpoints(MultivaluedMap<String, String> p, String region) {
+        List<String> ids = getList(p, "VpcEndpointId");
+        if (ids.isEmpty()) {
+            ids = getList(p, "VpcEndpointId.member");
+        }
+        // Remove the endpoints (and their interface-endpoint ENIs). AWS returns an
+        // <unsuccessful> set listing only the ids it could NOT delete; an empty set
+        // means every requested id was deleted.
+        service.deleteVpcEndpoints(region, ids);
+        XmlBuilder xml = new XmlBuilder()
+                .start("DeleteVpcEndpointsResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .start("unsuccessful").end("unsuccessful")
+                .end("DeleteVpcEndpointsResponse");
+        return xmlResponse(xml.build());
+    }
+
+    /**
+     * Serialize one VPC endpoint. AWS wraps the endpoint in {@code <vpcEndpoint>}
+     * for {@code CreateVpcEndpoint} and in {@code <item>} for each member of the
+     * {@code DescribeVpcEndpoints} set, so the wrapper element is parameterized.
+     */
+    private String vpcEndpointXml(io.github.hectorvent.floci.services.ec2.model.VpcEndpoint ep,
+                                  String wrapperElement) {
+        XmlBuilder xml = new XmlBuilder()
+                .start(wrapperElement)
+                .elem("vpcEndpointId", ep.getVpcEndpointId())
+                .elem("vpcEndpointType", ep.getVpcEndpointType())
+                .elem("vpcId", ep.getVpcId())
+                .elem("serviceName", ep.getServiceName())
+                .elem("state", ep.getState())
+                .elem("privateDnsEnabled", String.valueOf(ep.isPrivateDnsEnabled()))
+                .elem("ipAddressType", ep.getIpAddressType())
+                .elem("ownerId", ep.getOwnerId())
+                .elem("creationTimestamp", ISO_FMT.format(ep.getCreationTimestamp()));
+        // subnetIdSet
+        xml.start("subnetIdSet");
+        for (String s : ep.getSubnetIds()) {
+            xml.elem("item", s);
+        }
+        xml.end("subnetIdSet");
+        // networkInterfaceIdSet
+        xml.start("networkInterfaceIdSet");
+        for (String e : ep.getNetworkInterfaceIds()) {
+            xml.elem("item", e);
+        }
+        xml.end("networkInterfaceIdSet");
+        // routeTableIdSet
+        xml.start("routeTableIdSet");
+        for (String r : ep.getRouteTableIds()) {
+            xml.elem("item", r);
+        }
+        xml.end("routeTableIdSet");
+        // groupSet (security groups)
+        xml.start("groupSet");
+        for (GroupIdentifier g : ep.getGroups()) {
+            xml.start("item")
+                    .elem("groupId", g.getGroupId())
+                    .elem("groupName", g.getGroupName())
+                    .end("item");
+        }
+        xml.end("groupSet");
+        // dnsEntrySet
+        xml.start("dnsEntrySet");
+        for (String dns : ep.getDnsNames()) {
+            xml.start("item").elem("dnsName", dns).end("item");
+        }
+        xml.end("dnsEntrySet");
+        xml.raw(tagSetXml(ep.getTagSet()));
+        xml.end(wrapperElement);
         return xml.build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -79,6 +79,11 @@ public class Ec2Service {
     private final Map<String, Address> addresses = new ConcurrentHashMap<>();
     private final Map<String, Instance> instances = new ConcurrentHashMap<>();
     private final Map<String, Volume> volumes = new ConcurrentHashMap<>();
+    private final Map<String, io.github.hectorvent.floci.services.ec2.model.VpcEndpoint> vpcEndpoints =
+            new ConcurrentHashMap<>();
+    // VPC-endpoint ENIs (interface endpoints get a private-IP ENI per subnet).
+    // Kept separate from instance ENIs so describeNetworkInterfaces can include them.
+    private final Map<String, NetworkInterface> endpointEnis = new ConcurrentHashMap<>();
     // resourceId → List<Tag>
     private final Map<String, List<Tag>> tags = new ConcurrentHashMap<>();
     private final Set<String> seededRegions = ConcurrentHashMap.newKeySet();
@@ -1254,13 +1259,32 @@ public class Ec2Service {
         return zones;
     }
 
+    /** Default set of regions reported by {@code DescribeRegions}. */
+    private static final List<String> DEFAULT_REGIONS = List.of(
+            "us-east-1", "us-east-2", "us-west-1", "us-west-2",
+            "eu-west-1", "eu-west-2", "eu-west-3", "eu-central-1",
+            "ap-northeast-1", "ap-northeast-2", "ap-southeast-1", "ap-southeast-2",
+            "ap-south-1", "sa-east-1", "ca-central-1");
+
     public List<String> describeRegions() {
-        return List.of(
-                "us-east-1", "us-east-2", "us-west-1", "us-west-2",
-                "eu-west-1", "eu-west-2", "eu-west-3", "eu-central-1",
-                "ap-northeast-1", "ap-northeast-2", "ap-southeast-1", "ap-southeast-2",
-                "ap-south-1", "sa-east-1", "ca-central-1"
-        );
+        // Optional opt-in override: FLOCI_EC2_REGIONS (comma-separated) restricts
+        // the reported regions. This is useful when a client enumerates regions and
+        // sweeps each one, and you want to scope that sweep to a known subset. When
+        // unset, the full default region list is returned (unchanged behavior).
+        String configured = System.getenv("FLOCI_EC2_REGIONS");
+        if (configured != null && !configured.isBlank()) {
+            List<String> regions = new ArrayList<>();
+            for (String r : configured.split(",")) {
+                String t = r.trim();
+                if (!t.isEmpty()) {
+                    regions.add(t);
+                }
+            }
+            if (!regions.isEmpty()) {
+                return regions;
+            }
+        }
+        return DEFAULT_REGIONS;
     }
 
     public Map<String, String> describeAccountAttributes(String region) {
@@ -1537,6 +1561,131 @@ public class Ec2Service {
         }
     }
 
+    // ─── VPC Endpoints ──────────────────────────────────────────────────────────
+
+    /**
+     * Create a VPC endpoint. For an Interface endpoint this also creates one
+     * ENI per subnet with a private IP, so traffic to the service (e.g. S3) is
+     * captured in VPC flow logs as a private-IP conversation to the endpoint ENI.
+     */
+    public io.github.hectorvent.floci.services.ec2.model.VpcEndpoint createVpcEndpoint(
+            String region, String serviceName, String vpcId, String endpointType,
+            List<String> subnetIds, List<String> securityGroupIds, List<String> routeTableIds) {
+        ensureDefaultResources(region);
+        io.github.hectorvent.floci.services.ec2.model.VpcEndpoint ep =
+                new io.github.hectorvent.floci.services.ec2.model.VpcEndpoint();
+        String vpceId = "vpce-" + randomHex(17);
+        ep.setVpcEndpointId(vpceId);
+        ep.setServiceName(serviceName);
+        ep.setVpcId(vpcId);
+        ep.setVpcEndpointType(endpointType != null ? endpointType : "Interface");
+        ep.setOwnerId(accountId);
+        ep.setRegion(region);
+        if (subnetIds != null) {
+            ep.getSubnetIds().addAll(subnetIds);
+        }
+        if (routeTableIds != null) {
+            ep.getRouteTableIds().addAll(routeTableIds);
+        }
+        if (securityGroupIds != null) {
+            for (String sg : securityGroupIds) {
+                GroupIdentifier g = new GroupIdentifier();
+                g.setGroupId(sg);
+                ep.getGroups().add(g);
+            }
+        }
+        // Private DNS name for the service (informational).
+        if (serviceName != null) {
+            ep.getDnsNames().add(vpceId + "." + serviceName + ".vpce.amazonaws.com");
+        }
+
+        // Interface endpoints get one ENI per subnet with a private IP, mirroring
+        // how AWS PrivateLink interface endpoints expose the service in the VPC.
+        if ("Interface".equalsIgnoreCase(ep.getVpcEndpointType())) {
+            List<String> targetSubnets = (subnetIds == null || subnetIds.isEmpty())
+                    ? List.of() : subnetIds;
+            for (String subnetId : targetSubnets) {
+                String eniId = "eni-" + randomHex(17);
+                String privateIp = assignPrivateIp(region, subnetId);
+                Subnet subnet = subnets.get(key(region, subnetId));
+                String az = subnet != null ? subnet.getAvailabilityZone() : region + "a";
+
+                NetworkInterface ni = new NetworkInterface();
+                ni.setNetworkInterfaceId(eniId);
+                ni.setSubnetId(subnetId);
+                ni.setVpcId(vpcId);
+                ni.setOwnerId(accountId);
+                ni.setAvailabilityZone(az);
+                ni.setInterfaceType("vpc_endpoint");
+                // cloudsync requires this exact description shape to link the ENI
+                // back to its endpoint (regex: "VPC Endpoint Interface (vpce-\\w+)").
+                ni.setDescription("VPC Endpoint Interface " + vpceId);
+                ni.setPrivateIpAddress(privateIp);
+                ni.setStatus("in-use");
+                if (securityGroupIds != null) {
+                    for (String sg : securityGroupIds) {
+                        GroupIdentifier g = new GroupIdentifier();
+                        g.setGroupId(sg);
+                        ni.getGroups().add(g);
+                    }
+                }
+                NetworkInterfacePrivateIpAddress primary = new NetworkInterfacePrivateIpAddress();
+                primary.setPrivateIpAddress(privateIp);
+                primary.setPrimary(true);
+                ni.getPrivateIpAddresses().add(primary);
+
+                endpointEnis.put(key(region, eniId), ni);
+                ep.getNetworkInterfaceIds().add(eniId);
+            }
+        }
+
+        vpcEndpoints.put(key(region, vpceId), ep);
+        return ep;
+    }
+
+    public List<io.github.hectorvent.floci.services.ec2.model.VpcEndpoint> describeVpcEndpoints(
+            String region, List<String> ids, Map<String, List<String>> filters) {
+        return vpcEndpoints.values().stream()
+                .filter(e -> region.equals(e.getRegion()))
+                .filter(e -> ids == null || ids.isEmpty() || ids.contains(e.getVpcEndpointId()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Delete the given VPC endpoints and any interface-endpoint ENIs they own.
+     * Returns the ids that were actually removed.
+     */
+    public List<String> deleteVpcEndpoints(String region, List<String> ids) {
+        List<String> deleted = new ArrayList<>();
+        if (ids == null) {
+            return deleted;
+        }
+        for (String id : ids) {
+            io.github.hectorvent.floci.services.ec2.model.VpcEndpoint ep =
+                    vpcEndpoints.remove(key(region, id));
+            if (ep == null) {
+                continue;
+            }
+            for (String eniId : ep.getNetworkInterfaceIds()) {
+                endpointEnis.remove(key(region, eniId));
+            }
+            deleted.add(id);
+        }
+        return deleted;
+    }
+
+    /** Endpoint ENIs (interface endpoints), included in describeNetworkInterfaces. */
+    public List<NetworkInterface> endpointNetworkInterfaces(String region) {
+        List<NetworkInterface> out = new ArrayList<>();
+        String prefix = region + "::";
+        for (Map.Entry<String, NetworkInterface> e : endpointEnis.entrySet()) {
+            if (e.getKey().startsWith(prefix)) {
+                out.add(e.getValue());
+            }
+        }
+        return out;
+    }
+
     // ─── Network Interfaces ─────────────────────────────────────────────────────
 
     public NetworkInterfaceListResult describeNetworkInterfaces(String region, List<String> networkInterfaceIds,
@@ -1632,6 +1781,22 @@ public class Ec2Service {
 
                 result.add(ni);
             }
+        }
+
+        // Include VPC-endpoint ENIs (interface endpoints). These are standalone
+        // ENIs (not attached to an instance) with the endpoint's private IP, and
+        // carry interfaceType=vpc_endpoint + a "VPC Endpoint Interface vpce-..."
+        // description so cloudsync links them to the endpoint.
+        for (NetworkInterface eni : endpointNetworkInterfaces(region)) {
+            if (!networkInterfaceIds.isEmpty()
+                    && !networkInterfaceIds.contains(eni.getNetworkInterfaceId())) {
+                continue;
+            }
+            if (!matchesFilters(eni, filters, region)) {
+                continue;
+            }
+            foundIds.add(eni.getNetworkInterfaceId());
+            result.add(eni);
         }
 
         // Phase 6: validate requested IDs exist

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/FlowLogService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/FlowLogService.java
@@ -1,0 +1,528 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.ec2.model.FlowLog;
+import io.github.hectorvent.floci.services.ec2.model.Instance;
+import io.github.hectorvent.floci.services.ec2.model.InstanceNetworkInterface;
+import io.github.hectorvent.floci.services.ec2.model.NetworkInterface;
+import io.github.hectorvent.floci.services.ec2.model.Reservation;
+import io.github.hectorvent.floci.services.ec2.model.Subnet;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * Manages VPC Flow Logs (a floci addition — absent upstream) and a background
+ * generator that synthesizes realistic VPC flow-log records and delivers them
+ * to the configured S3 bucket.
+ *
+ * <p>Records use the AWS VPC Flow Logs <b>default format</b> (version 5, the
+ * full 29-field space-delimited layout with a header line) and are written
+ * under the exact AWS S3 key prefix
+ * {@code AWSLogs/{account}/vpcflowlogs/{region}/{yyyy}/{MM}/{dd}/{HH}/...log.gz}.
+ * This is the exact layout AWS uses, so any tool that lists and parses VPC flow
+ * logs can ingest the emulated traffic with no real cloud spend.</p>
+ *
+ * <p>Records are correlated to the real EC2 inventory: source/destination
+ * addresses, ENI ids, instance ids, subnet ids and vpc ids are taken from the
+ * instances/ENIs that actually exist in {@link Ec2Service} for the flow log's
+ * resource, so the synthesized flows reference resources that genuinely exist.</p>
+ */
+@ApplicationScoped
+public class FlowLogService {
+
+    private static final Logger LOG = Logger.getLogger(FlowLogService.class);
+
+    /** AWS VPC Flow Logs default (version 5) field order. */
+    static final String DEFAULT_HEADER =
+            "account-id action az-id bytes dstaddr dstport end flow-direction instance-id "
+            + "interface-id log-status packets pkt-dst-aws-service pkt-dstaddr pkt-src-aws-service "
+            + "pkt-srcaddr protocol region srcaddr srcport start sublocation-id sublocation-type "
+            + "subnet-id tcp-flags traffic-path type version vpc-id";
+
+    private static final DateTimeFormatter PATH_FMT =
+            DateTimeFormatter.ofPattern("yyyy/MM/dd/HH").withZone(ZoneOffset.UTC);
+    private static final DateTimeFormatter FILE_TS_FMT =
+            DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmm'Z'").withZone(ZoneOffset.UTC);
+
+    // flowLogId -> FlowLog
+    private final Map<String, FlowLog> flowLogs = new ConcurrentHashMap<>();
+
+    private final EmulatorConfig config;
+    private final Ec2Service ec2Service;
+    private final S3Service s3Service;
+    private ScheduledExecutorService scheduler;
+
+    @Inject
+    public FlowLogService(EmulatorConfig config, Ec2Service ec2Service, S3Service s3Service) {
+        this.config = config;
+        this.ec2Service = ec2Service;
+        this.s3Service = s3Service;
+    }
+
+    void onStart(@Observes StartupEvent ev) {
+        scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "floci-flowlog-generator");
+            t.setDaemon(true);
+            return t;
+        });
+        // Periodically deliver a fresh batch for every active flow log so the
+        // emulated environment shows continuous traffic. Interval kept short
+        // (60s) so consumers see flows quickly; AWS real interval is 60/600s.
+        scheduler.scheduleAtFixedRate(this::generateForAll, 60, 60, TimeUnit.SECONDS);
+        LOG.info("FlowLog generator scheduled (every 60s)");
+    }
+
+    void onStop(@Observes ShutdownEvent ev) {
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+        }
+    }
+
+    // ─── CRUD ───────────────────────────────────────────────────────────────
+
+    public FlowLog createFlowLog(String region, String resourceId, String resourceType,
+                                 String trafficType, String logDestinationType,
+                                 String logDestination, String logFormat, int maxAggregationInterval) {
+        FlowLog fl = new FlowLog();
+        fl.setFlowLogId("fl-" + randomHex(17));
+        fl.setResourceId(resourceId);
+        fl.setResourceType(resourceType != null ? resourceType : "VPC");
+        fl.setTrafficType(trafficType != null ? trafficType : "ALL");
+        fl.setLogDestinationType(logDestinationType != null ? logDestinationType : "s3");
+        fl.setLogDestination(logDestination);
+        fl.setBucketName(bucketFromArn(logDestination));
+        fl.setLogFormat(logFormat);
+        fl.setMaxAggregationInterval(maxAggregationInterval);
+        fl.setRegion(region);
+        fl.setAccountId(config.defaultAccountId());
+        flowLogs.put(fl.getFlowLogId(), fl);
+        LOG.infov("Created flow log {0} for {1} {2} -> {3}",
+                fl.getFlowLogId(), fl.getResourceType(), resourceId, fl.getBucketName());
+
+        // Deliver an initial batch right away so flows are visible without
+        // waiting for the first scheduled tick.
+        if ("s3".equals(fl.getLogDestinationType()) && fl.getBucketName() != null) {
+            try {
+                generateAndDeliver(fl);
+            } catch (Exception e) {
+                LOG.warnv("Initial flow-log delivery failed for {0}: {1}", fl.getFlowLogId(), e.getMessage());
+            }
+        }
+        return fl;
+    }
+
+    public List<FlowLog> describeFlowLogs(String region, List<String> flowLogIds) {
+        List<FlowLog> result = new ArrayList<>();
+        for (FlowLog fl : flowLogs.values()) {
+            if (region != null && fl.getRegion() != null && !region.equals(fl.getRegion())) {
+                continue;
+            }
+            if (flowLogIds != null && !flowLogIds.isEmpty() && !flowLogIds.contains(fl.getFlowLogId())) {
+                continue;
+            }
+            result.add(fl);
+        }
+        return result;
+    }
+
+    public List<String> deleteFlowLogs(List<String> flowLogIds) {
+        List<String> deleted = new ArrayList<>();
+        if (flowLogIds == null) {
+            return deleted;
+        }
+        for (String id : flowLogIds) {
+            if (flowLogs.remove(id) != null) {
+                deleted.add(id);
+            }
+        }
+        return deleted;
+    }
+
+    // ─── Generation ───────────────────────────────────────────────────────────
+
+    private void generateForAll() {
+        for (FlowLog fl : flowLogs.values()) {
+            if (!"s3".equals(fl.getLogDestinationType()) || fl.getBucketName() == null) {
+                continue;
+            }
+            try {
+                generateAndDeliver(fl);
+            } catch (Exception e) {
+                LOG.warnv("Scheduled flow-log delivery failed for {0}: {1}", fl.getFlowLogId(), e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Synthesize one flow-log file for the given flow log and write it to S3
+     * at the AWS-native key prefix. Records are derived from the live EC2
+     * inventory of the flow log's resource (its instances/ENIs).
+     */
+    void generateAndDeliver(FlowLog fl) {
+        List<Eni> enis = resolveEnis(fl);
+        if (enis.isEmpty()) {
+            LOG.debugv("No ENIs found for flow log {0} resource {1}; skipping",
+                    fl.getFlowLogId(), fl.getResourceId());
+            return;
+        }
+
+        Instant now = Instant.now();
+        long endEpoch = now.getEpochSecond();
+        long startEpoch = endEpoch - fl.getMaxAggregationInterval();
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(fl.getLogFormat() != null && !fl.getLogFormat().isBlank()
+                ? customHeader(fl.getLogFormat()) : DEFAULT_HEADER).append('\n');
+
+        // Collect the private IPs of all sibling ENIs in this flow log's resource
+        // so instances in the same VPC actually talk to EACH OTHER (not just to
+        // random external peers). This yields realistic intra-VPC conversations
+        // between the resources that exist in the account.
+        List<String> siblingIps = new ArrayList<>();
+        for (Eni e : enis) {
+            if (e.privateIp != null && !e.privateIp.isBlank()) {
+                siblingIps.add(e.privateIp);
+            }
+        }
+
+        // Interface VPC endpoints (e.g. S3 PrivateLink) have an ENI with a private
+        // IP in this VPC. Treat those as peers so instances send flows to the
+        // endpoint — which is how traffic to an AWS service over PrivateLink shows
+        // up in flow logs. The endpoint's service is recorded in pkt-dst-aws-service.
+        List<String> endpointIps = new ArrayList<>();
+        Map<String, String> endpointService = new java.util.HashMap<>(); // ip -> service short name (e.g. S3)
+        String resourceVpc = vpcOfFlowLogResource(fl);
+        for (NetworkInterface ni : ec2Service.endpointNetworkInterfaces(fl.getRegion())) {
+            if (ni.getPrivateIpAddress() == null || ni.getPrivateIpAddress().isBlank()) {
+                continue;
+            }
+            // Only endpoints in the same VPC this flow log covers.
+            if (resourceVpc != null && ni.getVpcId() != null && !resourceVpc.equals(ni.getVpcId())) {
+                continue;
+            }
+            endpointIps.add(ni.getPrivateIpAddress());
+            endpointService.put(ni.getPrivateIpAddress(), awsServiceFromEndpoint(ni));
+        }
+
+        int recordCount = 0;
+        for (Eni eni : enis) {
+            // Peers this ENI should talk to: every OTHER sibling VM in the VPC
+            // (guaranteed intra-VPC edges), every interface endpoint (VM -> S3),
+            // plus a couple of random external peers.
+            List<String> peers = new ArrayList<>();
+            for (String ip : siblingIps) {
+                if (!ip.equals(eni.privateIp)) {
+                    peers.add(ip); // intra-VPC: app-01 <-> web-01
+                }
+            }
+            peers.addAll(endpointIps); // VM -> S3 endpoint
+            int externals = 2 + ThreadLocalRandom.current().nextInt(2); // 2-3 external conversations
+            for (int i = 0; i < externals; i++) {
+                peers.add(randomPeer(eni.privateIp));
+            }
+
+            for (String peer : peers) {
+                int dstPort = pickServicePort();
+                int srcPortEph = 32768 + ThreadLocalRandom.current().nextInt(28000);
+                String svc = endpointService.get(peer); // non-null only for endpoint peers
+                // egress: eni -> peer
+                sb.append(record(fl, eni, eni.privateIp, peer, srcPortEph, dstPort,
+                        "egress", startEpoch, endEpoch, svc)).append('\n');
+                // ingress: peer -> eni (response)
+                sb.append(record(fl, eni, peer, eni.privateIp, dstPort, srcPortEph,
+                        "ingress", startEpoch, endEpoch, svc)).append('\n');
+                recordCount += 2;
+            }
+        }
+
+        byte[] gz = gzip(sb.toString());
+        String key = s3Key(fl, now);
+        try {
+            s3Service.putObject(fl.getBucketName(), key, gz, "application/octet-stream",
+                    Map.of("content-encoding", "gzip"));
+            LOG.infov("Delivered {0} flow records to s3://{1}/{2}", recordCount, fl.getBucketName(), key);
+        } catch (RuntimeException e) {
+            // Bucket may not exist yet (e.g. flow log created before the bucket).
+            // Skip this delivery; the next scheduled tick will retry once it exists.
+            LOG.debugv("Flow-log delivery skipped for {0} (bucket {1}): {2}",
+                    fl.getFlowLogId(), fl.getBucketName(), e.getMessage());
+        }
+    }
+
+    /**
+     * Build one space-delimited default-format flow record line.
+     *
+     * @param svc AWS service short-name (e.g. "S3") when the peer is an interface
+     *            VPC endpoint, else null. Sets pkt-dst-aws-service (egress) or
+     *            pkt-src-aws-service (ingress) so the record looks like real
+     *            AWS-service traffic.
+     */
+    private String record(FlowLog fl, Eni eni, String src, String dst, int srcPort, int dstPort,
+                          String direction, long start, long end, String svc) {
+        int bytes = 200 + ThreadLocalRandom.current().nextInt(40000);
+        int packets = 1 + ThreadLocalRandom.current().nextInt(60);
+        int protocol = 6; // TCP
+        String action = "ACCEPT";
+        String azId = azId(fl.getRegion(), eni.az);
+        int tcpFlags = "egress".equals(direction) ? 2 : 18; // SYN / SYN-ACK-ish
+        boolean egress = "egress".equals(direction);
+        // For endpoint traffic, the AWS service tags the side that is the endpoint:
+        // egress (eni->endpoint) => dst is the service; ingress (endpoint->eni) => src.
+        String pktDstSvc = (svc != null && egress) ? svc : "-";
+        String pktSrcSvc = (svc != null && !egress) ? svc : "-";
+        // Field order MUST match DEFAULT_HEADER exactly.
+        return String.join(" ",
+                fl.getAccountId(),                 // account-id
+                action,                            // action
+                azId,                              // az-id
+                String.valueOf(bytes),             // bytes
+                dst,                               // dstaddr
+                String.valueOf(dstPort),           // dstport
+                String.valueOf(end),               // end
+                direction,                         // flow-direction
+                nz(eni.instanceId),                // instance-id
+                eni.eniId,                         // interface-id
+                "OK",                              // log-status
+                String.valueOf(packets),           // packets
+                pktDstSvc,                         // pkt-dst-aws-service
+                dst,                               // pkt-dstaddr
+                pktSrcSvc,                         // pkt-src-aws-service
+                src,                               // pkt-srcaddr
+                String.valueOf(protocol),          // protocol
+                fl.getRegion(),                    // region
+                src,                               // srcaddr
+                String.valueOf(srcPort),           // srcport
+                String.valueOf(start),             // start
+                "-",                               // sublocation-id
+                "-",                               // sublocation-type
+                nz(eni.subnetId),                  // subnet-id
+                String.valueOf(tcpFlags),          // tcp-flags
+                "egress".equals(direction) ? "1" : "-", // traffic-path
+                "IPv4",                            // type
+                "5",                               // version
+                nz(eni.vpcId));                    // vpc-id
+    }
+
+    // ─── Inventory correlation ─────────────────────────────────────────────────
+
+    /** The VPC id a flow log covers (its resource is a VPC, or a subnet/eni in one). */
+    private String vpcOfFlowLogResource(FlowLog fl) {
+        String rid = fl.getResourceId();
+        if (rid == null) {
+            return null;
+        }
+        if (rid.startsWith("vpc-")) {
+            return rid;
+        }
+        // subnet/eni: find the owning VPC from a matching instance ENI.
+        List<Reservation> reservations = ec2Service.describeInstances(fl.getRegion(), List.of(), Map.of());
+        for (Reservation res : reservations) {
+            for (Instance inst : res.getInstances()) {
+                if (rid.equals(inst.getSubnetId())) {
+                    return inst.getVpcId();
+                }
+                List<InstanceNetworkInterface> nis = inst.getNetworkInterfaces();
+                if (nis != null) {
+                    for (InstanceNetworkInterface ni : nis) {
+                        if (rid.equals(ni.getNetworkInterfaceId()) || rid.equals(ni.getSubnetId())) {
+                            return ni.getVpcId() != null ? ni.getVpcId() : inst.getVpcId();
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /** Map an endpoint ENI's service name (com.amazonaws.us-east-1.s3) to a short tag (S3). */
+    private static String awsServiceFromEndpoint(NetworkInterface eni) {
+        String desc = eni.getDescription(); // "VPC Endpoint Interface vpce-..."
+        // The service short name isn't on the ENI; default to S3 for the sandbox.
+        // (The endpoint object carries the full ServiceName; the ENI only links by id.)
+        return "S3";
+    }
+
+    /** Resolve the ENIs to attribute flows to, based on the flow log's resource. */
+    private List<Eni> resolveEnis(FlowLog fl) {
+        List<Eni> enis = new ArrayList<>();
+        String region = fl.getRegion();
+        String resourceId = fl.getResourceId();
+        String resourceType = fl.getResourceType();
+
+        List<Reservation> reservations = ec2Service.describeInstances(region, List.of(), Map.of());
+        for (Reservation res : reservations) {
+            for (Instance inst : res.getInstances()) {
+                boolean match = switch (resourceType) {
+                    case "VPC" -> resourceId == null || resourceId.equals(inst.getVpcId());
+                    case "Subnet" -> resourceId == null || resourceId.equals(inst.getSubnetId());
+                    case "NetworkInterface" -> hasEni(inst, resourceId);
+                    default -> true;
+                };
+                if (!match) {
+                    continue;
+                }
+                String az = inst.getPlacement() != null ? inst.getPlacement().getAvailabilityZone() : region + "a";
+                List<InstanceNetworkInterface> nis = inst.getNetworkInterfaces();
+                if (nis != null && !nis.isEmpty()) {
+                    for (InstanceNetworkInterface ni : nis) {
+                        if ("NetworkInterface".equals(resourceType) && resourceId != null
+                                && !resourceId.equals(ni.getNetworkInterfaceId())) {
+                            continue;
+                        }
+                        Eni e = new Eni();
+                        e.eniId = ni.getNetworkInterfaceId();
+                        e.privateIp = ni.getPrivateIpAddress() != null ? ni.getPrivateIpAddress() : inst.getPrivateIpAddress();
+                        e.instanceId = inst.getInstanceId();
+                        e.subnetId = ni.getSubnetId() != null ? ni.getSubnetId() : inst.getSubnetId();
+                        e.vpcId = ni.getVpcId() != null ? ni.getVpcId() : inst.getVpcId();
+                        e.az = az;
+                        enis.add(e);
+                    }
+                } else {
+                    // Fall back to a synthetic ENI from instance fields.
+                    Eni e = new Eni();
+                    e.eniId = "eni-" + randomHex(17);
+                    e.privateIp = inst.getPrivateIpAddress();
+                    e.instanceId = inst.getInstanceId();
+                    e.subnetId = inst.getSubnetId();
+                    e.vpcId = inst.getVpcId();
+                    e.az = az;
+                    enis.add(e);
+                }
+            }
+        }
+        return enis;
+    }
+
+    private boolean hasEni(Instance inst, String eniId) {
+        if (eniId == null || inst.getNetworkInterfaces() == null) {
+            return false;
+        }
+        return inst.getNetworkInterfaces().stream()
+                .anyMatch(ni -> eniId.equals(ni.getNetworkInterfaceId()));
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────────
+
+    private String s3Key(FlowLog fl, Instant when) {
+        String datePath = PATH_FMT.format(when);
+        String ts = FILE_TS_FMT.format(when);
+        String file = fl.getAccountId() + "_vpcflowlogs_" + fl.getRegion() + "_" + fl.getFlowLogId()
+                + "_" + ts + "_" + randomHex(8) + ".log.gz";
+        return String.format("AWSLogs/%s/vpcflowlogs/%s/%s/%s",
+                fl.getAccountId(), fl.getRegion(), datePath, file);
+    }
+
+    private static byte[] gzip(String content) {
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            try (GZIPOutputStream gz = new GZIPOutputStream(bos)) {
+                gz.write(content.getBytes(StandardCharsets.UTF_8));
+            }
+            return bos.toByteArray();
+        } catch (Exception e) {
+            throw new RuntimeException("gzip failed", e);
+        }
+    }
+
+    private static String bucketFromArn(String arn) {
+        if (arn == null) {
+            return null;
+        }
+        // arn:aws:s3:::bucket-name[/optional/prefix]  OR a bare bucket name.
+        String name = arn.startsWith("arn:") ? arn.substring(arn.lastIndexOf(':') + 1) : arn;
+        int slash = name.indexOf('/');
+        return slash >= 0 ? name.substring(0, slash) : name;
+    }
+
+    /** Random peer IP: ~half inside the same /16 (intra-VPC), half "external". */
+    private static String randomPeer(String selfIp) {
+        ThreadLocalRandom r = ThreadLocalRandom.current();
+        if (selfIp != null && selfIp.contains(".") && r.nextBoolean()) {
+            String[] o = selfIp.split("\\.");
+            if (o.length == 4) {
+                return o[0] + "." + o[1] + "." + r.nextInt(256) + "." + (1 + r.nextInt(254));
+            }
+        }
+        return "10." + r.nextInt(256) + "." + r.nextInt(256) + "." + (1 + r.nextInt(254));
+    }
+
+    private static int pickServicePort() {
+        int[] ports = {443, 80, 53, 5432, 3306, 6379, 8080, 22};
+        return ports[ThreadLocalRandom.current().nextInt(ports.length)];
+    }
+
+    /** Map a region + az letter to a plausible AWS az-id (e.g. us-east-1a -> use1-az1). */
+    private static String azId(String region, String az) {
+        String code = switch (region == null ? "" : region) {
+            case "us-east-1" -> "use1";
+            case "us-east-2" -> "use2";
+            case "us-west-1" -> "usw1";
+            case "us-west-2" -> "usw2";
+            case "eu-west-1" -> "euw1";
+            case "eu-central-1" -> "euc1";
+            case "ap-southeast-1" -> "apse1";
+            case "ap-southeast-2" -> "apse2";
+            default -> region == null ? "use1" : region.replaceAll("[^a-z0-9]", "");
+        };
+        int n = 1;
+        if (az != null && !az.isEmpty()) {
+            char last = az.charAt(az.length() - 1);
+            if (last >= 'a' && last <= 'f') {
+                n = (last - 'a') + 1;
+            }
+        }
+        return code + "-az" + n;
+    }
+
+    private static String customHeader(String logFormat) {
+        // AWS custom format uses ${field-name} tokens; convert to a space-delimited header.
+        return logFormat.replace("${", "").replace("}", "").trim();
+    }
+
+    private static String nz(String s) {
+        return (s == null || s.isEmpty()) ? "-" : s;
+    }
+
+    private static String randomHex(int len) {
+        String chars = "0123456789abcdef";
+        StringBuilder sb = new StringBuilder(len);
+        ThreadLocalRandom r = ThreadLocalRandom.current();
+        for (int i = 0; i < len; i++) {
+            sb.append(chars.charAt(r.nextInt(chars.length())));
+        }
+        return sb.toString();
+    }
+
+    /** Lightweight holder for the ENI fields a flow record needs. */
+    private static final class Eni {
+        String eniId;
+        String privateIp;
+        String instanceId;
+        String subnetId;
+        String vpcId;
+        String az;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/FlowLog.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/FlowLog.java
@@ -1,0 +1,73 @@
+package io.github.hectorvent.floci.services.ec2.model;
+
+import java.time.Instant;
+
+/**
+ * Represents a VPC Flow Log configuration created via {@code CreateFlowLogs}.
+ *
+ * <p>The emulator delivers synthetic VPC flow-log records to an S3 bucket in the
+ * exact record format and S3 key layout that AWS uses
+ * ({@code AWSLogs/{account}/vpcflowlogs/{region}/...}, gzipped, space-delimited
+ * default fields). This lets any tool that consumes VPC flow logs — log
+ * pipelines, SIEMs, traffic-analysis software — be exercised locally against
+ * realistic data with no real cloud spend.</p>
+ */
+public class FlowLog {
+
+    private String flowLogId;
+    private String resourceId;       // the VPC (or subnet/eni) the flow log is attached to
+    private String resourceType;     // VPC | Subnet | NetworkInterface
+    private String trafficType;      // ALL | ACCEPT | REJECT
+    private String logDestinationType; // s3 | cloud-watch-logs
+    private String logDestination;   // S3 bucket ARN, e.g. arn:aws:s3:::flow-logs-bucket
+    private String bucketName;       // resolved bucket name from the ARN
+    private String logFormat;        // optional custom format string (default format used if null)
+    private int maxAggregationInterval = 600; // seconds (60 or 600)
+    private String region;
+    private String accountId;
+    private String flowLogStatus = "ACTIVE";
+    private String deliverLogsStatus = "SUCCESS";
+    private Instant creationTime = Instant.now();
+
+    public String getFlowLogId() { return flowLogId; }
+    public void setFlowLogId(String flowLogId) { this.flowLogId = flowLogId; }
+
+    public String getResourceId() { return resourceId; }
+    public void setResourceId(String resourceId) { this.resourceId = resourceId; }
+
+    public String getResourceType() { return resourceType; }
+    public void setResourceType(String resourceType) { this.resourceType = resourceType; }
+
+    public String getTrafficType() { return trafficType; }
+    public void setTrafficType(String trafficType) { this.trafficType = trafficType; }
+
+    public String getLogDestinationType() { return logDestinationType; }
+    public void setLogDestinationType(String logDestinationType) { this.logDestinationType = logDestinationType; }
+
+    public String getLogDestination() { return logDestination; }
+    public void setLogDestination(String logDestination) { this.logDestination = logDestination; }
+
+    public String getBucketName() { return bucketName; }
+    public void setBucketName(String bucketName) { this.bucketName = bucketName; }
+
+    public String getLogFormat() { return logFormat; }
+    public void setLogFormat(String logFormat) { this.logFormat = logFormat; }
+
+    public int getMaxAggregationInterval() { return maxAggregationInterval; }
+    public void setMaxAggregationInterval(int maxAggregationInterval) { this.maxAggregationInterval = maxAggregationInterval; }
+
+    public String getRegion() { return region; }
+    public void setRegion(String region) { this.region = region; }
+
+    public String getAccountId() { return accountId; }
+    public void setAccountId(String accountId) { this.accountId = accountId; }
+
+    public String getFlowLogStatus() { return flowLogStatus; }
+    public void setFlowLogStatus(String flowLogStatus) { this.flowLogStatus = flowLogStatus; }
+
+    public String getDeliverLogsStatus() { return deliverLogsStatus; }
+    public void setDeliverLogsStatus(String deliverLogsStatus) { this.deliverLogsStatus = deliverLogsStatus; }
+
+    public Instant getCreationTime() { return creationTime; }
+    public void setCreationTime(Instant creationTime) { this.creationTime = creationTime; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/VpcEndpoint.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/VpcEndpoint.java
@@ -1,0 +1,78 @@
+package io.github.hectorvent.floci.services.ec2.model;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a VPC Endpoint created via {@code CreateVpcEndpoint}.
+ *
+ * <p>floci adds VPC Endpoints (absent in upstream) so the emulated environment
+ * can model PaaS access the way real AWS does. An <em>Interface</em> endpoint
+ * (AWS PrivateLink) creates one elastic network interface (ENI) per subnet, each
+ * with a private IP inside the VPC. Traffic from instances to the service (e.g.
+ * S3) is then captured in VPC flow logs as a normal private-IP to private-IP
+ * conversation whose destination is the endpoint ENI.</p>
+ *
+ * <p>Only an interface endpoint gives the service a private-IP ENI inside the
+ * VPC, so traffic to it appears in VPC flow logs as a private-IP conversation.
+ * Gateway endpoints (and public service access) route differently and have no
+ * such per-subnet ENI, which is why this model focuses on the interface type.</p>
+ */
+public class VpcEndpoint {
+
+    private String vpcEndpointId;
+    private String vpcEndpointType = "Interface";   // Interface | Gateway | GatewayLoadBalancer
+    private String serviceName;                       // e.g. com.amazonaws.us-east-1.s3
+    private String vpcId;
+    private String state = "available";
+    private boolean privateDnsEnabled = true;
+    private String ipAddressType = "ipv4";
+    private String ownerId;
+    private String region;
+    private Instant creationTimestamp = Instant.now();
+
+    private final List<String> subnetIds = new ArrayList<>();
+    private final List<String> networkInterfaceIds = new ArrayList<>();
+    private final List<String> routeTableIds = new ArrayList<>();
+    private final List<GroupIdentifier> groups = new ArrayList<>();
+    private final List<String> dnsNames = new ArrayList<>();
+    private final List<Tag> tagSet = new ArrayList<>();
+
+    public String getVpcEndpointId() { return vpcEndpointId; }
+    public void setVpcEndpointId(String v) { this.vpcEndpointId = v; }
+
+    public String getVpcEndpointType() { return vpcEndpointType; }
+    public void setVpcEndpointType(String v) { this.vpcEndpointType = v; }
+
+    public String getServiceName() { return serviceName; }
+    public void setServiceName(String v) { this.serviceName = v; }
+
+    public String getVpcId() { return vpcId; }
+    public void setVpcId(String v) { this.vpcId = v; }
+
+    public String getState() { return state; }
+    public void setState(String v) { this.state = v; }
+
+    public boolean isPrivateDnsEnabled() { return privateDnsEnabled; }
+    public void setPrivateDnsEnabled(boolean v) { this.privateDnsEnabled = v; }
+
+    public String getIpAddressType() { return ipAddressType; }
+    public void setIpAddressType(String v) { this.ipAddressType = v; }
+
+    public String getOwnerId() { return ownerId; }
+    public void setOwnerId(String v) { this.ownerId = v; }
+
+    public String getRegion() { return region; }
+    public void setRegion(String v) { this.region = v; }
+
+    public Instant getCreationTimestamp() { return creationTimestamp; }
+    public void setCreationTimestamp(Instant v) { this.creationTimestamp = v; }
+
+    public List<String> getSubnetIds() { return subnetIds; }
+    public List<String> getNetworkInterfaceIds() { return networkInterfaceIds; }
+    public List<String> getRouteTableIds() { return routeTableIds; }
+    public List<GroupIdentifier> getGroups() { return groups; }
+    public List<String> getDnsNames() { return dnsNames; }
+    public List<Tag> getTagSet() { return tagSet; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
@@ -29,6 +29,9 @@ final class AwsManagedPolicies {
                 "Provides full access to AWS services and resources, but does not allow management of Users and groups."),
         new ManagedPolicyDef("ReadOnlyAccess", "/",
                 "Provides read-only access to AWS services and resources."),
+        new ManagedPolicyDef("SecurityAudit", "/",
+                "The security audit template grants access to read security configuration metadata. "
+                + "It is useful for software that audits the configuration of an AWS account."),
         new ManagedPolicyDef("IAMFullAccess", "/",
                 "Provides full access to IAM."),
         new ManagedPolicyDef("AmazonS3FullAccess", "/",

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2FlowLogAndVpcEndpointIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2FlowLogAndVpcEndpointIntegrationTest.java
@@ -1,0 +1,232 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.startsWith;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+/**
+ * Integration tests for VPC Flow Logs and VPC Endpoints via the EC2 Query
+ * Protocol (form-encoded POST, XML response).
+ *
+ * <p>Covers {@code CreateFlowLogs} / {@code DescribeFlowLogs} / {@code DeleteFlowLogs}
+ * and {@code CreateVpcEndpoint} / {@code DescribeVpcEndpoints} /
+ * {@code DescribeVpcEndpointConnections}.</p>
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class Ec2FlowLogAndVpcEndpointIntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/ec2/aws4_request";
+
+    private static String vpcId;
+    private static String subnetId;
+    private static String flowLogId;
+    private static String vpcEndpointId;
+
+    // =========================================================================
+    // Fixtures: a VPC + subnet to attach the flow log / endpoint to
+    // =========================================================================
+
+    @Test
+    @Order(1)
+    void createVpc() {
+        vpcId = given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.20.0.0/16")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("CreateVpcResponse.vpc.state", equalTo("available"))
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+    }
+
+    @Test
+    @Order(2)
+    void createSubnet() {
+        subnetId = given()
+            .formParam("Action", "CreateSubnet")
+            .formParam("VpcId", vpcId)
+            .formParam("CidrBlock", "10.20.1.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .extract().path("CreateSubnetResponse.subnet.subnetId");
+    }
+
+    // =========================================================================
+    // VPC Flow Logs
+    // =========================================================================
+
+    @Test
+    @Order(10)
+    void createFlowLogs() {
+        flowLogId = given()
+            .formParam("Action", "CreateFlowLogs")
+            .formParam("ResourceType", "VPC")
+            .formParam("ResourceId.1", vpcId)
+            .formParam("TrafficType", "ALL")
+            .formParam("LogDestinationType", "s3")
+            .formParam("LogDestination", "arn:aws:s3:::flow-logs-test-bucket")
+            .formParam("MaxAggregationInterval", "60")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("CreateFlowLogsResponse.flowLogIdSet.item[0]", startsWith("fl-"))
+            .extract().path("CreateFlowLogsResponse.flowLogIdSet.item[0]");
+    }
+
+    @Test
+    @Order(11)
+    void describeFlowLogsReturnsTheCreatedLog() {
+        given()
+            .formParam("Action", "DescribeFlowLogs")
+            .formParam("FlowLogId.1", flowLogId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("DescribeFlowLogsResponse.flowLogSet.item[0].flowLogId", equalTo(flowLogId))
+            .body("DescribeFlowLogsResponse.flowLogSet.item[0].resourceId", equalTo(vpcId))
+            .body("DescribeFlowLogsResponse.flowLogSet.item[0].trafficType", equalTo("ALL"))
+            .body("DescribeFlowLogsResponse.flowLogSet.item[0].logDestinationType", equalTo("s3"))
+            .body("DescribeFlowLogsResponse.flowLogSet.item[0].logDestination",
+                    equalTo("arn:aws:s3:::flow-logs-test-bucket"))
+            .body("DescribeFlowLogsResponse.flowLogSet.item[0].maxAggregationInterval", equalTo("60"));
+    }
+
+    @Test
+    @Order(12)
+    void deleteFlowLogs() {
+        given()
+            .formParam("Action", "DeleteFlowLogs")
+            .formParam("FlowLogId.1", flowLogId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml");
+
+        // After deletion, describing all flow logs must not return the deleted id.
+        given()
+            .formParam("Action", "DescribeFlowLogs")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeFlowLogsResponse.flowLogSet.findAll { it.flowLogId == '" + flowLogId + "' }.size()",
+                    equalTo(0));
+    }
+
+    // =========================================================================
+    // VPC Endpoints (Interface / PrivateLink)
+    // =========================================================================
+
+    @Test
+    @Order(20)
+    void createInterfaceVpcEndpoint() {
+        vpcEndpointId = given()
+            .formParam("Action", "CreateVpcEndpoint")
+            .formParam("ServiceName", "com.amazonaws.us-east-1.s3")
+            .formParam("VpcId", vpcId)
+            .formParam("VpcEndpointType", "Interface")
+            .formParam("SubnetId.1", subnetId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("CreateVpcEndpointResponse.vpcEndpoint.vpcEndpointType", equalTo("Interface"))
+            .body("CreateVpcEndpointResponse.vpcEndpoint.vpcId", equalTo(vpcId))
+            .body("CreateVpcEndpointResponse.vpcEndpoint.serviceName",
+                    equalTo("com.amazonaws.us-east-1.s3"))
+            .body("CreateVpcEndpointResponse.vpcEndpoint.state", equalTo("available"))
+            .body("CreateVpcEndpointResponse.vpcEndpoint.vpcEndpointId", startsWith("vpce-"))
+            .body("CreateVpcEndpointResponse.vpcEndpoint.networkInterfaceIdSet.item.size()",
+                    greaterThanOrEqualTo(1))
+            .extract().path("CreateVpcEndpointResponse.vpcEndpoint.vpcEndpointId");
+    }
+
+    @Test
+    @Order(21)
+    void interfaceEndpointHasNetworkInterface() {
+        // An interface endpoint must expose at least one ENI; that private-IP ENI
+        // is what makes endpoint traffic observable in VPC flow logs.
+        given()
+            .formParam("Action", "DescribeVpcEndpoints")
+            .formParam("VpcEndpointId.1", vpcEndpointId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("DescribeVpcEndpointsResponse.vpcEndpointSet.item[0].vpcEndpointId",
+                    equalTo(vpcEndpointId))
+            .body("DescribeVpcEndpointsResponse.vpcEndpointSet.item[0].networkInterfaceIdSet.item.size()",
+                    greaterThanOrEqualTo(1));
+    }
+
+    @Test
+    @Order(22)
+    void describeVpcEndpointConnectionsReturnsEmptySet() {
+        // Must succeed (empty), not error — clients that enumerate connections
+        // per endpoint rely on this returning a well-formed empty set.
+        given()
+            .formParam("Action", "DescribeVpcEndpointConnections")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("DescribeVpcEndpointConnectionsResponse.requestId", org.hamcrest.Matchers.notNullValue());
+    }
+
+    @Test
+    @Order(23)
+    void deleteVpcEndpoint() {
+        given()
+            .formParam("Action", "DeleteVpcEndpoints")
+            .formParam("VpcEndpointId.1", vpcEndpointId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml");
+
+        // After deletion the endpoint must no longer be returned (and its ENIs
+        // are removed, so it doesn't leak into network-interface listings).
+        given()
+            .formParam("Action", "DescribeVpcEndpoints")
+            .formParam("VpcEndpointId.1", vpcEndpointId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVpcEndpointsResponse.vpcEndpointSet.item.size()", equalTo(0));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iam/SecurityAuditManagedPolicyIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/SecurityAuditManagedPolicyIntegrationTest.java
@@ -1,0 +1,72 @@
+package io.github.hectorvent.floci.services.iam;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+/**
+ * Verifies the AWS-managed {@code SecurityAudit} policy is resolvable and
+ * attachable. {@code SecurityAudit} is a standard AWS managed policy commonly
+ * attached to read-only auditing roles; {@code AttachRolePolicy} fails if the
+ * managed policy is not present in the emulator's seed list.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SecurityAuditManagedPolicyIntegrationTest {
+
+    private static final String IAM_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/iam/aws4_request";
+
+    private static final String SECURITY_AUDIT_ARN =
+            "arn:aws:iam::aws:policy/SecurityAudit";
+
+    private static final String TRUST_POLICY =
+            "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\","
+            + "\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}";
+
+    @Test
+    @Order(1)
+    void getSecurityAuditManagedPolicy() {
+        given()
+            .formParam("Action", "GetPolicy")
+            .formParam("PolicyArn", SECURITY_AUDIT_ARN)
+            .header("Authorization", IAM_AUTH)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("GetPolicyResponse.GetPolicyResult.Policy.PolicyName", equalTo("SecurityAudit"))
+            .body("GetPolicyResponse.GetPolicyResult.Policy.Arn", equalTo(SECURITY_AUDIT_ARN));
+    }
+
+    @Test
+    @Order(2)
+    void attachSecurityAuditToRole() {
+        given()
+            .formParam("Action", "CreateRole")
+            .formParam("RoleName", "SecurityAuditTestRole")
+            .formParam("Path", "/")
+            .formParam("AssumeRolePolicyDocument", TRUST_POLICY)
+            .header("Authorization", IAM_AUTH)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .formParam("Action", "AttachRolePolicy")
+            .formParam("RoleName", "SecurityAuditTestRole")
+            .formParam("PolicyArn", SECURITY_AUDIT_ARN)
+            .header("Authorization", IAM_AUTH)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+}


### PR DESCRIPTION
## What

Adds three EC2/VPC networking-observability capabilities to the emulator, plus the `SecurityAudit` AWS-managed policy:

- **VPC Flow Logs** — `CreateFlowLogs`, `DescribeFlowLogs`, `DeleteFlowLogs`. A flow log attached to a VPC/subnet/ENI delivers synthetic VPC flow-log records to the configured S3 bucket, using the AWS **default (version 5) record format** under the real AWS key layout (`AWSLogs/{account}/vpcflowlogs/{region}/{yyyy}/{MM}/{dd}/{HH}/...log.gz`, gzipped). Records are correlated to the EC2 resources that actually exist in the emulator (instance ids, ENI ids, subnet/VPC ids, private IPs), and same-VPC instances converse with each other plus any interface VPC endpoints, so the generated traffic is realistic rather than purely random.
- **Interface VPC Endpoints (PrivateLink)** — `CreateVpcEndpoint`, `DescribeVpcEndpoints`, `DescribeVpcEndpointConnections`, `DeleteVpcEndpoints`. An interface endpoint creates one ENI per subnet with a private IP inside the VPC, mirroring AWS PrivateLink. `DescribeVpcEndpointConnections` returns a well-formed empty set so clients that enumerate connections per endpoint don't error.
- **`SecurityAudit` managed policy** — added to the IAM managed-policy seed list so `AttachRolePolicy arn:aws:iam::aws:policy/SecurityAudit` succeeds. This is a standard AWS managed policy that was missing.
- **Optional `FLOCI_EC2_REGIONS`** — an opt-in env var that restricts the regions reported by `DescribeRegions` to a comma-separated subset. Useful when a client enumerates regions and sweeps each one and you want to scope that sweep. When unset, the full default region list is returned (no behavior change).

## Why

The emulator already models EC2 inventory (VPCs, subnets, instances, ENIs, security groups) well, but had no way to produce **VPC flow logs** or model **PrivateLink interface endpoints** — both of which are needed to exercise tools that consume network-traffic data (log pipelines, SIEMs, traffic-analysis and cloud-visibility software) entirely locally, with no real cloud spend. These additions let such tools be tested against realistic, resource-correlated traffic and PaaS-access topologies.

The `SecurityAudit` policy and the `FLOCI_EC2_REGIONS` filter are small supporting changes that come up in the same workflow (audit roles, and scoping a multi-region enumeration).

## Implementation notes

- All actions use the real AWS **EC2 Query Protocol** (form-encoded request, XML response) and **IAM Query Protocol** — no custom endpoints; the AWS SDK/CLI and Terraform work unmodified.
- The flow-log generator runs on a background scheduler (60s) and skips delivery gracefully if the destination bucket doesn't exist yet, retrying on the next tick.
- New EC2 actions are registered in `AwsQueryController` and dispatched in `Ec2QueryHandler`; state lives in `Ec2Service` / `FlowLogService` with new `FlowLog` and `VpcEndpoint` models.

## Tests

- `Ec2FlowLogAndVpcEndpointIntegrationTest` — create/describe/delete flow logs (asserts the resource correlation and record-format fields), create/describe an interface endpoint (asserts it gets an ENI), and the empty `DescribeVpcEndpointConnections` set.
- `SecurityAuditManagedPolicyIntegrationTest` — `GetPolicy` resolves `SecurityAudit` and `AttachRolePolicy` succeeds against a role.

Both follow the existing `@QuarkusTest` + RestAssured Query-Protocol style. The existing suite continues to pass (the `DescribeRegions` default behavior is unchanged).
