### PR TITLE
fix: return XML error for missing action and add volume action fallbacks

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -165,7 +165,8 @@ public class AwsQueryController {
             "DescribeInstanceTypes", "DescribeInstanceTypeOfferings",
             "CreateLaunchTemplate", "CreateLaunchTemplateVersion", "DescribeLaunchTemplates", "DescribeLaunchTemplateVersions",
             "ModifyLaunchTemplate", "DeleteLaunchTemplate",
-            "DescribeNetworkInterfaces"
+            "DescribeNetworkInterfaces",
+            "CreateVolume", "DescribeVolumes", "DeleteVolume"
     );
 
     private final CloudFormationQueryHandler cloudFormationQueryHandler;
@@ -231,7 +232,8 @@ public class AwsQueryController {
 
         String action = formParams.getFirst("Action");
         if (action == null) {
-            return null;
+            return xmlErrorResponse("MissingAction",
+                    "The request must contain the parameter Action", 400);
         }
 
         String service = resolveService(authorization, action);

--- a/src/test/java/io/github/hectorvent/floci/core/common/AwsQueryControllerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/AwsQueryControllerIntegrationTest.java
@@ -1,0 +1,38 @@
+package io.github.hectorvent.floci.core.common;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+@QuarkusTest
+class AwsQueryControllerIntegrationTest {
+
+    @Test
+    void missingActionParameterReturns400MissingAction() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .contentType("application/xml")
+            .body("ErrorResponse.Error.Code", equalTo("MissingAction"))
+            .body("ErrorResponse.Error.Message", equalTo("The request must contain the parameter Action"));
+    }
+
+    @Test
+    void ec2ActionFallbackWithoutAuthorizationHeader() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeRegions")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("DescribeRegionsResponse.regionInfo.item.size()", greaterThan(0));
+    }
+}


### PR DESCRIPTION
Resolves #1333. This pull request addresses the XML parser error on clients when requests are made without the 'Action' parameter (returning a 400 Bad Request status and a structured XML 'MissingAction' error instead of a 204 No Content response with an empty body). It also adds missing EC2 volume actions ('CreateVolume', 'DescribeVolumes', 'DeleteVolume') to the unauthenticated fallback list in the query controller.