### PR TITLE
feat(eks): support managed node groups (create/describe/list/delete)

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/EksTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/EksTest.java
@@ -139,6 +139,65 @@ class EksTest {
                 .isInstanceOf(ResourceInUseException.class);
     }
 
+    // ──────────────────────────── Managed node groups (#1137) ────────────────────────────
+
+    private static final String NODEGROUP = "sdk-ng";
+
+    @Test
+    @Order(10)
+    void createNodegroup() {
+        CreateNodegroupResponse response = eks.createNodegroup(CreateNodegroupRequest.builder()
+                .clusterName(clusterName)
+                .nodegroupName(NODEGROUP)
+                .subnets("subnet-abc")
+                .nodeRole("arn:aws:iam::000000000000:role/eks-node-role")
+                .scalingConfig(NodegroupScalingConfig.builder()
+                        .minSize(1).maxSize(3).desiredSize(2).build())
+                .build());
+
+        assertThat(response.nodegroup().nodegroupName()).isEqualTo(NODEGROUP);
+        assertThat(response.nodegroup().clusterName()).isEqualTo(clusterName);
+        assertThat(response.nodegroup().nodegroupArn())
+                .contains("nodegroup/" + clusterName + "/" + NODEGROUP);
+        assertThat(response.nodegroup().status())
+                .isIn(NodegroupStatus.CREATING, NodegroupStatus.ACTIVE);
+        assertThat(response.nodegroup().scalingConfig().desiredSize()).isEqualTo(2);
+    }
+
+    @Test
+    @Order(11)
+    void listNodegroups() {
+        ListNodegroupsResponse response = eks.listNodegroups(ListNodegroupsRequest.builder()
+                .clusterName(clusterName).build());
+        assertThat(response.nodegroups()).contains(NODEGROUP);
+    }
+
+    @Test
+    @Order(12)
+    void describeNodegroup() {
+        DescribeNodegroupResponse response = eks.describeNodegroup(DescribeNodegroupRequest.builder()
+                .clusterName(clusterName).nodegroupName(NODEGROUP).build());
+        assertThat(response.nodegroup().nodegroupName()).isEqualTo(NODEGROUP);
+        assertThat(response.nodegroup().subnets()).contains("subnet-abc");
+        assertThat(response.nodegroup().amiType()).isNotNull();
+    }
+
+    @Test
+    @Order(13)
+    void describeMissingNodegroupFails() {
+        assertThatThrownBy(() -> eks.describeNodegroup(DescribeNodegroupRequest.builder()
+                        .clusterName(clusterName).nodegroupName("no-such-ng").build()))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    @Order(14)
+    void deleteNodegroup() {
+        DeleteNodegroupResponse response = eks.deleteNodegroup(DeleteNodegroupRequest.builder()
+                .clusterName(clusterName).nodegroupName(NODEGROUP).build());
+        assertThat(response.nodegroup().status()).isEqualTo(NodegroupStatus.DELETING);
+    }
+
     @Test
     @Order(100)
     void deleteCluster() {

--- a/src/main/java/io/github/hectorvent/floci/services/eks/EksController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eks/EksController.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.eks;
 
 import io.github.hectorvent.floci.services.eks.model.Cluster;
 import io.github.hectorvent.floci.services.eks.model.CreateClusterRequest;
+import io.github.hectorvent.floci.services.eks.model.Nodegroup;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
@@ -61,6 +62,41 @@ public class EksController {
     public Response deleteCluster(@PathParam("name") String name) {
         Cluster cluster = eksService.deleteCluster(name);
         return Response.ok(Map.of("cluster", cluster)).build();
+    }
+
+    // Managed node groups. These explicit routes outrank S3's path-style catch-all
+    // (@Path("/{bucket}/{key: .+}")), which previously swallowed these paths (issue #1137).
+
+    @POST
+    @Path("/clusters/{name}/node-groups")
+    public Response createNodegroup(@PathParam("name") String name, Nodegroup request) {
+        Nodegroup nodegroup = eksService.createNodegroup(name, request);
+        return Response.ok(Map.of("nodegroup", nodegroup)).build();
+    }
+
+    @GET
+    @Path("/clusters/{name}/node-groups")
+    public Response listNodegroups(@PathParam("name") String name,
+                                   @QueryParam("nextToken") String nextToken,
+                                   @QueryParam("maxResults") Integer maxResults) {
+        List<String> nodegroups = eksService.listNodegroups(name);
+        return Response.ok(Map.of("nodegroups", nodegroups)).build();
+    }
+
+    @GET
+    @Path("/clusters/{name}/node-groups/{nodegroupName}")
+    public Response describeNodegroup(@PathParam("name") String name,
+                                      @PathParam("nodegroupName") String nodegroupName) {
+        Nodegroup nodegroup = eksService.describeNodegroup(name, nodegroupName);
+        return Response.ok(Map.of("nodegroup", nodegroup)).build();
+    }
+
+    @DELETE
+    @Path("/clusters/{name}/node-groups/{nodegroupName}")
+    public Response deleteNodegroup(@PathParam("name") String name,
+                                    @PathParam("nodegroupName") String nodegroupName) {
+        Nodegroup nodegroup = eksService.deleteNodegroup(name, nodegroupName);
+        return Response.ok(Map.of("nodegroup", nodegroup)).build();
     }
 
 }

--- a/src/main/java/io/github/hectorvent/floci/services/eks/EksController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eks/EksController.java
@@ -76,9 +76,7 @@ public class EksController {
 
     @GET
     @Path("/clusters/{name}/node-groups")
-    public Response listNodegroups(@PathParam("name") String name,
-                                   @QueryParam("nextToken") String nextToken,
-                                   @QueryParam("maxResults") Integer maxResults) {
+    public Response listNodegroups(@PathParam("name") String name) {
         List<String> nodegroups = eksService.listNodegroups(name);
         return Response.ok(Map.of("nodegroups", nodegroups)).build();
     }

--- a/src/main/java/io/github/hectorvent/floci/services/eks/EksService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eks/EksService.java
@@ -13,6 +13,9 @@ import io.github.hectorvent.floci.services.eks.model.Cluster;
 import io.github.hectorvent.floci.services.eks.model.ClusterStatus;
 import io.github.hectorvent.floci.services.eks.model.CreateClusterRequest;
 import io.github.hectorvent.floci.services.eks.model.KubernetesNetworkConfig;
+import io.github.hectorvent.floci.services.eks.model.Nodegroup;
+import io.github.hectorvent.floci.services.eks.model.NodegroupScalingConfig;
+import io.github.hectorvent.floci.services.eks.model.NodegroupStatus;
 import io.github.hectorvent.floci.services.eks.model.ResourcesVpcConfig;
 import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.annotation.PostConstruct;
@@ -22,9 +25,12 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -36,6 +42,7 @@ public class EksService implements TagHandler {
     private static final Logger LOG = Logger.getLogger(EksService.class);
 
     private final StorageBackend<String, Cluster> storage;
+    private final StorageBackend<String, Nodegroup> nodegroupStorage;
     private final EmulatorConfig config;
     private final RegionResolver regionResolver;
     private final EksClusterManager clusterManager;
@@ -46,6 +53,8 @@ public class EksService implements TagHandler {
                       RegionResolver regionResolver, EksClusterManager clusterManager) {
         this.storage = storageFactory.create("eks", "eks-clusters.json",
                 new TypeReference<Map<String, Cluster>>() {});
+        this.nodegroupStorage = storageFactory.create("eks", "eks-nodegroups.json",
+                new TypeReference<Map<String, Nodegroup>>() {});
         this.config = config;
         this.regionResolver = regionResolver;
         this.clusterManager = clusterManager;
@@ -135,6 +144,103 @@ public class EksService implements TagHandler {
         }
         storage.delete(name);
         return cluster;
+    }
+
+    // ──────────────────────────── Managed node groups ────────────────────────────
+
+    public Nodegroup createNodegroup(String clusterName, Nodegroup request) {
+        Cluster cluster = describeCluster(clusterName);
+        String nodegroupName = request.getNodegroupName();
+        if (nodegroupName == null || nodegroupName.isBlank()) {
+            throw new AwsException("InvalidParameterException", "nodegroupName is required", 400);
+        }
+        if (request.getNodeRole() == null || request.getNodeRole().isBlank()) {
+            throw new AwsException("InvalidParameterException", "nodeRole is required", 400);
+        }
+        if (request.getSubnets() == null || request.getSubnets().isEmpty()) {
+            throw new AwsException("InvalidParameterException", "subnets are required", 400);
+        }
+        String key = nodegroupKey(clusterName, nodegroupName);
+        if (nodegroupStorage.get(key).isPresent()) {
+            throw new AwsException("ResourceInUseException",
+                    "NodeGroup already exists: " + nodegroupName, 409);
+        }
+
+        String region = config.defaultRegion();
+        String accountId = regionResolver.getAccountId();
+        Instant now = Instant.now();
+
+        Nodegroup ng = request;
+        ng.setClusterName(clusterName);
+        ng.setAccountId(accountId);
+        ng.setNodegroupArn(AwsArnUtils.Arn.of("eks", region, accountId,
+                "nodegroup/" + clusterName + "/" + nodegroupName + "/" + UUID.randomUUID()).toString());
+        ng.setCreatedAt(now);
+        ng.setModifiedAt(now);
+        // Mock node groups become ACTIVE immediately, mirroring mock-mode cluster creation;
+        // real worker nodes are not provisioned — k3s schedules pods on its built-in node.
+        ng.setStatus(NodegroupStatus.ACTIVE);
+        if (ng.getAmiType() == null) {
+            ng.setAmiType("AL2_x86_64");
+        }
+        if (ng.getCapacityType() == null) {
+            ng.setCapacityType("ON_DEMAND");
+        }
+        if (ng.getDiskSize() == null) {
+            ng.setDiskSize(20);
+        }
+        if (ng.getVersion() == null) {
+            ng.setVersion(cluster.getVersion());
+        }
+        if (ng.getReleaseVersion() == null) {
+            ng.setReleaseVersion(ng.getVersion() + "-eks-1");
+        }
+        if (ng.getInstanceTypes() == null || ng.getInstanceTypes().isEmpty()) {
+            ng.setInstanceTypes(List.of("t3.medium"));
+        }
+        if (ng.getScalingConfig() == null) {
+            NodegroupScalingConfig scaling = new NodegroupScalingConfig();
+            scaling.setMinSize(1);
+            scaling.setMaxSize(2);
+            scaling.setDesiredSize(2);
+            ng.setScalingConfig(scaling);
+        }
+        Map<String, Object> resources = new LinkedHashMap<>();
+        Map<String, Object> asg = new LinkedHashMap<>();
+        asg.put("name", "eks-" + nodegroupName + "-" + UUID.randomUUID().toString().substring(0, 8));
+        resources.put("autoScalingGroups", List.of(asg));
+        ng.setResources(resources);
+        Map<String, Object> health = new LinkedHashMap<>();
+        health.put("issues", new ArrayList<>());
+        ng.setHealth(health);
+
+        nodegroupStorage.put(key, ng);
+        return ng;
+    }
+
+    public Nodegroup describeNodegroup(String clusterName, String nodegroupName) {
+        return nodegroupStorage.get(nodegroupKey(clusterName, nodegroupName))
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "No node group found for name: " + nodegroupName + " in cluster: " + clusterName, 404));
+    }
+
+    public List<String> listNodegroups(String clusterName) {
+        describeCluster(clusterName);
+        return nodegroupStorage.scan(k -> true).stream()
+                .filter(ng -> clusterName.equals(ng.getClusterName()))
+                .map(Nodegroup::getNodegroupName)
+                .collect(Collectors.toList());
+    }
+
+    public Nodegroup deleteNodegroup(String clusterName, String nodegroupName) {
+        Nodegroup ng = describeNodegroup(clusterName, nodegroupName);
+        ng.setStatus(NodegroupStatus.DELETING);
+        nodegroupStorage.delete(nodegroupKey(clusterName, nodegroupName));
+        return ng;
+    }
+
+    private String nodegroupKey(String clusterName, String nodegroupName) {
+        return clusterName + "/" + nodegroupName;
     }
 
     @Override

--- a/src/main/java/io/github/hectorvent/floci/services/eks/model/Nodegroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eks/model/Nodegroup.java
@@ -1,0 +1,185 @@
+package io.github.hectorvent.floci.services.eks.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * EKS managed node group. Doubles as the {@code CreateNodegroup} request body (the input
+ * members are a subset) and the wire response. Recursive sub-structures
+ * (remoteAccess, taints, launchTemplate, updateConfig, nodeRepairConfig, resources, health)
+ * round-trip as generic JSON so we don't over-model what the management plane just echoes.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Nodegroup {
+
+    @JsonProperty("nodegroupName")
+    private String nodegroupName;
+
+    @JsonProperty("nodegroupArn")
+    private String nodegroupArn;
+
+    @JsonProperty("clusterName")
+    private String clusterName;
+
+    @JsonProperty("version")
+    private String version;
+
+    @JsonProperty("releaseVersion")
+    private String releaseVersion;
+
+    @JsonProperty("createdAt")
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+    private Instant createdAt;
+
+    @JsonProperty("modifiedAt")
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+    private Instant modifiedAt;
+
+    @JsonProperty("status")
+    private NodegroupStatus status;
+
+    @JsonProperty("capacityType")
+    private String capacityType;
+
+    @JsonProperty("scalingConfig")
+    private NodegroupScalingConfig scalingConfig;
+
+    @JsonProperty("instanceTypes")
+    private List<String> instanceTypes;
+
+    @JsonProperty("subnets")
+    private List<String> subnets;
+
+    @JsonProperty("remoteAccess")
+    private Object remoteAccess;
+
+    @JsonProperty("amiType")
+    private String amiType;
+
+    @JsonProperty("nodeRole")
+    private String nodeRole;
+
+    @JsonProperty("labels")
+    private Map<String, String> labels;
+
+    @JsonProperty("taints")
+    private List<Object> taints;
+
+    @JsonProperty("resources")
+    private Object resources;
+
+    @JsonProperty("diskSize")
+    private Integer diskSize;
+
+    @JsonProperty("health")
+    private Object health;
+
+    @JsonProperty("updateConfig")
+    private Object updateConfig;
+
+    @JsonProperty("nodeRepairConfig")
+    private Object nodeRepairConfig;
+
+    @JsonProperty("launchTemplate")
+    private Object launchTemplate;
+
+    @JsonProperty("tags")
+    private Map<String, String> tags;
+
+    @JsonProperty("clientRequestToken")
+    @JsonIgnore
+    private String clientRequestToken;
+
+    @JsonIgnore
+    private String accountId;
+
+    public Nodegroup() {}
+
+    public String getNodegroupName() { return nodegroupName; }
+    public void setNodegroupName(String nodegroupName) { this.nodegroupName = nodegroupName; }
+
+    public String getNodegroupArn() { return nodegroupArn; }
+    public void setNodegroupArn(String nodegroupArn) { this.nodegroupArn = nodegroupArn; }
+
+    public String getClusterName() { return clusterName; }
+    public void setClusterName(String clusterName) { this.clusterName = clusterName; }
+
+    public String getVersion() { return version; }
+    public void setVersion(String version) { this.version = version; }
+
+    public String getReleaseVersion() { return releaseVersion; }
+    public void setReleaseVersion(String releaseVersion) { this.releaseVersion = releaseVersion; }
+
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
+    public Instant getModifiedAt() { return modifiedAt; }
+    public void setModifiedAt(Instant modifiedAt) { this.modifiedAt = modifiedAt; }
+
+    public NodegroupStatus getStatus() { return status; }
+    public void setStatus(NodegroupStatus status) { this.status = status; }
+
+    public String getCapacityType() { return capacityType; }
+    public void setCapacityType(String capacityType) { this.capacityType = capacityType; }
+
+    public NodegroupScalingConfig getScalingConfig() { return scalingConfig; }
+    public void setScalingConfig(NodegroupScalingConfig scalingConfig) { this.scalingConfig = scalingConfig; }
+
+    public List<String> getInstanceTypes() { return instanceTypes; }
+    public void setInstanceTypes(List<String> instanceTypes) { this.instanceTypes = instanceTypes; }
+
+    public List<String> getSubnets() { return subnets; }
+    public void setSubnets(List<String> subnets) { this.subnets = subnets; }
+
+    public Object getRemoteAccess() { return remoteAccess; }
+    public void setRemoteAccess(Object remoteAccess) { this.remoteAccess = remoteAccess; }
+
+    public String getAmiType() { return amiType; }
+    public void setAmiType(String amiType) { this.amiType = amiType; }
+
+    public String getNodeRole() { return nodeRole; }
+    public void setNodeRole(String nodeRole) { this.nodeRole = nodeRole; }
+
+    public Map<String, String> getLabels() { return labels; }
+    public void setLabels(Map<String, String> labels) { this.labels = labels; }
+
+    public List<Object> getTaints() { return taints; }
+    public void setTaints(List<Object> taints) { this.taints = taints; }
+
+    public Object getResources() { return resources; }
+    public void setResources(Object resources) { this.resources = resources; }
+
+    public Integer getDiskSize() { return diskSize; }
+    public void setDiskSize(Integer diskSize) { this.diskSize = diskSize; }
+
+    public Object getHealth() { return health; }
+    public void setHealth(Object health) { this.health = health; }
+
+    public Object getUpdateConfig() { return updateConfig; }
+    public void setUpdateConfig(Object updateConfig) { this.updateConfig = updateConfig; }
+
+    public Object getNodeRepairConfig() { return nodeRepairConfig; }
+    public void setNodeRepairConfig(Object nodeRepairConfig) { this.nodeRepairConfig = nodeRepairConfig; }
+
+    public Object getLaunchTemplate() { return launchTemplate; }
+    public void setLaunchTemplate(Object launchTemplate) { this.launchTemplate = launchTemplate; }
+
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) { this.tags = tags; }
+
+    public String getClientRequestToken() { return clientRequestToken; }
+    public void setClientRequestToken(String clientRequestToken) { this.clientRequestToken = clientRequestToken; }
+
+    public String getAccountId() { return accountId; }
+    public void setAccountId(String accountId) { this.accountId = accountId; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/eks/model/NodegroupScalingConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eks/model/NodegroupScalingConfig.java
@@ -1,0 +1,31 @@
+package io.github.hectorvent.floci.services.eks.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/** EKS node group scaling configuration (min/max/desired worker count). */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NodegroupScalingConfig {
+
+    @JsonProperty("minSize")
+    private Integer minSize;
+
+    @JsonProperty("maxSize")
+    private Integer maxSize;
+
+    @JsonProperty("desiredSize")
+    private Integer desiredSize;
+
+    public NodegroupScalingConfig() {}
+
+    public Integer getMinSize() { return minSize; }
+    public void setMinSize(Integer minSize) { this.minSize = minSize; }
+
+    public Integer getMaxSize() { return maxSize; }
+    public void setMaxSize(Integer maxSize) { this.maxSize = maxSize; }
+
+    public Integer getDesiredSize() { return desiredSize; }
+    public void setDesiredSize(Integer desiredSize) { this.desiredSize = desiredSize; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/eks/model/NodegroupStatus.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eks/model/NodegroupStatus.java
@@ -1,0 +1,15 @@
+package io.github.hectorvent.floci.services.eks.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/** EKS managed node group lifecycle status (serialized as the enum name, e.g. "ACTIVE"). */
+@RegisterForReflection
+public enum NodegroupStatus {
+    CREATING,
+    ACTIVE,
+    UPDATING,
+    DELETING,
+    CREATE_FAILED,
+    DELETE_FAILED,
+    DEGRADED
+}

--- a/src/test/java/io/github/hectorvent/floci/services/eks/EksNodegroupIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eks/EksNodegroupIntegrationTest.java
@@ -1,0 +1,92 @@
+package io.github.hectorvent.floci.services.eks;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * EKS managed node group REST flow (issue #1137). The key regression: {@code
+ * POST /clusters/{name}/node-groups} must route to EKS and return a {@code nodegroup}
+ * envelope, not fall through to S3's path-style catch-all (which returned a 400 "POST
+ * requires ?uploads parameter").
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class EksNodegroupIntegrationTest {
+
+    private static final String JSON = "application/json";
+    private static final String CLUSTER = "ng-it-cluster";
+    private static final String NODE_ROLE = "arn:aws:iam::000000000000:role/eks-node-role";
+
+    @Test
+    @Order(1)
+    void createCluster() {
+        given().contentType(JSON)
+                .body("{\"name\":\"" + CLUSTER + "\",\"roleArn\":\"arn:aws:iam::000000000000:role/eks-role\","
+                        + "\"version\":\"1.29\"}")
+                .when().post("/clusters")
+                .then().statusCode(200)
+                .body("cluster.name", equalTo(CLUSTER));
+    }
+
+    @Test
+    @Order(2)
+    void createNodegroupRoutesToEksNotS3() {
+        given().contentType(JSON)
+                .body("{\"nodegroupName\":\"ng1\",\"subnets\":[\"subnet-abc\"],\"nodeRole\":\"" + NODE_ROLE + "\","
+                        + "\"scalingConfig\":{\"minSize\":1,\"maxSize\":3,\"desiredSize\":2}}")
+                .when().post("/clusters/" + CLUSTER + "/node-groups")
+                .then()
+                .statusCode(200)
+                // Regression: a nodegroup envelope proves EKS handled it, not S3.
+                .body("nodegroup.nodegroupName", equalTo("ng1"))
+                .body("nodegroup.clusterName", equalTo(CLUSTER))
+                .body("nodegroup.nodegroupArn", containsString("nodegroup/" + CLUSTER + "/ng1/"))
+                .body("nodegroup.status", anyOf(is("ACTIVE"), is("CREATING")))
+                .body("nodegroup.scalingConfig.desiredSize", equalTo(2))
+                .body("nodegroup.amiType", notNullValue());
+    }
+
+    @Test
+    @Order(3)
+    void listNodegroups() {
+        given().contentType(JSON)
+                .when().get("/clusters/" + CLUSTER + "/node-groups")
+                .then().statusCode(200)
+                .body("nodegroups", hasItem("ng1"));
+    }
+
+    @Test
+    @Order(4)
+    void describeNodegroup() {
+        given().contentType(JSON)
+                .when().get("/clusters/" + CLUSTER + "/node-groups/ng1")
+                .then().statusCode(200)
+                .body("nodegroup.nodegroupName", equalTo("ng1"))
+                .body("nodegroup.subnets[0]", equalTo("subnet-abc"))
+                .body("nodegroup.nodeRole", equalTo(NODE_ROLE));
+    }
+
+    @Test
+    @Order(5)
+    void deleteNodegroup() {
+        given().contentType(JSON)
+                .when().delete("/clusters/" + CLUSTER + "/node-groups/ng1")
+                .then().statusCode(200)
+                .body("nodegroup.status", equalTo("DELETING"));
+
+        given().contentType(JSON)
+                .when().get("/clusters/" + CLUSTER + "/node-groups/ng1")
+                .then().statusCode(404);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/eks/EksServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eks/EksServiceTest.java
@@ -8,6 +8,8 @@ import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.eks.model.ClusterStatus;
 import io.github.hectorvent.floci.services.eks.model.CreateClusterRequest;
 import io.github.hectorvent.floci.services.eks.model.Cluster;
+import io.github.hectorvent.floci.services.eks.model.Nodegroup;
+import io.github.hectorvent.floci.services.eks.model.NodegroupStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -27,8 +29,10 @@ class EksServiceTest {
     @BeforeEach
     void setUp() {
         StorageFactory storageFactory = Mockito.mock(StorageFactory.class);
+        // Return a distinct backend per create() call so the cluster and node-group stores
+        // don't share one instance (which would mix types and break node-group scans).
         when(storageFactory.create(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
-                .thenReturn(new InMemoryStorage<>());
+                .thenAnswer(invocation -> new InMemoryStorage<>());
 
         config = Mockito.mock(EmulatorConfig.class);
         var servicesConfig = Mockito.mock(EmulatorConfig.ServicesConfig.class);
@@ -142,5 +146,81 @@ class EksServiceTest {
         tags = eksService.listTagsForResource(arn);
         assertFalse(tags.containsKey("env"));
         assertEquals("platform", tags.get("team"));
+    }
+
+    // ──────────────────────────── Managed node groups (#1137) ────────────────────────────
+
+    private Cluster newCluster(String name) {
+        CreateClusterRequest req = new CreateClusterRequest();
+        req.setName(name);
+        req.setRoleArn("arn:aws:iam::000000000000:role/eks-role");
+        req.setVersion("1.29");
+        return eksService.createCluster(req);
+    }
+
+    private Nodegroup newNodegroupRequest(String name) {
+        Nodegroup ng = new Nodegroup();
+        ng.setNodegroupName(name);
+        ng.setSubnets(List.of("subnet-123"));
+        ng.setNodeRole("arn:aws:iam::000000000000:role/eks-node-role");
+        return ng;
+    }
+
+    @Test
+    void createNodegroupBecomesActiveWithDefaults() {
+        newCluster("ng-cluster");
+        Nodegroup ng = eksService.createNodegroup("ng-cluster", newNodegroupRequest("ng1"));
+
+        assertEquals("ng1", ng.getNodegroupName());
+        assertEquals("ng-cluster", ng.getClusterName());
+        assertEquals(NodegroupStatus.ACTIVE, ng.getStatus());
+        assertTrue(ng.getNodegroupArn().contains("nodegroup/ng-cluster/ng1/"));
+        assertEquals("AL2_x86_64", ng.getAmiType());
+        assertEquals("ON_DEMAND", ng.getCapacityType());
+        assertEquals(20, ng.getDiskSize());
+        assertEquals("1.29", ng.getVersion());
+        assertEquals(List.of("t3.medium"), ng.getInstanceTypes());
+        assertNotNull(ng.getScalingConfig());
+        assertEquals(2, ng.getScalingConfig().getDesiredSize());
+        assertNotNull(ng.getCreatedAt());
+    }
+
+    @Test
+    void createNodegroupOnMissingClusterFails() {
+        AwsException e = assertThrows(AwsException.class,
+                () -> eksService.createNodegroup("no-such-cluster", newNodegroupRequest("ng1")));
+        assertEquals("ResourceNotFoundException", e.getErrorCode());
+    }
+
+    @Test
+    void createNodegroupDuplicateFails() {
+        newCluster("ng-cluster");
+        eksService.createNodegroup("ng-cluster", newNodegroupRequest("ng1"));
+        AwsException e = assertThrows(AwsException.class,
+                () -> eksService.createNodegroup("ng-cluster", newNodegroupRequest("ng1")));
+        assertEquals("ResourceInUseException", e.getErrorCode());
+    }
+
+    @Test
+    void describeListAndDeleteNodegroup() {
+        newCluster("ng-cluster");
+        eksService.createNodegroup("ng-cluster", newNodegroupRequest("ng1"));
+        eksService.createNodegroup("ng-cluster", newNodegroupRequest("ng2"));
+
+        assertEquals("ng1", eksService.describeNodegroup("ng-cluster", "ng1").getNodegroupName());
+        assertEquals(List.of("ng1", "ng2"),
+                eksService.listNodegroups("ng-cluster").stream().sorted().toList());
+
+        Nodegroup deleted = eksService.deleteNodegroup("ng-cluster", "ng1");
+        assertEquals(NodegroupStatus.DELETING, deleted.getStatus());
+        assertThrows(AwsException.class, () -> eksService.describeNodegroup("ng-cluster", "ng1"));
+        assertEquals(List.of("ng2"), eksService.listNodegroups("ng-cluster"));
+    }
+
+    @Test
+    void listNodegroupsOnMissingClusterFails() {
+        AwsException e = assertThrows(AwsException.class,
+                () -> eksService.listNodegroups("no-such-cluster"));
+        assertEquals("ResourceNotFoundException", e.getErrorCode());
     }
 }


### PR DESCRIPTION
## Summary

Adds EKS managed node group support: `CreateNodegroup`, `DescribeNodegroup`, `ListNodegroups`, `DeleteNodegroup`. Closes #1137.

The reported bug was a routing bug, not a missing feature. `aws eks create-nodegroup` returned a `400` S3 error (*"POST requires ?uploads parameter"*) because `EksController` declared no route for `/clusters/{name}/node-groups`, so the request fell through to `S3Controller`'s path-style catch-all `@Path("/{bucket}/{key: .+}")`. The new explicit node group routes outrank that templated path, so the request reaches EKS.

Node groups are emulated as management-plane records that become `ACTIVE` immediately (mirroring mock-mode cluster creation); no real worker nodes are provisioned, since the per-cluster k3s container already schedules pods on its built-in node in real mode. Defaults match AWS (`amiType=AL2_x86_64`, `capacityType=ON_DEMAND`, `diskSize=20`, scaling `1/2/2`, synthesized `nodegroupArn`/`resources`/`health`). New stores go through `StorageFactory` (`eks-nodegroups.json`); cluster-not-found returns `ResourceNotFoundException` and duplicate names `ResourceInUseException`.

Out of scope (follow-up): `UpdateNodegroupConfig` / `UpdateNodegroupVersion` / `DescribeUpdate`.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Validated against the AWS SDK for Java v2 `EksClient` (`software.amazon.awssdk:eks`, BOM `2.42.24`) in `compatibility-tests/sdk-test-java` (`EksTest`): create/describe/list/delete node group plus the `ResourceNotFoundException` case, run against a live Floci. Request/response shapes and the `Nodegroup` envelope were checked against the EKS `service-2.json` model (paths `POST/GET/GET/DELETE /clusters/{name}/node-groups[/{nodegroupName}]`, required inputs `nodegroupName`/`subnets`/`nodeRole`, `NodegroupStatus` enum). The literal issue repro (`POST /clusters/c1/node-groups`) now returns an `ACTIVE` node group instead of the S3 error.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (`EksNodegroupIntegrationTest` RestAssured route-regression + `EksServiceTest` unit cases + `EksTest` SDK compat)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
