### PR TITLE
fix: reject relative S3 object keys

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -151,6 +151,7 @@ public class S3Controller {
                                   @Context HttpHeaders httpHeaders,
                                   byte[] body) {
         try {
+            validateRawUri();
             if (hasQueryParam(uriInfo, "notification")) {
                 return handlePutBucketNotification(bucket, body);
             }
@@ -237,6 +238,7 @@ public class S3Controller {
     public Response deleteBucket(@PathParam("bucket") String bucket,
                                   @Context UriInfo uriInfo) {
         try {
+            validateRawUri();
             if (hasQueryParam(uriInfo, "tagging")) {
                 s3Service.deleteBucketTagging(bucket);
                 return Response.noContent().build();
@@ -2486,9 +2488,37 @@ public class S3Controller {
 
     private void validateRawUri() {
         String rawUri = currentVertxRequest.getCurrent().request().uri();
-        String lower = rawUri.toLowerCase();
-        if (lower.contains("/..") || lower.contains("../") || lower.contains("%2e%2e") || lower.contains("%2e.") || lower.contains(".%2e")) {
+        int queryIndex = rawUri.indexOf('?');
+        String rawPath = queryIndex >= 0 ? rawUri.substring(0, queryIndex) : rawUri;
+        String decodedPath;
+        try {
+            decodedPath = URLDecoder.decode(rawPath, StandardCharsets.UTF_8);
+        }
+        catch (IllegalArgumentException e) {
             throw new AwsException("InvalidKey", "The specified key is invalid.", 400);
+        }
+
+        String[] segments = decodedPath.split("/", -1);
+        int firstKeySegment = decodedPath.startsWith("/") ? 2 : 1;
+        if (segments.length <= firstKeySegment) {
+            return;
+        }
+
+        int depth = 0;
+        for (int index = firstKeySegment; index < segments.length; index++) {
+            String segment = segments[index];
+            if (segment.isEmpty() || ".".equals(segment)) {
+                continue;
+            }
+            if ("..".equals(segment)) {
+                if (depth == 0) {
+                    throw new AwsException("InvalidKey", "The specified key is invalid.", 400);
+                }
+                depth--;
+            }
+            else {
+                depth++;
+            }
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -157,26 +157,6 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(10)
-    void pathTraversalInUrlIsNormalizedByFramework() {
-        // Vertx normalizes raw `..` in URL paths before the application layer,
-        // so /test-bucket/../../secret.txt becomes /secret.txt at the framework level
-        // and routes to a bucket-level handler (not S3Service.putObject for test-bucket).
-        //
-        // The actual service-layer traversal guard (resolveObjectPath) is tested
-        // in S3ServiceTest.resolvePathWithTraversalThrows.
-        //
-        // Verify that the normalized path does NOT result in a 500 error.
-        given()
-            .contentType("text/plain")
-            .body("safe-data")
-        .when()
-            .put("/test-bucket/../../secret.txt")
-        .then()
-            .statusCode(not(equalTo(500)));
-    }
-
-    @Test
     @Order(11)
     void listObjectsWithPrefix() {
         given()
@@ -1936,6 +1916,80 @@ class S3IntegrationTest {
         .then()
             .statusCode(400)
             .body(containsString("BadDigest"));
+    }
+
+    @Test
+    @Order(200)
+    void putObjectWithRawTraversalAboveBucketReturnsBadRequest() {
+        given()
+            .contentType("text/plain")
+            .body("safe-data")
+        .when()
+            .put("/test-bucket/../../secret.txt")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidKey"));
+    }
+
+    @Test
+    @Order(201)
+    void putObjectWithEncodedTraversalAboveBucketReturnsBadRequest() {
+        given()
+            .urlEncodingEnabled(false)
+            .contentType("text/plain")
+            .body("safe-data")
+        .when()
+            .put("/test-bucket/%2E%2E/%2E%2E/secret.txt")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidKey"));
+    }
+
+    @Test
+    @Order(202)
+    void putObjectWithEncodedSlashTraversalAboveBucketReturnsBadRequest() {
+        given()
+            .urlEncodingEnabled(false)
+            .contentType("text/plain")
+            .body("safe-data")
+        .when()
+            .put("/test-bucket/%2E%2E%2Fsecret.txt")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidKey"));
+    }
+
+    @Test
+    @Order(203)
+    void putObjectWithInternalTraversalSucceeds() {
+        given()
+            .urlEncodingEnabled(false)
+            .contentType("text/plain")
+            .body("safe-data")
+        .when()
+            .put("/test-bucket/docs/%2E%2E/file.txt")
+        .then()
+            .statusCode(200);
+
+        given()
+            .urlEncodingEnabled(false)
+        .when()
+            .get("/test-bucket/docs/%2E%2E/file.txt")
+        .then()
+            .statusCode(200)
+            .body(equalTo("safe-data"));
+    }
+
+    @Test
+    @Order(204)
+    void listObjectsAllowsTraversalInQueryString() {
+        given()
+            .urlEncodingEnabled(false)
+        .when()
+            .get("/test-bucket?prefix=../x")
+        .then()
+            .statusCode(200)
+            .body(containsString("ListBucketResult"));
     }
 
     private static String customerKeyMd5(String customerKey) {


### PR DESCRIPTION
Fixes #1231.

Rejects S3 PUT requests whose raw URI contains relative path traversal segments before normalized bucket or object routes can handle them as another operation. This makes PutObject with a key starting `../` return a Bad Request instead of acting on a normalized bucket path.
