### PR TITLE
fix: include AppSync parser resources in native image

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,12 +21,17 @@ quarkus:
     delay-enabled: true
   native:
     resources:
-      # The Pricing service reads its bundled snapshot, and EC2 reads its image
-      # catalog (ec2/image-catalog.yaml), at runtime via
+      # The Pricing service reads its bundled snapshot, EC2 reads its image
+      # catalog (ec2/image-catalog.yaml), and AppSync's GraphQL parser reads
+      # its message bundles at runtime via
       # ClassLoader#getResourceAsStream. Quarkus's static resource analysis
       # cannot detect these dynamically-built paths, so they are registered
       # explicitly to ensure GraalVM includes every file in the native image.
-      includes: pricing-snapshots/**,ui/*.html,ec2/*.yaml
+      includes:
+        - pricing-snapshots/**
+        - ui/*.html
+        - ec2/*.yaml
+        - i18n/*.properties
     additional-build-args:
       - --report-unsupported-elements-at-runtime
       - --allow-incomplete-classpath


### PR DESCRIPTION
AppSync schema creation now works from the native image when GraphQL Java loads its parser message bundle.

Fixes #1376
