### PR TITLE
fix(docker): fall back to the default command when entrypoint argv is empty

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -41,4 +41,20 @@ if [ "${LOCALSTACK_PARITY:-true}" != "false" ]; then
     . /usr/local/bin/localstack-parity.sh
 fi
 
+# Fall back to the image's default command when invoked with no arguments.
+# Some tooling re-executes this entrypoint directly with an empty argv —
+# Testcontainers' LocalStackContainer does exactly that via its starter
+# script — and `exec "$@"` with no argv would make the script reach EOF
+# and exit 0 without ever starting the emulator. LocalStack's entrypoint
+# ignores its argv entirely, so this keeps drop-in parity.
+# The default matches the CMD of the image variant: native images ship
+# /app/application, JVM images ship /app/quarkus-app/quarkus-run.jar.
+if [ $# -eq 0 ]; then
+    if [ -x /app/application ]; then
+        set -- /app/application -Dquarkus.http.host=0.0.0.0
+    else
+        set -- java -jar /app/quarkus-app/quarkus-run.jar -Dquarkus.http.host=0.0.0.0
+    fi
+fi
+
 exec "$@"

--- a/docker/test-entrypoint.sh
+++ b/docker/test-entrypoint.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# Unit tests for entrypoint.sh argument handling.
+# Run directly: sh docker/test-entrypoint.sh
+# Exit 0 on success, non-zero on first failure summary.
+#
+# These tests run the entrypoint as an unprivileged user with
+# LOCALSTACK_PARITY=false, so the root-only gosu block and the parity
+# script (installed at an absolute path inside the image) stay out of
+# the way. The root/gosu path is covered by the Docker image tests.
+
+set -eu
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/entrypoint.sh"
+PASS=0
+FAIL=0
+
+assert_eq() {
+    desc="$1"; expected="$2"; actual="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        printf '[PASS] %s\n' "${desc}"
+        PASS=$((PASS + 1))
+    else
+        printf '[FAIL] %s\n  expected: %s\n  actual:   %s\n' "${desc}" "${expected}" "${actual}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+if [ "$(id -u)" = '0' ]; then
+    echo "These tests must run as an unprivileged user (the root path re-execs via gosu)." >&2
+    exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT INT TERM
+
+# Stub java on PATH that prints the argv it was exec'd with.
+mkdir -p "${WORK}/bin"
+cat > "${WORK}/bin/java" <<'EOF'
+#!/bin/sh
+printf '%s\n' "java $*"
+EOF
+chmod +x "${WORK}/bin/java"
+
+# --- explicit arguments are exec'd unchanged ---
+assert_eq "explicit command is exec'd unchanged" \
+    "one two" \
+    "$(LOCALSTACK_PARITY=false sh "${SCRIPT}" echo one two)"
+
+assert_eq "explicit java command bypasses the fallback" \
+    "java -jar /custom/app.jar" \
+    "$(PATH="${WORK}/bin:${PATH}" LOCALSTACK_PARITY=false sh "${SCRIPT}" java -jar /custom/app.jar)"
+
+# --- empty argv falls back to the image default command ---
+# Without /app/application (JVM image layout), the fallback must exec the
+# Quarkus runner jar with the same arguments as the published image CMD.
+if [ ! -e /app/application ]; then
+    assert_eq "empty argv falls back to the JVM default command" \
+        "java -jar /app/quarkus-app/quarkus-run.jar -Dquarkus.http.host=0.0.0.0" \
+        "$(PATH="${WORK}/bin:${PATH}" LOCALSTACK_PARITY=false sh "${SCRIPT}")"
+else
+    printf '[SKIP] empty argv falls back to the JVM default command (/app/application exists on this host)\n'
+fi
+
+# With an executable /app/application (native image layout), the fallback
+# must prefer the native binary. Only runs where /app is writable or the
+# binary already exists (always true inside the published images).
+NATIVE_TESTABLE=false
+if [ -x /app/application ]; then
+    NATIVE_TESTABLE=true
+elif mkdir -p /app 2>/dev/null && [ -w /app ]; then
+    cat > /app/application <<'EOF'
+#!/bin/sh
+printf '%s\n' "/app/application $*"
+EOF
+    chmod +x /app/application
+    trap 'rm -f /app/application; rm -rf "${WORK}"' EXIT INT TERM
+    NATIVE_TESTABLE=true
+fi
+if [ "${NATIVE_TESTABLE}" = 'true' ]; then
+    assert_eq "empty argv prefers the native binary when present" \
+        "/app/application -Dquarkus.http.host=0.0.0.0" \
+        "$(LOCALSTACK_PARITY=false sh "${SCRIPT}")"
+else
+    printf '[SKIP] empty argv prefers the native binary when present (/app not writable)\n'
+fi
+
+printf '\n%d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" -eq 0 ]


### PR DESCRIPTION
Fixes #1279.

`exec "$@"` with an empty argv made the container exit 0 silently. Testcontainers'
`LocalStackContainer` invokes the entrypoint exactly that way (starter script,
`Cmd=[]`), so Floci could not be used as a LocalStack substitute from
testcontainers-java at all — the most common way JVM projects consume a LocalStack
image in CI.

**Change:** before the final `exec "$@"`, an empty argv now falls back to the image's
default command — `/app/application -Dquarkus.http.host=0.0.0.0` when the native
binary is present, otherwise the Quarkus runner jar (the JVM images' CMD). The
fallback sits at the bottom of the script so the gosu re-exec path (which re-enters
with `"$0" "$@"`) is covered by the same lines. Explicit argv (e.g. `docker run image
sh`) is untouched.

**Tests:** `docker/test-entrypoint.sh` (same style as `docker/test-localstack-parity.sh`,
run with `sh docker/test-entrypoint.sh`): explicit args pass through unchanged;
empty argv execs the JVM default when `/app/application` is absent; empty argv
prefers the native binary when present (skipped where `/app` is not writable —
covered by the image validation below).

**Validation (local images built from this branch):**
- `docker run --entrypoint /usr/local/bin/docker-entrypoint.sh <image>` (no args):
  before — exits 0 silently; after — serves :4566 and passes `/_floci/health`.
- Normal `docker run` / explicit-command runs unchanged.
- A stock testcontainers-java 1.21.4 `LocalStackContainer` with only
  `.asCompatibleSubstituteFor("localstack/localstack")` (no custom wait, no
  entrypoint modifier) starts in <2 s and passes an S3 put/get + SNS→SQS
  publish/receive round trip (together with the parity `Ready.` line PR).
- Full `mvn test` suite: unchanged vs. main on the same machine.

**Downstream:** Cato Networks (server-services, ~36 Testcontainers modules) pins
`floci/floci:1.5.23-compat` and carries a tagged
`withCreateContainerCmdModifier(...)`/"restore image entrypoint+cmd" workaround in
every SQS/S3/SNS fixture; those get deleted as soon as a release ships this. Same
contribution pipeline as #784.
