### PR TITLE
fix(glue): return partitions in deterministic order from GetPartitions

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
@@ -391,7 +391,23 @@ public class GlueService {
         String prefix = tableKey(databaseName, tableName) + ":";
         return partitionStore.scan(k -> k.startsWith(prefix)).stream()
                 .filter(partition -> matchesPartitionExpression(table, partition, expression))
+                .sorted(GlueService::comparePartitionValues)
                 .toList();
+    }
+
+    // The partition store scan returns values in storage iteration order, which is not stable.
+    // Return partitions ordered by their values so GetPartitions is deterministic across calls.
+    private static int comparePartitionValues(Partition a, Partition b) {
+        List<String> aValues = a.getValues() == null ? List.of() : a.getValues();
+        List<String> bValues = b.getValues() == null ? List.of() : b.getValues();
+        int shared = Math.min(aValues.size(), bValues.size());
+        for (int i = 0; i < shared; i++) {
+            int comparison = Comparator.nullsFirst(String::compareTo).compare(aValues.get(i), bValues.get(i));
+            if (comparison != 0) {
+                return comparison;
+            }
+        }
+        return Integer.compare(aValues.size(), bValues.size());
     }
 
     public void deletePartition(String databaseName, String tableName, List<String> partitionValues) {

--- a/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
@@ -387,6 +387,25 @@ class GlueServiceTest {
     }
 
     @Test
+    void getPartitionsReturnsPartitionsSortedByValuesRegardlessOfCreationOrder() {
+        Table table = new Table();
+        table.setName("plain");
+        table.setPartitionKeys(List.of(new Column("year", "string")));
+        glueService.createTable("db1", table);
+        for (String value : List.of("2028", "2026", "2027")) {
+            Partition partition = new Partition();
+            partition.setValues(List.of(value));
+            glueService.createPartition("db1", "plain", partition);
+        }
+
+        // Deterministic ordering: returned in sorted order, not storage-scan order. No re-sort here.
+        assertEquals(List.of(List.of("2026"), List.of("2027"), List.of("2028")),
+                glueService.getPartitions("db1", "plain").stream()
+                        .map(Partition::getValues)
+                        .toList());
+    }
+
+    @Test
     void partitionKeysDoNotCollideForCommaSeparatedValues() {
         Table table = new Table();
         table.setName("plain");


### PR DESCRIPTION
## Summary

`GlueService.getPartitions` returned partitions in storage-scan (map iteration) order, which is not stable across runs because partition keys embed the table name. The `sdk-test-awscli` "Glue catalog: table and partition lifecycle" compat test asserts `.Partitions[0].Values[0] == "2026"` (the first-created partition), so it passes or fails depending on scan order. This is a flake that arrived with the Glue partition APIs (#1315); it surfaces on PR compat runs (the suite runs on `pull_request`, not on push to main).

## Change

Sort partitions by their `Values` (lexicographically, element-wise) in `getPartitions`. This is deterministic, matches the existing sorted-list convention elsewhere in `GlueService` (e.g. `getUserDefinedFunctions`), and is consistent with the moto reference, which preserves a stable partition order (`get_partitions` returns `self.partitions.values()` and keeps in-place updates in position).

## Tests

- New `GlueServiceTest#getPartitionsReturnsPartitionsSortedByValuesRegardlessOfCreationOrder` creates partitions out of order (2028, 2026, 2027) and asserts sorted output, no re-sort in the assertion.
- Existing `GlueServiceTest` suite (43 tests) passes.