### PR TITLE
fix(cognito): 🐛 include USERNAME in SRP PASSWORD_VERIFIER challenge

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoAuthFlowHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoAuthFlowHandler.java
@@ -348,6 +348,7 @@ final class CognitoAuthFlowHandler {
                 "SALT", user.getSrpSalt(),
                 "SRP_B", bPublicHex,
                 "SECRET_BLOCK", secretBlockBase64,
+                "USERNAME", user.getUsername(),
                 "USER_ID_FOR_SRP", user.getUsername()
         ));
         return result;

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
@@ -720,6 +720,9 @@ class CognitoServiceTest {
         assertNotNull(params.get("SRP_B"));
         assertNotNull(params.get("SECRET_BLOCK"));
         assertEquals("bob", params.get("USER_ID_FOR_SRP"));
+        // Real AWS Cognito returns USERNAME alongside USER_ID_FOR_SRP; the .NET
+        // Amazon.Extensions.CognitoAuthentication SRP client requires it (issue #1305).
+        assertEquals("bob", params.get("USERNAME"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #1305

`InitiateAuth` with `USER_SRP_AUTH` returns a `PASSWORD_VERIFIER` challenge whose `ChallengeParameters` included `USER_ID_FOR_SRP` but **not** `USERNAME`. Real AWS Cognito returns both keys.

The .NET `Amazon.Extensions.CognitoAuthentication` / `Amazon.AspNetCore.Identity.Cognito` SRP client reads `ChallengeParameters["USERNAME"]` when building the password-verifier response, so it failed against floci with:

```
System.Collections.Generic.KeyNotFoundException: The given key 'USERNAME' was not present in the dictionary.
   at Amazon.Extensions.CognitoAuthentication.CognitoUser.CreateSrpPasswordVerifierAuthRequest(...)
```

## Change

- `CognitoAuthFlowHandler.handleUserSrpAuth`: add `USERNAME` (same value as `USER_ID_FOR_SRP`) to the `PASSWORD_VERIFIER` `ChallengeParameters`.
- Extend `CognitoServiceTest.initiateAuthWithUserSrpAuthFlow` to assert `USERNAME` is present.

## Testing

`./mvnw -Dtest=CognitoServiceTest test` — 80 passed, 0 failed.