### PR TITLE
feat(parity): emit LocalStack-compatible "Ready." log line on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,7 +692,7 @@ LocalStack environment variables are translated automatically:
 | `LAMBDA_REMOVE_CONTAINERS=1` | `FLOCI_SERVICES_LAMBDA_EPHEMERAL=true` |
 | `DEBUG=1` | `QUARKUS_LOG_LEVEL=DEBUG` |
 
-Init scripts mounted under `/etc/localstack/init/` run unchanged. The `/_localstack/init` and `/_localstack/health` endpoints are still served. Set `LOCALSTACK_PARITY=false` to opt out of automatic translation.
+Init scripts mounted under `/etc/localstack/init/` run unchanged. The `/_localstack/init` and `/_localstack/health` endpoints are still served. Once the emulator is up, the log also ends with a LocalStack-style `Ready.` line, so tooling that watches the log for it — such as the default wait strategy of Testcontainers' `LocalStackContainer` — works unchanged. Set `LOCALSTACK_PARITY=false` to opt out of automatic translation.
 
 See the [full migration guide](https://floci.io/floci/getting-started/migrate-from-localstack/).
 

--- a/docs/getting-started/migrate-from-localstack.md
+++ b/docs/getting-started/migrate-from-localstack.md
@@ -23,6 +23,8 @@ services:
 
 Explicitly set Floci variables always win — the translation only fills in values that haven't been set. To disable the translation entirely, set `LOCALSTACK_PARITY=false`.
 
+Unless parity is disabled, the startup log also ends with a LocalStack-style `Ready.` line (in addition to Floci's own banner), so tooling that watches the container log for LocalStack's readiness message — such as the default wait strategy of Testcontainers' `LocalStackContainer` — works without a custom wait.
+
 ## Step-by-step migration
 
 ### 1 — Change the image

--- a/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
@@ -42,6 +42,14 @@ public class EmulatorLifecycle {
     @ConfigProperty(name = "quarkus.application.version", defaultValue = "")
     Optional<String> appVersion = Optional.empty();
 
+    /**
+     * Bound to the LOCALSTACK_PARITY environment variable through the standard
+     * MicroProfile Config env-var mapping. Same gate as docker/entrypoint.sh:
+     * parity behavior is enabled unless the value is exactly "false".
+     */
+    @ConfigProperty(name = "localstack.parity", defaultValue = "true")
+    String localstackParity = "true";
+
     private final StorageFactory storageFactory;
     private final ServiceRegistry serviceRegistry;
     private final EmulatorConfig config;
@@ -135,7 +143,7 @@ public class EmulatorLifecycle {
         if (!hasStart && !hasReady) {
             initLifecycleState.markStartCompleted();
             initLifecycleState.markReadyCompleted();
-            LOG.info("=== AWS Local Emulator Ready ===");
+            logReady();
         }
     }
 
@@ -158,13 +166,27 @@ public class EmulatorLifecycle {
                 initializationHooksRunner.run(InitializationHook.READY);
             }
             initLifecycleState.markReadyCompleted();
-            LOG.info("=== AWS Local Emulator Ready ===");
+            logReady();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             LOG.error("Startup hook execution interrupted — shutting down", e);
         } catch (Exception e) {
             LOG.error("Startup hook execution failed — shutting down", e);
             Quarkus.asyncExit();
+        }
+    }
+
+    /**
+     * LocalStack prints a line ending in "Ready." when its gateway is up, and
+     * ecosystem tooling keys on it — Testcontainers' LocalStackContainer default
+     * wait strategy polls the log for the regex {@code .*Ready\.} and times out
+     * against Floci's banner alone. Emit the parity line alongside the banner so
+     * such tooling works out of the box.
+     */
+    private void logReady() {
+        LOG.info("=== AWS Local Emulator Ready ===");
+        if (!"false".equals(localstackParity)) {
+            LOG.info("Ready.");
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
@@ -32,7 +32,12 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -259,5 +264,84 @@ class EmulatorLifecycleTest {
         verify(elastiCacheContainerManager).stopAll();
         verify(rdsContainerManager).stopAll();
         verify(storageFactory).shutdownAll();
+    }
+
+    // --- LocalStack-parity "Ready." log line ---
+
+    /** Collects the messages EmulatorLifecycle logs while {@code action} runs. */
+    private List<String> lifecycleLogMessages(Runnable action) {
+        java.util.logging.Logger logger =
+                java.util.logging.Logger.getLogger(EmulatorLifecycle.class.getName());
+        List<String> messages = new CopyOnWriteArrayList<>();
+        java.util.logging.Handler handler = new java.util.logging.Handler() {
+            @Override
+            public void publish(java.util.logging.LogRecord logRecord) {
+                messages.add(logRecord.getMessage());
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        logger.addHandler(handler);
+        try {
+            action.run();
+        } finally {
+            logger.removeHandler(handler);
+        }
+        return messages;
+    }
+
+    @Test
+    @DisplayName("Should emit the LocalStack-parity \"Ready.\" line after the banner by default")
+    void shouldEmitParityReadyLineByDefault() {
+        stubStorageConfig();
+        when(initializationHooksRunner.hasHooks(InitializationHook.START)).thenReturn(false);
+        when(initializationHooksRunner.hasHooks(InitializationHook.READY)).thenReturn(false);
+
+        List<String> messages =
+                lifecycleLogMessages(() -> emulatorLifecycle.onStart(Mockito.mock(StartupEvent.class)));
+
+        assertEquals(1, messages.stream().filter("Ready."::equals).count(),
+                "Exactly one parity \"Ready.\" line must be emitted");
+        int banner = messages.indexOf("=== AWS Local Emulator Ready ===");
+        assertTrue(banner >= 0, "The Floci ready banner must still be emitted");
+        assertTrue(messages.indexOf("Ready.") > banner,
+                "The parity line must follow the banner");
+    }
+
+    @Test
+    @DisplayName("Should not emit the parity \"Ready.\" line when LOCALSTACK_PARITY=false")
+    void shouldNotEmitParityReadyLineWhenParityDisabled() {
+        stubStorageConfig();
+        when(initializationHooksRunner.hasHooks(InitializationHook.START)).thenReturn(false);
+        when(initializationHooksRunner.hasHooks(InitializationHook.READY)).thenReturn(false);
+        emulatorLifecycle.localstackParity = "false";
+
+        List<String> messages =
+                lifecycleLogMessages(() -> emulatorLifecycle.onStart(Mockito.mock(StartupEvent.class)));
+
+        assertFalse(messages.contains("Ready."),
+                "No parity line may be emitted when parity is disabled");
+        assertTrue(messages.contains("=== AWS Local Emulator Ready ==="),
+                "The Floci ready banner must still be emitted");
+    }
+
+    @Test
+    @DisplayName("Should emit the parity \"Ready.\" line on the deferred onHttpStart ready path too")
+    void shouldEmitParityReadyLineOnHttpStartPath() throws IOException, InterruptedException {
+        when(tlsConfig.enabled()).thenReturn(false);
+        when(initializationHooksRunner.hasHooks(InitializationHook.START)).thenReturn(true);
+        when(initializationHooksRunner.hasHooks(InitializationHook.READY)).thenReturn(false);
+
+        List<String> messages = lifecycleLogMessages(() ->
+                emulatorLifecycle.onHttpStart(new HttpServerStart(new HttpServerOptions().setPort(4566))));
+
+        assertEquals(1, messages.stream().filter("Ready."::equals).count(),
+                "Exactly one parity \"Ready.\" line must be emitted on the hook path");
     }
 }


### PR DESCRIPTION
Fixes #1280.

testcontainers-java's `LocalStackContainer` default wait strategy polls the container
log for `.*Ready\.\n` — LocalStack's readiness line. Floci's banner never matches, so
every stock usage times out after 60 s.

**Change:** `EmulatorLifecycle` now logs a single extra line, exactly `Ready.`, right
after the existing `=== AWS Local Emulator Ready ===` banner, on both ready paths
(no-hooks fast path in `onStart`, deferred path in `onHttpStart`). It is gated on the
existing parity switch: a new `localstack.parity` config property (bound to the
`LOCALSTACK_PARITY` env var through the standard MicroProfile env mapping) defaulting
to enabled, with the same "anything but the literal `false`" semantics as
`docker/entrypoint.sh`. With `LOCALSTACK_PARITY=false` the line is not printed.

**Tests:** three new `EmulatorLifecycleTest` cases capture the lifecycle logger's
records: exactly one `Ready.` after the banner by default; none when parity is
disabled (banner still present); exactly one on the deferred init-hooks path.

**Validation (local image built from this branch):**
- `docker logs <cid> | grep -c 'Ready\.$'` → `1` with parity on, `0` with
  `LOCALSTACK_PARITY=false`; `localstack/localstack:4.14.0` → `1` (parity).
- Stock testcontainers-java 1.21.4 `LocalStackContainer` (only
  `.asCompatibleSubstituteFor`, default wait) becomes ready in <2 s and passes an
  S3 + SNS→SQS round trip (together with the entrypoint PR #1283).
- Full `mvn test` suite: failure set identical to main on the same machine.

**Downstream:** Cato Networks' suites currently carry explicit
`.waitingFor(Wait.forHttp("/"))` workarounds on ~36 fixtures; an HTTP wait stays
reasonable practice, but stock fixtures shouldn't need it.

Docs: one sentence added to the README parity section and the migration guide.
