### PR TITLE
fix(s3): serve custom error document for missing keys in static websi…

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -305,8 +305,8 @@ public class S3Controller {
                                 @QueryParam("marker") String marker,
                                 @Context UriInfo uriInfo,
                                 @Context HttpHeaders httpHeaders) {
-        validateRawUri();
         try {
+            validateRawUri();
             if (hasQueryParam(uriInfo, "uploads")) {
                 return handleListMultipartUploads(bucket);
             }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -372,7 +372,17 @@ public class S3Controller {
                                     .header("x-amz-website-redirect-location", "index")
                                     .build();
                         } catch (AwsException e) {
-                            // If index.html is missing, we could serve ErrorDocument, but for now we fall back to listObjects
+                            if (webConfig.getErrorDocument() != null) {
+                                try {
+                                    S3Object errorObj = s3Service.getObject(bucket, webConfig.getErrorDocument());
+                                    return Response.status(404)
+                                            .entity(errorObj.getData())
+                                            .type(errorObj.getContentType())
+                                            .header("Content-Length", errorObj.getSize())
+                                            .build();
+                                } catch (AwsException ignored) {
+                                }
+                            }
                         }
                     }
                 } catch (AwsException e) {
@@ -625,6 +635,23 @@ public class S3Controller {
 
             return fullObjectResponse(bucket, key, versionId, obj, overrides);
         } catch (AwsException e) {
+            if ("NoSuchKey".equals(e.getErrorCode())) {
+                try {
+                    WebsiteConfiguration webConfig = s3Service.getBucketWebsite(bucket);
+                    if (webConfig.getErrorDocument() != null) {
+                        try {
+                            S3Object errorObj = s3Service.getObject(bucket, webConfig.getErrorDocument());
+                            return Response.status(404)
+                                    .entity(errorObj.getData())
+                                    .type(errorObj.getContentType())
+                                    .header("Content-Length", errorObj.getSize())
+                                    .build();
+                        } catch (AwsException ignored) {
+                        }
+                    }
+                } catch (AwsException ignored) {
+                }
+            }
             return xmlErrorResponse(e);
         }
     }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -303,9 +303,10 @@ public class S3Controller {
                                 @QueryParam("encoding-type") String encodingType,
                                 @QueryParam("key-marker") String keyMarker,
                                 @QueryParam("marker") String marker,
-                                @Context UriInfo uriInfo) {
+                                @Context UriInfo uriInfo,
+                                @Context HttpHeaders httpHeaders) {
+        validateRawUri();
         try {
-            validateRawUri();
             if (hasQueryParam(uriInfo, "uploads")) {
                 return handleListMultipartUploads(bucket);
             }
@@ -359,7 +360,7 @@ public class S3Controller {
             }
 
             // --- Website Hosting Redirection Logic ---
-            if (uriInfo.getQueryParameters().isEmpty() || (uriInfo.getQueryParameters().size() == 1 && hasQueryParam(uriInfo, "list-type"))) {
+            if (isWebsiteRequest(httpHeaders) && (uriInfo.getQueryParameters().isEmpty() || (uriInfo.getQueryParameters().size() == 1 && hasQueryParam(uriInfo, "list-type")))) {
                 try {
                     WebsiteConfiguration webConfig = s3Service.getBucketWebsite(bucket);
                     if (webConfig.getIndexDocument() != null) {
@@ -626,7 +627,7 @@ public class S3Controller {
 
             return fullObjectResponse(bucket, key, versionId, obj, overrides);
         } catch (AwsException e) {
-            if ("NoSuchKey".equals(e.getErrorCode())) {
+            if ("NoSuchKey".equals(e.getErrorCode()) && isWebsiteRequest(httpHeaders)) {
                 try {
                     WebsiteConfiguration webConfig = s3Service.getBucketWebsite(bucket);
                     Response r = serveErrorDocument(bucket, webConfig);
@@ -1986,6 +1987,11 @@ public class S3Controller {
         if (crc64nvme != null && !crc64nvme.equals(S3Checksum.crc64NvmeBase64(data))) {
             throw new AwsException("BadDigest", "The CRC64NVME checksum you specified did not match the payload.", 400);
         }
+    }
+
+    private static boolean isWebsiteRequest(HttpHeaders httpHeaders) {
+        String host = httpHeaders.getHeaderString("Host");
+        return host != null && host.contains("s3-website");
     }
 
     private Response serveErrorDocument(String bucket, WebsiteConfiguration cfg) {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -372,17 +372,8 @@ public class S3Controller {
                                     .header("x-amz-website-redirect-location", "index")
                                     .build();
                         } catch (AwsException e) {
-                            if (webConfig.getErrorDocument() != null) {
-                                try {
-                                    S3Object errorObj = s3Service.getObject(bucket, webConfig.getErrorDocument());
-                                    return Response.status(404)
-                                            .entity(errorObj.getData())
-                                            .type(errorObj.getContentType())
-                                            .header("Content-Length", errorObj.getSize())
-                                            .build();
-                                } catch (AwsException ignored) {
-                                }
-                            }
+                            Response r = serveErrorDocument(bucket, webConfig);
+                            if (r != null) return r;
                         }
                     }
                 } catch (AwsException e) {
@@ -638,17 +629,8 @@ public class S3Controller {
             if ("NoSuchKey".equals(e.getErrorCode())) {
                 try {
                     WebsiteConfiguration webConfig = s3Service.getBucketWebsite(bucket);
-                    if (webConfig.getErrorDocument() != null) {
-                        try {
-                            S3Object errorObj = s3Service.getObject(bucket, webConfig.getErrorDocument());
-                            return Response.status(404)
-                                    .entity(errorObj.getData())
-                                    .type(errorObj.getContentType())
-                                    .header("Content-Length", errorObj.getSize())
-                                    .build();
-                        } catch (AwsException ignored) {
-                        }
-                    }
+                    Response r = serveErrorDocument(bucket, webConfig);
+                    if (r != null) return r;
                 } catch (AwsException ignored) {
                 }
             }
@@ -2003,6 +1985,29 @@ public class S3Controller {
         String crc64nvme = httpHeaders.getHeaderString("x-amz-checksum-crc64nvme");
         if (crc64nvme != null && !crc64nvme.equals(S3Checksum.crc64NvmeBase64(data))) {
             throw new AwsException("BadDigest", "The CRC64NVME checksum you specified did not match the payload.", 400);
+        }
+    }
+
+    private Response serveErrorDocument(String bucket, WebsiteConfiguration cfg) {
+        if (cfg.getErrorDocument() == null) {
+            return null;
+        }
+        try {
+            S3Object err = s3Service.getObject(bucket, cfg.getErrorDocument());
+            return Response.status(404)
+                    .entity(err.getData())
+                    .type(err.getContentType())
+                    .header("Content-Length", err.getSize())
+                    .header("x-amz-error-code", "NoSuchKey")
+                    .header("x-amz-error-message", "The specified key does not exist.")
+                    .build();
+        } catch (AwsException ignored) {
+            return Response.status(404)
+                    .entity("<html><head><title>404 Not Found</title></head>\n<body><h1>404 Not Found</h1>\n<ul><li>Code: NoSuchKey</li><li>Message: The specified key does not exist.</li></ul></body></html>")
+                    .type(MediaType.TEXT_HTML)
+                    .header("x-amz-error-code", "NoSuchKey")
+                    .header("x-amz-error-message", "The specified key does not exist.")
+                    .build();
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
@@ -205,6 +205,10 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
         if (remainder.endsWith(".localhost.floci.io") || "localhost.floci.io".equals(remainder)) {
             return remainder.startsWith("s3.") || "localhost.floci.io".equals(remainder);
         }
+        // S3 website endpoints: bucket.s3-website-<region>.amazonaws.com, bucket.s3-website-<region>.localhost, etc.
+        if (remainder.startsWith("s3-website")) {
+            return true;
+        }
         return false;
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3WebsiteIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3WebsiteIntegrationTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.s3;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,10 @@ import static org.hamcrest.Matchers.*;
 class S3WebsiteIntegrationTest {
 
     private static final String BUCKET = "website-test-bucket";
+
+    private String websiteHost() {
+        return BUCKET + ".s3-website-us-east-1.localhost:" + RestAssured.port;
+    }
 
     @Test
     @Order(1)
@@ -88,8 +93,9 @@ class S3WebsiteIntegrationTest {
     @Order(6)
     void missingIndexServesErrorDocument() {
         given()
+            .header("Host", websiteHost())
         .when()
-            .get("/" + BUCKET)
+            .get("/")
         .then()
             .statusCode(404)
             .contentType("text/html")
@@ -114,8 +120,9 @@ class S3WebsiteIntegrationTest {
     @Order(8)
     void indexRedirectionWorks() {
         given()
+            .header("Host", websiteHost())
         .when()
-            .get("/" + BUCKET)
+            .get("/")
         .then()
             .statusCode(200)
             .contentType("text/html")
@@ -126,8 +133,9 @@ class S3WebsiteIntegrationTest {
     @Order(9)
     void missingKeyServesErrorDocument() {
         given()
+            .header("Host", websiteHost())
         .when()
-            .get("/" + BUCKET + "/missing-page")
+            .get("/missing-page")
         .then()
             .statusCode(404)
             .contentType("text/html")
@@ -138,12 +146,24 @@ class S3WebsiteIntegrationTest {
 
     @Test
     @Order(10)
+    void missingKeyReturnsXmlForRegularApiRequest() {
+        given()
+        .when()
+            .get("/" + BUCKET + "/missing-page")
+        .then()
+            .statusCode(404)
+            .body(containsString("NoSuchKey"));
+    }
+
+    @Test
+    @Order(11)
     void missingErrorDocumentServesHtmlFallback() {
         given().delete("/" + BUCKET + "/error.html");
 
         given()
+            .header("Host", websiteHost())
         .when()
-            .get("/" + BUCKET + "/missing-page")
+            .get("/missing-page")
         .then()
             .statusCode(404)
             .contentType("text/html")
@@ -162,7 +182,7 @@ class S3WebsiteIntegrationTest {
     }
 
     @Test
-    @Order(11)
+    @Order(12)
     void deleteWebsiteConfiguration() {
         given()
             .queryParam("website", "")
@@ -180,7 +200,7 @@ class S3WebsiteIntegrationTest {
     }
 
     @Test
-    @Order(12)
+    @Order(13)
     void cleanup() {
         given().delete("/" + BUCKET + "/index.html");
         given().delete("/" + BUCKET + "/error.html");

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3WebsiteIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3WebsiteIntegrationTest.java
@@ -93,6 +93,8 @@ class S3WebsiteIntegrationTest {
         .then()
             .statusCode(404)
             .contentType("text/html")
+            .header("x-amz-error-code", "NoSuchKey")
+            .header("x-amz-error-message", "The specified key does not exist.")
             .body(equalTo("<html><body>Custom Error</body></html>"));
     }
 
@@ -129,11 +131,38 @@ class S3WebsiteIntegrationTest {
         .then()
             .statusCode(404)
             .contentType("text/html")
+            .header("x-amz-error-code", "NoSuchKey")
+            .header("x-amz-error-message", "The specified key does not exist.")
             .body(equalTo("<html><body>Custom Error</body></html>"));
     }
 
     @Test
     @Order(10)
+    void missingErrorDocumentServesHtmlFallback() {
+        given().delete("/" + BUCKET + "/error.html");
+
+        given()
+        .when()
+            .get("/" + BUCKET + "/missing-page")
+        .then()
+            .statusCode(404)
+            .contentType("text/html")
+            .header("x-amz-error-code", "NoSuchKey")
+            .header("x-amz-error-message", "The specified key does not exist.")
+            .body(containsString("404 Not Found"))
+            .body(containsString("NoSuchKey"));
+
+        given()
+            .contentType("text/html")
+            .body("<html><body>Custom Error</body></html>")
+        .when()
+            .put("/" + BUCKET + "/error.html")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(11)
     void deleteWebsiteConfiguration() {
         given()
             .queryParam("website", "")
@@ -151,7 +180,7 @@ class S3WebsiteIntegrationTest {
     }
 
     @Test
-    @Order(11)
+    @Order(12)
     void cleanup() {
         given().delete("/" + BUCKET + "/index.html");
         given().delete("/" + BUCKET + "/error.html");

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3WebsiteIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3WebsiteIntegrationTest.java
@@ -74,19 +74,30 @@ class S3WebsiteIntegrationTest {
 
     @Test
     @Order(5)
-    void indexRedirectionNotWorkingYetWithoutIndexFile() {
-        // Access root - should return XML list because index.html is missing
+    void uploadErrorFile() {
         given()
+            .contentType("text/html")
+            .body("<html><body>Custom Error</body></html>")
         .when()
-            .get("/" + BUCKET)
+            .put("/" + BUCKET + "/error.html")
         .then()
-            .statusCode(200)
-            .contentType("application/xml")
-            .body(containsString("<ListBucketResult"));
+            .statusCode(200);
     }
 
     @Test
     @Order(6)
+    void missingIndexServesErrorDocument() {
+        given()
+        .when()
+            .get("/" + BUCKET)
+        .then()
+            .statusCode(404)
+            .contentType("text/html")
+            .body(equalTo("<html><body>Custom Error</body></html>"));
+    }
+
+    @Test
+    @Order(7)
     void uploadIndexFile() {
         given()
             .contentType("text/html")
@@ -98,9 +109,8 @@ class S3WebsiteIntegrationTest {
     }
 
     @Test
-    @Order(7)
+    @Order(8)
     void indexRedirectionWorks() {
-        // Access root - should now return index.html content
         given()
         .when()
             .get("/" + BUCKET)
@@ -111,7 +121,19 @@ class S3WebsiteIntegrationTest {
     }
 
     @Test
-    @Order(8)
+    @Order(9)
+    void missingKeyServesErrorDocument() {
+        given()
+        .when()
+            .get("/" + BUCKET + "/missing-page")
+        .then()
+            .statusCode(404)
+            .contentType("text/html")
+            .body(equalTo("<html><body>Custom Error</body></html>"));
+    }
+
+    @Test
+    @Order(10)
     void deleteWebsiteConfiguration() {
         given()
             .queryParam("website", "")
@@ -120,7 +142,6 @@ class S3WebsiteIntegrationTest {
         .then()
             .statusCode(204);
 
-        // Verify it's gone
         given()
             .queryParam("website", "")
         .when()
@@ -130,9 +151,10 @@ class S3WebsiteIntegrationTest {
     }
 
     @Test
-    @Order(9)
+    @Order(11)
     void cleanup() {
         given().delete("/" + BUCKET + "/index.html");
+        given().delete("/" + BUCKET + "/error.html");
         given().delete("/" + BUCKET);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsDynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsDynamoDbIntegrationTest.java
@@ -645,7 +645,10 @@ class StepFunctionsDynamoDbIntegrationTest {
                     .post("/");
             String status = resp.jsonPath().getString("status");
             if ("SUCCEEDED".equals(status)) {
-                return resp.jsonPath().getString("output");
+                String output = resp.jsonPath().getString("output");
+                if (output != null) {
+                    return output;
+                }
             }
             if ("FAILED".equals(status) || "ABORTED".equals(status)) {
                 fail("Execution " + status + ": " + resp.body().asString());


### PR DESCRIPTION
## Summary #964 

 serve custom error document for missing keys in static website hosting

When a bucket has a website configuration with an ErrorDocument, requests
to missing keys now return the error document with a 404 status instead
of the default XML NoSuchKey error.

Also fixes a flaky test in `StepFunctionsDynamoDbIntegrationTest` where
`waitForExecution` returned null output on slow CI runners, causing the
test to fail.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
