### PR TITLE
fix(compat): pre-create localstack/floci init hook dirs

### DIFF
--- a/docker/Dockerfile.compat
+++ b/docker/Dockerfile.compat
@@ -23,4 +23,13 @@ RUN microdnf install -y --nodocs python3 python3-pip \
 COPY bin/awslocal /usr/local/bin/awslocal
 RUN chmod +x /usr/local/bin/awslocal
 
+# Pre-create the init-hook directories so archive-based copies (Testcontainers
+# withCopyFileToContainer / `docker cp`) can drop hooks straight into them.
+# Docker's archive extract unpacks into an existing dir and never mkdir -p's the
+# parents, so without these the copy fails. Mirrors LocalStack, which ships
+# /etc/localstack/init. Owned by the runtime user (uid 1001, group root).
+RUN mkdir -p /etc/localstack/init/boot.d /etc/localstack/init/start.d /etc/localstack/init/ready.d \
+             /etc/floci/init/boot.d /etc/floci/init/start.d /etc/floci/init/ready.d \
+    && chown -R 1001:root /etc/localstack /etc/floci
+
 USER 1001


### PR DESCRIPTION
## Problem

The `floci/floci:<ver>-compat` image does not pre-create `/etc/localstack` or `/etc/floci`, nor their `init/{boot,start,ready}.d` subtrees — only `/etc` exists. LocalStack, by contrast, ships `/etc/localstack/init`.

This matters because Docker's archive-based copy — what Testcontainers' `withCopyFileToContainer(...)` and `docker cp` both use under the hood — extracts the tar **into an existing directory** and does **not** `mkdir -p` the parents. So copying an init hook to a path like `/etc/localstack/init/ready.d/x.sh` fails outright, forcing users onto less-portable bind-mounts instead of the standard init-hook injection pattern.

## Repro (stock `1.5.24-compat`)

```console
$ cid=$(docker create floci/floci:1.5.24-compat sleep 60)
$ docker cp init.sh $cid:/etc/localstack/init/ready.d/init.sh
Error response from daemon: Could not find the file /etc/localstack/init/ready.d in container <id>
$ docker rm -f $cid
```

## Fix

Pre-create the hook directories in `Dockerfile.compat` and `chown` them to the image's runtime user. The ownership (`1001:root`) and the `mkdir -p ... && chown ...` style mirror the existing `RUN` blocks in `docker/Dockerfile` (`useradd -r -u 1001 -g root ... floci`). The brace-glob is expanded to explicit paths so the build is independent of the base image's `/bin/sh` brace-expansion support.

```dockerfile
RUN mkdir -p /etc/localstack/init/boot.d /etc/localstack/init/start.d /etc/localstack/init/ready.d \
             /etc/floci/init/boot.d /etc/floci/init/start.d /etc/floci/init/ready.d \
    && chown -R 1001:root /etc/localstack /etc/floci
```

## Rationale: LocalStack parity

LocalStack pre-creates `/etc/localstack/init`, so its init-hook directories are valid `docker cp` / Testcontainers copy targets out of the box. This change brings the compat image to the same baseline (and additionally exposes the `/etc/floci/init/*` equivalents), so drop-in init hooks work without bind-mounts.

## Validation

The change is purely additive, so I validated it behaviorally against the published `floci/floci:1.5.24-compat` image (upstream CI builds the real `docker/Dockerfile.compat`):

1. **Stock image fails** — `docker cp file → /etc/localstack/init/ready.d/x.sh` errors with `Could not find the file /etc/localstack/init/ready.d in container` (the dir does not exist).
2. **Derived image applying the exact new `RUN` line** — all six leaf directories exist, owned `floci:root` (uid 1001, gid 0); the same `docker create` + `docker cp` into `/etc/localstack/init/ready.d/x.sh` now **exits 0** and the file lands correctly.
3. **Boot is unaffected** — `docker run` of the derived image reaches `HEALTHCHECK` status `healthy` in ~6s and logs `Ready.` normally.

Closes #1336
