### PR TITLE
fix(ses): omit unknown identities from GetIdentityNotificationAttributes

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
@@ -267,21 +267,22 @@ public class SesQueryHandler {
         var xml = new XmlBuilder().start("NotificationAttributes");
         for (String identityValue : identities) {
             Identity identity = sesService.getIdentityNotificationAttributes(identityValue, region);
+            if (identity == null) {
+                continue;
+            }
             xml.start("entry");
             xml.elem("key", identityValue);
             xml.start("value");
-            if (identity != null) {
-                xml.elem("BounceTopic", identity.getNotificationAttributes().getOrDefault("BounceTopic", ""));
-                xml.elem("ComplaintTopic", identity.getNotificationAttributes().getOrDefault("ComplaintTopic", ""));
-                xml.elem("DeliveryTopic", identity.getNotificationAttributes().getOrDefault("DeliveryTopic", ""));
-                xml.elem("ForwardingEnabled", String.valueOf(identity.isFeedbackForwardingEnabled()));
-                xml.elem("HeadersInBounceNotificationsEnabled",
-                        String.valueOf(identity.getHeadersInNotificationsEnabled().getOrDefault("Bounce", false)));
-                xml.elem("HeadersInComplaintNotificationsEnabled",
-                        String.valueOf(identity.getHeadersInNotificationsEnabled().getOrDefault("Complaint", false)));
-                xml.elem("HeadersInDeliveryNotificationsEnabled",
-                        String.valueOf(identity.getHeadersInNotificationsEnabled().getOrDefault("Delivery", false)));
-            }
+            xml.elem("BounceTopic", identity.getNotificationAttributes().getOrDefault("BounceTopic", ""));
+            xml.elem("ComplaintTopic", identity.getNotificationAttributes().getOrDefault("ComplaintTopic", ""));
+            xml.elem("DeliveryTopic", identity.getNotificationAttributes().getOrDefault("DeliveryTopic", ""));
+            xml.elem("ForwardingEnabled", String.valueOf(identity.isFeedbackForwardingEnabled()));
+            xml.elem("HeadersInBounceNotificationsEnabled",
+                    String.valueOf(identity.getHeadersInNotificationsEnabled().getOrDefault("Bounce", false)));
+            xml.elem("HeadersInComplaintNotificationsEnabled",
+                    String.valueOf(identity.getHeadersInNotificationsEnabled().getOrDefault("Complaint", false)));
+            xml.elem("HeadersInDeliveryNotificationsEnabled",
+                    String.valueOf(identity.getHeadersInNotificationsEnabled().getOrDefault("Delivery", false)));
             xml.end("value");
             xml.end("entry");
         }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesIdentityAttributesV1IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesIdentityAttributesV1IntegrationTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 
 @QuarkusTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -326,5 +327,43 @@ class SesIdentityAttributesV1IntegrationTest {
             .body(containsString("<HeadersInBounceNotificationsEnabled>true</HeadersInBounceNotificationsEnabled>"))
             .body(containsString("<HeadersInComplaintNotificationsEnabled>false</HeadersInComplaintNotificationsEnabled>"))
             .body(containsString("<HeadersInDeliveryNotificationsEnabled>false</HeadersInDeliveryNotificationsEnabled>"));
+    }
+
+    @Test
+    @Order(22)
+    void getIdentityNotificationAttributes_unknownIdentity_omittedFromMap() {
+        // Real AWS returns an empty NotificationAttributes map for an identity
+        // that doesn't exist, rather than an entry with empty values
+        // (verified against real AWS SES on 2026-06-13).
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "GetIdentityNotificationAttributes")
+            .formParam("Identities.member.1", "ghost-notif.floci.test")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("GetIdentityNotificationAttributesResponse"))
+            .body(containsString("<NotificationAttributes></NotificationAttributes>"))
+            .body(not(containsString("ghost-notif.floci.test")));
+    }
+
+    @Test
+    @Order(23)
+    void getIdentityNotificationAttributes_mixedKnownAndUnknown_returnsOnlyKnown() {
+        // The unknown identity is dropped from the map; the known one stays.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "GetIdentityNotificationAttributes")
+            .formParam("Identities.member.1", "v1-attrs.floci.test")
+            .formParam("Identities.member.2", "ghost-notif2.floci.test")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<key>v1-attrs.floci.test</key>"))
+            .body(not(containsString("ghost-notif2.floci.test")));
     }
 }


### PR DESCRIPTION
## Summary

`GetIdentityNotificationAttributes` emitted a `NotificationAttributes` map entry with an empty `<value>` for every queried identity, including ones that were never verified. Real AWS returns an empty map for an unknown identity (and drops it from a mixed query), never an entry with missing fields.

- The handler now skips identities the service doesn't know about, so an unknown identity is absent from the map
- The fabricated empty entry also violated the response contract — its value lacked the required `ForwardingEnabled` field
- Known identities are unaffected

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** for an unverified/unknown identity, the response contained an entry keyed by that identity with an empty value (no `ForwardingEnabled` or other fields).

**Expected (AWS) behavior:** verified against real AWS SES (2026-06-13):

- unknown identity → `NotificationAttributes` is an empty map (no entry)
- mixed known + unknown → only the known identity appears
- a present entry always includes `ForwardingEnabled` and the three `HeadersIn*NotificationsEnabled` flags

**Fixed behavior:** unknown identities are omitted from the map; known identities round-trip unchanged.

**Reproduction:**

```bash
# AWS (SES v1, us-east-1)
aws ses get-identity-notification-attributes --identities ghost.example.com
# → {"NotificationAttributes": {}}

aws ses verify-email-identity --email-address known@example.com
aws ses get-identity-notification-attributes --identities known@example.com ghost.example.com
# → only "known@example.com" present, with ForwardingEnabled + HeadersIn* flags

# cleanup (removes the identity created above)
aws ses delete-identity --identity known@example.com

# Floci (SES v1 Query protocol)
curl -s -X POST http://localhost:4566/ \
  -H 'Authorization: AWS4-HMAC-SHA256 Credential=test/20260101/us-east-1/ses/aws4_request' \
  --data 'Action=GetIdentityNotificationAttributes&Version=2010-12-01&Identities.member.1=ghost.example.com'
# before fix: <entry><key>ghost...</key><value></value></entry>
# after fix:  empty <NotificationAttributes/>, no entry
```

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)