### PR TITLE
fix(elbv2): enforce ALB subnet availability zone rules

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
@@ -67,7 +67,7 @@ public class ElbV2Service {
         String id = randomHex16();
         String arn = AwsArnUtils.Arn.of("elasticloadbalancing", region, regionResolver.getAccountId(), "loadbalancer/" + typePrefix + "/" + name + "/" + id).toString();
         String dnsName = name + "-" + id + ".elb.localhost";
-        String vpcId = resolveSubnetVpcId(region, subnets);
+        String vpcId = resolveSubnetVpcId(region, lbType, subnets);
 
         LoadBalancer lb = new LoadBalancer();
         lb.setLoadBalancerArn(arn);
@@ -170,7 +170,7 @@ public class ElbV2Service {
 
     public void setSubnets(String region, String arn, List<String> subnets) {
         LoadBalancer lb = requireLoadBalancer(region, arn);
-        String vpcId = resolveSubnetVpcId(region, subnets);
+        String vpcId = resolveSubnetVpcId(region, lb.getType(), subnets);
         if (vpcId != null && lb.getVpcId() != null && !lb.getVpcId().equals(vpcId)) {
             throw new AwsException("InvalidConfigurationRequest",
                     "All subnets must belong to the load balancer VPC.", 400);
@@ -691,18 +691,14 @@ public class ElbV2Service {
     }
 
     private List<AvailabilityZone> resolveAvailabilityZones(String region, List<String> subnetIds) {
+        if (subnetIds == null || subnetIds.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        Map<String, Subnet> subnetsById = resolveSubnetsById(region, subnetIds);
         List<AvailabilityZone> availabilityZones = new ArrayList<>();
         for (String subnetId : subnetIds) {
-            Subnet subnet;
-            try {
-                subnet = ec2Service.requireSubnet(region, subnetId);
-            } catch (AwsException e) {
-                if ("InvalidSubnetID.NotFound".equals(e.getErrorCode())) {
-                    throw new AwsException("SubnetNotFound",
-                            "Subnet '" + subnetId + "' not found", 400);
-                }
-                throw e;
-            }
+            Subnet subnet = subnetsById.get(subnetId);
             AvailabilityZone availabilityZone = new AvailabilityZone();
             availabilityZone.setSubnetId(subnet.getSubnetId());
             availabilityZone.setZoneName(subnet.getAvailabilityZone());
@@ -711,19 +707,27 @@ public class ElbV2Service {
         return availabilityZones;
     }
 
-    private String resolveSubnetVpcId(String region, List<String> subnetIds) {
+    private String resolveSubnetVpcId(String region, String lbType, List<String> subnetIds) {
         if (subnetIds == null || subnetIds.isEmpty()) {
             return null;
         }
 
-        List<Subnet> subnets = ec2Service.describeSubnets(region, subnetIds, Map.of());
-        Map<String, Subnet> subnetsById = subnets.stream()
-                .collect(Collectors.toMap(Subnet::getSubnetId, subnet -> subnet, (left, right) -> left));
+        Map<String, Subnet> subnetsById = resolveSubnetsById(region, subnetIds);
 
-        for (String subnetId : subnetIds) {
-            if (!subnetsById.containsKey(subnetId)) {
-                throw new AwsException("SubnetNotFound",
-                        "The subnet ID '" + subnetId + "' does not exist", 400);
+        if ("application".equals(lbType)) {
+            if (subnetIds.size() < 2) {
+                throw new AwsException("InvalidConfigurationRequest",
+                        "Application Load Balancers must be attached to subnets in at least two Availability Zones.", 400);
+            }
+
+            long distinctAvailabilityZones = subnetIds.stream()
+                    .map(subnetsById::get)
+                    .map(Subnet::getAvailabilityZone)
+                    .distinct()
+                    .count();
+            if (distinctAvailabilityZones < 2) {
+                throw new AwsException("InvalidConfigurationRequest",
+                        "Application Load Balancers must be attached to subnets in at least two Availability Zones.", 400);
             }
         }
 
@@ -740,6 +744,19 @@ public class ElbV2Service {
         return vpcIds.iterator().next();
     }
 
+    private Map<String, Subnet> resolveSubnetsById(String region, List<String> subnetIds) {
+        List<Subnet> subnets = ec2Service.describeSubnets(region, subnetIds, Map.of());
+        Map<String, Subnet> subnetsById = subnets.stream()
+                .collect(Collectors.toMap(Subnet::getSubnetId, subnet -> subnet, (left, right) -> left));
+
+        for (String subnetId : subnetIds) {
+            if (!subnetsById.containsKey(subnetId)) {
+                throw new AwsException("SubnetNotFound",
+                        "The subnet ID '" + subnetId + "' does not exist", 400);
+            }
+        }
+        return subnetsById;
+    }
     private TargetGroup requireTargetGroup(String region, String arn) {
         TargetGroup tg = targetGroups.getOrDefault(region, Map.of()).get(arn);
         if (tg == null) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -5127,7 +5127,7 @@ class CloudFormationIntegrationTest {
                     "Name": "cfn-tg",
                     "Protocol": "HTTP",
                     "Port": 80,
-                    "VpcId": "vpc-00000001",
+                    "VpcId": "vpc-default",
                     "TargetType": "ip",
                     "HealthCheckPath": "/health",
                     "Matcher": { "HttpCode": "200-299" }

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
@@ -290,6 +290,7 @@ class ElbV2IntegrationTest {
                 .formParam("Name", "set-subnets-test-lb")
                 .formParam("Type", "application")
                 .formParam("Subnets.member.1", "subnet-default-a")
+                .formParam("Subnets.member.2", "subnet-default-b")
                 .header("Authorization", AUTH)
             .when()
                 .post("/")
@@ -313,23 +314,58 @@ class ElbV2IntegrationTest {
 
     @Test
     @Order(12)
-    void setSubnetsAfterSubnetlessCreateCanAdoptCustomVpc() {
-        String customVpcId = given()
-                .formParam("Action", "CreateVpc")
-                .formParam("CidrBlock", "10.2.0.0/16")
+    void createLoadBalancerWithSingleSubnetThrowsInvalidConfigurationRequest() {
+        given()
+                .formParam("Action", "CreateLoadBalancer")
+                .formParam("Name", "single-subnet-lb")
+                .formParam("Type", "application")
+                .formParam("Subnets.member.1", "subnet-default-a")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(400)
+                .body("ErrorResponse.Error.Code", equalTo("InvalidConfigurationRequest"));
+    }
+
+    @Test
+    @Order(13)
+    void createLoadBalancerWithSubnetsInSameAvailabilityZoneThrowsInvalidConfigurationRequest() {
+        String secondSubnetId = given()
+                .formParam("Action", "CreateSubnet")
+                .formParam("VpcId", "vpc-default")
+                .formParam("CidrBlock", "172.31.64.0/24")
+                .formParam("AvailabilityZone", "us-east-1a")
                 .header("Authorization", EC2_AUTH)
             .when()
                 .post("/")
             .then()
                 .statusCode(200)
                 .extract()
-                .path("CreateVpcResponse.vpc.vpcId");
+                .path("CreateSubnetResponse.subnet.subnetId");
 
-        String customSubnetId = given()
+        given()
+                .formParam("Action", "CreateLoadBalancer")
+                .formParam("Name", "duplicate-az-lb")
+                .formParam("Type", "application")
+                .formParam("Subnets.member.1", "subnet-default-a")
+                .formParam("Subnets.member.2", secondSubnetId)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(400)
+                .body("ErrorResponse.Error.Code", equalTo("InvalidConfigurationRequest"));
+    }
+
+    @Test
+    @Order(14)
+    void setSubnetsWithSubnetsInSameAvailabilityZoneThrowsInvalidConfigurationRequest() {
+        String secondSubnetId = given()
                 .formParam("Action", "CreateSubnet")
-                .formParam("VpcId", customVpcId)
-                .formParam("CidrBlock", "10.2.1.0/24")
-                .formParam("AvailabilityZone", "us-east-1c")
+                .formParam("VpcId", "vpc-default")
+                .formParam("CidrBlock", "172.31.65.0/24")
+                .formParam("AvailabilityZone", "us-east-1a")
                 .header("Authorization", EC2_AUTH)
             .when()
                 .post("/")
@@ -340,7 +376,7 @@ class ElbV2IntegrationTest {
 
         String subnetlessLbArn = given()
                 .formParam("Action", "CreateLoadBalancer")
-                .formParam("Name", "subnetless-lb")
+                .formParam("Name", "set-duplicate-az-lb")
                 .formParam("Type", "application")
                 .header("Authorization", AUTH)
             .when()
@@ -353,7 +389,73 @@ class ElbV2IntegrationTest {
         given()
                 .formParam("Action", "SetSubnets")
                 .formParam("LoadBalancerArn", subnetlessLbArn)
-                .formParam("Subnets.member.1", customSubnetId)
+                .formParam("Subnets.member.1", "subnet-default-a")
+                .formParam("Subnets.member.2", secondSubnetId)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(400)
+                .body("ErrorResponse.Error.Code", equalTo("InvalidConfigurationRequest"));
+    }
+
+    @Test
+    @Order(15)
+    void setSubnetsAfterSubnetlessCreateCanAdoptCustomVpc() {
+        String customVpcId = given()
+                .formParam("Action", "CreateVpc")
+                .formParam("CidrBlock", "10.2.0.0/16")
+                .header("Authorization", EC2_AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("CreateVpcResponse.vpc.vpcId");
+
+        String customSubnetAId = given()
+                .formParam("Action", "CreateSubnet")
+                .formParam("VpcId", customVpcId)
+                .formParam("CidrBlock", "10.2.1.0/24")
+                .formParam("AvailabilityZone", "us-east-1b")
+                .header("Authorization", EC2_AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("CreateSubnetResponse.subnet.subnetId");
+
+        String customSubnetBId = given()
+                .formParam("Action", "CreateSubnet")
+                .formParam("VpcId", customVpcId)
+                .formParam("CidrBlock", "10.2.2.0/24")
+                .formParam("AvailabilityZone", "us-east-1c")
+                .header("Authorization", EC2_AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("CreateSubnetResponse.subnet.subnetId");
+
+        String subnetlessLbArn = given()
+                .formParam("Action", "CreateLoadBalancer")
+                .formParam("Name", "subnetless-adopt-vpc-lb")
+                .formParam("Type", "application")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.LoadBalancerArn");
+
+        given()
+                .formParam("Action", "SetSubnets")
+                .formParam("LoadBalancerArn", subnetlessLbArn)
+                .formParam("Subnets.member.1", customSubnetAId)
+                .formParam("Subnets.member.2", customSubnetBId)
                 .header("Authorization", AUTH)
             .when()
                 .post("/")
@@ -370,12 +472,12 @@ class ElbV2IntegrationTest {
                 .statusCode(200)
                 .body("DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancers.member.VpcId",
                         equalTo(customVpcId))
-                .body("DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancers.member.AvailabilityZones.member.SubnetId",
-                        equalTo(customSubnetId));
+                .body("DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancers.member.AvailabilityZones.member.size()",
+                        equalTo(2));
     }
 
     @Test
-    @Order(13)
+    @Order(16)
     void createLoadBalancerWithMissingSubnetThrowsSubnetNotFound() {
         given()
                 .formParam("Action", "CreateLoadBalancer")
@@ -393,7 +495,7 @@ class ElbV2IntegrationTest {
     // ── Target Groups ─────────────────────────────────────────────────────────
 
     @Test
-    @Order(14)
+    @Order(20)
     void createTargetGroup() {
         tgArn = given()
                 .formParam("Action", "CreateTargetGroup")
@@ -424,7 +526,7 @@ class ElbV2IntegrationTest {
     }
 
     @Test
-    @Order(15)
+    @Order(21)
     void describeTargetGroups() {
         given()
                 .formParam("Action", "DescribeTargetGroups")
@@ -439,7 +541,7 @@ class ElbV2IntegrationTest {
     }
 
     @Test
-    @Order(16)
+    @Order(22)
     void duplicateTargetGroupNameThrows() {
         given()
                 .formParam("Action", "CreateTargetGroup")
@@ -453,7 +555,7 @@ class ElbV2IntegrationTest {
     }
 
     @Test
-    @Order(17)
+    @Order(23)
     void modifyTargetGroupAttributes() {
         given()
                 .formParam("Action", "ModifyTargetGroupAttributes")
@@ -470,7 +572,7 @@ class ElbV2IntegrationTest {
     }
 
     @Test
-    @Order(18)
+    @Order(24)
     void describeTargetGroupsByMissingNameThrows() {
         given()
                 .formParam("Action", "DescribeTargetGroups")
@@ -484,7 +586,7 @@ class ElbV2IntegrationTest {
     }
 
     @Test
-    @Order(19)
+    @Order(25)
     void describeTargetGroupsByMissingArnThrows() {
         given()
                 .formParam("Action", "DescribeTargetGroups")
@@ -501,7 +603,7 @@ class ElbV2IntegrationTest {
     // ── Targets ───────────────────────────────────────────────────────────────
 
     @Test
-    @Order(20)
+    @Order(26)
     void registerTargets() {
         given()
                 .formParam("Action", "RegisterTargets")
@@ -518,7 +620,7 @@ class ElbV2IntegrationTest {
     }
 
     @Test
-    @Order(21)
+    @Order(27)
     void describeTargetHealthReturnsInitial() {
         given()
                 .formParam("Action", "DescribeTargetHealth")
@@ -922,7 +1024,7 @@ class ElbV2IntegrationTest {
     }
 
     @Test
-    @Order(73)
+    @Order(74)
     void createLoadBalancerWithMissingSubnetReturnsSubnetNotFound() {
         given()
                 .formParam("Action", "CreateLoadBalancer")
@@ -938,7 +1040,7 @@ class ElbV2IntegrationTest {
     }
 
     @Test
-    @Order(74)
+    @Order(75)
     void setSubnetsWithMissingSubnetReturnsSubnetNotFound() {
         String setSubnetsLbArn = given()
                 .formParam("Action", "CreateLoadBalancer")


### PR DESCRIPTION
## Summary

Align ELBv2 application load balancer subnet validation with AWS behavior for `CreateLoadBalancer` and `SetSubnets`. 
Closes #1219

- reject ALB subnet selections that provide fewer than two subnets when subnets are supplied
- reject ALB subnet selections that do not span at least two distinct Availability Zones
- preserve subnet-less load balancer compatibility by allowing the first `SetSubnets` call to establish the VPC
- add integration coverage for single-subnet rejection, same-AZ rejection, and subnet-less create compatibility

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Floci previously accepted invalid subnet placements for ALBs:

- `CreateLoadBalancer` accepted a single subnet for `Type=application`
- `CreateLoadBalancer` accepted multiple subnets even when they resolved to the same Availability Zone
- `SetSubnets` accepted same-AZ subnet combinations for ALBs

This change aligns Floci with AWS ELBv2 behavior by rejecting invalid ALB subnet/AZ combinations with `InvalidConfigurationRequest`, while keeping the existing Floci-compatible flow where a load balancer created without subnets can later adopt a valid subnet set and VPC through `SetSubnets`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)