### PR TITLE
fix(sqs): report ApproximateNumberOfMessagesDelayed in GetQueueAttributes

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
@@ -203,18 +203,32 @@ class GuardedMessageQueue {
         }
     }
 
-    record MessageCounts(long visible, long inFlight) {
+    record MessageCounts(long visible, long inFlight, long delayed) {
     }
 
+    /**
+     * Splits the queue contents the way AWS SQS reports them in
+     * GetQueueAttributes: visible (ApproximateNumberOfMessages), in flight
+     * (ApproximateNumberOfMessagesNotVisible) and delayed
+     * (ApproximateNumberOfMessagesDelayed). A message that is not visible and
+     * was never claimed — no receipt handle — can only be waiting out its
+     * DelaySeconds, so it counts as delayed rather than in flight.
+     */
     MessageCounts messageCounts() {
         try (var _ = hold()) {
             long visible = 0;
             long inFlight = 0;
+            long delayed = 0;
             for (Message m : messages) {
-                if (m.isVisible()) visible++;
-                else inFlight++;
+                if (m.isVisible()) {
+                    visible++;
+                } else if (m.getReceiptHandle() == null) {
+                    delayed++;
+                } else {
+                    inFlight++;
+                }
             }
-            return new MessageCounts(visible, inFlight);
+            return new MessageCounts(visible, inFlight, delayed);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -321,6 +321,7 @@ public class SqsService {
         var counts = getOrCreateQueue(storageKey).messageCounts();
         attrs.put("ApproximateNumberOfMessages", String.valueOf(counts.visible()));
         attrs.put("ApproximateNumberOfMessagesNotVisible", String.valueOf(counts.inFlight()));
+        attrs.put("ApproximateNumberOfMessagesDelayed", String.valueOf(counts.delayed()));
 
         if (attributeNames == null || attributeNames.contains("All")) {
             return attrs;
@@ -839,8 +840,8 @@ public class SqsService {
         }
 
         var srcQueueInitial = getOrCreateQueue(srcKey);
-        long toMove = srcQueueInitial.messageCounts().visible()
-                + srcQueueInitial.messageCounts().inFlight();
+        var srcCounts = srcQueueInitial.messageCounts();
+        long toMove = srcCounts.visible() + srcCounts.inFlight() + srcCounts.delayed();
 
         String taskHandle = "task-" + UUID.randomUUID();
         moveTasksByHandle.put(taskHandle, new MoveTask(

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueueTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueueTest.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.services.sqs.model.Message;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -148,20 +149,39 @@ class GuardedMessageQueueTest {
     }
 
     @Test
-    void messageCountsReturnsVisibleAndInFlight() {
+    void messageCountsReturnsVisibleInFlightAndDelayed() {
         queue.addMessage(new Message("msg1"));
         queue.addMessage(new Message("msg2"));
         queue.addMessage(new Message("msg3"));
+        Message delayedMessage = new Message("delayed");
+        delayedMessage.setVisibleAt(Instant.now().plusSeconds(60));
+        queue.addMessage(delayedMessage);
 
         var counts = queue.messageCounts();
         assertEquals(3, counts.visible());
         assertEquals(0, counts.inFlight());
+        assertEquals(1, counts.delayed(),
+                "A never-claimed message with a future visibleAt is delayed, not in flight");
 
         queue.claimVisibleMessages(2, 30, false, -1, null);
 
         var afterClaim = queue.messageCounts();
         assertEquals(1, afterClaim.visible());
-        assertEquals(2, afterClaim.inFlight());
+        assertEquals(2, afterClaim.inFlight(),
+                "Claimed messages are in flight, not delayed");
+        assertEquals(1, afterClaim.delayed());
+    }
+
+    @Test
+    void messageCountsDelayedMessageBecomesVisibleAfterDelay() {
+        Message delayedMessage = new Message("delayed");
+        delayedMessage.setVisibleAt(Instant.now().minusSeconds(1));
+        queue.addMessage(delayedMessage);
+
+        var counts = queue.messageCounts();
+        assertEquals(1, counts.visible(),
+                "A message whose delay has elapsed counts as visible");
+        assertEquals(0, counts.delayed());
     }
 
     // --- FIFO ---

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
@@ -224,7 +224,10 @@ class SqsIntegrationTest {
         .then()
             .statusCode(200)
             .body(containsString("<Attribute>"))
-            .body(containsString("QueueArn"));
+            .body(containsString("QueueArn"))
+            .body(containsString("ApproximateNumberOfMessages"))
+            .body(containsString("ApproximateNumberOfMessagesNotVisible"))
+            .body(containsString("ApproximateNumberOfMessagesDelayed"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
@@ -70,7 +70,10 @@ class SqsJsonProtocolTest {
             .post("/")
         .then()
             .statusCode(200)
-            .body("Attributes.QueueArn", notNullValue());
+            .body("Attributes.QueueArn", notNullValue())
+            .body("Attributes.ApproximateNumberOfMessages", notNullValue())
+            .body("Attributes.ApproximateNumberOfMessagesNotVisible", notNullValue())
+            .body("Attributes.ApproximateNumberOfMessagesDelayed", notNullValue());
     }
 
     // --- Queue-URL-path JSON 1.0 (POST /{accountId}/{queueName}) ---

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -225,6 +225,56 @@ class SqsServiceTest {
         assertNotNull(attrs.get("QueueArn"));
         assertNotNull(attrs.get("CreatedTimestamp"));
         assertEquals("1", attrs.get("ApproximateNumberOfMessages"));
+        assertEquals("0", attrs.get("ApproximateNumberOfMessagesNotVisible"));
+        assertEquals("0", attrs.get("ApproximateNumberOfMessagesDelayed"),
+                "The Delayed counter must always be present, \"0\" when nothing is delayed");
+    }
+
+    @Test
+    void getQueueAttributesReportsDelayedMessages() {
+        String region = "eu-west-1";
+        Queue queue = sqsService.createQueue("delayed-attr-queue", null, region);
+        sqsService.sendMessage(queue.getQueueUrl(), "msg", 1, region);
+
+        Map<String, String> whileDelayed =
+                sqsService.getQueueAttributes(queue.getQueueUrl(), List.of("All"), region);
+        assertEquals("0", whileDelayed.get("ApproximateNumberOfMessages"));
+        assertEquals("0", whileDelayed.get("ApproximateNumberOfMessagesNotVisible"),
+                "A delayed message is not in flight");
+        assertEquals("1", whileDelayed.get("ApproximateNumberOfMessagesDelayed"));
+
+        try { Thread.sleep(1100); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+
+        Map<String, String> afterDelay =
+                sqsService.getQueueAttributes(queue.getQueueUrl(), List.of("All"), region);
+        assertEquals("1", afterDelay.get("ApproximateNumberOfMessages"));
+        assertEquals("0", afterDelay.get("ApproximateNumberOfMessagesDelayed"),
+                "The Delayed counter must drop back to 0 once the message becomes visible");
+    }
+
+    @Test
+    void getQueueAttributesReportsInFlightSeparatelyFromDelayed() {
+        String region = "eu-west-1";
+        Queue queue = sqsService.createQueue("inflight-attr-queue", null, region);
+        sqsService.sendMessage(queue.getQueueUrl(), "msg", 0, region);
+        assertEquals(1, sqsService.receiveMessage(queue.getQueueUrl(), 1, 30, 0, region).size());
+
+        Map<String, String> attrs =
+                sqsService.getQueueAttributes(queue.getQueueUrl(), List.of("All"), region);
+        assertEquals("0", attrs.get("ApproximateNumberOfMessages"));
+        assertEquals("1", attrs.get("ApproximateNumberOfMessagesNotVisible"));
+        assertEquals("0", attrs.get("ApproximateNumberOfMessagesDelayed"),
+                "An in-flight (received) message must not count as delayed");
+    }
+
+    @Test
+    void getQueueAttributesReturnsDelayedWhenExplicitlyRequested() {
+        String region = "eu-west-1";
+        Queue queue = sqsService.createQueue("explicit-delayed-queue", null, region);
+
+        Map<String, String> attrs = sqsService.getQueueAttributes(queue.getQueueUrl(),
+                List.of("ApproximateNumberOfMessagesDelayed"), region);
+        assertEquals(Map.of("ApproximateNumberOfMessagesDelayed", "0"), attrs);
     }
 
     // --- FIFO Queue Tests ---


### PR DESCRIPTION
Fixes #1281.

**Change:** `GuardedMessageQueue.messageCounts()` now classifies messages the way AWS
reports them: visible / in flight / delayed. A message that is not visible and was
never claimed (no receipt handle) can only be waiting out its `DelaySeconds`, so it
counts as delayed; claimed messages stay in flight. `GetQueueAttributes` returns
`ApproximateNumberOfMessagesDelayed` (always present, `"0"` when none) alongside the
two existing counters — automatically on both the Query and JSON 1.0 paths, since
both handlers serialize the service-level map. This also corrects
`ApproximateNumberOfMessagesNotVisible`, which previously absorbed delayed messages
(AWS counts them only in Delayed). `StartMessageMoveTask`'s to-move estimate keeps
its previous total (visible + in flight + delayed, i.e. everything the mover drains).

**Tests:**
- `GuardedMessageQueueTest`: three-way classification incl. delayed→visible
  transition and claimed-vs-delayed separation.
- `SqsServiceTest`: fresh queue reports `"0"`; `DelaySeconds=1` message reports
  Delayed=1 / NotVisible=0 / Messages=0 and flips to Messages=1 / Delayed=0 after the
  delay; an in-flight (received) message reports NotVisible=1 / Delayed=0; explicit
  `AttributeNames=[ApproximateNumberOfMessagesDelayed]` returns exactly that key.
- Wire-level: Query (`SqsIntegrationTest`) and JSON (`SqsJsonProtocolTest`) responses
  contain all three counters.

**Validation:** behavior matrix against `localstack/localstack:4.14.0` — identical
observable lifecycle (`absent-key` bug before; present/0 → 1 while delayed → 0 after,
on both emulators after the fix). Full `mvn test` suite: failure set identical to
main on the same machine. (Checked against 4.14.0 because `localstack:latest` now
exits with a license error without an auth token.)

**Downstream:** Cato Networks' cato-events test helper (inherited by ~36 consumer
test classes) NFE'd on the absent key; it now carries a tagged absent-count=0 guard
that becomes pure defense-in-depth once this ships. Same pipeline as #784.
