### PR TITLE
fix: return BadRequest for S3 dot-dot paths

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -294,8 +294,8 @@ public class S3Controller {
                                 @QueryParam("key-marker") String keyMarker,
                                 @QueryParam("marker") String marker,
                                 @Context UriInfo uriInfo) {
-        validateRawUri();
         try {
+            validateRawUri();
             if (hasQueryParam(uriInfo, "uploads")) {
                 return handleListMultipartUploads(bucket);
             }
@@ -1973,6 +1973,9 @@ public class S3Controller {
     }
 
     private Response xmlErrorResponse(AwsException e) {
+        if (e.getMessage() == null) {
+            return Response.status(e.getHttpStatus()).build();
+        }
         String xml = new XmlBuilder()
                 .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
                 .start("Error")
@@ -2482,6 +2485,7 @@ public class S3Controller {
      * that JAX-RS path normalization would otherwise strip.
      */
     private String extractObjectKey(UriInfo uriInfo, String bucket) {
+        validateRawUri();
         String rawUri = currentVertxRequest.getCurrent().request().uri();
         int qIdx = rawUri.indexOf('?');
         String rawPath = qIdx >= 0 ? rawUri.substring(0, qIdx) : rawUri;
@@ -2524,7 +2528,7 @@ public class S3Controller {
             decodedPath = URLDecoder.decode(rawPath, StandardCharsets.UTF_8);
         }
         catch (IllegalArgumentException e) {
-            throw new AwsException("InvalidKey", "The specified key is invalid.", 400);
+            throw new AwsException("BadRequest", null, 400);
         }
 
         String[] segments = decodedPath.split("/", -1);
@@ -2541,7 +2545,7 @@ public class S3Controller {
             }
             if ("..".equals(segment)) {
                 if (depth == 0) {
-                    throw new AwsException("InvalidKey", "The specified key is invalid.", 400);
+                    throw new AwsException("BadRequest", null, 400);
                 }
                 depth--;
             }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -1894,7 +1894,7 @@ class S3IntegrationTest {
                 .get("/{bucket}/%2e%2e/%2e%2e/secret.txt")
         .then()
                 .statusCode(400)
-                .body(containsString("InvalidKey"));
+                .body(equalTo(""));
 
         // 2. Null byte (survives URL-decoding but fails java.nio.file.Path validation)
         given()
@@ -1917,7 +1917,7 @@ class S3IntegrationTest {
                 .get("/{bucket}/%2E%2E/%2E%2E/secret.txt")
         .then()
                 .statusCode(400)
-                .body(containsString("InvalidKey"));
+                .body(equalTo(""));
     }
 
     @Test
@@ -1969,7 +1969,7 @@ class S3IntegrationTest {
             .put("/test-bucket/../../secret.txt")
         .then()
             .statusCode(400)
-            .body(containsString("InvalidKey"));
+            .body(equalTo(""));
     }
 
     @Test
@@ -1983,7 +1983,7 @@ class S3IntegrationTest {
             .put("/test-bucket/%2E%2E/%2E%2E/secret.txt")
         .then()
             .statusCode(400)
-            .body(containsString("InvalidKey"));
+            .body(equalTo(""));
     }
 
     @Test
@@ -1997,7 +1997,7 @@ class S3IntegrationTest {
             .put("/test-bucket/%2E%2E%2Fsecret.txt")
         .then()
             .statusCode(400)
-            .body(containsString("InvalidKey"));
+            .body(equalTo(""));
     }
 
     @Test
@@ -2031,6 +2031,19 @@ class S3IntegrationTest {
         .then()
             .statusCode(200)
             .body(containsString("ListBucketResult"));
+    }
+
+    @Test
+    @Order(205)
+    void putObjectWithTraversalAfterBucketPrefixReturnsBadRequest() {
+        given()
+            .contentType("text/plain")
+            .body("safe-data")
+        .when()
+            .put("/test-bucket/../secret.txt")
+        .then()
+            .statusCode(400)
+            .body(equalTo(""));
     }
 
     private static String customerKeyMd5(String customerKey) {


### PR DESCRIPTION
Fixes #1320.

Makes S3 dot-dot object paths return the expected bad request response.