### PR TITLE
fix(athena): align ListWorkGroups with AWS behavior

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/athena/AthenaJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/AthenaJsonHandler.java
@@ -68,7 +68,7 @@ public class AthenaJsonHandler {
                 String name = request.has("WorkGroup") ? request.get("WorkGroup").asText() : "primary";
                 yield Response.ok(Map.of("WorkGroup", athenaService.getWorkGroup(name))).build();
             }
-            case "ListWorkGroups" -> Response.ok(Map.of("WorkGroups", athenaService.listWorkGroups())).build();
+            case "ListWorkGroups" -> Response.ok(Map.of("WorkGroups", athenaService.listWorkGroups(region))).build();
             case "CreateWorkGroup" -> {
                 CreateWorkGroupRequest createRequest = mapper.treeToValue(request, CreateWorkGroupRequest.class);
                 athenaService.createWorkGroup(createRequest, region);

--- a/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
@@ -166,8 +166,14 @@ public class AthenaService {
         );
     }
 
-    public List<Map<String, Object>> listWorkGroups() {
-        return List.of(Map.of("Name", DEFAULT_WORKGROUP, "State", "ENABLED"));
+    public List<Map<String, Object>> listWorkGroups(String region) {
+        List<Map<String, Object>> workGroups = new ArrayList<>();
+        workGroups.add(primaryWorkGroupSummary());
+        workGroups.addAll(workGroupStore.scan(k -> k.startsWith(region + ":")).stream()
+                .sorted(Comparator.comparing(WorkGroup::getName))
+                .map(this::toWorkGroupSummary)
+                .toList());
+        return workGroups;
     }
 
     public List<Map<String, Object>> listDataCatalogs() {
@@ -338,6 +344,30 @@ public class AthenaService {
         engineVersion.setSelectedEngineVersion(DEFAULT_ENGINE_VERSION);
         engineVersion.setEffectiveEngineVersion(DEFAULT_ENGINE_VERSION);
         return engineVersion;
+    }
+
+    private Map<String, Object> primaryWorkGroupSummary() {
+        return Map.of(
+                "Name", DEFAULT_WORKGROUP,
+                "State", "ENABLED",
+                "Configuration", Map.of(
+                        "EngineVersion", Map.of(
+                                "SelectedEngineVersion", DEFAULT_ENGINE_VERSION,
+                                "EffectiveEngineVersion", DEFAULT_ENGINE_VERSION
+                        ),
+                        "ResultConfiguration", Map.of("OutputLocation", "s3://" + DEFAULT_OUTPUT_BUCKET + "/results/"),
+                        "EnforceWorkGroupConfiguration", false,
+                        "PublishCloudWatchMetricsEnabled", false,
+                        "RequesterPaysEnabled", false
+                )
+        );
+    }
+
+    private Map<String, Object> toWorkGroupSummary(WorkGroup workGroup) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("Name", workGroup.getName());
+        result.put("State", workGroup.getState());
+        return result;
     }
 
     private List<WorkGroupTag> normalizeTags(List<WorkGroupTag> tags) {

--- a/src/test/java/io/github/hectorvent/floci/services/athena/AthenaCreateWorkGroupIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/athena/AthenaCreateWorkGroupIntegrationTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 
 @QuarkusTest
@@ -64,6 +65,40 @@ class AthenaCreateWorkGroupIntegrationTest {
             .statusCode(400)
             .body("__type", equalTo("InvalidRequestException"))
             .body("message", equalTo("WorkGroup already exists"));
+    }
+
+    @Test
+    void listWorkGroupsIncludesCreatedWorkGroupAlongsidePrimary() {
+        given()
+            .header("X-Amz-Target", "AmazonAthena.CreateWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "Name": "analytics-list",
+                  "Description": "analytics workgroup for reporting queries",
+                  "Configuration": {
+                    "ResultConfiguration": {
+                      "OutputLocation": "s3://test-bucket/athena-results/"
+                    }
+                  }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.ListWorkGroups")
+            .contentType(CONTENT_TYPE)
+            .body("{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("WorkGroups.size()", equalTo(2))
+            .body("WorkGroups.Name", contains("primary", "analytics-list"))
+            .body("WorkGroups.State", contains("ENABLED", "ENABLED"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #1175

Persisted Athena workgroups created via `CreateWorkGroup` are now returned from `ListWorkGroups` together with the built-in `primary` workgroup.

Added an integration test that creates a realistic workgroup payload and verifies the `ListWorkGroups` response shape, ordering, and states.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Before this change, `Athena.ListWorkGroups` always returned only the built-in `primary` workgroup and ignored workgroups previously created through `CreateWorkGroup`.

After this change, `Athena.ListWorkGroups` returns both the built-in `primary` workgroup and persisted user-created workgroups for the target region.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

./mvnw -Dtest=ElbV2IntegrationTest test passed; full ./mvnw test currently hits unrelated existing ElastiCacheMemcachedIntegrationTest connection-refused errors.