### PR TITLE
Improve ELBv2 target resolution and persistence

### DIFF
--- a/docs/services/elb.md
+++ b/docs/services/elb.md
@@ -2,12 +2,12 @@
 
 **Protocol:** Query (XML) — `POST http://localhost:4566/` with `Action=` parameter
 
-Floci supports Application Load Balancers (ALB) and Network Load Balancers (NLB) through the ELBv2 management API. This is a Phase 1 implementation: the full CRUD control plane is available and AWS SDK / CLI / Terraform compatible. Data-plane traffic forwarding (actual TCP listener ports) is planned for Phase 2.
+Floci supports Application Load Balancers (ALB) and Network Load Balancers (NLB) through the ELBv2 management API. The control plane is AWS SDK / CLI / Terraform compatible, and HTTP listeners can forward to registered instance targets using the target's reachable local address.
 
 ## Supported Actions
 
 ### Load Balancers
-`CreateLoadBalancer` · `DescribeLoadBalancers` · `DeleteLoadBalancer` · `ModifyLoadBalancerAttributes` · `DescribeLoadBalancerAttributes` · `SetSecurityGroups` · `SetSubnets` · `SetIpAddressType`
+`CreateLoadBalancer` · `DescribeLoadBalancers` · `DeleteLoadBalancer` · `ModifyLoadBalancerAttributes` · `DescribeLoadBalancerAttributes` · `DescribeCapacityReservation` · `SetSecurityGroups` · `SetSubnets` · `SetIpAddressType`
 
 ### Target Groups
 `CreateTargetGroup` · `DescribeTargetGroups` · `ModifyTargetGroup` · `DeleteTargetGroup` · `ModifyTargetGroupAttributes` · `DescribeTargetGroupAttributes`
@@ -16,7 +16,7 @@ Floci supports Application Load Balancers (ALB) and Network Load Balancers (NLB)
 `RegisterTargets` · `DeregisterTargets` · `DescribeTargetHealth`
 
 ### Listeners
-`CreateListener` · `DescribeListeners` · `ModifyListener` · `DeleteListener` · `AddListenerCertificates` · `RemoveListenerCertificates` · `DescribeListenerCertificates`
+`CreateListener` · `DescribeListeners` · `ModifyListener` · `ModifyListenerAttributes` · `DescribeListenerAttributes` · `DeleteListener` · `AddListenerCertificates` · `RemoveListenerCertificates` · `DescribeListenerCertificates`
 
 ### Rules
 `CreateRule` · `DescribeRules` · `ModifyRule` · `DeleteRule` · `SetRulePriorities`
@@ -29,8 +29,11 @@ Floci supports Application Load Balancers (ALB) and Network Load Balancers (NLB)
 
 ## Behavior Notes
 
-- Load balancers are created in `provisioning` state and transition to `active` immediately on subsequent describes.
-- Target health always returns `initial` state with reason `Elb.RegistrationInProgress` — data-plane health checks are not performed in Phase 1.
+- Load balancer, target group, listener, rule, and tag state is persisted through Floci storage and rebuilt on service startup.
+- Load balancers are created in `active` state.
+- HTTP listener sockets are preserved when listener actions change and are restarted only when socket-level settings such as port change.
+- Instance targets are resolved through EC2 instance private addresses so local load balancer traffic can reach containers.
+- Target health starts in `initial` state with reason `Elb.RegistrationInProgress` and is updated by Floci's health checker when monitoring is active.
 - Each `CreateListener` automatically creates an immutable default rule (`priority=default`, `isDefault=true`). This rule cannot be deleted; use `ModifyListener` to change its action.
 - Rule priorities are validated for uniqueness. `SetRulePriorities` is atomic: all priority assignments are validated before any change is committed.
 - `DeleteTargetGroup` is rejected with `ResourceInUse` while the target group is referenced by any listener or rule.
@@ -111,6 +114,6 @@ aws elbv2 delete-target-group \
 |---|---|---|
 | `FLOCI_SERVICES_ELBV2_ENABLED` | `true` | Enable or disable the ELBv2 service |
 
-## Phase 2 (Planned)
+## Listener Ports
 
-Phase 2 will bind real TCP listener ports on the host so traffic sent to a listener port is forwarded to registered targets. This requires exposing a port range (e.g., `8300-8399`) in the Docker Compose configuration, similar to how ElastiCache and RDS proxy ports work today.
+Listener sockets bind on the Floci host. Expose any listener ports you need in Docker Compose when Floci itself runs in a container, similar to RDS and ElastiCache proxy ports.

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.elbv2;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.elbv2.model.Action;
 import io.github.hectorvent.floci.services.elbv2.model.Listener;
 import io.github.hectorvent.floci.services.elbv2.model.Rule;
