### PR TITLE
feat(kms): add EnableKey support

### DIFF
--- a/docs/services/kms.md
+++ b/docs/services/kms.md
@@ -26,6 +26,7 @@
 | `ListAliases` | List all aliases |
 | `ScheduleKeyDeletion` | Mark a key for deletion |
 | `CancelKeyDeletion` | Cancel pending deletion |
+| `EnableKey` | Enable a key |
 | `DisableKey` | Disable a key |
 | `TagResource` | Tag a key |
 | `UntagResource` | Remove tags |

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
@@ -69,6 +69,7 @@ public class KmsJsonHandler {
             case "GetKeyRotationStatus" -> handleGetKeyRotationStatus(request, region);
             case "EnableKeyRotation" -> handleEnableKeyRotation(request, region);
             case "DisableKeyRotation" -> handleDisableKeyRotation(request, region);
+            case "EnableKey" -> handleEnableKey(request, region);
             case "DisableKey" -> handleDisableKey(request, region);
             case "RotateKeyOnDemand" -> handleRotateKeyOnDemand(request, region);
             default -> Response.status(400)
@@ -508,6 +509,11 @@ public class KmsJsonHandler {
 
     private Response handleDisableKeyRotation(JsonNode request, String region) {
         service.disableKeyRotation(request.path("KeyId").asText(), region);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleEnableKey(JsonNode request, String region) {
+        service.enableKey(request.path("KeyId").asText(), region);
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -523,6 +523,18 @@ public class KmsService {
         LOG.infov("Disabled key rotation for KMS key: {0} in {1}", key.getKeyId(), region);
     }
 
+    public void enableKey(String keyId, String region) {
+        KmsKey key = resolveKey(keyId, region);
+        if ("PendingDeletion".equals(key.getKeyState())) {
+            throw new AwsException("KMSInvalidStateException",
+                    "KMS key " + key.getKeyId() + " is pending deletion.", 400);
+        }
+        key.setEnabled(true);
+        key.setKeyState("Enabled");
+        keyStore.put(region + "::" + key.getKeyId(), key);
+        LOG.infov("Enabled KMS key: {0} in {1}", key.getKeyId(), region);
+    }
+
     public void disableKey(String keyId, String region) {
         KmsKey key = resolveKey(keyId, region);
         key.setEnabled(false);

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
@@ -382,6 +382,92 @@ class KmsIntegrationTest {
     }
 
     @Test
+    void enableKeyRestoresKeyState() {
+        String keyId = given()
+                .header("X-Amz-Target", "TrentService.CreateKey")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"Description\":\"enable-key\"}")
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("KeyMetadata.KeyId");
+
+        given()
+                .header("X-Amz-Target", "TrentService.DisableKey")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("""
+                    {"KeyId":"%s"}
+                    """.formatted(keyId))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+
+        given()
+                .header("X-Amz-Target", "TrentService.EnableKey")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("""
+                    {"KeyId":"%s"}
+                    """.formatted(keyId))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+
+        given()
+                .header("X-Amz-Target", "TrentService.DescribeKey")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("""
+                    {"KeyId":"%s"}
+                    """.formatted(keyId))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .body("KeyMetadata.Enabled", equalTo(true))
+                .body("KeyMetadata.KeyState", equalTo("Enabled"));
+    }
+
+    @Test
+    void enableKeyOnPendingDeletionKeyFails() {
+        String keyId = given()
+                .header("X-Amz-Target", "TrentService.CreateKey")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"Description\":\"enable-pending-deletion\"}")
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("KeyMetadata.KeyId");
+
+        given()
+                .header("X-Amz-Target", "TrentService.ScheduleKeyDeletion")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("""
+                    {"KeyId":"%s","PendingWindowInDays":7}
+                    """.formatted(keyId))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+
+        given()
+                .header("X-Amz-Target", "TrentService.EnableKey")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("""
+                    {"KeyId":"%s"}
+                    """.formatted(keyId))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("KMSInvalidStateException"));
+    }
+
+    @Test
     void updateKeyDescriptionRequiresDescription() {
         String keyId = given()
                 .header("X-Amz-Target", "TrentService.CreateKey")


### PR DESCRIPTION
## Summary

Implements the `EnableKey` API action for KMS, which re-enables a previously disabled key by
restoring its state to `Enabled`. Without this, keys disabled via `DisableKey` could not be
re-enabled, breaking standard key lifecycle workflows.

Closes #1356

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The `EnableKey` action uses the KMS JSON 1.1 protocol (`X-Amz-Target: TrentService.EnableKey`).
The request accepts a `KeyId` field and returns an empty response body on success, matching the
[AWS API reference](https://docs.aws.amazon.com/kms/latest/APIReference/API_EnableKey.html).

Attempting to enable a key in `PendingDeletion` state returns a `KMSInvalidStateException` (400),
consistent with AWS behavior.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)