### PR TITLE
Stream S3 range responses

### DIFF
--- a/docs/services/s3.md
+++ b/docs/services/s3.md
@@ -26,6 +26,12 @@
 
 **RestoreObject** is accepted but stubbed: Floci validates the request and returns `202 Accepted`, but no restore state machine runs.
 
+## Range Reads
+
+`GetObject` supports standard `Range: bytes=` requests. Partial responses return `206`, `Content-Range`, `Content-Length`, `Accept-Ranges: bytes`, and object metadata. Whole-object checksum headers are omitted on ranged responses because the stored checksum covers the full object, not the returned byte slice. Full-object and ranged reads stream object bytes from storage instead of materializing the response body first.
+
+Suffix ranges against empty objects return an empty `200` response, matching AWS behavior used by clients that issue tail reads.
+
 ## S3 Select
 
 `SelectObjectContent` runs SQL queries directly against S3 objects without downloading the entire file. Floci supports CSV, JSON Lines, JSON arrays, and Parquet inputs. The SQL dialect follows [AWS S3 Select SQL reference](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-select-sql-reference.html).

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -30,8 +30,10 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
 import jakarta.ws.rs.core.UriInfo;
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.io.StringReader;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -594,7 +596,7 @@ public class S3Controller {
                     return preconditionResponse;
                 }
             }
-            S3Object obj = s3Service.getObject(bucket, key, versionId);
+            S3Object obj = s3Service.headObject(bucket, key, versionId);
             S3Service.validateSseCustomerAccess(
                     obj,
                     httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-algorithm"),
@@ -609,17 +611,26 @@ public class S3Controller {
             }
 
             if (rangeHeader != null && rangeHeader.startsWith("bytes=")) {
-                return handleRangeRequest(obj, rangeHeader, overrides);
+                return handleRangeRequest(bucket, key, versionId, obj, rangeHeader, overrides);
             }
 
-            return fullObjectResponse(obj, overrides);
+            return fullObjectResponse(bucket, key, versionId, obj, overrides);
         } catch (AwsException e) {
             return xmlErrorResponse(e);
         }
     }
 
