### PR TITLE
feat(aws): expand EC2 and RDS availability catalogs

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/RdsControlPlaneTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/RdsControlPlaneTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.CreateDbSubnetGroupResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbSubnetGroupsResponse;
+import software.amazon.awssdk.services.rds.model.DescribeOrderableDbInstanceOptionsResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -51,5 +52,18 @@ class RdsControlPlaneTest {
         assertThat(describeResponse.dbSubnetGroups().get(0).subnets())
                 .extracting("subnetIdentifier")
                 .containsExactly("subnet-a", "subnet-b");
+    }
+
+    @Test
+    void sdkDiscoversCurrentSmallGravitonPostgresOption() {
+        DescribeOrderableDbInstanceOptionsResponse response = rds.describeOrderableDBInstanceOptions(b -> b
+                .engine("postgres")
+                .engineVersion("16.14")
+                .dbInstanceClass("db.t4g.small"));
+
+        assertThat(response.orderableDBInstanceOptions()).hasSize(1);
+        assertThat(response.orderableDBInstanceOptions().get(0).engine()).isEqualTo("postgres");
+        assertThat(response.orderableDBInstanceOptions().get(0).engineVersion()).isEqualTo("16.14");
+        assertThat(response.orderableDBInstanceOptions().get(0).dbInstanceClass()).isEqualTo("db.t4g.small");
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1776,6 +1776,10 @@ public class Ec2Service {
         allTypes.add(buildInstanceType("t4g.micro", 2, 1024, List.of("arm64")));
         allTypes.add(buildInstanceType("t4g.small", 2, 2048, List.of("arm64")));
         allTypes.add(buildInstanceType("t4g.medium", 2, 4096, List.of("arm64")));
+        allTypes.add(buildInstanceType("m6gd.2xlarge", 8, 32768, List.of("arm64")));
+        allTypes.add(buildInstanceType("m7gd.2xlarge", 8, 32768, List.of("arm64")));
+        allTypes.add(buildInstanceType("m8gd.medium", 1, 4096, List.of("arm64")));
+        allTypes.add(buildInstanceType("m8gd.2xlarge", 8, 32768, List.of("arm64")));
 
         if (instanceTypeNames.isEmpty()) {
             return allTypes;

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -381,8 +381,11 @@ public class RdsService {
                 Map.of("engine", "postgres", "engineVersion", "16.3", "dbInstanceClass", "db.t3.micro"),
                 Map.of("engine", "postgres", "engineVersion", "16.14", "dbInstanceClass", "db.t3.micro"),
                 Map.of("engine", "postgres", "engineVersion", "18.1", "dbInstanceClass", "db.t3.micro"),
+                Map.of("engine", "postgres", "engineVersion", "18.1", "dbInstanceClass", "db.m8g.large"),
+                Map.of("engine", "postgres", "engineVersion", "18.4", "dbInstanceClass", "db.m8g.large"),
                 Map.of("engine", "postgres", "engineVersion", "16.3", "dbInstanceClass", "db.t4g.micro"),
                 Map.of("engine", "postgres", "engineVersion", "16.3", "dbInstanceClass", "db.t4g.small"),
+                Map.of("engine", "postgres", "engineVersion", "16.14", "dbInstanceClass", "db.t4g.small"),
                 Map.of("engine", "postgres", "engineVersion", "16.3", "dbInstanceClass", "db.t4g.medium"),
                 Map.of("engine", "mysql", "engineVersion", "8.0", "dbInstanceClass", "db.t3.micro"),
                 Map.of("engine", "mariadb", "engineVersion", "11", "dbInstanceClass", "db.t3.micro")

--- a/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
@@ -95,7 +95,7 @@ public class RdsContainerManager {
         }
 
         // Handle persistence mounting
-        addPersistenceMounts(specBuilder, instanceId, volumeId, engine, envVars);
+        addPersistenceMounts(specBuilder, instanceId, volumeId, engine, image);
 
         // Add engine-specific command
         List<String> cmd = buildContainerCmd(engine);
@@ -150,25 +150,57 @@ public class RdsContainerManager {
     }
 
     private void addPersistenceMounts(ContainerBuilder.Builder specBuilder, String instanceId,
-                                      String volumeId, DatabaseEngine engine, List<String> envVars) {
+                                      String volumeId, DatabaseEngine engine, String image) {
         if (ContainerStorageHelper.isNamedVolumeMode(config)) {
             ContainerStorageHelper.applyStorage(
                     specBuilder, lifecycleManager, "rds", volumeId, instanceId,
-                    engineDefaultDataPath(engine));
+                    engineDefaultDataPath(engine, image));
             return;
         }
 
         // Legacy host-path mode: host-persistent-path is an absolute path
         String hostDataPath = Path.of(config.storage().hostPersistentPath(), "rds", instanceId).toString();
         ContainerStorageHelper.ensureHostDir(hostDataPath);
-        specBuilder.withBind(hostDataPath, engineDefaultDataPath(engine));
+        specBuilder.withBind(hostDataPath, engineDefaultDataPath(engine, image));
     }
 
-    private static String engineDefaultDataPath(DatabaseEngine engine) {
+    static String engineDefaultDataPath(DatabaseEngine engine, String image) {
         return switch (engine) {
-            case POSTGRES -> "/var/lib/postgresql/data";
+            case POSTGRES -> postgresDataPath(image);
             case MYSQL, MARIADB -> "/var/lib/mysql";
         };
+    }
+
+    private static String postgresDataPath(String image) {
+        if (postgresImageMajorVersion(image) >= 18) {
+            return "/var/lib/postgresql";
+        }
+        return "/var/lib/postgresql/data";
+    }
+
+    private static int postgresImageMajorVersion(String image) {
+        if (image == null || image.isBlank()) {
+            return -1;
+        }
+        String reference = image;
+        int digestSeparator = reference.indexOf('@');
+        if (digestSeparator >= 0) {
+            reference = reference.substring(0, digestSeparator);
+        }
+        int slashSeparator = reference.lastIndexOf('/');
+        int tagSeparator = reference.lastIndexOf(':');
+        if (tagSeparator < slashSeparator || tagSeparator == reference.length() - 1) {
+            return -1;
+        }
+        String tag = reference.substring(tagSeparator + 1);
+        int end = 0;
+        while (end < tag.length() && Character.isDigit(tag.charAt(end))) {
+            end++;
+        }
+        if (end == 0) {
+            return -1;
+        }
+        return Integer.parseInt(tag.substring(0, end));
     }
 
     private void initializeEngine(String containerName, String containerId, DatabaseEngine engine, String masterUsername) {

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -1,6 +1,8 @@
 package io.github.hectorvent.floci.services.ec2;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
@@ -274,6 +276,32 @@ class Ec2IntegrationTest {
                     equalTo("region"))
             .body("DescribeInstanceTypeOfferingsResponse.instanceTypeOfferingSet.item[0].location",
                     equalTo("us-east-1"));
+    }
+
+    @Test
+    @Order(20)
+    void describeModernGravitonInstanceTypeOfferingsByRegion() {
+        given()
+            .formParam("Action", "DescribeInstanceTypeOfferings")
+            .formParam("LocationType", "region")
+            .formParam("Filter.1.Name", "instance-type")
+            .formParam("Filter.1.Value.1", "m8gd.2xlarge")
+            .formParam("Filter.1.Value.2", "m7gd.2xlarge")
+            .formParam("Filter.1.Value.3", "m6gd.2xlarge")
+            .formParam("Filter.1.Value.4", "m8gd.medium")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("DescribeInstanceTypeOfferingsResponse.instanceTypeOfferingSet.item.size()", equalTo(4))
+            .body("DescribeInstanceTypeOfferingsResponse.instanceTypeOfferingSet.item.instanceType",
+                    containsInAnyOrder("m8gd.2xlarge", "m7gd.2xlarge", "m6gd.2xlarge", "m8gd.medium"))
+            .body("DescribeInstanceTypeOfferingsResponse.instanceTypeOfferingSet.item.locationType",
+                    everyItem(equalTo("region")))
+            .body("DescribeInstanceTypeOfferingsResponse.instanceTypeOfferingSet.item.location",
+                    everyItem(equalTo("us-east-1")));
     }
 
     // =========================================================================

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -259,6 +259,31 @@ class RdsServiceTest {
     }
 
     @Test
+    void describeOrderableDbInstanceOptionsIncludesModernGravitonPostgresClasses() {
+        var flociPinned = rdsService.describeOrderableDbInstanceOptions(
+                "postgres", "18.1", "db.m8g.large");
+        var awsEquivalent = rdsService.describeOrderableDbInstanceOptions(
+                "postgres", "18.4", "db.m8g.large");
+
+        assertEquals(1, flociPinned.size());
+        assertEquals("db.m8g.large", flociPinned.getFirst().get("dbInstanceClass"));
+        assertEquals("18.1", flociPinned.getFirst().get("engineVersion"));
+        assertEquals(1, awsEquivalent.size());
+        assertEquals("db.m8g.large", awsEquivalent.getFirst().get("dbInstanceClass"));
+        assertEquals("18.4", awsEquivalent.getFirst().get("engineVersion"));
+    }
+
+    @Test
+    void describeOrderableDbInstanceOptionsIncludesCurrentSmallGravitonPostgresClass() {
+        var result = rdsService.describeOrderableDbInstanceOptions(
+                "postgres", "16.14", "db.t4g.small");
+
+        assertEquals(1, result.size());
+        assertEquals("db.t4g.small", result.getFirst().get("dbInstanceClass"));
+        assertEquals("16.14", result.getFirst().get("engineVersion"));
+    }
+
+    @Test
     void deleteDbClusterFailsWhenMembersRemain() {
         DbCluster cluster = rdsService.createDbCluster("cluster1", "postgres", "13",
                 "admin", "password", "dbname", false, null);

--- a/src/test/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManagerTest.java
@@ -2,6 +2,9 @@ package io.github.hectorvent.floci.services.rds.container;
 
 import org.junit.jupiter.api.Test;
 
+import io.github.hectorvent.floci.services.rds.model.DatabaseEngine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RdsContainerManagerTest {
@@ -13,5 +16,31 @@ class RdsContainerManagerTest {
         assertTrue(sql.contains("pg_roles"));
         assertTrue(sql.contains("rolname = 'rds_iam'"));
         assertTrue(sql.contains("CREATE ROLE rds_iam"));
+    }
+
+    @Test
+    void postgres18UsesParentDataMount() {
+        assertEquals("/var/lib/postgresql",
+                RdsContainerManager.engineDefaultDataPath(DatabaseEngine.POSTGRES, "postgres:18.4-alpine"));
+        assertEquals("/var/lib/postgresql",
+                RdsContainerManager.engineDefaultDataPath(DatabaseEngine.POSTGRES, "registry.example.com/postgres:18-alpine"));
+        assertEquals("/var/lib/postgresql",
+                RdsContainerManager.engineDefaultDataPath(DatabaseEngine.POSTGRES,
+                        "postgres:18.4-alpine@sha256:1234567890abcdef"));
+        assertEquals("/var/lib/postgresql",
+                RdsContainerManager.engineDefaultDataPath(DatabaseEngine.POSTGRES,
+                        "localhost:5000/postgres:18.4-alpine"));
+    }
+
+    @Test
+    void olderPostgresUsesLegacyDataMount() {
+        assertEquals("/var/lib/postgresql/data",
+                RdsContainerManager.engineDefaultDataPath(DatabaseEngine.POSTGRES, "postgres:16-alpine"));
+        assertEquals("/var/lib/postgresql/data",
+                RdsContainerManager.engineDefaultDataPath(DatabaseEngine.POSTGRES, "postgres:17.6"));
+        assertEquals("/var/lib/postgresql/data",
+                RdsContainerManager.engineDefaultDataPath(DatabaseEngine.POSTGRES, "postgres:latest"));
+        assertEquals("/var/lib/postgresql/data",
+                RdsContainerManager.engineDefaultDataPath(DatabaseEngine.POSTGRES, "localhost:5000/postgres"));
     }
 }


### PR DESCRIPTION
## Summary
- add current Graviton EC2 instance types to DescribeInstanceTypes and offerings
- add additional PostgreSQL orderable RDS options, including PostgreSQL 18.x on db.m8g.large
- adjust PostgreSQL 18 container data mount handling for the official image layout

## Tests
- ./mvnw -Dtest='Ec2IntegrationTest,RdsServiceTest,RdsContainerManagerTest' test