### PR TITLE
fix(rds-data): add native MySQL JDBC support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,9 +230,8 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.mysql</groupId>
-            <artifactId>mysql-connector-j</artifactId>
-            <version>8.3.0</version>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-mysql</artifactId>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,8 @@ quarkus:
     host: 0.0.0.0
     limits:
       max-body-size: ${floci.max-request-size}M
+  datasource:
+    active: false
   security:
      security-providers: BC
   shutdown:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,6 +4,8 @@ quarkus:
     test-port: 0
     limits:
       max-body-size: ${floci.max-request-size}M
+  datasource:
+    active: false
 
 floci:
   base-url: "http://localhost:4566"


### PR DESCRIPTION
## Summary
Fixes #1351.

This updates the native-image packaging path used by RDS Data API MySQL execution. The bug report has the repro and native-vs-JVM context; follow-up CI coverage is tracked in #1353.

## Type of change
- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility
Verified `rds-data execute-statement` against a local MySQL/Aurora-compatible RDS resource on a `docker/Dockerfile.native-package` build using create/insert/select SQL.

Additional checks:

- `./mvnw -q -Dtest=RdsDataServiceTest,RdsDataControllerIntegrationTest test`
- `./mvnw -q -DskipTests package`
- `./mvnw -q clean package -Dnative -DskipTests`

## Checklist
- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added (native-image CI coverage tracked in #1353)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
