### PR TITLE
fix(ecs): add network mode and resources validation for fargate task …

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -1864,10 +1864,11 @@ public class CloudFormationResourceProvisioner {
         String memory = resolveOptional(props, "Memory", engine);
         String taskRoleArn = resolveOptional(props, "TaskRoleArn", engine);
         String executionRoleArn = resolveOptional(props, "ExecutionRoleArn", engine);
+        List<String> requiresCompatibilities = resolveStringListOrEmpty(props, "RequiresCompatibilities", engine);
 
         // Task definitions are immutable; each CFN update registers a fresh revision.
         TaskDefinition td = ecsService.registerTaskDefinition(family, containerDefs, networkMode, cpu, memory,
-                taskRoleArn, executionRoleArn, region);
+                taskRoleArn, executionRoleArn, requiresCompatibilities, region);
 
         r.setPhysicalId(td.getTaskDefinitionArn());
         r.getAttributes().put("TaskDefinitionArn", td.getTaskDefinitionArn());

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
@@ -207,10 +207,11 @@ public class EcsJsonHandler {
         String memory = req.has("memory") ? req.path("memory").asText() : null;
         String taskRoleArn = req.hasNonNull("taskRoleArn") ? req.path("taskRoleArn").asText() : null;
         String executionRoleArn = req.hasNonNull("executionRoleArn") ? req.path("executionRoleArn").asText() : null;
+        List<String> requiresCompatibilities = jsonArrayToList(req.path("requiresCompatibilities"));
         Map<String, String> tags = parseTagMap(req.path("tags"));
 
         TaskDefinition td = service.registerTaskDefinition(family, containerDefs, networkMode, cpu, memory,
-                taskRoleArn, executionRoleArn, tags, region);
+                taskRoleArn, executionRoleArn, requiresCompatibilities, tags, region);
         // Task-level volumes are not part of registerTaskDefinition's signature; set them on the
         // returned (and stored) task definition so they round-trip and reach RunTask launches.
         td.setVolumes(parseVolumes(req.path("volumes")));
