### PR TITLE
feat(cloudformation): provision CloudWatch Logs log groups

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -16,6 +16,7 @@ import io.github.hectorvent.floci.services.dynamodb.model.LocalSecondaryIndex;
 import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
 import io.github.hectorvent.floci.services.ecr.EcrService;
 import io.github.hectorvent.floci.services.ecr.model.Repository;
+import io.github.hectorvent.floci.services.cloudwatch.logs.CloudWatchLogsService;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.ec2.model.Tag;
 import io.github.hectorvent.floci.services.ecs.EcsService;
@@ -138,6 +139,7 @@ public class CloudFormationResourceProvisioner {
     private final Ec2Service ec2Service;
     private final RdsService rdsService;
     private final EksService eksService;
+    private final CloudWatchLogsService logsService;
 
     @Inject
     public CloudFormationResourceProvisioner(S3Service s3Service, SqsService sqsService,
@@ -161,7 +163,8 @@ public class CloudFormationResourceProvisioner {
                                              BatchService batchService,
                                              Ec2Service ec2Service,
                                              RdsService rdsService,
-                                             EksService eksService) {
+                                             EksService eksService,
+                                             CloudWatchLogsService logsService) {
         this.s3Service = s3Service;
         this.sqsService = sqsService;
         this.snsService = snsService;
@@ -188,6 +191,7 @@ public class CloudFormationResourceProvisioner {
         this.ec2Service = ec2Service;
         this.rdsService = rdsService;
         this.eksService = eksService;
+        this.logsService = logsService;
     }
 
     /**
@@ -307,6 +311,7 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::RDS::DBCluster" -> provisionDbCluster(resource, properties, engine, stackName);
                 case "AWS::EKS::Cluster" -> provisionEksCluster(resource, properties, engine, stackName);
                 case "AWS::EKS::Nodegroup" -> provisionEksNodegroup(resource, properties, engine, stackName);
+                case "AWS::Logs::LogGroup" -> provisionLogGroup(resource, properties, engine, region, accountId, stackName);
                 default -> {
                     if (resourceType != null && resourceType.startsWith("Custom::")) {
                         provisionCustomResource(resource, properties, engine, region, accountId, stackName);
@@ -398,6 +403,7 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::RDS::DBParameterGroup" -> rdsService.deleteDbParameterGroup(physicalId);
                 case "AWS::RDS::DBClusterParameterGroup" -> rdsService.deleteDbClusterParameterGroup(physicalId);
                 case "AWS::EKS::Cluster" -> eksService.deleteCluster(physicalId);
+                case "AWS::Logs::LogGroup" -> logsService.deleteLogGroup(physicalId, region);
                 default -> LOG.debugv("Skipping delete of unsupported resource type: {0}", resourceType);
             }
         } catch (Exception e) {
@@ -543,6 +549,39 @@ public class CloudFormationResourceProvisioner {
         r.setPhysicalId(addr.getPublicIp());
         r.getAttributes().put("AllocationId", addr.getAllocationId());
         r.getAttributes().put("PublicIp", addr.getPublicIp());
+    }
+
+    // ── CloudWatch Logs ─────────────────────────────────────────────────────────
+
+    private void provisionLogGroup(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                   String region, String accountId, String stackName) {
+        String name = resolveOptional(props, "LogGroupName", engine);
+        if (name == null || name.isBlank()) {
+            name = generatePhysicalName(stackName, r.getLogicalId(), 512, false);
+        }
+        Integer retentionInDays = null;
+        String retention = resolveOptional(props, "RetentionInDays", engine);
+        if (retention != null && !retention.isBlank()) {
+            try {
+                retentionInDays = Integer.valueOf(retention.trim());
+            } catch (NumberFormatException ignored) {
+                // leave unset
+            }
+        }
+        Map<String, String> tags = new HashMap<>();
+        if (props != null && props.has("Tags") && props.get("Tags").isArray()) {
+            for (JsonNode tag : props.get("Tags")) {
+                String key = engine.resolve(tag.path("Key"));
+                if (!key.isEmpty()) {
+                    tags.put(key, engine.resolve(tag.path("Value")));
+                }
+            }
+        }
+        logsService.createLogGroup(name, retentionInDays, tags, region);
+        // Ref returns the log group name; GetAtt Arn is arn:aws:logs:<region>:<account>:log-group:<name>:*
+        r.setPhysicalId(name);
+        r.getAttributes().put("Arn",
+                AwsArnUtils.Arn.of("logs", region, accountId, "log-group:" + name + ":*").toString());
     }
 
     private void provisionEc2Instance(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationLogsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationLogsIntegrationTest.java
@@ -1,0 +1,86 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.config.EncoderConfig;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * End-to-end check that CloudFormation provisions an AWS::Logs::LogGroup for real (into
+ * CloudWatchLogsService) rather than stubbing it. Log groups are metadata (no container), so the
+ * test is Docker-free.
+ */
+@QuarkusTest
+class CloudFormationLogsIntegrationTest {
+
+    private static final String CFN_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/cloudformation/aws4_request";
+    private static final String LOGS_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/logs/aws4_request";
+
+    @Test
+    void createStackProvisionsLogGroupVisibleToCloudWatchLogs() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String logGroupName = "/cfn/test/" + suffix;
+        String stackName = "cfn-logs-stack-" + suffix;
+
+        String template = """
+                {
+                  "Resources": {
+                    "LogGroup": {
+                      "Type": "AWS::Logs::LogGroup",
+                      "Properties": {
+                        "LogGroupName": "%s",
+                        "RetentionInDays": 7
+                      }
+                    }
+                  },
+                  "Outputs": {
+                    "GroupArn": {"Value": {"Fn::GetAtt": ["LogGroup", "Arn"]}}
+                  }
+                }
+                """.formatted(logGroupName);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Stack completes and Fn::GetAtt(LogGroup, Arn) resolves to the log group ARN.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"))
+            .body(containsString("log-group:" + logGroupName + ":*"));
+
+        // The log group really exists in CloudWatch Logs.
+        given()
+            .config(RestAssured.config().encoderConfig(EncoderConfig.encoderConfig()
+                    .encodeContentTypeAs("application/x-amz-json-1.1", ContentType.TEXT)))
+            .header("Authorization", LOGS_AUTH)
+            .header("X-Amz-Target", "Logs_20140328.DescribeLogGroups")
+            .contentType("application/x-amz-json-1.1")
+            .body("{\"logGroupNamePrefix\":\"" + logGroupName + "\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString(logGroupName));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CustomResourceProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CustomResourceProvisionerTest.java
@@ -48,7 +48,7 @@ class CustomResourceProvisionerTest {
 
         provisioner = new CloudFormationResourceProvisioner(
                 null, null, null, null, lambdaService, null, null, null, null, null,
-                null, null, null, null, null, null, mapper, store, endpoint, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, mapper, store, endpoint, null, null, null, null, null, null, null, null);
     }
 
     private CloudFormationTemplateEngine engine() {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
@@ -44,7 +44,7 @@ class RdsCfnProvisionerTest {
                 null, null, null, null, null, null,
                 mapper,
                 null, null, null, null, null, null, null,
-                rdsService, null);
+                rdsService, null, null);
     }
 
     private CloudFormationTemplateEngine engine() {


### PR DESCRIPTION
## Summary

Provisions `AWS::Logs::LogGroup` from CloudFormation instead of stubbing it. Injects `CloudWatchLogsService` and adds provision + delete handling: `CreateStack` creates the log group (mapping `LogGroupName`, `RetentionInDays` and `Tags`) and stack deletion removes it. `Ref` returns the log group name; `Fn::GetAtt "Arn"` returns `arn:aws:logs:<region>:<account>:log-group:<name>:*`.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

New resource type. `Ref` -> log group name and the `Fn::GetAtt "Arn"` shape verified against the AWS CloudFormation `AWS::Logs::LogGroup` reference. Provisioning delegates to the existing CloudWatch Logs service (JSON 1.1, `Logs_20140328.*`), so no new wire shapes are introduced.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (`CloudFormationLogsIntegrationTest`, Docker-free)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
