### PR TITLE
fix: include API Gateway VTL native metadata

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/VtlTemplateEngine.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/VtlTemplateEngine.java
@@ -5,9 +5,27 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.runtime.ParserPoolImpl;
 import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.directive.Break;
+import org.apache.velocity.runtime.directive.Define;
+import org.apache.velocity.runtime.directive.Evaluate;
+import org.apache.velocity.runtime.directive.Foreach;
+import org.apache.velocity.runtime.directive.Include;
+import org.apache.velocity.runtime.directive.Macro;
+import org.apache.velocity.runtime.directive.Parse;
+import org.apache.velocity.runtime.directive.Stop;
+import org.apache.velocity.runtime.parser.StandardParser;
+import org.apache.velocity.runtime.resource.ResourceCacheImpl;
+import org.apache.velocity.runtime.resource.ResourceManagerImpl;
+import org.apache.velocity.runtime.resource.loader.FileResourceLoader;
+import org.apache.velocity.runtime.resource.loader.StringResourceLoader;
+import org.apache.velocity.runtime.resource.util.StringResourceRepositoryImpl;
+import org.apache.velocity.util.introspection.TypeConversionHandlerImpl;
+import org.apache.velocity.util.introspection.UberspectImpl;
 
 import java.io.StringWriter;
 import java.net.URLDecoder;
@@ -24,6 +42,28 @@ import java.util.Map;
  * {@code $input}, {@code $util}, {@code $context}, {@code $stageVariables}.
  */
 @ApplicationScoped
+@RegisterForReflection(targets = {
+        VtlTemplateEngine.InputVariable.class,
+        VtlTemplateEngine.UtilVariable.class,
+        VtlTemplateEngine.ResponseOverride.class,
+        UberspectImpl.class,
+        TypeConversionHandlerImpl.class,
+        ResourceManagerImpl.class,
+        ResourceCacheImpl.class,
+        ParserPoolImpl.class,
+        FileResourceLoader.class,
+        StringResourceLoader.class,
+        StringResourceRepositoryImpl.class,
+        Foreach.class,
+        Include.class,
+        Parse.class,
+        Macro.class,
+        Evaluate.class,
+        Break.class,
+        Define.class,
+        Stop.class,
+        StandardParser.class,
+})
 public class VtlTemplateEngine {
 
     private final VelocityEngine engine;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,12 +21,17 @@ quarkus:
     delay-enabled: true
   native:
     resources:
-      # The Pricing service reads its bundled snapshot, and EC2 reads its image
-      # catalog (ec2/image-catalog.yaml), at runtime via
+      # The Pricing service reads its bundled snapshot, EC2 reads its image
+      # catalog (ec2/image-catalog.yaml), and API Gateway's Velocity engine
+      # reads its default properties at runtime via
       # ClassLoader#getResourceAsStream. Quarkus's static resource analysis
       # cannot detect these dynamically-built paths, so they are registered
       # explicitly to ensure GraalVM includes every file in the native image.
-      includes: pricing-snapshots/**,ui/*.html,ec2/*.yaml
+      includes:
+        - pricing-snapshots/**
+        - ui/*.html
+        - ec2/*.yaml
+        - org/apache/velocity/runtime/defaults/*.properties
     additional-build-args:
       - --report-unsupported-elements-at-runtime
       - --allow-incomplete-classpath


### PR DESCRIPTION
API Gateway REST API routes that use VTL mapping templates now work from the native image when Velocity loads its bundled defaults and class-name based components.

Fixes #1378
