### PR TITLE
fix(rds-data): register MySQL JDBC driver in native image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,10 @@
             <version>8.3.0</version>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-mysql</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>2.3.232</version>


### PR DESCRIPTION
## Problem

RDS Data API `ExecuteStatement` always fails on the published native image (`floci/floci:1.5.25`) against a provisioned, `available` Aurora MySQL cluster:

```json
{"__type":"DatabaseErrorException","message":"No suitable driver found for jdbc:mysql://..."}
```

`RdsDataConnectionFactory` opens `jdbc:mysql://…` via `DriverManager`, and `com.mysql:mysql-connector-j` is on the classpath — but in the native image Connector/J never self-registers. `DriverManager` is initialised at **build** time, so its registered-driver list is frozen before any driver runs its self-registration static initialiser. The JVM build is unaffected, which is why the compatibility tests don't catch it.

## Fix

Add the `quarkus-jdbc-mysql` extension, which provides the build-time driver registration and native-image metadata for Connector/J.

Note: registering `META-INF/services/java.sql.Driver` in `resource-config.json` (+ reflection on `com.mysql.cj.jdbc.Driver`) is **not** sufficient on its own — that only affects runtime resource/reflection visibility, not the build-time `DriverManager` initialisation. I tried that first and `ExecuteStatement` failed identically.

## Validation

Built a native image off `main` with this change via `docker/Dockerfile.native` and confirmed `ExecuteStatement` returns the expected result set. Also verified end-to-end against a downstream Testcontainers RDS Data round-trip (provision cluster + Secrets Manager secret → `ExecuteStatement SELECT 1`), which goes from failing to green on the patched image.

Closes #1354