### PR TITLE
fix: support Glue UpdateDatabase

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/glue-catalog.bats
+++ b/compatibility-tests/sdk-test-awscli/test/glue-catalog.bats
@@ -104,6 +104,25 @@ function_input() {
     found=$(echo "$output" | jq --arg name "$DB_NAME" '.DatabaseList | any(.Name == $name)')
     [ "$found" = "true" ]
 
+    run aws_cmd glue update-database \
+        --name "$DB_NAME" \
+        --database-input "{\"Name\":\"$DB_NAME\",\"Description\":\"updated database\",\"LocationUri\":\"s3://floci-glue-catalog/$DB_NAME/\"}"
+    assert_success
+
+    run aws_cmd glue get-database --name "$DB_NAME"
+    assert_success
+    description=$(json_get "$output" '.Database.Description')
+    location=$(json_get "$output" '.Database.LocationUri')
+    [ "$description" = "updated database" ]
+    [ "$location" = "s3://floci-glue-catalog/$DB_NAME/" ]
+
+    run aws_cmd glue update-database \
+        --name "$DB_NAME" \
+        --database-input "{\"Name\":\"${DB_NAME}-renamed\",\"Description\":\"renamed database\"}"
+    assert_failure
+    [[ "$output" == *"InvalidInputException"* ]]
+    [[ "$output" == *"Database cannot be renamed"* ]]
+
     run aws_cmd glue delete-database --name "$DB_NAME"
     assert_success
 

--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueJsonHandler.java
@@ -63,6 +63,12 @@ public class GlueJsonHandler {
                 glueService.deleteDatabase(name);
                 yield Response.ok().build();
             }
+            case "UpdateDatabase" -> {
+                String name = request.get("Name").asText();
+                Database db = mapper.treeToValue(request.get("DatabaseInput"), Database.class);
+                glueService.updateDatabase(name, db);
+                yield Response.ok().build();
+            }
             case "CreateTable" -> {
                 String dbName = request.get("DatabaseName").asText();
                 Table table = mapper.treeToValue(request.get("TableInput"), Table.class);

--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
@@ -91,6 +91,22 @@ public class GlueService {
         return databaseStore.scan(k -> true);
     }
 
+    public void updateDatabase(String name, Database database) {
+        Database existing = getDatabase(name);
+        String databaseName = normalizeName(database.getName());
+        if (!existing.getName().equals(databaseName)) {
+            throw new AwsException("InvalidInputException", "Database cannot be renamed", 400);
+        }
+        Database updated = new Database();
+        updated.setName(databaseName);
+        updated.setDescription(database.getDescription());
+        updated.setLocationUri(database.getLocationUri());
+        updated.setParameters(database.getParameters() == null ? null : new LinkedHashMap<>(database.getParameters()));
+        updated.setCreateTime(existing.getCreateTime());
+        databaseStore.put(databaseName, updated);
+        LOG.infov("Updated Glue Database: {0}", databaseName);
+    }
+
     public void deleteDatabase(String name) {
         String databaseName = getDatabase(name).getName();
         List<String> tableNames = tableStore.scan(k -> true).stream()

--- a/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
@@ -85,6 +85,36 @@ class GlueServiceTest {
     }
 
     @Test
+    void updateDatabaseUpdatesMetadata() {
+        assertNotNull(glueService.getDatabase("db1"));
+
+        Database database = new Database("db1");
+        database.setDescription("updated");
+        database.setLocationUri("s3://bucket/database/");
+        database.setParameters(Map.of("owner", "test"));
+
+        glueService.updateDatabase("db1", database);
+
+        Database updated = glueService.getDatabase("db1");
+        assertEquals("db1", updated.getName());
+        assertEquals("updated", updated.getDescription());
+        assertEquals("s3://bucket/database/", updated.getLocationUri());
+        assertEquals("test", updated.getParameters().get("owner"));
+    }
+
+    @Test
+    void updateDatabaseRejectsRename() {
+        assertNotNull(glueService.getDatabase("db1"));
+
+        Database database = new Database("renamed");
+
+        AwsException exception = assertThrows(AwsException.class, () -> glueService.updateDatabase("db1", database));
+
+        assertEquals("InvalidInputException", exception.getErrorCode());
+        assertEquals("Database cannot be renamed", exception.getMessage());
+    }
+
+    @Test
     void getTableWithValidSchemaReferenceReturnsDerivedColumns() {
         schemaRegistryService.createRegistry("r1", null, null, REGION);
         schemaRegistryService.createSchema(new RegistryId("r1", null),


### PR DESCRIPTION
Fixes #1229.

Adds support for the Glue UpdateDatabase API so callers can update database metadata. The behavior matches AWS behavior for database names: updating with the same name succeeds, while attempting to rename a database returns InvalidInputException.
