### PR TITLE
fix(config): make runtime defaults explicit

### DIFF
--- a/docs/configuration/advanced/application-yml.md
+++ b/docs/configuration/advanced/application-yml.md
@@ -36,7 +36,7 @@ The block below mirrors `src/main/resources/application.yml`, it's the effective
 
 ```yaml
 floci:
-  max-request-size: 512              # Max HTTP request body size in MB
+  max-request-size: 2048             # Max HTTP request body size in MB
   base-url: "http://localhost:4566"  # Used to build response URLs (SQS QueueUrl, SNS endpoints, etc.)
   # hostname: ""                     # When set, overrides the host in base-url for multi-container Docker
   default-region: us-east-1
@@ -141,6 +141,7 @@ floci:
     iam:
       enabled: true
       enforcement-enabled: false        # Set to true to enforce IAM policies on all requests
+      seed-deployer-principal: false    # Set to true to create a local floci-deployer admin principal
 
     elasticache:
       enabled: true

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -201,6 +201,7 @@ See [Initialization Hooks](./initialization-hooks.md) for lifecycle phases and s
 |---|---|---|
 | `FLOCI_SERVICES_IAM_ENABLED` | `true` | Enable the IAM service |
 | `FLOCI_SERVICES_IAM_ENFORCEMENT_ENABLED` | `false` | When `true`, enforce IAM policies on API calls. Leave `false` for most local development scenarios |
+| `FLOCI_SERVICES_IAM_SEED_DEPLOYER_PRINCIPAL` | `false` | Create a local `floci-deployer` IAM user with `AdministratorAccess` and static `floci`/`floci` credentials |
 
 ### KMS
 

--- a/docs/services/iam.md
+++ b/docs/services/iam.md
@@ -38,6 +38,9 @@
 ### Login Profiles
 `CreateLoginProfile` · `DeleteLoginProfile` · `UpdateLoginProfile`
 
+### Policy Simulation
+`SimulatePrincipalPolicy`
+
 ## AWS Managed Policies
 
 Floci seeds a catalog of commonly-used AWS managed policies at startup. These are attachable immediately without any setup:
@@ -58,6 +61,20 @@ Floci seeds a catalog of commonly-used AWS managed policies at startup. These ar
 `AmazonS3ObjectLambdaExecutionRolePolicy` · `CloudWatchLambdaInsightsExecutionRolePolicy` · `CloudWatchLambdaApplicationSignalsExecutionRolePolicy` · `AWSConfigRulesExecutionRole` · `AWSMSKReplicatorExecutionRole` · `AWS-SSM-DiagnosisAutomation-ExecutionRolePolicy` · `AWS-SSM-RemediationAutomation-ExecutionRolePolicy` · `AmazonSageMakerGeospatialExecutionRole` · `AmazonSageMakerCanvasEMRServerlessExecutionRolePolicy` · `SageMakerStudioBedrockFunctionExecutionRolePolicy` · `SageMakerStudioDomainExecutionRolePolicy` · `SageMakerStudioQueryExecutionRolePolicy` · `AmazonDataZoneDomainExecutionRolePolicy` · `AmazonBedrockAgentCoreMemoryBedrockModelInferenceExecutionRolePolicy` · `AWSPartnerCentralSellingResourceSnapshotJobExecutionRolePolicy`
 
 All seeded policies use a permissive wildcard document since Floci does not enforce IAM policy evaluation by default.
+
+## Optional Local Deployer Principal
+
+Floci can seed a local IAM user for development workflows that expect a concrete caller identity before provisioning starts. This is disabled by default.
+
+Enable it with:
+
+```bash
+FLOCI_SERVICES_IAM_SEED_DEPLOYER_PRINCIPAL=true
+```
+
+When enabled, Floci creates the `floci-deployer` user if it does not already exist, attaches `arn:aws:iam::aws:policy/AdministratorAccess`, and creates static `floci` / `floci` access-key credentials if that access key does not already exist. Existing users and access keys are preserved.
+
+Requests signed with the seeded access key return the deployer user ARN from `sts:GetCallerIdentity`.
 
 ## IAM Enforcement Mode
 
@@ -153,6 +170,7 @@ AWS_ACCESS_KEY_ID=$AKID AWS_SECRET_ACCESS_KEY=$SECRET \
 |---|---|---|
 | `FLOCI_SERVICES_IAM_ENABLED` | `true` | Enable or disable the service |
 | `FLOCI_SERVICES_IAM_ENFORCEMENT_ENABLED` | `false` | Enforce IAM policies on all inbound requests |
+| `FLOCI_SERVICES_IAM_SEED_DEPLOYER_PRINCIPAL` | `false` | Seed the optional `floci-deployer` user and `floci` / `floci` access key |
 
 ## Examples
 

--- a/docs/services/sts.md
+++ b/docs/services/sts.md
@@ -39,3 +39,5 @@ aws sts get-session-token --endpoint-url $AWS_ENDPOINT_URL
 ```
 
 `GetCallerIdentity` is commonly used in CI pipelines and integration tests as a quick connectivity check before running more complex tests.
