### PR TITLE
fix(msk): populate currentBrokerSoftwareInfo in cluster describe response

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/msk/MskController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/MskController.java
@@ -23,7 +23,8 @@ public class MskController {
     @Path("/v1/clusters")
     public Response createCluster(Map<String, Object> request) {
         String clusterName = (String) request.get("clusterName");
-        MskCluster cluster = mskService.createCluster(clusterName);
+        String kafkaVersion = (String) request.get("kafkaVersion");
+        MskCluster cluster = mskService.createCluster(clusterName, kafkaVersion);
         return Response.ok(Map.of("clusterArn", cluster.getClusterArn(), "clusterName", cluster.getClusterName(), "state", cluster.getState())).build();
     }
 
@@ -32,7 +33,8 @@ public class MskController {
     public Response createClusterV2(Map<String, Object> request) {
         // Simple mapping to V1 for now
         String clusterName = (String) request.get("clusterName");
-        MskCluster cluster = mskService.createCluster(clusterName);
+        String kafkaVersion = (String) request.get("kafkaVersion");
+        MskCluster cluster = mskService.createCluster(clusterName, kafkaVersion);
         return Response.ok(Map.of("clusterArn", cluster.getClusterArn(), "clusterName", cluster.getClusterName(), "state", cluster.getState())).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/msk/MskController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/MskController.java
@@ -30,10 +30,12 @@ public class MskController {
 
     @POST
     @Path("/api/v2/clusters")
+    @SuppressWarnings("unchecked")
     public Response createClusterV2(Map<String, Object> request) {
         // Simple mapping to V1 for now
         String clusterName = (String) request.get("clusterName");
-        String kafkaVersion = (String) request.get("kafkaVersion");
+        Map<String, Object> provisioned = (Map<String, Object>) request.get("provisioned");
+        String kafkaVersion = provisioned != null ? (String) provisioned.get("kafkaVersion") : null;
         MskCluster cluster = mskService.createCluster(clusterName, kafkaVersion);
         return Response.ok(Map.of("clusterArn", cluster.getClusterArn(), "clusterName", cluster.getClusterName(), "state", cluster.getState())).build();
     }

--- a/src/main/java/io/github/hectorvent/floci/services/msk/MskService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/MskService.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 public class MskService {
 
     private static final Logger LOG = Logger.getLogger(MskService.class);
+    private static final String DEFAULT_KAFKA_VERSION = "3.6.0";
     private final StorageBackend<String, MskCluster> storage;
     private final EmulatorConfig config;
     private final RegionResolver regionResolver;
@@ -60,6 +61,10 @@ public class MskService {
     }
 
     public MskCluster createCluster(String clusterName) {
+        return createCluster(clusterName, DEFAULT_KAFKA_VERSION);
+    }
+
+    public MskCluster createCluster(String clusterName, String kafkaVersion) {
         if (storage.scan(k -> true).stream().anyMatch(c -> c.getClusterName().equals(clusterName))) {
             throw new AwsException("ConflictException", "Cluster already exists: " + clusterName, 409);
         }
@@ -67,7 +72,8 @@ public class MskService {
         String accountId = regionResolver.getAccountId();
         String clusterArn = AwsArnUtils.Arn.of("kafka", config.defaultRegion(), accountId, "cluster/" + clusterName + "/" + java.util.UUID.randomUUID()).toString();
 
-        MskCluster cluster = new MskCluster(clusterArn, clusterName);
+        String resolvedKafkaVersion = (kafkaVersion == null || kafkaVersion.isBlank()) ? DEFAULT_KAFKA_VERSION : kafkaVersion;
+        MskCluster cluster = new MskCluster(clusterArn, clusterName, resolvedKafkaVersion);
         cluster.setAccountId(accountId);
         cluster.setVolumeId(String.format("%06x", new SecureRandom().nextInt(0xFFFFFF)));
         

--- a/src/main/java/io/github/hectorvent/floci/services/msk/model/BrokerSoftwareInfo.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/model/BrokerSoftwareInfo.java
@@ -1,0 +1,20 @@
+package io.github.hectorvent.floci.services.msk.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class BrokerSoftwareInfo {
+
+    @JsonProperty("kafkaVersion")
+    private String kafkaVersion;
+
+    public BrokerSoftwareInfo() {}
+
+    public BrokerSoftwareInfo(String kafkaVersion) {
+        this.kafkaVersion = kafkaVersion;
+    }
+
+    public String getKafkaVersion() { return kafkaVersion; }
+    public void setKafkaVersion(String kafkaVersion) { this.kafkaVersion = kafkaVersion; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/msk/model/MskCluster.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/model/MskCluster.java
@@ -33,6 +33,9 @@ public class MskCluster {
     @JsonProperty("zookeeperConnectString")
     private String zookeeperConnectString;
 
+    @JsonProperty("currentBrokerSoftwareInfo")
+    private BrokerSoftwareInfo currentBrokerSoftwareInfo;
+
     // Internal field, not directly in AWS response but needed for GetBootstrapBrokers
     private String bootstrapBrokers;
     
@@ -47,7 +50,7 @@ public class MskCluster {
 
     public MskCluster() {}
 
-    public MskCluster(String clusterArn, String clusterName) {
+    public MskCluster(String clusterArn, String clusterName, String kafkaVersion) {
         this.clusterArn = clusterArn;
         this.clusterName = clusterName;
         this.state = ClusterState.CREATING;
@@ -55,6 +58,7 @@ public class MskCluster {
         this.currentVersion = "K3V6I1"; // Example version
         this.numberOfBrokerNodes = 1;
         this.zookeeperConnectString = "localhost:2181"; // Mock ZK
+        this.currentBrokerSoftwareInfo = new BrokerSoftwareInfo(kafkaVersion);
     }
 
     public String getClusterArn() { return clusterArn; }
@@ -80,6 +84,9 @@ public class MskCluster {
 
     public String getZookeeperConnectString() { return zookeeperConnectString; }
     public void setZookeeperConnectString(String zookeeperConnectString) { this.zookeeperConnectString = zookeeperConnectString; }
+
+    public BrokerSoftwareInfo getCurrentBrokerSoftwareInfo() { return currentBrokerSoftwareInfo; }
+    public void setCurrentBrokerSoftwareInfo(BrokerSoftwareInfo currentBrokerSoftwareInfo) { this.currentBrokerSoftwareInfo = currentBrokerSoftwareInfo; }
 
     public String getBootstrapBrokers() { return bootstrapBrokers; }
     public void setBootstrapBrokers(String bootstrapBrokers) { this.bootstrapBrokers = bootstrapBrokers; }

--- a/src/test/java/io/github/hectorvent/floci/services/msk/MskControllerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/msk/MskControllerIntegrationTest.java
@@ -1,0 +1,74 @@
+package io.github.hectorvent.floci.services.msk;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+class MskControllerIntegrationTest {
+
+    @Test
+    void createClusterV1EchoesRequestedKafkaVersion() {
+        String clusterArn = given()
+            .contentType("application/json")
+            .body("""
+                {"clusterName": "v1-version-test", "kafkaVersion": "3.5.1"}
+                """)
+        .when()
+            .post("/v1/clusters")
+        .then()
+            .statusCode(200)
+            .extract().path("clusterArn");
+
+        given()
+        .when()
+            .get("/v1/clusters/{clusterArn}", clusterArn)
+        .then()
+            .statusCode(200)
+            .body("clusterInfo.currentBrokerSoftwareInfo.kafkaVersion", equalTo("3.5.1"));
+    }
+
+    @Test
+    void createClusterV2EchoesRequestedKafkaVersionFromProvisioned() {
+        String clusterArn = given()
+            .contentType("application/json")
+            .body("""
+                {"clusterName": "v2-version-test", "provisioned": {"kafkaVersion": "3.5.1"}}
+                """)
+        .when()
+            .post("/api/v2/clusters")
+        .then()
+            .statusCode(200)
+            .extract().path("clusterArn");
+
+        given()
+        .when()
+            .get("/api/v2/clusters/{clusterArn}", clusterArn)
+        .then()
+            .statusCode(200)
+            .body("clusterInfo.currentBrokerSoftwareInfo.kafkaVersion", equalTo("3.5.1"));
+    }
+
+    @Test
+    void createClusterV2WithoutProvisionedFallsBackToDefaultKafkaVersion() {
+        String clusterArn = given()
+            .contentType("application/json")
+            .body("""
+                {"clusterName": "v2-default-version-test"}
+                """)
+        .when()
+            .post("/api/v2/clusters")
+        .then()
+            .statusCode(200)
+            .extract().path("clusterArn");
+
+        given()
+        .when()
+            .get("/api/v2/clusters/{clusterArn}", clusterArn)
+        .then()
+            .statusCode(200)
+            .body("clusterInfo.currentBrokerSoftwareInfo.kafkaVersion", equalTo("3.6.0"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/msk/MskServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/msk/MskServiceTest.java
@@ -52,6 +52,20 @@ class MskServiceTest {
     }
 
     @Test
+    void createClusterPopulatesCurrentBrokerSoftwareInfoWithDefaultKafkaVersion() {
+        MskCluster cluster = mskService.createCluster("test-cluster");
+        assertNotNull(cluster.getCurrentBrokerSoftwareInfo());
+        assertEquals("3.6.0", cluster.getCurrentBrokerSoftwareInfo().getKafkaVersion());
+    }
+
+    @Test
+    void createClusterEchoesRequestedKafkaVersion() {
+        MskCluster cluster = mskService.createCluster("test-cluster", "3.5.1");
+        assertNotNull(cluster.getCurrentBrokerSoftwareInfo());
+        assertEquals("3.5.1", cluster.getCurrentBrokerSoftwareInfo().getKafkaVersion());
+    }
+
+    @Test
     void describeCluster() {
         MskCluster created = mskService.createCluster("test-cluster");
         MskCluster described = mskService.describeCluster(created.getClusterArn());

--- a/src/test/java/io/github/hectorvent/floci/services/msk/RedpandaManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/msk/RedpandaManagerTest.java
@@ -53,7 +53,7 @@ class RedpandaManagerTest {
     }
 
     private static MskCluster newCluster() {
-        return new MskCluster("arn:aws:kafka:us-east-1:000000000000:cluster/test-cluster/abc", "test-cluster");
+        return new MskCluster("arn:aws:kafka:us-east-1:000000000000:cluster/test-cluster/abc", "test-cluster", "3.6.0");
     }
 
     private int startFakeAdminServer() throws Exception {


### PR DESCRIPTION
## Summary

`DescribeCluster` / `DescribeClusterV2` never populated `currentBrokerSoftwareInfo`
in the response, so SDK / CLI / Terraform reads of
`ClusterInfo.CurrentBrokerSoftwareInfo.KafkaVersion` always saw `null`, even
though it's a real, commonly-inspected field on MSK clusters.

- Accept an optional `kafkaVersion` on `CreateCluster` / `CreateClusterV2`,
  defaulting to `3.6.0` when omitted or blank
- Add a `BrokerSoftwareInfo` model and populate
  `MskCluster.currentBrokerSoftwareInfo` at creation time so it round-trips
  through `DescribeCluster`
- Add `MskServiceTest` coverage for both the default-version and
  explicit-version paths

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Matches the real `DescribeClusterResponse` shape, where
`ClusterInfo.CurrentBrokerSoftwareInfo.KafkaVersion` reflects the version the
cluster was created with — `CreateCluster` callers that pass `kafkaVersion`
now see it echoed back on describe, and those that omit it get a sensible
default instead of `null`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (`MskServiceTest`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)