### PR TITLE
fix(cloudwatch): parse decimal epoch timestamps in JSON protocol handler

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsJsonHandler.java
@@ -95,8 +95,8 @@ public class CloudWatchMetricsJsonHandler {
         String metricName = request.path("MetricName").asText();
         List<Dimension> dimensions = parseDimensionsJson(request.path("Dimensions"));
         int period = request.path("Period").asInt(60);
-        Instant startTime = parseInstant(request.path("StartTime").asText(null));
-        Instant endTime = parseInstant(request.path("EndTime").asText(null));
+        Instant startTime = parseInstantNode(request.path("StartTime"));
+        Instant endTime = parseInstantNode(request.path("EndTime"));
 
         List<String> statistics = new ArrayList<>();
         JsonNode statsNode = request.path("Statistics");
@@ -313,7 +313,7 @@ public class CloudWatchMetricsJsonHandler {
             datum.setUnit(item.path("Unit").asText(null));
             JsonNode ts = item.path("Timestamp");
             if (!ts.isMissingNode()) {
-                Instant parsed = parseInstant(ts.asText(null));
+                Instant parsed = parseInstantNode(ts);
                 if (parsed != null) datum.setTimestamp(parsed.getEpochSecond());
             }
             datum.setDimensions(parseDimensionsJson(item.path("Dimensions")));

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsJsonHandlerTest.java
@@ -1,0 +1,117 @@
+package io.github.hectorvent.floci.services.cloudwatch.metrics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Handler-level tests for CloudWatchMetricsJsonHandler.
+ *
+ * The AWS SDK v2 serialises Instant values via DateUtils.formatUnixTimestampInstant(),
+ * which produces a plain decimal epoch-second number (e.g. 1750000000.123) written
+ * via JsonGenerator.writeNumber(String). Jackson deserialises this as a numeric node,
+ * which is what these tests replicate using BigDecimal to avoid double-precision artefacts.
+ */
+class CloudWatchMetricsJsonHandlerTest {
+
+    private static final String REGION = "us-east-1";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    // Fixed reference point — avoids wall-clock non-determinism.
+    private static final Instant EPOCH_NOW = Instant.parse("2025-06-16T12:00:00Z");
+    private static final Instant EPOCH_OLD = EPOCH_NOW.minusSeconds(86400);
+
+    private CloudWatchMetricsJsonHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        CloudWatchMetricsService service = new CloudWatchMetricsService(
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new RegionResolver(REGION, "000000000000")
+        );
+        handler = new CloudWatchMetricsJsonHandler(service, MAPPER);
+    }
+
+    /**
+     * Mimics DateUtils.formatUnixTimestampInstant: epoch millis as a decimal BigDecimal
+     * (epoch seconds with millisecond precision). Using BigDecimal avoids the scientific-
+     * notation and precision issues that arise when casting through double.
+     */
+    private static BigDecimal sdkTimestamp(Instant instant) {
+        return new BigDecimal(instant.toEpochMilli()).scaleByPowerOfTen(-3);
+    }
+
+    private Response putMetric(String namespace, String metricName,
+                                String dimName, String dimValue,
+                                double value, Instant timestamp) {
+        ObjectNode req = MAPPER.createObjectNode();
+        req.put("Namespace", namespace);
+        var datum = req.putArray("MetricData").addObject();
+        datum.put("MetricName", metricName);
+        datum.put("Value", value);
+        datum.put("Timestamp", sdkTimestamp(timestamp));
+        datum.putArray("Dimensions").addObject()
+                .put("Name", dimName).put("Value", dimValue);
+        return handler.handle("PutMetricData", req, REGION);
+    }
+
+    private ObjectNode getStats(String namespace, String metricName,
+                                 String dimName, String dimValue,
+                                 Instant startTime, Instant endTime, int period) {
+        ObjectNode req = MAPPER.createObjectNode();
+        req.put("Namespace", namespace);
+        req.put("MetricName", metricName);
+        req.put("Period", period);
+        req.put("StartTime", sdkTimestamp(startTime));
+        req.put("EndTime", sdkTimestamp(endTime));
+        req.putArray("Dimensions").addObject()
+                .put("Name", dimName).put("Value", dimValue);
+        req.putArray("Statistics").add("Sum");
+        Response resp = handler.handle("GetMetricStatistics", req, REGION);
+        assertEquals(200, resp.getStatus());
+        return (ObjectNode) resp.getEntity();
+    }
+
+    @Test
+    void putMetricData_decimalEpochTimestamp_storesCorrectTimestamp() {
+        assertEquals(200, putMetric("NS", "M", "type", "old", 200.0, EPOCH_OLD).getStatus());
+
+        // Wide window around the old timestamp — must find the datapoint
+        ObjectNode wide = getStats("NS", "M", "type", "old",
+                EPOCH_OLD.minusSeconds(60), EPOCH_OLD.plusSeconds(60), 3600);
+        assertEquals(1, wide.get("Datapoints").size(),
+                "metric stored with 24h-ago timestamp must be found when querying around that time");
+
+        // Narrow window around now — must not find the datapoint
+        ObjectNode narrow = getStats("NS", "M", "type", "old",
+                EPOCH_NOW.minusSeconds(10), EPOCH_NOW.plusSeconds(10), 60);
+        assertEquals(0, narrow.get("Datapoints").size(),
+                "metric stored with 24h-ago timestamp must not appear in a 20-second window around now");
+    }
+
+    @Test
+    void getMetricStatistics_decimalEpochStartEndTime_filtersOutOfRangeDatapoints() {
+        putMetric("NS", "M", "type", "current", 100.0, EPOCH_NOW);
+        putMetric("NS", "M", "type", "old", 200.0, EPOCH_OLD);
+
+        ObjectNode currentResult = getStats("NS", "M", "type", "current",
+                EPOCH_NOW.minusSeconds(10), EPOCH_NOW.plusSeconds(10), 60);
+        assertEquals(1, currentResult.get("Datapoints").size(),
+                "current metric must be returned for a window around now");
+
+        ObjectNode oldResult = getStats("NS", "M", "type", "old",
+                EPOCH_NOW.minusSeconds(10), EPOCH_NOW.plusSeconds(10), 60);
+        assertEquals(0, oldResult.get("Datapoints").size(),
+                "metric from 24h ago must not be returned for a 20-second window around now");
+    }
+}


### PR DESCRIPTION
## Summary

Fix `GetMetricStatistics` ignoring `startTime`/`endTime` when called via the AWS JSON protocol.

The AWS SDK v2 serialises `Instant` timestamps using `DateUtils.formatUnixTimestampInstant()`, which produces decimal epoch-second strings (e.g. `"1750000000.123"`). The JSON handler was calling
`parseInstant(node.asText())` which fails for this format: `Instant.parse()` rejects it (not ISO-8601) and `Long.parseLong()` rejects the decimal point. Both fall through and return `null`.

This caused two silent failures:
- **`GetMetricStatistics`**: `StartTime`/`EndTime` became `null`, defaulting the filter to `0…Long.MAX_VALUE` — all stored datapoints were returned regardless of the requested time range.
- **`PutMetricData`**: `MetricDatum.Timestamp` became `null`, so metrics were stored with the current time instead of the caller-supplied timestamp.

Fix: switch both call sites to `parseInstantNode(JsonNode)`, the existing helper that calls `node.asLong()` for numeric nodes and was already used correctly in `GetMetricData`.

Closes #1357

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** `GetMetricStatistics` returned all stored datapoints regardless of `startTime`/`endTime`. A 20-second query window around the current time returned a datapoint timestamped 24 hours ago.

**Verified with:** AWS SDK for Java v2 `2.46.10` — the SDK's `GetMetricStatisticsRequestMarshaller` uses `BaseAwsJsonProtocolFactory` (JSON protocol, `X-Amz-Target:
GraniteServiceVersion20100801.GetMetricStatistics`), which serialises timestamps as decimal epoch-second strings via `DateUtils.formatUnixTimestampInstant()`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (`CloudWatchMetricsJsonHandlerTest`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)