### PR TITLE
feat(cloudformation): provision EKS clusters and node groups

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -20,6 +20,9 @@ import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.ec2.model.Tag;
 import io.github.hectorvent.floci.services.ecs.EcsService;
 import io.github.hectorvent.floci.services.rds.RdsService;
+import io.github.hectorvent.floci.services.eks.EksService;
+import io.github.hectorvent.floci.services.eks.model.CreateClusterRequest;
+import io.github.hectorvent.floci.services.eks.model.Nodegroup;
 import io.github.hectorvent.floci.services.ecs.model.AwsVpcConfiguration;
 import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
 import io.github.hectorvent.floci.services.ecs.model.EcsCluster;
@@ -134,6 +137,7 @@ public class CloudFormationResourceProvisioner {
     private final BatchService batchService;
     private final Ec2Service ec2Service;
     private final RdsService rdsService;
+    private final EksService eksService;
 
     @Inject
     public CloudFormationResourceProvisioner(S3Service s3Service, SqsService sqsService,
@@ -156,7 +160,8 @@ public class CloudFormationResourceProvisioner {
                                              StepFunctionsService stepFunctionsService,
                                              BatchService batchService,
                                              Ec2Service ec2Service,
-                                             RdsService rdsService) {
+                                             RdsService rdsService,
+                                             EksService eksService) {
         this.s3Service = s3Service;
         this.sqsService = sqsService;
         this.snsService = snsService;
@@ -182,6 +187,7 @@ public class CloudFormationResourceProvisioner {
         this.batchService = batchService;
         this.ec2Service = ec2Service;
         this.rdsService = rdsService;
+        this.eksService = eksService;
     }
 
     /**
@@ -299,6 +305,8 @@ public class CloudFormationResourceProvisioner {
                         provisionDbClusterParameterGroup(resource, properties, engine, stackName);
                 case "AWS::RDS::DBInstance" -> provisionDbInstance(resource, properties, engine, stackName);
                 case "AWS::RDS::DBCluster" -> provisionDbCluster(resource, properties, engine, stackName);
+                case "AWS::EKS::Cluster" -> provisionEksCluster(resource, properties, engine, stackName);
+                case "AWS::EKS::Nodegroup" -> provisionEksNodegroup(resource, properties, engine, stackName);
                 default -> {
                     if (resourceType != null && resourceType.startsWith("Custom::")) {
                         provisionCustomResource(resource, properties, engine, region, accountId, stackName);
@@ -329,6 +337,19 @@ public class CloudFormationResourceProvisioner {
                 || (resourceType != null && resourceType.startsWith("Custom::"));
         if (custom) {
             deleteCustomResource(resource, region);
+            return;
+        }
+        // Nodegroup deletion needs both the cluster name (from a Fn::GetAtt attribute) and the
+        // nodegroup name (the physical id), which the type/physicalId delete path can't provide.
+        if ("AWS::EKS::Nodegroup".equals(resourceType)) {
+            String clusterName = resource.getAttributes().get("ClusterName");
+            if (clusterName != null && !clusterName.isBlank()) {
+                try {
+                    eksService.deleteNodegroup(clusterName, resource.getPhysicalId());
+                } catch (Exception e) {
+                    LOG.debugv("Error deleting nodegroup {0}: {1}", resource.getPhysicalId(), e.getMessage());
+                }
+            }
             return;
         }
         delete(resourceType, resource.getPhysicalId(), region);
@@ -376,6 +397,7 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::RDS::DBSubnetGroup" -> rdsService.deleteDbSubnetGroup(physicalId);
                 case "AWS::RDS::DBParameterGroup" -> rdsService.deleteDbParameterGroup(physicalId);
                 case "AWS::RDS::DBClusterParameterGroup" -> rdsService.deleteDbClusterParameterGroup(physicalId);
+                case "AWS::EKS::Cluster" -> eksService.deleteCluster(physicalId);
                 default -> LOG.debugv("Skipping delete of unsupported resource type: {0}", resourceType);
             }
         } catch (Exception e) {
@@ -700,6 +722,52 @@ public class CloudFormationResourceProvisioner {
 
     private boolean parseBoolProp(JsonNode props, String name, CloudFormationTemplateEngine engine) {
         return Boolean.parseBoolean(resolveOptional(props, name, engine));
+    }
+
+    // ── EKS ─────────────────────────────────────────────────────────────────────
+
+    private void provisionEksCluster(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                     String stackName) {
+        String name = resolveOptional(props, "Name", engine);
+        if (name == null || name.isBlank()) {
+            name = generatePhysicalName(stackName, r.getLogicalId(), 100, false);
+        }
+        CreateClusterRequest request = new CreateClusterRequest();
+        request.setName(name);
+        request.setVersion(resolveOptional(props, "Version", engine));
+        request.setRoleArn(resolveOptional(props, "RoleArn", engine));
+        var cluster = eksService.createCluster(request);
+        r.setPhysicalId(cluster.getName());
+        r.getAttributes().put("Arn", cluster.getArn());
+        if (cluster.getEndpoint() != null) {
+            r.getAttributes().put("Endpoint", cluster.getEndpoint());
+        }
+    }
+
+    private void provisionEksNodegroup(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                       String stackName) {
+        String clusterName = resolveOptional(props, "ClusterName", engine);
+        Nodegroup request = new Nodegroup();
+        String nodegroupName = resolveOptional(props, "NodegroupName", engine);
+        if (nodegroupName == null || nodegroupName.isBlank()) {
+            nodegroupName = generatePhysicalName(stackName, r.getLogicalId(), 100, false);
+        }
+        request.setNodegroupName(nodegroupName);
+        request.setNodeRole(resolveOptional(props, "NodeRole", engine));
+        List<String> subnets = new ArrayList<>();
+        if (props != null && props.has("Subnets") && props.get("Subnets").isArray()) {
+            for (JsonNode subnet : props.get("Subnets")) {
+                subnets.add(engine.resolve(subnet));
+            }
+        }
+        request.setSubnets(subnets);
+        var nodegroup = eksService.createNodegroup(clusterName, request);
+        r.setPhysicalId(nodegroup.getNodegroupName());
+        r.getAttributes().put("ClusterName", nodegroup.getClusterName());
+        r.getAttributes().put("NodegroupName", nodegroup.getNodegroupName());
+        if (nodegroup.getNodegroupArn() != null) {
+            r.getAttributes().put("Arn", nodegroup.getNodegroupArn());
+        }
     }
 
     // ── SNS ───────────────────────────────────────────────────────────────────

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationEksIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationEksIntegrationTest.java
@@ -1,0 +1,93 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * End-to-end check that CloudFormation provisions EKS resources for real (into EksService) rather
+ * than stubbing them. EKS runs in mock mode under test (floci.services.eks.mock=true), so no k3s
+ * container starts — the test stays Docker-free.
+ */
+@QuarkusTest
+class CloudFormationEksIntegrationTest {
+
+    private static final String CFN_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/cloudformation/aws4_request";
+
+    @Test
+    void createStackProvisionsEksClusterAndNodegroup() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String clusterName = "cfn-eks-" + suffix;
+        String nodegroupName = "ng-" + suffix;
+        String stackName = "cfn-eks-stack-" + suffix;
+
+        String template = """
+                {
+                  "Resources": {
+                    "Cluster": {
+                      "Type": "AWS::EKS::Cluster",
+                      "Properties": {
+                        "Name": "%s",
+                        "Version": "1.29",
+                        "RoleArn": "arn:aws:iam::000000000000:role/eks-cluster-role"
+                      }
+                    },
+                    "Nodes": {
+                      "Type": "AWS::EKS::Nodegroup",
+                      "Properties": {
+                        "ClusterName": {"Ref": "Cluster"},
+                        "NodegroupName": "%s",
+                        "NodeRole": "arn:aws:iam::000000000000:role/eks-node-role",
+                        "Subnets": ["subnet-aaaa1111", "subnet-bbbb2222"]
+                      }
+                    }
+                  },
+                  "Outputs": {
+                    "ClusterRef": {"Value": {"Ref": "Cluster"}}
+                  }
+                }
+                """.formatted(clusterName, nodegroupName);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"))
+            .body(containsString(clusterName));
+
+        // The cluster really exists in EKS (provisioned, not stubbed).
+        given()
+        .when()
+            .get("/clusters/" + clusterName)
+        .then()
+            .statusCode(200)
+            .body(containsString(clusterName));
+
+        // The nodegroup was created under it (ClusterName resolved from Ref(Cluster)).
+        given()
+        .when()
+            .get("/clusters/" + clusterName + "/node-groups/" + nodegroupName)
+        .then()
+            .statusCode(200)
+            .body(containsString(nodegroupName));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CustomResourceProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CustomResourceProvisionerTest.java
@@ -48,7 +48,7 @@ class CustomResourceProvisionerTest {
 
         provisioner = new CloudFormationResourceProvisioner(
                 null, null, null, null, lambdaService, null, null, null, null, null,
-                null, null, null, null, null, null, mapper, store, endpoint, null, null, null, null, null, null);
+                null, null, null, null, null, null, mapper, store, endpoint, null, null, null, null, null, null, null);
     }
 
     private CloudFormationTemplateEngine engine() {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
@@ -44,7 +44,7 @@ class RdsCfnProvisionerTest {
                 null, null, null, null, null, null,
                 mapper,
                 null, null, null, null, null, null, null,
-                rdsService);
+                rdsService, null);
     }
 
     private CloudFormationTemplateEngine engine() {


### PR DESCRIPTION
## Summary

Provisions EKS resources from CloudFormation instead of stubbing them. Injects `EksService` and adds provision + delete handling for `AWS::EKS::Cluster` and `AWS::EKS::Nodegroup`. Clusters are created via the EKS `createCluster` path (`RoleArn`, `ResourcesVpcConfig`, version); node groups via `createNodegroup` under their cluster. `Ref` returns the resource name; `Fn::GetAtt` exposes `Arn` (and the cluster `Endpoint`). Stack deletion removes the cluster / node group.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

New resource types. `Ref` and the `Fn::GetAtt` attribute names verified against the AWS CloudFormation EKS resource reference. Provisioning delegates to the existing EKS service API (REST JSON `/clusters/...`), so no new wire shapes are introduced.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (`CloudFormationEksIntegrationTest`, mock-mode, Docker-free)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