-    private Response fullObjectResponse(S3Object obj, ResponseHeaderOverrides overrides) {
-        var resp = Response.ok(obj.getData())
+    private Response fullObjectResponse(String bucket, String key, String versionId,
+                                        S3Object obj, ResponseHeaderOverrides overrides) {
+        String streamBucket = bucket;
+        String streamKey = key;
+        String streamVersionId = versionId;
+        StreamingOutput stream = output -> {
+            try (InputStream input = s3Service.openObjectStream(streamBucket, streamKey, streamVersionId)) {
+                input.transferTo(output);
+            }
+        };
+        var resp = Response.ok(stream)
                 .header("Content-Type", overrides.contentType() != null ? overrides.contentType() : obj.getContentType())
                 .header("Content-Length", obj.getSize())
                 .header("ETag", obj.getETag())
@@ -632,12 +643,13 @@ public class S3Controller {
         return resp.build();
     }
 
-    private Response handleRangeRequest(S3Object obj, String rangeHeader, ResponseHeaderOverrides overrides) {
-        byte[] data = obj.getData();
-        int totalSize = data.length;
+    private Response handleRangeRequest(String bucket, String key, String versionId,
+                                        S3Object obj, String rangeHeader,
+                                        ResponseHeaderOverrides overrides) {
+        long totalSize = obj.getSize();
         String rangeSpec = rangeHeader.substring("bytes=".length()).trim();
 
-        int start, end;
+        long start, end;
         try {
             int dash = rangeSpec.indexOf('-');
             if (dash < 0) {
@@ -649,15 +661,15 @@ public class S3Controller {
                 return invalidRangeResponse(totalSize);
             }
             if (before.isEmpty()) {
-                int suffix = Integer.parseInt(after);
+                long suffix = Long.parseLong(after);
                 if (suffix <= 0) {
                     return invalidRangeResponse(totalSize);
                 }
                 start = Math.max(0, totalSize - suffix);
                 end = totalSize - 1;
             } else {
-                start = Integer.parseInt(before);
-                end = after.isEmpty() ? totalSize - 1 : Math.min(Integer.parseInt(after), totalSize - 1);
+                start = Long.parseLong(before);
+                end = after.isEmpty() ? totalSize - 1 : Math.min(Long.parseLong(after), totalSize - 1);
             }
         } catch (NumberFormatException e) {
             return invalidRangeResponse(totalSize);
@@ -665,16 +677,22 @@ public class S3Controller {
 
         if (start < 0 || start >= totalSize || start > end) {
             if (totalSize == 0 && rangeSpec.startsWith("-")) {
-                return fullObjectResponse(obj, overrides);
+                return fullObjectResponse(bucket, key, versionId, obj, overrides);
             }
             return invalidRangeResponse(totalSize);
         }
 
-        byte[] rangeData = java.util.Arrays.copyOfRange(data, start, end + 1);
+        long length = end - start + 1;
+        StreamingOutput stream = output -> {
+            try (InputStream input = s3Service.openObjectStream(bucket, key, versionId)) {
+                input.skipNBytes(start);
+                transferLimited(input, output, length);
+            }
+        };
         var resp = Response.status(206)
-                .entity(rangeData)
+                .entity(stream)
                 .header("Content-Type", overrides.contentType() != null ? overrides.contentType() : obj.getContentType())
-                .header("Content-Length", rangeData.length)
+                .header("Content-Length", length)
                 .header("Content-Range", "bytes " + start + "-" + end + "/" + totalSize)
                 .header("ETag", obj.getETag())
                 .header("Last-Modified", RFC_822.format(obj.getLastModified()))
@@ -687,7 +705,21 @@ public class S3Controller {
         return resp.build();
     }
 
-    private Response invalidRangeResponse(int totalSize) {
+    private static void transferLimited(InputStream input, java.io.OutputStream output, long bytes)
+            throws java.io.IOException {
+        byte[] buffer = new byte[8192];
+        long remaining = bytes;
+        while (remaining > 0) {
+            int count = input.read(buffer, 0, (int) Math.min(buffer.length, remaining));
+            if (count < 0) {
+                break;
+            }
+            output.write(buffer, 0, count);
+            remaining -= count;
+        }
+    }
+
+    private Response invalidRangeResponse(long totalSize) {
         String xml = new XmlBuilder()
                 .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
                 .start("Error")

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -622,11 +622,8 @@ public class S3Controller {
 
     private Response fullObjectResponse(String bucket, String key, String versionId,
                                         S3Object obj, ResponseHeaderOverrides overrides) {
-        String streamBucket = bucket;
-        String streamKey = key;
-        String streamVersionId = versionId;
         StreamingOutput stream = output -> {
-            try (InputStream input = s3Service.openObjectStream(streamBucket, streamKey, streamVersionId)) {
+            try (InputStream input = s3Service.openObjectStream(bucket, key, versionId)) {
                 input.transferTo(output);
             }
         };
@@ -712,7 +709,7 @@ public class S3Controller {
         while (remaining > 0) {
             int count = input.read(buffer, 0, (int) Math.min(buffer.length, remaining));
             if (count < 0) {
-                break;
+                throw new java.io.EOFException("Object stream ended before the requested range was fully written.");
             }
             output.write(buffer, 0, count);
             remaining -= count;

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -425,7 +425,10 @@ public class S3Service {
             byte[] data = versionId != null
                     ? memoryDataStore.get(versionedKey(bucketName, key, versionId))
                     : memoryDataStore.get(objectKey(bucketName, key));
-            return new ByteArrayInputStream(data != null ? data : new byte[0]);
+            if (data == null) {
+                throw new IllegalStateException("S3 object data is missing for " + bucketName + "/" + key);
+            }
+            return new ByteArrayInputStream(data);
         }
         try {
             Path path = versionId != null

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -25,7 +25,9 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.io.ByteArrayOutputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -415,6 +417,24 @@ public class S3Service {
 
     public S3Object headObject(String bucketName, String key, String versionId) {
         return getObjectMetadata(bucketName, key, versionId);
+    }
+
+    public InputStream openObjectStream(String bucketName, String key, String versionId) {
+        getObjectMetadata(bucketName, key, versionId);
+        if (inMemory) {
+            byte[] data = versionId != null
+                    ? memoryDataStore.get(versionedKey(bucketName, key, versionId))
+                    : memoryDataStore.get(objectKey(bucketName, key));
+            return new ByteArrayInputStream(data != null ? data : new byte[0]);
+        }
+        try {
+            Path path = versionId != null
+                    ? resolveVersionedPath(bucketName, key, versionId)
+                    : resolveObjectPath(bucketName, key);
+            return Files.newInputStream(path);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to open S3 object stream", e);
+        }
     }
 
     public S3Object getObjectMetadata(String bucketName, String key, String versionId) {

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -630,6 +630,47 @@ class S3IntegrationTest {
     }
 
     @Test
+    @Order(42)
+    void getObjectRangeStreamsExactBytesFromLargeObject() {
+        String bucket = "stream-range-bucket";
+        String key = "large-range.txt";
+        byte[] body = alphabetBytes(1024 * 1024);
+        int start = 512 * 1024 + 13;
+        int end = start + 31;
+
+        given()
+        .when()
+            .put("/" + bucket)
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/octet-stream")
+            .header("x-amz-meta-kind", "stream-range")
+            .body(body)
+        .when()
+            .put("/" + bucket + "/" + key)
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Range", "bytes=" + start + "-" + end)
+        .when()
+            .get("/" + bucket + "/" + key)
+        .then()
+            .statusCode(206)
+            .header("Content-Range", equalTo("bytes " + start + "-" + end + "/" + body.length))
+            .header("Content-Length", equalTo("32"))
+            .header("Accept-Ranges", equalTo("bytes"))
+            .header("x-amz-meta-kind", equalTo("stream-range"))
+            .header("x-amz-checksum-crc64nvme", nullValue())
+            .body(equalTo(asciiSlice(body, start, 32)));
+
+        given().delete("/" + bucket + "/" + key).then().statusCode(204);
+        given().delete("/" + bucket).then().statusCode(204);
+    }
+
+    @Test
     @Order(50)
     void getObjectIfNoneMatchReturns304() {
         String eTag = given()
@@ -1946,5 +1987,17 @@ class S3IntegrationTest {
         catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("MD5 is not available", e);
         }
+    }
+
+    private static byte[] alphabetBytes(int size) {
+        byte[] bytes = new byte[size];
+        for (int i = 0; i < size; i++) {
+            bytes[i] = (byte) ('a' + (i % 26));
+        }
+        return bytes;
+    }
+
+    private static String asciiSlice(byte[] bytes, int start, int length) {
+        return new String(bytes, start, length, StandardCharsets.US_ASCII);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -200,6 +201,22 @@ class S3VersioningServiceTest {
                 .resolve(v1.getVersionId() + ".s3data");
         assertTrue(Files.exists(versionedPath),
                 "versioned file should be stored with .s3data suffix");
+    }
+
+    @Test
+    void openObjectStreamReadsSpecificVersionFromDisk() throws Exception {
+        S3Service diskService = new S3Service(new InMemoryStorage<>(), new InMemoryStorage<>(), tempDir, false);
+        diskService.createBucket("versioned-bucket", "us-east-1");
+        diskService.putBucketVersioning("versioned-bucket", "Enabled");
+        S3Object v1 = diskService.putObject("versioned-bucket", "stream.txt",
+                "first-version".getBytes(StandardCharsets.UTF_8), "text/plain", null);
+        diskService.putObject("versioned-bucket", "stream.txt",
+                "second-version".getBytes(StandardCharsets.UTF_8), "text/plain", null);
+
+        try (InputStream stream = diskService.openObjectStream(
+                "versioned-bucket", "stream.txt", v1.getVersionId())) {
+            assertEquals("first-version", new String(stream.readAllBytes(), StandardCharsets.UTF_8));
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Stream ranged S3 object responses instead of materializing the full object body
- Add coverage for streamed object reads and versioned reads
- Document range-read support in the S3 service page

## Tests
- ./mvnw test -Dtest=S3IntegrationTest,S3VersioningServiceTest