### PR TITLE
fix(rds): report DB parameter group attachments

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -621,6 +621,7 @@ public class RdsQueryHandler {
                .elem("Status", "active")
              .end("VpcSecurityGroupMembership")
            .end("VpcSecurityGroups")
+           .raw(dbParameterGroupsXml(i))
            .raw(dbSubnetGroupXml(dbSubnetGroupForInstance(i)))
            .elem("DbiResourceId", i.getDbiResourceId())
            .elem("DBInstanceArn", i.getDbInstanceArn());
@@ -640,6 +641,46 @@ public class RdsQueryHandler {
         writeTags(xml, i.getTags());
         xml.end("TagList");
         return xml.build();
+    }
+
+    private static String dbParameterGroupsXml(DbInstance instance) {
+        String name = dbParameterGroupName(instance);
+
+        XmlBuilder xml = new XmlBuilder().start("DBParameterGroups");
+        xml.start("DBParameterGroup")
+           .elem("DBParameterGroupName", name)
+           .elem("ParameterApplyStatus", "in-sync")
+           .end("DBParameterGroup");
+        return xml.end("DBParameterGroups").build();
+    }
+
+    private static String dbParameterGroupName(DbInstance instance) {
+        String name = instance.getParameterGroupName();
+        if (name != null && !name.isBlank()) {
+            return name;
+        }
+
+        String engine = instance.getEngine() != null
+                ? instance.getEngine().name().toLowerCase()
+                : "unknown";
+        return "default." + engine + dbEngineMajorVersion(instance);
+    }
+
+    private static String dbEngineMajorVersion(DbInstance instance) {
+        String engineVersion = instance.getEngineVersion();
+        if ((engineVersion == null || engineVersion.isBlank()) && instance.getEngine() != null) {
+            engineVersion = defaultEngineVersion(instance.getEngine().name());
+        }
+        if (engineVersion == null || engineVersion.isBlank()) {
+            return "";
+        }
+
+        String trimmed = engineVersion.trim();
+        int end = 0;
+        while (end < trimmed.length() && Character.isDigit(trimmed.charAt(end))) {
+            end++;
+        }
+        return end == 0 ? "" : trimmed.substring(0, end);
     }
 
     private static void writeTags(XmlBuilder xml, Map<String, String> tags) {

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -55,6 +55,34 @@ class RdsQueryHandlerTest {
     }
 
     @Test
+    void describeDbInstances_includesDbParameterGroupAttachment() {
+        DbInstance instance = makeInstance("mydb");
+        instance.setParameterGroupName("postgres18");
+        when(service.listDbInstances(null)).thenReturn(List.of(instance));
+
+        Response response = handler.handle("DescribeDBInstances", params());
+
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<DBParameterGroups>"));
+        assertTrue(body.contains("<DBParameterGroupName>postgres18</DBParameterGroupName>"));
+        assertTrue(body.contains("<ParameterApplyStatus>in-sync</ParameterApplyStatus>"));
+    }
+
+    @Test
+    void describeDbInstances_reportsDefaultDbParameterGroupWhenUnattached() {
+        DbInstance instance = makeInstance("mydb");
+        instance.setEngineVersion("16.3");
+        when(service.listDbInstances(null)).thenReturn(List.of(instance));
+
+        Response response = handler.handle("DescribeDBInstances", params());
+
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<DBParameterGroups>"));
+        assertTrue(body.contains("<DBParameterGroupName>default.postgres16</DBParameterGroupName>"));
+        assertTrue(body.contains("<ParameterApplyStatus>in-sync</ParameterApplyStatus>"));
+    }
+
+    @Test
     void describeDbInstances_filterByDirectIdentifier() {
         DbInstance instance = makeInstance("mydb");
         when(service.listDbInstances("mydb")).thenReturn(List.of(instance));


### PR DESCRIPTION
## Summary
- include DBParameterGroups in DescribeDBInstances responses
- report the stored DB parameter group name with an in-sync apply status
- preserve existing DB instance response shape around subnet groups, tags, and metadata

## Tests
- ./mvnw -Dtest='RdsQueryHandlerTest' test