### PR TITLE
fix(rds): align CreateDBInstance and CreateDBCluster parameter group validation with AWS behavior

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -192,6 +192,7 @@ public class RdsService {
         if (dbSubnetGroupName != null && !dbSubnetGroupName.isBlank()) {
             getDbSubnetGroup(dbSubnetGroupName);
         }
+        validateInstanceParameterGroup(paramGroupName, engineParam, engineVersion);
         int proxyPort = allocateProxyPort();
         if (masterUsername == null || masterUsername.isBlank()) {
             masterUsername = "root";
@@ -482,6 +483,7 @@ public class RdsService {
         }
 
         DatabaseEngine engine = resolveEngine(engineParam);
+        validateClusterParameterGroup(paramGroupName, engineParam, engineVersion);
         int proxyPort = allocateProxyPort();
         String image = imageForEngine(engine, engineVersion);
         String clusterVolumeId = String.format("%06x", new SecureRandom().nextInt(0xFFFFFF));
@@ -578,7 +580,7 @@ public class RdsService {
     public DbParameterGroup getDbParameterGroup(String name) {
         return parameterGroups.get(name).orElseThrow(() ->
                 new AwsException("DBParameterGroupNotFound",
-                        "DB parameter group " + name + " not found.", 404));
+                        "DBParameterGroupName doesn't refer to an existing DB parameter group.", 404));
     }
 
     public Collection<DbParameterGroup> listDbParameterGroups(String filterName) {
@@ -591,7 +593,7 @@ public class RdsService {
     public void deleteDbParameterGroup(String name) {
         if (parameterGroups.get(name).isEmpty()) {
             throw new AwsException("DBParameterGroupNotFound",
-                    "DB parameter group " + name + " not found.", 404);
+                    "DBParameterGroupName doesn't refer to an existing DB parameter group.", 404);
         }
         parameterGroups.delete(name);
     }
@@ -666,8 +668,8 @@ public class RdsService {
 
     public DbClusterParameterGroup getDbClusterParameterGroup(String name) {
         return clusterParameterGroups.get(name).orElseThrow(() ->
-                new AwsException("DBParameterGroupNotFound",
-                        "DB cluster parameter group " + name + " not found.", 404));
+                new AwsException("DBClusterParameterGroupNotFound",
+                        "DBClusterParameterGroupName doesn't refer to an existing DB cluster parameter group.", 404));
     }
 
     public Collection<DbClusterParameterGroup> listDbClusterParameterGroups(String filterName) {
@@ -679,8 +681,8 @@ public class RdsService {
 
     public void deleteDbClusterParameterGroup(String name) {
         if (clusterParameterGroups.get(name).isEmpty()) {
-            throw new AwsException("DBParameterGroupNotFound",
-                    "DB cluster parameter group " + name + " not found.", 404);
+            throw new AwsException("DBClusterParameterGroupNotFound",
+                    "DBClusterParameterGroupName doesn't refer to an existing DB cluster parameter group.", 404);
         }
         clusterParameterGroups.delete(name);
     }
@@ -729,8 +731,7 @@ public class RdsService {
             case "postgres", "aurora-postgresql" -> DatabaseEngine.POSTGRES;
             case "mysql", "aurora-mysql", "aurora" -> DatabaseEngine.MYSQL;
             case "mariadb" -> DatabaseEngine.MARIADB;
-            default -> throw new AwsException("InvalidParameterValue",
-                    "Unsupported engine: " + engineParam + ". Supported: postgres, mysql, mariadb.", 400);
+            default -> throw new AwsException("InvalidParameterValue", invalidParameterValueMessage(), 400);
         };
     }
 
@@ -741,6 +742,54 @@ public class RdsService {
             case MARIADB -> config.services().rds().defaultMariadbImage();
         };
         return imageForRequestedVersion(defaultImage, engineVersion);
+    }
+
+    private void validateInstanceParameterGroup(String paramGroupName, String engineParam, String engineVersion) {
+        if (paramGroupName == null || paramGroupName.isBlank()) {
+            return;
+        }
+        DbParameterGroup group = getDbParameterGroup(paramGroupName);
+        validateParameterGroupFamily(paramGroupName, group.getDbParameterGroupFamily(), engineParam, engineVersion);
+    }
+
+    private void validateClusterParameterGroup(String paramGroupName, String engineParam, String engineVersion) {
+        if (paramGroupName == null || paramGroupName.isBlank()) {
+            return;
+        }
+        DbClusterParameterGroup group = getDbClusterParameterGroup(paramGroupName);
+        validateParameterGroupFamily(paramGroupName, group.getDbParameterGroupFamily(), engineParam, engineVersion);
+    }
+
+    private void validateParameterGroupFamily(String groupName, String family, String engineParam, String engineVersion) {
+        String normalizedFamily = family == null ? "" : family.toLowerCase();
+        String expectedPrefix = expectedFamilyPrefix(engineParam);
+        if (!normalizedFamily.startsWith(expectedPrefix)) {
+            throw new AwsException("InvalidParameterCombination", invalidParameterCombinationMessage(), 400);
+        }
+    }
+
+    private String expectedFamilyPrefix(String engineParam) {
+        String normalizedEngine = effectiveEngineName(engineParam).toLowerCase();
+        return switch (normalizedEngine) {
+            case "postgres" -> "postgres";
+            case "aurora-postgresql" -> "aurora-postgresql";
+            case "mysql" -> "mysql";
+            case "aurora", "aurora-mysql" -> "aurora-mysql";
+            case "mariadb" -> "mariadb";
+            default -> throw new AwsException("InvalidParameterValue", invalidParameterValueMessage(), 400);
+        };
+    }
+
+    private String effectiveEngineName(String engineParam) {
+        return engineParam == null || engineParam.isBlank() ? "postgres" : engineParam;
+    }
+
+    private String invalidParameterValueMessage() {
+        return "A value that you provided for a parameter isn't valid. Check the parameter constraints and try again.";
+    }
+
+    private String invalidParameterCombinationMessage() {
+        return "Parameters that must not be used together were used together. Remove one of the conflicting parameters and try again.";
     }
 
     static String imageForRequestedVersion(String defaultImage, String engineVersion) {

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -312,7 +312,7 @@ class RdsQueryHandlerTest {
                 eq(null), eq(null), eq(null), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(false), eq(null), eq(java.util.Map.of())))
                 .thenThrow(new AwsException("InvalidParameterValue",
-                        "Unsupported engine: oracle. Supported: postgres, mysql, mariadb.", 400));
+                        "A value that you provided for a parameter isn't valid. Check the parameter constraints and try again.", 400));
 
         MultivaluedMap<String, String> p = params();
         p.add("DBInstanceIdentifier", "mydb");
