### PR TITLE
fix(sqs): release in-flight ReceiveMessage long polls when their queue is deleted

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -277,6 +277,11 @@ public class SqsService {
         if (dedupStore != null) {
             dedupStore.delete(storageKey);
         }
+        // Wake parked ReceiveMessage long polls so they observe the deletion
+        // and finish, instead of staying registered against this queue URL.
+        // Left alone they would survive a delete + recreate under the same URL
+        // and consume deliveries that belong to the new queue's consumers.
+        notifyReceivers(storageKey);
         LOG.infov("Deleted queue: {0}", queueUrl);
     }
 
@@ -591,8 +596,20 @@ public class SqsService {
         long start = System.currentTimeMillis();
         long maxWait = waitTimeSeconds * 1000L;
         Object lock = queueLocks.computeIfAbsent(storageKey, k -> new Object());
+        // The queue incarnation this call polls against. DeleteQueue removes it
+        // from messagesByQueue (and CreateQueue registers a fresh instance), so
+        // an identity change tells a parked long poll that its queue is gone.
+        GuardedMessageQueue polledQueue = getOrCreateQueue(storageKey);
 
         while (true) {
+            if (messagesByQueue.get(storageKey) != polledQueue) {
+                // The queue was deleted mid-poll (and possibly recreated under
+                // the same URL). Finish empty-handed: a receive opened against
+                // the deleted incarnation must not consume deliveries — nor
+                // burn ApproximateReceiveCount / redrive budget — that belong
+                // to the new queue's consumers.
+                return Collections.emptyList();
+            }
             List<Message> result = doReceiveMessage(storageKey, maxMessages, visibilityTimeout, region);
             if (!result.isEmpty() || maxWait <= 0) {
                 if (!result.isEmpty() && LOG.isTraceEnabled()) {

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -12,6 +12,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -894,5 +897,70 @@ class SqsServiceTest {
         sqsService.createQueue("attrs-bare", Map.of("VisibilityTimeout", "45"), region);
         Map<String, String> attrs = sqsService.getQueueAttributes("attrs-bare", List.of("VisibilityTimeout"), region);
         assertEquals("45", attrs.get("VisibilityTimeout"));
+    }
+
+    // --- DeleteQueue releases in-flight ReceiveMessage long polls ---
+
+    @Test
+    void deleteQueueReleasesParkedLongPoll() throws InterruptedException {
+        String region = "eu-west-1";
+        Queue queue = sqsService.createQueue("longpoll-release-queue", null, region);
+        String queueUrl = queue.getQueueUrl();
+
+        final var pollerEntered = new CountDownLatch(1);
+        final var staleResult = new AtomicReference<List<Message>>();
+        Thread stalePoller = new Thread(() -> {
+            pollerEntered.countDown();
+            staleResult.set(sqsService.receiveMessage(queueUrl, 1, 30, 8, region));
+        });
+        stalePoller.start();
+        assertTrue(pollerEntered.await(5, TimeUnit.SECONDS));
+        Thread.sleep(300); // let the poller park inside its long-poll wait
+
+        sqsService.deleteQueue(queueUrl, region);
+        stalePoller.join(2000);
+
+        assertFalse(stalePoller.isAlive(),
+                "DeleteQueue must release a parked long poll promptly, not leave it to wait out its full WaitTimeSeconds");
+        assertTrue(staleResult.get().isEmpty(),
+                "A long poll released by DeleteQueue must complete without messages");
+    }
+
+    @Test
+    void staleLongPollMustNotConsumeMessagesFromARecreatedQueue() throws InterruptedException {
+        String region = "eu-west-1";
+        Queue queue = sqsService.createQueue("recreate-longpoll-queue", null, region);
+        String queueUrl = queue.getQueueUrl();
+
+        // A long poll opened before the delete, e.g. a listener generation
+        // that is being torn down while its queue is recreated.
+        final var pollerEntered = new CountDownLatch(1);
+        final var staleResult = new AtomicReference<List<Message>>();
+        Thread stalePoller = new Thread(() -> {
+            pollerEntered.countDown();
+            staleResult.set(sqsService.receiveMessage(queueUrl, 1, 30, 8, region));
+        });
+        stalePoller.start();
+        assertTrue(pollerEntered.await(5, TimeUnit.SECONDS));
+        Thread.sleep(300); // let the poller park inside its long-poll wait
+
+        sqsService.deleteQueue(queueUrl, region);
+        Queue recreated = sqsService.createQueue("recreate-longpoll-queue", null, region);
+        sqsService.sendMessage(recreated.getQueueUrl(), "for-the-new-queue", 0, region);
+        // Give a surviving stale poll every chance to (incorrectly) grab the
+        // message before the legitimate receive arrives.
+        Thread.sleep(200);
+
+        List<Message> fresh = sqsService.receiveMessage(recreated.getQueueUrl(), 1, 30, 1, region);
+        stalePoller.join(9000);
+        assertFalse(stalePoller.isAlive());
+
+        assertEquals(1, fresh.size(),
+                "A receive opened after the recreate must get the new queue's message");
+        assertEquals("for-the-new-queue", fresh.get(0).getBody());
+        assertEquals(1, fresh.get(0).getReceiveCount(),
+                "The delivery to the live receiver must be the first receive (ApproximateReceiveCount = 1)");
+        assertTrue(staleResult.get().isEmpty(),
+                "The pre-delete long poll must not consume the recreated queue's delivery");
     }
 }


### PR DESCRIPTION
Fixes #1282.

**Change:** `receiveMessage` now captures the `GuardedMessageQueue` incarnation it
polls against and, on every poll-loop iteration, finishes with an empty result when
that incarnation is no longer the registered one. `deleteQueue` removes the
incarnation (as before) and now also wakes the queue's parked long polls so they
observe the deletion immediately instead of holding their registration for up to
`WaitTimeSeconds`. Net effect:

- a parked long poll is released (empty response) right when its queue is deleted —
  matching LocalStack's observable behavior, and
- a queue recreated under the same URL starts with a clean waiter registry: polls
  opened against the deleted incarnation can never claim (or burn
  `ApproximateReceiveCount` / redrive budget of) the new queue's messages.

**Tests** (both fail on main, pass with the fix):
- `deleteQueueReleasesParkedLongPoll` — a parked 8 s long poll completes empty within
  2 s of `DeleteQueue` instead of waiting out its window.
- `staleLongPollMustNotConsumeMessagesFromARecreatedQueue` — the exact bug sequence:
  park a long poll → delete → recreate same name → send. The fresh receive gets the
  message with `getReceiveCount()==1`; the stale poll gets nothing. On main this fails
  with the fresh receive empty-handed (the stale waiter consumed the delivery).

**Validation:** wire-level repro (curl, Query protocol) against local images — main:
"fresh receive got NOTHING / stale waiter CONSUMED the new queue's message"; this
branch: "fresh receive GOT message, ApproximateReceiveCount=1 / stale waiter got empty
response (released ~1s after delete)" — byte-for-byte the behavior of
`localstack/localstack:4.14.0` on the same probe (`latest` now requires a license
token, so 4.14.0 was the parity reference). Full `mvn test` suite: failure set
identical to main on the same machine.

**Out of scope:** accounting for deliveries handed to TCP-aborted-but-registered
connections (receive count consumed when a client dies mid-response). That semantics
arguably matches real AWS; with this fix the deleted-queue trigger for it disappears.
Can open a separate discussion issue if useful.

**Downstream:** Cato Networks' cato-events redrive test (`maxReceiveCount=1`,
queue recreate between tests) carries a tagged drain-sleep workaround that gets
deleted once this ships. Same pipeline as #784.
