### PR TITLE
Add RDS provisioning support

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/RdsControlPlaneTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/RdsControlPlaneTest.java
@@ -1,0 +1,55 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.CreateDbSubnetGroupResponse;
+import software.amazon.awssdk.services.rds.model.DescribeDbSubnetGroupsResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("RDS Control Plane")
+class RdsControlPlaneTest {
+
+    private static RdsClient rds;
+    private static String subnetGroupName;
+
+    @BeforeAll
+    static void setup() {
+        rds = TestFixtures.rdsClient();
+        subnetGroupName = TestFixtures.uniqueName("rds-subnets");
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (rds != null) {
+            try {
+                rds.deleteDBSubnetGroup(b -> b.dbSubnetGroupName(subnetGroupName));
+            } catch (Exception ignored) {
+            }
+            rds.close();
+        }
+    }
+
+    @Test
+    void sdkUnmarshalsDbSubnetGroupSubnets() {
+        CreateDbSubnetGroupResponse createResponse = rds.createDBSubnetGroup(b -> b
+                .dbSubnetGroupName(subnetGroupName)
+                .dbSubnetGroupDescription("SDK subnet group shape")
+                .subnetIds("subnet-a", "subnet-b"));
+
+        assertThat(createResponse.dbSubnetGroup().subnets())
+                .extracting("subnetIdentifier")
+                .containsExactly("subnet-a", "subnet-b");
+
+        DescribeDbSubnetGroupsResponse describeResponse = rds.describeDBSubnetGroups(b -> b
+                .dbSubnetGroupName(subnetGroupName));
+
+        assertThat(describeResponse.dbSubnetGroups()).hasSize(1);
+        assertThat(describeResponse.dbSubnetGroups().get(0).subnets())
+                .extracting("subnetIdentifier")
+                .containsExactly("subnet-a", "subnet-b");
+    }
+}

--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -18,7 +18,11 @@ Floci manages real PostgreSQL, MySQL, and MariaDB Docker containers and proxies 
 | `DescribeOrderableDBInstanceOptions` | List deterministic instance class options |
 | `CreateDBSubnetGroup` | Create a DB subnet group |
 | `DescribeDBSubnetGroups` | List DB subnet groups |
+| `ModifyDBSubnetGroup` | Update DB subnet group description and subnet list |
 | `DeleteDBSubnetGroup` | Delete a DB subnet group |
+| `AddTagsToResource` | Add tags to a DB resource |
+| `ListTagsForResource` | List tags for a DB resource |
+| `RemoveTagsFromResource` | Remove tags from a DB resource |
 | `CreateDBCluster` | Create an Aurora-compatible cluster |
 | `DescribeDBClusters` | List clusters |
 | `DeleteDBCluster` | Delete a cluster |

--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -15,6 +15,10 @@ Floci manages real PostgreSQL, MySQL, and MariaDB Docker containers and proxies 
 | `DeleteDBInstance` | Stop and remove an instance |
 | `ModifyDBInstance` | Update instance settings |
 | `RebootDBInstance` | Restart a database instance |
