### PR TITLE
fix(ecs): translate portMappings into Docker PortBindings for bridge mode

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManager.java
@@ -117,7 +117,8 @@ public class EcsContainerManager {
                 boolean publishToHost = !containerDetector.isRunningInContainer();
                 for (PortMapping pm : def.getPortMappings()) {
                     if (publishToHost) {
-                        specBuilder.withDynamicPort(pm.containerPort());
+                        int hostPort = pm.hostPort() > 0 ? pm.hostPort() : pm.containerPort();
+                        specBuilder.withPortBinding(hostPort, pm.containerPort());
                     } else {
                         specBuilder.withExposedPort(pm.containerPort());
                     }


### PR DESCRIPTION
## Problem
Fixes #1270

ECS task portMappings were not being translated into Docker PortBindings
when Floci launches containers in native mode. The container started 
successfully but was unreachable from the host.

## Root Cause
In EcsContainerManager.java, the port mapping loop used withDynamicPort()
which assigns a random host port and ignores the hostPort value defined
in the task definition. The pm.hostPort() value was never passed to Docker.

## Fix
Replaced withDynamicPort() with withPortBinding(containerPort, hostPort),
using the hostPort from the task definition. Falls back to containerPort
if hostPort is 0 (not set).

## Before
docker ps showed: 5000/tcp (no host binding)

## After  
docker ps shows: 0.0.0.0:5000->5000/tcp ✅
