### PR TITLE
fix(ses): persist inline options on v2 CreateConfigurationSet

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -1280,9 +1280,11 @@ public class SesController {
      * structure only; reason values are validated by the service layer.
      * Structural violations reproduce the AWS deserialization-layer errors
      * (verified against real AWS SES V2 on 2026-06-13): a non-array node and
-     * non-string elements fail with {@code SerializationException}. Missing /
-     * null yields an empty list for the PUT path, which AWS treats as an
-     * explicit empty override.
+     * non-string scalar / container elements fail with
+     * {@code SerializationException}, while {@code null} elements pass
+     * deserialization and are rejected by the service-layer value validation,
+     * exactly as AWS does. Missing / null yields an empty list for the PUT
+     * path, which AWS treats as an explicit empty override.
      */
     private static List<String> parseSuppressedReasons(JsonNode reasonsNode) {
         List<String> reasons = new ArrayList<>();

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -613,26 +613,23 @@ public class SesController {
             JsonNode suppressionNode = request.path("SuppressionOptions");
             if (!suppressionNode.isMissingNode() && !suppressionNode.isNull()) {
                 if (!suppressionNode.isObject()) {
-                    throw new AwsException("BadRequestException",
-                            "SuppressionOptions must be an object.", 400);
+                    throw new AwsException("SerializationException", "Expected null", 400);
+                }
+                JsonNode reasonsNode = suppressionNode.path("SuppressedReasons");
+                if (reasonsNode.isMissingNode() || reasonsNode.isNull()) {
+                    throw new AwsException("InternalFailure",
+                            "An internal failure has occurred.", 500);
                 }
                 SuppressionOptions options = new SuppressionOptions();
-                options.setSuppressedReasons(
-                        parseSuppressedReasons(suppressionNode.path("SuppressedReasons")));
+                options.setSuppressedReasons(parseSuppressedReasons(reasonsNode));
                 cs.setSuppressionOptions(options);
             }
             JsonNode sendingNode = request.path("SendingOptions");
             if (!sendingNode.isMissingNode() && !sendingNode.isNull()) {
                 if (!sendingNode.isObject()) {
-                    throw new AwsException("BadRequestException",
-                            "SendingOptions must be an object.", 400);
+                    throw new AwsException("SerializationException", "Expected null", 400);
                 }
-                JsonNode enabledNode = sendingNode.path("SendingEnabled");
-                if (enabledNode.isMissingNode() || enabledNode.isNull() || !enabledNode.isBoolean()) {
-                    throw new AwsException("BadRequestException",
-                            "SendingEnabled must be present and must be a boolean.", 400);
-                }
-                cs.setSendingEnabled(enabledNode.booleanValue());
+                cs.setSendingEnabled(parseSendingEnabled(sendingNode.path("SendingEnabled")));
             }
             sesService.createConfigurationSet(cs, region);
             LOG.infov("SES V2 CreateConfigurationSet: {0}", name);
@@ -1280,26 +1277,71 @@ public class SesController {
 
     /**
      * Parses a {@code SuppressedReasons} JSON array into a list, validating
-     * structure only (array of strings); reason values are validated by the
-     * service layer. Missing / null yields an empty list, which AWS treats as
-     * an explicit empty override.
+     * structure only; reason values are validated by the service layer.
+     * Structural violations reproduce the AWS deserialization-layer errors
+     * (verified against real AWS SES V2 on 2026-06-13): a non-array node and
+     * non-string elements fail with {@code SerializationException}. Missing /
+     * null yields an empty list for the PUT path, which AWS treats as an
+     * explicit empty override.
      */
     private static List<String> parseSuppressedReasons(JsonNode reasonsNode) {
         List<String> reasons = new ArrayList<>();
         if (!reasonsNode.isMissingNode() && !reasonsNode.isNull()) {
             if (!reasonsNode.isArray()) {
-                throw new AwsException("BadRequestException",
-                        "SuppressedReasons must be an array.", 400);
+                throw new AwsException("SerializationException", "Expected list or null", 400);
             }
             for (JsonNode r : reasonsNode) {
-                if (r.isNull() || !r.isTextual()) {
-                    throw new AwsException("BadRequestException",
-                            "SuppressedReasons entries must be strings.", 400);
+                if (r.isTextual() || r.isNull()) {
+                    reasons.add(r.asText(null));
+                } else if (r.isNumber()) {
+                    throw new AwsException("SerializationException",
+                            "NUMBER_VALUE can not be converted to a String", 400);
+                } else if (r.isBoolean()) {
+                    throw new AwsException("SerializationException",
+                            (r.booleanValue() ? "TRUE_VALUE" : "FALSE_VALUE")
+                                    + " can not be converted to a String", 400);
+                } else {
+                    throw unexpectedStartError(r);
                 }
-                reasons.add(r.asText());
             }
         }
         return reasons;
+    }
+
+    /**
+     * Reproduces the AWS deserialization behavior for {@code SendingEnabled}
+     * (verified against real AWS SES V2 on 2026-06-13): a missing member
+     * defaults to {@code false}, any string coerces to {@code true}, and
+     * explicit {@code null} or non-boolean scalars fail with
+     * {@code SerializationException}.
+     */
+    private static boolean parseSendingEnabled(JsonNode enabledNode) {
+        if (enabledNode.isMissingNode()) {
+            return false;
+        }
+        if (enabledNode.isBoolean()) {
+            return enabledNode.booleanValue();
+        }
+        if (enabledNode.isTextual()) {
+            return true;
+        }
+        if (enabledNode.isNull()) {
+            throw new AwsException("SerializationException", null, 400);
+        }
+        if (enabledNode.isNumber()) {
+            throw new AwsException("SerializationException",
+                    "NUMBER_VALUE can not be converted to a Boolean", 400);
+        }
+        throw unexpectedStartError(enabledNode);
+    }
+
+    private static AwsException unexpectedStartError(JsonNode node) {
+        if (node.isArray()) {
+            return new AwsException("SerializationException",
+                    "Start of list found where not expected", 400);
+        }
+        return new AwsException("SerializationException",
+                "Start of structure or map found where not expected.", 400);
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -12,6 +12,7 @@ import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.MessageHeader;
 import io.github.hectorvent.floci.services.ses.model.MessageTag;
 import io.github.hectorvent.floci.services.ses.model.SuppressedDestination;
+import io.github.hectorvent.floci.services.ses.model.SuppressionOptions;
 import io.github.hectorvent.floci.services.ses.model.Tag;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -609,6 +610,30 @@ public class SesController {
             if (parsedTags != null) {
                 cs.setTags(parsedTags);
             }
+            JsonNode suppressionNode = request.path("SuppressionOptions");
+            if (!suppressionNode.isMissingNode() && !suppressionNode.isNull()) {
+                if (!suppressionNode.isObject()) {
+                    throw new AwsException("BadRequestException",
+                            "SuppressionOptions must be an object.", 400);
+                }
+                SuppressionOptions options = new SuppressionOptions();
+                options.setSuppressedReasons(
+                        parseSuppressedReasons(suppressionNode.path("SuppressedReasons")));
+                cs.setSuppressionOptions(options);
+            }
+            JsonNode sendingNode = request.path("SendingOptions");
+            if (!sendingNode.isMissingNode() && !sendingNode.isNull()) {
+                if (!sendingNode.isObject()) {
+                    throw new AwsException("BadRequestException",
+                            "SendingOptions must be an object.", 400);
+                }
+                JsonNode enabledNode = sendingNode.path("SendingEnabled");
+                if (enabledNode.isMissingNode() || enabledNode.isNull() || !enabledNode.isBoolean()) {
+                    throw new AwsException("BadRequestException",
+                            "SendingEnabled must be present and must be a boolean.", 400);
+                }
+                cs.setSendingEnabled(enabledNode.booleanValue());
+            }
             sesService.createConfigurationSet(cs, region);
             LOG.infov("SES V2 CreateConfigurationSet: {0}", name);
             return Response.ok(objectMapper.createObjectNode()).build();
@@ -674,21 +699,7 @@ public class SesController {
                     ? objectMapper.createObjectNode()
                     : objectMapper.readTree(body);
             requireJsonObject(request);
-            JsonNode reasonsNode = request.path("SuppressedReasons");
-            List<String> reasons = new ArrayList<>();
-            if (!reasonsNode.isMissingNode() && !reasonsNode.isNull()) {
-                if (!reasonsNode.isArray()) {
-                    throw new AwsException("BadRequestException",
-                            "SuppressedReasons must be an array.", 400);
-                }
-                for (JsonNode r : reasonsNode) {
-                    if (r.isNull() || !r.isTextual()) {
-                        throw new AwsException("BadRequestException",
-                                "SuppressedReasons entries must be strings.", 400);
-                    }
-                    reasons.add(r.asText());
-                }
-            }
+            List<String> reasons = parseSuppressedReasons(request.path("SuppressedReasons"));
             sesService.putConfigurationSetSuppressionOptions(name, reasons, region);
             LOG.infov("SES V2 PutConfigurationSetSuppressionOptions: {0} on {1}", reasons, name);
             return Response.ok(objectMapper.createObjectNode()).build();
@@ -1265,6 +1276,30 @@ public class SesController {
                     t.path("Value").asText(null)));
         }
         return out;
+    }
+
+    /**
+     * Parses a {@code SuppressedReasons} JSON array into a list, validating
+     * structure only (array of strings); reason values are validated by the
+     * service layer. Missing / null yields an empty list, which AWS treats as
+     * an explicit empty override.
+     */
+    private static List<String> parseSuppressedReasons(JsonNode reasonsNode) {
+        List<String> reasons = new ArrayList<>();
+        if (!reasonsNode.isMissingNode() && !reasonsNode.isNull()) {
+            if (!reasonsNode.isArray()) {
+                throw new AwsException("BadRequestException",
+                        "SuppressedReasons must be an array.", 400);
+            }
+            for (JsonNode r : reasonsNode) {
+                if (r.isNull() || !r.isTextual()) {
+                    throw new AwsException("BadRequestException",
+                            "SuppressedReasons entries must be strings.", 400);
+                }
+                reasons.add(r.asText());
+            }
+        }
+        return reasons;
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -626,6 +626,12 @@ public class SesService {
                 validateTag(tag);
             }
         }
+        if (configSet.getSuppressionOptions() != null
+                && configSet.getSuppressionOptions().getSuppressedReasons() != null) {
+            for (String reason : configSet.getSuppressionOptions().getSuppressedReasons()) {
+                validateConfigSetSuppressionReason(reason);
+            }
+        }
         if (configSetStore.get(key).isPresent()) {
             throw new AwsException("ConfigurationSetAlreadyExists",
                     "Configuration set " + configSet.getName() + " already exists.", 400);

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -630,7 +630,8 @@ public class SesService {
                 && configSet.getSuppressionOptions().getSuppressedReasons() != null) {
             for (String reason : configSet.getSuppressionOptions().getSuppressedReasons()) {
                 if (reason == null) {
-                    validateConfigSetSuppressionReason(reason);
+                    throw new AwsException("BadRequestException",
+                            invalidSuppressionReasonMessage(null), 400);
                 }
                 if (!isValidConfigSetSuppressionReason(reason)) {
                     throw new AwsException("BadRequestException",
@@ -1360,12 +1361,16 @@ public class SesService {
     private static void validateConfigSetSuppressionReason(String reason) {
         if (!isValidConfigSetSuppressionReason(reason)) {
             throw new AwsException("BadRequestException",
-                    "Reason " + reason + " is invalid, must be one of [BOUNCE, COMPLAINT].", 400);
+                    invalidSuppressionReasonMessage(reason), 400);
         }
     }
 
     private static boolean isValidConfigSetSuppressionReason(String reason) {
         return "BOUNCE".equals(reason) || "COMPLAINT".equals(reason);
+    }
+
+    private static String invalidSuppressionReasonMessage(String reason) {
+        return "Reason " + reason + " is invalid, must be one of [BOUNCE, COMPLAINT].";
     }
 
     static void validateTag(Tag tag) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -629,7 +629,14 @@ public class SesService {
         if (configSet.getSuppressionOptions() != null
                 && configSet.getSuppressionOptions().getSuppressedReasons() != null) {
             for (String reason : configSet.getSuppressionOptions().getSuppressedReasons()) {
-                validateConfigSetSuppressionReason(reason);
+                if (!isValidConfigSetSuppressionReason(reason)) {
+                    throw new AwsException("BadRequestException",
+                            "1 validation error detected: Value at "
+                                    + "'suppressionOptions.suppressedReasons' failed to satisfy "
+                                    + "constraint: Member must satisfy constraint: "
+                                    + "[Member must satisfy enum value set: [BOUNCE, COMPLAINT]]",
+                            400);
+                }
             }
         }
         if (configSetStore.get(key).isPresent()) {
@@ -1342,13 +1349,19 @@ public class SesService {
      * V2 SES uses a different, simpler natural-language sentence on this
      * endpoint than on the three older suppression APIs above:
      *   "Reason <X> is invalid, must be one of [BOUNCE, COMPLAINT]."
-     * (Verified against real AWS V2 SES on 2026-06-03.)
+     * (Verified against real AWS V2 SES on 2026-06-03.) CreateConfigurationSet
+     * instead reports the constraint-style validation message; see
+     * {@link #createConfigurationSet}.
      */
     private static void validateConfigSetSuppressionReason(String reason) {
-        if (reason == null || (!"BOUNCE".equals(reason) && !"COMPLAINT".equals(reason))) {
+        if (!isValidConfigSetSuppressionReason(reason)) {
             throw new AwsException("BadRequestException",
                     "Reason " + reason + " is invalid, must be one of [BOUNCE, COMPLAINT].", 400);
         }
+    }
+
+    private static boolean isValidConfigSetSuppressionReason(String reason) {
+        return "BOUNCE".equals(reason) || "COMPLAINT".equals(reason);
     }
 
     static void validateTag(Tag tag) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -629,6 +629,9 @@ public class SesService {
         if (configSet.getSuppressionOptions() != null
                 && configSet.getSuppressionOptions().getSuppressedReasons() != null) {
             for (String reason : configSet.getSuppressionOptions().getSuppressedReasons()) {
+                if (reason == null) {
+                    validateConfigSetSuppressionReason(reason);
+                }
                 if (!isValidConfigSetSuppressionReason(reason)) {
                     throw new AwsException("BadRequestException",
                             "1 validation error detected: Value at "
@@ -1350,8 +1353,9 @@ public class SesService {
      * endpoint than on the three older suppression APIs above:
      *   "Reason <X> is invalid, must be one of [BOUNCE, COMPLAINT]."
      * (Verified against real AWS V2 SES on 2026-06-03.) CreateConfigurationSet
-     * instead reports the constraint-style validation message; see
-     * {@link #createConfigurationSet}.
+     * reports the constraint-style validation message for invalid non-null
+     * values but falls back to this sentence for null elements, matching AWS
+     * (verified 2026-06-13); see {@link #createConfigurationSet}.
      */
     private static void validateConfigSetSuppressionReason(String reason) {
         if (!isValidConfigSetSuppressionReason(reason)) {

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV2IntegrationTest.java
@@ -625,4 +625,43 @@ class SesConfigurationSetV2IntegrationTest {
             .body("__type", equalTo("SerializationException"))
             .body("message", equalTo("FALSE_VALUE can not be converted to a String"));
     }
+
+    @Test
+    @Order(28)
+    void createConfigurationSet_nonObjectOptionBlocks_serializationError() {
+        // "Expected null" looks odd but is the verbatim AWS response for a
+        // non-object option block (verified against real AWS SES V2 on
+        // 2026-06-13).
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "ConfigurationSetName": "v2-cs-string-suppression",
+                  "SuppressionOptions": "nope"
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("SerializationException"))
+            .body("message", equalTo("Expected null"));
+
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "ConfigurationSetName": "v2-cs-string-options",
+                  "SendingOptions": "nope"
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("SerializationException"))
+            .body("message", equalTo("Expected null"));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV2IntegrationTest.java
@@ -573,4 +573,56 @@ class SesConfigurationSetV2IntegrationTest {
             .statusCode(200)
             .body("SuppressionOptions.SuppressedReasons", hasSize(0));
     }
+
+    @Test
+    @Order(26)
+    void createConfigurationSet_nullSuppressedReason_rejectedWithPutStyleMessage() {
+        // A null element passes AWS deserialization ("Expected list or null")
+        // and fails value validation with the natural-language sentence, not
+        // the constraint-style message used for invalid non-null values
+        // (verified against real AWS SES V2 on 2026-06-13).
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "ConfigurationSetName": "v2-cs-null-reason",
+                  "SuppressionOptions": {"SuppressedReasons": ["BOUNCE", null]}
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("Reason null is invalid, must be one of [BOUNCE, COMPLAINT]."));
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/configuration-sets/v2-cs-null-reason")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(27)
+    void createConfigurationSet_booleanSuppressedReason_serializationError() {
+        // Verified against real AWS SES V2 on 2026-06-13.
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "ConfigurationSetName": "v2-cs-boolean-reason",
+                  "SuppressionOptions": {"SuppressedReasons": [false]}
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("SerializationException"))
+            .body("message", equalTo("FALSE_VALUE can not be converted to a String"));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV2IntegrationTest.java
@@ -320,4 +320,82 @@ class SesConfigurationSetV2IntegrationTest {
             .body("Tags.find { it.Key == 'team' }.Value", equalTo("platform"))
             .body("Tags.find { it.Key == 'env' }.Value", equalTo("stg"));
     }
+
+    @Test
+    @Order(17)
+    void createConfigurationSet_inlineOptions_echoedOnGet() {
+        // AWS echoes inline options set at create time verbatim
+        // (verified against real AWS SES V2 on 2026-06-12).
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "ConfigurationSetName": "v2-cs-inline-options",
+                  "SendingOptions": {"SendingEnabled": false},
+                  "SuppressionOptions": {"SuppressedReasons": ["BOUNCE"]}
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/configuration-sets/v2-cs-inline-options")
+        .then()
+            .statusCode(200)
+            .body("SendingOptions.SendingEnabled", equalTo(false))
+            .body("SuppressionOptions.SuppressedReasons", hasSize(1))
+            .body("SuppressionOptions.SuppressedReasons", hasItem("BOUNCE"));
+    }
+
+    @Test
+    @Order(18)
+    void createConfigurationSet_invalidSuppressionReason_rejectedWithoutCreating() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "ConfigurationSetName": "v2-cs-bad-reason",
+                  "SuppressionOptions": {"SuppressedReasons": ["INVALID"]}
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+
+        // Validation happens before the store write, so the set must not exist.
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/configuration-sets/v2-cs-bad-reason")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"));
+    }
+
+    @Test
+    @Order(19)
+    void createConfigurationSet_nonBooleanSendingEnabled_rejected() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "ConfigurationSetName": "v2-cs-bad-sending",
+                  "SendingOptions": {"SendingEnabled": "yes"}
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV2IntegrationTest.java
@@ -355,6 +355,10 @@ class SesConfigurationSetV2IntegrationTest {
     @Test
     @Order(18)
     void createConfigurationSet_invalidSuppressionReason_rejectedWithoutCreating() {
+        // Unlike PutConfigurationSetSuppressionOptions, AWS reports the
+        // constraint-style validation message on this endpoint, even for
+        // multiple invalid values (verified against real AWS SES V2 on
+        // 2026-06-13).
         given()
             .contentType("application/json")
             .header("Authorization", AUTH_HEADER)
@@ -368,7 +372,11 @@ class SesConfigurationSetV2IntegrationTest {
             .post("/v2/email/configuration-sets")
         .then()
             .statusCode(400)
-            .body("__type", equalTo("BadRequestException"));
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("1 validation error detected: Value at "
+                    + "'suppressionOptions.suppressedReasons' failed to satisfy constraint: "
+                    + "Member must satisfy constraint: "
+                    + "[Member must satisfy enum value set: [BOUNCE, COMPLAINT]]"));
 
         // Validation happens before the store write, so the set must not exist.
         given()
@@ -382,20 +390,187 @@ class SesConfigurationSetV2IntegrationTest {
 
     @Test
     @Order(19)
-    void createConfigurationSet_nonBooleanSendingEnabled_rejected() {
+    void createConfigurationSet_stringSendingEnabled_coercesToTrue() {
+        // AWS accepts any string for SendingEnabled and stores true
+        // (verified against real AWS SES V2 on 2026-06-13).
         given()
             .contentType("application/json")
             .header("Authorization", AUTH_HEADER)
             .body("""
                 {
-                  "ConfigurationSetName": "v2-cs-bad-sending",
+                  "ConfigurationSetName": "v2-cs-string-sending",
                   "SendingOptions": {"SendingEnabled": "yes"}
                 }
                 """)
         .when()
             .post("/v2/email/configuration-sets")
         .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/configuration-sets/v2-cs-string-sending")
+        .then()
+            .statusCode(200)
+            .body("SendingOptions.SendingEnabled", equalTo(true));
+    }
+
+    @Test
+    @Order(20)
+    void createConfigurationSet_emptySendingOptions_defaultsToFalse() {
+        // AWS treats a missing SendingEnabled member inside a present
+        // SendingOptions block as false, unlike a fully absent block which
+        // defaults to true (verified against real AWS SES V2 on 2026-06-13).
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "ConfigurationSetName": "v2-cs-empty-sending",
+                  "SendingOptions": {}
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/configuration-sets/v2-cs-empty-sending")
+        .then()
+            .statusCode(200)
+            .body("SendingOptions.SendingEnabled", equalTo(false));
+    }
+
+    @Test
+    @Order(21)
+    void createConfigurationSet_nullSendingEnabled_serializationError() {
+        // Explicit null fails AWS deserialization with a null message and the
+        // set is not created (verified against real AWS SES V2 on 2026-06-13).
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "ConfigurationSetName": "v2-cs-null-sending",
+                  "SendingOptions": {"SendingEnabled": null}
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
             .statusCode(400)
-            .body("__type", equalTo("BadRequestException"));
+            .body("__type", equalTo("SerializationException"));
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/configuration-sets/v2-cs-null-sending")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(22)
+    void createConfigurationSet_numberSendingEnabled_serializationError() {
+        // Verified against real AWS SES V2 on 2026-06-13.
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "ConfigurationSetName": "v2-cs-number-sending",
+                  "SendingOptions": {"SendingEnabled": 1}
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("SerializationException"))
+            .body("message", equalTo("NUMBER_VALUE can not be converted to a Boolean"));
+    }
+
+    @Test
+    @Order(23)
+    void createConfigurationSet_missingSuppressedReasons_internalFailure() {
+        // AWS itself returns 500 InternalFailure when SuppressionOptions is
+        // present without SuppressedReasons, and the set is not created;
+        // reproduced faithfully (verified against real AWS SES V2 on
+        // 2026-06-13).
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "ConfigurationSetName": "v2-cs-empty-suppression",
+                  "SuppressionOptions": {}
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(500)
+            .body("__type", equalTo("InternalFailure"))
+            .body("message", equalTo("An internal failure has occurred."));
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/configuration-sets/v2-cs-empty-suppression")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(24)
+    void createConfigurationSet_nonArraySuppressedReasons_serializationError() {
+        // Verified against real AWS SES V2 on 2026-06-13.
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "ConfigurationSetName": "v2-cs-string-reasons",
+                  "SuppressionOptions": {"SuppressedReasons": "BOUNCE"}
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("SerializationException"))
+            .body("message", equalTo("Expected list or null"));
+    }
+
+    @Test
+    @Order(25)
+    void createConfigurationSet_emptySuppressedReasonsList_echoedOnGet() {
+        // An explicit empty list is stored and echoed as-is
+        // (verified against real AWS SES V2 on 2026-06-13).
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "ConfigurationSetName": "v2-cs-empty-reasons",
+                  "SuppressionOptions": {"SuppressedReasons": []}
+                }
+                """)
+        .when()
+            .post("/v2/email/configuration-sets")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/configuration-sets/v2-cs-empty-reasons")
+        .then()
+            .statusCode(200)
+            .body("SuppressionOptions.SuppressedReasons", hasSize(0));
     }
 }


### PR DESCRIPTION
## Summary

SES v2 `CreateConfigurationSet` parsed only `ConfigurationSetName` and `Tags`, silently dropping the `SendingOptions` and `SuppressionOptions` blocks. `GetConfigurationSet` then fabricated a default `SendingOptions` (`SendingEnabled: true` via the null-means-enabled effective getter), so a set created with `SendingEnabled: false` read back as `true`, and `SuppressedReasons` vanished entirely.

- The controller now parses both blocks onto the `ConfigurationSet` before the single store write, so they persist atomically and round-trip through `GetConfigurationSet`
- Malformed inputs reproduce AWS's two error layers (verified against real AWS SES v2, 2026-06-13): type violations fail with `SerializationException` in the deserialization layer (`Expected null`, `Expected list or null`, token-style messages such as `NUMBER_VALUE can not be converted to a String`), value violations fail with `BadRequestException` using the constraint-style message (`1 validation error detected: ...`) — except null elements, which AWS rejects with the same natural-language sentence the PUT endpoint uses
- `SendingEnabled` follows AWS deserialization semantics: missing inside a present `SendingOptions` block → `false`, any string → `true`, explicit `null` → `SerializationException` with a null message
- `SuppressionOptions` without `SuppressedReasons` reproduces the `500 InternalFailure` AWS itself returns, so code developed against Floci fails the same way it would in production
- `SuppressedReasons` structural parsing is shared with `PutConfigurationSetSuppressionOptions` via a common helper
- The remaining five inline option groups (Tracking / Delivery / Reputation / Vdm / Archiving) have no model fields or endpoints yet and stay out of scope

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** options passed inline at create time were dropped; `GetConfigurationSet` returned `SendingEnabled: true` for a set created with `false`, and omitted `SuppressionOptions` that the create request specified.

**Expected (AWS) behavior:** verified against real AWS SES v2 (2026-06-12/13): `GetConfigurationSet` echoes the inline `SendingOptions` / `SuppressionOptions` set at create time verbatim, and malformed inputs are rejected by AWS's deserialization layer (`SerializationException`) or validation layer (`BadRequestException`) with the set left uncreated.

**Fixed behavior:** both blocks persist atomically at create and round-trip through `GetConfigurationSet`; error types, messages, and status codes match the live-verified AWS responses, including the `500 InternalFailure` for `SuppressionOptions` without `SuppressedReasons`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)