### PR TITLE
fix(sqs): 🐛 report ApproximateNumberOfMessagesDelayed in queue attributes

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
@@ -203,18 +203,25 @@ class GuardedMessageQueue {
         }
     }
 
-    record MessageCounts(long visible, long inFlight) {
+    record MessageCounts(long visible, long inFlight, long delayed) {
     }
 
     MessageCounts messageCounts() {
         try (var _ = hold()) {
             long visible = 0;
             long inFlight = 0;
+            long delayed = 0;
             for (Message m : messages) {
-                if (m.isVisible()) visible++;
-                else inFlight++;
+                if (m.isVisible()) {
+                    visible++;
+                } else if (m.getReceiptHandle() == null) {
+                    // Invisible but never claimed: waiting out its DelaySeconds
+                    delayed++;
+                } else {
+                    inFlight++;
+                }
             }
-            return new MessageCounts(visible, inFlight);
+            return new MessageCounts(visible, inFlight, delayed);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -321,6 +321,7 @@ public class SqsService {
         var counts = getOrCreateQueue(storageKey).messageCounts();
         attrs.put("ApproximateNumberOfMessages", String.valueOf(counts.visible()));
         attrs.put("ApproximateNumberOfMessagesNotVisible", String.valueOf(counts.inFlight()));
+        attrs.put("ApproximateNumberOfMessagesDelayed", String.valueOf(counts.delayed()));
 
         if (attributeNames == null || attributeNames.contains("All")) {
             return attrs;
@@ -839,8 +840,8 @@ public class SqsService {
         }
 
         var srcQueueInitial = getOrCreateQueue(srcKey);
-        long toMove = srcQueueInitial.messageCounts().visible()
-                + srcQueueInitial.messageCounts().inFlight();
+        var srcCounts = srcQueueInitial.messageCounts();
+        long toMove = srcCounts.visible() + srcCounts.inFlight() + srcCounts.delayed();
 
         String taskHandle = "task-" + UUID.randomUUID();
         moveTasksByHandle.put(taskHandle, new MoveTask(

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueueTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueueTest.java
@@ -156,12 +156,34 @@ class GuardedMessageQueueTest {
         var counts = queue.messageCounts();
         assertEquals(3, counts.visible());
         assertEquals(0, counts.inFlight());
+        assertEquals(0, counts.delayed());
 
         queue.claimVisibleMessages(2, 30, false, -1, null);
 
         var afterClaim = queue.messageCounts();
         assertEquals(1, afterClaim.visible());
         assertEquals(2, afterClaim.inFlight());
+        assertEquals(0, afterClaim.delayed());
+    }
+
+    @Test
+    void messageCountsReportsDelayedSeparatelyFromInFlight() {
+        Message delayed = new Message("delayed");
+        delayed.setVisibleAt(java.time.Instant.now().plusSeconds(30));
+        queue.addMessage(delayed);
+        queue.addMessage(new Message("visible"));
+
+        var counts = queue.messageCounts();
+        assertEquals(1, counts.visible());
+        assertEquals(0, counts.inFlight());
+        assertEquals(1, counts.delayed());
+
+        queue.claimVisibleMessages(1, 30, false, -1, null);
+
+        var afterClaim = queue.messageCounts();
+        assertEquals(0, afterClaim.visible());
+        assertEquals(1, afterClaim.inFlight());
+        assertEquals(1, afterClaim.delayed());
     }
 
     // --- FIFO ---

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -225,6 +225,25 @@ class SqsServiceTest {
         assertNotNull(attrs.get("QueueArn"));
         assertNotNull(attrs.get("CreatedTimestamp"));
         assertEquals("1", attrs.get("ApproximateNumberOfMessages"));
+        assertEquals("0", attrs.get("ApproximateNumberOfMessagesNotVisible"));
+        assertEquals("0", attrs.get("ApproximateNumberOfMessagesDelayed"));
+    }
+
+    @Test
+    void getQueueAttributesCountsDelayedMessagesSeparately() {
+        String region = "eu-west-1";
+        Queue queue = sqsService.createQueue("delayed-queue", null, region);
+
+        sqsService.sendMessage(queue.getQueueUrl(), "delayed", 30, region);
+
+        Map<String, String> attrs = sqsService.getQueueAttributes(queue.getQueueUrl(), List.of("All"), region);
+        assertEquals("0", attrs.get("ApproximateNumberOfMessages"));
+        assertEquals("0", attrs.get("ApproximateNumberOfMessagesNotVisible"));
+        assertEquals("1", attrs.get("ApproximateNumberOfMessagesDelayed"));
+
+        Map<String, String> explicit = sqsService.getQueueAttributes(queue.getQueueUrl(),
+                List.of("ApproximateNumberOfMessagesDelayed"), region);
+        assertEquals(Map.of("ApproximateNumberOfMessagesDelayed", "1"), explicit);
     }
 
     // --- FIFO Queue Tests ---


### PR DESCRIPTION
## Summary

Closes #1281

`GetQueueAttributes` never returned `ApproximateNumberOfMessagesDelayed`, neither when requested explicitly nor under `AttributeNames=All`. On top of that, messages waiting out their `DelaySeconds` were counted into `ApproximateNumberOfMessagesNotVisible`, while AWS counts delayed messages only in the Delayed counter (NotVisible is received-and-in-flight only).

Changes:

- `GuardedMessageQueue.messageCounts()` now distinguishes three states: visible, in flight (invisible with a receipt handle, i.e. claimed) and delayed (invisible and never claimed, i.e. waiting out `DelaySeconds`)
- `GetQueueAttributes` always returns `ApproximateNumberOfMessagesDelayed` alongside the other two counters, matching AWS and LocalStack ("0" on a fresh queue, "1" while a message is delayed, back to "0" once visible)
- delayed messages no longer inflate `ApproximateNumberOfMessagesNotVisible`
- the message move task total still includes delayed messages, so redrive counts are unchanged

Both the Query and JSON protocol paths share `SqsService.getQueueAttributes`, so the attribute is returned on both.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: clients reading the standard counter trio (queue drain helpers, test assertions, monitoring) hit NPE / NumberFormatException on the absent `ApproximateNumberOfMessagesDelayed` key, and delayed messages showed up under NotVisible. Real AWS and LocalStack always return all three counters.

## Checklist

- [x] `./mvnw test` passes locally (all SQS suites pass, 141 tests; the only failing classes are 16 Docker-dependent suites that fail identically on an unmodified `main` checkout on this machine, which has no Docker available)
- [x] New or updated integration test added (unit coverage in `GuardedMessageQueueTest` and `SqsServiceTest` for the delayed counter, including the explicit attribute-name filter path)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)