### PR TITLE
docs: update references after AGENT.md → AGENTS.md rename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,14 +121,14 @@ Do not include `Co-Authored-By` trailers for AI tools in commit messages. Attrib
 
 ## Architecture
 
-See [AGENT.md](AGENT.md) for a detailed description of the three-layer architecture (Controller → Service → Storage), the AWS wire protocol mapping, and conventions for adding new services.
+See [AGENTS.md](AGENTS.md) for a detailed description of the three-layer architecture (Controller → Service → Storage), the AWS wire protocol mapping, and conventions for adding new services.
 
-`AGENT.md` is the canonical agent instructions file for this repository. If your coding agent expects a different filename, create a local symlink to `AGENT.md` instead of copying the file.
+`AGENTS.md` is the canonical agent instructions file for this repository, following the [AGENTS.md standard](https://agents.md/). If your coding agent expects a different filename, create a local symlink to `AGENTS.md` instead of copying the file.
 
 ```bash
-ln -s AGENT.md CLAUDE.md
-ln -s AGENT.md GEMINI.md
-ln -s AGENT.md COPILOT.md
+ln -s AGENTS.md CLAUDE.md
+ln -s AGENTS.md GEMINI.md
+ln -s AGENTS.md COPILOT.md
 ```
 
 ## Adding a New AWS Service

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -76,18 +76,18 @@ wip: still working on this      # not a recognised type
 
 ## Adding a New AWS Service
 
-See [AGENT.md](https://github.com/floci-io/floci/blob/main/AGENT.md) for the full architecture guide. `AGENT.md` is the canonical agent instructions file for this repository. If your coding agent expects a different filename, create a local symlink to `AGENT.md` instead of copying it.
+See [AGENTS.md](https://github.com/floci-io/floci/blob/main/AGENTS.md) for the full architecture guide. `AGENTS.md` is the canonical agent instructions file for this repository, following the [AGENTS.md standard](https://agents.md/). If your coding agent expects a different filename, create a local symlink to `AGENTS.md` instead of copying it.
 
 ```bash
-ln -s AGENT.md CLAUDE.md
-ln -s AGENT.md GEMINI.md
-ln -s AGENT.md COPILOT.md
+ln -s AGENTS.md CLAUDE.md
+ln -s AGENTS.md GEMINI.md
+ln -s AGENTS.md COPILOT.md
 ```
 
 Quick summary:
 
 1. Create `src/main/java/.../services/<service>/` with a Controller, Service, and `model/` package
-2. Pick the right protocol (see the protocol table in `AGENT.md`)
+2. Pick the right protocol (see the protocol table in `AGENTS.md`)
 3. Register the service in `ServiceRegistry`
 4. Add config in `EmulatorConfig.java` and `application.yml`
 5. Add `*IntegrationTest.java` tests


### PR DESCRIPTION
## Summary

Follow-up to #1225. Updates documentation references that still pointed to `AGENT.md` after it was renamed to `AGENTS.md` (adopting the [AGENTS.md standard](https://agents.md/)). Updates the architecture-guide links, the canonical-file description, the symlink examples, and the protocol-table mention in `CONTRIBUTING.md` and `docs/contributing.md`.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

Not applicable — documentation-only change with no wire-protocol impact.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)