### PR TITLE
fix(ec2): enable embedded DNS for instances

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/dns/EmbeddedDnsServer.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/dns/EmbeddedDnsServer.java
@@ -23,6 +23,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.SequencedSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Embedded UDP/53 DNS server that runs inside the Floci container and is injected
@@ -56,6 +58,8 @@ public class EmbeddedDnsServer {
     private static final int FORWARD_TIMEOUT_MS = 1500;
     public static final String DEFAULT_SUFFIX = "localhost.floci.io";
     public static final String LOCALSTACK_SUFFIX = "localhost.localstack.cloud";
+    private static final Pattern EC2_PRIVATE_DNS_NAME =
+            Pattern.compile("^ip-(\\d{1,3})-(\\d{1,3})-(\\d{1,3})-(\\d{1,3})\\.ec2\\.internal$", Pattern.CASE_INSENSITIVE);
 
     // Well-known emulator wildcard DNS domains that always resolve to Floci's IP.
     // The suffix "localhost.X" covers "localhost.X" itself and "*.localhost.X" — it does
@@ -131,8 +135,9 @@ public class EmbeddedDnsServer {
             buf.getShort(); // qclass
             int questionEnd = buf.position();
 
-            if (qtype == 1 && matchesSuffix(qname)) {
-                byte[] response = buildAResponse(data, txId, questionOffset, questionEnd, myIp);
+            Optional<String> resolvedAddress = qtype == 1 ? resolveARecord(qname, myIp) : Optional.empty();
+            if (resolvedAddress.isPresent()) {
+                byte[] response = buildAResponse(data, txId, questionOffset, questionEnd, resolvedAddress.get());
                 socket.send(Buffer.buffer(response), senderPort, senderHost, v -> {});
             } else {
                 forwardAsync(vertx, socket, data, senderHost, senderPort);
@@ -156,6 +161,36 @@ public class EmbeddedDnsServer {
             }
         }
         return false;
+    }
+
+    Optional<String> resolveARecord(String name, String myIp) {
+        if (matchesSuffix(name)) {
+            return Optional.of(myIp);
+        }
+        return resolveEc2PrivateDnsName(name);
+    }
+
+    Optional<String> resolveEc2PrivateDnsName(String name) {
+        if (name == null || name.isEmpty()) {
+            return Optional.empty();
+        }
+        Matcher matcher = EC2_PRIVATE_DNS_NAME.matcher(name);
+        if (!matcher.matches()) {
+            return Optional.empty();
+        }
+
+        StringBuilder address = new StringBuilder();
+        for (int i = 1; i <= 4; i++) {
+            int octet = Integer.parseInt(matcher.group(i));
+            if (octet > 255) {
+                return Optional.empty();
+            }
+            if (i > 1) {
+                address.append('.');
+            }
+            address.append(octet);
+        }
+        return Optional.of(address.toString());
     }
 
     String readName(ByteBuffer buf, byte[] data) {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
@@ -112,6 +112,7 @@ public class Ec2ContainerManager {
                 ContainerSpec spec = containerBuilder.newContainer(dockerImage)
                         .withName(containerName)
                         .withEnv("AWS_EC2_METADATA_SERVICE_ENDPOINT", imdsEndpoint)
+                        .withEmbeddedDns()
                         .withEnv("AWS_EC2_INSTANCE_ID", instanceId)
                         .withEnv("AWS_DEFAULT_REGION", region)
                         .withPortBinding(22, sshHostPort)

--- a/src/test/java/io/github/hectorvent/floci/core/common/dns/EmbeddedDnsServerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/dns/EmbeddedDnsServerTest.java
@@ -75,6 +75,34 @@ class EmbeddedDnsServerTest {
         assertFalse(dns.matchesSuffix(""));
     }
 
+    // ── EC2 private DNS names ────────────────────────────────────────────────
+
+    @Test
+    void resolveEc2PrivateDnsName_decodesAwsIpName() {
+        assertEquals(
+                "172.16.128.9",
+                dns.resolveEc2PrivateDnsName("ip-172-16-128-9.ec2.internal").orElseThrow());
+    }
+
+    @Test
+    void resolveEc2PrivateDnsName_isCaseInsensitive() {
+        assertEquals(
+                "10.42.32.17",
+                dns.resolveEc2PrivateDnsName("IP-10-42-32-17.EC2.INTERNAL").orElseThrow());
+    }
+
+    @Test
+    void resolveEc2PrivateDnsName_rejectsInvalidOctets() {
+        assertTrue(dns.resolveEc2PrivateDnsName("ip-172-16-128-300.ec2.internal").isEmpty());
+    }
+
+    @Test
+    void resolveARecord_prefersEc2PrivateDnsAddressOverFlociWildcard() {
+        assertEquals(
+                "172.16.128.9",
+                dns.resolveARecord("ip-172-16-128-9.ec2.internal", "172.16.128.5").orElseThrow());
+    }
+
     // ── matchesSuffix — built-in emulator domains ─────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary
- inject Floci embedded DNS into EC2 instance containers
- resolve EC2 private DNS names such as ip-10-0-0-1.ec2.internal to their encoded address
- keep existing emulator wildcard DNS behavior intact

## Tests
- ./mvnw -Dtest='EmbeddedDnsServerTest' test