### PR TITLE
feat(cloudformation): provision Kinesis data streams

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -18,6 +18,7 @@ import io.github.hectorvent.floci.services.ecr.EcrService;
 import io.github.hectorvent.floci.services.ecr.model.Repository;
 import io.github.hectorvent.floci.services.cloudwatch.logs.CloudWatchLogsService;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.kinesis.KinesisService;
 import io.github.hectorvent.floci.services.ec2.model.Tag;
 import io.github.hectorvent.floci.services.ecs.EcsService;
 import io.github.hectorvent.floci.services.rds.RdsService;
@@ -140,6 +141,7 @@ public class CloudFormationResourceProvisioner {
     private final RdsService rdsService;
     private final EksService eksService;
     private final CloudWatchLogsService logsService;
+    private final KinesisService kinesisService;
 
     @Inject
     public CloudFormationResourceProvisioner(S3Service s3Service, SqsService sqsService,
@@ -164,7 +166,8 @@ public class CloudFormationResourceProvisioner {
                                              Ec2Service ec2Service,
                                              RdsService rdsService,
                                              EksService eksService,
-                                             CloudWatchLogsService logsService) {
+                                             CloudWatchLogsService logsService,
+                                             KinesisService kinesisService) {
         this.s3Service = s3Service;
         this.sqsService = sqsService;
         this.snsService = snsService;
@@ -192,6 +195,7 @@ public class CloudFormationResourceProvisioner {
         this.rdsService = rdsService;
         this.eksService = eksService;
         this.logsService = logsService;
+        this.kinesisService = kinesisService;
     }
 
     /**
@@ -312,6 +316,8 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::EKS::Cluster" -> provisionEksCluster(resource, properties, engine, stackName);
                 case "AWS::EKS::Nodegroup" -> provisionEksNodegroup(resource, properties, engine, stackName);
                 case "AWS::Logs::LogGroup" -> provisionLogGroup(resource, properties, engine, region, accountId, stackName);
+                case "AWS::Kinesis::Stream" ->
+                        provisionKinesisStream(resource, properties, engine, region, stackName);
                 default -> {
                     if (resourceType != null && resourceType.startsWith("Custom::")) {
                         provisionCustomResource(resource, properties, engine, region, accountId, stackName);
@@ -404,6 +410,7 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::RDS::DBClusterParameterGroup" -> rdsService.deleteDbClusterParameterGroup(physicalId);
                 case "AWS::EKS::Cluster" -> eksService.deleteCluster(physicalId);
                 case "AWS::Logs::LogGroup" -> logsService.deleteLogGroup(physicalId, region);
+                case "AWS::Kinesis::Stream" -> kinesisService.deleteStream(physicalId, region);
                 default -> LOG.debugv("Skipping delete of unsupported resource type: {0}", resourceType);
             }
         } catch (Exception e) {
@@ -582,6 +589,56 @@ public class CloudFormationResourceProvisioner {
         r.setPhysicalId(name);
         r.getAttributes().put("Arn",
                 AwsArnUtils.Arn.of("logs", region, accountId, "log-group:" + name + ":*").toString());
+    }
+
+    // ── Kinesis ─────────────────────────────────────────────────────────────────
+
+    private void provisionKinesisStream(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                        String region, String stackName) {
+        String name = resolveOptional(props, "Name", engine);
+        if (name == null || name.isBlank()) {
+            name = generatePhysicalName(stackName, r.getLogicalId(), 128, false);
+        }
+        String streamMode = null;
+        if (props != null && props.has("StreamModeDetails")) {
+            streamMode = engine.resolve(props.get("StreamModeDetails").path("StreamMode"));
+            if (streamMode != null && streamMode.isBlank()) {
+                streamMode = null;
+            }
+        }
+        // ShardCount is required for PROVISIONED streams; default to 1 when unset (ON_DEMAND ignores it).
+        int shardCount = 1;
+        String shards = resolveOptional(props, "ShardCount", engine);
+        if (shards != null && !shards.isBlank()) {
+            try {
+                shardCount = Integer.parseInt(shards.trim());
+            } catch (NumberFormatException ignored) {
+                // keep default
+            }
+        }
+
+        var stream = kinesisService.createStream(name, shardCount, streamMode, region);
+
+        String retention = resolveOptional(props, "RetentionPeriodHours", engine);
+        if (retention != null && !retention.isBlank()) {
+            try {
+                stream.setRetentionPeriodHours(Integer.parseInt(retention.trim()));
+            } catch (NumberFormatException ignored) {
+                // leave default
+            }
+        }
+        if (props != null && props.has("Tags") && props.get("Tags").isArray()) {
+            for (JsonNode tag : props.get("Tags")) {
+                String key = engine.resolve(tag.path("Key"));
+                if (!key.isEmpty()) {
+                    stream.getTags().put(key, engine.resolve(tag.path("Value")));
+                }
+            }
+        }
+
+        // Ref returns the stream name; Fn::GetAtt Arn returns the stream ARN.
+        r.setPhysicalId(name);
+        r.getAttributes().put("Arn", stream.getStreamArn());
     }
 
     private void provisionEc2Instance(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationKinesisIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationKinesisIntegrationTest.java
@@ -1,0 +1,88 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.config.EncoderConfig;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * End-to-end check that CloudFormation provisions an AWS::Kinesis::Stream for real (into
+ * KinesisService) rather than stubbing it. Streams are metadata (no container), so the test is
+ * Docker-free.
+ */
+@QuarkusTest
+class CloudFormationKinesisIntegrationTest {
+
+    private static final String CFN_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/cloudformation/aws4_request";
+    private static final String KINESIS_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/kinesis/aws4_request";
+
+    @Test
+    void createStackProvisionsStreamVisibleToKinesis() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String streamName = "cfn-stream-" + suffix;
+        String stackName = "cfn-kinesis-stack-" + suffix;
+
+        String template = """
+                {
+                  "Resources": {
+                    "Stream": {
+                      "Type": "AWS::Kinesis::Stream",
+                      "Properties": {
+                        "Name": "%s",
+                        "ShardCount": 2,
+                        "RetentionPeriodHours": 48
+                      }
+                    }
+                  },
+                  "Outputs": {
+                    "StreamArn": {"Value": {"Fn::GetAtt": ["Stream", "Arn"]}}
+                  }
+                }
+                """.formatted(streamName);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Stack completes and Fn::GetAtt(Stream, Arn) resolves to the real stream ARN.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"))
+            .body(containsString(":stream/" + streamName));
+
+        // The stream really exists in Kinesis.
+        given()
+            .config(RestAssured.config().encoderConfig(EncoderConfig.encoderConfig()
+                    .encodeContentTypeAs("application/x-amz-json-1.1", ContentType.TEXT)))
+            .header("Authorization", KINESIS_AUTH)
+            .header("X-Amz-Target", "Kinesis_20131202.DescribeStreamSummary")
+            .contentType("application/x-amz-json-1.1")
+            .body("{\"StreamName\":\"" + streamName + "\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString(streamName))
+            .body(containsString("\"RetentionPeriodHours\":48"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CustomResourceProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CustomResourceProvisionerTest.java
@@ -48,7 +48,7 @@ class CustomResourceProvisionerTest {
 
         provisioner = new CloudFormationResourceProvisioner(
                 null, null, null, null, lambdaService, null, null, null, null, null,
-                null, null, null, null, null, null, mapper, store, endpoint, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, mapper, store, endpoint, null, null, null, null, null, null, null, null, null);
     }
 
     private CloudFormationTemplateEngine engine() {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
@@ -44,7 +44,7 @@ class RdsCfnProvisionerTest {
                 null, null, null, null, null, null,
                 mapper,
                 null, null, null, null, null, null, null,
-                rdsService, null, null);
+                rdsService, null, null, null);
     }
 
     private CloudFormationTemplateEngine engine() {


### PR DESCRIPTION
## Summary

Provisions `AWS::Kinesis::Stream` from CloudFormation instead of stubbing it. Injects `KinesisService` and adds provision + delete handling, mapping `Name`, `ShardCount` (defaults to 1), `StreamModeDetails.StreamMode`, `RetentionPeriodHours` and `Tags`. `Ref` returns the stream name; `Fn::GetAtt "Arn"` returns the stream ARN. Stack deletion removes the stream.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

New resource type. `Ref` -> stream name and `Fn::GetAtt "Arn"` verified against the AWS CloudFormation `AWS::Kinesis::Stream` reference. Provisioning delegates to the existing Kinesis service (JSON 1.1, `Kinesis_20131202.*`), so no new wire shapes are introduced.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (`CloudFormationKinesisIntegrationTest`, Docker-free)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
