### PR TITLE
fix: register Glue catalog payloads for native image

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
@@ -18,6 +18,7 @@ import io.github.hectorvent.floci.services.glue.schemaregistry.SchemaToColumnsCo
 import io.github.hectorvent.floci.services.glue.schemaregistry.model.SchemaId;
 import io.github.hectorvent.floci.services.glue.schemaregistry.model.SchemaVersion;
 import io.github.hectorvent.floci.services.resourcegroupstagging.ResourceGroupsTaggingService;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -876,18 +877,22 @@ public class GlueService {
             @JsonProperty("TableName") String tableName,
             @JsonProperty("ErrorDetail") ErrorDetail errorDetail) {}
 
+    @RegisterForReflection
     public record BatchCreatePartitionError(
             @JsonProperty("PartitionValues") List<String> partitionValues,
             @JsonProperty("ErrorDetail") ErrorDetail errorDetail) {}
 
+    @RegisterForReflection
     public record BatchUpdatePartitionEntry(
             @JsonProperty("PartitionValueList") List<String> partitionValueList,
             @JsonProperty("PartitionInput") Partition partitionInput) {}
 
+    @RegisterForReflection
     public record BatchUpdatePartitionError(
             @JsonProperty("PartitionValueList") List<String> partitionValueList,
             @JsonProperty("ErrorDetail") ErrorDetail errorDetail) {}
 
+    @RegisterForReflection
     public record ErrorDetail(
             @JsonProperty("ErrorCode") String errorCode,
             @JsonProperty("ErrorMessage") String errorMessage) {}
@@ -896,6 +901,7 @@ public class GlueService {
             @JsonProperty("ColumnStatisticsList") List<Map<String, Object>> columnStatisticsList,
             @JsonProperty("Errors") List<ColumnError> errors) {}
 
+    @RegisterForReflection
     public record ColumnError(
             @JsonProperty("ColumnName") String columnName,
             @JsonProperty("Error") ErrorDetail error) {}


### PR DESCRIPTION
Glue catalog requests and responses now serialize correctly from the native image instead of returning an internal server error.

Fixes #1373
