### PR TITLE
Add storage-backed maps for service state

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/storage/StorageBackedMap.java
+++ b/src/main/java/io/github/hectorvent/floci/core/storage/StorageBackedMap.java
@@ -1,0 +1,145 @@
+package io.github.hectorvent.floci.core.storage;
+
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A mutable {@link Map} facade over {@link StorageBackend}.
+ *
+ * <p>This is intended for emulator services that already model their control
+ * plane as string-keyed maps. The facade preserves that API shape while routing
+ * mutations through the configured storage backend. Null keys and values are
+ * not supported.
+ */
+public class StorageBackedMap<V>
+        extends AbstractMap<String, V>
+{
+    private final StorageBackend<String, V> storage;
+
+    public StorageBackedMap(StorageBackend<String, V> storage)
+    {
+        this.storage = Objects.requireNonNull(storage, "storage is null");
+    }
+
+    @Override
+    public V put(String key, V value)
+    {
+        Objects.requireNonNull(key, "key is null");
+        Objects.requireNonNull(value, "value is null");
+        V previous = get(key);
+        storage.put(key, value);
+        return previous;
+    }
+
+    @Override
+    public V get(Object key)
+    {
+        if (!(key instanceof String stringKey)) {
+            return null;
+        }
+        return storage.get(stringKey).orElse(null);
+    }
+
+    @Override
+    public boolean containsKey(Object key)
+    {
+        if (!(key instanceof String stringKey)) {
+            return false;
+        }
+        return storage.get(stringKey).isPresent();
+    }
+
+    @Override
+    public V remove(Object key)
+    {
+        if (!(key instanceof String stringKey)) {
+            return null;
+        }
+        V previous = get(stringKey);
+        storage.delete(stringKey);
+        return previous;
+    }
+
+    @Override
+    public void clear()
+    {
+        storage.clear();
+    }
+
+    @Override
+    public Set<Entry<String, V>> entrySet()
+    {
+        return new AbstractSet<>()
+        {
+            @Override
+            public Iterator<Entry<String, V>> iterator()
+            {
+                Iterator<String> keys = snapshotKeys().iterator();
+                return new Iterator<>()
+                {
+                    private String currentKey;
+
+                    @Override
+                    public boolean hasNext()
+                    {
+                        return keys.hasNext();
+                    }
+
+                    @Override
+                    public Entry<String, V> next()
+                    {
+                        currentKey = keys.next();
+                        String entryKey = currentKey;
+                        return new Entry<>()
+                        {
+                            @Override
+                            public String getKey()
+                            {
+                                return entryKey;
+                            }
+
+                            @Override
+                            public V getValue()
+                            {
+                                return StorageBackedMap.this.get(entryKey);
+                            }
+
+                            @Override
+                            public V setValue(V value)
+                            {
+                                return StorageBackedMap.this.put(entryKey, value);
+                            }
+                        };
+                    }
+
+                    @Override
+                    public void remove()
+                    {
+                        if (currentKey == null) {
+                            throw new IllegalStateException("next has not been called");
+                        }
+                        storage.delete(currentKey);
+                        currentKey = null;
+                    }
+                };
+            }
+
+            @Override
+            public int size()
+            {
+                return snapshotKeys().size();
+            }
+        };
+    }
+
+    private List<String> snapshotKeys()
+    {
+        return new ArrayList<>(storage.keys());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/core/storage/StorageBackedMapTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/storage/StorageBackedMapTest.java
@@ -1,0 +1,105 @@
+package io.github.hectorvent.floci.core.storage;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StorageBackedMapTest
+{
+    @Test
+    void mapOperationsReadAndWriteThroughStorage()
+    {
+        InMemoryStorage<String, String> storage = new InMemoryStorage<>();
+        StorageBackedMap<String> map = new StorageBackedMap<>(storage);
+
+        assertNull(map.put("alpha", "one"));
+        assertEquals("one", storage.get("alpha").orElseThrow());
+        assertEquals("one", map.get("alpha"));
+        assertTrue(map.containsKey("alpha"));
+
+        assertEquals("one", map.replace("alpha", "two"));
+        assertEquals("two", storage.get("alpha").orElseThrow());
+
+        assertNull(map.putIfAbsent("beta", "three"));
+        assertEquals(Map.of("alpha", "two", "beta", "three"), Map.copyOf(map));
+
+        assertTrue(map.remove("alpha", "two"));
+        assertFalse(storage.get("alpha").isPresent());
+        assertEquals("three", map.remove("beta"));
+        assertTrue(map.isEmpty());
+    }
+
+    @Test
+    void rejectsNullValues()
+    {
+        InMemoryStorage<String, String> storage = new InMemoryStorage<>();
+        StorageBackedMap<String> map = new StorageBackedMap<>(storage);
+
+        assertThrows(NullPointerException.class, () -> map.put("alpha", null));
+        assertFalse(storage.get("alpha").isPresent());
+    }
+
+    @Test
+    void conditionalRemoveOnlyDeletesMatchingValues()
+    {
+        InMemoryStorage<String, String> storage = new InMemoryStorage<>();
+        StorageBackedMap<String> map = new StorageBackedMap<>(storage);
+        map.put("alpha", "one");
+
+        assertFalse(map.remove("alpha", "two"));
+        assertEquals("one", storage.get("alpha").orElseThrow());
+
+        assertTrue(map.remove("alpha", "one"));
+        assertFalse(storage.get("alpha").isPresent());
+    }
+
+    @Test
+    void conditionalReplaceOnlyUpdatesMatchingValues()
+    {
+        InMemoryStorage<String, String> storage = new InMemoryStorage<>();
+        StorageBackedMap<String> map = new StorageBackedMap<>(storage);
+        map.put("alpha", "one");
+
+        assertFalse(map.replace("alpha", "two", "three"));
+        assertEquals("one", storage.get("alpha").orElseThrow());
+
+        assertTrue(map.replace("alpha", "one", "three"));
+        assertEquals("three", storage.get("alpha").orElseThrow());
+    }
+
+    @Test
+    void entrySetSetValueWritesThroughStorage()
+    {
+        InMemoryStorage<String, String> storage = new InMemoryStorage<>();
+        StorageBackedMap<String> map = new StorageBackedMap<>(storage);
+        map.put("alpha", "one");
+
+        var entry = map.entrySet().iterator().next();
+
+        assertEquals("one", entry.setValue("two"));
+        assertEquals("two", storage.get("alpha").orElseThrow());
+        assertEquals("two", entry.getValue());
+    }
+
+    @Test
+    void entrySetIteratorRemoveDeletesFromStorage()
+    {
+        InMemoryStorage<String, String> storage = new InMemoryStorage<>();
+        StorageBackedMap<String> map = new StorageBackedMap<>(storage);
+        map.put("alpha", "one");
+
+        var iterator = map.entrySet().iterator();
+        assertTrue(iterator.hasNext());
+        iterator.next();
+        iterator.remove();
+
+        assertFalse(storage.get("alpha").isPresent());
+        assertTrue(map.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- Add a reusable storage-backed map abstraction for service state
- Keep the abstraction at the regular Map contract supported by StorageBackend
- Cover load, put, remove, clear, snapshot, iterator removal, and conditional map behavior with unit tests

## Tests
- ./mvnw test -Dtest=StorageBackedMapTest,IamServiceTest,IamIntegrationTest,KmsServiceTest,KmsIntegrationTest
- ./mvnw test

## Stack
This is Wave 1 PR 1 of 4.