+
+When `FLOCI_SERVICES_IAM_SEED_DEPLOYER_PRINCIPAL=true`, requests signed with the seeded `floci` access key return `arn:aws:iam::000000000000:user/floci-deployer`. Other unknown local credentials continue to return the account root ARN for backward compatibility.

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -50,7 +50,7 @@ public interface EmulatorConfig {
     @WithDefault("000000000000")
     String defaultAccountId();
 
-    @WithDefault("512")
+    @WithDefault("2048")
     int maxRequestSize();
 
     @WithDefault("public.ecr.aws")
@@ -506,6 +506,9 @@ public interface EmulatorConfig {
 
         @WithDefault("false")
         boolean enforcementEnabled();
+
+        @WithDefault("false")
+        boolean seedDeployerPrincipal();
     }
 
     interface MskServiceConfig {

--- a/src/main/java/io/github/hectorvent/floci/config/HttpOptionsCustomizer.java
+++ b/src/main/java/io/github/hectorvent/floci/config/HttpOptionsCustomizer.java
@@ -22,7 +22,7 @@ import jakarta.enterprise.context.ApplicationScoped;
  * </ul>
  *
  * The overall request body size is still bounded by
- * {@code quarkus.http.limits.max-body-size} (default 512 MB).
+ * {@code quarkus.http.limits.max-body-size} (default 2048 MB).
  */
 @ApplicationScoped
 public class HttpOptionsCustomizer implements HttpServerOptionsCustomizer {

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
@@ -49,6 +49,7 @@ public class IamService {
     private final StorageBackend<String, InstanceProfile> instanceProfiles;
     private final StorageBackend<String, SessionCredential> sessions;
     private final RegionResolver regionResolver;
+    private final boolean seedDeployerPrincipal;
 
     @Inject
     public IamService(StorageFactory storageFactory, EmulatorConfig config, RegionResolver regionResolver) {
@@ -60,7 +61,8 @@ public class IamService {
             storageFactory.create("iam", "iam-access-keys.json", new TypeReference<>() {}),
             storageFactory.create("iam", "iam-instance-profiles.json", new TypeReference<>() {}),
             storageFactory.create("iam", "iam-sessions.json", new TypeReference<>() {}),
-            regionResolver
+            regionResolver,
+            config.services().iam().seedDeployerPrincipal()
         );
     }
 
@@ -72,6 +74,18 @@ public class IamService {
                StorageBackend<String, InstanceProfile> instanceProfiles,
                StorageBackend<String, SessionCredential> sessions,
                RegionResolver regionResolver) {
+        this(users, groups, roles, policies, accessKeys, instanceProfiles, sessions, regionResolver, false);
+    }
+
+    IamService(StorageBackend<String, IamUser> users,
+               StorageBackend<String, IamGroup> groups,
+               StorageBackend<String, IamRole> roles,
+               StorageBackend<String, IamPolicy> policies,
+               StorageBackend<String, AccessKey> accessKeys,
+               StorageBackend<String, InstanceProfile> instanceProfiles,
+               StorageBackend<String, SessionCredential> sessions,
+               RegionResolver regionResolver,
+               boolean seedDeployerPrincipal) {
         this.users = users;
         this.groups = groups;
         this.roles = roles;
@@ -80,12 +94,15 @@ public class IamService {
         this.instanceProfiles = instanceProfiles;
         this.sessions = sessions;
         this.regionResolver = regionResolver;
+        this.seedDeployerPrincipal = seedDeployerPrincipal;
     }
 
     @PostConstruct
     void seedDefaults() {
         seedAwsManagedPolicies();
-        seedDefaultDeployerPrincipal();
+        if (seedDeployerPrincipal) {
+            seedDefaultDeployerPrincipal();
+        }
     }
 
     void seedAwsManagedPolicies() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,7 +52,7 @@ quarkus:
 
 floci:
   port: 4566
-  max-request-size: 512
+  max-request-size: 2048
   base-url: "http://localhost:4566"
   # hostname: ""  # When set, overrides the hostname in response URLs (e.g. SQS QueueUrl).
                    # Needed for multi-container Docker setups. Example: FLOCI_HOSTNAME=floci
@@ -175,6 +175,7 @@ floci:
     iam:
       enabled: true
       enforcement-enabled: false
+      seed-deployer-principal: false
     msk:
       enabled: true
       mock: false

--- a/src/test/java/io/github/hectorvent/floci/config/ApplicationDefaultsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/ApplicationDefaultsTest.java
@@ -6,7 +6,10 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -25,5 +28,26 @@ class ApplicationDefaultsTest {
                             .asBoolean(false),
                     "application.yml should enable CloudTrail by default");
         }
+    }
+
+    @Test
+    void productionConfigUsesExpectedRequestSizeLimit() throws IOException {
+        JsonNode config = new YAMLMapper().readTree(Path.of("src/main/resources/application.yml").toFile());
+
+        assertEquals(2048,
+                config.path("floci").path("max-request-size").asInt(),
+                "production application.yml should allow 2048 MB request bodies by default");
+    }
+
+    @Test
+    void productionConfigDoesNotSeedIamDeployerPrincipalByDefault() throws IOException {
+        JsonNode config = new YAMLMapper().readTree(Path.of("src/main/resources/application.yml").toFile());
+
+        assertFalse(config.path("floci")
+                        .path("services")
+                        .path("iam")
+                        .path("seed-deployer-principal")
+                        .asBoolean(true),
+                "production application.yml should not create default admin credentials unless enabled");
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
@@ -237,7 +237,7 @@ class IamIntegrationTest {
 
     @Test
     @Order(9)
-    void stsGetCallerIdentityHonoursSeededFlociAccessKey() {
+    void stsGetCallerIdentityFallsBackForUnseededFlociAccessKey() {
         given()
             .formParam("Action", "GetCallerIdentity")
             .header("Authorization",
@@ -249,7 +249,7 @@ class IamIntegrationTest {
             .contentType("application/xml")
             .body("GetCallerIdentityResponse.GetCallerIdentityResult.Account", equalTo("000000000000"))
             .body("GetCallerIdentityResponse.GetCallerIdentityResult.Arn",
-                    equalTo("arn:aws:iam::000000000000:user/floci-deployer"));
+                    equalTo("arn:aws:iam::000000000000:root"));
     }
 
     @Test
@@ -431,7 +431,7 @@ class IamIntegrationTest {
         .then()
             .statusCode(200)
             .body("ListUsersResponse.ListUsersResult.Users.member.UserName",
-                    hasItem("test-user"));
+                    equalTo("test-user"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
@@ -25,15 +25,24 @@ class IamServiceTest {
 
     @BeforeEach
     void setUp() {
-        iamService = new IamService(
+        iamService = iamService(false);
+    }
+
+    private static IamService iamService(boolean seedDeployerPrincipal) {
+        return iamService(seedDeployerPrincipal, new InMemoryStorage<>());
+    }
+
+    private static IamService iamService(boolean seedDeployerPrincipal, InMemoryStorage<String, AccessKey> accessKeys) {
+        return new IamService(
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
+                accessKeys,
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
-                new InMemoryStorage<>(),
-                new RegionResolver("us-east-1", "000000000000")
+                new RegionResolver("us-east-1", "000000000000"),
+                seedDeployerPrincipal
         );
     }
 
@@ -507,7 +516,16 @@ class IamServiceTest {
     }
 
     @Test
-    void seedDefaultsCreatesDefaultDeployerPrincipal() {
+    void seedDefaultsDoesNotCreateDefaultDeployerPrincipalByDefault() {
+        iamService.seedDefaults();
+
+        assertThrows(AwsException.class, () -> iamService.getUser("floci-deployer"));
+        assertTrue(iamService.resolveCallerArn("floci").isEmpty());
+    }
+
+    @Test
+    void seedDefaultsCreatesConfiguredDefaultDeployerPrincipal() {
+        iamService = iamService(true);
         iamService.seedDefaults();
 
         IamUser user = iamService.getUser("floci-deployer");
@@ -527,6 +545,21 @@ class IamServiceTest {
 
         assertEquals("InvalidInput", ex.getErrorCode());
         assertEquals("PolicySourceArn must identify an IAM user or role.", ex.getMessage());
+    }
+
+    @Test
+    void seedDefaultsDoesNotReplaceExistingDeployerAccessKey() {
+        InMemoryStorage<String, AccessKey> accessKeys = new InMemoryStorage<>();
+        iamService = iamService(true, accessKeys);
+        iamService.createUser("existing", "/");
+        accessKeys.put("floci", new AccessKey("floci", "existing-secret", "existing"));
+
+        iamService.seedDefaults();
+
+        assertEquals(
+                "arn:aws:iam::000000000000:user/existing",
+                iamService.resolveCallerArn("floci").orElseThrow());
+        assertEquals("existing-secret", iamService.findSecretKey("floci").orElseThrow());
     }
 
     @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -87,6 +87,7 @@ floci:
     iam:
       enabled: true
       enforcement-enabled: false
+      seed-deployer-principal: false
     msk:
       enabled: true
       mock: true


### PR DESCRIPTION
## Summary
- make the default request body size explicit in config and docs
- gate the seeded IAM deployer principal behind an opt-in config flag
- keep IAM managed policy seeding unchanged while avoiding default admin credentials

## Tests
- ./mvnw -Dtest='ApplicationDefaultsTest,IamServiceTest,IamIntegrationTest' test