### PR TITLE
fix(athena): 🐛 align GetWorkGroup with AWS behavior

### DIFF
--- a/docs/services/athena.md
+++ b/docs/services/athena.md
@@ -16,6 +16,7 @@ Floci emulates Amazon Athena with **real SQL execution** powered by a [floci-duc
 | `StopQueryExecution` | Cancels a running query |
 | `CreateWorkGroup` | Creates a new workgroup |
 | `GetWorkGroup` | Returns information about a workgroup |
+| `DeleteWorkGroup` | Deletes a workgroup |
 | `ListWorkGroups` | Lists all workgroups |
 
 ## How it works

--- a/src/main/java/io/github/hectorvent/floci/services/athena/AthenaJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/AthenaJsonHandler.java
@@ -66,7 +66,7 @@ public class AthenaJsonHandler {
             }
             case "GetWorkGroup" -> {
                 String name = request.has("WorkGroup") ? request.get("WorkGroup").asText() : "primary";
-                yield Response.ok(Map.of("WorkGroup", athenaService.getWorkGroup(name))).build();
+                yield Response.ok(Map.of("WorkGroup", athenaService.getWorkGroup(name, region))).build();
             }
             case "ListWorkGroups" -> Response.ok(Map.of("WorkGroups", athenaService.listWorkGroups(region))).build();
             case "CreateWorkGroup" -> {
@@ -102,6 +102,7 @@ public class AthenaJsonHandler {
                 if ("primary".equals(wg)) {
                     throw new AwsException("InvalidRequestException", "The primary workgroup cannot be deleted.", 400);
                 }
+                athenaService.deleteWorkGroup(wg, region);
                 yield Response.ok(Map.of()).build();
             }
             default -> throw new AwsException("InvalidAction", "Action " + action + " is not supported", 400);

--- a/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
@@ -149,21 +149,19 @@ public class AthenaService {
         return workGroup;
     }
 
-    public Map<String, Object> getWorkGroup(String name) {
-        return Map.of(
-                "Name", name == null || name.isBlank() ? DEFAULT_WORKGROUP : name,
-                "State", "ENABLED",
-                "Configuration", Map.of(
-                        "EngineVersion", Map.of(
-                                "SelectedEngineVersion", DEFAULT_ENGINE_VERSION,
-                                "EffectiveEngineVersion", DEFAULT_ENGINE_VERSION
-                        ),
-                        "ResultConfiguration", Map.of("OutputLocation", "s3://" + DEFAULT_OUTPUT_BUCKET + "/results/"),
-                        "EnforceWorkGroupConfiguration", false,
-                        "PublishCloudWatchMetricsEnabled", false,
-                        "RequesterPaysEnabled", false
-                )
-        );
+    public Map<String, Object> getWorkGroup(String name, String region) {
+        String resolved = name == null || name.isBlank() ? DEFAULT_WORKGROUP : name;
+        if (DEFAULT_WORKGROUP.equals(resolved)) {
+            return primaryWorkGroupSummary();
+        }
+        WorkGroup workGroup = workGroupStore.get(workGroupKey(region, resolved))
+                .orElseThrow(() -> new AwsException("InvalidRequestException",
+                        "WorkGroup " + resolved + " is not found.", 400));
+        return toWorkGroupDetail(workGroup);
+    }
+
+    public void deleteWorkGroup(String name, String region) {
+        workGroupStore.delete(workGroupKey(region, name));
     }
 
     public List<Map<String, Object>> listWorkGroups(String region) {
@@ -361,6 +359,22 @@ public class AthenaService {
                         "RequesterPaysEnabled", false
                 )
         );
+    }
+
+    private Map<String, Object> toWorkGroupDetail(WorkGroup workGroup) {
+        Map<String, Object> detail = new LinkedHashMap<>();
+        detail.put("Name", workGroup.getName());
+        detail.put("State", workGroup.getState());
+        if (workGroup.getDescription() != null) {
+            detail.put("Description", workGroup.getDescription());
+        }
+        if (workGroup.getCreationTime() != null) {
+            detail.put("CreationTime", workGroup.getCreationTime());
+        }
+        if (workGroup.getConfiguration() != null) {
+            detail.put("Configuration", workGroup.getConfiguration());
+        }
+        return detail;
     }
 
     private Map<String, Object> toWorkGroupSummary(WorkGroup workGroup) {

--- a/src/test/java/io/github/hectorvent/floci/services/athena/AthenaGetWorkGroupIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/athena/AthenaGetWorkGroupIntegrationTest.java
@@ -1,0 +1,136 @@
+package io.github.hectorvent.floci.services.athena;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+@QuarkusTest
+class AthenaGetWorkGroupIntegrationTest {
+
+    private static final String CONTENT_TYPE = "application/x-amz-json-1.1";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void getWorkGroupReturnsPrimaryDefaults() {
+        given()
+            .header("X-Amz-Target", "AmazonAthena.GetWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("{ \"WorkGroup\": \"primary\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("WorkGroup.Name", equalTo("primary"))
+            .body("WorkGroup.State", equalTo("ENABLED"))
+            .body("WorkGroup.Configuration.EngineVersion.EffectiveEngineVersion",
+                    equalTo("Athena engine version 3"));
+    }
+
+    @Test
+    void getWorkGroupReturnsCreatedWorkGroupDetails() {
+        given()
+            .header("X-Amz-Target", "AmazonAthena.CreateWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "Name": "analytics-get",
+                  "Description": "analytics workgroup for reporting queries",
+                  "Configuration": {
+                    "ResultConfiguration": {
+                      "OutputLocation": "s3://test-bucket/athena-results/"
+                    }
+                  }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.GetWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("{ \"WorkGroup\": \"analytics-get\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("WorkGroup.Name", equalTo("analytics-get"))
+            .body("WorkGroup.State", equalTo("ENABLED"))
+            .body("WorkGroup.Description", equalTo("analytics workgroup for reporting queries"))
+            .body("WorkGroup.CreationTime", notNullValue())
+            .body("WorkGroup.Configuration.ResultConfiguration.OutputLocation",
+                    equalTo("s3://test-bucket/athena-results/"))
+            .body("WorkGroup.Configuration.EngineVersion.EffectiveEngineVersion",
+                    equalTo("Athena engine version 3"));
+    }
+
+    @Test
+    void getWorkGroupNotFoundReturnsInvalidRequestException() {
+        given()
+            .header("X-Amz-Target", "AmazonAthena.GetWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("{ \"WorkGroup\": \"athena-workgroup-missing\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidRequestException"))
+            .body("message", equalTo("WorkGroup athena-workgroup-missing is not found."));
+    }
+
+    @Test
+    void deletedWorkGroupIsNoLongerReturnedAndNameCanBeReused() {
+        String createRequest = """
+            {
+              "Name": "analytics-delete-get"
+            }
+            """;
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.CreateWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body(createRequest)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.DeleteWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("{ \"WorkGroup\": \"analytics-delete-get\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.GetWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("{ \"WorkGroup\": \"analytics-delete-get\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidRequestException"));
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.CreateWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body(createRequest)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1128

`GetWorkGroup` previously returned a hardcoded default response for any workgroup name: it ignored everything stored by `CreateWorkGroup` (description, configuration, creation time) and returned `ENABLED` plus default configuration even for workgroups that do not exist.

This PR makes `GetWorkGroup` read real state, scoped by region:

- created workgroups return their stored `Name`, `State`, `Description`, `CreationTime` and `Configuration`
- unknown workgroups return `InvalidRequestException` (400) with the AWS message `WorkGroup <name> is not found.`
- the `primary` workgroup keeps its default view

It also completes `DeleteWorkGroup` (#1127 / PR #1213), which validated input but never removed the entry from the store. This was invisible while `GetWorkGroup` was hardcoded, but it already broke the create -> delete -> recreate cycle (`WorkGroup already exists`). Deletion now actually removes the stored entry while keeping the existing lenient 200 for non-existent names, so all tests added in #1213 still pass unchanged. `DeleteWorkGroup` is also added to the supported actions table in the docs.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: `aws athena get-work-group --work-group <created-wg>` returned default configuration instead of the stored one, and `--work-group <missing-wg>` returned 200 instead of `InvalidRequestException`. Real AWS returns the stored workgroup or fails with `WorkGroup <name> is not found.`

## Checklist

- [x] `./mvnw test` passes locally (all Athena suites pass; the only failing classes are 16 Docker-dependent suites that fail identically on an unmodified `main` checkout on this machine, which has no Docker available)
- [x] New or updated integration test added (`AthenaGetWorkGroupIntegrationTest`, 4 tests)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)