### PR TITLE
fix(ses): omit MailFromAttributes if MAIL FROM domain is not configured

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -1080,13 +1080,13 @@ public class SesController {
 
         result.set("DkimAttributes", buildDkimAttributes(identity));
 
-        ObjectNode mailFromAttributes = result.putObject("MailFromAttributes");
         String mailFromDomain = identity.getMailFromDomain();
-        mailFromAttributes.put("MailFromDomain", mailFromDomain == null ? "" : mailFromDomain);
-        mailFromAttributes.put("MailFromDomainStatus",
-                mailFromDomain == null ? "NOT_STARTED" : toV2Status(identity.getMailFromDomainStatus()));
-        mailFromAttributes.put("BehaviorOnMxFailure",
-                v1BehaviorToV2(identity.getBehaviorOnMxFailure()));
+        if (mailFromDomain != null && !mailFromDomain.isEmpty()) {
+            ObjectNode mailFromAttributes = result.putObject("MailFromAttributes");
+            mailFromAttributes.put("MailFromDomain", mailFromDomain);
+            mailFromAttributes.put("MailFromDomainStatus", toV2Status(identity.getMailFromDomainStatus()));
+            mailFromAttributes.put("BehaviorOnMxFailure", v1BehaviorToV2(identity.getBehaviorOnMxFailure()));
+        }
 
         result.putObject("Policies");
         ArrayNode tags = result.putArray("Tags");

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesIdentityAttributesV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesIdentityAttributesV2IntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 
 @QuarkusTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -30,6 +31,15 @@ class SesIdentityAttributesV2IntegrationTest {
             .post("/v2/email/identities")
         .then()
             .statusCode(200);
+
+        // Verify MailFromAttributes is omitted by default
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/identities/v2-attrs.floci.test")
+        .then()
+            .statusCode(200)
+            .body("MailFromAttributes", nullValue());
     }
 
     @Test
@@ -84,8 +94,7 @@ class SesIdentityAttributesV2IntegrationTest {
             .get("/v2/email/identities/v2-attrs.floci.test")
         .then()
             .statusCode(200)
-            .body("MailFromAttributes.MailFromDomain", equalTo(""))
-            .body("MailFromAttributes.MailFromDomainStatus", equalTo("NOT_STARTED"));
+            .body("MailFromAttributes", nullValue());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
@@ -1189,9 +1189,7 @@ class SesV2IntegrationTest {
             .body("DkimAttributes", notNullValue())
             .body("DkimAttributes.SigningEnabled", notNullValue())
             .body("DkimAttributes.Status", notNullValue())
-            .body("MailFromAttributes", notNullValue())
-            .body("MailFromAttributes.MailFromDomainStatus", equalTo("NOT_STARTED"))
-            .body("MailFromAttributes.BehaviorOnMxFailure", equalTo("USE_DEFAULT_VALUE"))
+            .body("MailFromAttributes", nullValue())
             .body("Policies", notNullValue())
             .body("Tags", notNullValue());
     }


### PR DESCRIPTION
For an identity with no MAIL FROM domain configured, GetEmailIdentity response should omit the MailFromAttributes block entirely rather than returning a custom 'NOT_STARTED' status which causes AWS SDK unmarshalling errors.