### PR TITLE
fix(SQS): max message size should be 1MB, not 256KB

### DIFF
--- a/docs/configuration/advanced/application-yml.md
+++ b/docs/configuration/advanced/application-yml.md
@@ -101,7 +101,7 @@ floci:
     sqs:
       enabled: true
       default-visibility-timeout: 30         # Seconds
-      max-message-size: 262144               # Bytes (256 KB)
+      max-message-size: 1048576              # Bytes (1 MB)
       clear-fifo-deduplication-cache-on-purge: false  # When true, PurgeQueue clears SQS FIFO dedup and SNS FIFO topic dedup for topics subscribed to that queue
 
     s3:
@@ -259,7 +259,7 @@ All keys in this table are declared on `EmulatorConfig` and accept environment v
 | `FLOCI_DNS_EXTRA_SUFFIXES`                         | *(unset)*        | Comma-separated extra hostname suffixes the embedded DNS server resolves to Floci's container IP. E.g. `localhost.localstack.cloud,localhost.example.internal` |
 | `FLOCI_SERVICES_SSM_MAX_PARAMETER_HISTORY`         | `5`              | Max parameter versions kept                                   |
 | `FLOCI_SERVICES_SQS_DEFAULT_VISIBILITY_TIMEOUT`    | `30`             | Default visibility timeout (seconds)                          |
-| `FLOCI_SERVICES_SQS_MAX_MESSAGE_SIZE`              | `262144`         | Max message size (bytes)                                      |
+| `FLOCI_SERVICES_SQS_MAX_MESSAGE_SIZE`              | `1048576`        | Max message size (bytes)                                      |
 | `FLOCI_SERVICES_SQS_CLEAR_FIFO_DEDUPLICATION_CACHE_ON_PURGE` | `false` | When `true`, `PurgeQueue` clears the FIFO 5-minute deduplication cache for the target queue and matching SNS FIFO topic dedup entries |
 | `FLOCI_SERVICES_S3_DEFAULT_PRESIGN_EXPIRY_SECONDS` | `3600`           | Pre-signed URL expiry                                         |
 | `FLOCI_SERVICES_DOCKER_NETWORK`                    | *(unset)*        | Shared Docker network for Lambda, RDS, ElastiCache containers |

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -145,7 +145,7 @@ See [Initialization Hooks](./initialization-hooks.md) for lifecycle phases and s
 |---|---|---|
 | `FLOCI_SERVICES_SQS_ENABLED` | `true` | Enable the SQS service |
 | `FLOCI_SERVICES_SQS_DEFAULT_VISIBILITY_TIMEOUT` | `30` | Default message visibility timeout in seconds |
-| `FLOCI_SERVICES_SQS_MAX_MESSAGE_SIZE` | `262144` | Maximum message body size in bytes (256 KB) |
+| `FLOCI_SERVICES_SQS_MAX_MESSAGE_SIZE` | `1048576` | Maximum message body size in bytes (1 MB) |
 | `FLOCI_SERVICES_SQS_CLEAR_FIFO_DEDUPLICATION_CACHE_ON_PURGE` | `false` | Reset the deduplication cache when a FIFO queue is purged |
 
 ### SNS

--- a/docs/services/sqs.md
+++ b/docs/services/sqs.md
@@ -81,7 +81,7 @@ curl -X DELETE "http://localhost:4566/_aws/sqs/messages?QueueUrl=$QUEUE_URL"
 |---|---|---|
 | `FLOCI_SERVICES_SQS_ENABLED` | `true` | Enable or disable the service |
 | `FLOCI_SERVICES_SQS_DEFAULT_VISIBILITY_TIMEOUT` | `30` | Default message visibility timeout (seconds) |
