### PR TITLE
Add SDK coverage for S3 ranged GetObject

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3Test.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3Test.java
@@ -501,6 +501,36 @@ class S3Test {
         assertInlineTaggingHeaderRejected(huge, 400, "InvalidArgument");
     }
 
+    @Test
+    @Order(33)
+    void getObjectRangeRoundTripsThroughSdk() {
+        String bucket = TestFixtures.uniqueName("range-sdk-bucket");
+        String key = "range.txt";
+        s3.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+        try {
+            s3.putObject(PutObjectRequest.builder()
+                            .bucket(bucket).key(key).build(),
+                    RequestBody.fromString(CONTENT));
+
+            var response = s3.getObjectAsBytes(GetObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .range("bytes=6-13")
+                    .build());
+
+            assertThat(response.asUtf8String()).isEqualTo("from AWS");
+            assertThat(response.response().contentLength()).isEqualTo(8);
+            assertThat(response.response().contentRange()).isEqualTo("bytes 6-13/" + CONTENT.length());
+        } finally {
+            try {
+                s3.deleteObject(DeleteObjectRequest.builder().bucket(bucket).key(key).build());
+            } catch (Exception ignored) {}
+            try {
+                s3.deleteBucket(DeleteBucketRequest.builder().bucket(bucket).build());
+            } catch (Exception ignored) {}
+        }
+    }
+
     private void assertInlineTaggingHeaderRejected(String rawTaggingHeader, int expectedStatus, String expectedErrorCode) {
         String bucket = TestFixtures.uniqueName("inline-tag-reject");
         String key = "rejected.txt";


### PR DESCRIPTION
Adds Java AWS SDK compatibility coverage for ranged S3 GetObject responses. The test verifies the SDK can consume a ranged response and observes the expected body bytes, Content-Length, and Content-Range values.\n\nVerification run locally:\n- ./mvnw -f compatibility-tests/sdk-test-java/pom.xml -DskipTests test-compile\n- ./mvnw test -Dtest=S3IntegrationTest,S3ServiceTest