### PR TITLE
refactor: remove unused code

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -367,7 +367,7 @@ public class ApiGatewayExecuteController {
                 if (result.getFunctionError() != null) {
                     return new AuthorizerResult(Response.status(403).build(), null, null);
                 }
-                
+
                 JsonNode policy = objectMapper.readTree(result.getPayload());
                 String effect = policy.path("policyDocument").path("Statement").get(0).path("Effect").asText("Deny");
                 if ("Deny".equalsIgnoreCase(effect)) {

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandler.java
@@ -699,7 +699,6 @@ public class ApiGatewayV2JsonHandler {
      * field lookups work regardless of whether the request arrived via the
      * REST path (lowerCamelCase body) or JSON 1.1 path (PascalCase body).
      */
-    @SuppressWarnings("unchecked")
     private Map<String, Object> toLowerCamelCase(Map<String, Object> map) {
         Map<String, Object> result = new LinkedHashMap<>();
         for (Map.Entry<String, Object> entry : map.entrySet()) {

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -165,7 +165,6 @@ public class AppSyncService {
         if (request.containsKey("openIDConnectConfig")) existing.setOpenIDConnectConfig((Map<String, Object>) request.get("openIDConnectConfig"));
         if (request.containsKey("userPoolConfig")) existing.setUserPoolConfig((Map<String, Object>) request.get("userPoolConfig"));
         if (request.containsKey("dns")) {
-            @SuppressWarnings("unchecked")
             Map<String, String> dns = (Map<String, String>) request.get("dns");
             existing.setDns(dns);
         }
@@ -431,7 +430,6 @@ public class AppSyncService {
         return paginate(functionStore.scan(k -> k.startsWith(apiId + "::")), nextToken, maxResults);
     }
 
-    @SuppressWarnings("unchecked")
     public FunctionConfiguration updateFunction(String apiId, String functionId, Map<String, Object> request) {
         FunctionConfiguration existing = getFunction(apiId, functionId);
         if (request.containsKey("description")) existing.setDescription((String) request.get("description"));

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncDirective.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncDirective.java
@@ -1,7 +1,6 @@
 package io.github.hectorvent.floci.services.appsync.graphql;
 
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public enum AppSyncDirective {
     AWS_API_KEY("aws_api_key", "directive @aws_api_key on OBJECT | FIELD_DEFINITION"),

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncSchemaParser.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncSchemaParser.java
@@ -10,7 +10,6 @@ import io.github.hectorvent.floci.services.appsync.graphql.scalars.AppSyncScalar
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;

--- a/src/main/java/io/github/hectorvent/floci/services/ce/CostExplorerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ce/CostExplorerService.java
@@ -15,8 +15,6 @@ import org.jboss.logging.Logger;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -815,7 +815,6 @@ public class CloudFormationResourceProvisioner {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private static Map<String, String> environmentVariables(Object value) {
         if (!(value instanceof Map<?, ?> envBlock)) {
             return Map.of();

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
@@ -81,7 +81,6 @@ public class CloudFormationService {
                 "cloudformation", "cloudformation-exports.json", new TypeReference<Map<String, String>>() {}));
     }
 
-    @SuppressWarnings("unchecked")
     private static <V> AccountAwareStorageBackend<V> asAccountAware(StorageBackend<String, V> backend) {
         return (AccountAwareStorageBackend<V>) backend;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildJsonHandler.java
@@ -267,7 +267,6 @@ public class CodeBuildJsonHandler {
         return Response.ok(Map.of("build", build)).build();
     }
 
-    @SuppressWarnings("unchecked")
     private <T> List<T> parseList(JsonNode req, String field, Class<T> type) throws Exception {
         if (!req.has(field) || req.get(field).isNull()) {
             return null;

--- a/src/main/java/io/github/hectorvent/floci/services/codedeploy/CodeDeployJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codedeploy/CodeDeployJsonHandler.java
@@ -325,7 +325,6 @@ public class CodeDeployJsonHandler {
         return Response.ok(Map.of()).build();
     }
 
-    @SuppressWarnings("unchecked")
     private Map<String, Object> extractGroupFields(JsonNode req) throws Exception {
         Map<String, Object> fields = new HashMap<>();
         for (String field : new String[]{"ec2TagFilters", "onPremisesInstanceTagFilters", "autoScalingGroups",

--- a/src/main/java/io/github/hectorvent/floci/services/codedeploy/CodeDeployService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codedeploy/CodeDeployService.java
@@ -26,7 +26,6 @@ import org.jboss.logging.Logger;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;

--- a/src/main/java/io/github/hectorvent/floci/services/codedeploy/CodeDeployService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codedeploy/CodeDeployService.java
@@ -585,7 +585,6 @@ public class CodeDeployService {
 
     // ---- Deployment state machine ----
 
-    @SuppressWarnings("unchecked")
     // ---- On-Premises Instances ----
 
     public OnPremisesInstance registerOnPremisesInstance(String region, String instanceName,
@@ -656,7 +655,6 @@ public class CodeDeployService {
 
     // ---- Server Platform Deployment ----
 
-    @SuppressWarnings("unchecked")
     private String createServerDeployment(String region, String appName, String groupName,
                                           DeploymentGroup group, String configName,
                                           Map<String, Object> revision, String description) {
@@ -810,7 +808,6 @@ public class CodeDeployService {
         return true;
     }
 
-    @SuppressWarnings("unchecked")
     private boolean executeHookStepsOnInstance(String region, String instanceId,
                                                List<Map<String, Object>> hookSteps,
                                                Map<String, Object> event) throws InterruptedException {
@@ -910,7 +907,6 @@ public class CodeDeployService {
         return info;
     }
 
-    @SuppressWarnings("unchecked")
     private List<String> resolveServerTargets(String region, DeploymentGroup group) {
         List<String> instanceIds = new ArrayList<>();
 

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoAuthFlowHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoAuthFlowHandler.java
@@ -765,7 +765,6 @@ final class CognitoAuthFlowHandler {
                 Boolean.TRUE.equals(resp.get("autoVerifyPhone")));
     }
 
-    @SuppressWarnings("unchecked")
     private CognitoService.ClaimsOverride firePreTokenGeneration(UserPool pool, UserPoolClient client, CognitoUser user,
                                                                   Map<String, String> clientMetadata, String triggerSource) {
         Map<String, Object> req = new HashMap<>();
@@ -791,7 +790,6 @@ final class CognitoAuthFlowHandler {
         return null;
     }
 
-    @SuppressWarnings("unchecked")
     private static CognitoService.ClaimsOverride parseV1Override(Map<?, ?> details) {
         Map<String, Object> claimsToAddOrOverride = asStringObjectMap(details.get("claimsToAddOrOverride"));
         List<String> claimsToSuppress = asStringList(details.get("claimsToSuppress"));
@@ -817,7 +815,6 @@ final class CognitoAuthFlowHandler {
                 groupsToOverride, iamRolesToOverride, preferredRole);
     }
 
-    @SuppressWarnings("unchecked")
     private static CognitoService.ClaimsOverride parseV2Override(Map<?, ?> details) {
         Map<String, Object> idAdd = null;
         List<String> idSuppress = null;
@@ -879,7 +876,6 @@ final class CognitoAuthFlowHandler {
         return cfg;
     }
 
-    @SuppressWarnings("unchecked")
     private CognitoUser tryUserMigration(UserPool pool, UserPoolClient client, String username, String password,
                                           Map<String, String> validationData, Map<String, String> clientMetadata,
                                           String triggerSource) {

--- a/src/main/java/io/github/hectorvent/floci/services/cur/CurService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cur/CurService.java
@@ -13,7 +13,6 @@ import org.jboss.logging.Logger;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/io/github/hectorvent/floci/services/cur/ParquetEmitter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cur/ParquetEmitter.java
@@ -14,7 +14,6 @@ import org.jboss.logging.Logger;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 /**

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbNumberUtils.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbNumberUtils.java
@@ -7,8 +7,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsException;
 
 import java.math.BigDecimal;
-import java.util.Iterator;
-import java.util.Map;
 
 /**
  * DynamoDB number validation and normalization.

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/ConditionalCheckFailedException.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/ConditionalCheckFailedException.java
@@ -1,9 +1,7 @@
 package io.github.hectorvent.floci.services.dynamodb.model;
 
-import io.github.hectorvent.floci.core.common.AwsException;
 import com.fasterxml.jackson.databind.JsonNode;
 
-import java.util.Map;
 
 public class ConditionalCheckFailedException extends io.github.hectorvent.floci.core.common.AwsException {
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -343,16 +343,16 @@ public class Ec2Service {
 
         return reservation;
     }
-    
+
     public Subnet requireSubnet(String region, String subnetId) {
         ensureDefaultResources(region);
         Subnet subnet = subnets.get(key(region, subnetId));
-        if (subnet == null) 
+        if (subnet == null)
             throw new AwsException("InvalidSubnetID.NotFound", "The subnet ID '" + subnetId + "' does not exist", 400);
 
         return subnet;
     }
-    
+
     private String assignPrivateIp(String region, String subnetId) {
         if (subnetId == null) {
             return "172.31.0." + (10 + new Random().nextInt(200));
@@ -406,7 +406,7 @@ public class Ec2Service {
         List<Map<String, String>> result = new ArrayList<>();
         for (String id : instanceIds) {
             Instance inst = getRequiredInstance(region, id);
-            
+
             if (config.services().ec2().mock() && "pending".equals(inst.getState().getName())) {
                 inst.setState(InstanceState.running());
             }
@@ -437,7 +437,7 @@ public class Ec2Service {
         List<Map<String, String>> result = new ArrayList<>();
         for (String id : instanceIds) {
             Instance inst = getRequiredInstance(region, id);
-            
+
             if (config.services().ec2().mock() && "pending".equals(inst.getState().getName())) {
                 inst.setState(InstanceState.running());
             }
@@ -543,9 +543,9 @@ public class Ec2Service {
 
     private Instance getRequiredInstance(String region, String instanceId) {
         Instance inst = instances.get(key(region, instanceId));
-        if (inst == null) 
+        if (inst == null)
             throw new AwsException("InvalidInstanceID.NotFound", "The instance ID '" + instanceId + "' does not exist", 400);
-        
+
         return inst;
     }
 
@@ -886,7 +886,7 @@ public class Ec2Service {
         SecurityGroup sg = securityGroups.get(key(region, groupId));
         if (sg == null)
             throw new AwsException("InvalidGroup.NotFound", "The security group '" + groupId + "' does not exist", 400);
-        
+
         return sg;
     }
 
@@ -1432,17 +1432,17 @@ public class Ec2Service {
 
     private InternetGateway getRequiredInternetGateway(String region, String igwId) {
         InternetGateway igw = internetGateways.get(key(region, igwId));
-        if (igw == null) 
+        if (igw == null)
             throw new AwsException("InvalidInternetGatewayID.NotFound", "The internet gateway '" + igwId + "' does not exist", 400);
-        
-        return igw; 
+
+        return igw;
     }
 
     // ─── Route Tables ──────────────────────────────────────────────────────────
 
     public RouteTable createRouteTable(String region, String vpcId) {
         ensureDefaultResources(region);
-        Vpc vpc = getRequiredVpc(region, vpcId); 
+        Vpc vpc = getRequiredVpc(region, vpcId);
 
         String rtId = "rtb-" + randomHex(8);
         RouteTable rt = new RouteTable();
@@ -1461,7 +1461,7 @@ public class Ec2Service {
             throw new AwsException("InvalidVpcID.NotFound", "The vpc ID '" + vpcId + "' does not exist", 400);
 
         return vpc;
-    }       
+    }
 
     public List<RouteTable> describeRouteTables(String region, List<String> routeTableIds, Map<String, List<String>> filters) {
         ensureDefaultResources(region);
@@ -1519,9 +1519,9 @@ public class Ec2Service {
 
     private RouteTable getRequiredRouteTable(String region, String routeTableId) {
         RouteTable rt = routeTables.get(key(region, routeTableId));
-        if (rt == null) 
+        if (rt == null)
             throw new AwsException("InvalidRouteTableID.NotFound", "The route table '" + routeTableId + "' does not exist", 400);
-        
+
         return rt;
     }
 
@@ -1610,9 +1610,9 @@ public class Ec2Service {
 
     private Address getRequiredAddress(String region, String allocationId) {
         Address addr = addresses.get(key(region, allocationId));
-        if (addr == null) 
+        if (addr == null)
             throw new AwsException("InvalidAllocationID.NotFound", "The allocation ID '" + allocationId + "' does not exist", 400);
-        
+
         return addr;
     }
 
@@ -1947,7 +1947,6 @@ public class Ec2Service {
         return true;
     }
 
-    @SuppressWarnings("unchecked")
     private List<Tag> getResourceTags(Object resource) {
         if (resource instanceof Instance inst) return inst.getTags();
         if (resource instanceof Vpc vpc) return vpc.getTags();

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -502,13 +502,11 @@ public class LambdaService {
                 @SuppressWarnings("unchecked")
                 Map<String, Object> imageConfig = (Map<String, Object>) ic;
                 if (imageConfig.containsKey("Command")) {
-                    @SuppressWarnings("unchecked")
                     List<String> cmd = imageConfig.get("Command") instanceof List<?>
                             ? ((List<?>) imageConfig.get("Command")).stream().map(Object::toString).toList() : null;
                     fn.setImageConfigCommand(cmd);
                 }
                 if (imageConfig.containsKey("EntryPoint")) {
-                    @SuppressWarnings("unchecked")
                     List<String> ep = imageConfig.get("EntryPoint") instanceof List<?>
                             ? ((List<?>) imageConfig.get("EntryPoint")).stream().map(Object::toString).toList() : null;
                     fn.setImageConfigEntryPoint(ep);
@@ -832,7 +830,7 @@ public class LambdaService {
         snapshot.setEnvironment(fn.getEnvironment());
         snapshot.setLastModified(System.currentTimeMillis());
         snapshot.setRevisionId(UUID.randomUUID().toString());
-        
+
         functionStore.save(region, snapshot);
         LOG.infov("Published version {0} for function {1}", version, functionName);
         return snapshot;
@@ -984,7 +982,7 @@ public class LambdaService {
         functionName = ref.name();
         qualifier = ref.qualifier();
         LambdaUrlConfig urlConfig = getFunctionUrlConfig(region, functionName, qualifier);
-        
+
         if (request.containsKey("AuthType")) {
             urlConfig.setAuthType((String) request.get("AuthType"));
         }

--- a/src/main/java/io/github/hectorvent/floci/services/msk/MskService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/MskService.java
@@ -17,10 +17,8 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.security.SecureRandom;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -70,7 +68,7 @@ public class MskService {
         MskCluster cluster = new MskCluster(clusterArn, clusterName);
         cluster.setAccountId(accountId);
         cluster.setVolumeId(String.format("%06x", new SecureRandom().nextInt(0xFFFFFF)));
-        
+
         if (config.services().msk().mock()) {
             cluster.setState(ClusterState.ACTIVE);
             cluster.setBootstrapBrokers("localhost:9092");

--- a/src/main/java/io/github/hectorvent/floci/services/pipes/PipesPoller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesPoller.java
@@ -224,7 +224,6 @@ public class PipesPoller {
             }
         }
         try {
-            @SuppressWarnings("unchecked")
             Map<String, Object> result = (pipeAccountId != null)
                     ? kinesisService.getRecordsForAccount(pipeAccountId, iterator, batchSize, region)
                     : kinesisService.getRecords(iterator, batchSize, region);
@@ -232,7 +231,6 @@ public class PipesPoller {
             if (nextIterator != null) {
                 kinesisIterators.put(pipeKey, nextIterator);
             }
-            @SuppressWarnings("unchecked")
             List<?> records = (List<?>) result.get("Records");
             if (records == null || records.isEmpty()) {
                 return;

--- a/src/main/java/io/github/hectorvent/floci/services/route53/Route53Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/route53/Route53Controller.java
@@ -30,7 +30,6 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/io/github/hectorvent/floci/services/route53/Route53Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/route53/Route53Service.java
@@ -18,7 +18,6 @@ import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/io/github/hectorvent/floci/services/ssm/SsmCommandService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssm/SsmCommandService.java
@@ -547,7 +547,6 @@ public class SsmCommandService {
         };
     }
 
-    @SuppressWarnings("unchecked")
     private Map<String, List<String>> parseParameters(JsonNode parametersNode) {
         if (parametersNode == null || parametersNode.isNull() || !parametersNode.isObject()) {
             return Map.of();

--- a/src/main/java/io/github/hectorvent/floci/services/transcribe/TranscribeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/transcribe/TranscribeService.java
@@ -9,7 +9,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**

--- a/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceMetadataComparisonTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceMetadataComparisonTest.java
@@ -17,13 +17,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for metadata loading and comparison in TlsConfigSource.
- * 
- * Tests the hostnameConfigChanged() method to verify:
- * - Returns true when metadata file doesn't exist
- * - Returns true when hostnames have changed
- * - Returns false when hostnames are the same (order-independent)
- * - Handles read/parse failures gracefully (returns true)
- * - Proper logging for different scenarios
+ *
+ * Tests the hostnameConfigChanged() method to verify: - Returns true when metadata file doesn't
+ * exist - Returns true when hostnames have changed - Returns false when hostnames are the same
+ * (order-independent) - Handles read/parse failures gracefully (returns true) - Proper logging for
+ * different scenarios
  */
 class TlsConfigSourceMetadataComparisonTest {
 
@@ -67,11 +65,11 @@ class TlsConfigSourceMetadataComparisonTest {
         // Arrange
         Path tlsDir = tempDir.resolve("tls");
         Files.createDirectories(tlsDir);
-        
+
         // Create metadata with old hostnames
         List<String> oldHostnames = List.of("localhost", "127.0.0.1", "oldhost");
         createMetadataFile(tlsDir, oldHostnames);
-        
+
         // Current hostnames are different
         List<String> currentHostnames = List.of("localhost", "127.0.0.1", "newhost");
 
@@ -87,11 +85,11 @@ class TlsConfigSourceMetadataComparisonTest {
         // Arrange
         Path tlsDir = tempDir.resolve("tls");
         Files.createDirectories(tlsDir);
-        
+
         // Create metadata with hostnames
         List<String> hostnames = List.of("localhost", "127.0.0.1", "myhost");
         createMetadataFile(tlsDir, hostnames);
-        
+
         // Current hostnames are the same
         List<String> currentHostnames = List.of("localhost", "127.0.0.1", "myhost");
 
@@ -107,11 +105,11 @@ class TlsConfigSourceMetadataComparisonTest {
         // Arrange
         Path tlsDir = tempDir.resolve("tls");
         Files.createDirectories(tlsDir);
-        
+
         // Create metadata with hostnames in one order
         List<String> hostnames = List.of("localhost", "myhost", "127.0.0.1");
         createMetadataFile(tlsDir, hostnames);
-        
+
         // Current hostnames in different order
         List<String> currentHostnames = List.of("127.0.0.1", "localhost", "myhost");
 
@@ -127,11 +125,11 @@ class TlsConfigSourceMetadataComparisonTest {
         // Arrange
         Path tlsDir = tempDir.resolve("tls");
         Files.createDirectories(tlsDir);
-        
+
         // Create metadata with fewer hostnames
         List<String> oldHostnames = List.of("localhost", "127.0.0.1");
         createMetadataFile(tlsDir, oldHostnames);
-        
+
         // Current hostnames include an additional hostname
         List<String> currentHostnames = List.of("localhost", "127.0.0.1", "newhost");
 
@@ -147,11 +145,11 @@ class TlsConfigSourceMetadataComparisonTest {
         // Arrange
         Path tlsDir = tempDir.resolve("tls");
         Files.createDirectories(tlsDir);
-        
+
         // Create metadata with more hostnames
         List<String> oldHostnames = List.of("localhost", "127.0.0.1", "oldhost");
         createMetadataFile(tlsDir, oldHostnames);
-        
+
         // Current hostnames have one removed
         List<String> currentHostnames = List.of("localhost", "127.0.0.1");
 
@@ -167,11 +165,11 @@ class TlsConfigSourceMetadataComparisonTest {
         // Arrange
         Path tlsDir = tempDir.resolve("tls");
         Files.createDirectories(tlsDir);
-        
+
         // Create malformed metadata file
         Path metadataFile = tlsDir.resolve("floci-selfsigned.metadata.json");
         Files.writeString(metadataFile, "{ invalid json }");
-        
+
         List<String> currentHostnames = List.of("localhost", "127.0.0.1");
 
         // Act
@@ -186,12 +184,12 @@ class TlsConfigSourceMetadataComparisonTest {
         // Arrange
         Path tlsDir = tempDir.resolve("tls");
         Files.createDirectories(tlsDir);
-        
+
         // Create metadata with null hostnames field
         Path metadataFile = tlsDir.resolve("floci-selfsigned.metadata.json");
         String json = "{\"generatedAt\":\"" + Instant.now().toString() + "\",\"flociVersion\":\"dev\"}";
         Files.writeString(metadataFile, json);
-        
+
         List<String> currentHostnames = List.of("localhost", "127.0.0.1");
 
         // Act
@@ -206,11 +204,11 @@ class TlsConfigSourceMetadataComparisonTest {
         // Arrange
         Path tlsDir = tempDir.resolve("tls");
         Files.createDirectories(tlsDir);
-        
+
         // Create metadata with empty hostnames list
         List<String> emptyHostnames = List.of();
         createMetadataFile(tlsDir, emptyHostnames);
-        
+
         // Current hostnames are also empty
         List<String> currentHostnames = List.of();
 
@@ -227,22 +225,21 @@ class TlsConfigSourceMetadataComparisonTest {
     private void createMetadataFile(Path tlsDir, List<String> hostnames) throws IOException {
         Path metadataFile = tlsDir.resolve("floci-selfsigned.metadata.json");
         CertificateMetadata metadata = CertificateMetadata.create(hostnames, "dev");
-        
+
         ObjectMapper objectMapper = new ObjectMapper();
         String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(metadata);
         Files.writeString(metadataFile, json);
     }
 
     /**
-     * Helper method to invoke the private hostnameConfigChanged() method via reflection.
-     * We need to disable TLS temporarily to avoid certificate generation in the constructor.
+     * Helper method to invoke the private hostnameConfigChanged() method via reflection. We need to
+     * disable TLS temporarily to avoid certificate generation in the constructor.
      */
-    @SuppressWarnings("unchecked")
     private boolean invokeHostnameConfigChanged(Path tlsDir, List<String> currentHostnames) throws Exception {
         // Temporarily disable TLS to avoid certificate generation in constructor
         String originalTlsEnabled = System.getProperty("floci.tls.enabled");
         System.setProperty("floci.tls.enabled", "false");
-        
+
         try {
             TlsConfigSource configSource = new TlsConfigSource();
             Method method = TlsConfigSource.class.getDeclaredMethod("hostnameConfigChanged", Path.class, List.class);

--- a/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceMetadataPersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceMetadataPersistenceTest.java
@@ -9,13 +9,12 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for metadata persistence in TlsConfigSource.
- * 
+ *
  * Tests that metadata is correctly persisted after certificate generation:
  * - Metadata file is created
  * - Metadata contains correct hostnames
@@ -55,7 +54,7 @@ class TlsConfigSourceMetadataPersistenceTest {
 
         // Assert
         Path metadataFile = tempDir.resolve("tls/floci-selfsigned.metadata.json");
-        assertTrue(Files.exists(metadataFile), 
+        assertTrue(Files.exists(metadataFile),
             "Metadata file should be created after certificate generation");
     }
 
@@ -70,19 +69,19 @@ class TlsConfigSourceMetadataPersistenceTest {
         // Assert
         Path metadataFile = tempDir.resolve("tls/floci-selfsigned.metadata.json");
         CertificateMetadata metadata = readMetadata(metadataFile);
-        
+
         assertNotNull(metadata.getHostnames(), "Hostnames should not be null");
-        assertTrue(metadata.getHostnames().contains("localhost"), 
+        assertTrue(metadata.getHostnames().contains("localhost"),
             "Metadata should contain 'localhost'");
-        assertTrue(metadata.getHostnames().contains("127.0.0.1"), 
+        assertTrue(metadata.getHostnames().contains("127.0.0.1"),
             "Metadata should contain '127.0.0.1'");
-        assertTrue(metadata.getHostnames().contains("0.0.0.0"), 
+        assertTrue(metadata.getHostnames().contains("0.0.0.0"),
             "Metadata should contain '0.0.0.0'");
-        assertTrue(metadata.getHostnames().contains("*.localhost"), 
+        assertTrue(metadata.getHostnames().contains("*.localhost"),
             "Metadata should contain '*.localhost'");
-        assertTrue(metadata.getHostnames().contains("localhost.floci.io"), 
+        assertTrue(metadata.getHostnames().contains("localhost.floci.io"),
             "Metadata should contain 'localhost.floci.io'");
-        assertTrue(metadata.getHostnames().contains("*.localhost.floci.io"), 
+        assertTrue(metadata.getHostnames().contains("*.localhost.floci.io"),
             "Metadata should contain '*.localhost.floci.io'");
     }
 
@@ -100,8 +99,8 @@ class TlsConfigSourceMetadataPersistenceTest {
         // Assert
         Path metadataFile = tempDir.resolve("tls/floci-selfsigned.metadata.json");
         CertificateMetadata metadata = readMetadata(metadataFile);
-        
-        assertTrue(metadata.getHostnames().contains("floci"), 
+
+        assertTrue(metadata.getHostnames().contains("floci"),
             "Metadata should contain custom hostname 'floci'");
     }
 
@@ -119,8 +118,8 @@ class TlsConfigSourceMetadataPersistenceTest {
         // Assert
         Path metadataFile = tempDir.resolve("tls/floci-selfsigned.metadata.json");
         CertificateMetadata metadata = readMetadata(metadataFile);
-        
-        assertTrue(metadata.getHostnames().contains("myhost"), 
+
+        assertTrue(metadata.getHostnames().contains("myhost"),
             "Metadata should contain hostname 'myhost' from base URL");
     }
 
@@ -139,10 +138,10 @@ class TlsConfigSourceMetadataPersistenceTest {
         // Assert
         Path metadataFile = tempDir.resolve("tls/floci-selfsigned.metadata.json");
         CertificateMetadata metadata = readMetadata(metadataFile);
-        
-        assertTrue(metadata.getHostnames().contains("newhost"), 
+
+        assertTrue(metadata.getHostnames().contains("newhost"),
             "Metadata should contain 'newhost' from FLOCI_HOSTNAME");
-        assertTrue(metadata.getHostnames().contains("oldhost"), 
+        assertTrue(metadata.getHostnames().contains("oldhost"),
             "Metadata should contain 'oldhost' from FLOCI_BASE_URL");
     }
 
@@ -157,10 +156,10 @@ class TlsConfigSourceMetadataPersistenceTest {
         // Assert
         Path metadataFile = tempDir.resolve("tls/floci-selfsigned.metadata.json");
         CertificateMetadata metadata = readMetadata(metadataFile);
-        
-        assertNotNull(metadata.getGeneratedAt(), 
+
+        assertNotNull(metadata.getGeneratedAt(),
             "Metadata should contain generatedAt timestamp");
-        assertFalse(metadata.getGeneratedAt().isBlank(), 
+        assertFalse(metadata.getGeneratedAt().isBlank(),
             "Timestamp should not be blank");
     }
 
@@ -175,10 +174,10 @@ class TlsConfigSourceMetadataPersistenceTest {
         // Assert
         Path metadataFile = tempDir.resolve("tls/floci-selfsigned.metadata.json");
         CertificateMetadata metadata = readMetadata(metadataFile);
-        
-        assertNotNull(metadata.getFlociVersion(), 
+
+        assertNotNull(metadata.getFlociVersion(),
             "Metadata should contain flociVersion");
-        assertEquals("dev", metadata.getFlociVersion(), 
+        assertEquals("dev", metadata.getFlociVersion(),
             "Version should default to 'dev' when FLOCI_VERSION not set");
     }
 
@@ -190,15 +189,15 @@ class TlsConfigSourceMetadataPersistenceTest {
         // Arrange
         // Note: We can't set environment variables in Java, so we'll test the default behavior
         // The actual environment variable handling is tested in integration tests
-        
+
         // Act
         new TlsConfigSource();
 
         // Assert
         Path metadataFile = tempDir.resolve("tls/floci-selfsigned.metadata.json");
         CertificateMetadata metadata = readMetadata(metadataFile);
-        
-        assertNotNull(metadata.getFlociVersion(), 
+
+        assertNotNull(metadata.getFlociVersion(),
             "Metadata should contain flociVersion");
     }
 
@@ -213,7 +212,7 @@ class TlsConfigSourceMetadataPersistenceTest {
         // Assert
         Path metadataFile = tempDir.resolve("tls/floci-selfsigned.metadata.json");
         String json = Files.readString(metadataFile);
-        
+
         assertFalse(json.isBlank(), "Metadata file should not be empty");
         assertTrue(json.contains("hostnames"), "JSON should contain 'hostnames' field");
         assertTrue(json.contains("generatedAt"), "JSON should contain 'generatedAt' field");

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/PortAllocatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/PortAllocatorTest.java
@@ -3,7 +3,6 @@ package io.github.hectorvent.floci.core.common.docker;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/proxy/HttpProxyInvokerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/proxy/HttpProxyInvokerTest.java
@@ -1,7 +1,6 @@
 package io.github.hectorvent.floci.services.apigatewayv2.proxy;
 
 import com.sun.net.httpserver.Headers;
-import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import io.github.hectorvent.floci.services.apigatewayv2.model.Integration;
 import org.junit.jupiter.api.AfterEach;
@@ -11,9 +10,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandlerTest.java
@@ -8,13 +8,11 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.ReservedTags;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
-import io.github.hectorvent.floci.services.cognito.model.UserPool;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.Spliterators;
 import java.util.stream.Collectors;
@@ -95,7 +93,7 @@ class CognitoJsonHandlerTest {
         assertEquals("test-pool", pool.get("Name").asText());
         assertTrue(pool.get("Arn").asText().contains("arn:aws:cognito-idp:us-east-1:000000000000:userpool/"));
         assertEquals("Enabled", pool.get("Status").asText());
-        
+
         // Check mandatory blocks for Terraform
         assertNotNull(pool.get("SchemaAttributes"));
         assertEquals(20, pool.get("SchemaAttributes").size(),

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
@@ -680,7 +680,6 @@ class CognitoServiceTest {
     // =========================================================================
 
     @Test
-    @SuppressWarnings("unchecked")
     void adminSetUserPasswordPermanentFalseChangesPassword() {
         UserPool pool = createPoolAndUser(); // alice has permanent "Perm1234!"
         UserPoolClient client = service.createUserPoolClient(pool.getId(), "c", false, false, List.of(), List.of());
@@ -1097,7 +1096,6 @@ class CognitoServiceTest {
         String session2 = (String) retryResult.get("Session");
 
         // Eventually correct answer issues tokens
-        @SuppressWarnings("unchecked")
         Map<String, Object> tokenResult = service.respondToAuthChallenge(
                 client.getClientId(), "CUSTOM_CHALLENGE", session2,
                 Map.of("USERNAME", "alice", "ANSWER", "secret-otp"));

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoStandardAttributesTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoStandardAttributesTest.java
@@ -2,7 +2,6 @@ package io.github.hectorvent.floci.services.cognito;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbExportIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbExportIntegrationTest.java
@@ -10,7 +10,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 import java.io.BufferedReader;
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.zip.GZIPInputStream;
 
 import static io.restassured.RestAssured.given;

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbStreamServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbStreamServiceTest.java
@@ -1,19 +1,15 @@
 package io.github.hectorvent.floci.services.dynamodb;
 
-import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.services.dynamodb.model.AttributeDefinition;
 import io.github.hectorvent.floci.services.dynamodb.model.KeySchemaElement;
 import io.github.hectorvent.floci.services.dynamodb.model.StreamDescription;
 import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -34,8 +30,8 @@ class DynamoDbStreamServiceTest {
     }
 
     private TableDefinition createTestTableWithStream() {
-        var tableDef = new TableDefinition("TestTable", 
-                List.of(new KeySchemaElement("userId", "HASH")),
+        var tableDef = new TableDefinition("TestTable",
+                        List.of(new KeySchemaElement("userId", "HASH")),
                 List.of(new AttributeDefinition("userId", "S")),
                 "us-east-1", "000000000000");
         tableDef.setStreamEnabled(true);

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisServiceTest.java
@@ -90,7 +90,6 @@ class KinesisServiceTest {
                 "TRIM_HORIZON", null, REGION);
         Map<String, Object> result = kinesisService.getRecords(iterator, 10, REGION);
 
-        @SuppressWarnings("unchecked")
         var records = (List<?>) result.get("Records");
         assertEquals(1, records.size());
     }
@@ -104,7 +103,6 @@ class KinesisServiceTest {
         String iterator = kinesisService.getShardIterator("my-stream", shardId, "LATEST", null, REGION);
         Map<String, Object> result = kinesisService.getRecords(iterator, 10, REGION);
 
-        @SuppressWarnings("unchecked")
         var records = (List<?>) result.get("Records");
         assertTrue(records.isEmpty());
         assertEquals(0L, ((Number) result.get("MillisBehindLatest")).longValue());
@@ -132,7 +130,6 @@ class KinesisServiceTest {
 
         Map<String, Object> result = kinesisService.getRecords(iterator, 10, REGION);
 
-        @SuppressWarnings("unchecked")
         var records = (List<?>) result.get("Records");
         assertEquals(2, records.size());
         assertEquals(0L, ((Number) result.get("MillisBehindLatest")).longValue());
@@ -157,7 +154,6 @@ class KinesisServiceTest {
 
         Map<String, Object> result = kinesisService.getRecords(iterator, 2, REGION);
 
-        @SuppressWarnings("unchecked")
         var returned = (List<?>) result.get("Records");
         assertEquals(2, returned.size());
         // Last returned = records[1] at +1500ms, tip = records[2] at +4000ms, delta = 2500ms

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaS3CodeIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaS3CodeIntegrationTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import java.io.ByteArrayOutputStream;
-import java.util.Base64;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsLambdaIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsLambdaIntegrationTest.java
@@ -3,9 +3,6 @@ package io.github.hectorvent.floci.services.sns;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 
@@ -16,7 +13,7 @@ class SnsLambdaIntegrationTest {
     void publish_toLambdaSubscriber() {
         // 1. Create a Lambda function using the REST API (skipping code to bypass validation)
         String functionName = "sns-subscriber-fn";
-        
+
         String lambdaRequest = String.format(
             "{\"FunctionName\":\"%s\",\"Runtime\":\"nodejs18.x\",\"Handler\":\"index.handler\",\"Role\":\"arn:aws:iam::000000000000:role/lambda-role\"}",
             functionName
@@ -68,7 +65,7 @@ class SnsLambdaIntegrationTest {
         .then()
             .statusCode(200)
             .body(containsString("<MessageId>"));
-        
+
         // Note: Actual invocation check would require mocking the Docker/Executor,
         // but here we just want to see if it reaches the delivery logic without crashing.
     }

--- a/src/test/java/io/github/hectorvent/floci/testutil/IamServiceTestHelper.java
+++ b/src/test/java/io/github/hectorvent/floci/testutil/IamServiceTestHelper.java
@@ -13,7 +13,6 @@ public final class IamServiceTestHelper {
     private IamServiceTestHelper() {
     }
 
-    @SuppressWarnings("unchecked")
     public static IamService iamServiceWithAccessKey(String accessKeyId, String secretAccessKey) {
         try {
             Constructor<IamService> constructor = IamService.class.getDeclaredConstructor(


### PR DESCRIPTION
## Summary

Remove unused imports, unnecessary `@SuppressWarnings("unchecked")` annotations, an unused constructor injection, and dead test references across the codebase. This PR also includes minor formatting cleanup. No behavior change is intended.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No wire-protocol behavior change. This PR only removes unused code, unnecessary warning suppressions, and minor formatting noise.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Local ./mvnw test is currently failing because of #1304, which is unrelated to the changes in this unused cleanup PR.