### PR TITLE
feat(cloudformation): provision RDS resources

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -19,6 +19,7 @@ import io.github.hectorvent.floci.services.ecr.model.Repository;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.ec2.model.Tag;
 import io.github.hectorvent.floci.services.ecs.EcsService;
+import io.github.hectorvent.floci.services.rds.RdsService;
 import io.github.hectorvent.floci.services.ecs.model.AwsVpcConfiguration;
 import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
 import io.github.hectorvent.floci.services.ecs.model.EcsCluster;
@@ -132,6 +133,7 @@ public class CloudFormationResourceProvisioner {
     private final StepFunctionsService stepFunctionsService;
     private final BatchService batchService;
     private final Ec2Service ec2Service;
+    private final RdsService rdsService;
 
     @Inject
     public CloudFormationResourceProvisioner(S3Service s3Service, SqsService sqsService,
@@ -153,7 +155,8 @@ public class CloudFormationResourceProvisioner {
                                              ElbV2Service elbV2Service,
                                              StepFunctionsService stepFunctionsService,
                                              BatchService batchService,
-                                             Ec2Service ec2Service) {
+                                             Ec2Service ec2Service,
+                                             RdsService rdsService) {
         this.s3Service = s3Service;
         this.sqsService = sqsService;
         this.snsService = snsService;
@@ -178,6 +181,7 @@ public class CloudFormationResourceProvisioner {
         this.stepFunctionsService = stepFunctionsService;
         this.batchService = batchService;
         this.ec2Service = ec2Service;
+        this.rdsService = rdsService;
     }
 
     /**
@@ -288,6 +292,13 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::EC2::NatGateway" -> provisionNatGateway(resource, properties, engine, region);
                 case "AWS::EC2::EIP" -> provisionEip(resource, region);
                 case "AWS::EC2::Instance" -> provisionEc2Instance(resource, properties, engine, region);
+                // RDS. DBInstance/DBCluster start real RDS containers (same as the direct API).
+                case "AWS::RDS::DBSubnetGroup" -> provisionDbSubnetGroup(resource, properties, engine, stackName);
+                case "AWS::RDS::DBParameterGroup" -> provisionDbParameterGroup(resource, properties, engine, stackName);
+                case "AWS::RDS::DBClusterParameterGroup" ->
+                        provisionDbClusterParameterGroup(resource, properties, engine, stackName);
+                case "AWS::RDS::DBInstance" -> provisionDbInstance(resource, properties, engine, stackName);
+                case "AWS::RDS::DBCluster" -> provisionDbCluster(resource, properties, engine, stackName);
                 default -> {
                     if (resourceType != null && resourceType.startsWith("Custom::")) {
                         provisionCustomResource(resource, properties, engine, region, accountId, stackName);
@@ -360,6 +371,11 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::ElasticLoadBalancingV2::Listener" -> elbV2Service.deleteListener(region, physicalId);
                 case "AWS::ElasticLoadBalancingV2::ListenerRule" -> elbV2Service.deleteRule(region, physicalId);
                 case "AWS::EC2::Instance" -> ec2Service.terminateInstances(region, List.of(physicalId));
+                case "AWS::RDS::DBInstance" -> rdsService.deleteDbInstance(physicalId);
+                case "AWS::RDS::DBCluster" -> rdsService.deleteDbCluster(physicalId);
+                case "AWS::RDS::DBSubnetGroup" -> rdsService.deleteDbSubnetGroup(physicalId);
+                case "AWS::RDS::DBParameterGroup" -> rdsService.deleteDbParameterGroup(physicalId);
+                case "AWS::RDS::DBClusterParameterGroup" -> rdsService.deleteDbClusterParameterGroup(physicalId);
                 default -> LOG.debugv("Skipping delete of unsupported resource type: {0}", resourceType);
             }
         } catch (Exception e) {
@@ -556,6 +572,134 @@ public class CloudFormationResourceProvisioner {
         if (instance.getPlacement() != null && instance.getPlacement().getAvailabilityZone() != null) {
             r.getAttributes().put("AvailabilityZone", instance.getPlacement().getAvailabilityZone());
         }
+    }
+
+    // ── RDS ─────────────────────────────────────────────────────────────────────
+
+    private void provisionDbSubnetGroup(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                        String stackName) {
+        String name = resolveOptional(props, "DBSubnetGroupName", engine);
+        if (name == null || name.isBlank()) {
+            name = generatePhysicalName(stackName, r.getLogicalId(), 60, true);
+        }
+        String description = firstNonBlank(resolveOptional(props, "DBSubnetGroupDescription", engine),
+                "Managed by CloudFormation");
+        List<String> subnetIds = new ArrayList<>();
+        if (props != null && props.has("SubnetIds") && props.get("SubnetIds").isArray()) {
+            for (JsonNode subnet : props.get("SubnetIds")) {
+                subnetIds.add(engine.resolve(subnet));
+            }
+        }
+        var group = rdsService.createDbSubnetGroup(name, description, subnetIds);
+        r.setPhysicalId(group.getDbSubnetGroupName());
+        r.getAttributes().put("DBSubnetGroupName", group.getDbSubnetGroupName());
+    }
+
+    private void provisionDbParameterGroup(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                           String stackName) {
+        String name = resolveOptional(props, "DBParameterGroupName", engine);
+        if (name == null || name.isBlank()) {
+            name = generatePhysicalName(stackName, r.getLogicalId(), 60, true);
+        }
+        String family = resolveOptional(props, "Family", engine);
+        String description = firstNonBlank(resolveOptional(props, "Description", engine),
+                "Managed by CloudFormation");
+        var group = rdsService.createDbParameterGroup(name, family, description);
+        r.setPhysicalId(group.getDbParameterGroupName());
+        r.getAttributes().put("DBParameterGroupName", group.getDbParameterGroupName());
+    }
+
+    private void provisionDbClusterParameterGroup(StackResource r, JsonNode props,
+                                                  CloudFormationTemplateEngine engine, String stackName) {
+        String name = resolveOptional(props, "DBClusterParameterGroupName", engine);
+        if (name == null || name.isBlank()) {
+            name = generatePhysicalName(stackName, r.getLogicalId(), 60, true);
+        }
+        String family = resolveOptional(props, "Family", engine);
+        String description = firstNonBlank(resolveOptional(props, "Description", engine),
+                "Managed by CloudFormation");
+        var group = rdsService.createDbClusterParameterGroup(name, family, description);
+        r.setPhysicalId(group.getDbClusterParameterGroupName());
+        r.getAttributes().put("DBClusterParameterGroupName", group.getDbClusterParameterGroupName());
+    }
+
+    private void provisionDbInstance(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                     String stackName) {
+        String id = resolveOptional(props, "DBInstanceIdentifier", engine);
+        if (id == null || id.isBlank()) {
+            id = generatePhysicalName(stackName, r.getLogicalId(), 60, true);
+        }
+        var instance = rdsService.createDbInstance(
+                id,
+                resolveOptional(props, "Engine", engine),
+                resolveOptional(props, "EngineVersion", engine),
+                resolveOptional(props, "MasterUsername", engine),
+                resolveOptional(props, "MasterUserPassword", engine),
+                resolveOptional(props, "DBName", engine),
+                firstNonBlank(resolveOptional(props, "DBInstanceClass", engine), "db.t3.micro"),
+                parseIntProp(props, "AllocatedStorage", engine, 20),
+                parseBoolProp(props, "EnableIAMDatabaseAuthentication", engine),
+                resolveOptional(props, "DBParameterGroupName", engine),
+                resolveOptional(props, "DBSubnetGroupName", engine),
+                resolveOptional(props, "DBClusterIdentifier", engine));
+        r.setPhysicalId(instance.getDbInstanceIdentifier());
+        r.getAttributes().put("DBInstanceIdentifier", instance.getDbInstanceIdentifier());
+        if (instance.getEndpoint() != null) {
+            r.getAttributes().put("Endpoint.Address", instance.getEndpoint().address());
+            r.getAttributes().put("Endpoint.Port", String.valueOf(instance.getEndpoint().port()));
+        }
+        if (instance.getDbInstanceArn() != null) {
+            r.getAttributes().put("DBInstanceArn", instance.getDbInstanceArn());
+        }
+    }
+
+    private void provisionDbCluster(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                    String stackName) {
+        String id = resolveOptional(props, "DBClusterIdentifier", engine);
+        if (id == null || id.isBlank()) {
+            id = generatePhysicalName(stackName, r.getLogicalId(), 60, true);
+        }
+        var cluster = rdsService.createDbCluster(
+                id,
+                resolveOptional(props, "Engine", engine),
+                resolveOptional(props, "EngineVersion", engine),
+                resolveOptional(props, "MasterUsername", engine),
+                resolveOptional(props, "MasterUserPassword", engine),
+                resolveOptional(props, "DatabaseName", engine),
+                parseBoolProp(props, "EnableIAMDatabaseAuthentication", engine),
+                resolveOptional(props, "DBClusterParameterGroupName", engine));
+        r.setPhysicalId(cluster.getDbClusterIdentifier());
+        r.getAttributes().put("DBClusterIdentifier", cluster.getDbClusterIdentifier());
+        if (cluster.getEndpoint() != null) {
+            r.getAttributes().put("Endpoint.Address", cluster.getEndpoint().address());
+            r.getAttributes().put("Endpoint.Port", String.valueOf(cluster.getEndpoint().port()));
+        }
+        if (cluster.getReaderEndpoint() != null) {
+            r.getAttributes().put("ReadEndpoint.Address", cluster.getReaderEndpoint().address());
+        }
+        if (cluster.getDbClusterArn() != null) {
+            r.getAttributes().put("DBClusterArn", cluster.getDbClusterArn());
+        }
+    }
+
+    private static String firstNonBlank(String value, String fallback) {
+        return (value == null || value.isBlank()) ? fallback : value;
+    }
+
+    private int parseIntProp(JsonNode props, String name, CloudFormationTemplateEngine engine, int fallback) {
+        String value = resolveOptional(props, name, engine);
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+
+    private boolean parseBoolProp(JsonNode props, String name, CloudFormationTemplateEngine engine) {
+        return Boolean.parseBoolean(resolveOptional(props, name, engine));
     }
 
     // ── SNS ───────────────────────────────────────────────────────────────────

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationRdsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationRdsIntegrationTest.java
@@ -1,0 +1,82 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * End-to-end check that CloudFormation provisions RDS resources for real. Uses DBSubnetGroup
+ * because it does not start a container, so the test stays Docker-free (DBInstance/DBCluster
+ * provisioning is covered by the mocked-service {@code RdsCfnProvisionerTest}).
+ */
+@QuarkusTest
+class CloudFormationRdsIntegrationTest {
+
+    private static final String CFN_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/cloudformation/aws4_request";
+    private static final String RDS_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/rds/aws4_request";
+
+    @Test
+    void createStackProvisionsDbSubnetGroupVisibleToRds() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String groupName = "cfn-rds-subnets-" + suffix;
+        String stackName = "cfn-rds-stack-" + suffix;
+
+        String template = """
+                {
+                  "Resources": {
+                    "DbSubnets": {
+                      "Type": "AWS::RDS::DBSubnetGroup",
+                      "Properties": {
+                        "DBSubnetGroupName": "%s",
+                        "DBSubnetGroupDescription": "managed by cfn",
+                        "SubnetIds": ["subnet-aaaa1111", "subnet-bbbb2222"]
+                      }
+                    }
+                  },
+                  "Outputs": {
+                    "GroupName": {"Value": {"Ref": "DbSubnets"}}
+                  }
+                }
+                """.formatted(groupName);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Stack reaches CREATE_COMPLETE and Ref(DbSubnets) exports the subnet group name.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"))
+            .body(containsString(groupName));
+
+        // The subnet group really exists in RDS (provisioned, not stubbed).
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", RDS_AUTH)
+            .formParam("Action", "DescribeDBSubnetGroups")
+            .formParam("DBSubnetGroupName", groupName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString(groupName));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CustomResourceProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CustomResourceProvisionerTest.java
@@ -48,7 +48,7 @@ class CustomResourceProvisionerTest {
 
         provisioner = new CloudFormationResourceProvisioner(
                 null, null, null, null, lambdaService, null, null, null, null, null,
-                null, null, null, null, null, null, mapper, store, endpoint, null, null, null, null, null);
+                null, null, null, null, null, null, mapper, store, endpoint, null, null, null, null, null, null);
     }
 
     private CloudFormationTemplateEngine engine() {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
@@ -1,0 +1,167 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.rds.RdsService;
+import io.github.hectorvent.floci.services.rds.model.DbCluster;
+import io.github.hectorvent.floci.services.rds.model.DbEndpoint;
+import io.github.hectorvent.floci.services.rds.model.DbInstance;
+import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
+import io.github.hectorvent.floci.services.rds.model.DbSubnetGroup;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies CloudFormation provisions RDS resources by delegating to {@link RdsService} (mocked, so
+ * no containers start) and maps CFN properties to the right create-method arguments, with
+ * Ref/GetAtt set from the returned resource.
+ */
+class RdsCfnProvisionerTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private RdsService rdsService;
+    private CloudFormationResourceProvisioner provisioner;
+
+    @BeforeEach
+    void setUp() {
+        rdsService = mock(RdsService.class);
+        provisioner = new CloudFormationResourceProvisioner(
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null,
+                mapper,
+                null, null, null, null, null, null, null,
+                rdsService);
+    }
+
+    private CloudFormationTemplateEngine engine() {
+        return new CloudFormationTemplateEngine("000000000000", "us-east-1", "my-stack",
+                "stack/id", Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), mapper,
+                (Function<String, String>) name -> null);
+    }
+
+    private JsonNode props(String json) {
+        try {
+            return mapper.readTree(json);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private StackResource provision(String logicalId, String type, String json) {
+        return provisioner.provision(logicalId, type, props(json), engine(),
+                "us-east-1", "000000000000", "my-stack");
+    }
+
+    @Test
+    void provisionsDbInstanceWithMappedArgsAndEndpointAttributes() {
+        DbInstance instance = mock(DbInstance.class);
+        when(instance.getDbInstanceIdentifier()).thenReturn("mydb");
+        when(instance.getEndpoint()).thenReturn(new DbEndpoint("mydb.local", 5432));
+        when(instance.getDbInstanceArn()).thenReturn("arn:aws:rds:us-east-1:000000000000:db:mydb");
+        when(rdsService.createDbInstance(any(), any(), any(), any(), any(), any(), any(),
+                anyInt(), anyBoolean(), any(), any(), any())).thenReturn(instance);
+
+        StackResource r = provision("Db", "AWS::RDS::DBInstance", """
+                {"DBInstanceIdentifier":"mydb","Engine":"postgres","EngineVersion":"16",
+                 "MasterUsername":"admin","MasterUserPassword":"secret","DBName":"appdb",
+                 "AllocatedStorage":50,"DBInstanceClass":"db.t3.small"}
+                """);
+
+        assertEquals("CREATE_COMPLETE", r.getStatus());
+        assertEquals("mydb", r.getPhysicalId());
+        assertEquals("mydb.local", r.getAttributes().get("Endpoint.Address"));
+        assertEquals("5432", r.getAttributes().get("Endpoint.Port"));
+        assertEquals("arn:aws:rds:us-east-1:000000000000:db:mydb", r.getAttributes().get("DBInstanceArn"));
+        // CFN properties mapped to the create-method arguments; absent optionals are null.
+        verify(rdsService).createDbInstance("mydb", "postgres", "16", "admin", "secret",
+                "appdb", "db.t3.small", 50, false, null, null, null);
+    }
+
+    @Test
+    void provisionsDbClusterWithReaderEndpoint() {
+        DbCluster cluster = mock(DbCluster.class);
+        when(cluster.getDbClusterIdentifier()).thenReturn("mycluster");
+        when(cluster.getEndpoint()).thenReturn(new DbEndpoint("mycluster.local", 5432));
+        when(cluster.getReaderEndpoint()).thenReturn(new DbEndpoint("mycluster-ro.local", 5432));
+        when(cluster.getDbClusterArn()).thenReturn("arn:aws:rds:us-east-1:000000000000:cluster:mycluster");
+        when(rdsService.createDbCluster(any(), any(), any(), any(), any(), any(), anyBoolean(), any()))
+                .thenReturn(cluster);
+
+        StackResource r = provision("Cluster", "AWS::RDS::DBCluster", """
+                {"DBClusterIdentifier":"mycluster","Engine":"aurora-postgresql","EngineVersion":"16.3",
+                 "MasterUsername":"admin","MasterUserPassword":"secret","DatabaseName":"appdb"}
+                """);
+
+        assertEquals("mycluster", r.getPhysicalId());
+        assertEquals("mycluster.local", r.getAttributes().get("Endpoint.Address"));
+        assertEquals("mycluster-ro.local", r.getAttributes().get("ReadEndpoint.Address"));
+        assertEquals("5432", r.getAttributes().get("Endpoint.Port"));
+        verify(rdsService).createDbCluster("mycluster", "aurora-postgresql", "16.3",
+                "admin", "secret", "appdb", false, null);
+    }
+
+    @Test
+    void provisionsDbSubnetGroupWithResolvedSubnetIds() {
+        DbSubnetGroup group = mock(DbSubnetGroup.class);
+        when(group.getDbSubnetGroupName()).thenReturn("my-subnet-group");
+        when(rdsService.createDbSubnetGroup(any(), any(), anyList())).thenReturn(group);
+
+        StackResource r = provision("Sg", "AWS::RDS::DBSubnetGroup", """
+                {"DBSubnetGroupName":"my-subnet-group","DBSubnetGroupDescription":"db subnets",
+                 "SubnetIds":["subnet-a","subnet-b"]}
+                """);
+
+        assertEquals("my-subnet-group", r.getPhysicalId());
+        assertEquals("my-subnet-group", r.getAttributes().get("DBSubnetGroupName"));
+        verify(rdsService).createDbSubnetGroup("my-subnet-group", "db subnets",
+                List.of("subnet-a", "subnet-b"));
+    }
+
+    @Test
+    void provisionsDbParameterGroup() {
+        DbParameterGroup group = mock(DbParameterGroup.class);
+        when(group.getDbParameterGroupName()).thenReturn("my-pg");
+        when(rdsService.createDbParameterGroup(any(), any(), any())).thenReturn(group);
+
+        StackResource r = provision("Pg", "AWS::RDS::DBParameterGroup", """
+                {"DBParameterGroupName":"my-pg","Family":"postgres16","Description":"params"}
+                """);
+
+        assertEquals("my-pg", r.getPhysicalId());
+        assertEquals("my-pg", r.getAttributes().get("DBParameterGroupName"));
+        verify(rdsService).createDbParameterGroup("my-pg", "postgres16", "params");
+    }
+
+    @Test
+    void deleteDelegatesToRdsServiceForEachRdsType() {
+        // Stack deletion tears down RDS resources via the physical id set at provision time.
+        provisioner.delete("AWS::RDS::DBInstance", "mydb", "us-east-1");
+        verify(rdsService).deleteDbInstance("mydb");
+
+        provisioner.delete("AWS::RDS::DBCluster", "mycluster", "us-east-1");
+        verify(rdsService).deleteDbCluster("mycluster");
+
+        provisioner.delete("AWS::RDS::DBSubnetGroup", "my-subnet-group", "us-east-1");
+        verify(rdsService).deleteDbSubnetGroup("my-subnet-group");
+
+        provisioner.delete("AWS::RDS::DBParameterGroup", "my-pg", "us-east-1");
+        verify(rdsService).deleteDbParameterGroup("my-pg");
+
+        provisioner.delete("AWS::RDS::DBClusterParameterGroup", "my-cpg", "us-east-1");
+        verify(rdsService).deleteDbClusterParameterGroup("my-cpg");
+    }
+}


### PR DESCRIPTION
## Summary

Provisions RDS resources from CloudFormation instead of stubbing them. Injects `RdsService` and adds provision + delete handling for `AWS::RDS::DBInstance`, `AWS::RDS::DBCluster`, `AWS::RDS::DBSubnetGroup`, `AWS::RDS::DBParameterGroup` and `AWS::RDS::DBClusterParameterGroup`. `DBInstance`/`DBCluster` start real RDS containers via the same path as the direct API. `Ref` returns the resource identifier; `Fn::GetAtt` exposes `Endpoint.Address`, `Endpoint.Port` and the resource ARN (plus `ReadEndpoint.Address` for clusters). Stack deletion removes each resource so create/delete stays symmetric.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

New resource types. `Ref` and the `Fn::GetAtt` attribute names (`Endpoint.Address`, `Endpoint.Port`, `ReadEndpoint.Address`, `DBInstanceArn`/`DBClusterArn`) verified against the AWS CloudFormation RDS resource reference. Provisioning delegates to the existing RDS service API paths, so no new wire shapes are introduced.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (`RdsCfnProvisionerTest` mocked-service unit test + Docker-free `CloudFormationRdsIntegrationTest`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