-| `FLOCI_SERVICES_SQS_MAX_MESSAGE_SIZE` | `262144` | Maximum message size in bytes (256 KB) |
+| `FLOCI_SERVICES_SQS_MAX_MESSAGE_SIZE` | `1048576` | Maximum message size in bytes (1 MB) |
 | `FLOCI_SERVICES_SQS_CLEAR_FIFO_DEDUPLICATION_CACHE_ON_PURGE` | `false` | When `true`, `PurgeQueue` also clears the FIFO deduplication cache for the queue and any SNS FIFO topics subscribed to it |
 
 ## Examples

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -444,7 +444,7 @@ public interface EmulatorConfig {
         @WithDefault("30")
         int defaultVisibilityTimeout();
 
-        @WithDefault("262144")
+        @WithDefault("1048576")
         int maxMessageSize();
 
         @WithDefault("false")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -136,7 +136,7 @@ floci:
     sqs:
       enabled: true
       default-visibility-timeout: 30
-      max-message-size: 262144
+      max-message-size: 1048576
       clear-fifo-deduplication-cache-on-purge: false
     s3:
       enabled: true

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
@@ -397,7 +397,7 @@ class SqsIntegrationTest {
             .extract().xmlPath().getString("CreateQueueResponse.CreateQueueResult.QueueUrl");
 
         try {
-            String bigBody = "x".repeat(100_000);
+            String bigBody = "x".repeat(400_000);
             given()
                 .contentType("application/x-www-form-urlencoded")
                 .formParam("Action", "SendMessageBatch")

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
@@ -178,9 +178,9 @@ class SqsJsonProtocolTest {
     @Test
     @Order(6)
     void sendMessageBatchExceedingQueueMaximumMessageSizeReturnsBatchRequestTooLong() {
-        // Default queue MaximumMessageSize is 262144 bytes. Each entry is well under the
+        // Default queue MaximumMessageSize is 1048576 bytes. Each entry is well under the
         // per-message limit; the sum is what trips the batch-level check.
-        String bigBody = "x".repeat(100_000);
+        String bigBody = "x".repeat(400_000);
         String body = "{\"QueueUrl\":\"" + queueUrl + "\","
                 + "\"Entries\":["
                 + "{\"Id\":\"a\",\"MessageBody\":\"" + bigBody + "\"},"

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceFactory.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceFactory.java
@@ -11,12 +11,12 @@ public class SqsServiceFactory {
 
     public static SqsService createInMemory(String baseUrl, RegionResolver regionResolver) {
         return new SqsService(new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
-                30, 262144, baseUrl, regionResolver);
+                30, 1048576, baseUrl, regionResolver);
     }
 
     public static SqsService createInMemoryWithFifoDedupPurgeAndSns(String baseUrl, RegionResolver regionResolver,
                                                                     SnsService snsService) {
         return new SqsService(new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
-                30, 262144, baseUrl, regionResolver, true, snsService);
+                30, 1048576, baseUrl, regionResolver, true, snsService);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -27,7 +27,7 @@ class SqsServiceTest {
 
     @BeforeEach
     void setUp() {
-        sqsService = new SqsService(new InMemoryStorage<>(), 30, 262144, BASE_URL);
+        sqsService = new SqsService(new InMemoryStorage<>(), 30, 1048576, BASE_URL);
     }
 
     @Test
@@ -468,7 +468,7 @@ class SqsServiceTest {
         String region = "eu-west-1";
         final var service = new SqsService(
                 new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
-                30, 262144, BASE_URL, new RegionResolver("us-east-1", "000000000000"), true, null);
+                30, 1048576, BASE_URL, new RegionResolver("us-east-1", "000000000000"), true, null);
 
         final var queue = service.createQueue("dedup-clear.fifo", Map.of("ContentBasedDeduplication", "true"), region);
 
@@ -524,7 +524,7 @@ class SqsServiceTest {
         final var dedupStore = new InMemoryStorage<String, Map<String, Long>>();
         final var service = new SqsService(
                 new InMemoryStorage<>(), new InMemoryStorage<>(), dedupStore,
-                30, 262144, BASE_URL, new RegionResolver("us-east-1", "000000000000"), true, null);
+                30, 1048576, BASE_URL, new RegionResolver("us-east-1", "000000000000"), true, null);
 
         final var queue = service.createQueue("dedup-store-clear.fifo",
                 Map.of("ContentBasedDeduplication", "true"), region);
@@ -882,9 +882,9 @@ class SqsServiceTest {
     void validateBatchPayloadSize_overQueueLimit_throwsBatchRequestTooLong() {
         Queue queue = sqsService.createQueue("batch-q", null, "us-east-1");
         AwsException ex = assertThrows(AwsException.class, () ->
-                sqsService.validateBatchPayloadSize(queue.getQueueUrl(), "us-east-1", 300_000));
+                sqsService.validateBatchPayloadSize(queue.getQueueUrl(), "us-east-1", 1_100_000));
         assertEquals("BatchRequestTooLong", ex.getErrorCode());
-        assertTrue(ex.getMessage().contains("262144"));
+        assertTrue(ex.getMessage().contains("1048576"));
     }
 
     @Test
@@ -913,7 +913,7 @@ class SqsServiceTest {
         final var sns = mock(SnsService.class);
         final var service = new SqsService(
                 new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
-                30, 262144, BASE_URL, new RegionResolver("us-east-1", "000000000000"), true, sns);
+                30, 1048576, BASE_URL, new RegionResolver("us-east-1", "000000000000"), true, sns);
         final var queue = service.createQueue("sns-dedup-delegate.fifo", Map.of("FifoQueue", "true"),region);
         service.purgeQueue(queue.getQueueUrl(), region);
         verify(sns).clearFifoDeduplicationCacheForSqsQueueSubscriptions(

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -63,7 +63,7 @@ floci:
     sqs:
       enabled: true
       default-visibility-timeout: 30
-      max-message-size: 262144
+      max-message-size: 1048576
     s3:
       enabled: true
       default-presign-expiry-seconds: 3600


### PR DESCRIPTION
## Summary

SQS max message size increased to 1MB from256KB.
Closes #1277 

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore


## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
