### PR TITLE
fix(ec2): embed image catalog in native image and load it lazily

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ImageCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ImageCatalog.java
@@ -22,36 +22,60 @@ public class Ec2ImageCatalog {
     private static final String CATALOG_RESOURCE_NAME = "ec2/image-catalog.yaml";
     private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
 
-    private final String defaultDockerImage;
-    private final List<CatalogImage> images;
-    private final Map<String, CatalogImage> imagesByIdOrAlias;
+    private volatile Loaded loaded;
 
     public Ec2ImageCatalog() {
-        this(readResource(CATALOG_RESOURCE_NAME, Catalog.class));
+        // The catalog is parsed lazily on first access rather than at bean
+        // construction. Mock mode never reads it, so eager loading would fail
+        // EC2 bean creation needlessly when the resource is unavailable.
     }
 
     Ec2ImageCatalog(Catalog catalog) {
-        this.defaultDockerImage = require(catalog.defaultDockerImage, "defaultDockerImage");
-        this.images = List.copyOf(catalog.images == null ? List.of() : catalog.images);
-        if (this.images.isEmpty()) {
-            throw new IllegalStateException("EC2 image catalog has no images: " + CATALOG_RESOURCE_NAME);
-        }
-        this.imagesByIdOrAlias = indexImages(this.images);
+        this.loaded = new Loaded(catalog);
     }
 
     public String defaultDockerImage() {
-        return defaultDockerImage;
+        return loaded().defaultDockerImage;
     }
 
     public List<CatalogImage> images() {
-        return images;
+        return loaded().images;
     }
 
     public Optional<CatalogImage> findByIdOrAlias(String imageId) {
         if (imageId == null || imageId.isBlank()) {
             return Optional.empty();
         }
-        return Optional.ofNullable(imagesByIdOrAlias.get(imageId));
+        return Optional.ofNullable(loaded().imagesByIdOrAlias.get(imageId));
+    }
+
+    private Loaded loaded() {
+        Loaded result = loaded;
+        if (result == null) {
+            synchronized (this) {
+                result = loaded;
+                if (result == null) {
+                    result = new Loaded(readResource(CATALOG_RESOURCE_NAME, Catalog.class));
+                    loaded = result;
+                }
+            }
+        }
+        return result;
+    }
+
+    private static final class Loaded {
+        private final String defaultDockerImage;
+        private final List<CatalogImage> images;
+        private final Map<String, CatalogImage> imagesByIdOrAlias;
+
+        Loaded(Catalog catalog) {
+            this.defaultDockerImage = require(catalog.defaultDockerImage, "defaultDockerImage");
+            this.images = List.copyOf(catalog.images == null ? List.of() : catalog.images);
+            if (this.images.isEmpty()) {
+                throw new IllegalStateException("EC2 image catalog has no images: " + CATALOG_RESOURCE_NAME);
+            }
+            this.imagesByIdOrAlias = indexImages(this.images);
+        }
     }
 
     private static <T> T readResource(String resourceName, Class<T> type) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,11 +19,12 @@ quarkus:
     delay-enabled: true
   native:
     resources:
-      # The Pricing service reads its bundled snapshot at runtime via
+      # The Pricing service reads its bundled snapshot, and EC2 reads its image
+      # catalog (ec2/image-catalog.yaml), at runtime via
       # ClassLoader#getResourceAsStream. Quarkus's static resource analysis
-      # cannot detect dynamically-built paths, so the tree is registered
+      # cannot detect these dynamically-built paths, so they are registered
       # explicitly to ensure GraalVM includes every file in the native image.
-      includes: pricing-snapshots/**
+      includes: pricing-snapshots/**,ec2/*.yaml
     additional-build-args:
       - --report-unsupported-elements-at-runtime
       - --allow-incomplete-classpath


### PR DESCRIPTION
## Summary

RunInstances returned 500 on the native image (regression in 1.5.24, #1252) because `ec2/image-catalog.yaml` was not embedded in the binary — the app-local `META-INF/native-image/resource-config.json` pattern is not reliably honored by Quarkus' native build, so `getResourceAsStream` returned null at runtime.

This registers the catalog via `quarkus.native.resources.includes` (mirroring the existing `pricing-snapshots/**` entry, which solves the identical problem), and makes `Ec2ImageCatalog` load lazily instead of in its constructor so a missing or unparseable resource no longer fails EC2 bean creation — which also keeps mock mode  `FLOCI_SERVICES_EC2_MOCK=true`) working, since it never reads the catalog.

Closes #1296 (and the duplicate #1298)

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: `RunInstances` on the published native `floci/floci:1.5.24`
returned `500 Internal Server Error` with `IllegalStateException: Missing EC2 image catalog resource: ec2/image-catalog.yaml` (reproduced against digest `sha256:5f83026…`); the same call returned a normal `RunInstancesResponse` on 1.5.23. The fix restores the 200 response. The bug is native-only — the JVM build loads the classpath resource fine — so the embedding fix is verified by the native CI build.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits
