### PR TITLE
fix(ec2): avoid mixed-type matcher in route table integration test

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -1,7 +1,6 @@
 package io.github.hectorvent.floci.services.ec2;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
@@ -375,8 +374,7 @@ class Ec2IntegrationTest {
         .then()
             .statusCode(200)
             .body("DescribeRouteTablesResponse.routeTableSet.item.vpcId", equalTo(vpcId))
-            .body("DescribeRouteTablesResponse.routeTableSet.item.associationSet.item.main",
-                anyOf(equalTo(true), equalTo("true")));
+            .body(containsString("<main>true</main>"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes a mixed-type Hamcrest matcher in `Ec2IntegrationTest.describeCreatedVpcMainRouteTable` by asserting the XML response body directly.

This removes a compilation issue exposed during cleanup without changing EC2 runtime behavior.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The previous test used `anyOf(equalTo(true), equalTo("true"))`, which relied on mixed matcher types and caused a compilation failure.

The updated assertion checks for `<main>true</main>` in the EC2 XML response, preserving the intended AWS-compatible expectation for the main route table association.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)