### PR TITLE
fix(scheduler): 🐛 support aws-sdk universal targets and FIFO MessageGroupId

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvoker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvoker.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.scheduler;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
@@ -19,9 +20,11 @@ import java.util.Map;
 
 /**
  * Delivers an EventBridge Scheduler target invocation to the underlying service.
- * Supports SQS, Lambda, SNS, and EventBridge PutEvents targets — mirrors the
- * subset handled by {@code EventBridgeInvoker} but using Scheduler's
- * {@link Target} model (raw {@code input} string, no JSONPath/template).
+ * Supports templated SQS, Lambda, SNS, and EventBridge PutEvents targets, plus
+ * universal targets ({@code arn:aws:scheduler:::aws-sdk:<service>:<action>}) for
+ * {@code sns:publish} and {@code sqs:sendMessage}. Mirrors the subset handled by
+ * {@code EventBridgeInvoker} but using Scheduler's {@link Target} model (raw
+ * {@code input} string, no JSONPath/template).
  */
 @ApplicationScoped
 public class ScheduleInvoker {
@@ -56,11 +59,23 @@ public class ScheduleInvoker {
         }
         String arn = target.getArn();
         String payload = target.getInput() != null ? target.getInput() : "{}";
-        String targetRegion = extractRegion(arn, region);
 
+        // Universal targets (arn:aws:scheduler:::aws-sdk:<service>:<action>) carry the
+        // real resource identifiers inside Input, not in the target ARN. Detect and
+        // dispatch them before the ARN-substring routing below, which would otherwise
+        // mis-match (e.g. "aws-sdk:sns:publish" contains ":sns:").
+        int sdkIdx = arn.indexOf(":aws-sdk:");
+        if (sdkIdx >= 0) {
+            invokeUniversalTarget(arn.substring(sdkIdx + ":aws-sdk:".length()), payload, region);
+            return;
+        }
+
+        String targetRegion = extractRegion(arn, region);
         if (arn.contains(":sqs:")) {
             String queueUrl = AwsArnUtils.arnToQueueUrl(arn, baseUrl);
-            sqsService.sendMessage(queueUrl, payload, 0, targetRegion);
+            String messageGroupId = target.getSqsParameters() != null
+                    ? target.getSqsParameters().getMessageGroupId() : null;
+            sqsService.sendMessage(queueUrl, payload, 0, messageGroupId, null, targetRegion);
             LOG.debugv("Scheduler delivered to SQS: {0}", arn);
         } else if (arn.contains(":lambda:") || arn.contains(":function:")) {
             String fnName = arn.substring(arn.lastIndexOf(':') + 1);
@@ -75,6 +90,50 @@ public class ScheduleInvoker {
         } else {
             LOG.warnv("Scheduler: unsupported target ARN type: {0}", arn);
         }
+    }
+
+    /**
+     * Dispatches an EventBridge Scheduler universal target ({@code aws-sdk:<service>:<action>}),
+     * reading the call parameters from the target's {@code Input} payload. Supports the
+     * common {@code sns:publish} and {@code sqs:sendMessage} actions; other actions are
+     * logged as unsupported.
+     */
+    private void invokeUniversalTarget(String serviceAction, String input, String region) {
+        JsonNode params;
+        try {
+            params = objectMapper.readTree(input == null || input.isBlank() ? "{}" : input);
+        } catch (Exception e) {
+            LOG.warnv("Scheduler: universal target {0} has unparseable Input: {1}", serviceAction, e.getMessage());
+            return;
+        }
+        switch (serviceAction) {
+            case "sns:publish" -> {
+                String topicArn = text(params, "TopicArn");
+                String targetArn = text(params, "TargetArn");
+                String message = text(params, "Message");
+                String subject = text(params, "Subject");
+                String messageGroupId = text(params, "MessageGroupId");
+                String messageDeduplicationId = text(params, "MessageDeduplicationId");
+                String snsRegion = extractRegion(topicArn != null ? topicArn : targetArn, region);
+                snsService.publish(topicArn, targetArn, null, message, subject, null,
+                        messageGroupId, messageDeduplicationId, snsRegion);
+                LOG.debugv("Scheduler delivered to SNS (universal target): {0}", topicArn);
+            }
+            case "sqs:sendMessage" -> {
+                String queueUrl = text(params, "QueueUrl");
+                String body = text(params, "MessageBody");
+                String messageGroupId = text(params, "MessageGroupId");
+                String messageDeduplicationId = text(params, "MessageDeduplicationId");
+                sqsService.sendMessage(queueUrl, body, 0, messageGroupId, messageDeduplicationId, region);
+                LOG.debugv("Scheduler delivered to SQS (universal target): {0}", queueUrl);
+            }
+            default -> LOG.warnv("Scheduler: unsupported universal target action: {0}", serviceAction);
+        }
+    }
+
+    private static String text(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        return value != null && !value.isNull() ? value.asText() : null;
     }
 
     private boolean isEventBridgePutEventsArn(String arn) {
@@ -105,6 +164,9 @@ public class ScheduleInvoker {
     }
 
     private static String extractRegion(String arn, String defaultRegion) {
+        if (arn == null) {
+            return defaultRegion;
+        }
         String[] parts = arn.split(":");
         return parts.length >= 4 && !parts[3].isEmpty() ? parts[3] : defaultRegion;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.services.scheduler.model.RetryPolicy;
 import io.github.hectorvent.floci.services.scheduler.model.Schedule;
 import io.github.hectorvent.floci.services.scheduler.model.ScheduleGroup;
 import io.github.hectorvent.floci.services.scheduler.model.ScheduleRequest;
+import io.github.hectorvent.floci.services.scheduler.model.SqsParameters;
 import io.github.hectorvent.floci.services.scheduler.model.Target;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -260,6 +261,12 @@ public class SchedulerController {
                 dlc.put("Arn", s.getTarget().getDeadLetterConfig().getArn());
                 t.put("DeadLetterConfig", dlc);
             }
+            if (s.getTarget().getSqsParameters() != null
+                    && s.getTarget().getSqsParameters().getMessageGroupId() != null) {
+                Map<String, Object> sp = new HashMap<>();
+                sp.put("MessageGroupId", s.getTarget().getSqsParameters().getMessageGroupId());
+                t.put("SqsParameters", sp);
+            }
             r.put("Target", t);
         }
         if (s.getDescription() != null) {
@@ -386,6 +393,14 @@ public class SchedulerController {
                 dlc.setArn(dlcNode.get("Arn").asText());
             }
             target.setDeadLetterConfig(dlc);
+        }
+        if (node.has("SqsParameters") && !node.get("SqsParameters").isNull()) {
+            JsonNode spNode = node.get("SqsParameters");
+            SqsParameters sp = new SqsParameters();
+            if (spNode.has("MessageGroupId") && !spNode.get("MessageGroupId").isNull()) {
+                sp.setMessageGroupId(spNode.get("MessageGroupId").asText());
+            }
+            target.setSqsParameters(sp);
         }
         return target;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/model/SqsParameters.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/model/SqsParameters.java
@@ -1,0 +1,22 @@
+package io.github.hectorvent.floci.services.scheduler.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * EventBridge Scheduler {@code Target.SqsParameters}. Carries the
+ * {@code MessageGroupId} required when the target is a FIFO SQS queue.
+ */
+@RegisterForReflection
+public class SqsParameters {
+
+    private String messageGroupId;
+
+    public SqsParameters() {}
+
+    public SqsParameters(String messageGroupId) {
+        this.messageGroupId = messageGroupId;
+    }
+
+    public String getMessageGroupId() { return messageGroupId; }
+    public void setMessageGroupId(String messageGroupId) { this.messageGroupId = messageGroupId; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/model/Target.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/model/Target.java
@@ -10,6 +10,7 @@ public class Target {
     private String input;
     private RetryPolicy retryPolicy;
     private DeadLetterConfig deadLetterConfig;
+    private SqsParameters sqsParameters;
 
     public Target() {}
 
@@ -34,4 +35,7 @@ public class Target {
 
     public DeadLetterConfig getDeadLetterConfig() { return deadLetterConfig; }
     public void setDeadLetterConfig(DeadLetterConfig deadLetterConfig) { this.deadLetterConfig = deadLetterConfig; }
+
+    public SqsParameters getSqsParameters() { return sqsParameters; }
+    public void setSqsParameters(SqsParameters sqsParameters) { this.sqsParameters = sqsParameters; }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvokerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvokerTest.java
@@ -1,0 +1,113 @@
+package io.github.hectorvent.floci.services.scheduler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.eventbridge.EventBridgeService;
+import io.github.hectorvent.floci.services.lambda.LambdaService;
+import io.github.hectorvent.floci.services.scheduler.model.SqsParameters;
+import io.github.hectorvent.floci.services.scheduler.model.Target;
+import io.github.hectorvent.floci.services.sns.SnsService;
+import io.github.hectorvent.floci.services.sqs.SqsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ScheduleInvokerTest {
+
+    private static final String TOPIC_ARN = "arn:aws:sns:us-east-1:000000000000:repro-topic";
+
+    private SqsService sqsService;
+    private LambdaService lambdaService;
+    private SnsService snsService;
+    private EventBridgeService eventBridgeService;
+    private ScheduleInvoker invoker;
+
+    @BeforeEach
+    void setUp() {
+        sqsService = mock(SqsService.class);
+        lambdaService = mock(LambdaService.class);
+        snsService = mock(SnsService.class);
+        eventBridgeService = mock(EventBridgeService.class);
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        when(config.baseUrl()).thenReturn("http://localhost:4566");
+        invoker = new ScheduleInvoker(sqsService, lambdaService, snsService,
+                eventBridgeService, new ObjectMapper(), config);
+    }
+
+    @Test
+    void universalSnsPublishReadsTopicArnAndMessageFromInput() {
+        Target target = new Target();
+        target.setArn("arn:aws:scheduler:::aws-sdk:sns:publish");
+        target.setRoleArn("arn:aws:iam::000000000000:role/x");
+        target.setInput("{\"TopicArn\":\"" + TOPIC_ARN + "\",\"Message\":\"scheduled-universal-target\"}");
+
+        invoker.invoke(target, "us-east-1");
+
+        // The real TopicArn from Input must be used, NOT the universal-target ARN.
+        verify(snsService).publish(eq(TOPIC_ARN), isNull(), isNull(),
+                eq("scheduled-universal-target"), isNull(), isNull(),
+                isNull(), isNull(), eq("us-east-1"));
+        verify(snsService, never()).publish(eq("arn:aws:scheduler:::aws-sdk:sns:publish"),
+                any(), any(), any(), any());
+    }
+
+    @Test
+    void universalSqsSendMessageReadsQueueUrlBodyAndGroupIdFromInput() {
+        Target target = new Target();
+        target.setArn("arn:aws:scheduler:::aws-sdk:sqs:sendMessage");
+        target.setRoleArn("arn:aws:iam::000000000000:role/x");
+        target.setInput("{\"QueueUrl\":\"http://localhost:4566/000000000000/q.fifo\","
+                + "\"MessageBody\":\"hi\",\"MessageGroupId\":\"g1\"}");
+
+        invoker.invoke(target, "us-east-1");
+
+        verify(sqsService).sendMessage(eq("http://localhost:4566/000000000000/q.fifo"),
+                eq("hi"), eq(0), eq("g1"), isNull(), eq("us-east-1"));
+    }
+
+    @Test
+    void templatedFifoSqsHonorsSqsParametersMessageGroupId() {
+        Target target = new Target();
+        target.setArn("arn:aws:sqs:us-east-1:000000000000:test.fifo");
+        target.setInput("{\"hello\":\"world\"}");
+        target.setSqsParameters(new SqsParameters("group-7"));
+
+        invoker.invoke(target, "us-east-1");
+
+        verify(sqsService).sendMessage(anyString(), eq("{\"hello\":\"world\"}"), eq(0),
+                eq("group-7"), isNull(), eq("us-east-1"));
+    }
+
+    @Test
+    void directSnsTopicArnStillDelivers() {
+        Target target = new Target();
+        target.setArn(TOPIC_ARN);
+        target.setInput("{\"hello\":\"world\"}");
+
+        invoker.invoke(target, "us-east-1");
+
+        verify(snsService).publish(eq(TOPIC_ARN), isNull(), eq("{\"hello\":\"world\"}"),
+                eq("Scheduler"), eq("us-east-1"));
+    }
+
+    @Test
+    void unsupportedUniversalActionDoesNotThrowOrDispatch() {
+        Target target = new Target();
+        target.setArn("arn:aws:scheduler:::aws-sdk:dynamodb:putItem");
+        target.setInput("{}");
+
+        invoker.invoke(target, "us-east-1");
+
+        verify(sqsService, never()).sendMessage(anyString(), anyString(), anyInt(), anyString(), any(), anyString());
+        verify(snsService, never()).publish(anyString(), any(), anyString(), anyString(), anyString());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerIntegrationTest.java
@@ -377,6 +377,35 @@ class SchedulerIntegrationTest {
     }
 
     @Test
+    @Order(20)
+    void createScheduleWithSqsParametersRoundTrips() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "ScheduleExpression": "rate(1 hour)",
+                    "FlexibleTimeWindow": {"Mode": "OFF"},
+                    "Target": {
+                        "Arn": "arn:aws:sqs:us-east-1:000000000000:my-queue.fifo",
+                        "RoleArn": "arn:aws:iam::000000000000:role/scheduler-role",
+                        "SqsParameters": {"MessageGroupId": "group-1"}
+                    }
+                }
+                """)
+        .when()
+            .post("/schedules/fifo-schedule")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/schedules/fifo-schedule")
+        .then()
+            .statusCode(200)
+            .body("Target.SqsParameters.MessageGroupId", equalTo("group-1"));
+    }
+
+    @Test
     @Order(21)
     void createScheduleInGroup() {
         // First create the group


### PR DESCRIPTION
## Summary

Closes #1265

EventBridge Scheduler **universal targets** (`arn:aws:scheduler:::aws-sdk:<service>:<action>`) were not handled, and `Target.SqsParameters` was dropped:

- `ScheduleInvoker` routed solely by substring-matching the target ARN. The universal ARN `arn:aws:scheduler:::aws-sdk:sns:publish` contains `:sns:`, so it took the SNS branch and passed **the universal-target ARN itself** to `SnsService.publish` as the topic, failing at fire time with `Topic does not exist`. The real `TopicArn` carried in the target's `Input` was never read. (For SNS this is the only way to publish from a schedule on real AWS.)
- The SQS branch never read `Target.SqsParameters.MessageGroupId`, so FIFO SQS targets failed with `The request must contain the parameter MessageGroupId`.

Changes:

- Detect the `aws-sdk:<service>:<action>` form **before** the ARN-substring routing and dispatch `sns:publish` / `sqs:sendMessage` using parameters parsed from `Input` (`TopicArn`/`Message`/`Subject`/FIFO ids; `QueueUrl`/`MessageBody`/`MessageGroupId`/`MessageDeduplicationId`). Unsupported universal actions are logged, not misfired.
- Add `SqsParameters` to the `Target` model, parse it in `SchedulerController`, serialize it back on GetSchedule, and honor `MessageGroupId` in the templated SQS branch.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: a schedule targeting `arn:aws:scheduler:::aws-sdk:sns:publish` with `Input={"TopicArn":"...","Message":"..."}` failed at fire time with `Topic does not exist` and nothing was published, even though a direct `sns publish` to the same topic succeeded. A FIFO SQS target with `SqsParameters.MessageGroupId` failed with `The request must contain the parameter MessageGroupId`.

Expected (matching real EventBridge Scheduler): at fire time FLOCI performs the underlying API call using the parameters in `Input`, and forwards `MessageGroupId` to FIFO SQS queues.

Verified against the reproduction in the issue (AWS CLI v2: `scheduler create-schedule` with the universal `sns:publish` target, observing delivery to a subscribed SQS queue).

## Checklist

- [x] `./mvnw test` passes locally for the affected suites: `ScheduleInvokerTest`, `ScheduleDispatcherTest`, `SchedulerServiceTest`, `SchedulerIntegrationTest` (106 passed). The full suite's only failures on this machine are the 16 Docker-dependent suites that fail identically on an unmodified `main` (no Docker available locally).
- [x] New or updated integration test added: new `ScheduleInvokerTest` (universal `sns:publish` reads the Input `TopicArn` not the universal ARN; universal `sqs:sendMessage` forwards `MessageGroupId`; templated FIFO honors `SqsParameters.MessageGroupId`; direct topic ARN still delivers; unsupported universal action neither throws nor dispatches) plus a `SqsParameters` round-trip assertion in `SchedulerIntegrationTest`.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