+| `DescribeOrderableDBInstanceOptions` | List deterministic instance class options |
+| `CreateDBSubnetGroup` | Create a DB subnet group |
+| `DescribeDBSubnetGroups` | List DB subnet groups |
+| `DeleteDBSubnetGroup` | Delete a DB subnet group |
 | `CreateDBCluster` | Create an Aurora-compatible cluster |
 | `DescribeDBClusters` | List clusters |
 | `DeleteDBCluster` | Delete a cluster |

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -309,6 +309,8 @@ public class AwsQueryController {
     private static final Set<String> RDS_ACTIONS = Set.of(
             "CreateDBInstance", "DescribeDBInstances", "DeleteDBInstance",
             "ModifyDBInstance", "RebootDBInstance",
+            "DescribeOrderableDBInstanceOptions",
+            "CreateDBSubnetGroup", "DescribeDBSubnetGroups", "DeleteDBSubnetGroup",
             "CreateDBCluster", "DescribeDBClusters", "DeleteDBCluster", "ModifyDBCluster",
             "CreateDBParameterGroup", "DescribeDBParameterGroups",
             "DeleteDBParameterGroup", "ModifyDBParameterGroup", "DescribeDBParameters"

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -310,7 +310,8 @@ public class AwsQueryController {
             "CreateDBInstance", "DescribeDBInstances", "DeleteDBInstance",
             "ModifyDBInstance", "RebootDBInstance",
             "DescribeOrderableDBInstanceOptions",
-            "CreateDBSubnetGroup", "DescribeDBSubnetGroups", "DeleteDBSubnetGroup",
+            "CreateDBSubnetGroup", "DescribeDBSubnetGroups", "ModifyDBSubnetGroup", "DeleteDBSubnetGroup",
+            "AddTagsToResource", "ListTagsForResource", "RemoveTagsFromResource",
             "CreateDBCluster", "DescribeDBClusters", "DeleteDBCluster", "ModifyDBCluster",
             "CreateDBParameterGroup", "DescribeDBParameterGroups",
             "DeleteDBParameterGroup", "ModifyDBParameterGroup", "DescribeDBParameters"

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -52,6 +52,7 @@ public class RdsQueryHandler {
                 case "DescribeOrderableDBInstanceOptions" -> handleDescribeOrderableDbInstanceOptions(params);
                 case "CreateDBSubnetGroup" -> handleCreateDbSubnetGroup(params);
                 case "DescribeDBSubnetGroups" -> handleDescribeDbSubnetGroups(params);
+                case "ModifyDBSubnetGroup" -> handleModifyDbSubnetGroup(params);
                 case "DeleteDBSubnetGroup" -> handleDeleteDbSubnetGroup(params);
                 case "CreateDBCluster" -> handleCreateDbCluster(params);
                 case "DescribeDBClusters" -> handleDescribeDbClusters(params);
@@ -220,6 +221,22 @@ public class RdsQueryHandler {
             }
             xml.end("DBSubnetGroups").start("Marker").end("Marker");
             return Response.ok(AwsQueryResponse.envelope("DescribeDBSubnetGroups", AwsNamespaces.RDS, xml.build())).build();
+        } catch (AwsException e) {
+            return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.RDS, e.getHttpStatus());
+        }
+    }
+
+    private Response handleModifyDbSubnetGroup(MultivaluedMap<String, String> params) {
+        String name = params.getFirst("DBSubnetGroupName");
+        if (name == null || name.isBlank()) {
+            return AwsQueryResponse.error("InvalidParameterValue",
+                    "DBSubnetGroupName is required.", AwsNamespaces.RDS, 400);
+        }
+        List<String> subnetIds = memberList(params, "SubnetIds");
+        try {
+            DbSubnetGroup group = service.modifyDbSubnetGroup(name, subnetIds);
+            return Response.ok(AwsQueryResponse.envelope("ModifyDBSubnetGroup",
+                    AwsNamespaces.RDS, dbSubnetGroupXml(group))).build();
         } catch (AwsException e) {
             return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.RDS, e.getHttpStatus());
         }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -20,6 +20,7 @@ import org.jboss.logging.Logger;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -68,6 +69,9 @@ public class RdsQueryHandler {
                 case "DeleteDBClusterParameterGroup" -> handleDeleteDbClusterParameterGroup(params);
                 case "ModifyDBClusterParameterGroup" -> handleModifyDbClusterParameterGroup(params);
                 case "DescribeDBClusterParameters" -> handleDescribeDbClusterParameters(params);
+                case "AddTagsToResource" -> handleAddTagsToResource(params);
+                case "ListTagsForResource" -> handleListTagsForResource(params);
+                case "RemoveTagsFromResource" -> handleRemoveTagsFromResource(params);
                 default -> AwsQueryResponse.error("UnsupportedOperation",
                         "Operation " + action + " is not supported.", AwsNamespaces.RDS, 400);
             };
@@ -102,6 +106,7 @@ public class RdsQueryHandler {
         String dbClusterIdentifier = params.getFirst("DBClusterIdentifier");
         boolean manageMasterUserPassword = "true".equalsIgnoreCase(params.getFirst("ManageMasterUserPassword"));
         String masterUserSecretKmsKeyId = params.getFirst("MasterUserSecretKmsKeyId");
+        Map<String, String> tags = parseTags(params);
 
         if (dbInstanceClass == null) {
             dbInstanceClass = "db.t3.micro";
@@ -114,7 +119,7 @@ public class RdsQueryHandler {
             DbInstance instance = service.createDbInstance(id, engine, engineVersion, masterUsername,
                     masterPassword, dbName, dbInstanceClass, allocatedStorage, iamEnabled,
                     paramGroupName, dbSubnetGroupName, dbClusterIdentifier,
-                    manageMasterUserPassword, masterUserSecretKmsKeyId);
+                    manageMasterUserPassword, masterUserSecretKmsKeyId, tags);
             String result = dbInstanceXml(instance);
             return Response.ok(AwsQueryResponse.envelope("CreateDBInstance", AwsNamespaces.RDS, result)).build();
         } catch (AwsException e) {
@@ -195,6 +200,38 @@ public class RdsQueryHandler {
         xml.end("OrderableDBInstanceOptions").start("Marker").end("Marker");
         return Response.ok(AwsQueryResponse.envelope("DescribeOrderableDBInstanceOptions",
                 AwsNamespaces.RDS, xml.build())).build();
+    }
+
+    private Response handleAddTagsToResource(MultivaluedMap<String, String> params) {
+        String resourceName = params.getFirst("ResourceName");
+        try {
+            service.addTagsToResource(resourceName, parseTags(params));
+            return Response.ok(AwsQueryResponse.envelope("AddTagsToResource", AwsNamespaces.RDS, "")).build();
+        } catch (AwsException e) {
+            return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.RDS, e.getHttpStatus());
+        }
+    }
+
+    private Response handleListTagsForResource(MultivaluedMap<String, String> params) {
+        String resourceName = params.getFirst("ResourceName");
+        try {
+            XmlBuilder xml = new XmlBuilder().start("TagList");
+            writeTags(xml, service.listTagsForResource(resourceName));
+            xml.end("TagList");
+            return Response.ok(AwsQueryResponse.envelope("ListTagsForResource", AwsNamespaces.RDS, xml.build())).build();
+        } catch (AwsException e) {
+            return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.RDS, e.getHttpStatus());
+        }
+    }
+
+    private Response handleRemoveTagsFromResource(MultivaluedMap<String, String> params) {
+        String resourceName = params.getFirst("ResourceName");
+        try {
+            service.removeTagsFromResource(resourceName, memberList(params, "TagKeys"));
+            return Response.ok(AwsQueryResponse.envelope("RemoveTagsFromResource", AwsNamespaces.RDS, "")).build();
+        } catch (AwsException e) {
+            return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.RDS, e.getHttpStatus());
+        }
     }
 
     private Response handleCreateDbSubnetGroup(MultivaluedMap<String, String> params) {
@@ -599,7 +636,20 @@ public class RdsQueryHandler {
         if (i.getDbClusterIdentifier() != null && !i.getDbClusterIdentifier().isBlank()) {
             xml.elem("DBClusterIdentifier", i.getDbClusterIdentifier());
         }
+        xml.start("TagList");
+        writeTags(xml, i.getTags());
+        xml.end("TagList");
         return xml.build();
+    }
+
+    private static void writeTags(XmlBuilder xml, Map<String, String> tags) {
+        if (tags == null) {
+            return;
+        }
+        tags.forEach((key, value) -> xml.start("Tag")
+                .elem("Key", key)
+                .elem("Value", value)
+                .end("Tag"));
     }
 
     private String dbSubnetGroupXml(DbSubnetGroup group) {
@@ -751,6 +801,24 @@ public class RdsQueryHandler {
                 .map(params::getFirst)
                 .filter(value -> value != null && !value.isBlank())
                 .toList();
+    }
+
+    private static Map<String, String> parseTags(MultivaluedMap<String, String> params) {
+        Map<String, String> tags = new LinkedHashMap<>();
+        readTags(params, "Tags.member", tags);
+        readTags(params, "Tags.Tag", tags);
+        readTags(params, "Tag", tags);
+        return tags;
+    }
+
+    private static void readTags(MultivaluedMap<String, String> params, String prefix, Map<String, String> tags) {
+        for (int i = 1; ; i++) {
+            String key = params.getFirst(prefix + "." + i + ".Key");
+            if (key == null) {
+                break;
+            }
+            tags.put(key, params.getFirst(prefix + "." + i + ".Value"));
+        }
     }
 
     private static int parseIntSafe(String value, int defaultValue) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -11,6 +11,7 @@ import io.github.hectorvent.floci.services.rds.model.DbEndpoint;
 import io.github.hectorvent.floci.services.rds.model.DbInstance;
 import io.github.hectorvent.floci.services.rds.model.DbInstanceStatus;
 import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
+import io.github.hectorvent.floci.services.rds.model.DbSubnetGroup;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -19,6 +20,7 @@ import org.jboss.logging.Logger;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -47,6 +49,10 @@ public class RdsQueryHandler {
                 case "DeleteDBInstance" -> handleDeleteDbInstance(params);
                 case "ModifyDBInstance" -> handleModifyDbInstance(params);
                 case "RebootDBInstance" -> handleRebootDbInstance(params);
+                case "DescribeOrderableDBInstanceOptions" -> handleDescribeOrderableDbInstanceOptions(params);
+                case "CreateDBSubnetGroup" -> handleCreateDbSubnetGroup(params);
+                case "DescribeDBSubnetGroups" -> handleDescribeDbSubnetGroups(params);
+                case "DeleteDBSubnetGroup" -> handleDeleteDbSubnetGroup(params);
                 case "CreateDBCluster" -> handleCreateDbCluster(params);
                 case "DescribeDBClusters" -> handleDescribeDbClusters(params);
                 case "DeleteDBCluster" -> handleDeleteDbCluster(params);
@@ -91,6 +97,7 @@ public class RdsQueryHandler {
         int allocatedStorage = allocatedStorageStr != null ? parseIntSafe(allocatedStorageStr, 20) : 20;
         boolean iamEnabled = "true".equalsIgnoreCase(params.getFirst("EnableIAMDatabaseAuthentication"));
         String paramGroupName = params.getFirst("DBParameterGroupName");
+        String dbSubnetGroupName = params.getFirst("DBSubnetGroupName");
         String dbClusterIdentifier = params.getFirst("DBClusterIdentifier");
 
         if (dbInstanceClass == null) {
@@ -103,7 +110,7 @@ public class RdsQueryHandler {
         try {
             DbInstance instance = service.createDbInstance(id, engine, engineVersion, masterUsername,
                     masterPassword, dbName, dbInstanceClass, allocatedStorage, iamEnabled,
-                    paramGroupName, dbClusterIdentifier);
+                    paramGroupName, dbSubnetGroupName, dbClusterIdentifier);
             String result = dbInstanceXml(instance);
             return Response.ok(AwsQueryResponse.envelope("CreateDBInstance", AwsNamespaces.RDS, result)).build();
         } catch (AwsException e) {
@@ -152,10 +159,81 @@ public class RdsQueryHandler {
         String newPassword = params.getFirst("MasterUserPassword");
         String iamStr = params.getFirst("EnableIAMDatabaseAuthentication");
         Boolean iamEnabled = iamStr != null ? Boolean.parseBoolean(iamStr) : null;
+        String dbSubnetGroupName = params.getFirst("DBSubnetGroupName");
         try {
-            DbInstance instance = service.modifyDbInstance(id, newPassword, iamEnabled);
+            DbInstance instance = service.modifyDbInstance(id, newPassword, iamEnabled, dbSubnetGroupName);
             String result = dbInstanceXml(instance);
             return Response.ok(AwsQueryResponse.envelope("ModifyDBInstance", AwsNamespaces.RDS, result)).build();
+        } catch (AwsException e) {
+            return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.RDS, e.getHttpStatus());
+        }
+    }
+
+    private Response handleDescribeOrderableDbInstanceOptions(MultivaluedMap<String, String> params) {
+        Collection<Map<String, String>> options = service.describeOrderableDbInstanceOptions(
+                params.getFirst("Engine"),
+                params.getFirst("EngineVersion"),
+                params.getFirst("DBInstanceClass"));
+        XmlBuilder xml = new XmlBuilder().start("OrderableDBInstanceOptions");
+        for (Map<String, String> option : options) {
+            xml.start("OrderableDBInstanceOption")
+               .elem("Engine", option.get("engine"))
+               .elem("EngineVersion", option.get("engineVersion"))
+               .elem("DBInstanceClass", option.get("dbInstanceClass"))
+               .elem("LicenseModel", "postgresql-license")
+               .start("AvailabilityZones")
+                 .start("AvailabilityZone")
+                   .elem("Name", config.defaultAvailabilityZone())
+                 .end("AvailabilityZone")
+               .end("AvailabilityZones")
+               .end("OrderableDBInstanceOption");
+        }
+        xml.end("OrderableDBInstanceOptions").start("Marker").end("Marker");
+        return Response.ok(AwsQueryResponse.envelope("DescribeOrderableDBInstanceOptions",
+                AwsNamespaces.RDS, xml.build())).build();
+    }
+
+    private Response handleCreateDbSubnetGroup(MultivaluedMap<String, String> params) {
+        String name = params.getFirst("DBSubnetGroupName");
+        if (name == null || name.isBlank()) {
+            return AwsQueryResponse.error("InvalidParameterValue",
+                    "DBSubnetGroupName is required.", AwsNamespaces.RDS, 400);
+        }
+        String description = params.getFirst("DBSubnetGroupDescription");
+        List<String> subnetIds = memberList(params, "SubnetIds");
+        try {
+            DbSubnetGroup group = service.createDbSubnetGroup(name, description, subnetIds);
+            return Response.ok(AwsQueryResponse.envelope("CreateDBSubnetGroup",
+                    AwsNamespaces.RDS, dbSubnetGroupXml(group))).build();
+        } catch (AwsException e) {
+            return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.RDS, e.getHttpStatus());
+        }
+    }
+
+    private Response handleDescribeDbSubnetGroups(MultivaluedMap<String, String> params) {
+        String filterName = params.getFirst("DBSubnetGroupName");
+        try {
+            Collection<DbSubnetGroup> result = service.listDbSubnetGroups(filterName);
+            XmlBuilder xml = new XmlBuilder().start("DBSubnetGroups");
+            for (DbSubnetGroup group : result) {
+                xml.start("DBSubnetGroup").raw(dbSubnetGroupInnerXml(group)).end("DBSubnetGroup");
+            }
+            xml.end("DBSubnetGroups").start("Marker").end("Marker");
+            return Response.ok(AwsQueryResponse.envelope("DescribeDBSubnetGroups", AwsNamespaces.RDS, xml.build())).build();
+        } catch (AwsException e) {
+            return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.RDS, e.getHttpStatus());
+        }
+    }
+
+    private Response handleDeleteDbSubnetGroup(MultivaluedMap<String, String> params) {
+        String name = params.getFirst("DBSubnetGroupName");
+        if (name == null || name.isBlank()) {
+            return AwsQueryResponse.error("InvalidParameterValue",
+                    "DBSubnetGroupName is required.", AwsNamespaces.RDS, 400);
+        }
+        try {
+            service.deleteDbSubnetGroup(name);
+            return Response.ok(AwsQueryResponse.envelope("DeleteDBSubnetGroup", AwsNamespaces.RDS, "")).build();
         } catch (AwsException e) {
             return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.RDS, e.getHttpStatus());
         }
@@ -486,26 +564,49 @@ public class RdsQueryHandler {
                .elem("Status", "active")
              .end("VpcSecurityGroupMembership")
            .end("VpcSecurityGroups")
-           .start("DBSubnetGroup")
-             .elem("DBSubnetGroupName", "default")
-             .elem("VpcId", "vpc-00000000")
-             .elem("SubnetGroupStatus", "Complete")
-             .start("Subnets")
-               .start("member")
-                 .elem("SubnetIdentifier", "subnet-00000000")
-                 .start("SubnetAvailabilityZone")
-                   .elem("Name", config.defaultAvailabilityZone())
-                 .end("SubnetAvailabilityZone")
-                 .elem("SubnetStatus", "Active")
-               .end("member")
-             .end("Subnets")
-           .end("DBSubnetGroup")
+           .raw(dbSubnetGroupXml(dbSubnetGroupForInstance(i)))
            .elem("DbiResourceId", i.getDbiResourceId())
            .elem("DBInstanceArn", i.getDbInstanceArn());
         if (i.getDbClusterIdentifier() != null && !i.getDbClusterIdentifier().isBlank()) {
             xml.elem("DBClusterIdentifier", i.getDbClusterIdentifier());
         }
         return xml.build();
+    }
+
+    private String dbSubnetGroupXml(DbSubnetGroup group) {
+        return new XmlBuilder().start("DBSubnetGroup").raw(dbSubnetGroupInnerXml(group)).end("DBSubnetGroup").build();
+    }
+
+    private String dbSubnetGroupInnerXml(DbSubnetGroup group) {
+        XmlBuilder xml = new XmlBuilder()
+           .elem("DBSubnetGroupName", group.getDbSubnetGroupName())
+           .elem("DBSubnetGroupDescription", group.getDbSubnetGroupDescription())
+           .elem("VpcId", group.getVpcId() != null ? group.getVpcId() : "vpc-00000000")
+           .elem("SubnetGroupStatus", "Complete")
+           .start("Subnets");
+        for (String subnetId : group.getSubnetIds()) {
+            xml.start("Subnet")
+               .elem("SubnetIdentifier", subnetId)
+               .start("SubnetAvailabilityZone")
+                 .elem("Name", config.defaultAvailabilityZone())
+               .end("SubnetAvailabilityZone")
+               .elem("SubnetStatus", "Active")
+               .end("Subnet");
+        }
+        return xml.end("Subnets").build();
+    }
+
+    private DbSubnetGroup dbSubnetGroupForInstance(DbInstance instance) {
+        String groupName = instance.getDbSubnetGroupName();
+        if (groupName != null && !groupName.isBlank()) {
+            try {
+                return service.getDbSubnetGroup(groupName);
+            } catch (AwsException ignored) {
+                return new DbSubnetGroup(groupName, "DB subnet group " + groupName,
+                        "vpc-00000000", List.of("subnet-00000000"));
+            }
+        }
+        return new DbSubnetGroup("default", "default", "vpc-00000000", List.of("subnet-00000000"));
     }
 
     private String dbClusterXml(DbCluster c) {
@@ -611,6 +712,16 @@ public class RdsQueryHandler {
             }
         }
         return null;
+    }
+
+    private static List<String> memberList(MultivaluedMap<String, String> params, String baseName) {
+        return params.keySet().stream()
+                .filter(key -> key.matches(java.util.regex.Pattern.quote(baseName)
+                        + "(\\.member|\\.SubnetIdentifier)?\\.\\d+"))
+                .sorted()
+                .map(params::getFirst)
+                .filter(value -> value != null && !value.isBlank())
+                .toList();
     }
 
     private static int parseIntSafe(String value, int defaultValue) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -100,6 +100,8 @@ public class RdsQueryHandler {
         String paramGroupName = params.getFirst("DBParameterGroupName");
         String dbSubnetGroupName = params.getFirst("DBSubnetGroupName");
         String dbClusterIdentifier = params.getFirst("DBClusterIdentifier");
+        boolean manageMasterUserPassword = "true".equalsIgnoreCase(params.getFirst("ManageMasterUserPassword"));
+        String masterUserSecretKmsKeyId = params.getFirst("MasterUserSecretKmsKeyId");
 
         if (dbInstanceClass == null) {
             dbInstanceClass = "db.t3.micro";
@@ -111,7 +113,8 @@ public class RdsQueryHandler {
         try {
             DbInstance instance = service.createDbInstance(id, engine, engineVersion, masterUsername,
                     masterPassword, dbName, dbInstanceClass, allocatedStorage, iamEnabled,
-                    paramGroupName, dbSubnetGroupName, dbClusterIdentifier);
+                    paramGroupName, dbSubnetGroupName, dbClusterIdentifier,
+                    manageMasterUserPassword, masterUserSecretKmsKeyId);
             String result = dbInstanceXml(instance);
             return Response.ok(AwsQueryResponse.envelope("CreateDBInstance", AwsNamespaces.RDS, result)).build();
         } catch (AwsException e) {
@@ -584,6 +587,15 @@ public class RdsQueryHandler {
            .raw(dbSubnetGroupXml(dbSubnetGroupForInstance(i)))
            .elem("DbiResourceId", i.getDbiResourceId())
            .elem("DBInstanceArn", i.getDbInstanceArn());
+        if (i.getMasterUserSecretArn() != null && !i.getMasterUserSecretArn().isBlank()) {
+            xml.start("MasterUserSecret")
+                    .elem("SecretArn", i.getMasterUserSecretArn())
+                    .elem("SecretStatus", i.getMasterUserSecretStatus() == null ? "active" : i.getMasterUserSecretStatus());
+            if (i.getMasterUserSecretKmsKeyId() != null && !i.getMasterUserSecretKmsKeyId().isBlank()) {
+                xml.elem("KmsKeyId", i.getMasterUserSecretKmsKeyId());
+            }
+            xml.end("MasterUserSecret");
+        }
         if (i.getDbClusterIdentifier() != null && !i.getDbClusterIdentifier().isBlank()) {
             xml.elem("DBClusterIdentifier", i.getDbClusterIdentifier());
         }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -797,10 +797,22 @@ public class RdsQueryHandler {
         return params.keySet().stream()
                 .filter(key -> key.matches(java.util.regex.Pattern.quote(baseName)
                         + "(\\.member|\\.SubnetIdentifier)?\\.\\d+"))
-                .sorted()
+                .sorted(java.util.Comparator.comparingInt(RdsQueryHandler::numericSuffix))
                 .map(params::getFirst)
                 .filter(value -> value != null && !value.isBlank())
                 .toList();
+    }
+
+    private static int numericSuffix(String key) {
+        int dot = key.lastIndexOf('.');
+        if (dot < 0 || dot == key.length() - 1) {
+            return Integer.MAX_VALUE;
+        }
+        try {
+            return Integer.parseInt(key.substring(dot + 1));
+        } catch (NumberFormatException e) {
+            return Integer.MAX_VALUE;
+        }
     }
 
     private static Map<String, String> parseTags(MultivaluedMap<String, String> params) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -143,6 +143,21 @@ public class RdsService {
                                        String dbClusterIdentifier,
                                        boolean manageMasterUserPassword,
                                        String masterUserSecretKmsKeyId) {
+        return createDbInstance(id, engineParam, engineVersion, masterUsername, masterPassword,
+                dbName, dbInstanceClass, allocatedStorage, iamEnabled, paramGroupName,
+                dbSubnetGroupName, dbClusterIdentifier, manageMasterUserPassword,
+                masterUserSecretKmsKeyId, Map.of());
+    }
+
+    public DbInstance createDbInstance(String id, String engineParam, String engineVersion,
+                                       String masterUsername, String masterPassword,
+                                       String dbName, String dbInstanceClass,
+                                       int allocatedStorage, boolean iamEnabled,
+                                       String paramGroupName, String dbSubnetGroupName,
+                                       String dbClusterIdentifier,
+                                       boolean manageMasterUserPassword,
+                                       String masterUserSecretKmsKeyId,
+                                       Map<String, String> tags) {
         if (instances.get(id).isPresent()) {
             throw new AwsException("DBInstanceAlreadyExists",
                     "DB instance " + id + " already exists.", 400);
@@ -204,6 +219,7 @@ public class RdsService {
         instance.setContainerPort(containerPort);
         instance.setVolumeId(instanceVolumeId);
         instance.setDockerVolumeName(instanceDockerVolumeName);
+        instance.setTags(tags);
 
         String region = regionResolver.getDefaultRegion();
         instance.setDbiResourceId("db-" + java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 24).toUpperCase());
@@ -227,6 +243,40 @@ public class RdsService {
         instances.put(id, instance);
         LOG.infov("DB instance {0} created, engine={1}, endpoint=localhost:{2}", id, engine, String.valueOf(proxyPort));
         return instance;
+    }
+
+    public Map<String, String> listTagsForResource(String resourceName) {
+        DbInstance instance = getDbInstance(dbInstanceIdentifierFromResourceName(resourceName));
+        return Map.copyOf(instance.getTags());
+    }
+
+    public void addTagsToResource(String resourceName, Map<String, String> tags) {
+        String id = dbInstanceIdentifierFromResourceName(resourceName);
+        DbInstance instance = getDbInstance(id);
+        Map<String, String> updated = new java.util.LinkedHashMap<>(instance.getTags());
+        updated.putAll(tags);
+        instance.setTags(updated);
+        instances.put(id, instance);
+    }
+
+    public void removeTagsFromResource(String resourceName, Collection<String> tagKeys) {
+        String id = dbInstanceIdentifierFromResourceName(resourceName);
+        DbInstance instance = getDbInstance(id);
+        Map<String, String> updated = new java.util.LinkedHashMap<>(instance.getTags());
+        tagKeys.forEach(updated::remove);
+        instance.setTags(updated);
+        instances.put(id, instance);
+    }
+
+    private static String dbInstanceIdentifierFromResourceName(String resourceName) {
+        if (resourceName == null || resourceName.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "ResourceName is required.", 400);
+        }
+        int marker = resourceName.lastIndexOf(":db:");
+        if (marker >= 0) {
+            return resourceName.substring(marker + 4);
+        }
+        return resourceName;
     }
 
     private void attachManagedMasterUserSecret(DbInstance instance, String region, String kmsKeyId) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -379,6 +379,7 @@ public class RdsService {
         List<Map<String, String>> options = List.of(
                 Map.of("engine", "postgres", "engineVersion", "16.3", "dbInstanceClass", "db.t3.micro"),
                 Map.of("engine", "postgres", "engineVersion", "16.14", "dbInstanceClass", "db.t3.micro"),
+                Map.of("engine", "postgres", "engineVersion", "18.1", "dbInstanceClass", "db.t3.micro"),
                 Map.of("engine", "postgres", "engineVersion", "16.3", "dbInstanceClass", "db.t4g.micro"),
                 Map.of("engine", "postgres", "engineVersion", "16.3", "dbInstanceClass", "db.t4g.small"),
                 Map.of("engine", "postgres", "engineVersion", "16.3", "dbInstanceClass", "db.t4g.medium"),

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -474,6 +474,17 @@ public class RdsService {
         return subnetGroups.scan(k -> true);
     }
 
+    public DbSubnetGroup modifyDbSubnetGroup(String name, List<String> subnetIds) {
+        DbSubnetGroup group = getDbSubnetGroup(name);
+        if (subnetIds == null || subnetIds.isEmpty()) {
+            throw new AwsException("InvalidParameterValue",
+                    "SubnetIds must contain at least one subnet.", 400);
+        }
+        group.setSubnetIds(subnetIds);
+        subnetGroups.put(name, group);
+        return group;
+    }
+
     public void deleteDbSubnetGroup(String name) {
         if (subnetGroups.get(name).isEmpty()) {
             throw new AwsException("DBSubnetGroupNotFoundFault",

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -17,6 +17,7 @@ import io.github.hectorvent.floci.services.rds.model.DbEndpoint;
 import io.github.hectorvent.floci.services.rds.model.DbInstance;
 import io.github.hectorvent.floci.services.rds.model.DbInstanceStatus;
 import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
+import io.github.hectorvent.floci.services.rds.model.DbSubnetGroup;
 import io.github.hectorvent.floci.services.rds.proxy.RdsProxyManager;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -44,6 +45,7 @@ public class RdsService {
     private final StorageBackend<String, DbCluster> clusters;
     private final StorageBackend<String, DbParameterGroup> parameterGroups;
     private final StorageBackend<String, DbClusterParameterGroup> clusterParameterGroups;
+    private final StorageBackend<String, DbSubnetGroup> subnetGroups;
     private final RdsContainerManager containerManager;
     private final RdsProxyManager proxyManager;
     private final RegionResolver regionResolver;
@@ -68,6 +70,8 @@ public class RdsService {
                 new TypeReference<Map<String, DbParameterGroup>>() {});
         this.clusterParameterGroups = storageFactory.create("rds", "rds-cluster-parameter-groups.json",
                 new TypeReference<Map<String, DbClusterParameterGroup>>() {});
+        this.subnetGroups = storageFactory.create("rds", "rds-subnet-groups.json",
+                new TypeReference<Map<String, DbSubnetGroup>>() {});
     }
 
     RdsService(RdsContainerManager containerManager,
@@ -77,7 +81,8 @@ public class RdsService {
                StorageBackend<String, DbInstance> instances,
                StorageBackend<String, DbCluster> clusters,
                StorageBackend<String, DbParameterGroup> parameterGroups,
-               StorageBackend<String, DbClusterParameterGroup> clusterParameterGroups) {
+               StorageBackend<String, DbClusterParameterGroup> clusterParameterGroups,
+               StorageBackend<String, DbSubnetGroup> subnetGroups) {
         this.containerManager = containerManager;
         this.proxyManager = proxyManager;
         this.regionResolver = regionResolver;
@@ -86,6 +91,7 @@ public class RdsService {
         this.clusters = clusters;
         this.parameterGroups = parameterGroups;
         this.clusterParameterGroups = clusterParameterGroups;
+        this.subnetGroups = subnetGroups;
     }
 
     public void restorePersistedRuntime() {
@@ -99,13 +105,17 @@ public class RdsService {
                                        String masterUsername, String masterPassword,
                                        String dbName, String dbInstanceClass,
                                        int allocatedStorage, boolean iamEnabled,
-                                       String paramGroupName, String dbClusterIdentifier) {
+                                       String paramGroupName, String dbSubnetGroupName,
+                                       String dbClusterIdentifier) {
         if (instances.get(id).isPresent()) {
             throw new AwsException("DBInstanceAlreadyExists",
                     "DB instance " + id + " already exists.", 400);
         }
 
         DatabaseEngine engine = resolveEngine(engineParam);
+        if (dbSubnetGroupName != null && !dbSubnetGroupName.isBlank()) {
+            getDbSubnetGroup(dbSubnetGroupName);
+        }
         int proxyPort = allocateProxyPort();
 
         String backendHost;
@@ -146,6 +156,7 @@ public class RdsService {
         DbInstance instance = new DbInstance(id, engine, engineVersion, masterUsername, masterPassword,
                 dbName, dbInstanceClass, allocatedStorage, DbInstanceStatus.AVAILABLE,
                 endpoint, iamEnabled, paramGroupName, dbClusterIdentifier, Instant.now(), proxyPort);
+        instance.setDbSubnetGroupName(dbSubnetGroupName);
         instance.setContainerId(containerId);
         instance.setContainerHost(containerHost);
         instance.setContainerPort(containerPort);
@@ -187,7 +198,8 @@ public class RdsService {
         return instances.scan(k -> true);
     }
 
-    public DbInstance modifyDbInstance(String id, String newPassword, Boolean iamEnabled) {
+    public DbInstance modifyDbInstance(String id, String newPassword, Boolean iamEnabled,
+                                       String dbSubnetGroupName) {
         DbInstance instance = getDbInstance(id);
         instance.setStatus(DbInstanceStatus.AVAILABLE);
         if (newPassword != null && !newPassword.isBlank()) {
@@ -196,9 +208,33 @@ public class RdsService {
         if (iamEnabled != null) {
             instance.setIamDatabaseAuthenticationEnabled(iamEnabled);
         }
+        if (dbSubnetGroupName != null && !dbSubnetGroupName.isBlank()) {
+            instance.setDbSubnetGroupName(dbSubnetGroupName);
+        }
         instances.put(id, instance);
         LOG.infov("DB instance {0} modified", id);
         return instance;
+    }
+
+    public List<Map<String, String>> describeOrderableDbInstanceOptions(String engine,
+                                                                        String engineVersion,
+                                                                        String dbInstanceClass) {
+        List<Map<String, String>> options = List.of(
+                Map.of("engine", "postgres", "engineVersion", "16.3", "dbInstanceClass", "db.t3.micro"),
+                Map.of("engine", "postgres", "engineVersion", "16.14", "dbInstanceClass", "db.t3.micro"),
+                Map.of("engine", "postgres", "engineVersion", "16.3", "dbInstanceClass", "db.t4g.micro"),
+                Map.of("engine", "postgres", "engineVersion", "16.3", "dbInstanceClass", "db.t4g.small"),
+                Map.of("engine", "postgres", "engineVersion", "16.3", "dbInstanceClass", "db.t4g.medium"),
+                Map.of("engine", "mysql", "engineVersion", "8.0", "dbInstanceClass", "db.t3.micro"),
+                Map.of("engine", "mariadb", "engineVersion", "11", "dbInstanceClass", "db.t3.micro")
+        );
+        return options.stream()
+                .filter(option -> engine == null || engine.isBlank() || engine.equalsIgnoreCase(option.get("engine")))
+                .filter(option -> engineVersion == null || engineVersion.isBlank()
+                        || engineVersion.equalsIgnoreCase(option.get("engineVersion")))
+                .filter(option -> dbInstanceClass == null || dbInstanceClass.isBlank()
+                        || dbInstanceClass.equalsIgnoreCase(option.get("dbInstanceClass")))
+                .toList();
     }
 
     public DbInstance rebootDbInstance(String id) {
@@ -409,6 +445,41 @@ public class RdsService {
         }
         parameterGroups.put(name, group);
         return group;
+    }
+
+    public DbSubnetGroup createDbSubnetGroup(String name, String description, List<String> subnetIds) {
+        if (subnetGroups.get(name).isPresent()) {
+            throw new AwsException("DBSubnetGroupAlreadyExists",
+                    "DB subnet group " + name + " already exists.", 400);
+        }
+        if (subnetIds == null || subnetIds.isEmpty()) {
+            throw new AwsException("InvalidParameterValue",
+                    "SubnetIds must contain at least one subnet.", 400);
+        }
+        DbSubnetGroup group = new DbSubnetGroup(name, description, "vpc-00000000", subnetIds);
+        subnetGroups.put(name, group);
+        return group;
+    }
+
+    public DbSubnetGroup getDbSubnetGroup(String name) {
+        return subnetGroups.get(name).orElseThrow(() ->
+                new AwsException("DBSubnetGroupNotFoundFault",
+                        "DB subnet group " + name + " not found.", 404));
+    }
+
+    public Collection<DbSubnetGroup> listDbSubnetGroups(String filterName) {
+        if (filterName != null && !filterName.isBlank()) {
+            return subnetGroups.get(filterName).map(List::of).orElse(List.of());
+        }
+        return subnetGroups.scan(k -> true);
+    }
+
+    public void deleteDbSubnetGroup(String name) {
+        if (subnetGroups.get(name).isEmpty()) {
+            throw new AwsException("DBSubnetGroupNotFoundFault",
+                    "DB subnet group " + name + " not found.", 404);
+        }
+        subnetGroups.delete(name);
     }
 
     // ── Cluster Parameter Groups ──────────────────────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -366,6 +366,7 @@ public class RdsService {
             instance.setIamDatabaseAuthenticationEnabled(iamEnabled);
         }
         if (dbSubnetGroupName != null && !dbSubnetGroupName.isBlank()) {
+            getDbSubnetGroup(dbSubnetGroupName);
             instance.setDbSubnetGroupName(dbSubnetGroupName);
         }
         instances.put(id, instance);

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
+import io.github.hectorvent.floci.core.common.docker.DockerHostResolver;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
@@ -58,6 +59,7 @@ public class RdsService {
     private final RegionResolver regionResolver;
     private final EmulatorConfig config;
     private final SecretsManagerService secretsManagerService;
+    private final DockerHostResolver dockerHostResolver;
     private final Set<Integer> usedPorts = ConcurrentHashMap.newKeySet();
     private static final Pattern IMAGE_TAG_VERSION_PATTERN = Pattern.compile("^(\\d+(?:\\.\\d+)*)(.*)$");
     private static final Pattern SAFE_IMAGE_TAG_PATTERN = Pattern.compile("[A-Za-z0-9._-]+");
@@ -68,12 +70,14 @@ public class RdsService {
                       RegionResolver regionResolver,
                       EmulatorConfig config,
                       StorageFactory storageFactory,
-                      SecretsManagerService secretsManagerService) {
+                      SecretsManagerService secretsManagerService,
+                      DockerHostResolver dockerHostResolver) {
         this.containerManager = containerManager;
         this.proxyManager = proxyManager;
         this.regionResolver = regionResolver;
         this.config = config;
         this.secretsManagerService = secretsManagerService;
+        this.dockerHostResolver = dockerHostResolver;
         this.instances = storageFactory.create("rds", "rds-instances.json",
                 new TypeReference<Map<String, DbInstance>>() {});
         this.clusters = storageFactory.create("rds", "rds-clusters.json",
@@ -96,7 +100,7 @@ public class RdsService {
                StorageBackend<String, DbClusterParameterGroup> clusterParameterGroups,
                StorageBackend<String, DbSubnetGroup> subnetGroups) {
         this(containerManager, proxyManager, regionResolver, config,
-                instances, clusters, parameterGroups, clusterParameterGroups, subnetGroups, null);
+                instances, clusters, parameterGroups, clusterParameterGroups, subnetGroups, null, null);
     }
 
     RdsService(RdsContainerManager containerManager,
@@ -109,11 +113,28 @@ public class RdsService {
                StorageBackend<String, DbClusterParameterGroup> clusterParameterGroups,
                StorageBackend<String, DbSubnetGroup> subnetGroups,
                SecretsManagerService secretsManagerService) {
+        this(containerManager, proxyManager, regionResolver, config,
+                instances, clusters, parameterGroups, clusterParameterGroups, subnetGroups,
+                secretsManagerService, null);
+    }
+
+    RdsService(RdsContainerManager containerManager,
+               RdsProxyManager proxyManager,
+               RegionResolver regionResolver,
+               EmulatorConfig config,
+               StorageBackend<String, DbInstance> instances,
+               StorageBackend<String, DbCluster> clusters,
+               StorageBackend<String, DbParameterGroup> parameterGroups,
+               StorageBackend<String, DbClusterParameterGroup> clusterParameterGroups,
+               StorageBackend<String, DbSubnetGroup> subnetGroups,
+               SecretsManagerService secretsManagerService,
+               DockerHostResolver dockerHostResolver) {
         this.containerManager = containerManager;
         this.proxyManager = proxyManager;
         this.regionResolver = regionResolver;
         this.config = config;
         this.secretsManagerService = secretsManagerService;
+        this.dockerHostResolver = dockerHostResolver;
         this.instances = instances;
         this.clusters = clusters;
         this.parameterGroups = parameterGroups;
@@ -213,7 +234,7 @@ public class RdsService {
             instanceDockerVolumeName = volumeName(instanceVolumeId, id);
         }
 
-        DbEndpoint endpoint = new DbEndpoint("localhost", proxyPort);
+        DbEndpoint endpoint = new DbEndpoint(proxyEndpointHost(), proxyPort);
         DbInstance instance = new DbInstance(id, engine, engineVersion, masterUsername, masterPassword,
                 dbName, dbInstanceClass, allocatedStorage, DbInstanceStatus.AVAILABLE,
                 endpoint, iamEnabled, paramGroupName, dbClusterIdentifier, Instant.now(), proxyPort);
@@ -465,7 +486,7 @@ public class RdsService {
 
         RdsContainerHandle handle = containerManager.start(id, clusterVolumeId, engine, image, masterUsername, masterPassword, databaseName);
 
-        DbEndpoint endpoint = new DbEndpoint("localhost", proxyPort);
+        DbEndpoint endpoint = new DbEndpoint(proxyEndpointHost(), proxyPort);
         DbCluster cluster = new DbCluster(id, engine, engineVersion, masterUsername, masterPassword,
                 databaseName, DbInstanceStatus.AVAILABLE, endpoint, endpoint,
                 iamEnabled, new ArrayList<>(), paramGroupName, Instant.now(), proxyPort);
@@ -767,6 +788,10 @@ public class RdsService {
         usedPorts.remove(port);
     }
 
+    private String proxyEndpointHost() {
+        return dockerHostResolver != null ? dockerHostResolver.resolve() : "localhost";
+    }
+
     private void restoreClusters() {
         for (DbCluster cluster : allClusters()) {
             if (cluster.getStatus() == DbInstanceStatus.DELETING) {
@@ -774,8 +799,8 @@ public class RdsService {
             }
             int proxyPort = reserveOrAllocateProxyPort(cluster.getProxyPort());
             cluster.setProxyPort(proxyPort);
-            cluster.setEndpoint(new DbEndpoint("localhost", proxyPort));
-            cluster.setReaderEndpoint(new DbEndpoint("localhost", proxyPort));
+            cluster.setEndpoint(new DbEndpoint(proxyEndpointHost(), proxyPort));
+            cluster.setReaderEndpoint(new DbEndpoint(proxyEndpointHost(), proxyPort));
             if (cluster.getDockerVolumeName() == null) {
                 cluster.setDockerVolumeName(volumeName(cluster.getVolumeId(), cluster.getDbClusterIdentifier()));
             }
@@ -810,7 +835,7 @@ public class RdsService {
             }
             int proxyPort = reserveOrAllocateProxyPort(instance.getProxyPort());
             instance.setProxyPort(proxyPort);
-            instance.setEndpoint(new DbEndpoint("localhost", proxyPort));
+            instance.setEndpoint(new DbEndpoint(proxyEndpointHost(), proxyPort));
             try {
                 String backendHost;
                 int backendPort;

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -1,6 +1,8 @@
 package io.github.hectorvent.floci.services.rds;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
@@ -19,6 +21,8 @@ import io.github.hectorvent.floci.services.rds.model.DbInstanceStatus;
 import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
 import io.github.hectorvent.floci.services.rds.model.DbSubnetGroup;
 import io.github.hectorvent.floci.services.rds.proxy.RdsProxyManager;
+import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerService;
+import io.github.hectorvent.floci.services.secretsmanager.model.Secret;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -40,6 +44,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class RdsService {
 
     private static final Logger LOG = Logger.getLogger(RdsService.class);
+    private static final ObjectMapper JSON = new ObjectMapper();
 
     private final StorageBackend<String, DbInstance> instances;
     private final StorageBackend<String, DbCluster> clusters;
@@ -50,6 +55,7 @@ public class RdsService {
     private final RdsProxyManager proxyManager;
     private final RegionResolver regionResolver;
     private final EmulatorConfig config;
+    private final SecretsManagerService secretsManagerService;
     private final Set<Integer> usedPorts = ConcurrentHashMap.newKeySet();
 
     @Inject
@@ -57,11 +63,13 @@ public class RdsService {
                       RdsProxyManager proxyManager,
                       RegionResolver regionResolver,
                       EmulatorConfig config,
-                      StorageFactory storageFactory) {
+                      StorageFactory storageFactory,
+                      SecretsManagerService secretsManagerService) {
         this.containerManager = containerManager;
         this.proxyManager = proxyManager;
         this.regionResolver = regionResolver;
         this.config = config;
+        this.secretsManagerService = secretsManagerService;
         this.instances = storageFactory.create("rds", "rds-instances.json",
                 new TypeReference<Map<String, DbInstance>>() {});
         this.clusters = storageFactory.create("rds", "rds-clusters.json",
@@ -83,10 +91,25 @@ public class RdsService {
                StorageBackend<String, DbParameterGroup> parameterGroups,
                StorageBackend<String, DbClusterParameterGroup> clusterParameterGroups,
                StorageBackend<String, DbSubnetGroup> subnetGroups) {
+        this(containerManager, proxyManager, regionResolver, config,
+                instances, clusters, parameterGroups, clusterParameterGroups, subnetGroups, null);
+    }
+
+    RdsService(RdsContainerManager containerManager,
+               RdsProxyManager proxyManager,
+               RegionResolver regionResolver,
+               EmulatorConfig config,
+               StorageBackend<String, DbInstance> instances,
+               StorageBackend<String, DbCluster> clusters,
+               StorageBackend<String, DbParameterGroup> parameterGroups,
+               StorageBackend<String, DbClusterParameterGroup> clusterParameterGroups,
+               StorageBackend<String, DbSubnetGroup> subnetGroups,
+               SecretsManagerService secretsManagerService) {
         this.containerManager = containerManager;
         this.proxyManager = proxyManager;
         this.regionResolver = regionResolver;
         this.config = config;
+        this.secretsManagerService = secretsManagerService;
         this.instances = instances;
         this.clusters = clusters;
         this.parameterGroups = parameterGroups;
@@ -107,6 +130,19 @@ public class RdsService {
                                        int allocatedStorage, boolean iamEnabled,
                                        String paramGroupName, String dbSubnetGroupName,
                                        String dbClusterIdentifier) {
+        return createDbInstance(id, engineParam, engineVersion, masterUsername, masterPassword,
+                dbName, dbInstanceClass, allocatedStorage, iamEnabled, paramGroupName,
+                dbSubnetGroupName, dbClusterIdentifier, false, null);
+    }
+
+    public DbInstance createDbInstance(String id, String engineParam, String engineVersion,
+                                       String masterUsername, String masterPassword,
+                                       String dbName, String dbInstanceClass,
+                                       int allocatedStorage, boolean iamEnabled,
+                                       String paramGroupName, String dbSubnetGroupName,
+                                       String dbClusterIdentifier,
+                                       boolean manageMasterUserPassword,
+                                       String masterUserSecretKmsKeyId) {
         if (instances.get(id).isPresent()) {
             throw new AwsException("DBInstanceAlreadyExists",
                     "DB instance " + id + " already exists.", 400);
@@ -117,6 +153,12 @@ public class RdsService {
             getDbSubnetGroup(dbSubnetGroupName);
         }
         int proxyPort = allocateProxyPort();
+        if (masterUsername == null || masterUsername.isBlank()) {
+            masterUsername = "root";
+        }
+        if (manageMasterUserPassword && (masterPassword == null || masterPassword.isBlank())) {
+            masterPassword = generatedMasterPassword();
+        }
 
         String backendHost;
         int backendPort;
@@ -166,10 +208,12 @@ public class RdsService {
         String region = regionResolver.getDefaultRegion();
         instance.setDbiResourceId("db-" + java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 24).toUpperCase());
         instance.setDbInstanceArn(regionResolver.buildArn("rds", region, "db:" + id));
+        if (manageMasterUserPassword) {
+            attachManagedMasterUserSecret(instance, region, masterUserSecretKmsKeyId);
+        }
 
-        String effectiveMasterUser = masterUsername != null ? masterUsername : "root";
         proxyManager.startProxy(id, engine, iamEnabled, proxyPort, backendHost, backendPort,
-                effectiveMasterUser, masterPassword, dbName,
+                masterUsername, masterPassword, dbName,
                 (user, pw) -> validateDbPassword(id, user, pw));
 
         if (dbClusterIdentifier != null && !dbClusterIdentifier.isBlank()) {
@@ -183,6 +227,44 @@ public class RdsService {
         instances.put(id, instance);
         LOG.infov("DB instance {0} created, engine={1}, endpoint=localhost:{2}", id, engine, String.valueOf(proxyPort));
         return instance;
+    }
+
+    private void attachManagedMasterUserSecret(DbInstance instance, String region, String kmsKeyId) {
+        if (secretsManagerService == null) {
+            throw new AwsException("InvalidParameterCombination",
+                    "ManageMasterUserPassword requires Secrets Manager support.", 400);
+        }
+        String secretName = "rds!" + instance.getDbiResourceId();
+        Secret secret = secretsManagerService.createSecret(
+                secretName,
+                managedMasterSecretString(instance),
+                null,
+                "Managed RDS master user secret for " + instance.getDbInstanceIdentifier(),
+                kmsKeyId,
+                null,
+                region);
+        instance.setMasterUserSecretArn(secret.getArn());
+        instance.setMasterUserSecretStatus("active");
+        instance.setMasterUserSecretKmsKeyId(kmsKeyId);
+    }
+
+    private static String managedMasterSecretString(DbInstance instance) {
+        try {
+            return JSON.writeValueAsString(Map.of(
+                    "username", instance.getMasterUsername(),
+                    "password", instance.getMasterPassword(),
+                    "engine", instance.getEngine().name().toLowerCase(),
+                    "host", instance.getEndpoint().address(),
+                    "port", instance.getEndpoint().port(),
+                    "dbname", instance.getDbName() == null ? "" : instance.getDbName(),
+                    "dbInstanceIdentifier", instance.getDbInstanceIdentifier()));
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Unable to serialize RDS master user secret", e);
+        }
+    }
+
+    private static String generatedMasterPassword() {
+        return "floci-" + java.util.UUID.randomUUID().toString().replace("-", "");
     }
 
     public DbInstance getDbInstance(String id) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Core RDS business logic — DB instances, clusters, and parameter groups.
@@ -57,6 +59,8 @@ public class RdsService {
     private final EmulatorConfig config;
     private final SecretsManagerService secretsManagerService;
     private final Set<Integer> usedPorts = ConcurrentHashMap.newKeySet();
+    private static final Pattern IMAGE_TAG_VERSION_PATTERN = Pattern.compile("^(\\d+(?:\\.\\d+)*)(.*)$");
+    private static final Pattern SAFE_IMAGE_TAG_PATTERN = Pattern.compile("[A-Za-z0-9._-]+");
 
     @Inject
     public RdsService(RdsContainerManager containerManager,
@@ -198,7 +202,7 @@ public class RdsService {
                     : volumeName(cluster.getVolumeId(), cluster.getDbClusterIdentifier());
         } else {
             // Standalone instance — start its own container
-            String image = imageForEngine(engine);
+            String image = imageForEngine(engine, engineVersion);
             instanceVolumeId = String.format("%06x", new SecureRandom().nextInt(0xFFFFFF));
             RdsContainerHandle handle = containerManager.start(id, instanceVolumeId, engine, image, masterUsername, masterPassword, dbName);
             backendHost = handle.getHost();
@@ -385,7 +389,7 @@ public class RdsService {
             } catch (Exception e) {
                 LOG.warnv("Error stopping container during reboot of {0}: {1}", id, e.getMessage());
             }
-            String image = imageForEngine(instance.getEngine());
+            String image = imageForEngine(instance.getEngine(), instance.getEngineVersion());
             RdsContainerHandle handle = containerManager.start(id, instance.getVolumeId(), instance.getEngine(), image,
                     instance.getMasterUsername(), instance.getMasterPassword(), instance.getDbName());
             instance.setContainerId(handle.getContainerId());
@@ -456,7 +460,7 @@ public class RdsService {
 
         DatabaseEngine engine = resolveEngine(engineParam);
         int proxyPort = allocateProxyPort();
-        String image = imageForEngine(engine);
+        String image = imageForEngine(engine, engineVersion);
         String clusterVolumeId = String.format("%06x", new SecureRandom().nextInt(0xFFFFFF));
 
         RdsContainerHandle handle = containerManager.start(id, clusterVolumeId, engine, image, masterUsername, masterPassword, databaseName);
@@ -707,12 +711,44 @@ public class RdsService {
         };
     }
 
-    private String imageForEngine(DatabaseEngine engine) {
-        return switch (engine) {
+    private String imageForEngine(DatabaseEngine engine, String engineVersion) {
+        String defaultImage = switch (engine) {
             case POSTGRES -> config.services().rds().defaultPostgresImage();
             case MYSQL -> config.services().rds().defaultMysqlImage();
             case MARIADB -> config.services().rds().defaultMariadbImage();
         };
+        return imageForRequestedVersion(defaultImage, engineVersion);
+    }
+
+    static String imageForRequestedVersion(String defaultImage, String engineVersion) {
+        if (engineVersion == null || engineVersion.isBlank()) {
+            return defaultImage;
+        }
+
+        String requestedTag = engineVersion.trim();
+        if (!SAFE_IMAGE_TAG_PATTERN.matcher(requestedTag).matches()) {
+            throw new AwsException("InvalidParameterValue",
+                    "Unsupported engine version tag: " + engineVersion, 400);
+        }
+
+        int tagSeparator = defaultImage.lastIndexOf(':');
+        int lastSlash = defaultImage.lastIndexOf('/');
+        if (tagSeparator <= lastSlash) {
+            return defaultImage + ":" + requestedTag;
+        }
+
+        String imageName = defaultImage.substring(0, tagSeparator);
+        String defaultTag = defaultImage.substring(tagSeparator + 1);
+        Matcher matcher = IMAGE_TAG_VERSION_PATTERN.matcher(defaultTag);
+        if (!matcher.matches()) {
+            return imageName + ":" + requestedTag;
+        }
+
+        String suffix = matcher.group(2);
+        if (!suffix.isEmpty() && !requestedTag.endsWith(suffix)) {
+            requestedTag += suffix;
+        }
+        return imageName + ":" + requestedTag;
     }
 
     private int allocateProxyPort() {
@@ -744,7 +780,7 @@ public class RdsService {
                 cluster.setDockerVolumeName(volumeName(cluster.getVolumeId(), cluster.getDbClusterIdentifier()));
             }
             try {
-                String image = imageForEngine(cluster.getEngine());
+                String image = imageForEngine(cluster.getEngine(), cluster.getEngineVersion());
                 RdsContainerHandle handle = containerManager.start(cluster.getDbClusterIdentifier(),
                         cluster.getVolumeId(), cluster.getEngine(), image,
                         cluster.getMasterUsername(), cluster.getMasterPassword(), cluster.getDatabaseName());
@@ -801,7 +837,7 @@ public class RdsService {
                     if (instance.getDockerVolumeName() == null) {
                         instance.setDockerVolumeName(volumeName(instance.getVolumeId(), instance.getDbInstanceIdentifier()));
                     }
-                    String image = imageForEngine(instance.getEngine());
+                    String image = imageForEngine(instance.getEngine(), instance.getEngineVersion());
                     RdsContainerHandle handle = containerManager.start(instance.getDbInstanceIdentifier(),
                             instance.getVolumeId(), instance.getEngine(), image,
                             instance.getMasterUsername(), instance.getMasterPassword(), instance.getDbName());

--- a/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.services.rds.container;
 
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.model.Frame;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.ServiceConfigAccess;
@@ -16,14 +18,17 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Manages backend Docker container lifecycle for RDS DB instances and clusters.
@@ -105,6 +110,7 @@ public class RdsContainerManager {
         EndpointInfo endpoint = info.getEndpoint(enginePort);
 
         LOG.infov("RDS backend for instance {0}: {1}", instanceId, endpoint);
+        initializeEngine(containerName, info.containerId(), engine, masterUsername);
 
         RdsContainerHandle handle = new RdsContainerHandle(
                 info.containerId(), instanceId, endpoint.host(), endpoint.port());
@@ -164,6 +170,98 @@ public class RdsContainerManager {
             case MYSQL, MARIADB -> "/var/lib/mysql";
         };
     }
+
+    private void initializeEngine(String containerName, String containerId, DatabaseEngine engine, String masterUsername) {
+        if (engine == DatabaseEngine.POSTGRES) {
+            initializePostgresIamRole(containerName, containerId, masterUsername);
+        }
+    }
+
+    static String postgresIamRoleInitSql() {
+        return """
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'rds_iam') THEN
+                        CREATE ROLE rds_iam;
+                    END IF;
+                END
+                $$;
+                """;
+    }
+
+    private void initializePostgresIamRole(String containerName, String containerId, String masterUsername) {
+        String effectiveUser = (masterUsername != null && !masterUsername.isBlank()) ? masterUsername : "postgres";
+        String[] cmd = {
+                "psql",
+                "-v", "ON_ERROR_STOP=1",
+                "-U", effectiveUser,
+                "-d", "postgres",
+                "-c", postgresIamRoleInitSql()
+        };
+        String lastOutput = "";
+        for (int attempt = 1; attempt <= 60; attempt++) {
+            try {
+                ContainerExecResult result = execInContainer(containerId, cmd, 5);
+                lastOutput = result.output();
+                if (result.exitCode() == 0) {
+                    LOG.infov("Initialized PostgreSQL IAM role in RDS container {0}", containerName);
+                    return;
+                }
+            } catch (Exception e) {
+                lastOutput = e.getMessage();
+            }
+            try {
+                TimeUnit.SECONDS.sleep(1);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted initializing PostgreSQL IAM role in " + containerName, e);
+            }
+        }
+        throw new IllegalStateException("Timed out initializing PostgreSQL IAM role in " + containerName + ": " + lastOutput);
+    }
+
+    private ContainerExecResult execInContainer(String containerId, String[] cmd, int timeoutSeconds) throws Exception {
+        String execId = lifecycleManager.getDockerClient().execCreateCmd(containerId)
+                .withCmd(cmd)
+                .withAttachStdout(true)
+                .withAttachStderr(true)
+                .exec()
+                .getId();
+
+        CountDownLatch latch = new CountDownLatch(1);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        lifecycleManager.getDockerClient().execStartCmd(execId).exec(new ResultCallback.Adapter<Frame>() {
+            @Override
+            public void onNext(Frame frame) {
+                if (frame.getPayload() != null) {
+                    try {
+                        output.write(frame.getPayload());
+                    } catch (IOException ignored) {
+                    }
+                }
+            }
+
+            @Override
+            public void onComplete() {
+                latch.countDown();
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                latch.countDown();
+            }
+        });
+        boolean completed = latch.await(timeoutSeconds, TimeUnit.SECONDS);
+        if (!completed) {
+            return new ContainerExecResult(-1, "Timed out after " + timeoutSeconds + "s");
+        }
+        Long exitCode = lifecycleManager.getDockerClient().inspectExecCmd(execId).exec().getExitCodeLong();
+        return new ContainerExecResult(
+                exitCode != null ? exitCode : -1,
+                output.toString(StandardCharsets.UTF_8));
+    }
+
+    record ContainerExecResult(long exitCode, String output) {}
 
     public void removeVolume(String instanceId, String volumeId) {
         if (ContainerStorageHelper.isNamedVolumeMode(config)) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
@@ -230,7 +230,7 @@ public class RdsContainerManager {
 
         CountDownLatch latch = new CountDownLatch(1);
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        lifecycleManager.getDockerClient().execStartCmd(execId).exec(new ResultCallback.Adapter<Frame>() {
+        Closeable callback = lifecycleManager.getDockerClient().execStartCmd(execId).exec(new ResultCallback.Adapter<Frame>() {
             @Override
             public void onNext(Frame frame) {
                 if (frame.getPayload() != null) {
@@ -248,17 +248,22 @@ public class RdsContainerManager {
 
             @Override
             public void onError(Throwable t) {
+                LOG.warnv(t, "Container exec {0} failed", execId);
                 latch.countDown();
             }
         });
-        boolean completed = latch.await(timeoutSeconds, TimeUnit.SECONDS);
-        if (!completed) {
-            return new ContainerExecResult(-1, "Timed out after " + timeoutSeconds + "s");
+        try {
+            boolean completed = latch.await(timeoutSeconds, TimeUnit.SECONDS);
+            if (!completed) {
+                return new ContainerExecResult(-1, "Timed out after " + timeoutSeconds + "s");
+            }
+            Long exitCode = lifecycleManager.getDockerClient().inspectExecCmd(execId).exec().getExitCodeLong();
+            return new ContainerExecResult(
+                    exitCode != null ? exitCode : -1,
+                    output.toString(StandardCharsets.UTF_8));
+        } finally {
+            callback.close();
         }
-        Long exitCode = lifecycleManager.getDockerClient().inspectExecCmd(execId).exec().getExitCodeLong();
-        return new ContainerExecResult(
-                exitCode != null ? exitCode : -1,
-                output.toString(StandardCharsets.UTF_8));
     }
 
     record ContainerExecResult(long exitCode, String output) {}

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstance.java
@@ -3,6 +3,8 @@ package io.github.hectorvent.floci.services.rds.model;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @RegisterForReflection
 public class DbInstance {
@@ -26,6 +28,7 @@ public class DbInstance {
     private String masterUserSecretArn;
     private String masterUserSecretStatus;
     private String masterUserSecretKmsKeyId;
+    private Map<String, String> tags = new LinkedHashMap<>();
     private Instant createdAt;
     private int proxyPort;
 
@@ -120,6 +123,9 @@ public class DbInstance {
 
     public String getMasterUserSecretKmsKeyId() { return masterUserSecretKmsKeyId; }
     public void setMasterUserSecretKmsKeyId(String masterUserSecretKmsKeyId) { this.masterUserSecretKmsKeyId = masterUserSecretKmsKeyId; }
+
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) { this.tags = tags != null ? new LinkedHashMap<>(tags) : new LinkedHashMap<>(); }
 
     public Instant getCreatedAt() { return createdAt; }
     public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstance.java
@@ -23,6 +23,9 @@ public class DbInstance {
     private String dbClusterIdentifier;
     private String dbiResourceId;
     private String dbInstanceArn;
+    private String masterUserSecretArn;
+    private String masterUserSecretStatus;
+    private String masterUserSecretKmsKeyId;
     private Instant createdAt;
     private int proxyPort;
 
@@ -108,6 +111,15 @@ public class DbInstance {
 
     public String getDbInstanceArn() { return dbInstanceArn; }
     public void setDbInstanceArn(String dbInstanceArn) { this.dbInstanceArn = dbInstanceArn; }
+
+    public String getMasterUserSecretArn() { return masterUserSecretArn; }
+    public void setMasterUserSecretArn(String masterUserSecretArn) { this.masterUserSecretArn = masterUserSecretArn; }
+
+    public String getMasterUserSecretStatus() { return masterUserSecretStatus; }
+    public void setMasterUserSecretStatus(String masterUserSecretStatus) { this.masterUserSecretStatus = masterUserSecretStatus; }
+
+    public String getMasterUserSecretKmsKeyId() { return masterUserSecretKmsKeyId; }
+    public void setMasterUserSecretKmsKeyId(String masterUserSecretKmsKeyId) { this.masterUserSecretKmsKeyId = masterUserSecretKmsKeyId; }
 
     public Instant getCreatedAt() { return createdAt; }
     public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstance.java
@@ -19,6 +19,7 @@ public class DbInstance {
     private DbEndpoint endpoint;
     private boolean iamDatabaseAuthenticationEnabled;
     private String parameterGroupName;
+    private String dbSubnetGroupName;
     private String dbClusterIdentifier;
     private String dbiResourceId;
     private String dbInstanceArn;
@@ -95,6 +96,9 @@ public class DbInstance {
 
     public String getParameterGroupName() { return parameterGroupName; }
     public void setParameterGroupName(String parameterGroupName) { this.parameterGroupName = parameterGroupName; }
+
+    public String getDbSubnetGroupName() { return dbSubnetGroupName; }
+    public void setDbSubnetGroupName(String dbSubnetGroupName) { this.dbSubnetGroupName = dbSubnetGroupName; }
 
     public String getDbClusterIdentifier() { return dbClusterIdentifier; }
     public void setDbClusterIdentifier(String dbClusterIdentifier) { this.dbClusterIdentifier = dbClusterIdentifier; }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbSubnetGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbSubnetGroup.java
@@ -32,7 +32,7 @@ public class DbSubnetGroup {
     public String getVpcId() { return vpcId; }
     public void setVpcId(String vpcId) { this.vpcId = vpcId; }
 
-    public List<String> getSubnetIds() { return subnetIds; }
+    public List<String> getSubnetIds() { return List.copyOf(subnetIds); }
     public void setSubnetIds(List<String> subnetIds) {
         this.subnetIds = subnetIds != null ? new ArrayList<>(subnetIds) : new ArrayList<>();
     }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbSubnetGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbSubnetGroup.java
@@ -1,0 +1,39 @@
+package io.github.hectorvent.floci.services.rds.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RegisterForReflection
+public class DbSubnetGroup {
+
+    private String dbSubnetGroupName;
+    private String dbSubnetGroupDescription;
+    private String vpcId;
+    private List<String> subnetIds = new ArrayList<>();
+
+    public DbSubnetGroup() {}
+
+    public DbSubnetGroup(String dbSubnetGroupName, String dbSubnetGroupDescription,
+                         String vpcId, List<String> subnetIds) {
+        this.dbSubnetGroupName = dbSubnetGroupName;
+        this.dbSubnetGroupDescription = dbSubnetGroupDescription;
+        this.vpcId = vpcId;
+        this.subnetIds = subnetIds != null ? new ArrayList<>(subnetIds) : new ArrayList<>();
+    }
+
+    public String getDbSubnetGroupName() { return dbSubnetGroupName; }
+    public void setDbSubnetGroupName(String dbSubnetGroupName) { this.dbSubnetGroupName = dbSubnetGroupName; }
+
+    public String getDbSubnetGroupDescription() { return dbSubnetGroupDescription; }
+    public void setDbSubnetGroupDescription(String dbSubnetGroupDescription) { this.dbSubnetGroupDescription = dbSubnetGroupDescription; }
+
+    public String getVpcId() { return vpcId; }
+    public void setVpcId(String vpcId) { this.vpcId = vpcId; }
+
+    public List<String> getSubnetIds() { return subnetIds; }
+    public void setSubnetIds(List<String> subnetIds) {
+        this.subnetIds = subnetIds != null ? new ArrayList<>(subnetIds) : new ArrayList<>();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandler.java
@@ -1,22 +1,44 @@
 package io.github.hectorvent.floci.services.rds.proxy;
 
 import org.jboss.logging.Logger;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 
 import javax.crypto.Mac;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
 import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.math.BigInteger;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,7 +48,7 @@ import java.util.Map;
  *
  * <p>Flow:
  * <ol>
- *   <li>Read client StartupMessage (handles SSL rejection)
+ *   <li>Read client StartupMessage (handles PostgreSQL SSL negotiation)
  *   <li>Challenge client with AuthenticationCleartextPassword
  *   <li>Read client password
  *   <li>Validate (IAM SigV4 or plain password)
@@ -41,21 +63,23 @@ public class PostgresProtocolHandler {
 
     private static final int SSL_REQUEST_CODE = 80877103;
     private static final int STARTUP_PROTOCOL_VERSION = 196608; // v3.0
+    private static volatile SSLContext serverSslContext;
 
     public static void handleAuth(Socket client, Socket backend,
                                   String masterUsername, String masterPassword, String dbName,
                                   boolean iamEnabled, RdsSigV4Validator sigV4,
                                   PasswordValidator passwordValidator) throws IOException {
 
-        InputStream clientIn = client.getInputStream();
-        OutputStream clientOut = client.getOutputStream();
-
         // Phase 1: Read client startup message (possibly preceded by SSL request)
-        String clientUsername = readStartupMessage(clientIn, clientOut);
-        if (clientUsername == null) {
+        StartupMessage startup = readStartupMessage(client);
+        if (startup == null) {
             closeQuietly(client);
             return;
         }
+        client = startup.socket();
+        String clientUsername = startup.username();
+        InputStream clientIn = client.getInputStream();
+        OutputStream clientOut = client.getOutputStream();
 
         // Phase 2: Challenge client with cleartext password request
         sendMessage(clientOut, 'R', intBytes(3)); // AuthenticationCleartextPassword
@@ -133,8 +157,11 @@ public class PostgresProtocolHandler {
 
     // ── Startup ───────────────────────────────────────────────────────────────
 
-    private static String readStartupMessage(InputStream in, OutputStream out) throws IOException {
+    private static StartupMessage readStartupMessage(Socket socket) throws IOException {
+        Socket currentSocket = socket;
         while (true) {
+            InputStream in = currentSocket.getInputStream();
+            OutputStream out = currentSocket.getOutputStream();
             int length = readInt32(in);
             if (length < 8) {
                 return null;
@@ -142,8 +169,9 @@ public class PostgresProtocolHandler {
             int proto = readInt32(in);
 
             if (proto == SSL_REQUEST_CODE) {
-                out.write('N'); // Reject SSL
+                out.write('S');
                 out.flush();
+                currentSocket = acceptSsl(currentSocket);
                 continue;
             }
 
@@ -155,9 +183,81 @@ public class PostgresProtocolHandler {
             byte[] payload = new byte[length - 8];
             readFully(in, payload);
             Map<String, String> params = parseStartupParams(payload);
-            return params.getOrDefault("user", "postgres");
+            return new StartupMessage(currentSocket, params.getOrDefault("user", "postgres"));
         }
     }
+
+    static Socket acceptSsl(Socket socket) throws IOException {
+        try {
+            SSLSocket sslSocket = (SSLSocket) serverSslContext().getSocketFactory()
+                    .createSocket(socket, socket.getInetAddress().getHostAddress(), socket.getPort(), true);
+            sslSocket.setUseClientMode(false);
+            sslSocket.startHandshake();
+            return sslSocket;
+        } catch (Exception e) {
+            throw new IOException("Unable to negotiate PostgreSQL SSL", e);
+        }
+    }
+
+    private static SSLContext serverSslContext() throws Exception {
+        SSLContext context = serverSslContext;
+        if (context != null) {
+            return context;
+        }
+        synchronized (PostgresProtocolHandler.class) {
+            context = serverSslContext;
+            if (context == null) {
+                context = createServerSslContext();
+                serverSslContext = context;
+            }
+            return context;
+        }
+    }
+
+    private static SSLContext createServerSslContext() throws Exception {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048, new SecureRandom());
+        KeyPair keyPair = generator.generateKeyPair();
+        Instant now = Instant.now();
+
+        X500Name name = new X500Name("CN=localhost");
+        X509v3CertificateBuilder certificateBuilder = new JcaX509v3CertificateBuilder(
+                name,
+                new BigInteger(128, new SecureRandom()),
+                Date.from(now.minus(1, ChronoUnit.MINUTES)),
+                Date.from(now.plus(365, ChronoUnit.DAYS)),
+                name,
+                keyPair.getPublic());
+        certificateBuilder.addExtension(Extension.subjectAlternativeName, false, new GeneralNames(new GeneralName[] {
+                new GeneralName(GeneralName.dNSName, "localhost"),
+                new GeneralName(GeneralName.iPAddress, "127.0.0.1")
+        }));
+
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .build(keyPair.getPrivate());
+        X509Certificate certificate = new JcaX509CertificateConverter()
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .getCertificate(certificateBuilder.build(signer));
+
+        char[] password = new char[0];
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        keyStore.load(null, password);
+        keyStore.setKeyEntry("floci-rds-postgres", keyPair.getPrivate(), password, new java.security.cert.Certificate[] {certificate});
+
+        KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        keyManagerFactory.init(keyStore, password);
+
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(keyManagerFactory.getKeyManagers(), null, new SecureRandom());
+        return context;
+    }
+
+    private record StartupMessage(Socket socket, String username) {}
 
     private static Map<String, String> parseStartupParams(byte[] data) {
         Map<String, String> params = new HashMap<>();

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -148,6 +148,78 @@ class RdsQueryHandlerTest {
     }
 
     @Test
+    void describeDbInstances_includesTagList() {
+        DbInstance instance = makeInstance("mydb");
+        instance.setTags(java.util.Map.of("example:ClusterId", "cluster-a", "Name", "mydb"));
+        when(service.listDbInstances(null)).thenReturn(List.of(instance));
+
+        Response response = handler.handle("DescribeDBInstances", params());
+
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<TagList>"));
+        assertTrue(body.contains("<Key>example:ClusterId</Key>"));
+        assertTrue(body.contains("<Value>cluster-a</Value>"));
+        assertTrue(body.contains("<Key>Name</Key>"));
+        assertTrue(body.contains("<Value>mydb</Value>"));
+    }
+
+    @Test
+    void createDbInstance_passesCreateTagsToService() {
+        DbInstance instance = makeInstance("mydb");
+        when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
+                eq(null), eq(null), eq(null), eq("db.t3.micro"),
+                eq(20), eq(false), eq(null), eq(null), eq(null), eq(false), eq(null),
+                eq(java.util.Map.of("example:ClusterId", "cluster-a", "Name", "mydb"))))
+                .thenReturn(instance);
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBInstanceIdentifier", "mydb");
+        p.add("Engine", "postgres");
+        p.add("Tags.member.1.Key", "example:ClusterId");
+        p.add("Tags.member.1.Value", "cluster-a");
+        p.add("Tags.member.2.Key", "Name");
+        p.add("Tags.member.2.Value", "mydb");
+        handler.handle("CreateDBInstance", p);
+
+        verify(service).createDbInstance("mydb", "postgres", "16.3",
+                null, null, null, "db.t3.micro", 20, false, null, null, null, false, null,
+                java.util.Map.of("example:ClusterId", "cluster-a", "Name", "mydb"));
+    }
+
+    @Test
+    void listTagsForResource_returnsStoredTags() {
+        when(service.listTagsForResource("arn:aws:rds:us-east-1:000000000000:db:mydb"))
+                .thenReturn(java.util.Map.of("Name", "mydb"));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("ResourceName", "arn:aws:rds:us-east-1:000000000000:db:mydb");
+        Response response = handler.handle("ListTagsForResource", p);
+
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<TagList>"));
+        assertTrue(body.contains("<Key>Name</Key>"));
+        assertTrue(body.contains("<Value>mydb</Value>"));
+    }
+
+    @Test
+    void addAndRemoveTagsForResource_passThrough() {
+        MultivaluedMap<String, String> add = params();
+        add.add("ResourceName", "arn:aws:rds:us-east-1:000000000000:db:mydb");
+        add.add("Tags.member.1.Key", "Name");
+        add.add("Tags.member.1.Value", "mydb");
+        handler.handle("AddTagsToResource", add);
+
+        verify(service).addTagsToResource("arn:aws:rds:us-east-1:000000000000:db:mydb", java.util.Map.of("Name", "mydb"));
+
+        MultivaluedMap<String, String> remove = params();
+        remove.add("ResourceName", "arn:aws:rds:us-east-1:000000000000:db:mydb");
+        remove.add("TagKeys.member.1", "Name");
+        handler.handle("RemoveTagsFromResource", remove);
+
+        verify(service).removeTagsFromResource("arn:aws:rds:us-east-1:000000000000:db:mydb", List.of("Name"));
+    }
+
+    @Test
     void describeOrderableDbInstanceOptions_usesServiceCatalog() {
         when(service.describeOrderableDbInstanceOptions("postgres", "16.3", "db.t4g.medium"))
                 .thenReturn(List.of(java.util.Map.of(
@@ -186,7 +258,7 @@ class RdsQueryHandlerTest {
         DbInstance instance = makeInstance("mydb");
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq("admin"), eq("secret"), eq("dbname"), eq("db.t3.micro"),
-                eq(20), eq(false), eq(null), eq(null), eq(null), eq(false), eq(null)))
+                eq(20), eq(false), eq(null), eq(null), eq(null), eq(false), eq(null), eq(java.util.Map.of())))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -199,7 +271,7 @@ class RdsQueryHandlerTest {
         handler.handle("CreateDBInstance", p);
 
         verify(service).createDbInstance("mydb", "postgres", "16.3",
-                "admin", "secret", "dbname", "db.t3.micro", 20, false, null, null, null, false, null);
+                "admin", "secret", "dbname", "db.t3.micro", 20, false, null, null, null, false, null, java.util.Map.of());
     }
 
     @Test
@@ -210,7 +282,7 @@ class RdsQueryHandlerTest {
         instance.setMasterUserSecretKmsKeyId("kms-key-1");
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq("admin"), eq(null), eq("dbname"), eq("db.t3.micro"),
-                eq(20), eq(false), eq(null), eq(null), eq(null), eq(true), eq("kms-key-1")))
+                eq(20), eq(false), eq(null), eq(null), eq(null), eq(true), eq("kms-key-1"), eq(java.util.Map.of())))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -228,7 +300,7 @@ class RdsQueryHandlerTest {
         assertTrue(body.contains("<SecretStatus>active</SecretStatus>"));
         assertTrue(body.contains("<KmsKeyId>kms-key-1</KmsKeyId>"));
         verify(service).createDbInstance("mydb", "postgres", "16.3",
-                "admin", null, "dbname", "db.t3.micro", 20, false, null, null, null, true, "kms-key-1");
+                "admin", null, "dbname", "db.t3.micro", 20, false, null, null, null, true, "kms-key-1", java.util.Map.of());
     }
 
     @Test
@@ -238,7 +310,7 @@ class RdsQueryHandlerTest {
         // AwsException wrapping into a 400 query error.
         when(service.createDbInstance(eq("mydb"), eq("oracle"), eq("1.0"),
                 eq(null), eq(null), eq(null), eq("db.t3.micro"),
-                eq(20), eq(false), eq(null), eq(null), eq(null), eq(false), eq(null)))
+                eq(20), eq(false), eq(null), eq(null), eq(null), eq(false), eq(null), eq(java.util.Map.of())))
                 .thenThrow(new AwsException("InvalidParameterValue",
                         "Unsupported engine: oracle. Supported: postgres, mysql, mariadb.", 400));
 

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.services.rds.model.DbClusterParameterGroup;
 import io.github.hectorvent.floci.services.rds.model.DbInstance;
 import io.github.hectorvent.floci.services.rds.model.DbInstanceStatus;
 import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
+import io.github.hectorvent.floci.services.rds.model.DbSubnetGroup;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
@@ -129,6 +130,43 @@ class RdsQueryHandlerTest {
         verify(service).listDbInstances(null);
     }
 
+    @Test
+    void describeDbInstances_usesStoredDbSubnetGroup() {
+        DbInstance instance = makeInstance("mydb");
+        instance.setDbSubnetGroupName("sample-db-subnets");
+        when(service.listDbInstances(null)).thenReturn(List.of(instance));
+        when(service.getDbSubnetGroup("sample-db-subnets")).thenReturn(new DbSubnetGroup(
+                "sample-db-subnets", "test subnets", "vpc-123", List.of("subnet-aaa", "subnet-bbb")));
+
+        Response response = handler.handle("DescribeDBInstances", params());
+
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<DBSubnetGroupName>sample-db-subnets</DBSubnetGroupName>"));
+        assertTrue(body.contains("<SubnetIdentifier>subnet-aaa</SubnetIdentifier>"));
+        assertTrue(body.contains("<SubnetIdentifier>subnet-bbb</SubnetIdentifier>"));
+        assertFalse(body.contains("<SubnetIdentifier>subnet-00000000</SubnetIdentifier>"));
+    }
+
+    @Test
+    void describeOrderableDbInstanceOptions_usesServiceCatalog() {
+        when(service.describeOrderableDbInstanceOptions("postgres", "16.3", "db.t4g.medium"))
+                .thenReturn(List.of(java.util.Map.of(
+                        "engine", "postgres",
+                        "engineVersion", "16.3",
+                        "dbInstanceClass", "db.t4g.medium")));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("Engine", "postgres");
+        p.add("EngineVersion", "16.3");
+        p.add("DBInstanceClass", "db.t4g.medium");
+        Response response = handler.handle("DescribeOrderableDBInstanceOptions", p);
+
+        String body = (String) response.getEntity();
+        assertEquals(200, response.getStatus());
+        assertTrue(body.contains("<OrderableDBInstanceOption>"));
+        assertTrue(body.contains("<DBInstanceClass>db.t4g.medium</DBInstanceClass>"));
+    }
+
     // ──────────────────────────── DBParameterGroups XML tag ──────────────────────
 
     @Test
@@ -148,7 +186,7 @@ class RdsQueryHandlerTest {
         DbInstance instance = makeInstance("mydb");
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq("admin"), eq("secret"), eq("dbname"), eq("db.t3.micro"),
-                eq(20), eq(false), eq(null), eq(null)))
+                eq(20), eq(false), eq(null), eq(null), eq(null)))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -161,7 +199,7 @@ class RdsQueryHandlerTest {
         handler.handle("CreateDBInstance", p);
 
         verify(service).createDbInstance("mydb", "postgres", "16.3",
-                "admin", "secret", "dbname", "db.t3.micro", 20, false, null, null);
+                "admin", "secret", "dbname", "db.t3.micro", 20, false, null, null, null);
     }
 
     @Test
@@ -171,7 +209,7 @@ class RdsQueryHandlerTest {
         // AwsException wrapping into a 400 query error.
         when(service.createDbInstance(eq("mydb"), eq("oracle"), eq("1.0"),
                 eq(null), eq(null), eq(null), eq("db.t3.micro"),
-                eq(20), eq(false), eq(null), eq(null)))
+                eq(20), eq(false), eq(null), eq(null), eq(null)))
                 .thenThrow(new AwsException("InvalidParameterValue",
                         "Unsupported engine: oracle. Supported: postgres, mysql, mariadb.", 400));
 
@@ -182,6 +220,29 @@ class RdsQueryHandlerTest {
 
         assertEquals(400, response.getStatus());
         assertTrue(((String) response.getEntity()).contains("InvalidParameterValue"));
+    }
+
+    @Test
+    void createDbSubnetGroup_passesSubnetMembersToService() {
+        when(service.createDbSubnetGroup("sample-db-subnets", "test", List.of("subnet-aaa", "subnet-bbb")))
+                .thenReturn(new DbSubnetGroup(
+                        "sample-db-subnets", "test", "vpc-123", List.of("subnet-aaa", "subnet-bbb")));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBSubnetGroupName", "sample-db-subnets");
+        p.add("DBSubnetGroupDescription", "test");
+        p.add("SubnetIds.SubnetIdentifier.1", "subnet-aaa");
+        p.add("SubnetIds.SubnetIdentifier.2", "subnet-bbb");
+        Response response = handler.handle("CreateDBSubnetGroup", p);
+
+        verify(service).createDbSubnetGroup("sample-db-subnets", "test", List.of("subnet-aaa", "subnet-bbb"));
+        String body = (String) response.getEntity();
+        assertEquals(200, response.getStatus());
+        assertTrue(body.contains("<DBSubnetGroupName>sample-db-subnets</DBSubnetGroupName>"));
+        assertTrue(body.contains("<Subnets><Subnet>"));
+        assertFalse(body.contains("<Subnets><member>"));
+        assertTrue(body.contains("<SubnetIdentifier>subnet-aaa</SubnetIdentifier>"));
+        assertTrue(body.contains("<SubnetIdentifier>subnet-bbb</SubnetIdentifier>"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -186,7 +186,7 @@ class RdsQueryHandlerTest {
         DbInstance instance = makeInstance("mydb");
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq("admin"), eq("secret"), eq("dbname"), eq("db.t3.micro"),
-                eq(20), eq(false), eq(null), eq(null), eq(null)))
+                eq(20), eq(false), eq(null), eq(null), eq(null), eq(false), eq(null)))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -199,7 +199,36 @@ class RdsQueryHandlerTest {
         handler.handle("CreateDBInstance", p);
 
         verify(service).createDbInstance("mydb", "postgres", "16.3",
-                "admin", "secret", "dbname", "db.t3.micro", 20, false, null, null, null);
+                "admin", "secret", "dbname", "db.t3.micro", 20, false, null, null, null, false, null);
+    }
+
+    @Test
+    void createDbInstancePassesManagedMasterUserSecretOptions() {
+        DbInstance instance = makeInstance("mydb");
+        instance.setMasterUserSecretArn("arn:aws:secretsmanager:us-east-1:000000000000:secret:rds!db-123456");
+        instance.setMasterUserSecretStatus("active");
+        instance.setMasterUserSecretKmsKeyId("kms-key-1");
+        when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
+                eq("admin"), eq(null), eq("dbname"), eq("db.t3.micro"),
+                eq(20), eq(false), eq(null), eq(null), eq(null), eq(true), eq("kms-key-1")))
+                .thenReturn(instance);
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBInstanceIdentifier", "mydb");
+        p.add("Engine", "postgres");
+        p.add("MasterUsername", "admin");
+        p.add("DBName", "dbname");
+        p.add("ManageMasterUserPassword", "true");
+        p.add("MasterUserSecretKmsKeyId", "kms-key-1");
+        Response response = handler.handle("CreateDBInstance", p);
+
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<MasterUserSecret>"));
+        assertTrue(body.contains("<SecretArn>arn:aws:secretsmanager:us-east-1:000000000000:secret:rds!db-123456</SecretArn>"));
+        assertTrue(body.contains("<SecretStatus>active</SecretStatus>"));
+        assertTrue(body.contains("<KmsKeyId>kms-key-1</KmsKeyId>"));
+        verify(service).createDbInstance("mydb", "postgres", "16.3",
+                "admin", null, "dbname", "db.t3.micro", 20, false, null, null, null, true, "kms-key-1");
     }
 
     @Test
@@ -209,7 +238,7 @@ class RdsQueryHandlerTest {
         // AwsException wrapping into a 400 query error.
         when(service.createDbInstance(eq("mydb"), eq("oracle"), eq("1.0"),
                 eq(null), eq(null), eq(null), eq("db.t3.micro"),
-                eq(20), eq(false), eq(null), eq(null), eq(null)))
+                eq(20), eq(false), eq(null), eq(null), eq(null), eq(false), eq(null)))
                 .thenThrow(new AwsException("InvalidParameterValue",
                         "Unsupported engine: oracle. Supported: postgres, mysql, mariadb.", 400));
 

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -246,6 +246,28 @@ class RdsQueryHandlerTest {
     }
 
     @Test
+    void modifyDbSubnetGroup_passesSubnetMembersToService() {
+        when(service.modifyDbSubnetGroup("sample-db-subnets", List.of("subnet-new-a", "subnet-new-b")))
+                .thenReturn(new DbSubnetGroup(
+                        "sample-db-subnets", "test", "vpc-123", List.of("subnet-new-a", "subnet-new-b")));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBSubnetGroupName", "sample-db-subnets");
+        p.add("SubnetIds.SubnetIdentifier.1", "subnet-new-a");
+        p.add("SubnetIds.SubnetIdentifier.2", "subnet-new-b");
+        Response response = handler.handle("ModifyDBSubnetGroup", p);
+
+        verify(service).modifyDbSubnetGroup("sample-db-subnets", List.of("subnet-new-a", "subnet-new-b"));
+        String body = (String) response.getEntity();
+        assertEquals(200, response.getStatus());
+        assertTrue(body.contains("<DBSubnetGroupName>sample-db-subnets</DBSubnetGroupName>"));
+        assertTrue(body.contains("<Subnets><Subnet>"));
+        assertFalse(body.contains("<Subnets><member>"));
+        assertTrue(body.contains("<SubnetIdentifier>subnet-new-a</SubnetIdentifier>"));
+        assertTrue(body.contains("<SubnetIdentifier>subnet-new-b</SubnetIdentifier>"));
+    }
+
+    @Test
     void modifyDbParameterGroup_ignoresParametersWithoutValue() {
         DbParameterGroup group = new DbParameterGroup("pg1", "postgres15", "test group");
         when(service.modifyDbParameterGroup(eq("pg1"), eq(java.util.Map.of("max_connections", "200"))))

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -75,6 +75,25 @@ class RdsServiceTest {
     }
 
     @Test
+    void dbInstanceTagsRoundTripAndMutateByArn() {
+        DbInstance instance = rdsService.createDbInstance("mydb", "postgres", "13",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, false, null,
+                java.util.Map.of("example:ClusterId", "cluster-a"));
+
+        assertEquals(java.util.Map.of("example:ClusterId", "cluster-a"),
+                rdsService.listTagsForResource(instance.getDbInstanceArn()));
+
+        rdsService.addTagsToResource(instance.getDbInstanceArn(), java.util.Map.of("Name", "mydb"));
+        assertEquals(java.util.Map.of("example:ClusterId", "cluster-a", "Name", "mydb"),
+                rdsService.listTagsForResource(instance.getDbInstanceArn()));
+
+        rdsService.removeTagsFromResource(instance.getDbInstanceArn(), java.util.List.of("Name"));
+        assertEquals(java.util.Map.of("example:ClusterId", "cluster-a"),
+                rdsService.listTagsForResource(instance.getDbInstanceArn()));
+    }
+
+    @Test
     void createDbInstanceWithManagedMasterPasswordCreatesSecret() {
         SecretsManagerService secretsManager = mock(SecretsManagerService.class);
         Secret secret = new Secret();

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -14,8 +14,11 @@ import io.github.hectorvent.floci.services.rds.model.DbInstance;
 import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
 import io.github.hectorvent.floci.services.rds.model.DbSubnetGroup;
 import io.github.hectorvent.floci.services.rds.proxy.RdsProxyManager;
+import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerService;
+import io.github.hectorvent.floci.services.secretsmanager.model.Secret;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.Collection;
 
@@ -69,6 +72,37 @@ class RdsServiceTest {
         assertNotNull(instance.getDbiResourceId());
         assertTrue(instance.getDbiResourceId().startsWith("db-"));
         assertEquals("arn:aws:rds:us-east-1:123456789012:db:mydb", instance.getDbInstanceArn());
+    }
+
+    @Test
+    void createDbInstanceWithManagedMasterPasswordCreatesSecret() {
+        SecretsManagerService secretsManager = mock(SecretsManagerService.class);
+        Secret secret = new Secret();
+        secret.setArn("arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!db-secret");
+        when(secretsManager.createSecret(any(), any(), eq(null), any(), eq("kms-key-1"), eq(null), eq("us-east-1")))
+                .thenReturn(secret);
+        RdsService service = newService(containerManager, proxyManager,
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                secretsManager);
+
+        DbInstance instance = service.createDbInstance("mydb", "postgres", "13",
+                "admin", null, "dbname", "db.t3.micro",
+                20, true, null, null, null, true, "kms-key-1");
+
+        assertEquals("arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!db-secret", instance.getMasterUserSecretArn());
+        assertEquals("active", instance.getMasterUserSecretStatus());
+        assertEquals("kms-key-1", instance.getMasterUserSecretKmsKeyId());
+        assertNotNull(instance.getMasterPassword());
+        assertTrue(instance.getMasterPassword().startsWith("floci-"));
+
+        ArgumentCaptor<String> secretName = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> secretString = ArgumentCaptor.forClass(String.class);
+        verify(secretsManager).createSecret(secretName.capture(), secretString.capture(), eq(null), any(), eq("kms-key-1"), eq(null), eq("us-east-1"));
+        assertTrue(secretName.getValue().startsWith("rds!db-"));
+        assertTrue(secretString.getValue().contains("\"username\":\"admin\""));
+        assertTrue(secretString.getValue().contains("\"password\":\"" + instance.getMasterPassword() + "\""));
+        assertTrue(secretString.getValue().contains("\"dbInstanceIdentifier\":\"mydb\""));
     }
 
     @Test
@@ -315,7 +349,17 @@ class RdsServiceTest {
                                   StorageBackend<String, DbCluster> clusters,
                                   StorageBackend<String, DbParameterGroup> parameterGroups,
                                   StorageBackend<String, DbClusterParameterGroup> clusterParameterGroups) {
+        return newService(containerManager, proxyManager, instances, clusters, parameterGroups, clusterParameterGroups, null);
+    }
+
+    private RdsService newService(RdsContainerManager containerManager,
+                                  RdsProxyManager proxyManager,
+                                  StorageBackend<String, DbInstance> instances,
+                                  StorageBackend<String, DbCluster> clusters,
+                                  StorageBackend<String, DbParameterGroup> parameterGroups,
+                                  StorageBackend<String, DbClusterParameterGroup> clusterParameterGroups,
+                                  SecretsManagerService secretsManager) {
         return new RdsService(containerManager, proxyManager, regionResolver, config,
-                instances, clusters, parameterGroups, clusterParameterGroups, new InMemoryStorage<>());
+                instances, clusters, parameterGroups, clusterParameterGroups, new InMemoryStorage<>(), secretsManager);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -238,11 +238,11 @@ class RdsServiceTest {
     @Test
     void describeOrderableDbInstanceOptionsFiltersByEngineVersionAndClass() {
         var result = rdsService.describeOrderableDbInstanceOptions(
-                "postgres", "16.14", "db.t3.micro");
+                "postgres", "18.1", "db.t3.micro");
 
         assertEquals(1, result.size());
         assertEquals("postgres", result.getFirst().get("engine"));
-        assertEquals("16.14", result.getFirst().get("engineVersion"));
+        assertEquals("18.1", result.getFirst().get("engineVersion"));
         assertEquals("db.t3.micro", result.getFirst().get("dbInstanceClass"));
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -12,6 +12,7 @@ import io.github.hectorvent.floci.services.rds.container.RdsContainerHandle;
 import io.github.hectorvent.floci.services.rds.container.RdsContainerManager;
 import io.github.hectorvent.floci.services.rds.model.DbInstance;
 import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
+import io.github.hectorvent.floci.services.rds.model.DbSubnetGroup;
 import io.github.hectorvent.floci.services.rds.proxy.RdsProxyManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,8 +21,11 @@ import java.util.Collection;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -59,7 +63,7 @@ class RdsServiceTest {
     void createDbInstanceGeneratesMissingFields() {
         DbInstance instance = rdsService.createDbInstance("mydb", "postgres", "13",
                 "admin", "password", "dbname", "db.t3.micro",
-                20, false, null, null);
+                20, false, null, null, null);
 
         assertEquals("mydb", instance.getDbInstanceIdentifier());
         assertNotNull(instance.getDbiResourceId());
@@ -71,7 +75,7 @@ class RdsServiceTest {
     void listDbInstancesIsCaseInsensitive() {
         rdsService.createDbInstance("mydb", "postgres", "13",
                 "admin", "password", "dbname", "db.t3.micro",
-                20, false, null, null);
+                20, false, null, null, null);
 
         Collection<DbInstance> result = rdsService.listDbInstances("MYDB");
         assertEquals(1, result.size());
@@ -91,9 +95,9 @@ class RdsServiceTest {
     void modifyDbInstanceBlankPasswordDoesNotOverwriteExistingPassword() {
         rdsService.createDbInstance("mydb", "postgres", "13",
                 "admin", "original-password", "dbname", "db.t3.micro",
-                20, false, null, null);
+                20, false, null, null, null);
 
-        DbInstance modified = rdsService.modifyDbInstance("mydb", "   ", null);
+        DbInstance modified = rdsService.modifyDbInstance("mydb", "   ", null, null);
 
         assertEquals("original-password", modified.getMasterPassword());
         assertFalse(modified.isIamDatabaseAuthenticationEnabled());
@@ -103,12 +107,49 @@ class RdsServiceTest {
     void modifyDbInstanceCanToggleIamWithoutChangingPassword() {
         rdsService.createDbInstance("mydb", "postgres", "13",
                 "admin", "original-password", "dbname", "db.t3.micro",
-                20, false, null, null);
+                20, false, null, null, null);
 
-        DbInstance modified = rdsService.modifyDbInstance("mydb", null, true);
+        DbInstance modified = rdsService.modifyDbInstance("mydb", null, true, null);
 
         assertEquals("original-password", modified.getMasterPassword());
         assertTrue(modified.isIamDatabaseAuthenticationEnabled());
+    }
+
+    @Test
+    void dbSubnetGroupRoundTrip() {
+        DbSubnetGroup group = rdsService.createDbSubnetGroup(
+                "sample-db-subnets", "test", java.util.List.of("subnet-aaa", "subnet-bbb"));
+
+        assertEquals("sample-db-subnets", group.getDbSubnetGroupName());
+        assertEquals(java.util.List.of("subnet-aaa", "subnet-bbb"), group.getSubnetIds());
+        assertEquals(1, rdsService.listDbSubnetGroups("sample-db-subnets").size());
+
+        rdsService.deleteDbSubnetGroup("sample-db-subnets");
+        assertTrue(rdsService.listDbSubnetGroups("sample-db-subnets").isEmpty());
+    }
+
+    @Test
+    void createDbInstanceRejectsMissingDbSubnetGroupBeforeStartingRuntime() {
+        AwsException exception = assertThrows(AwsException.class, () ->
+                rdsService.createDbInstance("mydb", "postgres", "13",
+                        "admin", "password", "dbname", "db.t3.micro",
+                        20, false, null, "missing-subnet-group", null));
+
+        assertEquals("DBSubnetGroupNotFoundFault", exception.getErrorCode());
+        verify(containerManager, never()).start(any(), any(), any(), any(), any(), any(), any());
+        verify(proxyManager, never()).startProxy(any(), any(), anyBoolean(), anyInt(),
+                any(), anyInt(), any(), any(), any(), any());
+    }
+
+    @Test
+    void describeOrderableDbInstanceOptionsFiltersByEngineVersionAndClass() {
+        var result = rdsService.describeOrderableDbInstanceOptions(
+                "postgres", "16.14", "db.t3.micro");
+
+        assertEquals(1, result.size());
+        assertEquals("postgres", result.getFirst().get("engine"));
+        assertEquals("16.14", result.getFirst().get("engineVersion"));
+        assertEquals("db.t3.micro", result.getFirst().get("dbInstanceClass"));
     }
 
     @Test
@@ -190,7 +231,7 @@ class RdsServiceTest {
                 instances, clusters, parameterGroups, clusterParameterGroups);
         DbInstance created = initialService.createDbInstance("mydb", "postgres", "16.3",
                 "admin", "secret", "app", "db.t3.micro",
-                20, false, null, null);
+                20, false, null, null, null);
 
         String persistedVolumeId = created.getVolumeId();
         int persistedProxyPort = created.getProxyPort();
@@ -236,7 +277,7 @@ class RdsServiceTest {
                 "admin", "secret", "app", false, null);
         DbInstance member = initialService.createDbInstance("member1", "aurora-postgresql", "16.3",
                 "admin", "secret", "app", "db.t3.medium",
-                20, false, null, "cluster1");
+                20, false, null, null, "cluster1");
 
         RdsContainerManager restoredContainerManager = mock(RdsContainerManager.class);
         RdsProxyManager restoredProxyManager = mock(RdsProxyManager.class);
@@ -275,6 +316,6 @@ class RdsServiceTest {
                                   StorageBackend<String, DbParameterGroup> parameterGroups,
                                   StorageBackend<String, DbClusterParameterGroup> clusterParameterGroups) {
         return new RdsService(containerManager, proxyManager, regionResolver, config,
-                instances, clusters, parameterGroups, clusterParameterGroups);
+                instances, clusters, parameterGroups, clusterParameterGroups, new InMemoryStorage<>());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -210,6 +210,18 @@ class RdsServiceTest {
     }
 
     @Test
+    void modifyDbInstanceRejectsMissingDbSubnetGroup() {
+        rdsService.createDbInstance("mydb", "postgres", "13",
+                "admin", "original-password", "dbname", "db.t3.micro",
+                20, false, null, null, null);
+
+        AwsException exception = assertThrows(AwsException.class,
+                () -> rdsService.modifyDbInstance("mydb", null, null, "missing-subnet-group"));
+
+        assertEquals("DBSubnetGroupNotFoundFault", exception.getErrorCode());
+    }
+
+    @Test
     void dbSubnetGroupRoundTrip() {
         DbSubnetGroup group = rdsService.createDbSubnetGroup(
                 "sample-db-subnets", "test", java.util.List.of("subnet-aaa", "subnet-bbb"));

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.rds;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.docker.DockerHostResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.services.rds.model.DatabaseEngine;
@@ -116,6 +117,21 @@ class RdsServiceTest {
         rdsService.removeTagsFromResource(instance.getDbInstanceArn(), java.util.List.of("Name"));
         assertEquals(java.util.Map.of("example:ClusterId", "cluster-a"),
                 rdsService.listTagsForResource(instance.getDbInstanceArn()));
+    }
+
+    @Test
+    void dbInstanceEndpointUsesResolvedProxyHost() {
+        DockerHostResolver dockerHostResolver = mock(DockerHostResolver.class);
+        when(dockerHostResolver.resolve()).thenReturn("floci.local");
+        RdsService service = new RdsService(containerManager, proxyManager, regionResolver, config,
+                new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
+                new InMemoryStorage<>(), new InMemoryStorage<>(), null, dockerHostResolver);
+
+        DbInstance instance = service.createDbInstance("mydb", "postgres", "13",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null);
+
+        assertEquals("floci.local", instance.getEndpoint().address());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -53,6 +53,9 @@ class RdsServiceTest {
         when(servicesConfig.rds()).thenReturn(rdsConfig);
         when(rdsConfig.proxyBasePort()).thenReturn(7000);
         when(rdsConfig.proxyMaxPort()).thenReturn(7099);
+        when(rdsConfig.defaultPostgresImage()).thenReturn("postgres:16-alpine");
+        when(rdsConfig.defaultMysqlImage()).thenReturn("mysql:8.0");
+        when(rdsConfig.defaultMariadbImage()).thenReturn("mariadb:11");
 
         rdsService = newService(containerManager, proxyManager,
                 new InMemoryStorage<>(), new InMemoryStorage<>(),
@@ -72,6 +75,28 @@ class RdsServiceTest {
         assertNotNull(instance.getDbiResourceId());
         assertTrue(instance.getDbiResourceId().startsWith("db-"));
         assertEquals("arn:aws:rds:us-east-1:123456789012:db:mydb", instance.getDbInstanceArn());
+    }
+
+    @Test
+    void postgresImageUsesRequestedEngineVersionAndDefaultFlavor() {
+        assertEquals("postgres:18.1-alpine",
+                RdsService.imageForRequestedVersion("postgres:16-alpine", "18.1"));
+        assertEquals("example.com/library/postgres:18.1-alpine",
+                RdsService.imageForRequestedVersion("example.com/library/postgres:16-alpine", "18.1"));
+        assertEquals("postgres:18.1",
+                RdsService.imageForRequestedVersion("postgres", "18.1"));
+        assertEquals("postgres:18.1-alpine",
+                RdsService.imageForRequestedVersion("postgres:16-alpine", "18.1-alpine"));
+    }
+
+    @Test
+    void createDbInstanceStartsContainerWithRequestedEngineVersionImage() {
+        rdsService.createDbInstance("mydb", "postgres", "18.1",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null);
+
+        verify(containerManager).start(eq("mydb"), any(), eq(DatabaseEngine.POSTGRES),
+                eq("postgres:18.1-alpine"), eq("admin"), eq("password"), eq("dbname"));
     }
 
     @Test
@@ -308,7 +333,7 @@ class RdsServiceTest {
         assertEquals(15432, restored.getContainerPort());
 
         verify(restoredContainerManager).start(eq("mydb"), eq(persistedVolumeId),
-                eq(DatabaseEngine.POSTGRES), any(), eq("admin"), eq("secret"), eq("app"));
+                eq(DatabaseEngine.POSTGRES), eq("postgres:16.3-alpine"), eq("admin"), eq("secret"), eq("app"));
         verify(restoredProxyManager).startProxy(eq("mydb"), eq(DatabaseEngine.POSTGRES),
                 eq(false), eq(persistedProxyPort), eq("127.0.0.1"), eq(15432),
                 eq("admin"), eq("secret"), eq("app"), any());
@@ -353,7 +378,7 @@ class RdsServiceTest {
         assertEquals(15432, restoredMember.getContainerPort());
 
         verify(restoredContainerManager).start(eq("cluster1"), eq(cluster.getVolumeId()),
-                eq(DatabaseEngine.POSTGRES), any(), eq("admin"), eq("secret"), eq("app"));
+                eq(DatabaseEngine.POSTGRES), eq("postgres:16.3-alpine"), eq("admin"), eq("secret"), eq("app"));
         verify(restoredProxyManager).startProxy(eq("cluster1"), eq(DatabaseEngine.POSTGRES),
                 eq(false), eq(cluster.getProxyPort()), eq("127.0.0.1"), eq(15432),
                 eq("admin"), eq("secret"), eq("app"), any());

--- a/src/test/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManagerTest.java
@@ -1,0 +1,17 @@
+package io.github.hectorvent.floci.services.rds.container;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RdsContainerManagerTest {
+
+    @Test
+    void postgresInitSqlCreatesRdsIamRoleWhenMissing() {
+        String sql = RdsContainerManager.postgresIamRoleInitSql();
+
+        assertTrue(sql.contains("pg_roles"));
+        assertTrue(sql.contains("rolname = 'rds_iam'"));
+        assertTrue(sql.contains("CREATE ROLE rds_iam"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java
@@ -1,0 +1,86 @@
+package io.github.hectorvent.floci.services.rds.proxy;
+
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PostgresProtocolHandlerTest {
+
+    private static final int SSL_REQUEST_CODE = 80877103;
+
+    @Test
+    void acceptsPostgresSslRequestAndUpgradesSocket() throws Exception {
+        ArrayBlockingQueue<Integer> serverRead = new ArrayBlockingQueue<>(1);
+
+        try (ServerSocket server = new ServerSocket(0)) {
+            Thread.ofVirtual().start(() -> {
+                try (Socket accepted = server.accept()) {
+                    DataInputStream in = new DataInputStream(accepted.getInputStream());
+                    DataOutputStream out = new DataOutputStream(accepted.getOutputStream());
+                    assertEquals(8, in.readInt());
+                    assertEquals(SSL_REQUEST_CODE, in.readInt());
+
+                    out.writeByte('S');
+                    out.flush();
+                    Socket sslSocket = PostgresProtocolHandler.acceptSsl(accepted);
+                    serverRead.add(sslSocket.getInputStream().read());
+                    sslSocket.getOutputStream().write(99);
+                    sslSocket.getOutputStream().flush();
+                    sslSocket.close();
+                } catch (Exception e) {
+                    serverRead.add(-1);
+                }
+            });
+
+            try (Socket rawClient = new Socket("localhost", server.getLocalPort())) {
+                DataOutputStream out = new DataOutputStream(rawClient.getOutputStream());
+                DataInputStream in = new DataInputStream(rawClient.getInputStream());
+                out.writeInt(8);
+                out.writeInt(SSL_REQUEST_CODE);
+                out.flush();
+                assertEquals('S', in.readUnsignedByte());
+
+                SSLSocket sslClient = (SSLSocket) trustAllContext().getSocketFactory()
+                        .createSocket(rawClient, "localhost", server.getLocalPort(), true);
+                sslClient.setUseClientMode(true);
+                sslClient.startHandshake();
+                sslClient.getOutputStream().write(42);
+                sslClient.getOutputStream().flush();
+                assertEquals(99, sslClient.getInputStream().read());
+                sslClient.close();
+            }
+        }
+
+        assertEquals(42, serverRead.poll(5, TimeUnit.SECONDS));
+    }
+
+    private static SSLContext trustAllContext() throws Exception {
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(null, new TrustManager[] {new X509TrustManager() {
+            @Override
+            public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+
+            @Override
+            public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+            }
+        }}, new SecureRandom());
+        return context;
+    }
+}


### PR DESCRIPTION
## Summary
- Add DB subnet group APIs and orderable instance options
- Preserve instance tags and requested engine versions
- Return managed master user secret metadata and routable proxy endpoints
- Improve PostgreSQL proxy compatibility for SSL negotiation and IAM role setup

## Tests
- ./mvnw test -Dtest=RdsQueryHandlerTest,RdsServiceTest,PostgresProtocolHandlerTest,RdsContainerManagerTest