### PR TITLE
fix: reject missing Glue table deletes

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/glue-catalog.bats
+++ b/compatibility-tests/sdk-test-awscli/test/glue-catalog.bats
@@ -246,6 +246,12 @@ function_input() {
         --database-name "$DB_NAME" \
         --name "$TABLE_NAME"
     assert_failure
+
+    run aws_cmd glue delete-table \
+        --database-name "$DB_NAME" \
+        --name "$TABLE_NAME"
+    assert_failure
+    [[ "$output" == *"EntityNotFoundException"* ]]
 }
 
 @test "Glue catalog: batch delete table" {

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/GlueCatalogTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/GlueCatalogTest.java
@@ -226,6 +226,11 @@ class GlueCatalogTest {
                 .name(TABLE_NAME)
                 .build()))
                 .isInstanceOf(EntityNotFoundException.class);
+        assertThatThrownBy(() -> glue.deleteTable(DeleteTableRequest.builder()
+                .databaseName(DATABASE_NAME)
+                .name(TABLE_NAME)
+                .build()))
+                .isInstanceOf(EntityNotFoundException.class);
 
         glue.deleteDatabase(DeleteDatabaseRequest.builder()
                 .name(DATABASE_NAME)

--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
@@ -221,6 +221,7 @@ public class GlueService {
     }
 
     public void deleteTable(String databaseName, String tableName) {
+        getTable(databaseName, tableName);
         String key = tableKey(databaseName, tableName);
         tableStore.delete(key);
         tableVersionStore.keys().stream()

--- a/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
@@ -368,6 +368,15 @@ class GlueServiceTest {
     }
 
     @Test
+    void deleteTableForMissingTableThrows() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> glueService.deleteTable("db1", "missing_table"));
+
+        assertEquals("EntityNotFoundException", ex.getErrorCode());
+        assertTrue(ex.getMessage().contains("db1.missing_table"));
+    }
+
+    @Test
     void updateTableWithCurrentVersionIdSucceedsAndIncrementsVersionId() {
         Table table = new Table();
         table.setName("plain");


### PR DESCRIPTION
Fixes #1318.

Makes Glue report missing tables consistently when deleting tables.