### PR TITLE
fix(elbv2): validate subnet VPC consistency for load balancers

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
@@ -67,6 +67,7 @@ public class ElbV2Service {
         String id = randomHex16();
         String arn = AwsArnUtils.Arn.of("elasticloadbalancing", region, regionResolver.getAccountId(), "loadbalancer/" + typePrefix + "/" + name + "/" + id).toString();
         String dnsName = name + "-" + id + ".elb.localhost";
+        String vpcId = resolveSubnetVpcId(region, subnets);
 
         LoadBalancer lb = new LoadBalancer();
         lb.setLoadBalancerArn(arn);
@@ -75,7 +76,7 @@ public class ElbV2Service {
         lb.setCreatedTime(Instant.now());
         lb.setLoadBalancerName(name);
         lb.setScheme(lbScheme);
-        lb.setVpcId("vpc-00000001");
+        lb.setVpcId(vpcId);
         lb.setState("active");
         lb.setType(lbType);
         lb.setIpAddressType(ipType);
@@ -169,7 +170,15 @@ public class ElbV2Service {
 
     public void setSubnets(String region, String arn, List<String> subnets) {
         LoadBalancer lb = requireLoadBalancer(region, arn);
+        String vpcId = resolveSubnetVpcId(region, subnets);
+        if (vpcId != null && lb.getVpcId() != null && !lb.getVpcId().equals(vpcId)) {
+            throw new AwsException("InvalidConfigurationRequest",
+                    "All subnets must belong to the load balancer VPC.", 400);
+        }
         lb.setAvailabilityZones(resolveAvailabilityZones(region, subnets));
+        if (vpcId != null) {
+            lb.setVpcId(vpcId);
+        }
     }
 
     public void setIpAddressType(String region, String arn, String ipAddressType) {
@@ -700,6 +709,35 @@ public class ElbV2Service {
             availabilityZones.add(availabilityZone);
         }
         return availabilityZones;
+    }
+
+    private String resolveSubnetVpcId(String region, List<String> subnetIds) {
+        if (subnetIds == null || subnetIds.isEmpty()) {
+            return null;
+        }
+
+        List<Subnet> subnets = ec2Service.describeSubnets(region, subnetIds, Map.of());
+        Map<String, Subnet> subnetsById = subnets.stream()
+                .collect(Collectors.toMap(Subnet::getSubnetId, subnet -> subnet, (left, right) -> left));
+
+        for (String subnetId : subnetIds) {
+            if (!subnetsById.containsKey(subnetId)) {
+                throw new AwsException("SubnetNotFound",
+                        "The subnet ID '" + subnetId + "' does not exist", 400);
+            }
+        }
+
+        Set<String> vpcIds = subnetIds.stream()
+                .map(subnetsById::get)
+                .map(Subnet::getVpcId)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        if (vpcIds.size() > 1) {
+            throw new AwsException("InvalidConfigurationRequest",
+                    "All subnets must belong to the same VPC.", 400);
+        }
+
+        return vpcIds.iterator().next();
     }
 
     private TargetGroup requireTargetGroup(String region, String arn) {

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
@@ -18,6 +18,8 @@ class ElbV2IntegrationTest {
 
     private static final String AUTH =
             "AWS4-HMAC-SHA256 Credential=test/20260427/us-east-1/elasticloadbalancing/aws4_request";
+    private static final String EC2_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260427/us-east-1/ec2/aws4_request";
 
     private static String lbArn;
     private static String tgArn;
@@ -215,10 +217,183 @@ class ElbV2IntegrationTest {
                         equalTo("us-east-1b"));
     }
 
+    @Test
+    @Order(10)
+    void createLoadBalancerWithSubnetsFromDifferentVpcsThrows() {
+        String otherVpcId = given()
+                .formParam("Action", "CreateVpc")
+                .formParam("CidrBlock", "10.0.0.0/16")
+                .header("Authorization", EC2_AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("CreateVpcResponse.vpc.vpcId");
+
+        String otherSubnetId = given()
+                .formParam("Action", "CreateSubnet")
+                .formParam("VpcId", otherVpcId)
+                .formParam("CidrBlock", "10.0.1.0/24")
+                .formParam("AvailabilityZone", "us-east-1a")
+                .header("Authorization", EC2_AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("CreateSubnetResponse.subnet.subnetId");
+
+        given()
+                .formParam("Action", "CreateLoadBalancer")
+                .formParam("Name", "mixed-vpc-lb")
+                .formParam("Type", "application")
+                .formParam("Subnets.member.1", "subnet-default-a")
+                .formParam("Subnets.member.2", otherSubnetId)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(400)
+                .body("ErrorResponse.Error.Code", equalTo("InvalidConfigurationRequest"));
+    }
+
+    @Test
+    @Order(11)
+    void setSubnetsWithSubnetsFromDifferentVpcsThrows() {
+        String otherVpcId = given()
+                .formParam("Action", "CreateVpc")
+                .formParam("CidrBlock", "10.1.0.0/16")
+                .header("Authorization", EC2_AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("CreateVpcResponse.vpc.vpcId");
+
+        String otherSubnetId = given()
+                .formParam("Action", "CreateSubnet")
+                .formParam("VpcId", otherVpcId)
+                .formParam("CidrBlock", "10.1.1.0/24")
+                .formParam("AvailabilityZone", "us-east-1b")
+                .header("Authorization", EC2_AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("CreateSubnetResponse.subnet.subnetId");
+
+        String subnetLbArn = given()
+                .formParam("Action", "CreateLoadBalancer")
+                .formParam("Name", "set-subnets-test-lb")
+                .formParam("Type", "application")
+                .formParam("Subnets.member.1", "subnet-default-a")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.LoadBalancerArn");
+
+        given()
+                .formParam("Action", "SetSubnets")
+                .formParam("LoadBalancerArn", subnetLbArn)
+                .formParam("Subnets.member.1", "subnet-default-a")
+                .formParam("Subnets.member.2", otherSubnetId)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(400)
+                .body("ErrorResponse.Error.Code", equalTo("InvalidConfigurationRequest"));
+    }
+
+    @Test
+    @Order(12)
+    void setSubnetsAfterSubnetlessCreateCanAdoptCustomVpc() {
+        String customVpcId = given()
+                .formParam("Action", "CreateVpc")
+                .formParam("CidrBlock", "10.2.0.0/16")
+                .header("Authorization", EC2_AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("CreateVpcResponse.vpc.vpcId");
+
+        String customSubnetId = given()
+                .formParam("Action", "CreateSubnet")
+                .formParam("VpcId", customVpcId)
+                .formParam("CidrBlock", "10.2.1.0/24")
+                .formParam("AvailabilityZone", "us-east-1c")
+                .header("Authorization", EC2_AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("CreateSubnetResponse.subnet.subnetId");
+
+        String subnetlessLbArn = given()
+                .formParam("Action", "CreateLoadBalancer")
+                .formParam("Name", "subnetless-lb")
+                .formParam("Type", "application")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.LoadBalancerArn");
+
+        given()
+                .formParam("Action", "SetSubnets")
+                .formParam("LoadBalancerArn", subnetlessLbArn)
+                .formParam("Subnets.member.1", customSubnetId)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+
+        given()
+                .formParam("Action", "DescribeLoadBalancers")
+                .formParam("LoadBalancerArns.member.1", subnetlessLbArn)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body("DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancers.member.VpcId",
+                        equalTo(customVpcId))
+                .body("DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancers.member.AvailabilityZones.member.SubnetId",
+                        equalTo(customSubnetId));
+    }
+
+    @Test
+    @Order(13)
+    void createLoadBalancerWithMissingSubnetThrowsSubnetNotFound() {
+        given()
+                .formParam("Action", "CreateLoadBalancer")
+                .formParam("Name", "missing-subnet-lb")
+                .formParam("Type", "application")
+                .formParam("Subnets.member.1", "subnet-does-not-exist")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(400)
+                .body("ErrorResponse.Error.Code", equalTo("SubnetNotFound"));
+    }
+
     // ── Target Groups ─────────────────────────────────────────────────────────
 
     @Test
-    @Order(10)
+    @Order(14)
     void createTargetGroup() {
         tgArn = given()
                 .formParam("Action", "CreateTargetGroup")
@@ -249,7 +424,7 @@ class ElbV2IntegrationTest {
     }
 
     @Test
-    @Order(11)
+    @Order(15)
     void describeTargetGroups() {
         given()
                 .formParam("Action", "DescribeTargetGroups")
@@ -264,7 +439,7 @@ class ElbV2IntegrationTest {
     }
 
     @Test
-    @Order(12)
+    @Order(16)
     void duplicateTargetGroupNameThrows() {
         given()
                 .formParam("Action", "CreateTargetGroup")
@@ -278,7 +453,7 @@ class ElbV2IntegrationTest {
     }
 
     @Test
-    @Order(13)
+    @Order(17)
     void modifyTargetGroupAttributes() {
         given()
                 .formParam("Action", "ModifyTargetGroupAttributes")
@@ -295,7 +470,7 @@ class ElbV2IntegrationTest {
     }
 
     @Test
-    @Order(14)
+    @Order(18)
     void describeTargetGroupsByMissingNameThrows() {
         given()
                 .formParam("Action", "DescribeTargetGroups")
@@ -309,7 +484,7 @@ class ElbV2IntegrationTest {
     }
 
     @Test
-    @Order(15)
+    @Order(19)
     void describeTargetGroupsByMissingArnThrows() {
         given()
                 .formParam("Action", "DescribeTargetGroups")


### PR DESCRIPTION
## Summary

Closes #1220

Fix ELBv2 subnet validation for `CreateLoadBalancer` and `SetSubnets` so load balancers reject subnet combinations from different VPCs.

- Validate all provided subnet IDs through EC2 and reject cross-VPC combinations with `InvalidConfigurationRequest`
- Return `SubnetNotFound` for missing subnet IDs to match ELBv2 API behavior
- Preserve existing Floci behavior for subnet-less load balancers by allowing the first `SetSubnets` call to establish the VPC
- Add integration coverage for create-time rejection, update-time rejection, subnet-less create compatibility, and missing subnet errors

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Floci previously accepted subnets from different VPCs for both `CreateLoadBalancer` and `SetSubnets`, while AWS rejects those requests.

This change aligns Floci with ELBv2 behavior by:

- rejecting cross-VPC subnet combinations with `InvalidConfigurationRequest`
- returning `SubnetNotFound` when a specified subnet does not exist
- keeping the existing Floci-compatible flow where a load balancer can be created without subnets and assigned to a VPC later via `SetSubnets`

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

./mvnw -Dtest=ElbV2IntegrationTest test passed; full ./mvnw test currently hits unrelated existing ElastiCacheMemcachedIntegrationTest connection-refused errors.
