### PR TITLE
fix: support Glue column statistics

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/glue-catalog.bats
+++ b/compatibility-tests/sdk-test-awscli/test/glue-catalog.bats
@@ -71,6 +71,25 @@ create_table() {
         --table-input "$(table_input "$name" "$description")" >/dev/null
 }
 
+column_statistics_input() {
+    jq -n '[
+        {
+            ColumnName: "id",
+            ColumnType: "int",
+            AnalyzedTime: "2026-06-08T00:00:00Z",
+            StatisticsData: {
+                Type: "LONG",
+                LongColumnStatisticsData: {
+                    MinimumValue: 1,
+                    MaximumValue: 10,
+                    NumberOfNulls: 0,
+                    NumberOfDistinctValues: 10
+                }
+            }
+        }
+    ]'
+}
+
 function_input() {
     local owner="$1"
     jq -n \
@@ -148,6 +167,24 @@ function_input() {
     version_id=$(json_get "$output" '.Table.VersionId')
     [ "$description" = "updated" ]
     [ "$version_id" = "1" ]
+
+    run aws_cmd glue update-column-statistics-for-table \
+        --database-name "$DB_NAME" \
+        --table-name "$TABLE_NAME" \
+        --column-statistics-list "$(column_statistics_input)"
+    assert_success
+
+    run aws_cmd glue get-column-statistics-for-table \
+        --database-name "$DB_NAME" \
+        --table-name "$TABLE_NAME" \
+        --column-names id
+    assert_success
+    column_name=$(json_get "$output" '.ColumnStatisticsList[0].ColumnName')
+    statistics_type=$(json_get "$output" '.ColumnStatisticsList[0].StatisticsData.Type')
+    minimum_value=$(json_get "$output" '.ColumnStatisticsList[0].StatisticsData.LongColumnStatisticsData.MinimumValue')
+    [ "$column_name" = "id" ]
+    [ "$statistics_type" = "LONG" ]
+    [ "$minimum_value" = "1" ]
 
     run aws_cmd glue create-partition \
         --database-name "$DB_NAME" \

--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueJsonHandler.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 public class GlueJsonHandler {
 
     private static final TypeReference<List<String>> STRING_LIST = new TypeReference<>() {};
+    private static final TypeReference<List<Map<String, Object>>> MAP_LIST = new TypeReference<>() {};
 
     private final GlueService glueService;
     private final GlueSchemaRegistryService schemaRegistryService;
@@ -99,6 +100,8 @@ public class GlueJsonHandler {
                 List<String> tableNames = mapper.convertValue(request.get("TablesToDelete"), STRING_LIST);
                 yield Response.ok(Map.of("Errors", glueService.batchDeleteTables(dbName, tableNames))).build();
             }
+            case "UpdateColumnStatisticsForTable" -> handleUpdateColumnStatisticsForTable(request);
+            case "GetColumnStatisticsForTable" -> handleGetColumnStatisticsForTable(request);
             case "CreatePartition" -> {
                 String dbName = request.get("DatabaseName").asText();
                 String tableName = request.get("TableName").asText();
@@ -141,6 +144,25 @@ public class GlueJsonHandler {
             case "GetTags" -> handleGetTags(request);
             default -> throw new AwsException("InvalidAction", "Action " + action + " is not supported", 400);
         };
+    }
+
+    private Response handleUpdateColumnStatisticsForTable(JsonNode request) {
+        String dbName = request.get("DatabaseName").asText();
+        String tableName = request.get("TableName").asText();
+        List<Map<String, Object>> columnStatistics =
+                mapper.convertValue(request.get("ColumnStatisticsList"), MAP_LIST);
+        glueService.updateColumnStatisticsForTable(dbName, tableName, columnStatistics);
+        return Response.ok(Map.of("Errors", List.of())).build();
+    }
+
+    private Response handleGetColumnStatisticsForTable(JsonNode request) {
+        String dbName = request.get("DatabaseName").asText();
+        String tableName = request.get("TableName").asText();
+        List<String> columnNames = mapper.convertValue(request.get("ColumnNames"), STRING_LIST);
+        return Response.ok(Map.of(
+                "ColumnStatisticsList",
+                glueService.getColumnStatisticsForTable(dbName, tableName, columnNames)))
+                .build();
     }
 
     private Response handleCreateUserDefinedFunction(JsonNode request) throws Exception {

--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
@@ -38,9 +38,11 @@ public class GlueService {
     private static final Logger LOG = Logger.getLogger(GlueService.class);
     private static final int MAX_FUNCTION_PATTERN_LENGTH = 255;
     private static final int MAX_FUNCTION_RESULTS = 100;
+    static final String COLUMN_NAME = "ColumnName";
 
     private final StorageBackend<String, Database> databaseStore;
     private final StorageBackend<String, Table> tableStore;
+    private final StorageBackend<String, Map<String, Object>> columnStatisticsStore;
     private final StorageBackend<String, Partition> partitionStore;
     private final StorageBackend<String, UserDefinedFunction> functionStore;
     private final GlueSchemaRegistryService schemaRegistryService;
@@ -52,6 +54,7 @@ public class GlueService {
                        RegionResolver regionResolver) {
         this.databaseStore = storageFactory.create("glue", "databases.json", new TypeReference<>() {});
         this.tableStore = storageFactory.create("glue", "tables.json", new TypeReference<>() {});
+        this.columnStatisticsStore = storageFactory.create("glue", "column_statistics.json", new TypeReference<>() {});
         this.partitionStore = storageFactory.create("glue", "partitions.json", new TypeReference<>() {});
         this.functionStore = storageFactory.create("glue", "functions.json", new TypeReference<>() {});
         this.schemaRegistryService = schemaRegistryService;
@@ -60,12 +63,14 @@ public class GlueService {
 
     GlueService(StorageBackend<String, Database> databaseStore,
                 StorageBackend<String, Table> tableStore,
+                StorageBackend<String, Map<String, Object>> columnStatisticsStore,
                 StorageBackend<String, Partition> partitionStore,
                 StorageBackend<String, UserDefinedFunction> functionStore,
                 GlueSchemaRegistryService schemaRegistryService,
                 RegionResolver regionResolver) {
         this.databaseStore = databaseStore;
         this.tableStore = tableStore;
+        this.columnStatisticsStore = columnStatisticsStore;
         this.partitionStore = partitionStore;
         this.functionStore = functionStore;
         this.schemaRegistryService = schemaRegistryService;
@@ -166,6 +171,9 @@ public class GlueService {
     public void deleteTable(String databaseName, String tableName) {
         String key = tableKey(databaseName, tableName);
         tableStore.delete(key);
+        columnStatisticsStore.keys().stream()
+                .filter(statisticsKey -> statisticsKey.startsWith(key + ":"))
+                .forEach(columnStatisticsStore::delete);
         partitionStore.scan(k -> k.startsWith(key + ":")).forEach(p -> {
             partitionStore.delete(key + ":" + String.join(",", p.getValues()));
         });
@@ -187,6 +195,34 @@ public class GlueService {
             deleteTable(databaseName, tableName);
         }
         return errors;
+    }
+
+    public void updateColumnStatisticsForTable(
+            String databaseName,
+            String tableName,
+            List<Map<String, Object>> columnStatistics) {
+        Table table = getTable(databaseName, tableName);
+        for (Map<String, Object> statistics : columnStatistics) {
+            Object columnName = statistics.get(COLUMN_NAME);
+            if (columnName != null) {
+                columnStatisticsStore.put(
+                        columnStatisticsKey(table.getDatabaseName(), table.getName(), columnName.toString()),
+                        new LinkedHashMap<>(statistics));
+            }
+        }
+    }
+
+    public List<Map<String, Object>> getColumnStatisticsForTable(
+            String databaseName,
+            String tableName,
+            List<String> columnNames) {
+        Table table = getTable(databaseName, tableName);
+        List<Map<String, Object>> columnStatistics = new ArrayList<>();
+        for (String columnName : columnNames) {
+            columnStatisticsStore.get(columnStatisticsKey(table.getDatabaseName(), table.getName(), columnName))
+                    .ifPresent(statistics -> columnStatistics.add(new LinkedHashMap<>(statistics)));
+        }
+        return columnStatistics;
     }
 
     public void createPartition(String databaseName, String tableName, Partition partition) {
@@ -318,6 +354,10 @@ public class GlueService {
 
     private static String tableKey(String databaseName, String tableName) {
         return normalizeName(databaseName) + ":" + normalizeName(tableName);
+    }
+
+    private static String columnStatisticsKey(String databaseName, String tableName, String columnName) {
+        return tableKey(databaseName, tableName) + ":" + normalizeName(columnName);
     }
 
     private static String normalizeName(String name) {

--- a/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -46,6 +47,7 @@ class GlueServiceTest {
     private GlueService glueService;
     private GlueSchemaRegistryService schemaRegistryService;
     private StorageBackend<String, Table> tableStore;
+    private StorageBackend<String, Map<String, Object>> columnStatisticsStore;
     private StorageBackend<String, Partition> partitionStore;
 
     @BeforeEach
@@ -54,10 +56,12 @@ class GlueServiceTest {
         StorageFactory storageFactory = new InMemoryStorageFactory();
         schemaRegistryService = new GlueSchemaRegistryService(storageFactory, regionResolver);
         tableStore = new InMemoryStorage<>();
+        columnStatisticsStore = new InMemoryStorage<>();
         partitionStore = new InMemoryStorage<>();
         glueService = new GlueService(
                 new InMemoryStorage<String, Database>(),
                 tableStore,
+                columnStatisticsStore,
                 partitionStore,
                 new InMemoryStorage<String, UserDefinedFunction>(),
                 schemaRegistryService, regionResolver);
@@ -502,6 +506,42 @@ class GlueServiceTest {
         AwsException ex = assertThrows(AwsException.class,
                 () -> glueService.getTable("db1", "existing"));
         assertEquals("EntityNotFoundException", ex.getErrorCode());
+    }
+
+    @Test
+    void columnStatisticsCanBeUpdatedAndRetrieved() {
+        Table table = new Table();
+        table.setName("plain");
+        glueService.createTable("db1", table);
+        Map<String, Object> statistics = new LinkedHashMap<>();
+        statistics.put(GlueService.COLUMN_NAME, "id");
+        statistics.put("ColumnType", "int");
+        statistics.put("StatisticsData", Map.of(
+                "Type", "LONG",
+                "LongColumnStatisticsData", Map.of(
+                        "MinimumValue", 1,
+                        "MaximumValue", 10,
+                        "NumberOfNulls", 0,
+                        "NumberOfDistinctValues", 10)));
+
+        glueService.updateColumnStatisticsForTable("db1", "plain", List.of(statistics));
+
+        List<Map<String, Object>> fetched = glueService.getColumnStatisticsForTable("db1", "plain", List.of("id"));
+        assertEquals(1, fetched.size());
+        assertEquals("id", fetched.get(0).get(GlueService.COLUMN_NAME));
+        assertEquals("LONG", ((Map<?, ?>) fetched.get(0).get("StatisticsData")).get("Type"));
+    }
+
+    @Test
+    void deleteTableDeletesColumnStatistics() {
+        Table table = new Table();
+        table.setName("plain");
+        glueService.createTable("db1", table);
+        glueService.updateColumnStatisticsForTable("db1", "plain", List.of(Map.of(GlueService.COLUMN_NAME, "id")));
+
+        glueService.deleteTable("db1", "plain");
+
+        assertTrue(columnStatisticsStore.scan(k -> true).isEmpty());
     }
 
     @Test


### PR DESCRIPTION
Fixes #1228.

Adds support for the Glue table column statistics APIs so callers can store statistics with UpdateColumnStatisticsForTable and retrieve them with GetColumnStatisticsForTable.
