### PR TITLE
feat(cloudformation): provision Auto Scaling groups and launch configurations

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -19,6 +19,7 @@ import io.github.hectorvent.floci.services.ecr.model.Repository;
 import io.github.hectorvent.floci.services.cloudwatch.logs.CloudWatchLogsService;
 import io.github.hectorvent.floci.services.cloudwatch.metrics.CloudWatchMetricsService;
 import io.github.hectorvent.floci.services.cloudwatch.metrics.model.Dimension;
+import io.github.hectorvent.floci.services.autoscaling.AutoScalingService;
 import io.github.hectorvent.floci.services.cloudwatch.metrics.model.MetricAlarm;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.kinesis.KinesisService;
@@ -146,6 +147,7 @@ public class CloudFormationResourceProvisioner {
     private final CloudWatchLogsService logsService;
     private final KinesisService kinesisService;
     private final CloudWatchMetricsService cloudWatchMetricsService;
+    private final AutoScalingService autoScalingService;
 
     @Inject
     public CloudFormationResourceProvisioner(S3Service s3Service, SqsService sqsService,
@@ -172,7 +174,8 @@ public class CloudFormationResourceProvisioner {
                                              EksService eksService,
                                              CloudWatchLogsService logsService,
                                              KinesisService kinesisService,
-                                             CloudWatchMetricsService cloudWatchMetricsService) {
+                                             CloudWatchMetricsService cloudWatchMetricsService,
+                                             AutoScalingService autoScalingService) {
         this.s3Service = s3Service;
         this.sqsService = sqsService;
         this.snsService = snsService;
@@ -202,6 +205,7 @@ public class CloudFormationResourceProvisioner {
         this.logsService = logsService;
         this.kinesisService = kinesisService;
         this.cloudWatchMetricsService = cloudWatchMetricsService;
+        this.autoScalingService = autoScalingService;
     }
 
     /**
@@ -326,6 +330,10 @@ public class CloudFormationResourceProvisioner {
                         provisionKinesisStream(resource, properties, engine, region, stackName);
                 case "AWS::CloudWatch::Alarm" ->
                         provisionCloudWatchAlarm(resource, properties, engine, region, stackName);
+                case "AWS::AutoScaling::LaunchConfiguration" ->
+                        provisionLaunchConfiguration(resource, properties, engine, region, stackName);
+                case "AWS::AutoScaling::AutoScalingGroup" ->
+                        provisionAutoScalingGroup(resource, properties, engine, region, stackName);
                 default -> {
                     if (resourceType != null && resourceType.startsWith("Custom::")) {
                         provisionCustomResource(resource, properties, engine, region, accountId, stackName);
@@ -421,6 +429,10 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::Kinesis::Stream" -> kinesisService.deleteStream(physicalId, region);
                 case "AWS::CloudWatch::Alarm" ->
                         cloudWatchMetricsService.deleteAlarms(List.of(physicalId), region);
+                case "AWS::AutoScaling::LaunchConfiguration" ->
+                        autoScalingService.deleteLaunchConfiguration(region, physicalId);
+                case "AWS::AutoScaling::AutoScalingGroup" ->
+                        autoScalingService.deleteAutoScalingGroup(region, physicalId, true);
                 default -> LOG.debugv("Skipping delete of unsupported resource type: {0}", resourceType);
             }
         } catch (Exception e) {
@@ -713,6 +725,94 @@ public class CloudFormationResourceProvisioner {
                 }
             }
         }
+    }
+
+    // ── Auto Scaling ────────────────────────────────────────────────────────────
+
+    private void provisionLaunchConfiguration(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                              String region, String stackName) {
+        String name = resolveOptional(props, "LaunchConfigurationName", engine);
+        if (name == null || name.isBlank()) {
+            name = generatePhysicalName(stackName, r.getLogicalId(), 255, false);
+        }
+        String associatePublicIp = resolveOptional(props, "AssociatePublicIpAddress", engine);
+        var lc = autoScalingService.createLaunchConfiguration(region, name,
+                resolveOptional(props, "ImageId", engine),
+                resolveOptional(props, "InstanceType", engine),
+                resolveOptional(props, "KeyName", engine),
+                resolveStringList(props, "SecurityGroups", engine),
+                resolveOptional(props, "UserData", engine),
+                resolveOptional(props, "IamInstanceProfile", engine),
+                Boolean.parseBoolean(associatePublicIp));
+        // Ref returns the launch configuration name.
+        r.setPhysicalId(name);
+        r.getAttributes().put("Arn", lc.getLaunchConfigurationArn());
+    }
+
+    private void provisionAutoScalingGroup(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                           String region, String stackName) {
+        String name = resolveOptional(props, "AutoScalingGroupName", engine);
+        if (name == null || name.isBlank()) {
+            name = generatePhysicalName(stackName, r.getLogicalId(), 255, false);
+        }
+        String launchConfigName = resolveOptional(props, "LaunchConfigurationName", engine);
+        String launchTemplateName = null;
+        String launchTemplateVersion = null;
+        if (props != null && props.has("LaunchTemplate")) {
+            JsonNode lt = props.get("LaunchTemplate");
+            launchTemplateName = engine.resolve(lt.path("LaunchTemplateName"));
+            if (launchTemplateName == null || launchTemplateName.isBlank()) {
+                launchTemplateName = engine.resolve(lt.path("LaunchTemplateId"));
+            }
+            launchTemplateVersion = engine.resolve(lt.path("Version"));
+        }
+
+        var asg = autoScalingService.createAutoScalingGroup(region, name,
+                blankToNull(launchConfigName), blankToNull(launchTemplateName), blankToNull(launchTemplateVersion),
+                parseIntProp(props, "MinSize", engine, 0),
+                parseIntProp(props, "MaxSize", engine, 0),
+                parseIntProp(props, "DesiredCapacity", engine, 0),
+                parseIntProp(props, "Cooldown", engine, 0),
+                resolveStringList(props, "AvailabilityZones", engine),
+                resolveStringList(props, "TargetGroupARNs", engine),
+                resolveStringList(props, "LoadBalancerNames", engine),
+                resolveOptional(props, "HealthCheckType", engine),
+                parseIntProp(props, "HealthCheckGracePeriod", engine, 0),
+                resolveStringList(props, "TerminationPolicies", engine),
+                resolveAsgTags(props, engine));
+        // Ref returns the Auto Scaling group name; Fn::GetAtt Arn returns the ASG ARN.
+        r.setPhysicalId(name);
+        r.getAttributes().put("Arn", asg.getAutoScalingGroupArn());
+    }
+
+    private Map<String, String> resolveAsgTags(JsonNode props, CloudFormationTemplateEngine engine) {
+        Map<String, String> tags = new LinkedHashMap<>();
+        if (props != null && props.has("Tags") && props.get("Tags").isArray()) {
+            for (JsonNode tag : props.get("Tags")) {
+                String key = engine.resolve(tag.path("Key"));
+                if (!key.isEmpty()) {
+                    tags.put(key, engine.resolve(tag.path("Value")));
+                }
+            }
+        }
+        return tags;
+    }
+
+    private List<String> resolveStringList(JsonNode props, String field, CloudFormationTemplateEngine engine) {
+        List<String> values = new ArrayList<>();
+        if (props != null && props.has(field) && props.get(field).isArray()) {
+            for (JsonNode element : props.get(field)) {
+                String resolved = engine.resolve(element);
+                if (resolved != null && !resolved.isBlank()) {
+                    values.add(resolved);
+                }
+            }
+        }
+        return values;
+    }
+
+    private String blankToNull(String value) {
+        return (value == null || value.isBlank()) ? null : value;
     }
 
     private void provisionEc2Instance(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationAutoScalingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationAutoScalingIntegrationTest.java
@@ -1,0 +1,96 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * End-to-end check that CloudFormation provisions AWS::AutoScaling::LaunchConfiguration and
+ * AWS::AutoScaling::AutoScalingGroup for real (into AutoScalingService) rather than stubbing them,
+ * and that the group references the launch configuration created in the same stack. Both are
+ * metadata (no container), so the test is Docker-free. Auto Scaling is the Query API.
+ */
+@QuarkusTest
+class CloudFormationAutoScalingIntegrationTest {
+
+    private static final String CFN_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/cloudformation/aws4_request";
+    private static final String ASG_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/autoscaling/aws4_request";
+
+    @Test
+    void createStackProvisionsAutoScalingGroupVisibleToAutoScaling() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String lcName = "cfn-lc-" + suffix;
+        String asgName = "cfn-asg-" + suffix;
+        String stackName = "cfn-asg-stack-" + suffix;
+
+        String template = """
+                {
+                  "Resources": {
+                    "LaunchConfig": {
+                      "Type": "AWS::AutoScaling::LaunchConfiguration",
+                      "Properties": {
+                        "LaunchConfigurationName": "%s",
+                        "ImageId": "ami-12345678",
+                        "InstanceType": "t3.micro"
+                      }
+                    },
+                    "Asg": {
+                      "Type": "AWS::AutoScaling::AutoScalingGroup",
+                      "Properties": {
+                        "AutoScalingGroupName": "%s",
+                        "LaunchConfigurationName": {"Ref": "LaunchConfig"},
+                        "MinSize": 1,
+                        "MaxSize": 3,
+                        "DesiredCapacity": 2,
+                        "AvailabilityZones": ["us-east-1a"]
+                      }
+                    }
+                  },
+                  "Outputs": {
+                    "AsgArn": {"Value": {"Fn::GetAtt": ["Asg", "Arn"]}}
+                  }
+                }
+                """.formatted(lcName, asgName);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Stack completes and Fn::GetAtt(Asg, Arn) resolves to the real ASG ARN.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"))
+            .body(containsString(":autoScalingGroup:" + asgName));
+
+        // The group really exists in Auto Scaling and references the launch configuration.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", ASG_AUTH)
+            .formParam("Action", "DescribeAutoScalingGroups")
+            .formParam("AutoScalingGroupNames.member.1", asgName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString(asgName))
+            .body(containsString(lcName));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CustomResourceProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CustomResourceProvisionerTest.java
@@ -48,7 +48,7 @@ class CustomResourceProvisionerTest {
 
         provisioner = new CloudFormationResourceProvisioner(
                 null, null, null, null, lambdaService, null, null, null, null, null,
-                null, null, null, null, null, null, mapper, store, endpoint, null, null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, mapper, store, endpoint, null, null, null, null, null, null, null, null, null, null, null);
     }
 
     private CloudFormationTemplateEngine engine() {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
@@ -44,7 +44,7 @@ class RdsCfnProvisionerTest {
                 null, null, null, null, null, null,
                 mapper,
                 null, null, null, null, null, null, null,
-                rdsService, null, null, null, null);
+                rdsService, null, null, null, null, null);
     }
 
     private CloudFormationTemplateEngine engine() {


### PR DESCRIPTION
## Summary

Provisions Auto Scaling resources from CloudFormation instead of stubbing them. Injects `AutoScalingService` and adds provision + delete handling for `AWS::AutoScaling::LaunchConfiguration` and `AWS::AutoScaling::AutoScalingGroup`. Launch configurations map `ImageId`, `InstanceType`, `KeyName`, `SecurityGroups`, `UserData`, `IamInstanceProfile`; groups map the launch configuration (or `LaunchTemplate`), `MinSize`/`MaxSize`/`DesiredCapacity`, `Cooldown`, `AvailabilityZones`, `TargetGroupARNs`, `LoadBalancerNames`, `HealthCheckType`/`GracePeriod`, `TerminationPolicies` and `Tags`. `Ref` returns the resource name; `Fn::GetAtt "Arn"` returns the resource ARN. Stack deletion removes them.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

New resource types. `Ref` and `Fn::GetAtt "Arn"` verified against the AWS CloudFormation Auto Scaling resource reference. Provisioning delegates to the existing Auto Scaling service API paths, so no new wire shapes are introduced.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (`CloudFormationAutoScalingIntegrationTest`: an ASG that Refs an in-stack launch configuration, Docker-free)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
