### PR TITLE
fix(ses): canonicalize only the domain of suppression-list email addresses

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -42,6 +42,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -1170,7 +1171,20 @@ public class SesService {
         validateSuppressionReason(reason, "reason", false);
         String key = suppressionKey(region, normalized);
         SuppressedDestination existing = suppressionStore.get(key).orElse(null);
+        // Migrate a legacy entry persisted by a pre-canonicalization Floci (which
+        // stored the address trim-only) onto the canonical key, so a re-PUT doesn't
+        // leave a stuck duplicate alongside the new entry.
+        if (existing == null) {
+            String legacy = suppressionKey(region, emailAddress.trim());
+            if (!legacy.equals(key)) {
+                existing = suppressionStore.get(legacy).orElse(null);
+                if (existing != null) {
+                    suppressionStore.delete(legacy);
+                }
+            }
+        }
         SuppressedDestination entry = existing != null ? existing : new SuppressedDestination(normalized, reason);
+        entry.setEmailAddress(normalized);
         entry.setReason(reason);
         entry.setLastUpdateTime(Instant.now());
         suppressionStore.put(key, entry);
@@ -1179,7 +1193,8 @@ public class SesService {
 
     public SuppressedDestination getSuppressedDestination(String region, String emailAddress) {
         String normalized = normalizeSuppressionEmail(emailAddress);
-        return suppressionStore.get(suppressionKey(region, normalized))
+        return existingSuppressionKey(region, emailAddress, normalized)
+                .flatMap(suppressionStore::get)
                 .orElseThrow(() -> new AwsException("NotFoundException",
                         "Email address " + normalized + " does not exist on your suppression list.",
                         404));
@@ -1187,14 +1202,30 @@ public class SesService {
 
     public void deleteSuppressedDestination(String region, String emailAddress) {
         String normalized = normalizeSuppressionEmail(emailAddress);
-        String key = suppressionKey(region, normalized);
-        if (suppressionStore.get(key).isEmpty()) {
-            throw new AwsException("NotFoundException",
-                    "Email address " + normalized + " does not exist on your suppression list.",
-                    404);
-        }
+        String key = existingSuppressionKey(region, emailAddress, normalized)
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "Email address " + normalized + " does not exist on your suppression list.",
+                        404));
         suppressionStore.delete(key);
         LOG.infov("Removed suppression entry for {0} in region {1}", normalized, region);
+    }
+
+    /**
+     * Resolve the storage key an entry currently lives under: the canonical
+     * (domain-lower-cased) key, or — for entries persisted by a pre-canonicalization
+     * Floci that stored the address trim-only — the legacy raw-trimmed key. Lets
+     * GET/DELETE reach and remove legacy entries without a keyspace scan.
+     */
+    private Optional<String> existingSuppressionKey(String region, String rawEmail, String normalized) {
+        String canonical = suppressionKey(region, normalized);
+        if (suppressionStore.get(canonical).isPresent()) {
+            return Optional.of(canonical);
+        }
+        String legacy = suppressionKey(region, rawEmail.trim());
+        if (!legacy.equals(canonical) && suppressionStore.get(legacy).isPresent()) {
+            return Optional.of(legacy);
+        }
+        return Optional.empty();
     }
 
     public List<SuppressedDestination> listSuppressedDestinations(String region, List<String> reasonFilters) {
@@ -1251,7 +1282,8 @@ public class SesService {
                 continue;
             }
             String normalized = normalizeSuppressionEmail(address);
-            SuppressedDestination entry = suppressionStore.get(suppressionKey(region, normalized))
+            SuppressedDestination entry = existingSuppressionKey(region, address, normalized)
+                    .flatMap(suppressionStore::get)
                     .orElse(null);
             if (entry != null && entry.getReason() != null
                     && reasonFilter.contains(entry.getReason())) {
@@ -1306,9 +1338,11 @@ public class SesService {
             return null;
         }
         // Share the same normalization used when entries are stored
-        // (`normalizeSuppressionEmail`) so lookups can't drift apart from inserts.
+        // (`normalizeSuppressionEmail`) so lookups can't drift apart from inserts,
+        // with the same legacy-key fallback as GET/DELETE.
         String normalized = normalizeSuppressionEmail(emailAddress);
-        SuppressedDestination entry = suppressionStore.get(suppressionKey(region, normalized))
+        SuppressedDestination entry = existingSuppressionKey(region, emailAddress, normalized)
+                .flatMap(suppressionStore::get)
                 .orElse(null);
         if (entry == null || entry.getReason() == null) {
             return null;
@@ -1324,8 +1358,19 @@ public class SesService {
         if (emailAddress == null || emailAddress.isBlank()) {
             throw new AwsException("BadRequestException", "EmailAddress is required.", 400);
         }
-        // AWS trims leading/trailing whitespace from EmailAddress before storing.
-        return emailAddress.trim();
+        // AWS trims the EmailAddress and canonicalizes only the domain to lower
+        // case; the local-part keeps its case. Verified against real AWS SES V2
+        // (2026-06-15): `Foo@Example.COM` and `Foo@example.com` collapse to one
+        // suppression entry (`Foo@example.com`), but `Foo@x` and `foo@x` are two
+        // distinct entries. Lower-casing the whole address would wrongly merge
+        // local-part variants and alter the stored value on read-back.
+        // Locale.ROOT avoids the JVM-locale Turkish-i pitfall.
+        String trimmed = emailAddress.trim();
+        int at = trimmed.lastIndexOf('@');
+        if (at < 0) {
+            return trimmed;
+        }
+        return trimmed.substring(0, at) + "@" + trimmed.substring(at + 1).toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -1170,31 +1170,26 @@ public class SesService {
         String normalized = normalizeSuppressionEmail(emailAddress);
         validateSuppressionReason(reason, "reason", false);
         String key = suppressionKey(region, normalized);
-        SuppressedDestination existing = suppressionStore.get(key).orElse(null);
-        // Migrate a legacy entry persisted by a pre-canonicalization Floci (which
-        // stored the address trim-only) onto the canonical key, so a re-PUT doesn't
-        // leave a stuck duplicate alongside the new entry.
-        if (existing == null) {
-            String legacy = suppressionKey(region, emailAddress.trim());
-            if (!legacy.equals(key)) {
-                existing = suppressionStore.get(legacy).orElse(null);
-                if (existing != null) {
-                    suppressionStore.delete(legacy);
-                }
-            }
-        }
-        SuppressedDestination entry = existing != null ? existing : new SuppressedDestination(normalized, reason);
+        SuppressionMatch match = existingSuppressionMatch(region, emailAddress, normalized).orElse(null);
+        SuppressedDestination entry = match != null ? match.entry() : new SuppressedDestination(normalized, reason);
         entry.setEmailAddress(normalized);
         entry.setReason(reason);
         entry.setLastUpdateTime(Instant.now());
+        // Write the canonical key first, then drop a legacy key it migrated from,
+        // so a failed write can't lose the entry. The legacy form was persisted by
+        // a pre-canonicalization Floci (trim-only key); migrating it avoids leaving
+        // a stuck duplicate after a re-PUT.
         suppressionStore.put(key, entry);
+        if (match != null && !match.key().equals(key)) {
+            suppressionStore.delete(match.key());
+        }
         LOG.infov("Suppressed destination {0} in region {1} (reason={2})", normalized, region, reason);
     }
 
     public SuppressedDestination getSuppressedDestination(String region, String emailAddress) {
         String normalized = normalizeSuppressionEmail(emailAddress);
-        return existingSuppressionKey(region, emailAddress, normalized)
-                .flatMap(suppressionStore::get)
+        return existingSuppressionMatch(region, emailAddress, normalized)
+                .map(SuppressionMatch::entry)
                 .orElseThrow(() -> new AwsException("NotFoundException",
                         "Email address " + normalized + " does not exist on your suppression list.",
                         404));
@@ -1202,28 +1197,36 @@ public class SesService {
 
     public void deleteSuppressedDestination(String region, String emailAddress) {
         String normalized = normalizeSuppressionEmail(emailAddress);
-        String key = existingSuppressionKey(region, emailAddress, normalized)
+        SuppressionMatch match = existingSuppressionMatch(region, emailAddress, normalized)
                 .orElseThrow(() -> new AwsException("NotFoundException",
                         "Email address " + normalized + " does not exist on your suppression list.",
                         404));
-        suppressionStore.delete(key);
+        suppressionStore.delete(match.key());
         LOG.infov("Removed suppression entry for {0} in region {1}", normalized, region);
     }
 
+    /** A suppression entry together with the storage key it currently lives under. */
+    private record SuppressionMatch(String key, SuppressedDestination entry) {
+    }
+
     /**
-     * Resolve the storage key an entry currently lives under: the canonical
-     * (domain-lower-cased) key, or — for entries persisted by a pre-canonicalization
-     * Floci that stored the address trim-only — the legacy raw-trimmed key. Lets
-     * GET/DELETE reach and remove legacy entries without a keyspace scan.
+     * Resolve a suppression entry by its canonical (domain-lower-cased) key, falling
+     * back to the legacy raw-trimmed key used by a pre-canonicalization Floci. Returns
+     * the entry and the key it was found under in a single read per candidate, so
+     * callers don't re-fetch the store.
      */
-    private Optional<String> existingSuppressionKey(String region, String rawEmail, String normalized) {
+    private Optional<SuppressionMatch> existingSuppressionMatch(String region, String rawEmail, String normalized) {
         String canonical = suppressionKey(region, normalized);
-        if (suppressionStore.get(canonical).isPresent()) {
-            return Optional.of(canonical);
+        Optional<SuppressedDestination> hit = suppressionStore.get(canonical);
+        if (hit.isPresent()) {
+            return Optional.of(new SuppressionMatch(canonical, hit.get()));
         }
         String legacy = suppressionKey(region, rawEmail.trim());
-        if (!legacy.equals(canonical) && suppressionStore.get(legacy).isPresent()) {
-            return Optional.of(legacy);
+        if (!legacy.equals(canonical)) {
+            Optional<SuppressedDestination> legacyHit = suppressionStore.get(legacy);
+            if (legacyHit.isPresent()) {
+                return Optional.of(new SuppressionMatch(legacy, legacyHit.get()));
+            }
         }
         return Optional.empty();
     }
@@ -1282,8 +1285,8 @@ public class SesService {
                 continue;
             }
             String normalized = normalizeSuppressionEmail(address);
-            SuppressedDestination entry = existingSuppressionKey(region, address, normalized)
-                    .flatMap(suppressionStore::get)
+            SuppressedDestination entry = existingSuppressionMatch(region, address, normalized)
+                    .map(SuppressionMatch::entry)
                     .orElse(null);
             if (entry != null && entry.getReason() != null
                     && reasonFilter.contains(entry.getReason())) {
@@ -1341,8 +1344,8 @@ public class SesService {
         // (`normalizeSuppressionEmail`) so lookups can't drift apart from inserts,
         // with the same legacy-key fallback as GET/DELETE.
         String normalized = normalizeSuppressionEmail(emailAddress);
-        SuppressedDestination entry = existingSuppressionKey(region, emailAddress, normalized)
-                .flatMap(suppressionStore::get)
+        SuppressedDestination entry = existingSuppressionMatch(region, emailAddress, normalized)
+                .map(SuppressionMatch::entry)
                 .orElse(null);
         if (entry == null || entry.getReason() == null) {
             return null;

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSuppressionLegacyKeyTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSuppressionLegacyKeyTest.java
@@ -1,0 +1,90 @@
+package io.github.hectorvent.floci.services.ses;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
+import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
+import io.github.hectorvent.floci.services.ses.model.Identity;
+import io.github.hectorvent.floci.services.ses.model.SentEmail;
+import io.github.hectorvent.floci.services.ses.model.SuppressedDestination;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Backward-compat for suppression entries persisted by a pre-canonicalization Floci,
+ * which stored the address trim-only — so an entry with an upper-case domain lives under
+ * a key the new domain-lower-casing lookup would otherwise miss. GET/DELETE fall back to
+ * the legacy key, and PUT migrates it onto the canonical key. Only reachable by seeding
+ * the store directly (the HTTP API always normalizes), so it lives at the unit layer.
+ */
+class SesServiceSuppressionLegacyKeyTest {
+
+    private static final String REGION = "us-east-1";
+    // A pre-canonicalization entry: trim-only key with an upper-case domain.
+    private static final String LEGACY_ADDR = "Foo.Bar@Example.COM";
+    private static final String LEGACY_KEY = "suppression::" + REGION + "::" + LEGACY_ADDR;
+    private static final String CANONICAL_KEY = "suppression::" + REGION + "::Foo.Bar@example.com";
+
+    private SesService service;
+    private InMemoryStorage<String, SuppressedDestination> suppressionStore;
+
+    @BeforeEach
+    void setUp() {
+        suppressionStore = new InMemoryStorage<>();
+        service = new SesService(
+                new InMemoryStorage<String, Identity>(),
+                new InMemoryStorage<String, SentEmail>(),
+                new InMemoryStorage<String, Boolean>(),
+                new InMemoryStorage<String, EmailTemplate>(),
+                new InMemoryStorage<String, ConfigurationSet>(),
+                suppressionStore,
+                new InMemoryStorage<String, AccountSuppressionAttributes>(),
+                mock(SmtpRelay.class),
+                new ObjectMapper());
+    }
+
+    private void seedLegacyEntry() {
+        suppressionStore.put(LEGACY_KEY, new SuppressedDestination(LEGACY_ADDR, "BOUNCE"));
+    }
+
+    @Test
+    void getReachesLegacyEntryByExactAddress() {
+        seedLegacyEntry();
+        SuppressedDestination got = service.getSuppressedDestination(REGION, LEGACY_ADDR);
+        assertEquals(LEGACY_ADDR, got.getEmailAddress());
+        assertEquals("BOUNCE", got.getReason());
+    }
+
+    @Test
+    void deleteRemovesLegacyEntry() {
+        seedLegacyEntry();
+        service.deleteSuppressedDestination(REGION, LEGACY_ADDR);
+        assertFalse(suppressionStore.get(LEGACY_KEY).isPresent());
+    }
+
+    @Test
+    void sendTimeSuppressionReasonReachesLegacyEntry() {
+        // The event / send-time path (resolveSuppressionReason, collectSuppressedReasons)
+        // must also honor the legacy key, or a legacy entry stays deletable but no longer
+        // suppresses sends. Default fresh account suppresses [BOUNCE, COMPLAINT].
+        seedLegacyEntry();
+        assertEquals("BOUNCE", service.resolveSuppressionReason(LEGACY_ADDR, null, REGION));
+    }
+
+    @Test
+    void putMigratesLegacyEntryOntoCanonicalKeyWithoutDuplicate() {
+        seedLegacyEntry();
+        service.putSuppressedDestination(REGION, LEGACY_ADDR, "COMPLAINT");
+        assertFalse(suppressionStore.get(LEGACY_KEY).isPresent(), "legacy key should be migrated away");
+        assertTrue(suppressionStore.get(CANONICAL_KEY).isPresent(), "entry should live under canonical key");
+        SuppressedDestination migrated = suppressionStore.get(CANONICAL_KEY).orElseThrow();
+        assertEquals("Foo.Bar@example.com", migrated.getEmailAddress());
+        assertEquals("COMPLAINT", migrated.getReason());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesSuppressionV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesSuppressionV2IntegrationTest.java
@@ -367,20 +367,32 @@ class SesSuppressionV2IntegrationTest {
     @Test
     @Order(21)
     void getSuppressedDestination_domainCaseInsensitive_localCaseSensitive() {
-        // Seeded by @Order(20): MixedCase@example.com. A differing domain case still
-        // hits the entry; a differing local-part case does not (it is a different key).
+        // Self-contained: seed its own entry so the test is order-independent.
+        // A differing domain case still hits the entry; a differing local-part case
+        // does not (it is a different key).
         given()
+            .contentType("application/json")
             .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailAddress": "CaseProbe@Example.COM", "Reason": "BOUNCE"}
+                """)
         .when()
-            .get("/v2/email/suppression/addresses/MixedCase@EXAMPLE.com")
+            .put("/v2/email/suppression/addresses")
         .then()
-            .statusCode(200)
-            .body("SuppressedDestination.EmailAddress", equalTo("MixedCase@example.com"));
+            .statusCode(200);
 
         given()
             .header("Authorization", AUTH_HEADER)
         .when()
-            .get("/v2/email/suppression/addresses/mixedcase@example.com")
+            .get("/v2/email/suppression/addresses/CaseProbe@EXAMPLE.com")
+        .then()
+            .statusCode(200)
+            .body("SuppressedDestination.EmailAddress", equalTo("CaseProbe@example.com"));
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/suppression/addresses/caseprobe@example.com")
         .then()
             .statusCode(404);
     }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesSuppressionV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesSuppressionV2IntegrationTest.java
@@ -336,4 +336,162 @@ class SesSuppressionV2IntegrationTest {
             .body("SuppressedDestinationSummaries.EmailAddress",
                   hasItems("multi-bounce@example.com", "complaint-1@example.com"));
     }
+
+    @Test
+    @Order(20)
+    void putSuppressedDestination_lowercasesDomainPreservesLocalPart() {
+        // Verified against real AWS SES V2 (2026-06-15): AWS canonicalizes only the
+        // domain to lower case; the local-part keeps its case. PUT MixedCase@Example.COM
+        // is stored and read back as MixedCase@example.com.
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailAddress": "MixedCase@Example.COM", "Reason": "BOUNCE"}
+                """)
+        .when()
+            .put("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/suppression/addresses/MixedCase@Example.COM")
+        .then()
+            .statusCode(200)
+            .body("SuppressedDestination.EmailAddress", equalTo("MixedCase@example.com"))
+            .body("SuppressedDestination.Reason", equalTo("BOUNCE"));
+    }
+
+    @Test
+    @Order(21)
+    void getSuppressedDestination_domainCaseInsensitive_localCaseSensitive() {
+        // Seeded by @Order(20): MixedCase@example.com. A differing domain case still
+        // hits the entry; a differing local-part case does not (it is a different key).
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/suppression/addresses/MixedCase@EXAMPLE.com")
+        .then()
+            .statusCode(200)
+            .body("SuppressedDestination.EmailAddress", equalTo("MixedCase@example.com"));
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/suppression/addresses/mixedcase@example.com")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(22)
+    void deleteSuppressedDestination_domainCaseInsensitive() {
+        // PUT one domain case, DELETE a different domain case (same local-part), GET 404.
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailAddress": "DeleteMe@Example.com", "Reason": "COMPLAINT"}
+                """)
+        .when()
+            .put("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .delete("/v2/email/suppression/addresses/DeleteMe@EXAMPLE.com")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/suppression/addresses/DeleteMe@example.com")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(23)
+    void putSuppressedDestination_domainCaseCollision_lastPutWins() {
+        // Same local-part, domain differing only in case: one entry, latest Reason wins.
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailAddress": "UpdateTarget@example.com", "Reason": "BOUNCE"}
+                """)
+        .when()
+            .put("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailAddress": "UpdateTarget@EXAMPLE.com", "Reason": "COMPLAINT"}
+                """)
+        .when()
+            .put("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/suppression/addresses/UpdateTarget@example.com")
+        .then()
+            .statusCode(200)
+            .body("SuppressedDestination.EmailAddress", equalTo("UpdateTarget@example.com"))
+            .body("SuppressedDestination.Reason", equalTo("COMPLAINT"));
+    }
+
+    @Test
+    @Order(24)
+    void putSuppressedDestination_localPartCaseDifference_distinctEntries() {
+        // Local-part case differences are distinct entries (not merged), each keeping
+        // its own Reason. Verified against real AWS SES V2 (2026-06-15).
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailAddress": "LocalCase@distinct.example.com", "Reason": "BOUNCE"}
+                """)
+        .when()
+            .put("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {"EmailAddress": "localcase@distinct.example.com", "Reason": "COMPLAINT"}
+                """)
+        .when()
+            .put("/v2/email/suppression/addresses")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/suppression/addresses/LocalCase@distinct.example.com")
+        .then()
+            .statusCode(200)
+            .body("SuppressedDestination.Reason", equalTo("BOUNCE"));
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/v2/email/suppression/addresses/localcase@distinct.example.com")
+        .then()
+            .statusCode(200)
+            .body("SuppressedDestination.Reason", equalTo("COMPLAINT"));
+    }
 }


### PR DESCRIPTION
## Summary

Real AWS SES V2 treats suppression-list addresses as **case-sensitive on the local-part and case-insensitive only on the domain**. Floci's `normalizeSuppressionEmail` trimmed and lower-cased the whole address, which over-normalized: it merged distinct local-part variants and altered the address on read-back.

- `normalizeSuppressionEmail` now lower-cases only the part after the last `@` (the domain) and preserves the local-part. `Locale.ROOT` keeps the transform JVM-locale-independent (Turkish-i pitfall).
- Backward-compat: entries persisted by a pre-canonicalization Floci live under a trim-only key. All five suppression lookups (PUT / GET / DELETE / send-time check / event resolution) fall back to that legacy key via `existingSuppressionKey`, and PUT migrates the entry onto the canonical key — so older entries stay readable, deletable, and still suppress sends, without a re-PUT leaving a stuck duplicate.
- Tests pin the verified behavior; a unit test seeds a legacy-keyed entry directly (the HTTP API always normalizes).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against real AWS SES V2 (2026-06-15):

- `PutSuppressedDestination` for `Foo.Bar@Example.COM` is stored as `Foo.Bar@example.com` — the domain is lower-cased, the local-part is preserved.
- `GetSuppressedDestination` / `DeleteSuppressedDestination` match the domain case-insensitively but the local-part **case-sensitively**: `foo.bar@example.com` does not resolve to `Foo.Bar@example.com` (`NotFoundException`).
- `Foo@x` and `foo@x` are two separate entries; `Foo@X.COM` and `Foo@x.com` are the same entry (latest `Reason` wins).

**Reproduction:**

```bash
# AWS (SES v2, us-east-1)
aws sesv2 put-suppressed-destination --email-address "Foo.Bar@Example.COM" --reason BOUNCE
aws sesv2 list-suppressed-destinations \
  --query "SuppressedDestinationSummaries[?contains(EmailAddress,'foo.bar')].EmailAddress"
# → ["Foo.Bar@example.com"]   (domain lowered, local-part preserved)
aws sesv2 get-suppressed-destination --email-address "foo.bar@example.com"
# → NotFoundException          (local-part is case-sensitive)
# cleanup
aws sesv2 delete-suppressed-destination --email-address "Foo.Bar@example.com"
```

The earlier trim-only behavior diverged from this; the fix lower-cases only the domain.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)