### PR TITLE
fix(ses): keep MailFromAttributes block when MAIL FROM is unconfigured

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -1080,12 +1080,12 @@ public class SesController {
 
         result.set("DkimAttributes", buildDkimAttributes(identity));
 
+        ObjectNode mailFromAttributes = result.putObject("MailFromAttributes");
+        mailFromAttributes.put("BehaviorOnMxFailure", v1BehaviorToV2(identity.getBehaviorOnMxFailure()));
         String mailFromDomain = identity.getMailFromDomain();
         if (mailFromDomain != null && !mailFromDomain.isEmpty()) {
-            ObjectNode mailFromAttributes = result.putObject("MailFromAttributes");
             mailFromAttributes.put("MailFromDomain", mailFromDomain);
             mailFromAttributes.put("MailFromDomainStatus", toV2Status(identity.getMailFromDomainStatus()));
-            mailFromAttributes.put("BehaviorOnMxFailure", v1BehaviorToV2(identity.getBehaviorOnMxFailure()));
         }
 
         result.putObject("Policies");

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -474,7 +474,9 @@ public class SesService {
                         "Identity <" + identityValue + "> does not exist.", 400));
         identity.setMailFromDomain(clearing ? null : mailFromDomain);
         identity.setMailFromDomainStatus(clearing ? "Pending" : "Success");
-        if (normalizedBehavior != null) {
+        if (clearing) {
+            identity.setBehaviorOnMxFailure("UseDefaultValue");
+        } else if (normalizedBehavior != null) {
             identity.setBehaviorOnMxFailure(normalizedBehavior);
         }
         identityStore.put(key, identity);

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesIdentityAttributesV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesIdentityAttributesV2IntegrationTest.java
@@ -32,14 +32,18 @@ class SesIdentityAttributesV2IntegrationTest {
         .then()
             .statusCode(200);
 
-        // Verify MailFromAttributes is omitted by default
+        // With no MAIL FROM domain configured, AWS keeps the MailFromAttributes
+        // block carrying only BehaviorOnMxFailure and omits the inner
+        // MailFromDomain / MailFromDomainStatus fields.
         given()
             .header("Authorization", AUTH_HEADER)
         .when()
             .get("/v2/email/identities/v2-attrs.floci.test")
         .then()
             .statusCode(200)
-            .body("MailFromAttributes", nullValue());
+            .body("MailFromAttributes.BehaviorOnMxFailure", equalTo("USE_DEFAULT_VALUE"))
+            .body("MailFromAttributes.MailFromDomain", nullValue())
+            .body("MailFromAttributes.MailFromDomainStatus", nullValue());
     }
 
     @Test
@@ -88,13 +92,18 @@ class SesIdentityAttributesV2IntegrationTest {
         .then()
             .statusCode(200);
 
+        // Clearing the MAIL FROM domain returns to the unconfigured shape:
+        // the block stays, BehaviorOnMxFailure resets to USE_DEFAULT_VALUE,
+        // and the inner domain / status fields drop out.
         given()
             .header("Authorization", AUTH_HEADER)
         .when()
             .get("/v2/email/identities/v2-attrs.floci.test")
         .then()
             .statusCode(200)
-            .body("MailFromAttributes", nullValue());
+            .body("MailFromAttributes.BehaviorOnMxFailure", equalTo("USE_DEFAULT_VALUE"))
+            .body("MailFromAttributes.MailFromDomain", nullValue())
+            .body("MailFromAttributes.MailFromDomainStatus", nullValue());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
@@ -1189,7 +1189,9 @@ class SesV2IntegrationTest {
             .body("DkimAttributes", notNullValue())
             .body("DkimAttributes.SigningEnabled", notNullValue())
             .body("DkimAttributes.Status", notNullValue())
-            .body("MailFromAttributes", nullValue())
+            .body("MailFromAttributes.BehaviorOnMxFailure", equalTo("USE_DEFAULT_VALUE"))
+            .body("MailFromAttributes.MailFromDomain", nullValue())
+            .body("MailFromAttributes.MailFromDomainStatus", nullValue())
             .body("Policies", notNullValue())
             .body("Tags", notNullValue());
     }


### PR DESCRIPTION
## Summary

Closes #1245.

`GetEmailIdentity` dropped the entire `MailFromAttributes` block for an identity with no MAIL FROM domain configured, so an AWS SDK caller saw `mailFromAttributes() == null` against the emulator but non-null against real AWS. This regressed after #1273, which followed the (later-corrected) original suggestion in #1245 to omit the whole block.

- `buildFullIdentityResponse` now always emits the `MailFromAttributes` block carrying `BehaviorOnMxFailure`, and adds the inner `MailFromDomain` / `MailFromDomainStatus` fields only when a MAIL FROM domain is configured
- Clearing the MAIL FROM domain resets `BehaviorOnMxFailure` to `UseDefaultValue`, so a cleared identity is indistinguishable from one that was never configured
- Integration tests assert the block-present / inner-fields-absent shape for the unconfigured, configured, and cleared cases

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** for an identity with no MAIL FROM domain configured, `GetEmailIdentity` omitted the whole `MailFromAttributes` block, so the field was absent in the response.

**Expected (AWS) behavior:** verified against real AWS SES v2 across the fresh, configured, and cleared states. AWS keeps the `MailFromAttributes` block carrying `BehaviorOnMxFailure` and omits only the inner `MailFromDomain` / `MailFromDomainStatus` fields; clearing the domain resets `BehaviorOnMxFailure` to `USE_DEFAULT_VALUE`:

```json
{ "BehaviorOnMxFailure": "USE_DEFAULT_VALUE" }
```

**Fixed behavior:** the block is always present with `BehaviorOnMxFailure`; the inner domain/status fields appear only when configured, and a cleared identity returns to the unconfigured shape.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)