@@ -321,6 +321,7 @@ class RdsQueryHandlerTest {
 
         assertEquals(400, response.getStatus());
         assertTrue(((String) response.getEntity()).contains("InvalidParameterValue"));
+        assertTrue(((String) response.getEntity()).contains("Check the parameter constraints and try again."));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -166,6 +166,29 @@ class RdsServiceTest {
     }
 
     @Test
+    void createDbInstanceRejectsUnknownParameterGroup() {
+        AwsException exception = assertThrows(AwsException.class, () -> rdsService.createDbInstance("mydb", "postgres", "13",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, "does-not-exist", null, null));
+
+        assertEquals("DBParameterGroupNotFound", exception.getErrorCode());
+        assertEquals("DBParameterGroupName doesn't refer to an existing DB parameter group.", exception.getMessage());
+    }
+
+    @Test
+    void createDbInstanceRejectsIncompatibleParameterGroupFamily() {
+        rdsService.createDbParameterGroup("pg1", "mysql8.0", "test group");
+
+        AwsException exception = assertThrows(AwsException.class, () -> rdsService.createDbInstance("mydb", "postgres", "13",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, "pg1", null, null));
+
+        assertEquals("InvalidParameterCombination", exception.getErrorCode());
+        assertEquals("Parameters that must not be used together were used together. Remove one of the conflicting parameters and try again.",
+                exception.getMessage());
+    }
+
+    @Test
     void listDbInstancesIsCaseInsensitive() {
         rdsService.createDbInstance("mydb", "postgres", "13",
                 "admin", "password", "dbname", "db.t3.micro",
@@ -272,6 +295,27 @@ class RdsServiceTest {
     }
 
     @Test
+    void createDbClusterRejectsUnknownClusterParameterGroup() {
+        AwsException exception = assertThrows(AwsException.class, () -> rdsService.createDbCluster("cluster1", "aurora-postgresql", "16.3",
+                "admin", "password", "dbname", false, "does-not-exist"));
+
+        assertEquals("DBClusterParameterGroupNotFound", exception.getErrorCode());
+        assertEquals("DBClusterParameterGroupName doesn't refer to an existing DB cluster parameter group.", exception.getMessage());
+    }
+
+    @Test
+    void createDbClusterRejectsIncompatibleClusterParameterGroupFamily() {
+        rdsService.createDbClusterParameterGroup("cpg1", "aurora-mysql8.0", "test group");
+
+        AwsException exception = assertThrows(AwsException.class, () -> rdsService.createDbCluster("cluster1", "aurora-postgresql", "16.3",
+                "admin", "password", "dbname", false, "cpg1"));
+
+        assertEquals("InvalidParameterCombination", exception.getErrorCode());
+        assertEquals("Parameters that must not be used together were used together. Remove one of the conflicting parameters and try again.",
+                exception.getMessage());
+    }
+
+    @Test
     void createDbClusterParameterGroupRoundTrip() {
         DbClusterParameterGroup created = rdsService.createDbClusterParameterGroup(
                 "cpg1", "aurora-postgresql16", "test cluster group");
@@ -312,7 +356,8 @@ class RdsServiceTest {
         AwsException exception = assertThrows(AwsException.class, () ->
                 rdsService.deleteDbClusterParameterGroup("nonexistent"));
 
-        assertEquals("DBParameterGroupNotFound", exception.getErrorCode());
+        assertEquals("DBClusterParameterGroupNotFound", exception.getErrorCode());
+        assertEquals("DBClusterParameterGroupName doesn't refer to an existing DB cluster parameter group.", exception.getMessage());
     }
 
     @Test
@@ -320,7 +365,8 @@ class RdsServiceTest {
         AwsException exception = assertThrows(AwsException.class, () ->
                 rdsService.getDbClusterParameterGroup("nonexistent"));
 
-        assertEquals("DBParameterGroupNotFound", exception.getErrorCode());
+        assertEquals("DBClusterParameterGroupNotFound", exception.getErrorCode());
+        assertEquals("DBClusterParameterGroupName doesn't refer to an existing DB cluster parameter group.", exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Align RDS `CreateDBInstance` and `CreateDBCluster` parameter group validation with AWS behavior. Closes #1278

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Before this change, Floci accepted `DBParameterGroupName` and `DBClusterParameterGroupName` during RDS creation without verifying that the referenced parameter group existed or that its family matched the requested engine. This change adds create-time validation for both instance and cluster parameter groups, and aligns not-found error codes and messages with the AWS API reference where documented.

Verified against AWS RDS API reference:
- `CreateDBInstance` returns `DBParameterGroupNotFound` when `DBParameterGroupName` doesn't refer to an existing DB parameter group.
- `CreateDBCluster` returns `DBClusterParameterGroupNotFound` when `DBClusterParameterGroupName` doesn't refer to an existing DB cluster parameter group.
- incompatible engine and parameter group family combinations are rejected with `InvalidParameterCombination`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)