### PR TITLE
fix(msk): poll correct Redpanda admin readiness endpoint

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/msk/RedpandaManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/RedpandaManager.java
@@ -29,7 +29,7 @@ public class RedpandaManager {
 
     private static final Logger LOG = Logger.getLogger(RedpandaManager.class);
     private static final int KAFKA_PORT = 9092;
-    private static final int ADMIN_PORT = 9644;
+    static final int ADMIN_PORT = 9644;
 
     // Redpanda's Admin API exposes readiness at /v1/status/ready. /ready always returns 404
     private static final String ADMIN_READY_PATH = "/v1/status/ready";

--- a/src/main/java/io/github/hectorvent/floci/services/msk/RedpandaManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/RedpandaManager.java
@@ -31,6 +31,9 @@ public class RedpandaManager {
     private static final int KAFKA_PORT = 9092;
     private static final int ADMIN_PORT = 9644;
 
+    // Redpanda's Admin API exposes readiness at /v1/status/ready. /ready always returns 404
+    private static final String ADMIN_READY_PATH = "/v1/status/ready";
+
     private final ContainerBuilder containerBuilder;
     private final ContainerLifecycleManager lifecycleManager;
     private final ContainerLogStreamer logStreamer;
@@ -137,13 +140,13 @@ public class RedpandaManager {
             var bindings = inspect.getNetworkSettings().getPorts().getBindings();
             var binding = bindings.get(com.github.dockerjava.api.model.ExposedPort.tcp(ADMIN_PORT));
             if (binding != null && binding.length > 0) {
-                adminUrl = "http://localhost:" + binding[0].getHostPortSpec() + "/ready";
+                adminUrl = "http://localhost:" + binding[0].getHostPortSpec() + ADMIN_READY_PATH;
             } else {
                 return false;
             }
         } else {
             String containerIp = bootstrap.split(":")[0];
-            adminUrl = "http://" + containerIp + ":" + ADMIN_PORT + "/ready";
+            adminUrl = "http://" + containerIp + ":" + ADMIN_PORT + ADMIN_READY_PATH;
         }
 
         try {

--- a/src/test/java/io/github/hectorvent/floci/services/msk/RedpandaManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/msk/RedpandaManagerTest.java
@@ -1,0 +1,101 @@
+package io.github.hectorvent.floci.services.msk;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.InspectContainerCmd;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.Ports;
+import com.sun.net.httpserver.HttpServer;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
+import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
+import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
+import io.github.hectorvent.floci.services.msk.model.MskCluster;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.net.InetSocketAddress;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RedpandaManagerTest {
+
+    @Mock
+    private ContainerBuilder containerBuilder;
+    @Mock
+    private ContainerLifecycleManager lifecycleManager;
+    @Mock
+    private ContainerLogStreamer logStreamer;
+    @Mock
+    private ContainerDetector containerDetector;
+    @Mock
+    private EmulatorConfig config;
+    @Mock
+    private RegionResolver regionResolver;
+
+    private HttpServer adminServer;
+
+    @AfterEach
+    void tearDown() {
+        if (adminServer != null) {
+            adminServer.stop(0);
+        }
+    }
+
+    private static MskCluster newCluster() {
+        return new MskCluster("arn:aws:kafka:us-east-1:000000000000:cluster/test-cluster/abc", "test-cluster");
+    }
+
+    private int startFakeAdminServer() throws Exception {
+        adminServer = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        adminServer.createContext("/v1/status/ready", exchange -> {
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        adminServer.createContext("/ready", exchange -> {
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+        });
+        adminServer.start();
+        return adminServer.getAddress().getPort();
+    }
+
+    @Test
+    void isReadyPollsTheCorrectAdminReadinessPathInNativeMode() throws Exception {
+        int adminHostPort = startFakeAdminServer();
+
+        when(containerDetector.isRunningInContainer()).thenReturn(false);
+
+        DockerClient dockerClient = mock(DockerClient.class);
+        InspectContainerCmd inspectCmd = mock(InspectContainerCmd.class);
+        InspectContainerResponse inspect = mock(InspectContainerResponse.class, RETURNS_DEEP_STUBS);
+
+        when(lifecycleManager.getDockerClient()).thenReturn(dockerClient);
+        when(dockerClient.inspectContainerCmd("container-id")).thenReturn(inspectCmd);
+        when(inspectCmd.exec()).thenReturn(inspect);
+        when(inspect.getNetworkSettings().getPorts().getBindings()).thenReturn(Map.of(
+                ExposedPort.tcp(RedpandaManager.ADMIN_PORT),
+                new Ports.Binding[] { new Ports.Binding("0.0.0.0", String.valueOf(adminHostPort)) }));
+
+        RedpandaManager manager = new RedpandaManager(
+                containerBuilder, lifecycleManager, logStreamer, containerDetector, config, regionResolver);
+
+        MskCluster cluster = newCluster();
+        cluster.setContainerId("container-id");
+        cluster.setBootstrapBrokers("localhost:19092");
+
+        assertTrue(manager.isReady(cluster),
+                "isReady() should report ready once /v1/status/ready answers 200; "
+                        + "if it regresses to polling /ready (which always 404s), this assertion fails");
+    }
+}


### PR DESCRIPTION
## Summary

`RedpandaManager.isReady()` polls Redpanda's admin API to decide whether the
MSK-emulation container is ready, but it polled `/ready` — an endpoint that
always returns 404 on Redpanda's actual admin API. The cluster therefore
never reported ready, and anything waiting on it (e.g. Terraform's
`create_msk = true` provisioning) timed out.

- Poll `/v1/status/ready` (the endpoint Redpanda's admin API actually serves
  readiness on) instead of `/ready`
- Add `RedpandaManagerTest.isReadyPollsTheCorrectAdminReadinessPathInNativeMode`:
  a local HTTP server stands in for the admin API (200 on `/v1/status/ready`,
  404 on `/ready`), the Docker container-inspect chain is mocked to resolve
  the admin port binding to it, and `isReady()` is asserted to report ready —
  reverting `ADMIN_READY_PATH` back to `/ready` makes the test fail, pinning
  the fix as a regression guard

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Not an AWS wire-protocol change — `/v1/status/ready` is Redpanda's own admin
API (the container floci runs to emulate MSK locally), not an AWS API
surface. Verified locally end-to-end: with the fix, `isReady()` correctly
reports the Redpanda container ready and Terraform's `create_msk = true`
provisioning completes against it.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (`RedpandaManagerTest`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)