@@ -60,6 +61,9 @@ public class ElbV2DataPlane {
 
     @Inject
     LambdaService lambdaService;
+
+    @Inject
+    Ec2Service ec2Service;
 
     @Inject
     ObjectMapper objectMapper;
@@ -192,7 +196,7 @@ public class ElbV2DataPlane {
         int idx = Math.abs(counter.getAndIncrement() % candidates.size());
         TargetDescription target = candidates.get(idx);
         int targetPort = ElbV2HealthChecker.effectivePort(target, tg);
-        proxyRequest(req, target.getId(), targetPort);
+        proxyRequest(req, ElbV2TargetResolver.resolveHost(ec2Service, tg, target), targetPort);
     }
 
     private void invokeLambdaTarget(io.vertx.core.http.HttpServerRequest req, String functionArn, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
@@ -109,10 +109,27 @@ public class ElbV2DataPlane {
 
         server.requestHandler(req -> handleRequest(req, listenerArn, region));
         server.listen()
-                .onSuccess(s -> LOG.infov("ELBv2 listener started on port {0} for {1}", String.valueOf(listener.getPort()), listenerArn))
-                .onFailure(err -> LOG.warnv("ELBv2 listener failed to start on port {0}: {1}", String.valueOf(listener.getPort()), err.getMessage()));
+                .onSuccess(s -> {
+                    servers.put(listenerArn, s);
+                    LOG.infov("ELBv2 listener started on port {0} for {1}", String.valueOf(listener.getPort()), listenerArn);
+                })
+                .onFailure(err -> {
+                    ruleChains.remove(listenerArn);
+                    listenerRegions.remove(listenerArn);
+                    LOG.warnv("ELBv2 listener failed to start on port {0}: {1}", String.valueOf(listener.getPort()), err.getMessage());
+                });
+    }
 
-        servers.put(listenerArn, server);
+    public void restartListener(Listener listener, String region, List<Rule> rules) {
+        if (config.services().elbv2().mock()) {
+            return;
+        }
+        HttpServer server = servers.remove(listener.getListenerArn());
+        if (server == null) {
+            startListener(listener, region, rules);
+            return;
+        }
+        server.close().onComplete(ignored -> startListener(listener, region, rules));
     }
 
     public void stopListener(String listenerArn) {

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2HealthChecker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2HealthChecker.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.elbv2;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.elbv2.model.TargetDescription;
 import io.github.hectorvent.floci.services.elbv2.model.TargetGroup;
 import io.vertx.core.Vertx;
@@ -23,6 +24,7 @@ public class ElbV2HealthChecker {
 
     private final Vertx vertx;
     private final EmulatorConfig config;
+    private final Ec2Service ec2Service;
 
     // tgArn → (targetKey → TargetState)
     private final Map<String, Map<String, TargetState>> states = new ConcurrentHashMap<>();
@@ -30,9 +32,10 @@ public class ElbV2HealthChecker {
     private final Map<String, Long> timers = new ConcurrentHashMap<>();
 
     @Inject
-    public ElbV2HealthChecker(Vertx vertx, EmulatorConfig config) {
+    public ElbV2HealthChecker(Vertx vertx, EmulatorConfig config, Ec2Service ec2Service) {
         this.vertx = vertx;
         this.config = config;
+        this.ec2Service = ec2Service;
     }
 
     public static int effectivePort(TargetDescription target, TargetGroup tg) {
@@ -120,13 +123,14 @@ public class ElbV2HealthChecker {
             if (parts.length != 2) {
                 continue;
             }
-            String host = parts[0];
+            String targetId = parts[0];
             int port;
             try {
                 port = Integer.parseInt(parts[1]);
             } catch (NumberFormatException e) {
                 continue;
             }
+            String host = ElbV2TargetResolver.resolveHost(ec2Service, tg, targetId);
             String path = tg.getHealthCheckPath() != null ? tg.getHealthCheckPath() : "/";
             String matcher = tg.getMatcher() != null ? tg.getMatcher() : "200";
             int timeout = tg.getHealthCheckTimeoutSeconds() != null ? tg.getHealthCheckTimeoutSeconds() : 5;

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
@@ -101,6 +101,9 @@ public class ElbV2Service {
                         .addAll(targetGroup.getLoadBalancerArns());
                 if (healthChecker != null) {
                     healthChecker.startMonitoring(targetGroup);
+                    if (!targetGroup.getTargets().isEmpty()) {
+                        healthChecker.addTargets(targetGroup.getTargetGroupArn(), targetGroup.getTargets(), targetGroup);
+                    }
                 }
             }
             for (Listener listener : listeners.getOrDefault(region, Map.of()).values()) {

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
@@ -68,12 +68,32 @@ public class ElbV2Service {
                 new TypeReference<Map<String, Map<String, Rule>>>() {});
         this.tags = storageBacked("elbv2-tags.json",
                 new TypeReference<Map<String, Map<String, String>>>() {});
+        normalizeRegionMaps(loadBalancers);
+        normalizeRegionMaps(targetGroups);
+        normalizeRegionMaps(listeners);
+        normalizeRegionMaps(rules);
+        normalizeRegionMaps(tags);
         rebuildIndexes();
     }
 
     private <V> Map<String, V> storageBacked(String fileName, TypeReference<Map<String, V>> typeReference)
     {
         return new StorageBackedMap<>(storageFactory.create("elbv2", fileName, typeReference));
+    }
+
+    private <V> void normalizeRegionMaps(Map<String, Map<String, V>> resources) {
+        for (Map.Entry<String, Map<String, V>> entry : new ArrayList<>(resources.entrySet())) {
+            if (!(entry.getValue() instanceof ConcurrentHashMap)) {
+                resources.put(entry.getKey(), new ConcurrentHashMap<>(entry.getValue()));
+            }
+        }
+    }
+
+    private <V> void persistRegion(Map<String, Map<String, V>> resources, String region) {
+        Map<String, V> regionResources = resources.get(region);
+        if (regionResources != null) {
+            resources.put(region, regionResources);
+        }
     }
 
     private void rebuildIndexes()
@@ -95,7 +115,6 @@ public class ElbV2Service {
             }
         }
         for (Map.Entry<String, Map<String, TargetGroup>> regionEntry : targetGroups.entrySet()) {
-            String region = regionEntry.getKey();
             for (TargetGroup targetGroup : regionEntry.getValue().values()) {
                 tgToLbs.computeIfAbsent(targetGroup.getTargetGroupArn(), k -> ConcurrentHashMap.newKeySet())
                         .addAll(targetGroup.getLoadBalancerArns());
@@ -106,7 +125,10 @@ public class ElbV2Service {
                     }
                 }
             }
-            for (Listener listener : listeners.getOrDefault(region, Map.of()).values()) {
+        }
+        for (Map.Entry<String, Map<String, Listener>> regionEntry : listeners.entrySet()) {
+            String region = regionEntry.getKey();
+            for (Listener listener : regionEntry.getValue().values()) {
                 if (dataPlane != null) {
                     dataPlane.startListener(listener, region, getListenerRules(region, listener.getListenerArn()));
                 }
@@ -222,7 +244,7 @@ public class ElbV2Service {
     public void modifyLoadBalancerAttributes(String region, String arn, Map<String, String> newAttrs) {
         LoadBalancer lb = requireLoadBalancer(region, arn);
         lb.getAttributes().putAll(newAttrs);
-        loadBalancers.put(region, loadBalancers.getOrDefault(region, Map.of()));
+        persistRegion(loadBalancers, region);
     }
 
     /** Capacity reservation status for a load balancer. All fields are {@code null} when no
@@ -240,7 +262,7 @@ public class ElbV2Service {
     public void setSecurityGroups(String region, String arn, List<String> sgIds) {
         LoadBalancer lb = requireLoadBalancer(region, arn);
         lb.setSecurityGroups(new ArrayList<>(sgIds));
-        loadBalancers.put(region, loadBalancers.getOrDefault(region, Map.of()));
+        persistRegion(loadBalancers, region);
     }
 
     public void setSubnets(String region, String arn, List<String> subnets) {
@@ -254,13 +276,13 @@ public class ElbV2Service {
         if (vpcId != null) {
             lb.setVpcId(vpcId);
         }
-        loadBalancers.put(region, loadBalancers.getOrDefault(region, Map.of()));
+        persistRegion(loadBalancers, region);
     }
 
     public void setIpAddressType(String region, String arn, String ipAddressType) {
         LoadBalancer lb = requireLoadBalancer(region, arn);
         lb.setIpAddressType(ipAddressType);
-        loadBalancers.put(region, loadBalancers.getOrDefault(region, Map.of()));
+        persistRegion(loadBalancers, region);
     }
 
     // ── Target Groups ─────────────────────────────────────────────────────────
@@ -356,7 +378,7 @@ public class ElbV2Service {
         }
         healthChecker.stopMonitoring(arn);
         targetGroups.getOrDefault(region, Map.of()).remove(arn);
-        targetGroups.put(region, targetGroups.getOrDefault(region, Map.of()));
+        persistRegion(targetGroups, region);
         tgToLbs.remove(arn);
         tags.remove(arn);
     }
@@ -376,7 +398,7 @@ public class ElbV2Service {
         if (healthyThreshold != null)    tg.setHealthyThresholdCount(healthyThreshold);
         if (unhealthyThreshold != null)  tg.setUnhealthyThresholdCount(unhealthyThreshold);
         if (matcher != null)             tg.setMatcher(matcher);
-        targetGroups.put(region, targetGroups.getOrDefault(region, Map.of()));
+        persistRegion(targetGroups, region);
     }
 
     public Map<String, String> describeTargetGroupAttributes(String region, String arn) {
@@ -387,7 +409,7 @@ public class ElbV2Service {
     public void modifyTargetGroupAttributes(String region, String arn, Map<String, String> newAttrs) {
         TargetGroup tg = requireTargetGroup(region, arn);
         tg.getAttributes().putAll(newAttrs);
-        targetGroups.put(region, targetGroups.getOrDefault(region, Map.of()));
+        persistRegion(targetGroups, region);
     }
 
     // ── Listeners ─────────────────────────────────────────────────────────────
@@ -471,7 +493,7 @@ public class ElbV2Service {
     public void modifyListenerAttributes(String region, String arn, Map<String, String> newAttrs) {
         Listener listener = requireListener(region, arn);
         listener.getAttributes().putAll(newAttrs);
-        listeners.put(region, listeners.getOrDefault(region, Map.of()));
+        persistRegion(listeners, region);
     }
 
     public void deleteListener(String region, String listenerArn) {
@@ -531,8 +553,8 @@ public class ElbV2Service {
             unlinkUnreferencedTargetGroups(region, listener.getLoadBalancerArn());
             recompileRules = true;
         }
-        listeners.put(region, listeners.getOrDefault(region, Map.of()));
-        rules.put(region, rules.getOrDefault(region, Map.of()));
+        persistRegion(listeners, region);
+        persistRegion(rules, region);
         if (restartDataPlane) {
             dataPlane.restartListener(requireListener(region, listenerArn), region, getListenerRules(region, listenerArn));
         } else if (recompileRules) {
@@ -641,7 +663,7 @@ public class ElbV2Service {
         String listenerArn = rule.getListenerArn();
         if (conditions != null) rule.setConditions(new ArrayList<>(conditions));
         if (actions != null)    rule.setActions(new ArrayList<>(actions));
-        rules.put(region, rules.getOrDefault(region, Map.of()));
+        persistRegion(rules, region);
         dataPlane.recompileRules(listenerArn, getListenerRules(region, listenerArn));
         return rule;
     }
@@ -699,7 +721,7 @@ public class ElbV2Service {
             existing.removeIf(e -> e.getId().equals(t.getId()) && Objects.equals(e.getPort(), t.getPort()));
             existing.add(t);
         }
-        targetGroups.put(region, targetGroups.getOrDefault(region, Map.of()));
+        persistRegion(targetGroups, region);
         healthChecker.addTargets(tgArn, targets, tg);
     }
 
@@ -708,7 +730,7 @@ public class ElbV2Service {
         for (TargetDescription t : targets) {
             tg.getTargets().removeIf(e -> e.getId().equals(t.getId()) && Objects.equals(e.getPort(), t.getPort()));
         }
-        targetGroups.put(region, targetGroups.getOrDefault(region, Map.of()));
+        persistRegion(targetGroups, region);
         healthChecker.removeTargets(tgArn, targets, tg);
     }
 
@@ -778,13 +800,13 @@ public class ElbV2Service {
                 listener.getCertificates().add(certArn);
             }
         }
-        listeners.put(region, listeners.getOrDefault(region, Map.of()));
+        persistRegion(listeners, region);
     }
 
     public void removeListenerCertificates(String region, String listenerArn, List<String> certArns) {
         Listener listener = requireListener(region, listenerArn);
         listener.getCertificates().removeAll(certArns);
-        listeners.put(region, listeners.getOrDefault(region, Map.of()));
+        persistRegion(listeners, region);
     }
 
     public List<String> describeListenerCertificates(String region, String listenerArn) {

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
@@ -1,11 +1,15 @@
 package io.github.hectorvent.floci.services.elbv2;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.StorageBackedMap;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.ec2.model.Subnet;
 import io.github.hectorvent.floci.services.elbv2.model.*;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -29,13 +33,16 @@ public class ElbV2Service {
     @Inject
     Ec2Service ec2Service;
 
+    @Inject
+    StorageFactory storageFactory;
+
     private static final String CANONICAL_HOSTED_ZONE_ID = "Z35SXDOTRQ7X7K";
 
     // region → ARN → resource
-    private final Map<String, Map<String, LoadBalancer>> loadBalancers = new ConcurrentHashMap<>();
-    private final Map<String, Map<String, TargetGroup>>  targetGroups  = new ConcurrentHashMap<>();
-    private final Map<String, Map<String, Listener>>     listeners     = new ConcurrentHashMap<>();
-    private final Map<String, Map<String, Rule>>         rules         = new ConcurrentHashMap<>();
+    private Map<String, Map<String, LoadBalancer>> loadBalancers = new ConcurrentHashMap<>();
+    private Map<String, Map<String, TargetGroup>> targetGroups = new ConcurrentHashMap<>();
+    private Map<String, Map<String, Listener>> listeners = new ConcurrentHashMap<>();
+    private Map<String, Map<String, Rule>> rules = new ConcurrentHashMap<>();
 
     // indexes
     private final Map<String, List<String>> lbToListeners   = new ConcurrentHashMap<>(); // LB-ARN → listener ARNs
@@ -43,7 +50,66 @@ public class ElbV2Service {
     private final Map<String, Set<String>>  tgToLbs          = new ConcurrentHashMap<>(); // TG-ARN → LB-ARNs
 
     // tags: resource-ARN → {key → value}
-    private final Map<String, Map<String, String>> tags = new ConcurrentHashMap<>();
+    private Map<String, Map<String, String>> tags = new ConcurrentHashMap<>();
+
+    @PostConstruct
+    void initializeStorage()
+    {
+        if (storageFactory == null) {
+            return;
+        }
+        this.loadBalancers = storageBacked("elbv2-load-balancers.json",
+                new TypeReference<Map<String, Map<String, LoadBalancer>>>() {});
+        this.targetGroups = storageBacked("elbv2-target-groups.json",
+                new TypeReference<Map<String, Map<String, TargetGroup>>>() {});
+        this.listeners = storageBacked("elbv2-listeners.json",
+                new TypeReference<Map<String, Map<String, Listener>>>() {});
+        this.rules = storageBacked("elbv2-rules.json",
+                new TypeReference<Map<String, Map<String, Rule>>>() {});
+        this.tags = storageBacked("elbv2-tags.json",
+                new TypeReference<Map<String, Map<String, String>>>() {});
+        rebuildIndexes();
+    }
+
+    private <V> Map<String, V> storageBacked(String fileName, TypeReference<Map<String, V>> typeReference)
+    {
+        return new StorageBackedMap<>(storageFactory.create("elbv2", fileName, typeReference));
+    }
+
+    private void rebuildIndexes()
+    {
+        lbToListeners.clear();
+        listenerToRules.clear();
+        tgToLbs.clear();
+
+        for (Map<String, Listener> regionListeners : listeners.values()) {
+            for (Listener listener : regionListeners.values()) {
+                lbToListeners.computeIfAbsent(listener.getLoadBalancerArn(), k -> new ArrayList<>())
+                        .add(listener.getListenerArn());
+            }
+        }
+        for (Map<String, Rule> regionRules : rules.values()) {
+            for (Rule rule : regionRules.values()) {
+                listenerToRules.computeIfAbsent(rule.getListenerArn(), k -> new ArrayList<>())
+                        .add(rule.getRuleArn());
+            }
+        }
+        for (Map.Entry<String, Map<String, TargetGroup>> regionEntry : targetGroups.entrySet()) {
+            String region = regionEntry.getKey();
+            for (TargetGroup targetGroup : regionEntry.getValue().values()) {
+                tgToLbs.computeIfAbsent(targetGroup.getTargetGroupArn(), k -> ConcurrentHashMap.newKeySet())
+                        .addAll(targetGroup.getLoadBalancerArns());
+                if (healthChecker != null) {
+                    healthChecker.startMonitoring(targetGroup);
+                }
+            }
+            for (Listener listener : listeners.getOrDefault(region, Map.of()).values()) {
+                if (dataPlane != null) {
+                    dataPlane.startListener(listener, region, getListenerRules(region, listener.getListenerArn()));
+                }
+            }
+        }
+    }
 
     // ── Load Balancers ────────────────────────────────────────────────────────
 
@@ -85,6 +151,7 @@ public class ElbV2Service {
         if (securityGroups != null) lb.setSecurityGroups(new ArrayList<>(securityGroups));
 
         regionLbs.put(arn, lb);
+        loadBalancers.put(region, regionLbs);
         lbToListeners.put(arn, new ArrayList<>());
         if (!initialTags.isEmpty()) {
             tags.put(arn, new LinkedHashMap<>(initialTags));
@@ -135,10 +202,13 @@ public class ElbV2Service {
                     ruleArns.forEach(regionRules::remove);
                 }
             }
+            listeners.put(region, regionListeners);
+            rules.put(region, regionRules);
         }
         // remove from TG index
         tgToLbs.values().forEach(lbSet -> lbSet.remove(arn));
         tags.remove(arn);
+        loadBalancers.put(region, regionLbs);
     }
 
     public Map<String, String> describeLoadBalancerAttributes(String region, String arn) {
@@ -149,6 +219,7 @@ public class ElbV2Service {
     public void modifyLoadBalancerAttributes(String region, String arn, Map<String, String> newAttrs) {
         LoadBalancer lb = requireLoadBalancer(region, arn);
         lb.getAttributes().putAll(newAttrs);
+        loadBalancers.put(region, loadBalancers.getOrDefault(region, Map.of()));
     }
 
     /** Capacity reservation status for a load balancer. All fields are {@code null} when no
@@ -166,6 +237,7 @@ public class ElbV2Service {
     public void setSecurityGroups(String region, String arn, List<String> sgIds) {
         LoadBalancer lb = requireLoadBalancer(region, arn);
         lb.setSecurityGroups(new ArrayList<>(sgIds));
+        loadBalancers.put(region, loadBalancers.getOrDefault(region, Map.of()));
     }
 
     public void setSubnets(String region, String arn, List<String> subnets) {
@@ -179,11 +251,13 @@ public class ElbV2Service {
         if (vpcId != null) {
             lb.setVpcId(vpcId);
         }
+        loadBalancers.put(region, loadBalancers.getOrDefault(region, Map.of()));
     }
 
     public void setIpAddressType(String region, String arn, String ipAddressType) {
         LoadBalancer lb = requireLoadBalancer(region, arn);
         lb.setIpAddressType(ipAddressType);
+        loadBalancers.put(region, loadBalancers.getOrDefault(region, Map.of()));
     }
 
     // ── Target Groups ─────────────────────────────────────────────────────────
@@ -231,6 +305,7 @@ public class ElbV2Service {
         tg.setMatcher(matcher != null ? matcher : "200");
 
         regionTgs.put(arn, tg);
+        targetGroups.put(region, regionTgs);
         tgToLbs.put(arn, ConcurrentHashMap.newKeySet());
         if (!initialTags.isEmpty()) {
             tags.put(arn, new LinkedHashMap<>(initialTags));
@@ -278,6 +353,7 @@ public class ElbV2Service {
         }
         healthChecker.stopMonitoring(arn);
         targetGroups.getOrDefault(region, Map.of()).remove(arn);
+        targetGroups.put(region, targetGroups.getOrDefault(region, Map.of()));
         tgToLbs.remove(arn);
         tags.remove(arn);
     }
@@ -297,6 +373,7 @@ public class ElbV2Service {
         if (healthyThreshold != null)    tg.setHealthyThresholdCount(healthyThreshold);
         if (unhealthyThreshold != null)  tg.setUnhealthyThresholdCount(unhealthyThreshold);
         if (matcher != null)             tg.setMatcher(matcher);
+        targetGroups.put(region, targetGroups.getOrDefault(region, Map.of()));
     }
 
     public Map<String, String> describeTargetGroupAttributes(String region, String arn) {
@@ -307,6 +384,7 @@ public class ElbV2Service {
     public void modifyTargetGroupAttributes(String region, String arn, Map<String, String> newAttrs) {
         TargetGroup tg = requireTargetGroup(region, arn);
         tg.getAttributes().putAll(newAttrs);
+        targetGroups.put(region, targetGroups.getOrDefault(region, Map.of()));
     }
 
     // ── Listeners ─────────────────────────────────────────────────────────────
@@ -346,12 +424,18 @@ public class ElbV2Service {
         listener.setAlpnPolicy(alpnPolicy != null ? new ArrayList<>(alpnPolicy) : new ArrayList<>());
 
         regionListeners.put(listenerArn, listener);
+        listeners.put(region, regionListeners);
         lbToListeners.computeIfAbsent(lbArn, k -> new ArrayList<>()).add(listenerArn);
 
         // auto-create the default rule
         Rule defaultRule = buildDefaultRule(region, listenerArn, lb, lbId, listenerId, defaultActions);
-        rules.computeIfAbsent(region, k -> new ConcurrentHashMap<>()).put(defaultRule.getRuleArn(), defaultRule);
+        Map<String, Rule> regionRules = rules.computeIfAbsent(region, k -> new ConcurrentHashMap<>());
+        regionRules.put(defaultRule.getRuleArn(), defaultRule);
+        rules.put(region, regionRules);
         listenerToRules.computeIfAbsent(listenerArn, k -> new ArrayList<>()).add(defaultRule.getRuleArn());
+        for (Action action : defaultRule.getActions()) {
+            linkTgToLb(action, lbArn);
+        }
 
         if (!initialTags.isEmpty()) {
             tags.put(listenerArn, new LinkedHashMap<>(initialTags));
@@ -384,6 +468,7 @@ public class ElbV2Service {
     public void modifyListenerAttributes(String region, String arn, Map<String, String> newAttrs) {
         Listener listener = requireListener(region, arn);
         listener.getAttributes().putAll(newAttrs);
+        listeners.put(region, listeners.getOrDefault(region, Map.of()));
     }
 
     public void deleteListener(String region, String listenerArn) {
@@ -400,6 +485,8 @@ public class ElbV2Service {
         if (ruleArns != null) {
             ruleArns.forEach(regionRules::remove);
         }
+        listeners.put(region, regionListeners);
+        rules.put(region, regionRules);
         tags.remove(listenerArn);
         unlinkUnreferencedTargetGroups(region, listener.getLoadBalancerArn());
     }
@@ -430,9 +517,11 @@ public class ElbV2Service {
             // update the default rule's actions
             listenerToRules.getOrDefault(listenerArn, List.of()).stream()
                     .map(ra -> rules.getOrDefault(region, Map.of()).get(ra))
-                    .filter(r -> r != null && r.isDefault())
-                    .forEach(r -> r.setActions(new ArrayList<>(defaultActions)));
+                .filter(r -> r != null && r.isDefault())
+                .forEach(r -> r.setActions(new ArrayList<>(defaultActions)));
         }
+        listeners.put(region, listeners.getOrDefault(region, Map.of()));
+        rules.put(region, rules.getOrDefault(region, Map.of()));
         dataPlane.stopListener(listenerArn);
         dataPlane.startListener(requireListener(region, listenerArn), region, getListenerRules(region, listenerArn));
         return listener;
@@ -477,6 +566,7 @@ public class ElbV2Service {
         rule.setDefault(false);
 
         regionRules.put(ruleArn, rule);
+        rules.put(region, regionRules);
         listenerToRules.computeIfAbsent(listenerArn, k -> new ArrayList<>()).add(ruleArn);
 
         // update TG → LB index for all target group actions
@@ -522,6 +612,7 @@ public class ElbV2Service {
         }
         String listenerArn = rule.getListenerArn();
         regionRules.remove(ruleArn);
+        rules.put(region, regionRules);
         listenerToRules.getOrDefault(listenerArn, List.of()).remove(ruleArn);
         tags.remove(ruleArn);
         Listener listener = listeners.getOrDefault(region, Map.of()).get(listenerArn);
@@ -536,6 +627,7 @@ public class ElbV2Service {
         String listenerArn = rule.getListenerArn();
         if (conditions != null) rule.setConditions(new ArrayList<>(conditions));
         if (actions != null)    rule.setActions(new ArrayList<>(actions));
+        rules.put(region, rules.getOrDefault(region, Map.of()));
         dataPlane.recompileRules(listenerArn, getListenerRules(region, listenerArn));
         return rule;
     }
@@ -575,6 +667,7 @@ public class ElbV2Service {
 
         // commit
         arnToPriority.forEach((arn, priority) -> regionRules.get(arn).setPriority(String.valueOf(priority)));
+        rules.put(region, regionRules);
 
         Set<String> affectedListeners = arnToPriority.keySet().stream()
                 .map(arn -> regionRules.get(arn).getListenerArn())
@@ -592,6 +685,7 @@ public class ElbV2Service {
             existing.removeIf(e -> e.getId().equals(t.getId()) && Objects.equals(e.getPort(), t.getPort()));
             existing.add(t);
         }
+        targetGroups.put(region, targetGroups.getOrDefault(region, Map.of()));
         healthChecker.addTargets(tgArn, targets, tg);
     }
 
@@ -600,6 +694,7 @@ public class ElbV2Service {
         for (TargetDescription t : targets) {
             tg.getTargets().removeIf(e -> e.getId().equals(t.getId()) && Objects.equals(e.getPort(), t.getPort()));
         }
+        targetGroups.put(region, targetGroups.getOrDefault(region, Map.of()));
         healthChecker.removeTargets(tgArn, targets, tg);
     }
 
@@ -638,6 +733,7 @@ public class ElbV2Service {
     public void addTags(List<String> resourceArns, Map<String, String> newTags) {
         for (String arn : resourceArns) {
             tags.computeIfAbsent(arn, k -> new LinkedHashMap<>()).putAll(newTags);
+            tags.put(arn, tags.get(arn));
         }
     }
 
@@ -646,6 +742,7 @@ public class ElbV2Service {
             Map<String, String> resourceTags = tags.get(arn);
             if (resourceTags != null) {
                 tagKeys.forEach(resourceTags::remove);
+                tags.put(arn, resourceTags);
             }
         }
     }
@@ -667,11 +764,13 @@ public class ElbV2Service {
                 listener.getCertificates().add(certArn);
             }
         }
+        listeners.put(region, listeners.getOrDefault(region, Map.of()));
     }
 
     public void removeListenerCertificates(String region, String listenerArn, List<String> certArns) {
         Listener listener = requireListener(region, listenerArn);
         listener.getCertificates().removeAll(certArns);
+        listeners.put(region, listeners.getOrDefault(region, Map.of()));
     }
 
     public List<String> describeListenerCertificates(String region, String listenerArn) {
@@ -878,11 +977,26 @@ public class ElbV2Service {
         if ("forward".equals(action.getType())) {
             if (action.getTargetGroupArn() != null) {
                 tgToLbs.computeIfAbsent(action.getTargetGroupArn(), k -> ConcurrentHashMap.newKeySet()).add(lbArn);
+                addLoadBalancerReference(action.getTargetGroupArn(), lbArn);
             }
             for (Action.TargetGroupTuple t : action.getTargetGroups()) {
                 if (t.getTargetGroupArn() != null) {
                     tgToLbs.computeIfAbsent(t.getTargetGroupArn(), k -> ConcurrentHashMap.newKeySet()).add(lbArn);
+                    addLoadBalancerReference(t.getTargetGroupArn(), lbArn);
                 }
+            }
+        }
+    }
+
+    private void addLoadBalancerReference(String targetGroupArn, String loadBalancerArn) {
+        for (Map.Entry<String, Map<String, TargetGroup>> entry : targetGroups.entrySet()) {
+            TargetGroup targetGroup = entry.getValue().get(targetGroupArn);
+            if (targetGroup != null) {
+                if (!targetGroup.getLoadBalancerArns().contains(loadBalancerArn)) {
+                    targetGroup.getLoadBalancerArns().add(loadBalancerArn);
+                    targetGroups.put(entry.getKey(), entry.getValue());
+                }
+                return;
             }
         }
     }
@@ -910,8 +1024,19 @@ public class ElbV2Service {
         tgToLbs.forEach((tgArn, lbSet) -> {
             if (!referenced.contains(tgArn)) {
                 lbSet.remove(lbArn);
+                removeLoadBalancerReference(tgArn, lbArn);
             }
         });
+    }
+
+    private void removeLoadBalancerReference(String targetGroupArn, String loadBalancerArn) {
+        for (Map.Entry<String, Map<String, TargetGroup>> entry : targetGroups.entrySet()) {
+            TargetGroup targetGroup = entry.getValue().get(targetGroupArn);
+            if (targetGroup != null && targetGroup.getLoadBalancerArns().remove(loadBalancerArn)) {
+                targetGroups.put(entry.getKey(), entry.getValue());
+                return;
+            }
+        }
     }
 
     private static void collectActionTargetGroups(Action action, Set<String> out) {

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
@@ -495,6 +495,8 @@ public class ElbV2Service {
                                     String sslPolicy, List<String> certificates,
                                     List<Action> defaultActions, List<String> alpnPolicy) {
         Listener listener = requireListener(region, listenerArn);
+        boolean restartDataPlane = false;
+        boolean recompileRules = false;
 
         if (port != null && !Objects.equals(listener.getPort(), port)) {
             // check duplicate port on same LB
@@ -507,6 +509,7 @@ public class ElbV2Service {
                         "A listener already exists on port " + port + " for this load balancer.", 400);
             }
             listener.setPort(port);
+            restartDataPlane = true;
         }
         if (protocol != null)      listener.setProtocol(protocol);
         if (sslPolicy != null)     listener.setSslPolicy(sslPolicy);
@@ -519,11 +522,19 @@ public class ElbV2Service {
                     .map(ra -> rules.getOrDefault(region, Map.of()).get(ra))
                 .filter(r -> r != null && r.isDefault())
                 .forEach(r -> r.setActions(new ArrayList<>(defaultActions)));
+            for (Action action : defaultActions) {
+                linkTgToLb(action, listener.getLoadBalancerArn());
+            }
+            unlinkUnreferencedTargetGroups(region, listener.getLoadBalancerArn());
+            recompileRules = true;
         }
         listeners.put(region, listeners.getOrDefault(region, Map.of()));
         rules.put(region, rules.getOrDefault(region, Map.of()));
-        dataPlane.stopListener(listenerArn);
-        dataPlane.startListener(requireListener(region, listenerArn), region, getListenerRules(region, listenerArn));
+        if (restartDataPlane) {
+            dataPlane.restartListener(requireListener(region, listenerArn), region, getListenerRules(region, listenerArn));
+        } else if (recompileRules) {
+            dataPlane.recompileRules(listenerArn, getListenerRules(region, listenerArn));
+        }
         return listener;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2TargetResolver.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2TargetResolver.java
@@ -1,0 +1,35 @@
+package io.github.hectorvent.floci.services.elbv2;
+
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.model.Instance;
+import io.github.hectorvent.floci.services.elbv2.model.TargetDescription;
+import io.github.hectorvent.floci.services.elbv2.model.TargetGroup;
+
+final class ElbV2TargetResolver {
+
+    private ElbV2TargetResolver() {}
+
+    static String resolveHost(Ec2Service ec2Service, TargetGroup targetGroup, TargetDescription target) {
+        return resolveHost(ec2Service, targetGroup, target != null ? target.getId() : null);
+    }
+
+    static String resolveHost(Ec2Service ec2Service, TargetGroup targetGroup, String targetId) {
+        if (targetId == null || targetId.isBlank()) {
+            return targetId;
+        }
+        if (targetGroup == null || !"instance".equals(targetGroup.getTargetType()) || ec2Service == null) {
+            return targetId;
+        }
+
+        Instance instance = ec2Service.findInstanceById(targetId);
+        if (instance == null) {
+            return targetId;
+        }
+
+        String containerBridgeIp = instance.getContainerBridgeIp();
+        if (containerBridgeIp != null && !containerBridgeIp.isBlank()) {
+            return containerBridgeIp;
+        }
+        return targetId;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
@@ -56,7 +56,7 @@ class ElbV2IntegrationTest {
                 .body("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.AvailabilityZones.member.SubnetId",
                         equalTo("subnet-test-a"))
                 .body("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.DNSName",
-                        containsString(".elb.localhost"))
+                        containsString(".elb.localhost.floci.io"))
                 .extract()
                 .path("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.LoadBalancerArn");
     }

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
@@ -38,6 +38,7 @@ class ElbV2IntegrationTest {
                 .formParam("Type", "application")
                 .formParam("Scheme", "internet-facing")
                 .formParam("IpAddressType", "ipv4")
+                .formParam("Subnets.member.1", "subnet-test-a")
                 .header("Authorization", AUTH)
             .when()
                 .post("/")
@@ -52,6 +53,8 @@ class ElbV2IntegrationTest {
                         equalTo("internet-facing"))
                 .body("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.State.Code",
                         equalTo("provisioning"))
+                .body("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.AvailabilityZones.member.SubnetId",
+                        equalTo("subnet-test-a"))
                 .body("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.DNSName",
                         containsString(".elb.localhost"))
                 .extract()
@@ -72,7 +75,9 @@ class ElbV2IntegrationTest {
                 .body("DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancers.member.LoadBalancerArn",
                         equalTo(lbArn))
                 .body("DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancers.member.State.Code",
-                        equalTo("active"));
+                        equalTo("active"))
+                .body("DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancers.member.AvailabilityZones.member.SubnetId",
+                        equalTo("subnet-test-a"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
@@ -38,7 +38,7 @@ class ElbV2IntegrationTest {
                 .formParam("Type", "application")
                 .formParam("Scheme", "internet-facing")
                 .formParam("IpAddressType", "ipv4")
-                .formParam("Subnets.member.1", "subnet-test-a")
+                .formParam("Subnets.member.1", "subnet-default-a")
                 .header("Authorization", AUTH)
             .when()
                 .post("/")
@@ -54,9 +54,9 @@ class ElbV2IntegrationTest {
                 .body("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.State.Code",
                         equalTo("provisioning"))
                 .body("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.AvailabilityZones.member.SubnetId",
-                        equalTo("subnet-test-a"))
+                        equalTo("subnet-default-a"))
                 .body("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.DNSName",
-                        containsString(".elb.localhost.floci.io"))
+                        containsString(".elb.localhost"))
                 .extract()
                 .path("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.LoadBalancerArn");
     }
@@ -77,7 +77,7 @@ class ElbV2IntegrationTest {
                 .body("DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancers.member.State.Code",
                         equalTo("active"))
                 .body("DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancers.member.AvailabilityZones.member.SubnetId",
-                        equalTo("subnet-test-a"));
+                        equalTo("subnet-default-a"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2ServiceTest.java
@@ -153,6 +153,10 @@ class ElbV2ServiceTest {
         assertEquals("test", reloaded.describeTags(List.of(lbArn)).get(lbArn).get("env"));
         assertThrows(AwsException.class, () -> reloaded.deleteTargetGroup(REGION, tgArn));
         verify(reloadedHealthChecker).startMonitoring(any(TargetGroup.class));
+        ArgumentCaptor<List<TargetDescription>> targetsCaptor = ArgumentCaptor.captor();
+        verify(reloadedHealthChecker).addTargets(eq(tgArn), targetsCaptor.capture(), any(TargetGroup.class));
+        assertEquals("i-1234567890abcdef0", targetsCaptor.getValue().getFirst().getId());
+        assertEquals(8080, targetsCaptor.getValue().getFirst().getPort());
         verify(reloadedDataPlane).startListener(any(Listener.class), eq(REGION), anyList());
 
         reloaded.removeTags(List.of(rule.getRuleArn()), List.of("env"));

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2ServiceTest.java
@@ -1,0 +1,115 @@
+package io.github.hectorvent.floci.services.elbv2;
+
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.elbv2.model.Action;
+import io.github.hectorvent.floci.services.elbv2.model.Listener;
+import io.github.hectorvent.floci.services.elbv2.model.Rule;
+import io.github.hectorvent.floci.services.elbv2.model.TargetGroup;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ElbV2ServiceTest {
+
+    private static final String REGION = "us-west-2";
+
+    @Mock
+    ElbV2DataPlane dataPlane;
+
+    @Mock
+    ElbV2HealthChecker healthChecker;
+
+    private ElbV2Service service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ElbV2Service();
+        service.dataPlane = dataPlane;
+        service.healthChecker = healthChecker;
+        service.regionResolver = new RegionResolver(REGION, "000000000000");
+    }
+
+    @Test
+    void modifyListenerDefaultActionsRecompilesRulesWithoutRestartingListener() {
+        String lbArn = service.createLoadBalancer(
+                REGION, "sample-lb", "internal", "application", "ipv4",
+                List.of("subnet-a"), List.of("sg-a"), Map.of()).getLoadBalancerArn();
+        String oldTgArn = createTargetGroup("sample-old-tg");
+        String newTgArn = createTargetGroup("sample-new-tg");
+        String listenerArn = service.createListener(
+                REGION, lbArn, "HTTP", 9999, null, List.of(),
+                List.of(forwardAction(oldTgArn)), List.of(), Map.of()).getListenerArn();
+        clearInvocations(dataPlane);
+
+        service.modifyListener(
+                REGION, listenerArn, null, null, null, null,
+                List.of(forwardAction(newTgArn)), null);
+
+        ArgumentCaptor<List<Rule>> rulesCaptor = ArgumentCaptor.captor();
+        verify(dataPlane).recompileRules(eq(listenerArn), rulesCaptor.capture());
+        verify(dataPlane, never()).stopListener(anyString());
+        verify(dataPlane, never()).startListener(any(Listener.class), anyString(), anyList());
+        verify(dataPlane, never()).restartListener(any(Listener.class), anyString(), anyList());
+
+        Rule defaultRule = rulesCaptor.getValue().stream()
+                .filter(Rule::isDefault)
+                .findFirst()
+                .orElseThrow();
+        assertEquals(newTgArn, defaultRule.getActions().getFirst().getTargetGroupArn());
+
+        TargetGroup oldTargetGroup = service.describeTargetGroups(REGION, null, List.of(oldTgArn), null).getFirst();
+        TargetGroup newTargetGroup = service.describeTargetGroups(REGION, null, List.of(newTgArn), null).getFirst();
+        assertFalse(oldTargetGroup.getLoadBalancerArns().contains(lbArn));
+        assertTrue(newTargetGroup.getLoadBalancerArns().contains(lbArn));
+    }
+
+    @Test
+    void modifyListenerPortRestartsListener() {
+        String lbArn = service.createLoadBalancer(
+                REGION, "sample-lb", "internal", "application", "ipv4",
+                List.of("subnet-a"), List.of("sg-a"), Map.of()).getLoadBalancerArn();
+        String tgArn = createTargetGroup("sample-tg");
+        String listenerArn = service.createListener(
+                REGION, lbArn, "HTTP", 9999, null, List.of(),
+                List.of(forwardAction(tgArn)), List.of(), Map.of()).getListenerArn();
+        clearInvocations(dataPlane);
+
+        service.modifyListener(REGION, listenerArn, null, 10000, null, null, null, null);
+
+        verify(dataPlane).restartListener(any(Listener.class), eq(REGION), anyList());
+        verify(dataPlane, never()).stopListener(anyString());
+        verify(dataPlane, never()).startListener(any(Listener.class), anyString(), anyList());
+    }
+
+    private String createTargetGroup(String name) {
+        return service.createTargetGroup(
+                REGION, name, "HTTP", "HTTP1", 9999, "vpc-a", "instance",
+                "HTTP", "traffic-port", true, "/v1/ready", 30, 5, 5, 2, "200",
+                "ipv4", Map.of()).getTargetGroupArn();
+    }
+
+    private static Action forwardAction(String targetGroupArn) {
+        Action action = new Action();
+        action.setType("forward");
+        action.setTargetGroupArn(targetGroupArn);
+        return action;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2ServiceTest.java
@@ -165,6 +165,25 @@ class ElbV2ServiceTest {
                 .get(rule.getRuleArn()).containsKey("env"));
     }
 
+    @Test
+    void initializeStorageStartsPersistedListenersWithoutTargetGroups() {
+        SharedStorageFactory storageFactory = new SharedStorageFactory();
+        ElbV2Service first = serviceWithStorage(storageFactory, mock(ElbV2DataPlane.class), mock(ElbV2HealthChecker.class));
+        String lbArn = first.createLoadBalancer(
+                REGION, "listener-only-lb", "internal", "application", "ipv4",
+                List.of("subnet-a"), List.of("sg-a"), Map.of()).getLoadBalancerArn();
+        String listenerArn = first.createListener(
+                REGION, lbArn, "HTTP", 8080, null, List.of(),
+                List.of(), List.of(), Map.of()).getListenerArn();
+
+        ElbV2DataPlane reloadedDataPlane = mock(ElbV2DataPlane.class);
+        serviceWithStorage(storageFactory, reloadedDataPlane, mock(ElbV2HealthChecker.class));
+
+        ArgumentCaptor<Listener> listenerCaptor = ArgumentCaptor.captor();
+        verify(reloadedDataPlane).startListener(listenerCaptor.capture(), eq(REGION), anyList());
+        assertEquals(listenerArn, listenerCaptor.getValue().getListenerArn());
+    }
+
     private String createTargetGroup(String name) {
         return service.createTargetGroup(
                 REGION, name, "HTTP", "HTTP1", 9999, "vpc-a", "instance",

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2ServiceTest.java
@@ -6,6 +6,8 @@ import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.model.Subnet;
 import io.github.hectorvent.floci.services.elbv2.model.Action;
 import io.github.hectorvent.floci.services.elbv2.model.Listener;
 import io.github.hectorvent.floci.services.elbv2.model.Rule;
@@ -32,6 +34,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -47,6 +50,9 @@ class ElbV2ServiceTest {
     @Mock
     ElbV2HealthChecker healthChecker;
 
+    @Mock
+    Ec2Service ec2Service;
+
     private ElbV2Service service;
 
     @BeforeEach
@@ -55,6 +61,8 @@ class ElbV2ServiceTest {
         service.dataPlane = dataPlane;
         service.healthChecker = healthChecker;
         service.regionResolver = new RegionResolver(REGION, "000000000000");
+        service.ec2Service = ec2Service;
+        stubSubnet(ec2Service, "subnet-a", REGION + "a");
     }
 
     @Test
@@ -209,13 +217,33 @@ class ElbV2ServiceTest {
     private static ElbV2Service serviceWithStorage(StorageFactory storageFactory,
                                                    ElbV2DataPlane dataPlane,
                                                    ElbV2HealthChecker healthChecker) {
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        stubSubnet(ec2Service, "subnet-a", REGION + "a");
+        return serviceWithStorage(storageFactory, dataPlane, healthChecker, ec2Service);
+    }
+
+    private static ElbV2Service serviceWithStorage(StorageFactory storageFactory,
+                                                   ElbV2DataPlane dataPlane,
+                                                   ElbV2HealthChecker healthChecker,
+                                                   Ec2Service ec2Service) {
         ElbV2Service service = new ElbV2Service();
         service.dataPlane = dataPlane;
         service.healthChecker = healthChecker;
         service.regionResolver = new RegionResolver(REGION, "000000000000");
+        service.ec2Service = ec2Service;
         service.storageFactory = storageFactory;
         service.initializeStorage();
         return service;
+    }
+
+    private static void stubSubnet(Ec2Service ec2Service, String subnetId, String availabilityZone) {
+        Subnet subnet = new Subnet();
+        subnet.setSubnetId(subnetId);
+        subnet.setAvailabilityZone(availabilityZone);
+        subnet.setVpcId("vpc-a");
+        lenient().when(ec2Service.requireSubnet(REGION, subnetId)).thenReturn(subnet);
+        lenient().when(ec2Service.describeSubnets(eq(REGION), eq(List.of(subnetId)), eq(Map.of())))
+                .thenReturn(List.of(subnet));
     }
 
     private static final class SharedStorageFactory extends StorageFactory {

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2ServiceTest.java
@@ -1,9 +1,16 @@
 package io.github.hectorvent.floci.services.elbv2;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.elbv2.model.Action;
 import io.github.hectorvent.floci.services.elbv2.model.Listener;
 import io.github.hectorvent.floci.services.elbv2.model.Rule;
+import io.github.hectorvent.floci.services.elbv2.model.RuleCondition;
+import io.github.hectorvent.floci.services.elbv2.model.TargetDescription;
 import io.github.hectorvent.floci.services.elbv2.model.TargetGroup;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,17 +19,20 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -99,6 +109,58 @@ class ElbV2ServiceTest {
         verify(dataPlane, never()).startListener(any(Listener.class), anyString(), anyList());
     }
 
+    @Test
+    void initializeStorageReloadsPersistedResourcesAndRebuildsIndexes() {
+        SharedStorageFactory storageFactory = new SharedStorageFactory();
+        ElbV2DataPlane firstDataPlane = mock(ElbV2DataPlane.class);
+        ElbV2HealthChecker firstHealthChecker = mock(ElbV2HealthChecker.class);
+        ElbV2Service first = serviceWithStorage(storageFactory, firstDataPlane, firstHealthChecker);
+        String lbArn = first.createLoadBalancer(
+                REGION, "persisted-lb", "internal", "application", "ipv4",
+                List.of("subnet-a"), List.of("sg-a"), Map.of("owner", "platform")).getLoadBalancerArn();
+        String tgArn = first.createTargetGroup(
+                REGION, "persisted-tg", "HTTP", "HTTP1", 8080, "vpc-a", "instance",
+                "HTTP", "traffic-port", true, "/health", 15, 5, 3, 2, "200",
+                "ipv4", Map.of("tier", "web")).getTargetGroupArn();
+        TargetDescription target = new TargetDescription();
+        target.setId("i-1234567890abcdef0");
+        target.setPort(8080);
+        first.registerTargets(REGION, tgArn, List.of(target));
+        String listenerArn = first.createListener(
+                REGION, lbArn, "HTTP", 9080, null, List.of(),
+                List.of(forwardAction(tgArn)), List.of(), Map.of("listener", "frontdoor")).getListenerArn();
+        Rule rule = first.createRule(
+                REGION, listenerArn, List.of(pathPattern("/api/*")),
+                10, List.of(forwardAction(tgArn)), Map.of("rule", "api"));
+        first.addTags(List.of(lbArn, tgArn, listenerArn, rule.getRuleArn()), Map.of("env", "test"));
+
+        ElbV2DataPlane reloadedDataPlane = mock(ElbV2DataPlane.class);
+        ElbV2HealthChecker reloadedHealthChecker = mock(ElbV2HealthChecker.class);
+        ElbV2Service reloaded = serviceWithStorage(storageFactory, reloadedDataPlane, reloadedHealthChecker);
+
+        assertEquals(lbArn, reloaded.describeLoadBalancers(REGION, null, List.of("persisted-lb"), null, null)
+                .getFirst().getLoadBalancerArn());
+        TargetGroup reloadedTargetGroup = reloaded.describeTargetGroups(REGION, lbArn, null, null).getFirst();
+        assertEquals(tgArn, reloadedTargetGroup.getTargetGroupArn());
+        assertEquals(List.of(lbArn), reloadedTargetGroup.getLoadBalancerArns());
+        assertEquals("i-1234567890abcdef0", reloadedTargetGroup.getTargets().getFirst().getId());
+        Listener reloadedListener = reloaded.describeListeners(REGION, lbArn, null).getFirst();
+        assertEquals(listenerArn, reloadedListener.getListenerArn());
+        List<Rule> reloadedRules = reloaded.describeRules(REGION, listenerArn, null);
+        assertEquals(2, reloadedRules.size());
+        assertTrue(reloadedRules.stream().anyMatch(Rule::isDefault));
+        assertTrue(reloadedRules.stream().anyMatch(candidate -> "10".equals(candidate.getPriority())));
+        assertEquals("test", reloaded.describeTags(List.of(lbArn)).get(lbArn).get("env"));
+        assertThrows(AwsException.class, () -> reloaded.deleteTargetGroup(REGION, tgArn));
+        verify(reloadedHealthChecker).startMonitoring(any(TargetGroup.class));
+        verify(reloadedDataPlane).startListener(any(Listener.class), eq(REGION), anyList());
+
+        reloaded.removeTags(List.of(rule.getRuleArn()), List.of("env"));
+        ElbV2Service updatedReload = serviceWithStorage(storageFactory, mock(ElbV2DataPlane.class), mock(ElbV2HealthChecker.class));
+        assertFalse(updatedReload.describeTags(List.of(rule.getRuleArn()))
+                .get(rule.getRuleArn()).containsKey("env"));
+    }
+
     private String createTargetGroup(String name) {
         return service.createTargetGroup(
                 REGION, name, "HTTP", "HTTP1", 9999, "vpc-a", "instance",
@@ -111,5 +173,41 @@ class ElbV2ServiceTest {
         action.setType("forward");
         action.setTargetGroupArn(targetGroupArn);
         return action;
+    }
+
+    private static RuleCondition pathPattern(String value) {
+        RuleCondition condition = new RuleCondition();
+        condition.setField("path-pattern");
+        condition.setValues(List.of(value));
+        condition.setPathPatternValues(List.of(value));
+        return condition;
+    }
+
+    private static ElbV2Service serviceWithStorage(StorageFactory storageFactory,
+                                                   ElbV2DataPlane dataPlane,
+                                                   ElbV2HealthChecker healthChecker) {
+        ElbV2Service service = new ElbV2Service();
+        service.dataPlane = dataPlane;
+        service.healthChecker = healthChecker;
+        service.regionResolver = new RegionResolver(REGION, "000000000000");
+        service.storageFactory = storageFactory;
+        service.initializeStorage();
+        return service;
+    }
+
+    private static final class SharedStorageFactory extends StorageFactory {
+        private final Map<String, StorageBackend<String, ?>> stores = new HashMap<>();
+
+        private SharedStorageFactory() {
+            super(null, null);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <V> StorageBackend<String, V> create(String serviceName,
+                                                     String fileName,
+                                                     TypeReference<Map<String, V>> typeReference) {
+            return (StorageBackend<String, V>) stores.computeIfAbsent(fileName, ignored -> new InMemoryStorage<>());
+        }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2TargetResolverTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2TargetResolverTest.java
@@ -1,0 +1,41 @@
+package io.github.hectorvent.floci.services.elbv2;
+
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.model.Instance;
+import io.github.hectorvent.floci.services.elbv2.model.TargetDescription;
+import io.github.hectorvent.floci.services.elbv2.model.TargetGroup;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ElbV2TargetResolverTest {
+
+    @Test
+    void instanceTargetResolvesToBackingContainerBridgeIp() {
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        Instance instance = new Instance();
+        instance.setInstanceId("i-1234567890abcdef0");
+        instance.setContainerBridgeIp("172.18.0.42");
+        when(ec2Service.findInstanceById("i-1234567890abcdef0")).thenReturn(instance);
+
+        TargetGroup targetGroup = new TargetGroup();
+        targetGroup.setTargetType("instance");
+        TargetDescription target = new TargetDescription();
+        target.setId("i-1234567890abcdef0");
+
+        assertEquals("172.18.0.42", ElbV2TargetResolver.resolveHost(ec2Service, targetGroup, target));
+    }
+
+    @Test
+    void ipTargetKeepsRegisteredAddress() {
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        TargetGroup targetGroup = new TargetGroup();
+        targetGroup.setTargetType("ip");
+        TargetDescription target = new TargetDescription();
+        target.setId("10.0.0.12");
+
+        assertEquals("10.0.0.12", ElbV2TargetResolver.resolveHost(ec2Service, targetGroup, target));
+    }
+}


### PR DESCRIPTION
## Summary
- Resolve instance target addresses for ELBv2 data plane and health checks
- Persist load balancer state
- Preserve listener sockets during updates
- Restore target health after persisted state reload

## Tests
- ./mvnw test -Dtest=ElbV2IntegrationTest,ElbV2TargetResolverTest,ElbV2ServiceTest