### PR TITLE
fix(appconfig): 🐛 stop AppConfig route hijacking S3 bucket named "configuration"

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigConfigurationRouteFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigConfigurationRouteFilter.java
@@ -1,0 +1,57 @@
+package io.github.hectorvent.floci.services.appconfig;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.core.UriInfo;
+import jakarta.ws.rs.ext.Provider;
+
+import java.net.URI;
+
+/**
+ * Pre-matching filter that disambiguates {@code GET /configuration} between the
+ * AppConfigData runtime API (GetLatestConfiguration) and an S3 bucket literally
+ * named {@code configuration} (issue #1294).
+ *
+ * <p>A genuine AppConfigData GetLatestConfiguration request always carries a
+ * {@code configuration_token} query parameter, while a path-style S3
+ * ListObjectsV2 request does not. When the token is present the request is
+ * rewritten onto the internal AppConfigData path so {@link AppConfigDataController}
+ * handles it; otherwise the bare {@code /configuration} path is left untouched
+ * and falls through to S3's {@code /{bucket}} route.
+ *
+ * <p>The internal path contains an underscore, which S3 bucket names forbid, so
+ * it can never collide with a real bucket. This mirrors the existing routing
+ * filters ({@code SqsQueueUrlRouterFilter}, {@code LambdaUrlRoutingFilter}) that
+ * resolve path collisions before JAX-RS resource matching.
+ */
+@Provider
+@PreMatching
+public class AppConfigConfigurationRouteFilter implements ContainerRequestFilter {
+
+    /** Internal-only path that {@link AppConfigDataController} binds for GetLatestConfiguration. */
+    static final String INTERNAL_PATH = "/_appconfigdata_configuration";
+
+    @Override
+    public void filter(ContainerRequestContext ctx) {
+        if (!"GET".equals(ctx.getMethod())) {
+            return;
+        }
+        UriInfo uriInfo = ctx.getUriInfo();
+        String path = uriInfo.getPath();
+        if (path.startsWith("/")) {
+            path = path.substring(1);
+        }
+        if (!"configuration".equals(path)) {
+            return;
+        }
+        String token = uriInfo.getQueryParameters().getFirst("configuration_token");
+        if (token == null || token.isBlank()) {
+            // No token: this is an S3 path-style request to a bucket named
+            // "configuration". Leave the path so it matches S3's /{bucket} route.
+            return;
+        }
+        URI rewritten = uriInfo.getRequestUriBuilder().replacePath(INTERNAL_PATH).build();
+        ctx.setRequestUri(rewritten);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigDataController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigDataController.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.appconfig;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.appconfig.AppConfigDataService.ConfigurationData;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
@@ -35,9 +36,17 @@ public class AppConfigDataController {
         return Response.status(201).entity(Map.of("InitialConfigurationToken", token)).build();
     }
 
+    // Bound to an internal path rather than the public "/configuration" so that
+    // an S3 bucket named "configuration" is not shadowed by this route (issue
+    // #1294). AppConfigConfigurationRouteFilter rewrites genuine GetLatestConfiguration
+    // requests (those carrying a configuration_token) onto this path; requests
+    // without a token fall through to S3's /{bucket} handler.
     @GET
-    @Path("/configuration")
+    @Path(AppConfigConfigurationRouteFilter.INTERNAL_PATH)
     public Response getLatestConfiguration(@QueryParam("configuration_token") String token) {
+        if (token == null || token.isBlank()) {
+            throw new AwsException("BadRequestException", "configuration_token is required", 400);
+        }
         ConfigurationData data = service.getLatestConfiguration(token);
         return Response.ok(data.content())
                 .header("Content-Type", data.contentType())

--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigDataController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigDataController.java
@@ -1,7 +1,6 @@
 package io.github.hectorvent.floci.services.appconfig;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.appconfig.AppConfigDataService.ConfigurationData;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
@@ -44,9 +43,6 @@ public class AppConfigDataController {
     @GET
     @Path(AppConfigConfigurationRouteFilter.INTERNAL_PATH)
     public Response getLatestConfiguration(@QueryParam("configuration_token") String token) {
-        if (token == null || token.isBlank()) {
-            throw new AwsException("BadRequestException", "configuration_token is required", 400);
-        }
         ConfigurationData data = service.getLatestConfiguration(token);
         return Response.ok(data.content())
                 .header("Content-Type", data.contentType())

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ConfigurationBucketIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ConfigurationBucketIntegrationTest.java
@@ -1,0 +1,89 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * An S3 bucket named exactly <code>configuration</code> must NOT collide with
+ * the AppConfigData runtime route (<code>GET /configuration</code>, issue #1294).
+ *
+ * <p>Discriminator: a genuine AppConfigData GetLatestConfiguration request always
+ * carries a <code>configuration_token</code> query parameter. An S3 path-style
+ * request to a bucket named <code>configuration</code> does not, so it must be
+ * routed to S3 instead of NPE-ing inside the AppConfig handler.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class S3ConfigurationBucketIntegrationTest {
+
+    private static final String BUCKET = "configuration";
+    private static final String KEY = "settings.json";
+    private static final String BODY = "{\"feature\":\"on\"}";
+
+    @Test
+    @Order(0)
+    void createConfigurationBucket() {
+        given()
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(1)
+    void listObjectsV2_mustNotBeRoutedToAppConfig() {
+        String body = given()
+            .queryParam("list-type", "2")
+        .when()
+            .get("/" + BUCKET)
+        .then()
+            .statusCode(200)
+            .body(containsString("ListBucketResult"))
+            .body(containsString("<Name>configuration</Name>"))
+            .extract().asString();
+
+        if (body.contains("BadRequestException") || body.contains("Invalid configuration token")) {
+            throw new AssertionError(
+                "GET /" + BUCKET + "?list-type=2 was routed to AppConfig instead of S3. Response: " + body);
+        }
+    }
+
+    @Test
+    @Order(2)
+    void putAndGetObjectInConfigurationBucket() {
+        given()
+            .header("Content-Type", "application/json")
+            .body(BODY)
+        .when()
+            .put("/" + BUCKET + "/" + KEY)
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "/" + KEY)
+        .then()
+            .statusCode(200)
+            .body(equalTo(BODY));
+    }
+
+    @Test
+    @Order(3)
+    void listObjectsV2_returnsStoredObject() {
+        given()
+            .queryParam("list-type", "2")
+        .when()
+            .get("/" + BUCKET)
+        .then()
+            .statusCode(200)
+            .body(containsString("<Key>" + KEY + "</Key>"));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1294

A path-style S3 request to a bucket named exactly `configuration` (e.g. `GET /configuration?list-type=2`, ListObjectsV2) matched AppConfigData's literal `GET /configuration` route ahead of S3's `/{bucket}` template. With no `configuration_token`, the AppConfig handler called `sessionStore.get(null)` and returned **HTTP 500** (`NullPointerException`) for routine list/read calls against a perfectly valid bucket.

Fix via path rewrite (consistent with `SqsQueueUrlRouterFilter` / `LambdaUrlRoutingFilter`):

- AppConfigData `GetLatestConfiguration` now binds an internal path instead of the public `/configuration`.
- A new `@PreMatching` `AppConfigConfigurationRouteFilter` rewrites genuine requests (those carrying a `configuration_token`) onto that internal path; requests without a token keep the bare `/configuration` path, which now falls through to S3's `/{bucket}` route.
- The internal path contains an underscore (forbidden in S3 bucket names), so it can never collide with a real bucket.

This is the reverse-direction sibling of #996 (an AppConfig LIST falling into S3's `/{bucket}/{key:.+}` catch-all).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: `aws s3api list-objects-v2 --bucket configuration` (against a created, empty bucket) returned HTTP 500 instead of an empty `ListBucketResult`. Only the literal name `configuration` collided; other names (`cato-configuration`, `appconfig`, etc.) worked. Observed stack trace:

```
java.lang.NullPointerException
  at java.util.concurrent.ConcurrentHashMap.get
  at ...AppConfigDataService.getLatestConfiguration(AppConfigDataService.java:52)
  at ...AppConfigDataController.getLatestConfiguration(AppConfigDataController.java:41)
```

Disambiguation matches AWS: AppConfigData `GetLatestConfiguration` is `GET /configuration` with a required `configuration_token`; S3 path-style ListObjectsV2 has no such token, so it is routed to S3.

## Checklist

- [x] `./mvnw test` passes locally for the affected suites: `S3ConfigurationBucketIntegrationTest` + `AppConfigIntegrationTest` (26 passed, incl. genuine AppConfig `GetLatestConfiguration` with a token, an invalid token, and an empty configuration) and `S3IntegrationTest` (113 passed, no routing regression). The full suite's only failures on this machine are the 16 Docker-dependent suites that fail identically on an unmodified `main` (no Docker available locally).
- [x] New or updated integration test added: `S3ConfigurationBucketIntegrationTest` (RestAssured) creates bucket `configuration`, asserts ListObjectsV2 returns `ListBucketResult` (not an AppConfig error), then puts/gets/lists an object.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
