### PR TITLE
feat(ssm): execute run commands in EC2 containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ For operation-level compatibility, see the [Services Overview](https://floci.io/
 | Service | How it works | Notable features |
 |---|---|---|
 | SSM Parameter Store | In-process | Version history, labels, SecureString, tagging |
-| SSM Run Command | In-process | SendCommand, GetCommandInvocation, ListCommands, CancelCommand, agent polling via ec2messages |
+| SSM Run Command | In-process + EC2 containers | SendCommand, GetCommandInvocation, ListCommands, CancelCommand, direct EC2 container execution, agent polling via ec2messages |
 | SQS | In-process | Standard and FIFO queues, DLQ, visibility timeout, batch operations, tagging |
 | SNS | In-process | Topics, subscriptions, SQS, Lambda and HTTP delivery, tagging |
 | S3 | In-process | Versioning, multipart upload, pre-signed URLs, Object Lock, event notifications |

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SsmTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SsmTest.java
@@ -3,15 +3,24 @@ package com.floci.test;
 import org.junit.jupiter.api.*;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.model.AddTagsToResourceRequest;
+import software.amazon.awssdk.services.ssm.model.CancelCommandRequest;
+import software.amazon.awssdk.services.ssm.model.CommandInvocationStatus;
+import software.amazon.awssdk.services.ssm.model.CommandStatus;
 import software.amazon.awssdk.services.ssm.model.DeleteParameterRequest;
 import software.amazon.awssdk.services.ssm.model.DeleteParametersRequest;
 import software.amazon.awssdk.services.ssm.model.DeleteParametersResponse;
 import software.amazon.awssdk.services.ssm.model.DescribeParametersRequest;
 import software.amazon.awssdk.services.ssm.model.DescribeParametersResponse;
+import software.amazon.awssdk.services.ssm.model.GetCommandInvocationRequest;
+import software.amazon.awssdk.services.ssm.model.GetCommandInvocationResponse;
 import software.amazon.awssdk.services.ssm.model.GetParameterHistoryRequest;
 import software.amazon.awssdk.services.ssm.model.GetParameterHistoryResponse;
 import software.amazon.awssdk.services.ssm.model.GetParameterRequest;
 import software.amazon.awssdk.services.ssm.model.GetParameterResponse;
+import software.amazon.awssdk.services.ssm.model.ListCommandInvocationsRequest;
+import software.amazon.awssdk.services.ssm.model.ListCommandInvocationsResponse;
+import software.amazon.awssdk.services.ssm.model.ListCommandsRequest;
+import software.amazon.awssdk.services.ssm.model.ListCommandsResponse;
 import software.amazon.awssdk.services.ssm.model.GetParametersByPathRequest;
 import software.amazon.awssdk.services.ssm.model.GetParametersByPathResponse;
 import software.amazon.awssdk.services.ssm.model.GetParametersRequest;
@@ -24,8 +33,13 @@ import software.amazon.awssdk.services.ssm.model.ParameterType;
 import software.amazon.awssdk.services.ssm.model.PutParameterRequest;
 import software.amazon.awssdk.services.ssm.model.PutParameterResponse;
 import software.amazon.awssdk.services.ssm.model.RemoveTagsFromResourceRequest;
+import software.amazon.awssdk.services.ssm.model.SendCommandRequest;
+import software.amazon.awssdk.services.ssm.model.SendCommandResponse;
 
 import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.Map;
 
 @DisplayName("SSM Parameter Store")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -34,6 +48,8 @@ class SsmTest {
     private static SsmClient ssm;
     private static final String PARAM_NAME = "/sdk-test/param";
     private static final String PARAM_VALUE = "param-value-123";
+    private static final String COMMAND_INSTANCE_ID = "i-sdk-ssm-1";
+    private static String commandId;
 
     @BeforeAll
     static void setup() {
@@ -224,5 +240,74 @@ class SsmTest {
                         .build());
 
         assertThat(response.deletedParameters()).hasSize(2);
+    }
+
+    @Test
+    @Order(13)
+    void sendCommandCreatesPendingInvocation() {
+        SendCommandResponse response = ssm.sendCommand(SendCommandRequest.builder()
+                .documentName("AWS-RunShellScript")
+                .instanceIds(COMMAND_INSTANCE_ID)
+                .comment("sdk compatibility run command")
+                .parameters(Map.of("commands", List.of("echo floci-sdk")))
+                .timeoutSeconds(60)
+                .build());
+
+        commandId = response.command().commandId();
+        assertThat(commandId).isNotBlank();
+        assertThat(response.command().documentName()).isEqualTo("AWS-RunShellScript");
+        assertThat(response.command().instanceIds()).containsExactly(COMMAND_INSTANCE_ID);
+        assertThat(response.command().status()).isEqualTo(CommandStatus.IN_PROGRESS);
+
+        GetCommandInvocationResponse invocation = ssm.getCommandInvocation(
+                GetCommandInvocationRequest.builder()
+                        .commandId(commandId)
+                        .instanceId(COMMAND_INSTANCE_ID)
+                        .build());
+        assertThat(invocation.status()).isEqualTo(CommandInvocationStatus.PENDING);
+        assertThat(invocation.standardOutputContent()).isEmpty();
+    }
+
+    @Test
+    @Order(14)
+    void listRunCommandsAndInvocations() {
+        ListCommandsResponse commands = ssm.listCommands(
+                ListCommandsRequest.builder().commandId(commandId).build());
+        assertThat(commands.commands())
+                .singleElement()
+                .satisfies(command -> {
+                    assertThat(command.commandId()).isEqualTo(commandId);
+                    assertThat(command.instanceIds()).contains(COMMAND_INSTANCE_ID);
+                    assertThat(command.status()).isEqualTo(CommandStatus.IN_PROGRESS);
+                });
+
+        ListCommandInvocationsResponse invocations = ssm.listCommandInvocations(
+                ListCommandInvocationsRequest.builder()
+                        .commandId(commandId)
+                        .instanceId(COMMAND_INSTANCE_ID)
+                        .build());
+        assertThat(invocations.commandInvocations())
+                .singleElement()
+                .satisfies(invocation -> {
+                    assertThat(invocation.commandId()).isEqualTo(commandId);
+                    assertThat(invocation.instanceId()).isEqualTo(COMMAND_INSTANCE_ID);
+                    assertThat(invocation.status()).isEqualTo(CommandInvocationStatus.PENDING);
+                });
+    }
+
+    @Test
+    @Order(15)
+    void cancelCommandUpdatesInvocationStatus() {
+        ssm.cancelCommand(CancelCommandRequest.builder()
+                .commandId(commandId)
+                .instanceIds(COMMAND_INSTANCE_ID)
+                .build());
+
+        GetCommandInvocationResponse invocation = ssm.getCommandInvocation(
+                GetCommandInvocationRequest.builder()
+                        .commandId(commandId)
+                        .instanceId(COMMAND_INSTANCE_ID)
+                        .build());
+        assertThat(invocation.status()).isEqualTo(CommandInvocationStatus.CANCELLED);
     }
 }

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -10,7 +10,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 
 | Service | Endpoint | Protocol | Supported operations |
 |---|---|---|---|
-| [SSM](ssm.md) | `POST /` + `X-Amz-Target: AmazonSSM.*` | JSON 1.1 | 12 |
+| [SSM](ssm.md) | `POST /` + `X-Amz-Target: AmazonSSM.*` / `AmazonSSMMessageDeliveryService.*` | JSON 1.1 | 22 |
 | [SQS](sqs.md) | `POST /` with `Action=` param | Query / JSON | 20 |
 | [SNS](sns.md) | `POST /` with `Action=` param | Query / JSON | 17 |
 | [S3](s3.md) | `/{bucket}/{key}` | REST XML | 58 |
@@ -19,7 +19,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [Lambda](lambda.md) | `/2015-03-31/functions/...` | REST JSON | 30 |
 | [API Gateway v1](api-gateway.md) | `/restapis/...` | REST JSON | 64 |
 | [API Gateway v2](api-gateway.md#v2) | `/v2/apis/...` | REST JSON | 48 + data-plane |
-| [IAM](iam.md) | `POST /` with `Action=` param | Query | 68 |
+| [IAM](iam.md) | `POST /` with `Action=` param | Query | 76 |
 | [STS](sts.md) | `POST /` with `Action=` param | Query | 7 |
 | [Cognito](cognito.md) | `POST /` + `X-Amz-Target: AWSCognitoIdentityProviderService.*` | JSON 1.1 | 43 |
 | [KMS](kms.md) | `POST /` + `X-Amz-Target: TrentService.*` | JSON 1.1 | 34 |

--- a/docs/services/ssm.md
+++ b/docs/services/ssm.md
@@ -1,9 +1,11 @@
-# SSM Parameter Store
+# SSM
 
 **Protocol:** JSON 1.1 (`X-Amz-Target: AmazonSSM.*`)
 **Endpoint:** `POST http://localhost:4566/`
 
 ## Supported Actions
+
+### Parameter Store
 
 | Action | Description |
 |---|---|
@@ -19,6 +21,34 @@
 | `AddTagsToResource` | Tag a parameter |
 | `ListTagsForResource` | List tags on a parameter |
 | `RemoveTagsFromResource` | Remove tags from a parameter |
+
+### Run Command
+
+| Action | Description |
+|---|---|
+| `UpdateInstanceInformation` | Register or update an SSM agent record for an instance |
+| `DescribeInstanceInformation` | List registered SSM managed instances |
+| `SendCommand` | Create command invocations for target instances |
+| `GetCommandInvocation` | Return a command invocation result |
+| `ListCommands` | List command records |
+| `ListCommandInvocations` | List command invocation records |
+| `CancelCommand` | Cancel pending or in-progress command invocations |
+
+### ec2messages Agent Protocol
+
+| Action | Description |
+|---|---|
+| `GetMessages` | Agent polls for pending command messages |
+| `AcknowledgeMessage` | Agent acknowledges receipt of a command message |
+| `SendReply` | Agent reports command output and status |
+
+## Run Command Execution
+
+`SendCommand` supports the `AWS-RunShellScript` document. For EC2 instances launched by Floci in real Docker mode, Floci creates the command invocation, returns the command response, and then runs the script asynchronously inside the target instance container. Callers observe completion through `GetCommandInvocation`. `stdout`, `stderr`, response code, start time, and end time are recorded on the invocation.
+
+If the target is not a Floci EC2 container, or if the document is not supported for direct execution, Floci falls back to the SSM agent polling flow. In that mode, `SendCommand` queues an ec2messages payload and the invocation completes after an agent calls `SendReply`.
+
+Direct command output follows the AWS inline output limits: first 24,000 characters of stdout and first 8,000 characters of stderr. Commands that exceed `TimeoutSeconds` are constrained inside the target container when the container has the `timeout` command available, and terminal timeout results are marked `TimedOut` with `StatusDetails` set to `Execution Timed Out`; commands with nonzero exit codes are marked `Failed`.
 
 ## Configuration
 
@@ -51,6 +81,12 @@ aws ssm get-parameters-by-path --endpoint-url $AWS_ENDPOINT_URL \
 # Delete
 aws ssm delete-parameter --endpoint-url $AWS_ENDPOINT_URL \
   --name /app/db/host
+
+# Run a shell command on a Floci EC2 instance
+aws ssm send-command --endpoint-url $AWS_ENDPOINT_URL \
+  --instance-ids i-0123456789abcdef0 \
+  --document-name AWS-RunShellScript \
+  --parameters commands='["echo hello"]'
 ```
 
 ## Parameter Types

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
@@ -232,6 +232,10 @@ public class Ec2ContainerManager {
         });
     }
 
+    boolean isContainerRunning(String containerId) {
+        return containerId != null && !containerId.isBlank() && lifecycleManager.isContainerRunning(containerId);
+    }
+
     /**
      * Terminates an instance: forcefully removes the container.
      * Updates state through shutting-down → terminated.

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1068,6 +1068,11 @@ public class Ec2Service {
                 .orElse(null);
     }
 
+    public boolean isInstanceContainerRunning(String instanceId) {
+        Instance instance = findInstanceById(instanceId);
+        return instance != null && containerManager.isContainerRunning(instance.getDockerContainerId());
+    }
+
     public KeyPair findKeyPair(String region, String keyName) {
         if (keyName == null) {
             return null;

--- a/src/main/java/io/github/hectorvent/floci/services/ssm/SsmCommandService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssm/SsmCommandService.java
@@ -24,8 +24,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
  * Handles SSM agent registration and command execution lifecycle:
@@ -37,13 +40,16 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 public class SsmCommandService {
 
     private static final Logger LOG = Logger.getLogger(SsmCommandService.class);
-    private static final int MAX_OUTPUT_CHARS = 24000;
+    private static final int MAX_STDOUT_CHARS = 24000;
+    private static final int MAX_STDERR_CHARS = 8000;
 
     private final StorageBackend<String, InstanceInformation> instanceStore;
     private final StorageBackend<String, Command> commandStore;
     private final StorageBackend<String, CommandInvocation> invocationStore;
     private final ObjectMapper objectMapper;
     private final RegionResolver regionResolver;
+    private final SsmDirectCommandExecutor directCommandExecutor;
+    private final ExecutorService directExecutionExecutor;
 
     // In-memory queues: instanceId → pending messages. Not persisted — lost on restart.
     private final ConcurrentHashMap<String, Queue<PendingMessage>> messageQueues = new ConcurrentHashMap<>();
@@ -51,12 +57,22 @@ public class SsmCommandService {
     private final ConcurrentHashMap<String, String[]> messageIndex = new ConcurrentHashMap<>();
 
     @Inject
-    public SsmCommandService(StorageFactory storageFactory, ObjectMapper objectMapper, RegionResolver regionResolver) {
+    public SsmCommandService(
+            StorageFactory storageFactory,
+            ObjectMapper objectMapper,
+            RegionResolver regionResolver,
+            SsmDirectCommandExecutor directCommandExecutor) {
         this.instanceStore = storageFactory.create("ssm", "ssm-instances.json", new TypeReference<>() {});
         this.commandStore = storageFactory.create("ssm", "ssm-commands.json", new TypeReference<>() {});
         this.invocationStore = storageFactory.create("ssm", "ssm-invocations.json", new TypeReference<>() {});
         this.objectMapper = objectMapper;
         this.regionResolver = regionResolver;
+        this.directCommandExecutor = directCommandExecutor;
+        this.directExecutionExecutor = Executors.newCachedThreadPool(runnable -> {
+            Thread thread = new Thread(runnable, "floci-ssm-direct-execution");
+            thread.setDaemon(true);
+            return thread;
+        });
     }
 
     // ── Agent registration ──────────────────────────────────────────────────
@@ -119,6 +135,7 @@ public class SsmCommandService {
 
         String commandId = UUID.randomUUID().toString();
         Instant now = Instant.now();
+        List<DirectExecutionRequest> directExecutionRequests = new ArrayList<>();
 
         Command command = new Command();
         command.setCommandId(commandId);
@@ -129,7 +146,7 @@ public class SsmCommandService {
         command.setInstanceIds(new ArrayList<>(instanceIds));
         command.setRequestedDateTime(now);
         command.setStatus("Pending");
-        command.setStatusDetails("Pending");
+        command.setStatusDetails(statusDetails("Pending"));
         command.setTimeoutSeconds(timeoutSeconds);
         command.setTargetCount(instanceIds.size());
         command.setOutputS3BucketName(outputS3Bucket.isEmpty() ? null : outputS3Bucket);
@@ -138,9 +155,11 @@ public class SsmCommandService {
         command.setRegion(region);
         command.setExpiresAfter(now.plusSeconds(timeoutSeconds));
 
+        command.setStatus("InProgress");
+        command.setStatusDetails(statusDetails("InProgress"));
         commandStore.put(commandKey(region, commandId), command);
 
-        // Create invocations and queue messages for each target instance
+        // Create invocations and queue messages or directly execute against Floci EC2 containers.
         for (String instanceId : instanceIds) {
             CommandInvocation inv = new CommandInvocation();
             inv.setCommandId(commandId);
@@ -150,20 +169,33 @@ public class SsmCommandService {
             inv.setDocumentVersion(documentVersion);
             inv.setRequestedDateTime(now);
             inv.setStatus("Pending");
-            inv.setStatusDetails("Pending");
+            inv.setStatusDetails(statusDetails("Pending"));
             inv.setRegion(region);
-            invocationStore.put(invocationKey(region, commandId, instanceId), inv);
 
-            queueMessage(commandId, instanceId, documentName, parameters, timeoutSeconds, region);
+            if (directCommandExecutor.supports(instanceId, documentName)) {
+                inv.setStatus("InProgress");
+                inv.setStatusDetails(statusDetails("InProgress"));
+                invocationStore.put(invocationKey(region, commandId, instanceId), inv);
+                directExecutionRequests.add(new DirectExecutionRequest(instanceId, documentName, parameters));
+            }
+            else {
+                invocationStore.put(invocationKey(region, commandId, instanceId), inv);
+                queueMessage(commandId, instanceId, documentName, parameters, timeoutSeconds, region);
+            }
         }
 
-        // Transition command to InProgress since messages are queued
-        command.setStatus("InProgress");
-        command.setStatusDetails("InProgress");
-        commandStore.put(commandKey(region, commandId), command);
-
         LOG.infov("SendCommand: commandId={0} document={1} targets={2}", commandId, documentName, instanceIds);
-        return command;
+        Command response = copyCommand(command);
+        for (DirectExecutionRequest directExecutionRequest : directExecutionRequests) {
+            runDirectCommandAsync(
+                    commandId,
+                    directExecutionRequest.instanceId(),
+                    directExecutionRequest.documentName(),
+                    directExecutionRequest.parameters(),
+                    timeoutSeconds,
+                    region);
+        }
+        return response;
     }
 
     public CommandInvocation getCommandInvocation(String commandId, String instanceId, String region) {
@@ -269,7 +301,7 @@ public class SsmCommandService {
         invocationStore.get(invKey).ifPresent(inv -> {
             if ("Pending".equals(inv.getStatus())) {
                 inv.setStatus("InProgress");
-                inv.setStatusDetails("InProgress");
+                inv.setStatusDetails(statusDetails("InProgress"));
                 inv.setExecutionStartDateTime(Instant.now());
                 invocationStore.put(invKey, inv);
             }
@@ -312,18 +344,18 @@ public class SsmCommandService {
             }
 
             // Trim output to AWS limits
-            if (stdout.length() > MAX_OUTPUT_CHARS) {
-                stdout = stdout.substring(stdout.length() - MAX_OUTPUT_CHARS);
+            if (stdout.length() > MAX_STDOUT_CHARS) {
+                stdout = truncateOutput(stdout, MAX_STDOUT_CHARS);
             }
-            if (stderr.length() > MAX_OUTPUT_CHARS) {
-                stderr = stderr.substring(stderr.length() - MAX_OUTPUT_CHARS);
+            if (stderr.length() > MAX_STDERR_CHARS) {
+                stderr = truncateOutput(stderr, MAX_STDERR_CHARS);
             }
 
             String invKey = invocationKey(region, commandId, instanceId);
             CommandInvocation inv = invocationStore.get(invKey).orElse(null);
             if (inv != null) {
                 inv.setStatus(toInvocationStatus(status));
-                inv.setStatusDetails(toInvocationStatus(status));
+                inv.setStatusDetails(statusDetails(toInvocationStatus(status)));
                 inv.setStandardOutputContent(stdout);
                 inv.setStandardErrorContent(stderr);
                 inv.setResponseCode(returnCode);
@@ -383,7 +415,7 @@ public class SsmCommandService {
         command.setInstanceIds(List.of(instanceId));
         command.setRequestedDateTime(now);
         command.setStatus("InProgress");
-        command.setStatusDetails("InProgress");
+        command.setStatusDetails(statusDetails("InProgress"));
         command.setTimeoutSeconds(timeoutSeconds);
         command.setTargetCount(1);
         command.setRegion(region);
@@ -397,7 +429,7 @@ public class SsmCommandService {
         inv.setDocumentVersion("$DEFAULT");
         inv.setRequestedDateTime(now);
         inv.setStatus("Pending");
-        inv.setStatusDetails("Pending");
+        inv.setStatusDetails(statusDetails("Pending"));
         inv.setRegion(region);
         invocationStore.put(invocationKey(region, commandId, instanceId), inv);
 
@@ -412,6 +444,57 @@ public class SsmCommandService {
     }
 
     // ── Internal helpers ────────────────────────────────────────────────────
+
+    private void runDirectCommandAsync(
+            String commandId,
+            String instanceId,
+            String documentName,
+            Map<String, List<String>> parameters,
+            int timeoutSeconds,
+            String region) {
+        CompletableFuture.runAsync(() -> {
+            String invKey = invocationKey(region, commandId, instanceId);
+            CommandInvocation invocation = invocationStore.get(invKey).orElse(null);
+            if (invocation == null || "Cancelled".equals(invocation.getStatus())) {
+                return;
+            }
+
+            SsmDirectCommandExecutor.ExecutionResult result = directCommandExecutor
+                    .executeIfSupported(instanceId, documentName, parameters, timeoutSeconds)
+                    .orElse(null);
+            if (result == null) {
+                invocation.setStatus("Pending");
+                invocation.setStatusDetails(statusDetails("Pending"));
+                invocationStore.put(invKey, invocation);
+                queueMessage(commandId, instanceId, documentName, parameters, timeoutSeconds, region);
+                updateCommandStatus(commandId, region);
+                return;
+            }
+            applyDirectResult(invocation, result);
+            invocationStore.put(invKey, invocation);
+            updateCommandStatus(commandId, region);
+        }, directExecutionExecutor);
+    }
+
+    private void applyDirectResult(CommandInvocation invocation, SsmDirectCommandExecutor.ExecutionResult result) {
+        invocation.setStatus(result.status());
+        invocation.setStatusDetails(statusDetails(result.status()));
+        invocation.setStandardOutputContent(truncateOutput(result.standardOutput(), MAX_STDOUT_CHARS));
+        invocation.setStandardErrorContent(truncateOutput(result.standardError(), MAX_STDERR_CHARS));
+        invocation.setResponseCode(result.responseCode());
+        invocation.setExecutionStartDateTime(result.executionStartDateTime());
+        invocation.setExecutionEndDateTime(result.executionEndDateTime());
+    }
+
+    private static String truncateOutput(String output, int maxChars) {
+        if (output == null) {
+            return "";
+        }
+        if (output.length() <= maxChars) {
+            return output;
+        }
+        return output.substring(0, maxChars);
+    }
 
     private void queueMessage(String commandId, String instanceId, String documentName,
                               Map<String, List<String>> parameters, int timeoutSeconds, String region) {
@@ -510,6 +593,7 @@ public class SsmCommandService {
         List<String> instanceIds = command.getInstanceIds();
         int completed = 0;
         int errors = 0;
+        int timedOut = 0;
         boolean anyInProgress = false;
 
         for (String iid : instanceIds) {
@@ -521,6 +605,9 @@ public class SsmCommandService {
             } else if ("Failed".equals(s) || "TimedOut".equals(s) || "Cancelled".equals(s)) {
                 completed++;
                 errors++;
+                if ("TimedOut".equals(s)) {
+                    timedOut++;
+                }
             } else if ("InProgress".equals(s) || "Pending".equals(s)) {
                 anyInProgress = true;
             }
@@ -530,11 +617,25 @@ public class SsmCommandService {
         command.setErrorCount(errors);
 
         if (!anyInProgress && completed == instanceIds.size()) {
-            command.setStatus(errors == 0 ? "Success" : (errors == instanceIds.size() ? "Failed" : "Success"));
-            command.setStatusDetails(command.getStatus());
+            String status = commandStatus(errors, timedOut, instanceIds.size());
+            command.setStatus(status);
+            command.setStatusDetails(statusDetails(command.getStatus()));
         }
 
         commandStore.put(commandKey(region, commandId), command);
+    }
+
+    private static String commandStatus(int errors, int timedOut, int targetCount) {
+        if (errors == 0) {
+            return "Success";
+        }
+        if (timedOut == targetCount) {
+            return "TimedOut";
+        }
+        if (errors == targetCount) {
+            return "Failed";
+        }
+        return "Success";
     }
 
     private static String toInvocationStatus(String agentStatus) {
@@ -547,6 +648,43 @@ public class SsmCommandService {
         };
     }
 
+    private static String statusDetails(String status) {
+        return switch (status) {
+            case "InProgress" -> "In Progress";
+            case "TimedOut" -> "Execution Timed Out";
+            default -> status;
+        };
+    }
+
+    private static Command copyCommand(Command source) {
+        Command copy = new Command();
+        copy.setCommandId(source.getCommandId());
+        copy.setDocumentName(source.getDocumentName());
+        copy.setDocumentVersion(source.getDocumentVersion());
+        copy.setComment(source.getComment());
+        copy.setExpiresAfter(source.getExpiresAfter());
+        copy.setParameters(source.getParameters());
+        copy.setInstanceIds(source.getInstanceIds() == null ? null : new ArrayList<>(source.getInstanceIds()));
+        copy.setRequestedDateTime(source.getRequestedDateTime());
+        copy.setStatus(source.getStatus());
+        copy.setStatusDetails(source.getStatusDetails());
+        copy.setTimeoutSeconds(source.getTimeoutSeconds());
+        copy.setTargetCount(source.getTargetCount());
+        copy.setCompletedCount(source.getCompletedCount());
+        copy.setErrorCount(source.getErrorCount());
+        copy.setOutputS3BucketName(source.getOutputS3BucketName());
+        copy.setOutputS3KeyPrefix(source.getOutputS3KeyPrefix());
+        copy.setOutputS3Region(source.getOutputS3Region());
+        copy.setRegion(source.getRegion());
+        return copy;
+    }
+
+    private record DirectExecutionRequest(
+            String instanceId,
+            String documentName,
+            Map<String, List<String>> parameters) {}
+
+    @SuppressWarnings("unchecked")
     private Map<String, List<String>> parseParameters(JsonNode parametersNode) {
         if (parametersNode == null || parametersNode.isNull() || !parametersNode.isObject()) {
             return Map.of();

--- a/src/main/java/io/github/hectorvent/floci/services/ssm/SsmDirectCommandExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssm/SsmDirectCommandExecutor.java
@@ -1,0 +1,214 @@
+package io.github.hectorvent.floci.services.ssm;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.api.model.StreamType;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.model.Instance;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+@ApplicationScoped
+public class SsmDirectCommandExecutor {
+
+    private static final Logger LOG = Logger.getLogger(SsmDirectCommandExecutor.class);
+
+    private final DockerClient dockerClient;
+    private final Ec2Service ec2Service;
+
+    @Inject
+    public SsmDirectCommandExecutor(DockerClient dockerClient, Ec2Service ec2Service) {
+        this.dockerClient = dockerClient;
+        this.ec2Service = ec2Service;
+    }
+
+    public Optional<ExecutionResult> executeIfSupported(
+            String instanceId,
+            String documentName,
+            Map<String, List<String>> parameters,
+            int timeoutSeconds) {
+        if (!supports(instanceId, documentName)) {
+            return Optional.empty();
+        }
+
+        Instance instance = ec2Service.findInstanceById(instanceId);
+        String script = String.join("\n", parameters.getOrDefault("commands", List.of()));
+        if (script.isBlank()) {
+            return Optional.of(ExecutionResult.success("", "", 0));
+        }
+
+        String workingDirectory = parameters.getOrDefault("workingDirectory", List.of(""))
+                .stream()
+                .filter(value -> value != null && !value.isBlank())
+                .findFirst()
+                .orElse(null);
+
+        try {
+            return Optional.of(executeInContainer(instance.getDockerContainerId(), script, workingDirectory, timeoutSeconds));
+        }
+        catch (Exception e) {
+            LOG.warnv(e, "SSM direct command failed for instance {0}", instanceId);
+            return Optional.of(ExecutionResult.failed("", e.getMessage() != null ? e.getMessage() : e.toString(), 1));
+        }
+    }
+
+    public boolean supports(String instanceId, String documentName) {
+        if (!"AWS-RunShellScript".equals(documentName)) {
+            return false;
+        }
+
+        Instance instance = ec2Service.findInstanceById(instanceId);
+        if (instance == null || instance.getDockerContainerId() == null || instance.getDockerContainerId().isBlank()) {
+            return false;
+        }
+        return ec2Service.isInstanceContainerRunning(instanceId);
+    }
+
+    private ExecutionResult executeInContainer(String containerId, String script, String workingDirectory, int timeoutSeconds)
+            throws InterruptedException {
+        String[] cmd = {"sh", "-c", timeoutWrappedScript(script, timeoutSeconds)};
+        var create = dockerClient.execCreateCmd(containerId)
+                .withCmd(cmd)
+                .withAttachStdout(true)
+                .withAttachStderr(true);
+        if (workingDirectory != null) {
+            create.withWorkingDir(workingDirectory);
+        }
+
+        String execId = create.exec().getId();
+        CountDownLatch latch = new CountDownLatch(1);
+        ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+        ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+        Instant start = Instant.now();
+
+        ResultCallback<Frame> callback = dockerClient.execStartCmd(execId).exec(new ResultCallback.Adapter<Frame>() {
+            @Override
+            public void onNext(Frame frame) {
+                byte[] payload = frame.getPayload();
+                if (payload == null) {
+                    return;
+                }
+                ByteArrayOutputStream target = frame.getStreamType() == StreamType.STDERR ? stderr : stdout;
+                try {
+                    target.write(payload);
+                }
+                catch (IOException ignored) {
+                }
+            }
+
+            @Override
+            public void onComplete() {
+                latch.countDown();
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                try {
+                    stderr.write((throwable.getMessage() != null ? throwable.getMessage() : throwable.toString())
+                            .getBytes(StandardCharsets.UTF_8));
+                }
+                catch (IOException ignored) {
+                }
+                latch.countDown();
+            }
+        });
+
+        boolean completed = latch.await(hostTimeoutSeconds(timeoutSeconds), TimeUnit.SECONDS);
+        if (!completed) {
+            closeQuietly(callback);
+            return ExecutionResult.timedOut(
+                    stdout.toString(StandardCharsets.UTF_8),
+                    "Timed out after " + timeoutSeconds + "s",
+                    start);
+        }
+
+        Long exitCode = dockerClient.inspectExecCmd(execId).exec().getExitCodeLong();
+        int responseCode = exitCode != null ? exitCode.intValue() : 1;
+        String standardOutput = stdout.toString(StandardCharsets.UTF_8);
+        String standardError = stderr.toString(StandardCharsets.UTF_8);
+        if (isTimeoutExitCode(responseCode)) {
+            return ExecutionResult.timedOut(standardOutput, standardError, start);
+        }
+        if (responseCode == 0) {
+            return ExecutionResult.success(standardOutput, standardError, responseCode, start);
+        }
+        return ExecutionResult.failed(standardOutput, standardError, responseCode, start);
+    }
+
+    private static String timeoutWrappedScript(String script, int timeoutSeconds) {
+        if (timeoutSeconds < 1) {
+            return script;
+        }
+        String timeout = timeoutSeconds + "s";
+        return "if command -v timeout >/dev/null 2>&1; then "
+                + "timeout --kill-after=1s " + shellSingleQuote(timeout) + " sh -c " + shellSingleQuote(script) + "; "
+                + "else sh -c " + shellSingleQuote(script) + "; fi";
+    }
+
+    private static long hostTimeoutSeconds(int timeoutSeconds) {
+        if (timeoutSeconds < 1) {
+            return 0;
+        }
+        return timeoutSeconds + 2L;
+    }
+
+    private static boolean isTimeoutExitCode(int responseCode) {
+        return responseCode == 124 || responseCode == 137 || responseCode == 143;
+    }
+
+    private static String shellSingleQuote(String value) {
+        return "'" + value.replace("'", "'\"'\"'") + "'";
+    }
+
+    private static void closeQuietly(Closeable closeable) {
+        if (closeable == null) {
+            return;
+        }
+        try {
+            closeable.close();
+        }
+        catch (IOException ignored) {
+        }
+    }
+
+    public record ExecutionResult(
+            String status,
+            String standardOutput,
+            String standardError,
+            int responseCode,
+            Instant executionStartDateTime,
+            Instant executionEndDateTime) {
+        static ExecutionResult success(String standardOutput, String standardError, int responseCode) {
+            return success(standardOutput, standardError, responseCode, Instant.now());
+        }
+
+        static ExecutionResult success(String standardOutput, String standardError, int responseCode, Instant start) {
+            return new ExecutionResult("Success", standardOutput, standardError, responseCode, start, Instant.now());
+        }
+
+        static ExecutionResult failed(String standardOutput, String standardError, int responseCode) {
+            return failed(standardOutput, standardError, responseCode, Instant.now());
+        }
+
+        static ExecutionResult failed(String standardOutput, String standardError, int responseCode, Instant start) {
+            return new ExecutionResult("Failed", standardOutput, standardError, responseCode, start, Instant.now());
+        }
+
+        static ExecutionResult timedOut(String standardOutput, String standardError, Instant start) {
+            return new ExecutionResult("TimedOut", standardOutput, standardError, -1, start, Instant.now());
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ssm/SsmCommandServiceDirectExecutionTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssm/SsmCommandServiceDirectExecutionTest.java
@@ -1,0 +1,332 @@
+package io.github.hectorvent.floci.services.ssm;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.ssm.model.Command;
+import io.github.hectorvent.floci.services.ssm.model.CommandInvocation;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SsmCommandServiceDirectExecutionTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final RegionResolver regionResolver = mock(RegionResolver.class);
+
+    @Test
+    void directExecutionCompletesCommandWithoutQueuedAgentMessage() throws Exception {
+        SsmDirectCommandExecutor executor = mock(SsmDirectCommandExecutor.class);
+        Instant start = Instant.parse("2026-06-07T00:00:00Z");
+        Instant end = Instant.parse("2026-06-07T00:00:01Z");
+        when(executor.supports(eq("i-container"), eq("AWS-RunShellScript"))).thenReturn(true);
+        when(executor.executeIfSupported(eq("i-container"), eq("AWS-RunShellScript"), any(), eq(60)))
+                .thenReturn(Optional.of(new SsmDirectCommandExecutor.ExecutionResult(
+                        "Success", "hello\n", "", 0, start, end)));
+
+        SsmCommandService service = new SsmCommandService(
+                new InMemoryStorageFactory(),
+                objectMapper,
+                regionResolver,
+                executor);
+
+        Command command = service.sendCommand(objectMapper.readTree("""
+                {
+                  "InstanceIds": ["i-container"],
+                  "DocumentName": "AWS-RunShellScript",
+                  "Parameters": {
+                    "commands": ["echo hello"]
+                  },
+                  "TimeoutSeconds": 60
+                }
+                """), "us-west-2");
+
+        assertEquals("InProgress", command.getStatus());
+        assertEquals("In Progress", command.getStatusDetails());
+        assertEquals(0, command.getCompletedCount());
+        assertEquals("Success", waitForCommandStatus(service, command.getCommandId(), "us-west-2"));
+
+        CommandInvocation invocation = service.getCommandInvocation(command.getCommandId(), "i-container", "us-west-2");
+        assertEquals("Success", invocation.getStatus());
+        assertEquals(0, invocation.getResponseCode());
+        assertEquals("hello\n", invocation.getStandardOutputContent());
+        assertEquals(start, invocation.getExecutionStartDateTime());
+        assertEquals(end, invocation.getExecutionEndDateTime());
+        assertTrue(service.getMessages("i-container", "request-id", 30).isEmpty());
+    }
+
+    @Test
+    void unsupportedDirectExecutionFallsBackToAgentQueue() throws Exception {
+        SsmDirectCommandExecutor executor = mock(SsmDirectCommandExecutor.class);
+        when(executor.supports(eq("i-agent"), eq("AWS-RunShellScript"))).thenReturn(false);
+
+        SsmCommandService service = new SsmCommandService(
+                new InMemoryStorageFactory(),
+                objectMapper,
+                regionResolver,
+                executor);
+
+        Command command = service.sendCommand(objectMapper.readTree("""
+                {
+                  "InstanceIds": ["i-agent"],
+                  "DocumentName": "AWS-RunShellScript",
+                  "Parameters": {
+                    "commands": ["echo hello"]
+                  },
+                  "TimeoutSeconds": 60
+                }
+                """), "us-west-2");
+
+        assertEquals("InProgress", command.getStatus());
+        assertEquals("In Progress", command.getStatusDetails());
+        CommandInvocation invocation = service.getCommandInvocation(command.getCommandId(), "i-agent", "us-west-2");
+        assertEquals("Pending", invocation.getStatus());
+        assertEquals(1, service.getMessages("i-agent", "request-id", 30).size());
+    }
+
+    @Test
+    void directTimeoutMarksCommandTimedOut() throws Exception {
+        SsmDirectCommandExecutor executor = mock(SsmDirectCommandExecutor.class);
+        Instant start = Instant.parse("2026-06-07T00:00:00Z");
+        Instant end = Instant.parse("2026-06-07T00:00:05Z");
+        when(executor.supports(eq("i-timeout"), eq("AWS-RunShellScript"))).thenReturn(true);
+        when(executor.executeIfSupported(eq("i-timeout"), eq("AWS-RunShellScript"), any(), eq(5)))
+                .thenReturn(Optional.of(new SsmDirectCommandExecutor.ExecutionResult(
+                        "TimedOut", "", "Timed out after 5s", -1, start, end)));
+
+        SsmCommandService service = new SsmCommandService(
+                new InMemoryStorageFactory(),
+                objectMapper,
+                regionResolver,
+                executor);
+
+        Command command = service.sendCommand(objectMapper.readTree("""
+                {
+                  "InstanceIds": ["i-timeout"],
+                  "DocumentName": "AWS-RunShellScript",
+                  "Parameters": {
+                    "commands": ["sleep 100"]
+                  },
+                  "TimeoutSeconds": 5
+                }
+                """), "us-west-2");
+
+        assertEquals("TimedOut", waitForCommandStatus(service, command.getCommandId(), "us-west-2"));
+        Command updatedCommand = service.listCommands(command.getCommandId(), null, "us-west-2").getFirst();
+        assertEquals("Execution Timed Out", updatedCommand.getStatusDetails());
+
+        CommandInvocation invocation = service.getCommandInvocation(command.getCommandId(), "i-timeout", "us-west-2");
+        assertEquals("TimedOut", invocation.getStatus());
+        assertEquals("Execution Timed Out", invocation.getStatusDetails());
+        assertEquals(-1, invocation.getResponseCode());
+        assertEquals("Timed out after 5s", invocation.getStandardErrorContent());
+    }
+
+    @Test
+    void mixedDirectAndQueuedTargetsRemainInProgress() throws Exception {
+        SsmDirectCommandExecutor executor = mock(SsmDirectCommandExecutor.class);
+        Instant start = Instant.parse("2026-06-07T00:00:00Z");
+        Instant end = Instant.parse("2026-06-07T00:00:01Z");
+        when(executor.supports(eq("i-container"), eq("AWS-RunShellScript"))).thenReturn(true);
+        when(executor.supports(eq("i-agent"), eq("AWS-RunShellScript"))).thenReturn(false);
+        when(executor.executeIfSupported(eq("i-container"), eq("AWS-RunShellScript"), any(), eq(60)))
+                .thenReturn(Optional.of(new SsmDirectCommandExecutor.ExecutionResult(
+                        "Success", "done\n", "", 0, start, end)));
+
+        SsmCommandService service = new SsmCommandService(
+                new InMemoryStorageFactory(),
+                objectMapper,
+                regionResolver,
+                executor);
+
+        Command command = service.sendCommand(objectMapper.readTree("""
+                {
+                  "InstanceIds": ["i-container", "i-agent"],
+                  "DocumentName": "AWS-RunShellScript",
+                  "Parameters": {
+                    "commands": ["echo done"]
+                  },
+                  "TimeoutSeconds": 60
+                }
+                """), "us-west-2");
+
+        assertEquals("InProgress", command.getStatus());
+        assertEquals("In Progress", command.getStatusDetails());
+        waitForInvocationStatus(service, command.getCommandId(), "i-container", "us-west-2", "Success");
+        Command updatedCommand = service.listCommands(command.getCommandId(), null, "us-west-2").getFirst();
+        assertEquals(1, updatedCommand.getCompletedCount());
+        assertEquals(0, command.getErrorCount());
+        assertEquals("Success",
+                service.getCommandInvocation(command.getCommandId(), "i-container", "us-west-2").getStatus());
+        assertEquals("Pending",
+                service.getCommandInvocation(command.getCommandId(), "i-agent", "us-west-2").getStatus());
+        assertEquals(1, service.getMessages("i-agent", "request-id", 30).size());
+    }
+
+    @Test
+    void directExecutionReturnsBeforeContainerCommandCompletes() throws Exception {
+        SsmDirectCommandExecutor executor = mock(SsmDirectCommandExecutor.class);
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        Instant start = Instant.parse("2026-06-07T00:00:00Z");
+        Instant end = Instant.parse("2026-06-07T00:00:01Z");
+        when(executor.supports(eq("i-container"), eq("AWS-RunShellScript"))).thenReturn(true);
+        when(executor.executeIfSupported(eq("i-container"), eq("AWS-RunShellScript"), any(), eq(60)))
+                .thenAnswer(invocation -> {
+                    started.countDown();
+                    assertTrue(release.await(5, TimeUnit.SECONDS));
+                    return Optional.of(new SsmDirectCommandExecutor.ExecutionResult(
+                            "Success", "done\n", "", 0, start, end));
+                });
+
+        SsmCommandService service = new SsmCommandService(
+                new InMemoryStorageFactory(),
+                objectMapper,
+                regionResolver,
+                executor);
+
+        Command command = service.sendCommand(objectMapper.readTree("""
+                {
+                  "InstanceIds": ["i-container"],
+                  "DocumentName": "AWS-RunShellScript",
+                  "Parameters": {
+                    "commands": ["sleep 1 && echo done"]
+                  },
+                  "TimeoutSeconds": 60
+                }
+                """), "us-west-2");
+
+        assertEquals("InProgress", command.getStatus());
+        assertEquals("In Progress", command.getStatusDetails());
+        CommandInvocation invocation = service.getCommandInvocation(command.getCommandId(), "i-container", "us-west-2");
+        assertEquals("InProgress", invocation.getStatus());
+        assertEquals("In Progress", invocation.getStatusDetails());
+        assertTrue(started.await(5, TimeUnit.SECONDS));
+
+        release.countDown();
+        assertEquals("Success", waitForCommandStatus(service, command.getCommandId(), "us-west-2"));
+    }
+
+    @Test
+    void directExecutionThatBecomesUnsupportedFallsBackToAgentQueue() throws Exception {
+        SsmDirectCommandExecutor executor = mock(SsmDirectCommandExecutor.class);
+        when(executor.supports(eq("i-container"), eq("AWS-RunShellScript"))).thenReturn(true);
+        when(executor.executeIfSupported(eq("i-container"), eq("AWS-RunShellScript"), any(), eq(60)))
+                .thenReturn(Optional.empty());
+
+        SsmCommandService service = new SsmCommandService(
+                new InMemoryStorageFactory(),
+                objectMapper,
+                regionResolver,
+                executor);
+
+        Command command = service.sendCommand(objectMapper.readTree("""
+                {
+                  "InstanceIds": ["i-container"],
+                  "DocumentName": "AWS-RunShellScript",
+                  "Parameters": {
+                    "commands": ["echo hello"]
+                  },
+                  "TimeoutSeconds": 60
+                }
+                """), "us-west-2");
+
+        assertEquals("InProgress", command.getStatus());
+        assertEquals(1, waitForMessageCount(service, "i-container"));
+        CommandInvocation invocation = service.getCommandInvocation(command.getCommandId(), "i-container", "us-west-2");
+        assertEquals("Pending", invocation.getStatus());
+        assertEquals("Pending", invocation.getStatusDetails());
+    }
+
+    @Test
+    void directExecutionUsesAwsOutputLimitsFromBeginning() throws Exception {
+        SsmDirectCommandExecutor executor = mock(SsmDirectCommandExecutor.class);
+        String stdout = "o".repeat(24_010) + "tail";
+        String stderr = "e".repeat(8_010) + "tail";
+        when(executor.supports(eq("i-container"), eq("AWS-RunShellScript"))).thenReturn(true);
+        when(executor.executeIfSupported(eq("i-container"), eq("AWS-RunShellScript"), any(), eq(60)))
+                .thenReturn(Optional.of(new SsmDirectCommandExecutor.ExecutionResult(
+                        "Failed", stdout, stderr, 1, Instant.parse("2026-06-07T00:00:00Z"), Instant.parse("2026-06-07T00:00:01Z"))));
+
+        SsmCommandService service = new SsmCommandService(
+                new InMemoryStorageFactory(),
+                objectMapper,
+                regionResolver,
+                executor);
+
+        Command command = service.sendCommand(objectMapper.readTree("""
+                {
+                  "InstanceIds": ["i-container"],
+                  "DocumentName": "AWS-RunShellScript",
+                  "Parameters": {
+                    "commands": ["printf output"]
+                  },
+                  "TimeoutSeconds": 60
+                }
+                """), "us-west-2");
+
+        assertEquals("Failed", waitForCommandStatus(service, command.getCommandId(), "us-west-2"));
+        CommandInvocation invocation = service.getCommandInvocation(command.getCommandId(), "i-container", "us-west-2");
+        assertEquals(24_000, invocation.getStandardOutputContent().length());
+        assertEquals(8_000, invocation.getStandardErrorContent().length());
+        assertEquals("o".repeat(24_000), invocation.getStandardOutputContent());
+        assertEquals("e".repeat(8_000), invocation.getStandardErrorContent());
+    }
+
+    private static String waitForCommandStatus(SsmCommandService service, String commandId, String region) throws InterruptedException {
+        for (int i = 0; i < 50; i++) {
+            Command command = service.listCommands(commandId, null, region).getFirst();
+            if (!"InProgress".equals(command.getStatus())) {
+                return command.getStatus();
+            }
+            TimeUnit.MILLISECONDS.sleep(20);
+        }
+        return service.listCommands(commandId, null, region).getFirst().getStatus();
+    }
+
+    private static void waitForInvocationStatus(SsmCommandService service, String commandId, String instanceId, String region, String status) throws InterruptedException {
+        for (int i = 0; i < 50; i++) {
+            if (status.equals(service.getCommandInvocation(commandId, instanceId, region).getStatus())) {
+                return;
+            }
+            TimeUnit.MILLISECONDS.sleep(20);
+        }
+    }
+
+    private static int waitForMessageCount(SsmCommandService service, String instanceId) throws InterruptedException {
+        for (int i = 0; i < 50; i++) {
+            int messageCount = service.getMessages(instanceId, "request-id", 30).size();
+            if (messageCount > 0) {
+                return messageCount;
+            }
+            TimeUnit.MILLISECONDS.sleep(20);
+        }
+        return 0;
+    }
+
+    private static final class InMemoryStorageFactory extends StorageFactory {
+        private InMemoryStorageFactory() {
+            super(null, null);
+        }
+
+        @Override
+        public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+                                                    TypeReference<Map<String, V>> typeReference) {
+            return new InMemoryStorage<>();
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ssm/SsmDirectCommandExecutorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssm/SsmDirectCommandExecutorTest.java
@@ -1,0 +1,268 @@
+package io.github.hectorvent.floci.services.ssm;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.command.ExecCreateCmd;
+import com.github.dockerjava.api.command.ExecCreateCmdResponse;
+import com.github.dockerjava.api.command.ExecStartCmd;
+import com.github.dockerjava.api.command.InspectExecCmd;
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.api.model.StreamType;
+import com.github.dockerjava.api.command.InspectExecResponse;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.model.Instance;
+import io.github.hectorvent.floci.services.ec2.model.InstanceState;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+class SsmDirectCommandExecutorTest {
+
+    @Test
+    void executesRunShellScriptInsideEc2Container() throws Exception {
+        DockerClient dockerClient = mock(DockerClient.class);
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        Instance instance = instance("i-container", "container-1");
+        when(ec2Service.findInstanceById("i-container")).thenReturn(instance);
+        when(ec2Service.isInstanceContainerRunning("i-container")).thenReturn(true);
+
+        ExecCreateCmd execCreate = mock(ExecCreateCmd.class, withSettings().defaultAnswer(RETURNS_SELF));
+        ExecCreateCmdResponse execCreateResponse = mock(ExecCreateCmdResponse.class);
+        when(execCreateResponse.getId()).thenReturn("exec-1");
+        when(execCreate.exec()).thenReturn(execCreateResponse);
+        when(dockerClient.execCreateCmd("container-1")).thenReturn(execCreate);
+
+        ExecStartCmd execStart = mock(ExecStartCmd.class);
+        AtomicReference<ResultCallback<Frame>> callback = new AtomicReference<>();
+        when(execStart.exec(any())).thenAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            ResultCallback<Frame> resultCallback = invocation.getArgument(0);
+            callback.set(resultCallback);
+            resultCallback.onNext(new Frame(StreamType.STDOUT, "stdout\n".getBytes()));
+            resultCallback.onNext(new Frame(StreamType.STDERR, "stderr\n".getBytes()));
+            resultCallback.onComplete();
+            return resultCallback;
+        });
+        when(dockerClient.execStartCmd("exec-1")).thenReturn(execStart);
+
+        InspectExecCmd inspectExec = mock(InspectExecCmd.class);
+        InspectExecResponse inspectExecResponse = mock(InspectExecResponse.class);
+        when(inspectExecResponse.getExitCodeLong()).thenReturn(0L);
+        when(inspectExec.exec()).thenReturn(inspectExecResponse);
+        when(dockerClient.inspectExecCmd("exec-1")).thenReturn(inspectExec);
+
+        SsmDirectCommandExecutor executor = new SsmDirectCommandExecutor(dockerClient, ec2Service);
+        Optional<SsmDirectCommandExecutor.ExecutionResult> result = executor.executeIfSupported(
+                "i-container",
+                "AWS-RunShellScript",
+                Map.of("commands", List.of("echo stdout"), "workingDirectory", List.of("/tmp")),
+                30);
+
+        assertTrue(result.isPresent());
+        assertEquals("Success", result.get().status());
+        assertEquals("stdout\n", result.get().standardOutput());
+        assertEquals("stderr\n", result.get().standardError());
+        assertEquals(0, result.get().responseCode());
+        assertTrue(callback.get() != null);
+        verify(execCreate).withCmd(
+                eq("sh"),
+                eq("-c"),
+                argThat(command -> command.contains("timeout --kill-after=1s '30s' sh -c")
+                        && command.contains("'echo stdout'")));
+    }
+
+    @Test
+    void returnsEmptyWhenInstanceIsNotContainerBacked() {
+        DockerClient dockerClient = mock(DockerClient.class);
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        when(ec2Service.findInstanceById("i-agent")).thenReturn(null);
+
+        SsmDirectCommandExecutor executor = new SsmDirectCommandExecutor(dockerClient, ec2Service);
+        Optional<SsmDirectCommandExecutor.ExecutionResult> result = executor.executeIfSupported(
+                "i-agent",
+                "AWS-RunShellScript",
+                Map.of("commands", List.of("echo agent")),
+                30);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void returnsEmptyForUnsupportedDocument() {
+        DockerClient dockerClient = mock(DockerClient.class);
+        Ec2Service ec2Service = mock(Ec2Service.class);
+
+        SsmDirectCommandExecutor executor = new SsmDirectCommandExecutor(dockerClient, ec2Service);
+        Optional<SsmDirectCommandExecutor.ExecutionResult> result = executor.executeIfSupported(
+                "i-container",
+                "AWS-RunPowerShellScript",
+                Map.of("commands", List.of("Write-Host nope")),
+                30);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void blankRunShellScriptCompletesWithoutDockerExec() {
+        DockerClient dockerClient = mock(DockerClient.class);
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        Instance instance = instance("i-container", "container-1");
+        when(ec2Service.findInstanceById("i-container")).thenReturn(instance);
+        when(ec2Service.isInstanceContainerRunning("i-container")).thenReturn(true);
+
+        SsmDirectCommandExecutor executor = new SsmDirectCommandExecutor(dockerClient, ec2Service);
+        Optional<SsmDirectCommandExecutor.ExecutionResult> result = executor.executeIfSupported(
+                "i-container",
+                "AWS-RunShellScript",
+                Map.of("commands", List.of("")),
+                30);
+
+        assertTrue(result.isPresent());
+        assertEquals("Success", result.get().status());
+        assertEquals("", result.get().standardOutput());
+        assertEquals(0, result.get().responseCode());
+        verifyNoInteractions(dockerClient);
+    }
+
+    @Test
+    void nonZeroExitCodeMapsToFailedResult() {
+        DockerClient dockerClient = mock(DockerClient.class);
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        Instance instance = instance("i-container", "container-1");
+        when(ec2Service.findInstanceById("i-container")).thenReturn(instance);
+        when(ec2Service.isInstanceContainerRunning("i-container")).thenReturn(true);
+
+        ExecCreateCmd execCreate = mock(ExecCreateCmd.class, withSettings().defaultAnswer(RETURNS_SELF));
+        ExecCreateCmdResponse execCreateResponse = mock(ExecCreateCmdResponse.class);
+        when(execCreateResponse.getId()).thenReturn("exec-1");
+        when(execCreate.exec()).thenReturn(execCreateResponse);
+        when(dockerClient.execCreateCmd("container-1")).thenReturn(execCreate);
+
+        ExecStartCmd execStart = mock(ExecStartCmd.class);
+        when(execStart.exec(any())).thenAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            ResultCallback<Frame> resultCallback = invocation.getArgument(0);
+            resultCallback.onNext(new Frame(StreamType.STDERR, "nope\n".getBytes()));
+            resultCallback.onComplete();
+            return resultCallback;
+        });
+        when(dockerClient.execStartCmd("exec-1")).thenReturn(execStart);
+
+        InspectExecCmd inspectExec = mock(InspectExecCmd.class);
+        InspectExecResponse inspectExecResponse = mock(InspectExecResponse.class);
+        when(inspectExecResponse.getExitCodeLong()).thenReturn(7L);
+        when(inspectExec.exec()).thenReturn(inspectExecResponse);
+        when(dockerClient.inspectExecCmd("exec-1")).thenReturn(inspectExec);
+
+        SsmDirectCommandExecutor executor = new SsmDirectCommandExecutor(dockerClient, ec2Service);
+        Optional<SsmDirectCommandExecutor.ExecutionResult> result = executor.executeIfSupported(
+                "i-container",
+                "AWS-RunShellScript",
+                Map.of("commands", List.of("exit 7")),
+                30);
+
+        assertTrue(result.isPresent());
+        assertEquals("Failed", result.get().status());
+        assertEquals("nope\n", result.get().standardError());
+        assertEquals(7, result.get().responseCode());
+    }
+
+    @Test
+    void timeoutClosesDockerExecCallback() throws Exception {
+        DockerClient dockerClient = mock(DockerClient.class);
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        Instance instance = instance("i-container", "container-1");
+        when(ec2Service.findInstanceById("i-container")).thenReturn(instance);
+        when(ec2Service.isInstanceContainerRunning("i-container")).thenReturn(true);
+
+        ExecCreateCmd execCreate = mock(ExecCreateCmd.class, withSettings().defaultAnswer(RETURNS_SELF));
+        ExecCreateCmdResponse execCreateResponse = mock(ExecCreateCmdResponse.class);
+        when(execCreateResponse.getId()).thenReturn("exec-1");
+        when(execCreate.exec()).thenReturn(execCreateResponse);
+        when(dockerClient.execCreateCmd("container-1")).thenReturn(execCreate);
+
+        ExecStartCmd execStart = mock(ExecStartCmd.class);
+        @SuppressWarnings("unchecked")
+        ResultCallback<Frame> callback = mock(ResultCallback.class);
+        when(execStart.exec(any())).thenReturn(callback);
+        when(dockerClient.execStartCmd("exec-1")).thenReturn(execStart);
+
+        SsmDirectCommandExecutor executor = new SsmDirectCommandExecutor(dockerClient, ec2Service);
+        Optional<SsmDirectCommandExecutor.ExecutionResult> result = executor.executeIfSupported(
+                "i-container",
+                "AWS-RunShellScript",
+                Map.of("commands", List.of("sleep 100")),
+                0);
+
+        assertTrue(result.isPresent());
+        assertEquals("TimedOut", result.get().status());
+        assertEquals(-1, result.get().responseCode());
+        verify(callback).close();
+    }
+
+    @Test
+    void timeoutExitCodeMapsToTimedOutResult() throws Exception {
+        DockerClient dockerClient = mock(DockerClient.class);
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        Instance instance = instance("i-container", "container-1");
+        when(ec2Service.findInstanceById("i-container")).thenReturn(instance);
+        when(ec2Service.isInstanceContainerRunning("i-container")).thenReturn(true);
+
+        ExecCreateCmd execCreate = mock(ExecCreateCmd.class, withSettings().defaultAnswer(RETURNS_SELF));
+        ExecCreateCmdResponse execCreateResponse = mock(ExecCreateCmdResponse.class);
+        when(execCreateResponse.getId()).thenReturn("exec-1");
+        when(execCreate.exec()).thenReturn(execCreateResponse);
+        when(dockerClient.execCreateCmd("container-1")).thenReturn(execCreate);
+
+        ExecStartCmd execStart = mock(ExecStartCmd.class);
+        when(execStart.exec(any())).thenAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            ResultCallback<Frame> resultCallback = invocation.getArgument(0);
+            resultCallback.onNext(new Frame(StreamType.STDERR, "terminated\n".getBytes()));
+            resultCallback.onComplete();
+            return resultCallback;
+        });
+        when(dockerClient.execStartCmd("exec-1")).thenReturn(execStart);
+
+        InspectExecCmd inspectExec = mock(InspectExecCmd.class);
+        InspectExecResponse inspectExecResponse = mock(InspectExecResponse.class);
+        when(inspectExecResponse.getExitCodeLong()).thenReturn(124L);
+        when(inspectExec.exec()).thenReturn(inspectExecResponse);
+        when(dockerClient.inspectExecCmd("exec-1")).thenReturn(inspectExec);
+
+        SsmDirectCommandExecutor executor = new SsmDirectCommandExecutor(dockerClient, ec2Service);
+        Optional<SsmDirectCommandExecutor.ExecutionResult> result = executor.executeIfSupported(
+                "i-container",
+                "AWS-RunShellScript",
+                Map.of("commands", List.of("sleep 100")),
+                1);
+
+        assertTrue(result.isPresent());
+        assertEquals("TimedOut", result.get().status());
+        assertEquals(-1, result.get().responseCode());
+        assertEquals("terminated\n", result.get().standardError());
+    }
+
+    private static Instance instance(String instanceId, String containerId) {
+        Instance instance = new Instance();
+        instance.setInstanceId(instanceId);
+        instance.setDockerContainerId(containerId);
+        instance.setState(InstanceState.running());
+        return instance;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ssm/SsmSendCommandIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssm/SsmSendCommandIntegrationTest.java
@@ -1,18 +1,29 @@
 package io.github.hectorvent.floci.services.ssm;
 
 import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.time.Instant;
 import java.util.Base64;
+import java.util.Optional;
 import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
 
 @QuarkusTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -21,10 +32,19 @@ class SsmSendCommandIntegrationTest {
     private static final String SSM_CT = "application/x-amz-json-1.1";
     private static final String INSTANCE_ID = "i-0abc1234def56789a";
     private static String commandId;
+    private static final SsmDirectCommandExecutor directCommandExecutor = mock(SsmDirectCommandExecutor.class);
 
     @BeforeAll
     static void setup() {
         RestAssuredJsonUtils.configureAwsContentTypes();
+        QuarkusMock.installMockForType(directCommandExecutor, SsmDirectCommandExecutor.class);
+    }
+
+    @BeforeEach
+    void resetDirectExecution() {
+        reset(directCommandExecutor);
+        when(directCommandExecutor.executeIfSupported(anyString(), anyString(), any(), anyInt()))
+                .thenReturn(Optional.empty());
     }
 
     // ── Agent registration ─────────────────────────────────────────────────
@@ -356,6 +376,79 @@ class SsmSendCommandIntegrationTest {
         .then()
             .statusCode(200)
             .body("Commands[0].Status", equalTo("Cancelled"));
+    }
+
+    @Test
+    @Order(11)
+    void sendCommandDirectlyExecutesForContainerBackedInstance() {
+        Instant start = Instant.parse("2026-06-07T00:00:00Z");
+        Instant end = Instant.parse("2026-06-07T00:00:01Z");
+        when(directCommandExecutor.supports(eq("i-direct-container"), eq("AWS-RunShellScript")))
+                .thenReturn(true);
+        when(directCommandExecutor.executeIfSupported(
+                eq("i-direct-container"),
+                eq("AWS-RunShellScript"),
+                any(),
+                eq(60)))
+                .thenReturn(Optional.of(new SsmDirectCommandExecutor.ExecutionResult(
+                        "Success", "direct-output\n", "", 0, start, end)));
+
+        String response = given()
+            .header("X-Amz-Target", "AmazonSSM.SendCommand")
+            .contentType(SSM_CT)
+            .body("""
+                {
+                    "InstanceIds": ["i-direct-container"],
+                    "DocumentName": "AWS-RunShellScript",
+                    "Parameters": { "commands": ["echo direct-output"] },
+                    "TimeoutSeconds": 60
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Command.Status", equalTo("InProgress"))
+            .body("Command.StatusDetails", equalTo("In Progress"))
+            .body("Command.CompletedCount", equalTo(0))
+            .body("Command.ErrorCount", equalTo(0))
+            .extract().body().asString();
+
+        String cid = io.restassured.path.json.JsonPath.from(response).getString("Command.CommandId");
+
+        given()
+            .header("X-Amz-Target", "AmazonSSM.GetCommandInvocation")
+            .contentType(SSM_CT)
+            .body("""
+                {
+                    "CommandId": "%s",
+                    "InstanceId": "i-direct-container"
+                }
+                """.formatted(cid))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Status", equalTo("Success"))
+            .body("StatusDetails", equalTo("Success"))
+            .body("ResponseCode", equalTo(0))
+            .body("StandardOutputContent", equalTo("direct-output\n"));
+
+        given()
+            .header("X-Amz-Target", "AmazonSSMMessageDeliveryService.GetMessages")
+            .contentType(SSM_CT)
+            .body("""
+                {
+                    "Destination": "i-direct-container",
+                    "MessagesRequestId": "%s",
+                    "VisibilityTimeoutInSeconds": 30
+                }
+                """.formatted(UUID.randomUUID()))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Messages", empty());
     }
 
     private static String buildReplyPayload(String stdout, String status, int returnCode) {


### PR DESCRIPTION
## Summary

Adds direct execution support for SSM Run Command against locally managed EC2 containers.

This lets Floci accept `SendCommand` requests for shell/script documents, execute the command in the target EC2 container when a runtime container is available, and surface invocation status/output through the existing SSM command APIs.

## Compatibility Notes

- Preserves existing agent-polling behavior for instances without direct container execution.
- Keeps the public surface on the existing AWS SSM APIs; no custom endpoints are introduced.
- Uses EC2 runtime metadata to resolve eligible local containers.
- Treats unavailable containers and execution failures as command invocation status changes rather than transport-level API failures.

## Tests

- `./mvnw -Dtest='SsmCommandServiceDirectExecutionTest,SsmDirectCommandExecutorTest,SsmIntegrationTest' test`

## Branch-Family Verification

After rebasing the capability family on current `origin/main` and dropping the merged IAM preflight member:

- `hojo branch-family verify`: PASS, 11 members, 0 findings
- `hojo branch-family rebuild --dry-run`: PASS, dropped unowned commits 0
