### PR TITLE
chore(cloudmap): drop redundant native-image init-at-run-time arg

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,7 +44,6 @@ quarkus:
       - --initialize-at-run-time=io.github.hectorvent.floci.services.route53.Route53Service
       - --initialize-at-run-time=io.github.hectorvent.floci.services.kms.KmsService
       - --initialize-at-run-time=io.github.hectorvent.floci.services.cloudfront.CloudFrontService
-      - --initialize-at-run-time=io.github.hectorvent.floci.services.cloudmap.CloudMapService
 
 
 floci:


### PR DESCRIPTION
## Summary

Follow-up cleanup after #1271 and #1289 (both merged).

- #1271 registered `CloudMapService` under `--initialize-at-run-time` to keep its `static final SecureRandom` out of the GraalVM image heap.
- #1289 then made that `SecureRandom` a non-static instance field, so the class no longer holds a build-time random instance at all.

The `--initialize-at-run-time=...CloudMapService` arg is now dead config. This removes it, keeping the native-image arg list limited to classes that genuinely need run-time initialization.

Safe because the static field is already gone: the `NativeImageRuntimeInitializationTest` guard (added by #1271) only requires registration for classes that declare a `static` `Random`/`SecureRandom` field, and `CloudMapService` no longer does — the guard still passes.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No behavior change. Build-config only: removes a redundant GraalVM `--initialize-at-run-time` entry. Runtime behavior of Cloud Map is unaffected.

## Checklist

- [x] `./mvnw test` passes locally (`NativeImageRuntimeInitializationTest`: 1/1)
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- No new test: build-config-only change; covered by the existing NativeImageRuntimeInitializationTest guard from #1271. -->
