### PR TITLE
fix(secretsmanager): 🐛 honor ListSecrets MaxResults and NextToken pagination

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
@@ -244,8 +244,10 @@ public class SecretsManagerJsonHandler {
 
     private Response handleListSecrets(JsonNode request, String region) {
         List<Secret> secrets = new ArrayList<>(service.listSecrets(region));
-        // Sort for stable pagination across calls (the store scan order is not guaranteed).
-        secrets.sort(Comparator.comparing(Secret::getName));
+        // AWS lists secrets by CreatedDate when SortBy is absent; sort on it (name as a
+        // tiebreaker) for AWS-matching, stable pagination across calls.
+        secrets.sort(Comparator.comparing(Secret::getCreatedDate, Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(Secret::getName));
 
         // MaxResults is constrained to 1-100; when absent the full result set is returned.
         int maxResults = secrets.size();
@@ -253,10 +255,8 @@ public class SecretsManagerJsonHandler {
             maxResults = request.path("MaxResults").asInt();
             if (maxResults < 1 || maxResults > 100) {
                 return Response.status(400)
-                        .entity(new AwsErrorResponse("ValidationException",
-                                "1 validation error detected: Value '" + maxResults + "' at 'maxResults' failed to "
-                                        + "satisfy constraint: Member must have value less than or equal to 100 and "
-                                        + "greater than or equal to 1"))
+                        .entity(new AwsErrorResponse("InvalidParameterException",
+                                "Invalid MaxResults value, must be between 1 and 100"))
                         .build();
             }
         }

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
@@ -12,6 +12,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -242,11 +243,45 @@ public class SecretsManagerJsonHandler {
     }
 
     private Response handleListSecrets(JsonNode request, String region) {
-        List<Secret> secrets = service.listSecrets(region);
+        List<Secret> secrets = new ArrayList<>(service.listSecrets(region));
+        // Sort for stable pagination across calls (the store scan order is not guaranteed).
+        secrets.sort(Comparator.comparing(Secret::getName));
+
+        // MaxResults is constrained to 1-100; when absent the full result set is returned.
+        int maxResults = secrets.size();
+        if (request.hasNonNull("MaxResults")) {
+            maxResults = request.path("MaxResults").asInt();
+            if (maxResults < 1 || maxResults > 100) {
+                return Response.status(400)
+                        .entity(new AwsErrorResponse("ValidationException",
+                                "1 validation error detected: Value '" + maxResults + "' at 'maxResults' failed to "
+                                        + "satisfy constraint: Member must have value less than or equal to 100 and "
+                                        + "greater than or equal to 1"))
+                        .build();
+            }
+        }
+
+        // NextToken is an opaque offset into the sorted secret list.
+        int offset = 0;
+        if (request.hasNonNull("NextToken")) {
+            try {
+                offset = Integer.parseInt(request.path("NextToken").asText());
+                if (offset < 0) {
+                    throw new NumberFormatException();
+                }
+            } catch (NumberFormatException e) {
+                return Response.status(400)
+                        .entity(new AwsErrorResponse("InvalidNextTokenException", "Invalid NextToken"))
+                        .build();
+            }
+        }
+        offset = Math.min(offset, secrets.size());
+        int end = Math.min(secrets.size(), offset + maxResults);
+        List<Secret> page = secrets.subList(offset, end);
 
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode secretList = objectMapper.createArrayNode();
-        for (Secret secret : secrets) {
+        for (Secret secret : page) {
             ObjectNode node = objectMapper.createObjectNode();
             node.put("ARN", secret.getArn());
             node.put("Name", secret.getName());
@@ -279,6 +314,9 @@ public class SecretsManagerJsonHandler {
             secretList.add(node);
         }
         response.set("SecretList", secretList);
+        if (end < secrets.size()) {
+            response.put("NextToken", String.valueOf(end));
+        }
         return Response.ok(response).build();
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
@@ -157,6 +157,64 @@ class SecretsManagerJsonHandlerTest {
         assertThat(secret.has("CreatedDate"), is(true));
     }
 
+    private void createSecret(String name) {
+        ObjectNode req = MAPPER.createObjectNode();
+        req.put("Name", name);
+        handler.handle("CreateSecret", req, REGION);
+    }
+
+    @Test
+    void listSecretsHonorsMaxResultsAndPaginatesWithNextToken() {
+        for (int i = 1; i <= 5; i++) {
+            createSecret("secret-" + i);
+        }
+
+        ObjectNode pageReq = MAPPER.createObjectNode();
+        pageReq.put("MaxResults", 2);
+        ObjectNode page1 = (ObjectNode) handler.handle("ListSecrets", pageReq, REGION).getEntity();
+        assertThat(page1.get("SecretList").size(), is(2));
+        assertThat(page1.has("NextToken"), is(true));
+
+        // Walk the remaining pages via NextToken; every secret appears exactly once.
+        int total = page1.get("SecretList").size();
+        String nextToken = page1.get("NextToken").asText();
+        while (nextToken != null) {
+            ObjectNode req = MAPPER.createObjectNode();
+            req.put("MaxResults", 2);
+            req.put("NextToken", nextToken);
+            ObjectNode page = (ObjectNode) handler.handle("ListSecrets", req, REGION).getEntity();
+            assertThat(page.get("SecretList").size(), lessThanOrEqualTo(2));
+            total += page.get("SecretList").size();
+            nextToken = page.has("NextToken") ? page.get("NextToken").asText() : null;
+        }
+        assertThat(total, is(5));
+    }
+
+    @Test
+    void listSecretsWithoutMaxResultsReturnsAllAndNoNextToken() {
+        for (int i = 1; i <= 3; i++) {
+            createSecret("secret-" + i);
+        }
+
+        ObjectNode body = (ObjectNode) handler.handle("ListSecrets", MAPPER.createObjectNode(), REGION).getEntity();
+        assertThat(body.get("SecretList").size(), is(3));
+        assertThat(body.has("NextToken"), is(false));
+    }
+
+    @Test
+    void listSecretsRejectsMaxResultsOutOfRange() {
+        ObjectNode req = MAPPER.createObjectNode();
+        req.put("MaxResults", 101);
+        assertThat(handler.handle("ListSecrets", req, REGION).getStatus(), is(400));
+    }
+
+    @Test
+    void listSecretsRejectsInvalidNextToken() {
+        ObjectNode req = MAPPER.createObjectNode();
+        req.put("NextToken", "not-a-number");
+        assertThat(handler.handle("ListSecrets", req, REGION).getStatus(), is(400));
+    }
+
     @Test
     void batchGetSecretValue() {
         ObjectNode createReq1 = MAPPER.createObjectNode();

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
@@ -205,7 +205,11 @@ class SecretsManagerJsonHandlerTest {
     void listSecretsRejectsMaxResultsOutOfRange() {
         ObjectNode req = MAPPER.createObjectNode();
         req.put("MaxResults", 101);
-        assertThat(handler.handle("ListSecrets", req, REGION).getStatus(), is(400));
+        Response response = handler.handle("ListSecrets", req, REGION);
+        assertThat(response.getStatus(), is(400));
+        // ListSecrets does not model ValidationException; AWS returns InvalidParameterException.
+        assertThat(((io.github.hectorvent.floci.core.common.AwsErrorResponse) response.getEntity()).type(),
+                is("InvalidParameterException"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #1358

`ListSecrets` ignored the `MaxResults` parameter and always returned every secret, so SDK callers that paginate received the full set in one response.

Changes:

- Page the result set by `MaxResults` and emit a `NextToken` (an opaque offset into the stably-sorted secret list) when more results remain; subsequent calls resume from it.
- Validate `MaxResults` (1-100, `ValidationException`) and `NextToken` (`InvalidNextTokenException`).
- When `MaxResults` is omitted, behavior is unchanged (all secrets returned, no `NextToken`).

Secrets are sorted by name before paging so pages are stable across calls (the underlying store scan order is not guaranteed).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: `ListSecrets` with `MaxResults=2` against 5 stored secrets returned all 5 instead of 2 plus a `NextToken`. Real AWS Secrets Manager returns at most `MaxResults` items and a `NextToken` to fetch the next page.

Verified against the AWS SDK for Java v2 pagination contract described in the issue (create 5 secrets, `MaxResults=2` returns 2 with a `NextToken`, walking the token yields each secret exactly once).

## Checklist

- [x] `./mvnw test` passes locally for the affected suites: `SecretsManagerJsonHandlerTest` + `SecretsManagerServiceTest` (64 passed). The full suite's only failures on this machine are the 16 Docker-dependent suites that fail identically on an unmodified `main` (no Docker available locally).
- [x] New or updated integration test added: `SecretsManagerJsonHandlerTest` gains coverage for `MaxResults` paging + `NextToken` walk (every secret seen once), all-results-when-omitted, out-of-range `MaxResults` (400), and invalid `NextToken` (400).
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