@@ -922,6 +923,11 @@ public class EcsJsonHandler {
         if (td.getMemory() != null) { n.put("memory", td.getMemory()); }
         if (td.getTaskRoleArn() != null) { n.put("taskRoleArn", td.getTaskRoleArn()); }
         if (td.getExecutionRoleArn() != null) { n.put("executionRoleArn", td.getExecutionRoleArn()); }
+        if (td.getRequiresCompatibilities() != null && !td.getRequiresCompatibilities().isEmpty()) {
+            ArrayNode arr = objectMapper.createArrayNode();
+            td.getRequiresCompatibilities().forEach(arr::add);
+            n.set("requiresCompatibilities", arr);
+        }
 
         ArrayNode containers = objectMapper.createArrayNode();
         if (td.getContainerDefinitions() != null) {

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
@@ -928,6 +928,11 @@ public class EcsJsonHandler {
             td.getRequiresCompatibilities().forEach(arr::add);
             n.set("requiresCompatibilities", arr);
         }
+        if (td.getCompatibilities() != null && !td.getCompatibilities().isEmpty()) {
+            ArrayNode arr = objectMapper.createArrayNode();
+            td.getCompatibilities().forEach(arr::add);
+            n.set("compatibilities", arr);
+        }
 
         ArrayNode containers = objectMapper.createArrayNode();
         if (td.getContainerDefinitions() != null) {

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
@@ -193,15 +193,28 @@ public class EcsService {
     public TaskDefinition registerTaskDefinition(String family, List<ContainerDefinition> containerDefs,
                                                   NetworkMode networkMode, String cpu, String memory,
                                                   String taskRoleArn, String executionRoleArn,
+                                                  List<String> requiresCompatibilities,
                                                   String region) {
         return registerTaskDefinition(family, containerDefs, networkMode, cpu, memory,
-                taskRoleArn, executionRoleArn, null, region);
+                taskRoleArn, executionRoleArn, requiresCompatibilities, null, region);
     }
 
     public TaskDefinition registerTaskDefinition(String family, List<ContainerDefinition> containerDefs,
                                                   NetworkMode networkMode, String cpu, String memory,
                                                   String taskRoleArn, String executionRoleArn,
+                                                  List<String> requiresCompatibilities,
                                                   Map<String, String> tags, String region) {
+        if (requiresCompatibilities != null && requiresCompatibilities.contains("FARGATE")) {
+            if (networkMode != NetworkMode.awsvpc) {
+                throw new AwsException("ClientException", "Fargate requires task definition to have network mode awsvpc.", 400);
+            }
+            if (cpu == null || memory == null) {
+                throw new AwsException("ClientException", "Fargate requires task definition to have cpu and memory reservation.", 400);
+            }
+            if (!isValidFargateCpuMemory(cpu, memory)) {
+                throw new AwsException("ClientException", "Fargate requires item to be to be a valid size. Task CPU or memory value is invalid.", 400);
+            }
+        }
         int revision = latestRevisions.merge(family, 1, Integer::sum);
 
         TaskDefinition td = new TaskDefinition();
@@ -213,6 +226,7 @@ public class EcsService {
         td.setMemory(memory);
         td.setTaskRoleArn(taskRoleArn);
         td.setExecutionRoleArn(executionRoleArn);
+        td.setRequiresCompatibilities(requiresCompatibilities);
         td.setContainerDefinitions(containerDefs != null ? containerDefs : List.of());
         td.setTaskDefinitionArn(regionResolver.buildArn("ecs", region,
                 "task-definition/" + family + ":" + revision));
@@ -223,6 +237,63 @@ public class EcsService {
         taskDefinitions.put(family + ":" + revision, td);
         LOG.infov("Registered task definition: {0}:{1}", family, revision);
         return td;
+    }
+
+    private boolean isValidFargateCpuMemory(String cpuStr, String memStr) {
+        if (cpuStr == null || memStr == null) return false;
+        int cpu = parseCpu(cpuStr);
+        int memory = parseMemory(memStr);
+        if (cpu <= 0 || memory <= 0) return false;
+
+        if (cpu == 256) return memory == 512 || memory == 1024 || memory == 2048;
+        if (cpu == 512) return memory >= 1024 && memory <= 4096 && memory % 1024 == 0;
+        if (cpu == 1024) return memory >= 2048 && memory <= 8192 && memory % 1024 == 0;
+        if (cpu == 2048) return memory >= 4096 && memory <= 16384 && memory % 1024 == 0;
+        if (cpu == 4096) return memory >= 8192 && memory <= 30720 && memory % 1024 == 0;
+        if (cpu == 8192) return memory >= 16384 && memory <= 61440 && memory % 4096 == 0;
+        if (cpu == 16384) return memory >= 32768 && memory <= 122880 && memory % 8192 == 0;
+        
+        return false;
+    }
+
+    private int parseCpu(String cpu) {
+        if (cpu.toUpperCase().endsWith("VCPU")) {
+            try {
+                double v = Double.parseDouble(cpu.substring(0, cpu.length() - 4).trim());
+                return (int) Math.round(v * 1024);
+            } catch (NumberFormatException e) {
+                return -1;
+            }
+        }
+        try {
+            return Integer.parseInt(cpu.trim());
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    private int parseMemory(String mem) {
+        if (mem.toUpperCase().endsWith("GB")) {
+            try {
+                double v = Double.parseDouble(mem.substring(0, mem.length() - 2).trim());
+                return (int) Math.round(v * 1024);
+            } catch (NumberFormatException e) {
+                return -1;
+            }
+        }
+        if (mem.toUpperCase().endsWith("MB") || mem.toUpperCase().endsWith("MIB")) {
+            try {
+                double v = Double.parseDouble(mem.replaceAll("(?i)mib|mb", "").trim());
+                return (int) Math.round(v);
+            } catch (NumberFormatException e) {
+                return -1;
+            }
+        }
+        try {
+            return Integer.parseInt(mem.trim());
+        } catch (NumberFormatException e) {
+            return -1;
+        }
     }
 
     public TaskDefinition describeTaskDefinition(String taskDefinitionRef, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
@@ -206,13 +206,16 @@ public class EcsService {
                                                   Map<String, String> tags, String region) {
         if (requiresCompatibilities != null && requiresCompatibilities.contains("FARGATE")) {
             if (networkMode != NetworkMode.awsvpc) {
-                throw new AwsException("ClientException", "Fargate requires task definition to have network mode awsvpc.", 400);
+                throw new AwsException("ClientException", "Fargate only supports network mode 'awsvpc'.", 400);
             }
-            if (cpu == null || memory == null) {
-                throw new AwsException("ClientException", "Fargate requires task definition to have cpu and memory reservation.", 400);
+            if (cpu == null) {
+                throw new AwsException("ClientException", "Fargate requires that 'cpu' be defined at the task level.", 400);
+            }
+            if (memory == null) {
+                throw new AwsException("ClientException", "Fargate requires that 'memory' be defined at the task level.", 400);
             }
             if (!isValidFargateCpuMemory(cpu, memory)) {
-                throw new AwsException("ClientException", "Fargate requires item to be to be a valid size. Task CPU or memory value is invalid.", 400);
+                throw new AwsException("ClientException", "No Fargate configuration exists for given values.", 400);
             }
         }
         int revision = latestRevisions.merge(family, 1, Integer::sum);
@@ -226,8 +229,15 @@ public class EcsService {
         td.setMemory(memory);
         td.setTaskRoleArn(taskRoleArn);
         td.setExecutionRoleArn(executionRoleArn);
-        td.setRequiresCompatibilities(requiresCompatibilities);
         td.setContainerDefinitions(containerDefs != null ? containerDefs : List.of());
+        td.setRequiresCompatibilities(requiresCompatibilities);
+
+        if (requiresCompatibilities != null && !requiresCompatibilities.isEmpty()) {
+            td.setCompatibilities(new java.util.ArrayList<>(requiresCompatibilities));
+        } else {
+            td.setCompatibilities(java.util.List.of("EC2"));
+        }
+
         td.setTaskDefinitionArn(regionResolver.buildArn("ecs", region,
                 "task-definition/" + family + ":" + revision));
         if (tags != null && !tags.isEmpty()) {

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/TaskDefinition.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/TaskDefinition.java
@@ -21,6 +21,7 @@ public class TaskDefinition {
     private List<ContainerDefinition> containerDefinitions;
     private List<Volume> volumes;
     private List<String> requiresCompatibilities;
+    private List<String> compatibilities;
     private Map<String, String> tags = new HashMap<>();
 
     public String getTaskDefinitionArn() { return taskDefinitionArn; }
@@ -60,6 +61,9 @@ public class TaskDefinition {
 
     public List<String> getRequiresCompatibilities() { return requiresCompatibilities; }
     public void setRequiresCompatibilities(List<String> requiresCompatibilities) { this.requiresCompatibilities = requiresCompatibilities; }
+
+    public List<String> getCompatibilities() { return compatibilities; }
+    public void setCompatibilities(List<String> compatibilities) { this.compatibilities = compatibilities; }
 
     public Map<String, String> getTags() { return tags; }
     public void setTags(Map<String, String> tags) { this.tags = tags; }

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/TaskDefinition.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/TaskDefinition.java
@@ -20,6 +20,7 @@ public class TaskDefinition {
     private String executionRoleArn;
     private List<ContainerDefinition> containerDefinitions;
     private List<Volume> volumes;
+    private List<String> requiresCompatibilities;
     private Map<String, String> tags = new HashMap<>();
 
     public String getTaskDefinitionArn() { return taskDefinitionArn; }
@@ -56,6 +57,9 @@ public class TaskDefinition {
 
     public List<Volume> getVolumes() { return volumes; }
     public void setVolumes(List<Volume> volumes) { this.volumes = volumes; }
+
+    public List<String> getRequiresCompatibilities() { return requiresCompatibilities; }
+    public void setRequiresCompatibilities(List<String> requiresCompatibilities) { this.requiresCompatibilities = requiresCompatibilities; }
 
     public Map<String, String> getTags() { return tags; }
     public void setTags(Map<String, String> tags) { this.tags = tags; }

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/EcsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/EcsIntegrationTest.java
@@ -193,6 +193,7 @@ class EcsIntegrationTest {
             .body("taskDefinition.containerDefinitions", hasSize(1))
             .body("taskDefinition.containerDefinitions[0].name", equalTo("app"))
             .body("taskDefinition.requiresCompatibilities", hasItem("FARGATE"))
+            .body("taskDefinition.compatibilities", hasItem("FARGATE"))
         .extract()
             .path("taskDefinition.taskDefinitionArn");
 
@@ -211,6 +212,32 @@ class EcsIntegrationTest {
 
     @Test
     @Order(11)
+    void registerTaskDefinitionWithoutRequiresCompatibilitiesShouldDefaultToEc2() {
+        ecs("RegisterTaskDefinition")
+                .body("""
+                {
+                    "family": "ec2-fallback-family",
+                    "containerDefinitions": [
+                        {
+                            "name": "app",
+                            "image": "nginx:latest",
+                            "essential": true
+                        }
+                    ]
+                }
+                """)
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .body("taskDefinition.family", equalTo("ec2-fallback-family"))
+                .body("taskDefinition.compatibilities", hasItem("EC2"))
+                // requiresCompatibilities shouldn't exist or should be empty
+                .body("taskDefinition.requiresCompatibilities", org.hamcrest.Matchers.nullValue());
+    }
+
+    @Test
+    @Order(12)
     void registerTaskDefinitionWithFargateButBridgeModeShouldFail() {
         ecs("RegisterTaskDefinition")
                 .body("""
@@ -234,18 +261,19 @@ class EcsIntegrationTest {
                 .then()
                 .statusCode(400)
                 .body("__type", containsString("ClientException"))
-                .body("message", containsString("Fargate requires task definition to have network mode awsvpc."));
+                .body("message", containsString("Fargate only supports network mode 'awsvpc'."));
     }
 
     @Test
-    @Order(12)
-    void registerTaskDefinitionWithFargateButMissingResourcesShouldFail() {
+    @Order(13)
+    void registerTaskDefinitionWithFargateButMissingCpuShouldFail() {
         ecs("RegisterTaskDefinition")
                 .body("""
                 {
-                    "family": "invalid-fargate-resources",
+                    "family": "invalid-fargate-cpu",
                     "requiresCompatibilities": ["FARGATE"],
                     "networkMode": "awsvpc",
+                    "memory": "512",
                     "containerDefinitions": [
                         {
                             "name": "app",
@@ -260,11 +288,38 @@ class EcsIntegrationTest {
                 .then()
                 .statusCode(400)
                 .body("__type", containsString("ClientException"))
-                .body("message", containsString("Fargate requires task definition to have cpu and memory reservation."));
+                .body("message", containsString("Fargate requires that 'cpu' be defined at the task level."));
     }
 
     @Test
-    @Order(13)
+    @Order(14)
+    void registerTaskDefinitionWithFargateButMissingMemoryShouldFail() {
+        ecs("RegisterTaskDefinition")
+                .body("""
+                {
+                    "family": "invalid-fargate-memory",
+                    "requiresCompatibilities": ["FARGATE"],
+                    "networkMode": "awsvpc",
+                    "cpu": "256",
+                    "containerDefinitions": [
+                        {
+                            "name": "app",
+                            "image": "nginx:latest",
+                            "essential": true
+                        }
+                    ]
+                }
+                """)
+                .when()
+                .post("/")
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("ClientException"))
+                .body("message", containsString("Fargate requires that 'memory' be defined at the task level."));
+    }
+
+    @Test
+    @Order(15)
     void registerTaskDefinitionWithFargateButInvalidSizesShouldFail() {
         ecs("RegisterTaskDefinition")
                 .body("""
@@ -288,11 +343,11 @@ class EcsIntegrationTest {
                 .then()
                 .statusCode(400)
                 .body("__type", containsString("ClientException"))
-                .body("message", containsString("Fargate requires item to be to be a valid size. Task CPU or memory value is invalid."));
+                .body("message", containsString("No Fargate configuration exists for given values."));
     }
 
     @Test
-    @Order(14)
+    @Order(16)
     void describeTaskDefinition() {
         ecs("DescribeTaskDefinition")
             .body("""
@@ -308,7 +363,7 @@ class EcsIntegrationTest {
     }
 
     @Test
-    @Order(15)
+    @Order(17)
     void listTaskDefinitions() {
         ecs("ListTaskDefinitions")
             .body("{}")
@@ -320,7 +375,7 @@ class EcsIntegrationTest {
     }
 
     @Test
-    @Order(16)
+    @Order(18)
     void listTaskDefinitionFamilies() {
         ecs("ListTaskDefinitionFamilies")
             .body("{}")

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/EcsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/EcsIntegrationTest.java
@@ -192,6 +192,7 @@ class EcsIntegrationTest {
             .body("taskDefinition.taskDefinitionArn", containsString(TASK_DEF_FAMILY))
             .body("taskDefinition.containerDefinitions", hasSize(1))
             .body("taskDefinition.containerDefinitions[0].name", equalTo("app"))
+            .body("taskDefinition.requiresCompatibilities", hasItem("FARGATE"))
         .extract()
             .path("taskDefinition.taskDefinitionArn");
 
@@ -210,6 +211,88 @@ class EcsIntegrationTest {
 
     @Test
     @Order(11)
+    void registerTaskDefinitionWithFargateButBridgeModeShouldFail() {
+        ecs("RegisterTaskDefinition")
+                .body("""
+                {
+                    "family": "invalid-fargate-bridge",
+                    "requiresCompatibilities": ["FARGATE"],
+                    "networkMode": "bridge",
+                    "cpu": "256",
+                    "memory": "512",
+                    "containerDefinitions": [
+                        {
+                            "name": "app",
+                            "image": "nginx:latest",
+                            "essential": true
+                        }
+                    ]
+                }
+                """)
+                .when()
+                .post("/")
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("ClientException"))
+                .body("message", containsString("Fargate requires task definition to have network mode awsvpc."));
+    }
+
+    @Test
+    @Order(12)
+    void registerTaskDefinitionWithFargateButMissingResourcesShouldFail() {
+        ecs("RegisterTaskDefinition")
+                .body("""
+                {
+                    "family": "invalid-fargate-resources",
+                    "requiresCompatibilities": ["FARGATE"],
+                    "networkMode": "awsvpc",
+                    "containerDefinitions": [
+                        {
+                            "name": "app",
+                            "image": "nginx:latest",
+                            "essential": true
+                        }
+                    ]
+                }
+                """)
+                .when()
+                .post("/")
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("ClientException"))
+                .body("message", containsString("Fargate requires task definition to have cpu and memory reservation."));
+    }
+
+    @Test
+    @Order(13)
+    void registerTaskDefinitionWithFargateButInvalidSizesShouldFail() {
+        ecs("RegisterTaskDefinition")
+                .body("""
+                {
+                    "family": "invalid-fargate-sizes",
+                    "requiresCompatibilities": ["FARGATE"],
+                    "networkMode": "awsvpc",
+                    "cpu": "256",
+                    "memory": "1000",
+                    "containerDefinitions": [
+                        {
+                            "name": "app",
+                            "image": "nginx:latest",
+                            "essential": true
+                        }
+                    ]
+                }
+                """)
+                .when()
+                .post("/")
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("ClientException"))
+                .body("message", containsString("Fargate requires item to be to be a valid size. Task CPU or memory value is invalid."));
+    }
+
+    @Test
+    @Order(14)
     void describeTaskDefinition() {
         ecs("DescribeTaskDefinition")
             .body("""
@@ -225,7 +308,7 @@ class EcsIntegrationTest {
     }
 
     @Test
-    @Order(12)
+    @Order(15)
     void listTaskDefinitions() {
         ecs("ListTaskDefinitions")
             .body("{}")
@@ -237,7 +320,7 @@ class EcsIntegrationTest {
     }
 
     @Test
-    @Order(13)
+    @Order(16)
     void listTaskDefinitionFamilies() {
         ecs("ListTaskDefinitionFamilies")
             .body("{}")

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandlerVolumesTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandlerVolumesTest.java
@@ -39,7 +39,7 @@ class EcsJsonHandlerVolumesTest {
         objectMapper = new ObjectMapper();
         service = mock(EcsService.class);
         // Echo the parsed container definitions (arg index 1) back inside a task definition.
-        when(service.registerTaskDefinition(anyString(), any(), any(), any(), any(), any(), any(), any(), anyString()))
+        when(service.registerTaskDefinition(anyString(), any(), any(), any(), any(), any(), any(), any(), any(), anyString()))
                 .thenAnswer(inv -> {
                     TaskDefinition td = new TaskDefinition();
                     td.setFamily(inv.getArgument(0));


### PR DESCRIPTION
## Summary
Fixes missing validation for Fargate task definitions, ensuring Floci strictly mirrors AWS ECS behavior. Previously, Fargate tasks could be registered without task-level CPU and memory, and defaulted to `bridge` network mode. This fix strictly enforces `awsvpc` network mode and validates that task-level CPU/Memory allocations match supported Fargate pairing tiers exactly. It also fixes a bug where `requiresCompatibilities` was dropped during CloudFormation template parsing.

Closes #1269

## Type of change
- [X] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility
- Fargate task definitions previously allowed missing task-level `cpu` and `memory` reservations, and defaulted the `networkMode` to `bridge`. When deployed to real AWS, this causes immediate failures.
- Floci now strictly enforces that Fargate tasks declare both task-level `cpu` and `memory` and use `awsvpc` network mode. It also strictly validates that the requested CPU/Memory pairing is a valid Fargate tier size, returning the exact `ClientException` error strings produced by AWS.

## Checklist
- [X] `./mvnw test` passes locally
- [X] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)


Local test note:
All targeted EcsIntegrationTest assertions pass cleanly. General suite testing experienced unrelated timeouts primarily in apigatewayv2 WebSocket/Lambda routing (java.util.concurrent.TimeoutException) and an isolated ecr repository test. These are isolated to the local testing environment's Docker daemon bootstrapping delays during Lambda function simulation and are unrelated to the ECS validation logic.