### PR TITLE
test(elbv2): use two subnets so ALB tests satisfy the two-AZ rule

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
@@ -39,6 +39,7 @@ class ElbV2IntegrationTest {
                 .formParam("Scheme", "internet-facing")
                 .formParam("IpAddressType", "ipv4")
                 .formParam("Subnets.member.1", "subnet-default-a")
+                .formParam("Subnets.member.2", "subnet-default-b")
                 .header("Authorization", AUTH)
             .when()
                 .post("/")
@@ -54,7 +55,7 @@ class ElbV2IntegrationTest {
                 .body("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.State.Code",
                         equalTo("provisioning"))
                 .body("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.AvailabilityZones.member.SubnetId",
-                        equalTo("subnet-default-a"))
+                        hasItems("subnet-default-a", "subnet-default-b"))
                 .body("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.DNSName",
                         containsString(".elb.localhost"))
                 .extract()
@@ -77,7 +78,7 @@ class ElbV2IntegrationTest {
                 .body("DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancers.member.State.Code",
                         equalTo("active"))
                 .body("DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancers.member.AvailabilityZones.member.SubnetId",
-                        equalTo("subnet-default-a"));
+                        hasItems("subnet-default-a", "subnet-default-b"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2ServiceTest.java
@@ -44,6 +44,9 @@ class ElbV2ServiceTest {
 
     private static final String REGION = "us-west-2";
 
+    // Application Load Balancers require subnets in at least two Availability Zones.
+    private static final List<String> ALB_SUBNETS = List.of("subnet-a", "subnet-b");
+
     @Mock
     ElbV2DataPlane dataPlane;
 
@@ -62,14 +65,14 @@ class ElbV2ServiceTest {
         service.healthChecker = healthChecker;
         service.regionResolver = new RegionResolver(REGION, "000000000000");
         service.ec2Service = ec2Service;
-        stubSubnet(ec2Service, "subnet-a", REGION + "a");
+        stubAlbSubnets(ec2Service);
     }
 
     @Test
     void modifyListenerDefaultActionsRecompilesRulesWithoutRestartingListener() {
         String lbArn = service.createLoadBalancer(
                 REGION, "sample-lb", "internal", "application", "ipv4",
-                List.of("subnet-a"), List.of("sg-a"), Map.of()).getLoadBalancerArn();
+                ALB_SUBNETS, List.of("sg-a"), Map.of()).getLoadBalancerArn();
         String oldTgArn = createTargetGroup("sample-old-tg");
         String newTgArn = createTargetGroup("sample-new-tg");
         String listenerArn = service.createListener(
@@ -103,7 +106,7 @@ class ElbV2ServiceTest {
     void modifyListenerPortRestartsListener() {
         String lbArn = service.createLoadBalancer(
                 REGION, "sample-lb", "internal", "application", "ipv4",
-                List.of("subnet-a"), List.of("sg-a"), Map.of()).getLoadBalancerArn();
+                ALB_SUBNETS, List.of("sg-a"), Map.of()).getLoadBalancerArn();
         String tgArn = createTargetGroup("sample-tg");
         String listenerArn = service.createListener(
                 REGION, lbArn, "HTTP", 9999, null, List.of(),
@@ -125,7 +128,7 @@ class ElbV2ServiceTest {
         ElbV2Service first = serviceWithStorage(storageFactory, firstDataPlane, firstHealthChecker);
         String lbArn = first.createLoadBalancer(
                 REGION, "persisted-lb", "internal", "application", "ipv4",
-                List.of("subnet-a"), List.of("sg-a"), Map.of("owner", "platform")).getLoadBalancerArn();
+                ALB_SUBNETS, List.of("sg-a"), Map.of("owner", "platform")).getLoadBalancerArn();
         String tgArn = first.createTargetGroup(
                 REGION, "persisted-tg", "HTTP", "HTTP1", 8080, "vpc-a", "instance",
                 "HTTP", "traffic-port", true, "/health", 15, 5, 3, 2, "200",
@@ -179,7 +182,7 @@ class ElbV2ServiceTest {
         ElbV2Service first = serviceWithStorage(storageFactory, mock(ElbV2DataPlane.class), mock(ElbV2HealthChecker.class));
         String lbArn = first.createLoadBalancer(
                 REGION, "listener-only-lb", "internal", "application", "ipv4",
-                List.of("subnet-a"), List.of("sg-a"), Map.of()).getLoadBalancerArn();
+                ALB_SUBNETS, List.of("sg-a"), Map.of()).getLoadBalancerArn();
         String listenerArn = first.createListener(
                 REGION, lbArn, "HTTP", 8080, null, List.of(),
                 List.of(), List.of(), Map.of()).getListenerArn();
@@ -218,7 +221,7 @@ class ElbV2ServiceTest {
                                                    ElbV2DataPlane dataPlane,
                                                    ElbV2HealthChecker healthChecker) {
         Ec2Service ec2Service = mock(Ec2Service.class);
-        stubSubnet(ec2Service, "subnet-a", REGION + "a");
+        stubAlbSubnets(ec2Service);
         return serviceWithStorage(storageFactory, dataPlane, healthChecker, ec2Service);
     }
 
@@ -236,14 +239,21 @@ class ElbV2ServiceTest {
         return service;
     }
 
-    private static void stubSubnet(Ec2Service ec2Service, String subnetId, String availabilityZone) {
+    private static void stubAlbSubnets(Ec2Service ec2Service) {
+        Subnet subnetA = subnet("subnet-a", REGION + "a");
+        Subnet subnetB = subnet("subnet-b", REGION + "b");
+        lenient().when(ec2Service.requireSubnet(REGION, "subnet-a")).thenReturn(subnetA);
+        lenient().when(ec2Service.requireSubnet(REGION, "subnet-b")).thenReturn(subnetB);
+        lenient().when(ec2Service.describeSubnets(eq(REGION), eq(ALB_SUBNETS), eq(Map.of())))
+                .thenReturn(List.of(subnetA, subnetB));
+    }
+
+    private static Subnet subnet(String subnetId, String availabilityZone) {
         Subnet subnet = new Subnet();
         subnet.setSubnetId(subnetId);
         subnet.setAvailabilityZone(availabilityZone);
         subnet.setVpcId("vpc-a");
-        lenient().when(ec2Service.requireSubnet(REGION, subnetId)).thenReturn(subnet);
-        lenient().when(ec2Service.describeSubnets(eq(REGION), eq(List.of(subnetId)), eq(Map.of())))
-                .thenReturn(List.of(subnet));
+        return subnet;
     }
 
     private static final class SharedStorageFactory extends StorageFactory {


### PR DESCRIPTION
## Summary

`#1247` made `CreateLoadBalancer` reject Application Load Balancers attached to
fewer than two Availability Zones, but the ELB v2 tests still created ALBs with a
single subnet — leaving `ElbV2ServiceTest` red on `main` (4 errors:
`Application Load Balancers must be attached to subnets in at least two
Availability Zones`).

This updates both ELB v2 test classes to create ALBs with **two subnets in two
AZs** and asserts both appear in the returned `AvailabilityZones` members,
aligning the coverage with the now-enforced AWS behavior and restoring a green
build.

Test-only change — no service code is modified.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore  <!-- test-only (`test:`) -->

## AWS Compatibility

Matches real AWS: an ALB must span ≥2 AZs, and `CreateLoadBalancer` /
`DescribeLoadBalancers` echo every provided subnet as an `AvailabilityZones`
member with the matching `SubnetId`. Exercised at the wire level (RestAssured
Query endpoint) and at the service level (`ElbV2ServiceTest`).

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits
