### PR TITLE
fix(elasticache): return reachable Memcached configuration endpoints

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheMemcachedService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheMemcachedService.java
@@ -51,7 +51,7 @@ public class ElastiCacheMemcachedService {
 
         ElastiCacheContainerHandle handle = containerManager.start(clusterId, image);
 
-        String endpointHost = config.hostname().orElse("localhost");
+        String endpointHost = resolveEndpointHost(handle);
         Endpoint endpoint = new Endpoint(endpointHost, handle.getPort());
 
         CacheCluster cluster = new CacheCluster(
@@ -97,5 +97,9 @@ public class ElastiCacheMemcachedService {
         clusters.delete(clusterId);
         LOG.infov("Memcached cluster {0} deleted", clusterId);
         return cluster;
+    }
+
+    private String resolveEndpointHost(ElastiCacheContainerHandle handle) {
+        return config.hostname().orElse(handle.getHost());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheMemcachedIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheMemcachedIntegrationTest.java
@@ -30,6 +30,7 @@ class ElastiCacheMemcachedIntegrationTest {
     private static final String CLUSTER_ID = "it-memcached-cluster";
     private static final int SOCKET_TIMEOUT_MS = 10_000;
 
+    private static String clusterHost;
     private static int clusterPort;
 
     @BeforeAll
@@ -51,7 +52,7 @@ class ElastiCacheMemcachedIntegrationTest {
     @Test
     @Order(1)
     void createCacheCluster() {
-        clusterPort =
+        var response =
                 given()
                     .formParam("Action", "CreateCacheCluster")
                     .formParam("CacheClusterId", CLUSTER_ID)
@@ -68,8 +69,12 @@ class ElastiCacheMemcachedIntegrationTest {
                     .body("CreateCacheClusterResponse.CreateCacheClusterResult.CacheCluster.ConfigurationEndpoint.Address", notNullValue())
                     .body("CreateCacheClusterResponse.CreateCacheClusterResult.CacheCluster.ConfigurationEndpoint.Port", notNullValue())
                 .extract()
-                    .xmlPath()
-                    .getInt("CreateCacheClusterResponse.CreateCacheClusterResult.CacheCluster.ConfigurationEndpoint.Port");
+                    .xmlPath();
+
+        clusterHost = response.getString(
+                "CreateCacheClusterResponse.CreateCacheClusterResult.CacheCluster.ConfigurationEndpoint.Address");
+        clusterPort = response.getInt(
+                "CreateCacheClusterResponse.CreateCacheClusterResult.CacheCluster.ConfigurationEndpoint.Port");
     }
 
     @Test
@@ -106,7 +111,7 @@ class ElastiCacheMemcachedIntegrationTest {
     @Test
     @Order(4)
     void memcachedAcceptsSetAndGet() throws Exception {
-        try (Socket socket = new Socket("localhost", clusterPort)) {
+        try (Socket socket = new Socket(clusterHost, clusterPort)) {
             socket.setSoTimeout(SOCKET_TIMEOUT_MS);
             OutputStream out = socket.getOutputStream();
             InputStream in = socket.getInputStream();
@@ -128,7 +133,7 @@ class ElastiCacheMemcachedIntegrationTest {
     @Test
     @Order(5)
     void versionCommandResponds() throws Exception {
-        try (Socket socket = new Socket("localhost", clusterPort)) {
+        try (Socket socket = new Socket(clusterHost, clusterPort)) {
             socket.setSoTimeout(SOCKET_TIMEOUT_MS);
             socket.getOutputStream().write("version\r\n".getBytes(StandardCharsets.UTF_8));
             socket.getOutputStream().flush();

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheMemcachedServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheMemcachedServiceTest.java
@@ -96,4 +96,29 @@ class ElastiCacheMemcachedServiceTest {
         AwsException ex = assertThrows(AwsException.class, () -> service.getCacheCluster("my-cluster"));
         assertEquals("CacheClusterNotFound", ex.getErrorCode());
     }
+
+    @Test
+    void createClusterUsesContainerHostWhenHostnameNotConfigured() {
+        ElastiCacheMemcachedContainerManager containerManager = mock(ElastiCacheMemcachedContainerManager.class);
+        StorageFactory storageFactory = mock(StorageFactory.class);
+        EmulatorConfig config = mock(EmulatorConfig.class);
+
+        EmulatorConfig.ServicesConfig servicesConfig = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.ElastiCacheServiceConfig ecConfig = mock(EmulatorConfig.ElastiCacheServiceConfig.class);
+        when(config.services()).thenReturn(servicesConfig);
+        when(servicesConfig.elasticache()).thenReturn(ecConfig);
+        when(ecConfig.defaultMemcachedImage()).thenReturn("memcached:1.6");
+        when(config.hostname()).thenReturn(Optional.empty());
+
+        when(storageFactory.create(anyString(), anyString(), any())).thenAnswer(inv -> new InMemoryStorage<>());
+        when(containerManager.start(anyString(), anyString()))
+                .thenReturn(new ElastiCacheContainerHandle("cid", "cluster", "172.20.0.10", 11211));
+
+        ElastiCacheMemcachedService containerModeService =
+                new ElastiCacheMemcachedService(containerManager, storageFactory, config);
+
+        CacheCluster cluster = containerModeService.createCacheCluster("container-cluster");
+
+        assertEquals("172.20.0.10", cluster.getConfigurationEndpoint().address());
+    }
 }


### PR DESCRIPTION
## Summary

Fix ElastiCache Memcached `ConfigurationEndpoint` handling so `CreateCacheCluster` and `DescribeCacheClusters` return an address reachable from the caller's current runtime mode. Closes #1246.

- stop hardcoding `localhost` for Memcached configuration endpoints when no hostname override is configured
- return the actual container handle host so native-host and containerized local environments both receive a reachable endpoint
- update Memcached integration coverage to connect using the advertised `ConfigurationEndpoint.Address` and `Port`
- add unit coverage for hostname resolution when no explicit hostname is configured

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Floci previously returned `localhost` for Memcached `ConfigurationEndpoint.Address` even when the Memcached backend was only reachable through a Docker-network address in containerized local environments.

This change aligns the Memcached endpoint behavior with the actual runtime networking by:

- returning the real reachable backend host from the started Memcached container handle when no explicit hostname override is configured
- keeping explicit hostname overrides intact when users configure them
- validating the advertised endpoint through integration tests that connect using the API response rather than a hardcoded `localhost`

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)