### PR TITLE
feat(autoscaling): support group reconciliation and refresh

### DIFF
--- a/docs/services/ec2.md
+++ b/docs/services/ec2.md
@@ -45,7 +45,9 @@ Key pairs created with `CreateKeyPair` contain dummy private key material. Impor
 
 ## UserData
 
-`UserData` must be base64-encoded in the request (matching the AWS wire format). Floci decodes it, copies the script into `/tmp/user-data.sh` inside the container, and executes it with `sh` after SSH key injection. Output is captured and logged.
+`UserData` must be base64-encoded in the request (matching the AWS wire format). Floci decodes it, copies the script into `/tmp/user-data.sh` inside the container, and executes the script directly after SSH key injection so the script shebang selects the interpreter. Output is captured and logged.
+
+EC2 containers receive `AWS_EC2_METADATA_SERVICE_ENDPOINT` for IMDS and `AWS_ENDPOINT_URL` for AWS service API calls back to Floci.
 
 ## Instance Metadata Service (IMDS)
 
@@ -143,7 +145,9 @@ Floci seeds the following resources on first use in each region so Terraform, th
 `DescribeInstanceTypes` · `DescribeInstanceTypeOfferings`
 
 ### Launch Templates
-`CreateLaunchTemplate` · `DescribeLaunchTemplates` · `DeleteLaunchTemplate`
+`CreateLaunchTemplate` · `CreateLaunchTemplateVersion` · `DescribeLaunchTemplates` · `DescribeLaunchTemplateVersions` · `ModifyLaunchTemplate` · `DeleteLaunchTemplate`
+
+Launch templates store versioned launch data. New template versions can be created from an existing source version, and `ModifyLaunchTemplate` updates the default version used by later launches.
 
 ### IAM Instance Profiles
 `DescribeIamInstanceProfileAssociations`

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -113,6 +113,7 @@ public class AwsQueryController {
             "CreateLaunchConfiguration", "DescribeLaunchConfigurations", "DeleteLaunchConfiguration",
             "CreateAutoScalingGroup", "UpdateAutoScalingGroup", "DeleteAutoScalingGroup",
             "DescribeAutoScalingGroups", "SetDesiredCapacity",
+            "StartInstanceRefresh", "DescribeInstanceRefreshes",
             "CreateOrUpdateTags", "DeleteTags",
             "DescribeAutoScalingInstances", "AttachInstances", "DetachInstances",
             "TerminateInstanceInAutoScalingGroup",

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java
@@ -287,6 +287,7 @@ public class AutoScalingQueryHandler {
             if (inst.getLaunchConfigurationName() != null) {
                 xml.elem("LaunchConfigurationName", inst.getLaunchConfigurationName());
             }
+            appendInstanceLaunchTemplateXml(xml, inst);
             if (inst.getInstanceType() != null) { xml.elem("InstanceType", inst.getInstanceType()); }
             xml.end("member");
         }
@@ -445,14 +446,32 @@ public class AutoScalingQueryHandler {
             if (inst.getLaunchConfigurationName() != null) {
                 xml.elem("LaunchConfigurationName", inst.getLaunchConfigurationName());
             }
+            appendInstanceLaunchTemplateXml(xml, inst);
             if (inst.getInstanceType() != null) { xml.elem("InstanceType", inst.getInstanceType()); }
             xml.end("member");
         }
         xml.end("AutoScalingInstances")
            .end("DescribeAutoScalingInstancesResult")
-           .raw(AwsQueryResponse.responseMetadata())
-           .end("DescribeAutoScalingInstancesResponse");
+                .raw(AwsQueryResponse.responseMetadata())
+                .end("DescribeAutoScalingInstancesResponse");
         return ok(xml.build());
+    }
+
+    private static void appendInstanceLaunchTemplateXml(XmlBuilder xml, AsgInstance inst) {
+        if (inst.getLaunchTemplateId() == null && inst.getLaunchTemplateName() == null) {
+            return;
+        }
+        xml.start("LaunchTemplate");
+        if (inst.getLaunchTemplateId() != null) {
+            xml.elem("LaunchTemplateId", inst.getLaunchTemplateId());
+        }
+        if (inst.getLaunchTemplateName() != null) {
+            xml.elem("LaunchTemplateName", inst.getLaunchTemplateName());
+        }
+        if (inst.getLaunchTemplateVersion() != null) {
+            xml.elem("Version", inst.getLaunchTemplateVersion());
+        }
+        xml.end("LaunchTemplate");
     }
 
     private Response handleAttachInstances(MultivaluedMap<String, String> p, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java
@@ -44,6 +44,10 @@ public class AutoScalingQueryHandler {
                 case "DeleteAutoScalingGroup"       -> handleDeleteAutoScalingGroup(p, region);
                 case "DescribeAutoScalingGroups"    -> handleDescribeAutoScalingGroups(p, region);
                 case "SetDesiredCapacity"           -> handleSetDesiredCapacity(p, region);
+                case "StartInstanceRefresh"         -> handleStartInstanceRefresh(p, region);
+                case "DescribeInstanceRefreshes"    -> handleDescribeInstanceRefreshes(p, region);
+                case "CreateOrUpdateTags"           -> handleCreateOrUpdateTags(p, region);
+                case "DeleteTags"                   -> handleDeleteTags(p, region);
                 // Instances
                 case "DescribeAutoScalingInstances" -> handleDescribeAutoScalingInstances(p, region);
                 case "AttachInstances"              -> handleAttachInstances(p, region);
@@ -149,6 +153,7 @@ public class AutoScalingQueryHandler {
         service.createAutoScalingGroup(region,
                 p.getFirst("AutoScalingGroupName"),
                 p.getFirst("LaunchConfigurationName"),
+                p.getFirst("LaunchTemplate.LaunchTemplateId"),
                 p.getFirst("LaunchTemplate.LaunchTemplateName"),
                 p.getFirst("LaunchTemplate.Version"),
                 intParam(p, "MinSize", 0),
@@ -156,6 +161,7 @@ public class AutoScalingQueryHandler {
                 intParam(p, "DesiredCapacity", intParam(p, "MinSize", 0)),
                 intParam(p, "DefaultCooldown", 300),
                 memberList(p, "AvailabilityZones"),
+                commaList(p.getFirst("VPCZoneIdentifier")),
                 memberList(p, "TargetGroupARNs"),
                 memberList(p, "LoadBalancerNames"),
                 p.getFirst("HealthCheckType"),
@@ -171,9 +177,11 @@ public class AutoScalingQueryHandler {
     private Response handleUpdateAutoScalingGroup(MultivaluedMap<String, String> p, String region) {
         List<String> azs = memberList(p, "AvailabilityZones");
         List<String> tps = memberList(p, "TerminationPolicies");
+        List<String> subnetIds = commaList(p.getFirst("VPCZoneIdentifier"));
         service.updateAutoScalingGroup(region,
                 p.getFirst("AutoScalingGroupName"),
                 p.getFirst("LaunchConfigurationName"),
+                p.getFirst("LaunchTemplate.LaunchTemplateId"),
                 p.getFirst("LaunchTemplate.LaunchTemplateName"),
                 p.getFirst("LaunchTemplate.Version"),
                 p.getFirst("MinSize") != null ? Integer.parseInt(p.getFirst("MinSize")) : null,
@@ -181,6 +189,7 @@ public class AutoScalingQueryHandler {
                 p.getFirst("DesiredCapacity") != null ? Integer.parseInt(p.getFirst("DesiredCapacity")) : null,
                 p.getFirst("DefaultCooldown") != null ? Integer.parseInt(p.getFirst("DefaultCooldown")) : null,
                 azs.isEmpty() ? null : azs,
+                subnetIds.isEmpty() ? null : subnetIds,
                 p.getFirst("HealthCheckType"),
                 p.getFirst("HealthCheckGracePeriod") != null ? Integer.parseInt(p.getFirst("HealthCheckGracePeriod")) : null,
                 tps.isEmpty() ? null : tps);
@@ -233,9 +242,14 @@ public class AutoScalingQueryHandler {
         if (asg.getLaunchConfigurationName() != null) {
             xml.elem("LaunchConfigurationName", asg.getLaunchConfigurationName());
         }
-        if (asg.getLaunchTemplateName() != null) {
-            xml.start("LaunchTemplate")
-               .elem("LaunchTemplateName", asg.getLaunchTemplateName());
+        if (asg.getLaunchTemplateId() != null || asg.getLaunchTemplateName() != null) {
+            xml.start("LaunchTemplate");
+            if (asg.getLaunchTemplateId() != null) {
+                xml.elem("LaunchTemplateId", asg.getLaunchTemplateId());
+            }
+            if (asg.getLaunchTemplateName() != null) {
+                xml.elem("LaunchTemplateName", asg.getLaunchTemplateName());
+            }
             if (asg.getLaunchTemplateVersion() != null) {
                 xml.elem("Version", asg.getLaunchTemplateVersion());
             }
@@ -245,6 +259,10 @@ public class AutoScalingQueryHandler {
         xml.start("AvailabilityZones");
         for (String az : asg.getAvailabilityZones()) { xml.elem("member", az); }
         xml.end("AvailabilityZones");
+
+        if (!asg.getSubnetIds().isEmpty()) {
+            xml.elem("VPCZoneIdentifier", String.join(",", asg.getSubnetIds()));
+        }
 
         xml.start("TargetGroupARNs");
         for (String arn : asg.getTargetGroupARNs()) { xml.elem("member", arn); }
@@ -297,6 +315,115 @@ public class AutoScalingQueryHandler {
                 .start("SetDesiredCapacityResponse", NS)
                   .raw(AwsQueryResponse.responseMetadata())
                 .end("SetDesiredCapacityResponse").build());
+    }
+
+    private Response handleStartInstanceRefresh(MultivaluedMap<String, String> p, String region) {
+        InstanceRefresh refresh = service.startInstanceRefresh(region,
+                p.getFirst("AutoScalingGroupName"), parseInstanceRefresh(p));
+        return ok(new XmlBuilder()
+                .start("StartInstanceRefreshResponse", NS)
+                  .start("StartInstanceRefreshResult")
+                    .elem("InstanceRefreshId", refresh.getInstanceRefreshId())
+                  .end("StartInstanceRefreshResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("StartInstanceRefreshResponse").build());
+    }
+
+    private Response handleDescribeInstanceRefreshes(MultivaluedMap<String, String> p, String region) {
+        AutoScalingService.InstanceRefreshPage page = service.describeInstanceRefreshes(region,
+                p.getFirst("AutoScalingGroupName"),
+                memberList(p, "InstanceRefreshIds"),
+                nullableIntParam(p, "MaxRecords"),
+                p.getFirst("NextToken"));
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeInstanceRefreshesResponse", NS)
+                  .start("DescribeInstanceRefreshesResult")
+                    .start("InstanceRefreshes");
+        for (InstanceRefresh refresh : page.instanceRefreshes()) {
+            appendInstanceRefreshXml(xml, refresh);
+        }
+        xml.end("InstanceRefreshes");
+        if (page.nextToken() != null) {
+            xml.elem("NextToken", page.nextToken());
+        }
+        xml.end("DescribeInstanceRefreshesResult")
+           .raw(AwsQueryResponse.responseMetadata())
+           .end("DescribeInstanceRefreshesResponse");
+        return ok(xml.build());
+    }
+
+    private void appendInstanceRefreshXml(XmlBuilder xml, InstanceRefresh refresh) {
+        xml.start("member")
+           .elem("InstanceRefreshId", refresh.getInstanceRefreshId())
+           .elem("AutoScalingGroupName", refresh.getAutoScalingGroupName())
+           .elem("Status", refresh.getStatus())
+           .elem("StatusReason", refresh.getStatusReason())
+           .elem("PercentageComplete", String.valueOf(refresh.getPercentageComplete()))
+           .elem("InstancesToUpdate", String.valueOf(refresh.getInstancesToUpdate()))
+           .elem("StartTime", ISO_FMT.format(refresh.getStartTime()));
+        if (refresh.getEndTime() != null) {
+            xml.elem("EndTime", ISO_FMT.format(refresh.getEndTime()));
+        }
+        if (refresh.getStrategy() != null) {
+            xml.elem("Strategy", refresh.getStrategy());
+        }
+        appendDesiredConfigurationXml(xml, refresh);
+        appendPreferencesXml(xml, refresh);
+        xml.end("member");
+    }
+
+    private void appendDesiredConfigurationXml(XmlBuilder xml, InstanceRefresh refresh) {
+        if (!refresh.hasDesiredConfiguration()) {
+            return;
+        }
+        xml.start("DesiredConfiguration")
+           .start("LaunchTemplate")
+           .elem("LaunchTemplateId", refresh.getDesiredLaunchTemplateId())
+           .elem("LaunchTemplateName", refresh.getDesiredLaunchTemplateName())
+           .elem("Version", refresh.getDesiredLaunchTemplateVersion())
+           .end("LaunchTemplate")
+           .end("DesiredConfiguration");
+    }
+
+    private void appendPreferencesXml(XmlBuilder xml, InstanceRefresh refresh) {
+        xml.start("Preferences")
+           .elem("MinHealthyPercentage", intString(refresh.getMinHealthyPercentage()))
+           .elem("MaxHealthyPercentage", intString(refresh.getMaxHealthyPercentage()))
+           .elem("InstanceWarmup", intString(refresh.getInstanceWarmup()))
+           .elem("SkipMatching", boolString(refresh.getSkipMatching()))
+           .elem("AutoRollback", boolString(refresh.getAutoRollback()))
+           .elem("ScaleInProtectedInstances", refresh.getScaleInProtectedInstances())
+           .elem("StandbyInstances", refresh.getStandbyInstances())
+           .elem("CheckpointDelay", intString(refresh.getCheckpointDelay()))
+           .elem("BakeTime", intString(refresh.getBakeTime()));
+        if (!refresh.getCheckpointPercentages().isEmpty()) {
+            xml.start("CheckpointPercentages");
+            for (Integer percentage : refresh.getCheckpointPercentages()) {
+                xml.elem("member", String.valueOf(percentage));
+            }
+            xml.end("CheckpointPercentages");
+        }
+        xml.end("Preferences");
+    }
+
+    private Response handleCreateOrUpdateTags(MultivaluedMap<String, String> p, String region) {
+        for (TagRequest tag : parseTagRequests(p)) {
+            service.createOrUpdateTags(region, tag.resourceId(), tag.resourceType(), Map.of(tag.key(), tag.value()));
+        }
+        return ok(new XmlBuilder()
+                .start("CreateOrUpdateTagsResponse", NS)
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("CreateOrUpdateTagsResponse").build());
+    }
+
+    private Response handleDeleteTags(MultivaluedMap<String, String> p, String region) {
+        for (TagRequest tag : parseTagRequests(p)) {
+            service.deleteTags(region, tag.resourceId(), tag.resourceType(), List.of(tag.key()));
+        }
+        return ok(new XmlBuilder()
+                .start("DeleteTagsResponse", NS)
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("DeleteTagsResponse").build());
     }
 
     // ── Instances ─────────────────────────────────────────────────────────────
@@ -709,6 +836,16 @@ public class AutoScalingQueryHandler {
         return result;
     }
 
+    private List<String> commaList(String value) {
+        if (value == null || value.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(value.split(","))
+                .map(String::trim)
+                .filter(item -> !item.isEmpty())
+                .toList();
+    }
+
     private Map<String, String> parseTags(MultivaluedMap<String, String> p) {
         Map<String, String> result = new LinkedHashMap<>();
         for (int i = 1; ; i++) {
@@ -720,10 +857,76 @@ public class AutoScalingQueryHandler {
         return result;
     }
 
+    private List<TagRequest> parseTagRequests(MultivaluedMap<String, String> p) {
+        List<TagRequest> result = new ArrayList<>();
+        for (int i = 1; ; i++) {
+            String key = p.getFirst("Tags.member." + i + ".Key");
+            if (key == null) { break; }
+            String resourceId = p.getFirst("Tags.member." + i + ".ResourceId");
+            String resourceType = p.getFirst("Tags.member." + i + ".ResourceType");
+            String value = p.getFirst("Tags.member." + i + ".Value");
+            result.add(new TagRequest(resourceId, resourceType, key, value != null ? value : ""));
+        }
+        return result;
+    }
+
+    private record TagRequest(String resourceId, String resourceType, String key, String value) {}
+
+    private InstanceRefresh parseInstanceRefresh(MultivaluedMap<String, String> p) {
+        InstanceRefresh refresh = new InstanceRefresh();
+        refresh.setStrategy(p.getFirst("Strategy"));
+        refresh.setDesiredLaunchTemplateId(p.getFirst("DesiredConfiguration.LaunchTemplate.LaunchTemplateId"));
+        refresh.setDesiredLaunchTemplateName(p.getFirst("DesiredConfiguration.LaunchTemplate.LaunchTemplateName"));
+        refresh.setDesiredLaunchTemplateVersion(p.getFirst("DesiredConfiguration.LaunchTemplate.Version"));
+        refresh.setMinHealthyPercentage(nullableIntParam(p, "Preferences.MinHealthyPercentage"));
+        refresh.setMaxHealthyPercentage(nullableIntParam(p, "Preferences.MaxHealthyPercentage"));
+        refresh.setInstanceWarmup(nullableIntParam(p, "Preferences.InstanceWarmup"));
+        refresh.setSkipMatching(nullableBoolParam(p, "Preferences.SkipMatching"));
+        refresh.setAutoRollback(nullableBoolParam(p, "Preferences.AutoRollback"));
+        refresh.setScaleInProtectedInstances(p.getFirst("Preferences.ScaleInProtectedInstances"));
+        refresh.setStandbyInstances(p.getFirst("Preferences.StandbyInstances"));
+        refresh.setCheckpointDelay(nullableIntParam(p, "Preferences.CheckpointDelay"));
+        refresh.setBakeTime(nullableIntParam(p, "Preferences.BakeTime"));
+        refresh.setCheckpointPercentages(memberIntList(p, "Preferences.CheckpointPercentages"));
+        return refresh;
+    }
+
+    private List<Integer> memberIntList(MultivaluedMap<String, String> p, String prefix) {
+        List<Integer> result = new ArrayList<>();
+        for (String value : memberList(p, prefix)) {
+            try {
+                result.add(Integer.parseInt(value));
+            } catch (NumberFormatException ignored) {
+                // Keep Query parsing permissive like the existing integer helpers.
+            }
+        }
+        return result;
+    }
+
     private int intParam(MultivaluedMap<String, String> p, String key, int defaultValue) {
         String val = p.getFirst(key);
         if (val == null || val.isBlank()) { return defaultValue; }
         try { return Integer.parseInt(val); } catch (NumberFormatException e) { return defaultValue; }
+    }
+
+    private Integer nullableIntParam(MultivaluedMap<String, String> p, String key) {
+        String val = p.getFirst(key);
+        if (val == null || val.isBlank()) { return null; }
+        try { return Integer.parseInt(val); } catch (NumberFormatException e) { return null; }
+    }
+
+    private Boolean nullableBoolParam(MultivaluedMap<String, String> p, String key) {
+        String val = p.getFirst(key);
+        if (val == null || val.isBlank()) { return null; }
+        return Boolean.parseBoolean(val);
+    }
+
+    private String intString(Integer value) {
+        return value != null ? String.valueOf(value) : null;
+    }
+
+    private String boolString(Boolean value) {
+        return value != null ? String.valueOf(value) : null;
     }
 
     private Response ok(String xml) {

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
@@ -5,15 +5,21 @@ import io.github.hectorvent.floci.services.autoscaling.model.AutoScalingGroup;
 import io.github.hectorvent.floci.services.autoscaling.model.LaunchConfiguration;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.ec2.model.Instance;
+import io.github.hectorvent.floci.services.ec2.model.LaunchTemplate;
 import io.github.hectorvent.floci.services.ec2.model.Reservation;
 import io.github.hectorvent.floci.services.elbv2.ElbV2Service;
 import io.github.hectorvent.floci.services.elbv2.model.TargetDescription;
+import io.github.hectorvent.floci.services.elbv2.model.TargetHealth;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
+import io.quarkus.runtime.StartupEvent;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -43,6 +49,10 @@ public class AutoScalingReconciler {
         scheduler.scheduleAtFixedRate(this::reconcileAll, 5, 10, TimeUnit.SECONDS);
     }
 
+    void onStart(@Observes StartupEvent event) {
+        LOG.debug("Auto Scaling reconciler initialized");
+    }
+
     void reconcileAll() {
         for (AutoScalingGroup asg : asgService.describeAutoScalingGroups(null, null)) {
             try {
@@ -54,21 +64,34 @@ public class AutoScalingReconciler {
     }
 
     public void reconcile(AutoScalingGroup asg) {
+        removeTerminatingInstances(asg);
+        removeStaleInstances(asg);
+        removeOrphanedTargetRegistrations(asg);
         promoteReadyInstances(asg);
 
-        long inService = asg.getInstances().stream()
-                .filter(i -> "InService".equals(i.getLifecycleState()))
-                .count();
+        long activeCapacity = activeCapacity(asg);
         int desired = asg.getDesiredCapacity();
 
-        if (inService < desired) {
-            scaleOut(asg, (int) (desired - inService));
-        } else if (inService > desired) {
-            scaleIn(asg, (int) (inService - desired));
+        if (activeCapacity < desired) {
+            scaleOut(asg, (int) (desired - activeCapacity));
+        } else if (activeCapacity > desired) {
+            scaleIn(asg, (int) (activeCapacity - desired));
         }
+        asgService.saveAutoScalingGroup(asg);
+        asgService.completeInstanceRefreshIfSettled(asg.getRegion(), asg.getAutoScalingGroupName());
+    }
+
+    static long activeCapacity(AutoScalingGroup asg) {
+        return asg.getInstances().stream()
+                .filter(i -> {
+                    String state = i.getLifecycleState();
+                    return "Pending".equals(state) || "InService".equals(state);
+                })
+                .count();
     }
 
     private void promoteReadyInstances(AutoScalingGroup asg) {
+        boolean changed = false;
         for (AsgInstance asgInst : asg.getInstances()) {
             if (!"Pending".equals(asgInst.getLifecycleState())) {
                 continue;
@@ -85,6 +108,7 @@ public class AutoScalingReconciler {
                     asgInst.setLifecycleState("InService");
                     asgInst.setHealthStatus("Healthy");
                     registerWithTargetGroups(asg, asgInst);
+                    changed = true;
                     asgService.recordActivity(asg.getRegion(), asg.getAutoScalingGroupName(),
                             "Launching a new EC2 instance: " + asgInst.getInstanceId(),
                             "An instance was started in response to a desired capacity change.",
@@ -97,31 +121,122 @@ public class AutoScalingReconciler {
                         asg.getAutoScalingGroupName(), asgInst.getInstanceId(), e.getMessage());
             }
         }
+        if (changed) {
+            asgService.saveAutoScalingGroup(asg);
+        }
+    }
+
+    private void removeStaleInstances(AutoScalingGroup asg) {
+        List<AsgInstance> staleInstances = asg.getInstances().stream()
+                .filter(instance -> isActiveLifecycleState(instance.getLifecycleState()))
+                .filter(instance -> !ec2Service.isInstanceContainerRunning(instance.getInstanceId()))
+                .collect(Collectors.toList());
+        if (staleInstances.isEmpty()) {
+            return;
+        }
+
+        List<String> instanceIds = staleInstances.stream()
+                .map(AsgInstance::getInstanceId)
+                .collect(Collectors.toList());
+        asg.getInstances().removeIf(instance -> instanceIds.contains(instance.getInstanceId()));
+        asgService.saveAutoScalingGroup(asg);
+        asgService.recordActivity(asg.getRegion(), asg.getAutoScalingGroupName(),
+                "Removing stale EC2 instance reference(s): " + instanceIds,
+                "Persisted Auto Scaling state referenced instance containers that are no longer running.",
+                "Successful");
+        LOG.infov("ASG {0}: removed stale instance reference(s) {1}",
+                asg.getAutoScalingGroupName(), instanceIds);
+    }
+
+    private void removeOrphanedTargetRegistrations(AutoScalingGroup asg) {
+        if (asg.getTargetGroupARNs().isEmpty()) {
+            return;
+        }
+
+        Set<String> activeInstanceIds = asg.getInstances().stream()
+                .filter(instance -> isActiveLifecycleState(instance.getLifecycleState()))
+                .map(AsgInstance::getInstanceId)
+                .collect(Collectors.toSet());
+
+        for (String tgArn : asg.getTargetGroupARNs()) {
+            try {
+                List<TargetDescription> orphanedTargets = elbV2Service.describeTargetHealth(
+                                asg.getRegion(), tgArn, List.of()).stream()
+                        .map(TargetHealth::getTarget)
+                        .filter(target -> target != null && target.getId() != null)
+                        .filter(target -> !activeInstanceIds.contains(target.getId()))
+                        .collect(Collectors.toList());
+                if (!orphanedTargets.isEmpty()) {
+                    elbV2Service.deregisterTargets(asg.getRegion(), tgArn, orphanedTargets);
+                    LOG.infov("ASG {0}: deregistered orphaned target(s) {1} from TG {2}",
+                            asg.getAutoScalingGroupName(),
+                            orphanedTargets.stream().map(TargetDescription::getId).collect(Collectors.toList()),
+                            tgArn);
+                }
+            } catch (Exception e) {
+                LOG.debugv("ASG {0}: could not reconcile TG {1}: {2}",
+                        asg.getAutoScalingGroupName(), tgArn, e.getMessage());
+            }
+        }
+    }
+
+    private void removeTerminatingInstances(AutoScalingGroup asg) {
+        List<AsgInstance> terminatingInstances = asg.getInstances().stream()
+                .filter(instance -> "Terminating".equals(instance.getLifecycleState()))
+                .collect(Collectors.toList());
+        if (terminatingInstances.isEmpty()) {
+            return;
+        }
+
+        List<String> instanceIds = terminatingInstances.stream()
+                .map(AsgInstance::getInstanceId)
+                .collect(Collectors.toList());
+        deregisterFromTargetGroups(asg, instanceIds);
+        try {
+            ec2Service.terminateInstances(asg.getRegion(), instanceIds);
+        } catch (Exception e) {
+            LOG.warnv("ASG {0}: failed to terminate refreshing instances {1}: {2}",
+                    asg.getAutoScalingGroupName(), instanceIds, e.getMessage());
+        }
+
+        asg.getInstances().removeIf(instance -> instanceIds.contains(instance.getInstanceId()));
+        asgService.saveAutoScalingGroup(asg);
+        asgService.recordActivity(asg.getRegion(), asg.getAutoScalingGroupName(),
+                "Terminating EC2 instance(s) for refresh: " + instanceIds,
+                "An instance refresh requested replacement of active instances.",
+                "Successful");
+        LOG.infov("ASG {0}: terminated instance(s) for refresh {1}",
+                asg.getAutoScalingGroupName(), instanceIds);
+    }
+
+    private static boolean isActiveLifecycleState(String state) {
+        return "Pending".equals(state) || "InService".equals(state);
     }
 
     private void scaleOut(AutoScalingGroup asg, int count) {
-        LaunchConfiguration lc = resolveLaunchConfiguration(asg);
-        if (lc == null) {
-            LOG.warnv("ASG {0}: no launch configuration found, cannot scale out", asg.getAutoScalingGroupName());
+        LaunchSource launchSource = resolveLaunchSource(asg);
+        if (launchSource == null) {
+            LOG.warnv("ASG {0}: no launch source found, cannot scale out", asg.getAutoScalingGroupName());
             return;
         }
         LOG.infov("ASG {0}: scaling out by {1}", asg.getAutoScalingGroupName(), count);
         String az = asg.getAvailabilityZones().isEmpty()
                 ? asg.getRegion() + "a"
                 : asg.getAvailabilityZones().get(0);
+        String subnetId = asg.getSubnetIds().isEmpty() ? null : asg.getSubnetIds().get(0);
         try {
             Reservation reservation = ec2Service.runInstances(
                     asg.getRegion(),
-                    lc.getImageId(),
-                    lc.getInstanceType(),
+                    launchSource.imageId(),
+                    launchSource.instanceType(),
                     count, count,
-                    lc.getKeyName(),
-                    lc.getSecurityGroups(),
+                    launchSource.keyName(),
+                    launchSource.securityGroupIds(),
+                    subnetId,
                     null,
-                    null,
-                    null,
-                    lc.getUserData(),
-                    lc.getIamInstanceProfile());
+                    launchSource.instanceTags(),
+                    launchSource.userData(),
+                    launchSource.iamInstanceProfile());
 
             for (Instance ec2Inst : reservation.getInstances()) {
                 AsgInstance asgInst = new AsgInstance();
@@ -129,12 +244,16 @@ public class AutoScalingReconciler {
                 asgInst.setAvailabilityZone(az);
                 asgInst.setLifecycleState("Pending");
                 asgInst.setHealthStatus("Healthy");
-                asgInst.setLaunchConfigurationName(lc.getLaunchConfigurationName());
-                asgInst.setInstanceType(lc.getInstanceType());
+                asgInst.setLaunchConfigurationName(launchSource.launchConfigurationName());
+                asgInst.setLaunchTemplateId(launchSource.launchTemplateId());
+                asgInst.setLaunchTemplateName(launchSource.launchTemplateName());
+                asgInst.setLaunchTemplateVersion(launchSource.launchTemplateVersion());
+                asgInst.setInstanceType(launchSource.instanceType());
                 asg.getInstances().add(asgInst);
                 LOG.infov("ASG {0}: launched instance {1} (Pending)",
                         asg.getAutoScalingGroupName(), ec2Inst.getInstanceId());
             }
+            asgService.saveAutoScalingGroup(asg);
         } catch (Exception e) {
             LOG.warnv("ASG {0}: failed to launch instances: {1}",
                     asg.getAutoScalingGroupName(), e.getMessage());
@@ -157,7 +276,24 @@ public class AutoScalingReconciler {
                 .map(AsgInstance::getInstanceId)
                 .collect(Collectors.toList());
 
-        // Deregister from all attached target groups first
+        deregisterFromTargetGroups(asg, instanceIds);
+
+        try {
+            ec2Service.terminateInstances(asg.getRegion(), instanceIds);
+        } catch (Exception e) {
+            LOG.warnv("ASG {0}: failed to terminate instances {1}: {2}",
+                    asg.getAutoScalingGroupName(), instanceIds, e.getMessage());
+        }
+
+        asg.getInstances().removeIf(i -> instanceIds.contains(i.getInstanceId()));
+        asgService.saveAutoScalingGroup(asg);
+        asgService.recordActivity(asg.getRegion(), asg.getAutoScalingGroupName(),
+                "Terminating EC2 instance(s): " + instanceIds,
+                "An instance was terminated in response to a desired capacity change.",
+                "Successful");
+    }
+
+    private void deregisterFromTargetGroups(AutoScalingGroup asg, List<String> instanceIds) {
         for (String tgArn : asg.getTargetGroupARNs()) {
             try {
                 List<TargetDescription> targets = instanceIds.stream()
@@ -169,19 +305,6 @@ public class AutoScalingReconciler {
                         asg.getAutoScalingGroupName(), tgArn, e.getMessage());
             }
         }
-
-        try {
-            ec2Service.terminateInstances(asg.getRegion(), instanceIds);
-        } catch (Exception e) {
-            LOG.warnv("ASG {0}: failed to terminate instances {1}: {2}",
-                    asg.getAutoScalingGroupName(), instanceIds, e.getMessage());
-        }
-
-        asg.getInstances().removeIf(i -> instanceIds.contains(i.getInstanceId()));
-        asgService.recordActivity(asg.getRegion(), asg.getAutoScalingGroupName(),
-                "Terminating EC2 instance(s): " + instanceIds,
-                "An instance was terminated in response to a desired capacity change.",
-                "Successful");
     }
 
     private void registerWithTargetGroups(AutoScalingGroup asg, AsgInstance asgInst) {
@@ -199,6 +322,47 @@ public class AutoScalingReconciler {
         }
     }
 
+    private LaunchSource resolveLaunchSource(AutoScalingGroup asg) {
+        LaunchConfiguration lc = resolveLaunchConfiguration(asg);
+        if (lc != null) {
+            return new LaunchSource(
+                    lc.getLaunchConfigurationName(),
+                    lc.getImageId(),
+                    lc.getInstanceType(),
+                    lc.getKeyName(),
+                    lc.getSecurityGroups(),
+                    List.of(),
+                    lc.getUserData(),
+                    lc.getIamInstanceProfile(),
+                    null,
+                    null,
+                    null);
+        }
+
+        LaunchTemplate launchTemplate = resolveLaunchTemplate(asg);
+        if (launchTemplate != null) {
+            LaunchTemplate.LaunchTemplateVersion version = ec2Service.resolveLaunchTemplateVersion(
+                    asg.getRegion(),
+                    launchTemplate.getLaunchTemplateId(),
+                    null,
+                    asg.getLaunchTemplateVersion());
+            return new LaunchSource(
+                    null,
+                    version.getImageId(),
+                    version.getInstanceType(),
+                    version.getKeyName(),
+                    version.getSecurityGroupIds(),
+                    version.getInstanceTags(),
+                    version.getUserData(),
+                    null,
+                    asg.getLaunchTemplateId(),
+                    asg.getLaunchTemplateName(),
+                    asg.getLaunchTemplateVersion());
+        }
+
+        return null;
+    }
+
     private LaunchConfiguration resolveLaunchConfiguration(AutoScalingGroup asg) {
         String lcName = asg.getLaunchConfigurationName();
         if (lcName == null || lcName.isBlank()) {
@@ -208,6 +372,33 @@ public class AutoScalingReconciler {
                 asg.getRegion(), List.of(lcName));
         return lcs.isEmpty() ? null : lcs.get(0);
     }
+
+    private LaunchTemplate resolveLaunchTemplate(AutoScalingGroup asg) {
+        String ltId = asg.getLaunchTemplateId();
+        String ltName = asg.getLaunchTemplateName();
+        if ((ltId == null || ltId.isBlank()) && (ltName == null || ltName.isBlank())) {
+            return null;
+        }
+        List<LaunchTemplate> launchTemplates = ec2Service.describeLaunchTemplates(
+                asg.getRegion(),
+                ltId == null || ltId.isBlank() ? List.of() : List.of(ltId),
+                ltName == null || ltName.isBlank() ? List.of() : List.of(ltName),
+                Map.of());
+        return launchTemplates.isEmpty() ? null : launchTemplates.get(0);
+    }
+
+    private record LaunchSource(
+            String launchConfigurationName,
+            String imageId,
+            String instanceType,
+            String keyName,
+            List<String> securityGroupIds,
+            List<io.github.hectorvent.floci.services.ec2.model.Tag> instanceTags,
+            String userData,
+            String iamInstanceProfile,
+            String launchTemplateId,
+            String launchTemplateName,
+            String launchTemplateVersion) {}
 
     // Override for describeAutoScalingGroups with null region (all regions)
     // The service only filters by region when non-null; null means all.

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
@@ -341,23 +341,27 @@ public class AutoScalingReconciler {
 
         LaunchTemplate launchTemplate = resolveLaunchTemplate(asg);
         if (launchTemplate != null) {
-            LaunchTemplate.LaunchTemplateVersion version = ec2Service.resolveLaunchTemplateVersion(
+            LaunchTemplate version = ec2Service.describeLaunchTemplateVersions(
                     asg.getRegion(),
                     launchTemplate.getLaunchTemplateId(),
                     null,
-                    asg.getLaunchTemplateVersion());
+                    asg.getLaunchTemplateVersion() == null ? List.of() : List.of(asg.getLaunchTemplateVersion()))
+                    .getFirst();
+            String resolvedVersion = version.getLatestVersionNumber() != null
+                    ? version.getLatestVersionNumber()
+                    : asg.getLaunchTemplateVersion();
             return new LaunchSource(
                     null,
                     version.getImageId(),
                     version.getInstanceType(),
                     version.getKeyName(),
                     version.getSecurityGroupIds(),
-                    version.getInstanceTags(),
+                    List.of(),
                     version.getUserData(),
                     null,
                     asg.getLaunchTemplateId(),
                     asg.getLaunchTemplateName(),
-                    asg.getLaunchTemplateVersion());
+                    resolvedVersion);
         }
 
         return null;

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
@@ -1,9 +1,14 @@
 package io.github.hectorvent.floci.services.autoscaling;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.StorageBackedMap;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.autoscaling.model.*;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -18,12 +23,38 @@ public class AutoScalingService {
     @Inject
     RegionResolver regionResolver;
 
+    @Inject
+    StorageFactory storageFactory;
+
+    @Inject
+    Ec2Service ec2Service;
+
     // region :: name → resource
-    private final Map<String, LaunchConfiguration> launchConfigs = new ConcurrentHashMap<>();
-    private final Map<String, AutoScalingGroup>    groups         = new ConcurrentHashMap<>();
-    private final Map<String, LifecycleHook>       hooks          = new ConcurrentHashMap<>();
-    private final Map<String, ScalingPolicy>       policies       = new ConcurrentHashMap<>();
-    private final Map<String, ScalingActivity>     activities     = new ConcurrentHashMap<>();
+    private Map<String, LaunchConfiguration> launchConfigs = new ConcurrentHashMap<>();
+    private Map<String, AutoScalingGroup> groups = new ConcurrentHashMap<>();
+    private Map<String, LifecycleHook> hooks = new ConcurrentHashMap<>();
+    private Map<String, ScalingPolicy> policies = new ConcurrentHashMap<>();
+    private Map<String, ScalingActivity> activities = new ConcurrentHashMap<>();
+    private Map<String, InstanceRefresh> instanceRefreshes = new ConcurrentHashMap<>();
+
+    @PostConstruct
+    void initializeStorage()
+    {
+        if (storageFactory == null) {
+            return;
+        }
+        this.launchConfigs = storageBacked("autoscaling-launch-configurations.json", new TypeReference<Map<String, LaunchConfiguration>>() {});
+        this.groups = storageBacked("autoscaling-groups.json", new TypeReference<Map<String, AutoScalingGroup>>() {});
+        this.hooks = storageBacked("autoscaling-lifecycle-hooks.json", new TypeReference<Map<String, LifecycleHook>>() {});
+        this.policies = storageBacked("autoscaling-policies.json", new TypeReference<Map<String, ScalingPolicy>>() {});
+        this.activities = storageBacked("autoscaling-activities.json", new TypeReference<Map<String, ScalingActivity>>() {});
+        this.instanceRefreshes = storageBacked("autoscaling-instance-refreshes.json", new TypeReference<Map<String, InstanceRefresh>>() {});
+    }
+
+    private <V> Map<String, V> storageBacked(String fileName, TypeReference<Map<String, V>> typeReference)
+    {
+        return new StorageBackedMap<>(storageFactory.create("autoscaling", fileName, typeReference));
+    }
 
     // ── Launch Configurations ──────────────────────────────────────────────────
 
@@ -78,9 +109,11 @@ public class AutoScalingService {
 
     public AutoScalingGroup createAutoScalingGroup(String region, String name,
                                                     String launchConfigName,
-                                                    String launchTemplateName, String launchTemplateVersion,
+                                                    String launchTemplateId, String launchTemplateName,
+                                                    String launchTemplateVersion,
                                                     int minSize, int maxSize, int desiredCapacity,
                                                     int defaultCooldown, List<String> availabilityZones,
+                                                    List<String> subnetIds,
                                                     List<String> targetGroupArns, List<String> lbNames,
                                                     String healthCheckType, int healthCheckGracePeriod,
                                                     List<String> terminationPolicies,
@@ -90,7 +123,7 @@ public class AutoScalingService {
             throw new AwsException("AlreadyExists",
                     "Auto Scaling group '" + name + "' already exists.", 400);
         }
-        if (launchConfigName == null && launchTemplateName == null) {
+        if (launchConfigName == null && launchTemplateId == null && launchTemplateName == null) {
             throw new AwsException("ValidationError",
                     "Either LaunchConfigurationName or LaunchTemplate must be specified.", 400);
         }
@@ -101,6 +134,7 @@ public class AutoScalingService {
                 AwsArnUtils.Arn.of("autoscaling", region, regionResolver.getAccountId(),
                         "autoScalingGroup:" + name).toString());
         asg.setLaunchConfigurationName(launchConfigName);
+        asg.setLaunchTemplateId(launchTemplateId);
         asg.setLaunchTemplateName(launchTemplateName);
         asg.setLaunchTemplateVersion(launchTemplateVersion);
         asg.setMinSize(minSize);
@@ -108,6 +142,7 @@ public class AutoScalingService {
         asg.setDesiredCapacity(desiredCapacity);
         asg.setDefaultCooldown(defaultCooldown > 0 ? defaultCooldown : 300);
         asg.setAvailabilityZones(availabilityZones != null ? new ArrayList<>(availabilityZones) : new ArrayList<>());
+        asg.setSubnetIds(subnetIds != null ? new ArrayList<>(subnetIds) : new ArrayList<>());
         asg.setTargetGroupARNs(targetGroupArns != null ? new ArrayList<>(targetGroupArns) : new ArrayList<>());
         asg.setLoadBalancerNames(lbNames != null ? new ArrayList<>(lbNames) : new ArrayList<>());
         asg.setHealthCheckType(healthCheckType != null ? healthCheckType : "EC2");
@@ -124,16 +159,19 @@ public class AutoScalingService {
 
     public void updateAutoScalingGroup(String region, String name,
                                         String launchConfigName,
-                                        String launchTemplateName, String launchTemplateVersion,
+                                        String launchTemplateId, String launchTemplateName,
+                                        String launchTemplateVersion,
                                         Integer minSize, Integer maxSize, Integer desiredCapacity,
                                         Integer defaultCooldown, List<String> availabilityZones,
+                                        List<String> subnetIds,
                                         String healthCheckType, Integer healthCheckGracePeriod,
                                         List<String> terminationPolicies) {
         AutoScalingGroup asg = requireGroup(region, name);
         if (launchConfigName != null) {
             asg.setLaunchConfigurationName(launchConfigName);
         }
-        if (launchTemplateName != null) {
+        if (launchTemplateId != null || launchTemplateName != null) {
+            asg.setLaunchTemplateId(launchTemplateId);
             asg.setLaunchTemplateName(launchTemplateName);
             asg.setLaunchTemplateVersion(launchTemplateVersion);
         }
@@ -142,9 +180,11 @@ public class AutoScalingService {
         if (desiredCapacity != null) { asg.setDesiredCapacity(desiredCapacity); }
         if (defaultCooldown != null) { asg.setDefaultCooldown(defaultCooldown); }
         if (availabilityZones != null) { asg.setAvailabilityZones(new ArrayList<>(availabilityZones)); }
+        if (subnetIds != null) { asg.setSubnetIds(new ArrayList<>(subnetIds)); }
         if (healthCheckType != null) { asg.setHealthCheckType(healthCheckType); }
         if (healthCheckGracePeriod != null) { asg.setHealthCheckGracePeriod(healthCheckGracePeriod); }
         if (terminationPolicies != null) { asg.setTerminationPolicies(new ArrayList<>(terminationPolicies)); }
+        groups.put(asgKey(region, name), asg);
     }
 
     public void deleteAutoScalingGroup(String region, String name, boolean forceDelete) {
@@ -157,10 +197,24 @@ public class AutoScalingService {
                     "Auto Scaling group '" + name + "' has " + active.size()
                             + " instance(s). Set ForceDelete=true to delete anyway.", 400);
         }
+        if (forceDelete && ec2Service != null && !active.isEmpty()) {
+            active.stream()
+                    .map(AsgInstance::getInstanceId)
+                    .filter(Objects::nonNull)
+                    .forEach(instanceId -> {
+                        try {
+                            ec2Service.terminateInstances(region, List.of(instanceId));
+                        }
+                        catch (AwsException ignored) {
+                            // ForceDelete should remove stale ASG membership even if EC2 no longer has the instance.
+                        }
+                    });
+        }
         groups.remove(asgKey(region, name));
         // clean up associated hooks and policies
         hooks.entrySet().removeIf(e -> e.getValue().getAutoScalingGroupName().equals(name));
         policies.entrySet().removeIf(e -> e.getValue().getAutoScalingGroupName().equals(name));
+        instanceRefreshes.entrySet().removeIf(e -> e.getValue().getAutoScalingGroupName().equals(name));
     }
 
     public List<AutoScalingGroup> describeAutoScalingGroups(String region, List<String> names) {
@@ -175,6 +229,10 @@ public class AutoScalingService {
                 .collect(Collectors.toList());
     }
 
+    public void saveAutoScalingGroup(AutoScalingGroup asg) {
+        groups.put(asgKey(asg.getRegion(), asg.getAutoScalingGroupName()), asg);
+    }
+
     public void setDesiredCapacity(String region, String name, int desiredCapacity) {
         AutoScalingGroup asg = requireGroup(region, name);
         if (desiredCapacity < asg.getMinSize() || desiredCapacity > asg.getMaxSize()) {
@@ -183,6 +241,27 @@ public class AutoScalingService {
                             + asg.getMinSize() + " and MaxSize=" + asg.getMaxSize() + ".", 400);
         }
         asg.setDesiredCapacity(desiredCapacity);
+        groups.put(asgKey(region, name), asg);
+    }
+
+    public void createOrUpdateTags(String region, String resourceId, String resourceType, Map<String, String> tags) {
+        AutoScalingGroup asg = requireTaggableGroup(region, resourceId, resourceType);
+        asg.getTags().putAll(tags);
+        groups.put(asgKey(region, asg.getAutoScalingGroupName()), asg);
+    }
+
+    public void deleteTags(String region, String resourceId, String resourceType, List<String> tagKeys) {
+        AutoScalingGroup asg = requireTaggableGroup(region, resourceId, resourceType);
+        tagKeys.forEach(asg.getTags()::remove);
+        groups.put(asgKey(region, asg.getAutoScalingGroupName()), asg);
+    }
+
+    private AutoScalingGroup requireTaggableGroup(String region, String resourceId, String resourceType) {
+        if (!"auto-scaling-group".equals(resourceType)) {
+            throw new AwsException("ValidationError",
+                    "Unsupported tag resource type '" + resourceType + "'.", 400);
+        }
+        return requireGroup(region, resourceId);
     }
 
     // ── Instance management ────────────────────────────────────────────────────
@@ -209,11 +288,15 @@ public class AutoScalingService {
             inst.setAvailabilityZone(
                     asg.getAvailabilityZones().isEmpty() ? region + "a" : asg.getAvailabilityZones().get(0));
             inst.setLaunchConfigurationName(asg.getLaunchConfigurationName());
+            inst.setLaunchTemplateId(asg.getLaunchTemplateId());
+            inst.setLaunchTemplateName(asg.getLaunchTemplateName());
+            inst.setLaunchTemplateVersion(asg.getLaunchTemplateVersion());
             asg.getInstances().add(inst);
         }
         if (asg.getInstances().size() > asg.getDesiredCapacity()) {
             asg.setDesiredCapacity(asg.getInstances().size());
         }
+        groups.put(asgKey(region, name), asg);
     }
 
     public void detachInstances(String region, String name, List<String> instanceIds,
@@ -224,6 +307,7 @@ public class AutoScalingService {
             int newDesired = Math.max(asg.getMinSize(), asg.getDesiredCapacity() - instanceIds.size());
             asg.setDesiredCapacity(newDesired);
         }
+        groups.put(asgKey(region, name), asg);
     }
 
     public void terminateInstanceInAutoScalingGroup(String region, String instanceId,
@@ -242,6 +326,100 @@ public class AutoScalingService {
             int newDesired = Math.max(asg.getMinSize(), asg.getDesiredCapacity() - 1);
             asg.setDesiredCapacity(newDesired);
         }
+        groups.put(asgKey(region, asg.getAutoScalingGroupName()), asg);
+    }
+
+    // ── Instance refreshes ────────────────────────────────────────────────────
+
+    public InstanceRefresh startInstanceRefresh(String region, String asgName, InstanceRefresh requestedRefresh) {
+        AutoScalingGroup asg = requireGroup(region, asgName);
+        boolean activeRefresh = instanceRefreshes.values().stream()
+                .filter(r -> region.equals(r.getRegion()))
+                .filter(r -> asgName.equals(r.getAutoScalingGroupName()))
+                .anyMatch(r -> isActiveRefreshStatus(r.getStatus()));
+        if (activeRefresh) {
+            throw new AwsException("InstanceRefreshInProgress",
+                    "An active instance refresh already exists for Auto Scaling group '" + asgName + "'.", 400);
+        }
+
+        Instant now = Instant.now();
+        InstanceRefresh refresh = new InstanceRefresh();
+        refresh.setInstanceRefreshId(UUID.randomUUID().toString());
+        refresh.setAutoScalingGroupName(asgName);
+        refresh.setStrategy(normalizeRefreshStrategy(requestedRefresh.getStrategy()));
+        refresh.setStartTime(now);
+        refresh.setRegion(region);
+        copyDesiredConfiguration(requestedRefresh, refresh);
+        copyPreferences(requestedRefresh, refresh);
+
+        applyDesiredConfiguration(asg, refresh);
+        List<String> instanceIds = markInstancesForRefresh(asg, refresh);
+        if (instanceIds.isEmpty()) {
+            refresh.setStatus("Successful");
+            refresh.setStatusReason("Instance refresh completed.");
+            refresh.setPercentageComplete(100);
+            refresh.setInstancesToUpdate(0);
+            refresh.setEndTime(now);
+        } else {
+            refresh.setStatus("InProgress");
+            refresh.setStatusReason("Instance refresh in progress.");
+            refresh.setPercentageComplete(0);
+            refresh.setInstancesToUpdate(instanceIds.size());
+        }
+        instanceRefreshes.put(instanceRefreshKey(region, asgName, refresh.getInstanceRefreshId()), refresh);
+        groups.put(asgKey(region, asgName), asg);
+        if (!instanceIds.isEmpty()) {
+            recordActivity(region, asgName,
+                    "Marked EC2 instance(s) for refresh: " + instanceIds,
+                    "At " + now + " an instance refresh selected active instances for replacement.",
+                    "Successful");
+        }
+        recordActivity(region, asgName,
+                "Started instance refresh " + refresh.getInstanceRefreshId() + ".",
+                "At " + now + " an instance refresh was started.",
+                "Successful");
+        return refresh;
+    }
+
+    public void completeInstanceRefreshIfSettled(String region, String asgName) {
+        AutoScalingGroup asg = requireGroup(region, asgName);
+        List<InstanceRefresh> activeRefreshes = instanceRefreshes.values().stream()
+                .filter(r -> region.equals(r.getRegion()))
+                .filter(r -> asgName.equals(r.getAutoScalingGroupName()))
+                .filter(r -> isActiveRefreshStatus(r.getStatus()))
+                .collect(Collectors.toList());
+        for (InstanceRefresh refresh : activeRefreshes) {
+            int remaining = remainingInstancesToUpdate(asg);
+            refresh.setInstancesToUpdate(remaining);
+            refresh.setPercentageComplete(remaining == 0 ? 100 : 0);
+            if (remaining == 0) {
+                refresh.setStatus("Successful");
+                refresh.setStatusReason("Instance refresh completed.");
+                refresh.setEndTime(Instant.now());
+            }
+            instanceRefreshes.put(instanceRefreshKey(region, asgName, refresh.getInstanceRefreshId()), refresh);
+        }
+    }
+
+    public InstanceRefreshPage describeInstanceRefreshes(String region, String asgName, List<String> refreshIds,
+                                                          Integer maxRecords, String nextToken) {
+        requireGroup(region, asgName);
+        int offset = parseNextToken(nextToken);
+        int limit = maxRecords != null ? Math.min(Math.max(maxRecords, 1), 100) : 50;
+        Set<String> requestedIds = refreshIds != null && !refreshIds.isEmpty()
+                ? new HashSet<>(refreshIds) : null;
+        List<InstanceRefresh> matches = instanceRefreshes.values().stream()
+                .filter(r -> region.equals(r.getRegion()))
+                .filter(r -> asgName.equals(r.getAutoScalingGroupName()))
+                .filter(r -> requestedIds == null || requestedIds.contains(r.getInstanceRefreshId()))
+                .sorted(Comparator.comparing(InstanceRefresh::getStartTime).reversed())
+                .collect(Collectors.toList());
+        if (offset > matches.size()) {
+            throw new AwsException("InvalidNextToken", "The NextToken value is not valid.", 400);
+        }
+        int end = Math.min(offset + limit, matches.size());
+        String followingToken = end < matches.size() ? String.valueOf(end) : null;
+        return new InstanceRefreshPage(matches.subList(offset, end), followingToken);
     }
 
     // ── Load balancer attachment ───────────────────────────────────────────────
@@ -253,11 +431,13 @@ public class AutoScalingService {
                 asg.getTargetGroupARNs().add(arn);
             }
         }
+        groups.put(asgKey(region, name), asg);
     }
 
     public void detachLoadBalancerTargetGroups(String region, String name, List<String> tgArns) {
         AutoScalingGroup asg = requireGroup(region, name);
         asg.getTargetGroupARNs().removeAll(tgArns);
+        groups.put(asgKey(region, name), asg);
     }
 
     public List<String> describeLoadBalancerTargetGroups(String region, String name) {
@@ -271,10 +451,13 @@ public class AutoScalingService {
                 asg.getLoadBalancerNames().add(lb);
             }
         }
+        groups.put(asgKey(region, name), asg);
     }
 
     public void detachLoadBalancers(String region, String name, List<String> lbNames) {
-        requireGroup(region, name).getLoadBalancerNames().removeAll(lbNames);
+        AutoScalingGroup asg = requireGroup(region, name);
+        asg.getLoadBalancerNames().removeAll(lbNames);
+        groups.put(asgKey(region, name), asg);
     }
 
     // ── Lifecycle hooks ────────────────────────────────────────────────────────
@@ -294,6 +477,7 @@ public class AutoScalingService {
         hook.setNotificationMetadata(notificationMetadata);
         if (heartbeatTimeout != null) { hook.setHeartbeatTimeout(heartbeatTimeout); }
         if (defaultResult != null) { hook.setDefaultResult(defaultResult); }
+        hooks.put(key, hook);
     }
 
     public void deleteLifecycleHook(String region, String asgName, String hookName) {
@@ -335,6 +519,7 @@ public class AutoScalingService {
         policy.setScalingAdjustment(scalingAdjustment);
         policy.setCooldown(cooldown);
         policy.setRegion(region);
+        policies.put(key, policy);
         return policy;
     }
 
@@ -383,8 +568,11 @@ public class AutoScalingService {
             activity.setStatusCode(statusCode);
             activity.setStatusMessage(statusMessage);
             activity.setProgress(100);
+            activities.put(activityId, activity);
         }
     }
+
+    public record InstanceRefreshPage(List<InstanceRefresh> instanceRefreshes, String nextToken) {}
 
     // ── Internal helpers ───────────────────────────────────────────────────────
 
@@ -411,5 +599,148 @@ public class AutoScalingService {
 
     private static String policyKey(String region, String asgName, String policyName) {
         return region + "::" + asgName + "::" + policyName;
+    }
+
+    private static String instanceRefreshKey(String region, String asgName, String refreshId) {
+        return region + "::" + asgName + "::" + refreshId;
+    }
+
+    private static boolean isActiveRefreshStatus(String status) {
+        return "Pending".equals(status)
+                || "InProgress".equals(status)
+                || "Cancelling".equals(status)
+                || "RollbackInProgress".equals(status)
+                || "Baking".equals(status);
+    }
+
+    private static String normalizeRefreshStrategy(String strategy) {
+        if (strategy == null || strategy.isBlank()) {
+            return "Rolling";
+        }
+        if (!"Rolling".equals(strategy) && !"ReplaceRootVolume".equals(strategy)) {
+            throw new AwsException("ValidationError",
+                    "Unsupported instance refresh strategy '" + strategy + "'.", 400);
+        }
+        return strategy;
+    }
+
+    private static int parseNextToken(String nextToken) {
+        if (nextToken == null || nextToken.isBlank()) {
+            return 0;
+        }
+        try {
+            int offset = Integer.parseInt(nextToken);
+            if (offset < 0) {
+                throw new NumberFormatException("negative");
+            }
+            return offset;
+        } catch (NumberFormatException e) {
+            throw new AwsException("InvalidNextToken", "The NextToken value is not valid.", 400);
+        }
+    }
+
+    private static void copyDesiredConfiguration(InstanceRefresh source, InstanceRefresh target) {
+        target.setDesiredLaunchTemplateId(source.getDesiredLaunchTemplateId());
+        target.setDesiredLaunchTemplateName(source.getDesiredLaunchTemplateName());
+        target.setDesiredLaunchTemplateVersion(source.getDesiredLaunchTemplateVersion());
+    }
+
+    private static void copyPreferences(InstanceRefresh source, InstanceRefresh target) {
+        target.setMinHealthyPercentage(source.getMinHealthyPercentage());
+        target.setMaxHealthyPercentage(source.getMaxHealthyPercentage());
+        target.setInstanceWarmup(source.getInstanceWarmup());
+        target.setSkipMatching(source.getSkipMatching());
+        target.setAutoRollback(source.getAutoRollback());
+        target.setScaleInProtectedInstances(source.getScaleInProtectedInstances());
+        target.setStandbyInstances(source.getStandbyInstances());
+        target.setCheckpointDelay(source.getCheckpointDelay());
+        target.setBakeTime(source.getBakeTime());
+        target.setCheckpointPercentages(new ArrayList<>(source.getCheckpointPercentages()));
+    }
+
+    private static void applyDesiredConfiguration(AutoScalingGroup asg, InstanceRefresh refresh) {
+        if (!refresh.hasDesiredConfiguration()) {
+            return;
+        }
+        if (refresh.getDesiredLaunchTemplateId() != null || refresh.getDesiredLaunchTemplateName() != null) {
+            asg.setLaunchTemplateId(refresh.getDesiredLaunchTemplateId());
+            asg.setLaunchTemplateName(refresh.getDesiredLaunchTemplateName());
+            asg.setLaunchConfigurationName(null);
+        }
+        if (refresh.getDesiredLaunchTemplateVersion() != null) {
+            asg.setLaunchTemplateVersion(refresh.getDesiredLaunchTemplateVersion());
+        }
+    }
+
+    private static List<String> markInstancesForRefresh(AutoScalingGroup asg, InstanceRefresh refresh) {
+        boolean skipMatching = Boolean.TRUE.equals(refresh.getSkipMatching());
+        List<String> instanceIds = new ArrayList<>();
+        for (AsgInstance instance : asg.getInstances()) {
+            if (!isRefreshCandidate(instance, asg, skipMatching)) {
+                continue;
+            }
+            instance.setLifecycleState("Terminating");
+            instanceIds.add(instance.getInstanceId());
+        }
+        return instanceIds;
+    }
+
+    private static boolean isRefreshCandidate(AsgInstance instance, AutoScalingGroup asg, boolean skipMatching) {
+        String state = instance.getLifecycleState();
+        if (!"Pending".equals(state) && !"InService".equals(state)) {
+            return false;
+        }
+        if (!skipMatching) {
+            return true;
+        }
+        if (isDynamicLaunchTemplateVersion(asg.getLaunchTemplateVersion())
+                && (asg.getLaunchTemplateId() != null || asg.getLaunchTemplateName() != null)) {
+            return true;
+        }
+        return !Objects.equals(instance.getLaunchConfigurationName(), asg.getLaunchConfigurationName())
+                || !Objects.equals(instance.getLaunchTemplateId(), asg.getLaunchTemplateId())
+                || !Objects.equals(instance.getLaunchTemplateName(), asg.getLaunchTemplateName())
+                || !Objects.equals(instance.getLaunchTemplateVersion(), asg.getLaunchTemplateVersion());
+    }
+
+    private static int remainingInstancesToUpdate(AutoScalingGroup asg) {
+        int remaining = 0;
+        int matchingInService = 0;
+        for (AsgInstance instance : asg.getInstances()) {
+            String state = instance.getLifecycleState();
+            if ("Terminating".equals(state) || "Pending".equals(state)) {
+                remaining++;
+                continue;
+            }
+            if ("InService".equals(state)) {
+                if (matchesCurrentLaunchSource(instance, asg)) {
+                    matchingInService++;
+                } else {
+                    remaining++;
+                }
+            }
+        }
+        remaining += Math.max(0, asg.getDesiredCapacity() - matchingInService);
+        return remaining;
+    }
+
+    private static boolean matchesCurrentLaunchSource(AsgInstance instance, AutoScalingGroup asg) {
+        if (isDynamicLaunchTemplateVersion(asg.getLaunchTemplateVersion())
+                && Objects.equals(instance.getLaunchTemplateId(), asg.getLaunchTemplateId())
+                && Objects.equals(instance.getLaunchTemplateName(), asg.getLaunchTemplateName())) {
+            return true;
+        }
+        return Objects.equals(instance.getLaunchConfigurationName(), asg.getLaunchConfigurationName())
+                && Objects.equals(instance.getLaunchTemplateId(), asg.getLaunchTemplateId())
+                && Objects.equals(instance.getLaunchTemplateName(), asg.getLaunchTemplateName())
+                && Objects.equals(instance.getLaunchTemplateVersion(), asg.getLaunchTemplateVersion());
+    }
+
+    private static boolean isLaunchTemplateVersionAlias(String version) {
+        return "$Latest".equals(version) || "$Default".equals(version);
+    }
+
+    private static boolean isDynamicLaunchTemplateVersion(String version) {
+        return version == null || version.isBlank() || isLaunchTemplateVersionAlias(version);
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/AsgInstance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/AsgInstance.java
@@ -12,6 +12,9 @@ public class AsgInstance {
     private String lifecycleState;   // Pending | InService | Terminating | Terminated | Detached
     private String healthStatus;     // Healthy | Unhealthy
     private String launchConfigurationName;
+    private String launchTemplateId;
+    private String launchTemplateName;
+    private String launchTemplateVersion;
     private String instanceType;
     private boolean protectedFromScaleIn;
 
@@ -31,6 +34,15 @@ public class AsgInstance {
 
     public String getLaunchConfigurationName() { return launchConfigurationName; }
     public void setLaunchConfigurationName(String v) { this.launchConfigurationName = v; }
+
+    public String getLaunchTemplateId() { return launchTemplateId; }
+    public void setLaunchTemplateId(String v) { this.launchTemplateId = v; }
+
+    public String getLaunchTemplateName() { return launchTemplateName; }
+    public void setLaunchTemplateName(String v) { this.launchTemplateName = v; }
+
+    public String getLaunchTemplateVersion() { return launchTemplateVersion; }
+    public void setLaunchTemplateVersion(String v) { this.launchTemplateVersion = v; }
 
     public String getInstanceType() { return instanceType; }
     public void setInstanceType(String v) { this.instanceType = v; }

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/AutoScalingGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/AutoScalingGroup.java
@@ -16,6 +16,7 @@ public class AutoScalingGroup {
     private String autoScalingGroupName;
     private String autoScalingGroupArn;
     private String launchConfigurationName;
+    private String launchTemplateId;
     private String launchTemplateName;
     private String launchTemplateVersion;
     private int minSize;
@@ -23,6 +24,7 @@ public class AutoScalingGroup {
     private int desiredCapacity;
     private int defaultCooldown = 300;
     private List<String> availabilityZones = new ArrayList<>();
+    private List<String> subnetIds = new ArrayList<>();
     private List<String> loadBalancerNames = new ArrayList<>();
     private List<String> targetGroupARNs = new ArrayList<>();
     private String healthCheckType = "EC2";
@@ -45,6 +47,9 @@ public class AutoScalingGroup {
     public String getLaunchConfigurationName() { return launchConfigurationName; }
     public void setLaunchConfigurationName(String v) { this.launchConfigurationName = v; }
 
+    public String getLaunchTemplateId() { return launchTemplateId; }
+    public void setLaunchTemplateId(String v) { this.launchTemplateId = v; }
+
     public String getLaunchTemplateName() { return launchTemplateName; }
     public void setLaunchTemplateName(String v) { this.launchTemplateName = v; }
 
@@ -65,6 +70,9 @@ public class AutoScalingGroup {
 
     public List<String> getAvailabilityZones() { return availabilityZones; }
     public void setAvailabilityZones(List<String> v) { this.availabilityZones = v; }
+
+    public List<String> getSubnetIds() { return subnetIds; }
+    public void setSubnetIds(List<String> v) { this.subnetIds = v; }
 
     public List<String> getLoadBalancerNames() { return loadBalancerNames; }
     public void setLoadBalancerNames(List<String> v) { this.loadBalancerNames = v; }

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/InstanceRefresh.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/InstanceRefresh.java
@@ -1,0 +1,131 @@
+package io.github.hectorvent.floci.services.autoscaling.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class InstanceRefresh {
+
+    private String instanceRefreshId;
+    private String autoScalingGroupName;
+    private String strategy = "Rolling";
+    private String status;
+    private String statusReason;
+    private int percentageComplete;
+    private int instancesToUpdate;
+    private Instant startTime;
+    private Instant endTime;
+    private String region;
+
+    private String desiredLaunchTemplateId;
+    private String desiredLaunchTemplateName;
+    private String desiredLaunchTemplateVersion;
+
+    private Integer minHealthyPercentage;
+    private Integer maxHealthyPercentage;
+    private Integer instanceWarmup;
+    private Boolean skipMatching;
+    private Boolean autoRollback;
+    private String scaleInProtectedInstances;
+    private String standbyInstances;
+    private Integer checkpointDelay;
+    private Integer bakeTime;
+    private List<Integer> checkpointPercentages = new ArrayList<>();
+
+    public InstanceRefresh() {}
+
+    public String getInstanceRefreshId() { return instanceRefreshId; }
+    public void setInstanceRefreshId(String v) { this.instanceRefreshId = v; }
+
+    public String getAutoScalingGroupName() { return autoScalingGroupName; }
+    public void setAutoScalingGroupName(String v) { this.autoScalingGroupName = v; }
+
+    public String getStrategy() { return strategy; }
+    public void setStrategy(String v) { this.strategy = v; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String v) { this.status = v; }
+
+    public String getStatusReason() { return statusReason; }
+    public void setStatusReason(String v) { this.statusReason = v; }
+
+    public int getPercentageComplete() { return percentageComplete; }
+    public void setPercentageComplete(int v) { this.percentageComplete = v; }
+
+    public int getInstancesToUpdate() { return instancesToUpdate; }
+    public void setInstancesToUpdate(int v) { this.instancesToUpdate = v; }
+
+    public Instant getStartTime() { return startTime; }
+    public void setStartTime(Instant v) { this.startTime = v; }
+
+    public Instant getEndTime() { return endTime; }
+    public void setEndTime(Instant v) { this.endTime = v; }
+
+    public String getRegion() { return region; }
+    public void setRegion(String v) { this.region = v; }
+
+    public String getDesiredLaunchTemplateId() { return desiredLaunchTemplateId; }
+    public void setDesiredLaunchTemplateId(String v) { this.desiredLaunchTemplateId = v; }
+
+    public String getDesiredLaunchTemplateName() { return desiredLaunchTemplateName; }
+    public void setDesiredLaunchTemplateName(String v) { this.desiredLaunchTemplateName = v; }
+
+    public String getDesiredLaunchTemplateVersion() { return desiredLaunchTemplateVersion; }
+    public void setDesiredLaunchTemplateVersion(String v) { this.desiredLaunchTemplateVersion = v; }
+
+    public Integer getMinHealthyPercentage() { return minHealthyPercentage; }
+    public void setMinHealthyPercentage(Integer v) { this.minHealthyPercentage = v; }
+
+    public Integer getMaxHealthyPercentage() { return maxHealthyPercentage; }
+    public void setMaxHealthyPercentage(Integer v) { this.maxHealthyPercentage = v; }
+
+    public Integer getInstanceWarmup() { return instanceWarmup; }
+    public void setInstanceWarmup(Integer v) { this.instanceWarmup = v; }
+
+    public Boolean getSkipMatching() { return skipMatching; }
+    public void setSkipMatching(Boolean v) { this.skipMatching = v; }
+
+    public Boolean getAutoRollback() { return autoRollback; }
+    public void setAutoRollback(Boolean v) { this.autoRollback = v; }
+
+    public String getScaleInProtectedInstances() { return scaleInProtectedInstances; }
+    public void setScaleInProtectedInstances(String v) { this.scaleInProtectedInstances = v; }
+
+    public String getStandbyInstances() { return standbyInstances; }
+    public void setStandbyInstances(String v) { this.standbyInstances = v; }
+
+    public Integer getCheckpointDelay() { return checkpointDelay; }
+    public void setCheckpointDelay(Integer v) { this.checkpointDelay = v; }
+
+    public Integer getBakeTime() { return bakeTime; }
+    public void setBakeTime(Integer v) { this.bakeTime = v; }
+
+    public List<Integer> getCheckpointPercentages() { return checkpointPercentages; }
+    public void setCheckpointPercentages(List<Integer> v) {
+        this.checkpointPercentages = v != null ? v : new ArrayList<>();
+    }
+
+    public boolean hasDesiredConfiguration() {
+        return desiredLaunchTemplateId != null
+                || desiredLaunchTemplateName != null
+                || desiredLaunchTemplateVersion != null;
+    }
+
+    public boolean hasPreferences() {
+        return minHealthyPercentage != null
+                || maxHealthyPercentage != null
+                || instanceWarmup != null
+                || skipMatching != null
+                || autoRollback != null
+                || scaleInProtectedInstances != null
+                || standbyInstances != null
+                || checkpointDelay != null
+                || bakeTime != null
+                || !checkpointPercentages.isEmpty();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -776,12 +776,13 @@ public class CloudFormationResourceProvisioner {
         }
 
         var asg = autoScalingService.createAutoScalingGroup(region, name,
-                blankToNull(launchConfigName), blankToNull(launchTemplateName), blankToNull(launchTemplateVersion),
+                blankToNull(launchConfigName), null, blankToNull(launchTemplateName), blankToNull(launchTemplateVersion),
                 parseIntProp(props, "MinSize", engine, 0),
                 parseIntProp(props, "MaxSize", engine, 0),
                 parseIntProp(props, "DesiredCapacity", engine, 0),
                 parseIntProp(props, "Cooldown", engine, 0),
                 resolveStringList(props, "AvailabilityZones", engine),
+                resolveStringList(props, "VPCZoneIdentifier", engine),
                 resolveStringList(props, "TargetGroupARNs", engine),
                 resolveStringList(props, "LoadBalancerNames", engine),
                 resolveOptional(props, "HealthCheckType", engine),

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
@@ -25,11 +25,17 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Manages Docker container lifecycle for EC2 instances.
@@ -40,6 +46,10 @@ import java.util.concurrent.TimeUnit;
 public class Ec2ContainerManager {
 
     private static final Logger LOG = Logger.getLogger(Ec2ContainerManager.class);
+    private static final String USER_DATA_SCRIPT_PATH = "/tmp/user-data.sh";
+    private static final Pattern MIME_BOUNDARY = Pattern.compile("(?im)^content-type:\\s*multipart/[^;]+;\\s*boundary=\"?([^\";\\n\\r]+)\"?.*$");
+    static int containerBridgeIpAttempts = 30;
+    static long containerBridgeIpPollMillis = 500;
 
     private final ContainerBuilder containerBuilder;
     private final ContainerLifecycleManager lifecycleManager;
@@ -106,18 +116,23 @@ public class Ec2ContainerManager {
                 String flociHost = dockerHostResolver.resolve();
                 int imdsPort = config.services().ec2().imdsPort();
                 String imdsEndpoint = "http://" + flociHost + ":" + imdsPort;
+                String serviceEndpoint = "http://" + flociHost + ":4566";
 
                 // Build container spec — use tail -f /dev/null to keep container alive
                 // regardless of the base image's default CMD.
                 ContainerSpec spec = containerBuilder.newContainer(dockerImage)
                         .withName(containerName)
-                        .withEnv("AWS_EC2_METADATA_SERVICE_ENDPOINT", imdsEndpoint)
                         .withEmbeddedDns()
+                        .withDockerNetwork(Optional.empty())
+                        .withEnv(localAwsEnvironment(region, serviceEndpoint, imdsEndpoint))
                         .withEnv("AWS_EC2_INSTANCE_ID", instanceId)
-                        .withEnv("AWS_DEFAULT_REGION", region)
                         .withPortBinding(22, sshHostPort)
                         .withHostDockerInternalOnLinux()
                         .withLogRotation()
+                        // EC2 instances expose IMDS on 169.254.169.254. Floci
+                        // needs network administration privileges in the local
+                        // container to attach that link-local address.
+                        .withPrivileged(true)
                         .withCmd(List.of("tail", "-f", "/dev/null"))
                         .build();
 
@@ -143,16 +158,32 @@ public class Ec2ContainerManager {
                     return;
                 }
 
-                // Discover the container's bridge IP for IMDS registration
-                String containerIp = getContainerBridgeIp(containerId);
+                // Discover the container's bridge IP for IMDS registration.
+                // Docker can report the container as running before network
+                // settings are populated; wait here so IMDS is registered
+                // before link-local metadata validation and UserData run.
+                String containerIp = waitForContainerBridgeIp(containerId, instanceId);
                 if (containerIp != null && !containerIp.isBlank()) {
                     instance.setContainerBridgeIp(containerIp);
+                    exposeReachablePrivateAddress(instance, containerIp);
                     metadataServer.registerContainer(containerIp, instanceId, instance);
                 }
+                else {
+                    LOG.warnv("EC2 instance {0} container {1} did not receive a usable bridge IP for IMDS",
+                            instanceId, containerId);
+                    instance.setState(InstanceState.terminated());
+                    return;
+                }
+
+                configureLinkLocalMetadataEndpoint(containerId, instanceId, flociHost, imdsPort);
 
                 // Set public-facing addresses
                 instance.setPublicIpAddress("127.0.0.1");
                 instance.setPublicDnsName("localhost");
+
+                instance.setState(InstanceState.running());
+                LOG.infov("EC2 instance {0} running in container {1} (SSH host port {2})",
+                        instanceId, containerId, String.valueOf(sshHostPort));
 
                 // Inject SSH public key
                 if (publicKey != null && !publicKey.isBlank()) {
@@ -165,10 +196,6 @@ public class Ec2ContainerManager {
                 if (userData != null && !userData.isBlank()) {
                     executeUserData(containerId, instanceId, userData, region);
                 }
-
-                instance.setState(InstanceState.running());
-                LOG.infov("EC2 instance {0} running in container {1} (SSH host port {2})",
-                        instanceId, containerId, String.valueOf(sshHostPort));
 
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
@@ -224,6 +251,13 @@ public class Ec2ContainerManager {
                         Thread.sleep(500);
                     }
                 }
+                String instanceId = instance.getInstanceId();
+                String containerIp = waitForContainerBridgeIp(containerId, instanceId);
+                if (containerIp != null && !containerIp.isBlank()) {
+                    instance.setContainerBridgeIp(containerIp);
+                    exposeReachablePrivateAddress(instance, containerIp);
+                    metadataServer.registerContainer(containerIp, instanceId, instance);
+                }
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             } catch (Exception e) {
@@ -235,6 +269,51 @@ public class Ec2ContainerManager {
 
     boolean isContainerRunning(String containerId) {
         return containerId != null && !containerId.isBlank() && lifecycleManager.isContainerRunning(containerId);
+    }
+
+    boolean restoreMetadataRegistration(Instance instance) {
+        if (instance == null || instance.getDockerContainerId() == null) {
+            return false;
+        }
+        String containerId = instance.getDockerContainerId();
+        if (!lifecycleManager.isContainerRunning(containerId)) {
+            return false;
+        }
+
+        String containerIp = getContainerBridgeIp(containerId);
+        if (containerIp == null || containerIp.isBlank()) {
+            containerIp = instance.getContainerBridgeIp();
+        }
+        if (containerIp == null || containerIp.isBlank()) {
+            LOG.warnv("Could not restore IMDS registration for EC2 instance {0}: no container IP",
+                    instance.getInstanceId());
+            return false;
+        }
+
+        String previousContainerIp = instance.getContainerBridgeIp();
+        if (previousContainerIp != null && !previousContainerIp.isBlank() && !previousContainerIp.equals(containerIp)) {
+            metadataServer.unregisterContainer(previousContainerIp, instance);
+        }
+        instance.setContainerBridgeIp(containerIp);
+        exposeReachablePrivateAddress(instance, containerIp);
+        metadataServer.registerContainer(containerIp, instance.getInstanceId(), instance);
+        return true;
+    }
+
+    static void exposeReachablePrivateAddress(Instance instance, String privateIp) {
+        if (instance == null || privateIp == null || privateIp.isBlank()) {
+            return;
+        }
+
+        String privateDnsName = "ip-" + privateIp.replace('.', '-') + ".ec2.internal";
+        instance.setPrivateIpAddress(privateIp);
+        instance.setPrivateDnsName(privateDnsName);
+        if (instance.getNetworkInterfaces() != null) {
+            instance.getNetworkInterfaces().forEach(networkInterface -> {
+                networkInterface.setPrivateIpAddress(privateIp);
+                networkInterface.setPrivateDnsName(privateDnsName);
+            });
+        }
     }
 
     /**
@@ -266,7 +345,7 @@ public class Ec2ContainerManager {
             if (sshHostPort > 0) {
                 portAllocator.release(sshHostPort);
             }
-            metadataServer.unregisterContainer(containerIp);
+            metadataServer.unregisterContainer(containerIp, instance);
             instance.setState(InstanceState.terminated());
             instance.setTerminatedAt(System.currentTimeMillis());
         });
@@ -288,6 +367,11 @@ public class Ec2ContainerManager {
                 LOG.warnv("Error rebooting EC2 container {0}: {1}", containerId, e.getMessage());
             }
         });
+    }
+
+    public boolean isContainerRunning(Instance instance) {
+        String containerId = instance.getDockerContainerId();
+        return containerId != null && lifecycleManager.isContainerRunning(containerId);
     }
 
     private void injectSshKey(String containerId, String publicKey) {
@@ -333,52 +417,205 @@ public class Ec2ContainerManager {
 
     private void executeUserData(String containerId, String instanceId, String userData, String region) {
         try {
-            byte[] script = userData.getBytes(StandardCharsets.UTF_8);
-            byte[] tar = buildSingleFileTar("user-data.sh", script, 0755);
-            dockerClient.copyArchiveToContainerCmd(containerId)
-                    .withRemotePath("/tmp")
-                    .withTarInputStream(new ByteArrayInputStream(tar))
-                    .exec();
-
-            String logGroup = "/aws/ec2/" + instanceId;
-            String logStream = logStreamer.generateLogStreamName("user-data");
-
-            // Execute the script and stream output to CloudWatch
-            String execId = dockerClient.execCreateCmd(containerId)
-                    .withCmd("sh", "/tmp/user-data.sh")
-                    .withAttachStdout(true)
-                    .withAttachStderr(true)
-                    .exec()
-                    .getId();
-
-            ByteArrayOutputStream output = new ByteArrayOutputStream();
-            CountDownLatch latch = new CountDownLatch(1);
-
-            dockerClient.execStartCmd(execId).exec(new ResultCallback.Adapter<Frame>() {
-                @Override
-                public void onNext(Frame frame) {
-                    if (frame.getPayload() != null) {
-                        try { output.write(frame.getPayload()); } catch (IOException ignored) {}
-                    }
-                }
-                @Override
-                public void onComplete() { latch.countDown(); }
-                @Override
-                public void onError(Throwable t) { latch.countDown(); }
-            });
-
-            boolean completed = latch.await(30, TimeUnit.MINUTES);
-            if (!completed) {
-                LOG.warnv("UserData execution timed out for EC2 instance {0}", instanceId);
+            List<String> shellScripts = userDataShellScripts(userData);
+            if (shellScripts.isEmpty()) {
+                LOG.infov("UserData for EC2 instance {0} did not contain executable shellscript parts", instanceId);
+                return;
             }
 
-            LOG.infov("UserData execution completed for EC2 instance {0}", instanceId);
+            for (int i = 0; i < shellScripts.size(); i++) {
+                executeUserDataShellScript(containerId, instanceId, shellScripts.get(i), i + 1, shellScripts.size());
+            }
         } catch (Exception e) {
             LOG.warnv("UserData execution failed for EC2 instance {0}: {1}", instanceId, e.getMessage());
         }
     }
 
+    private void executeUserDataShellScript(String containerId, String instanceId, String scriptContent, int partNumber, int partCount) throws Exception {
+        byte[] script = scriptContent.getBytes(StandardCharsets.UTF_8);
+        byte[] tar = buildSingleFileTar("user-data.sh", script, 0755);
+        dockerClient.copyArchiveToContainerCmd(containerId)
+                .withRemotePath("/tmp")
+                .withTarInputStream(new ByteArrayInputStream(tar))
+                .exec();
+
+        // Execute the script directly so Docker honors its shebang, matching cloud-init shellscript behavior.
+        String execId = dockerClient.execCreateCmd(containerId)
+                .withCmd(userDataExecutionCommand())
+                .withAttachStdout(true)
+                .withAttachStderr(true)
+                .exec()
+                .getId();
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        dockerClient.execStartCmd(execId).exec(new ResultCallback.Adapter<Frame>() {
+            @Override
+            public void onNext(Frame frame) {
+                if (frame.getPayload() != null) {
+                    try { output.write(frame.getPayload()); } catch (IOException ignored) {}
+                }
+            }
+            @Override
+            public void onComplete() { latch.countDown(); }
+            @Override
+            public void onError(Throwable t) { latch.countDown(); }
+        });
+
+        boolean completed = latch.await(30, TimeUnit.MINUTES);
+        if (!completed) {
+            LOG.warnv("UserData shellscript part {0}/{1} timed out for EC2 instance {2}", partNumber, partCount, instanceId);
+            return;
+        }
+
+        Long exitCode = dockerClient.inspectExecCmd(execId).exec().getExitCodeLong();
+        if (exitCode != null && exitCode != 0) {
+            LOG.warnv("UserData shellscript part {0}/{1} failed for EC2 instance {2} with exit code {3}: {4}",
+                    partNumber, partCount, instanceId, exitCode, summarizeUserDataOutput(output));
+            return;
+        }
+
+        LOG.infov("UserData shellscript part {0}/{1} completed for EC2 instance {2}: {3}",
+                partNumber, partCount, instanceId, summarizeUserDataOutput(output));
+    }
+
+    static List<String> userDataShellScripts(String userData) {
+        if (userData == null || userData.isBlank()) {
+            return List.of();
+        }
+
+        String normalized = userData.replace("\r\n", "\n").replace('\r', '\n');
+        String trimmed = normalized.stripLeading();
+        if (trimmed.startsWith("#!")) {
+            return List.of(normalized);
+        }
+
+        Matcher matcher = MIME_BOUNDARY.matcher(normalized);
+        if (!matcher.find()) {
+            return List.of();
+        }
+
+        String boundary = matcher.group(1).trim();
+        if (boundary.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> scripts = new ArrayList<>();
+        String marker = "--" + boundary;
+        for (String segment : normalized.split(Pattern.quote(marker))) {
+            String part = segment.stripLeading();
+            if (part.isBlank() || part.startsWith("--")) {
+                continue;
+            }
+            int headerEnd = part.indexOf("\n\n");
+            if (headerEnd < 0) {
+                continue;
+            }
+            String headers = part.substring(0, headerEnd);
+            String body = part.substring(headerEnd + 2);
+            if (hasShellscriptContentType(headers)) {
+                scripts.add(body.stripTrailing() + "\n");
+            }
+        }
+        return List.copyOf(scripts);
+    }
+
+    private static boolean hasShellscriptContentType(String headers) {
+        for (String line : headers.split("\n")) {
+            String lower = line.toLowerCase(Locale.ROOT).strip();
+            if (lower.startsWith("content-type:") && lower.contains("text/x-shellscript")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static String[] userDataExecutionCommand() {
+        return new String[]{USER_DATA_SCRIPT_PATH};
+    }
+
+    static String[] metadataProxyInstallCommand() {
+        return new String[]{"sh", "-c", String.join("\n",
+                "set -eu",
+                "if command -v ip >/dev/null 2>&1 && command -v socat >/dev/null 2>&1 && command -v curl >/dev/null 2>&1; then exit 0; fi",
+                "if command -v apt-get >/dev/null 2>&1; then",
+                "  apt-get update -qq >/dev/null",
+                "  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iproute2 socat curl ca-certificates >/dev/null",
+                "elif command -v dnf >/dev/null 2>&1; then",
+                "  dnf install -y iproute socat curl ca-certificates >/dev/null",
+                "elif command -v apk >/dev/null 2>&1; then",
+                "  apk add --no-cache iproute2 socat curl ca-certificates >/dev/null",
+                "else",
+                "  echo 'No supported package manager found for IMDS proxy dependencies' >&2",
+                "  exit 1",
+                "fi")};
+    }
+
+    static String[] metadataProxyStartCommand(String flociHost, int imdsPort) {
+        return new String[]{"sh", "-c", String.join("\n",
+                "set -eu",
+                "ip addr show dev lo | grep -q '169.254.169.254/32' || ip addr add 169.254.169.254/32 dev lo",
+                "if [ -f /tmp/floci-imds-proxy.pid ] && kill -0 \"$(cat /tmp/floci-imds-proxy.pid)\" 2>/dev/null; then",
+                "  exit 0",
+                "fi",
+                "nohup socat TCP-LISTEN:80,bind=169.254.169.254,fork,reuseaddr TCP:" + flociHost + ":" + imdsPort + " >/tmp/floci-imds-proxy.log 2>&1 &",
+                "echo $! > /tmp/floci-imds-proxy.pid",
+                "for i in 1 2 3 4 5 6 7 8 9 10 11 12; do",
+                "  curl -fsS --max-time 1 http://169.254.169.254/latest/meta-data/instance-id >/dev/null && exit 0",
+                "  sleep 1",
+                "done",
+                "cat /tmp/floci-imds-proxy.log >&2 || true",
+                "exit 1")};
+    }
+
+    static List<String> localAwsEnvironment(String region, String serviceEndpoint, String imdsEndpoint) {
+        return List.of(
+                "AWS_EC2_METADATA_SERVICE_ENDPOINT=" + imdsEndpoint,
+                "AWS_ENDPOINT_URL=" + serviceEndpoint,
+                "AWS_DEFAULT_REGION=" + region,
+                "AWS_REGION=" + region,
+                "AWS_ACCESS_KEY_ID=test",
+                "AWS_SECRET_ACCESS_KEY=test",
+                "AWS_SESSION_TOKEN=test-session-token");
+    }
+
+    private static String summarizeUserDataOutput(ByteArrayOutputStream output) {
+        String text = output.toString(StandardCharsets.UTF_8).stripTrailing();
+        if (text.isBlank()) {
+            return "(no output)";
+        }
+        int start = Math.max(0, text.length() - 2048);
+        return text.substring(start);
+    }
+
+    private void configureLinkLocalMetadataEndpoint(String containerId, String instanceId, String flociHost, int imdsPort) {
+        try {
+            ContainerExecResult install = execInContainerForResult(containerId, metadataProxyInstallCommand(), 180);
+            if (install.exitCode() != 0) {
+                LOG.warnv("Could not install IMDS proxy dependencies for EC2 instance {0}: {1}",
+                        instanceId, install.summary());
+                return;
+            }
+
+            ContainerExecResult start = execInContainerForResult(containerId, metadataProxyStartCommand(flociHost, imdsPort), 30);
+            if (start.exitCode() != 0) {
+                LOG.warnv("Could not start link-local IMDS proxy for EC2 instance {0}: {1}",
+                        instanceId, start.summary());
+                return;
+            }
+
+            LOG.infov("Configured link-local IMDS endpoint for EC2 instance {0}", instanceId);
+        } catch (Exception e) {
+            LOG.warnv("Could not configure link-local IMDS endpoint for EC2 instance {0}: {1}", instanceId, e.getMessage());
+        }
+    }
+
     private void execInContainer(String containerId, String[] cmd, int timeoutSeconds) throws Exception {
+        execInContainerForResult(containerId, cmd, timeoutSeconds);
+    }
+
+    private ContainerExecResult execInContainerForResult(String containerId, String[] cmd, int timeoutSeconds) throws Exception {
         String execId = dockerClient.execCreateCmd(containerId)
                 .withCmd(cmd)
                 .withAttachStdout(true)
@@ -387,13 +624,31 @@ public class Ec2ContainerManager {
                 .getId();
 
         CountDownLatch latch = new CountDownLatch(1);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
         dockerClient.execStartCmd(execId).exec(new ResultCallback.Adapter<Frame>() {
+            @Override
+            public void onNext(Frame frame) {
+                if (frame.getPayload() != null) {
+                    try { output.write(frame.getPayload()); } catch (IOException ignored) {}
+                }
+            }
             @Override
             public void onComplete() { latch.countDown(); }
             @Override
             public void onError(Throwable t) { latch.countDown(); }
         });
-        latch.await(timeoutSeconds, TimeUnit.SECONDS);
+        boolean completed = latch.await(timeoutSeconds, TimeUnit.SECONDS);
+        if (!completed) {
+            return new ContainerExecResult(-1, "Timed out after " + timeoutSeconds + "s");
+        }
+        Long exitCode = dockerClient.inspectExecCmd(execId).exec().getExitCodeLong();
+        return new ContainerExecResult(exitCode != null ? exitCode : -1, summarizeUserDataOutput(output));
+    }
+
+    record ContainerExecResult(long exitCode, String output) {
+        String summary() {
+            return output == null || output.isBlank() ? "(no output)" : output;
+        }
     }
 
     private String getContainerBridgeIp(String containerId) {
@@ -402,9 +657,9 @@ public class Ec2ContainerManager {
             if (inspect.getNetworkSettings() != null) {
                 var networks = inspect.getNetworkSettings().getNetworks();
                 if (networks != null) {
-                    ContainerNetwork bridge = networks.get("bridge");
-                    if (bridge != null && bridge.getIpAddress() != null && !bridge.getIpAddress().isBlank()) {
-                        return bridge.getIpAddress();
+                    Optional<String> preferredIp = preferredMetadataSourceIp(networks);
+                    if (preferredIp.isPresent()) {
+                        return preferredIp.get();
                     }
                 }
                 String ip = inspect.getNetworkSettings().getIpAddress();
@@ -416,6 +671,41 @@ public class Ec2ContainerManager {
             LOG.warnv("Could not inspect container {0} for bridge IP: {1}", containerId, e.getMessage());
         }
         return null;
+    }
+
+    private String waitForContainerBridgeIp(String containerId, String instanceId) throws InterruptedException {
+        for (int i = 0; i < containerBridgeIpAttempts; i++) {
+            String containerIp = getContainerBridgeIp(containerId);
+            if (containerIp != null && !containerIp.isBlank()) {
+                return containerIp;
+            }
+            Thread.sleep(containerBridgeIpPollMillis);
+        }
+        LOG.warnv("Timed out waiting for EC2 instance {0} container {1} bridge IP", instanceId, containerId);
+        return null;
+    }
+
+    static Optional<String> preferredMetadataSourceIp(Map<String, ContainerNetwork> networks) {
+        if (networks == null || networks.isEmpty()) {
+            return Optional.empty();
+        }
+        Optional<String> configuredNetworkIp = networks.entrySet().stream()
+                .filter(entry -> !"bridge".equals(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .map(ContainerNetwork::getIpAddress)
+                .filter(ip -> ip != null && !ip.isBlank())
+                .findFirst();
+        if (configuredNetworkIp.isPresent()) {
+            return configuredNetworkIp;
+        }
+        ContainerNetwork bridge = networks.get("bridge");
+        if (bridge != null && bridge.getIpAddress() != null && !bridge.getIpAddress().isBlank()) {
+            return Optional.of(bridge.getIpAddress());
+        }
+        return networks.values().stream()
+                .map(ContainerNetwork::getIpAddress)
+                .filter(ip -> ip != null && !ip.isBlank())
+                .findFirst();
     }
 
     private byte[] buildSingleFileTar(String filename, byte[] content, int mode) throws IOException {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2MetadataServer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2MetadataServer.java
@@ -11,10 +11,13 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -33,6 +36,7 @@ public class Ec2MetadataServer {
     private static final Logger LOG = Logger.getLogger(Ec2MetadataServer.class);
     private static final DateTimeFormatter ISO = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
             .withZone(ZoneOffset.UTC);
+    private static final String INSTANCE_TAGS_PREFIX = "/latest/meta-data/tags/instance/";
 
     private final Vertx vertx;
     private final EmulatorConfig config;
@@ -59,10 +63,14 @@ public class Ec2MetadataServer {
     }
 
     /** Called by Ec2ContainerManager when a container is terminated. */
-    public void unregisterContainer(String containerIp) {
-        if (containerIp != null) {
-            containerIpToInstance.remove(containerIp);
+    public void unregisterContainer(String containerIp, Instance instance) {
+        if (containerIp != null && instance != null) {
+            containerIpToInstance.remove(containerIp, instance);
         }
+    }
+
+    Optional<Instance> registeredContainer(String containerIp) {
+        return Optional.ofNullable(containerIpToInstance.get(containerIp));
     }
 
     public CompletableFuture<Void> start() {
@@ -92,6 +100,9 @@ public class Ec2MetadataServer {
         router.get("/latest/meta-data/iam/info").handler(ctx -> handleIamInfo(ctx));
         router.get("/latest/meta-data/iam/security-credentials/").handler(ctx -> handleCredentialsList(ctx));
         router.get("/latest/meta-data/iam/security-credentials/:role").handler(ctx -> handleCredentials(ctx));
+        router.get("/latest/meta-data/tags/instance").handler(ctx -> handleInstanceTagKeys(ctx));
+        router.get("/latest/meta-data/tags/instance/").handler(ctx -> handleInstanceTagKeys(ctx));
+        router.getWithRegex("/latest/meta-data/tags/instance/.+").handler(ctx -> handleInstanceTagValue(ctx));
         router.get("/latest/user-data").handler(ctx -> handleUserData(ctx));
         router.get("/latest/dynamic/instance-identity/document").handler(ctx -> handleIdentityDocument(ctx));
 
@@ -245,6 +256,36 @@ public class Ec2MetadataServer {
                 .end(body);
     }
 
+    private void handleInstanceTagKeys(RoutingContext ctx) {
+        Instance inst = resolveInstance(ctx);
+        if (inst == null) {
+            return;
+        }
+        ctx.response().setStatusCode(200)
+                .putHeader("content-type", "text/plain")
+                .end(instanceTagKeys(inst));
+    }
+
+    private void handleInstanceTagValue(RoutingContext ctx) {
+        Instance inst = resolveInstance(ctx);
+        if (inst == null) {
+            return;
+        }
+
+        String path = ctx.request().path();
+        String tagKey = path.length() <= INSTANCE_TAGS_PREFIX.length()
+                ? ""
+                : URLDecoder.decode(path.substring(INSTANCE_TAGS_PREFIX.length()), StandardCharsets.UTF_8);
+        Optional<String> value = instanceTagValue(inst, tagKey);
+        if (value.isEmpty()) {
+            ctx.response().setStatusCode(404).end("not-found");
+            return;
+        }
+        ctx.response().setStatusCode(200)
+                .putHeader("content-type", "text/plain")
+                .end(value.get());
+    }
+
     private void handleUserData(RoutingContext ctx) {
         Instance inst = resolveInstance(ctx);
         if (inst == null) {
@@ -324,5 +365,34 @@ public class Ec2MetadataServer {
 
     private static String nvl(String s) {
         return s != null ? s : "";
+    }
+
+    static String instanceTagKeys(Instance instance) {
+        StringBuilder tags = new StringBuilder();
+        if (instance == null || instance.getTags() == null) {
+            return "";
+        }
+        for (var tag : instance.getTags()) {
+            if (tag.getKey() == null || tag.getKey().isBlank()) {
+                continue;
+            }
+            if (!tags.isEmpty()) {
+                tags.append("\n");
+            }
+            tags.append(tag.getKey());
+        }
+        return tags.toString();
+    }
+
+    static Optional<String> instanceTagValue(Instance instance, String key) {
+        if (instance == null || instance.getTags() == null || key == null) {
+            return Optional.empty();
+        }
+        for (var tag : instance.getTags()) {
+            if (key.equals(tag.getKey())) {
+                return Optional.of(nvl(tag.getValue()));
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.ec2;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.AwsNamespaces;
 import io.github.hectorvent.floci.core.common.XmlBuilder;
+import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.services.ec2.model.*;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -27,10 +28,12 @@ public class Ec2QueryHandler {
             .withZone(ZoneOffset.UTC);
 
     private final Ec2Service service;
+    private final EmulatorConfig config;
 
     @Inject
-    public Ec2QueryHandler(Ec2Service service) {
+    public Ec2QueryHandler(Ec2Service service, EmulatorConfig config) {
         this.service = service;
+        this.config = config;
     }
 
     public Response handle(String action, MultivaluedMap<String, String> params, String region) {
@@ -244,6 +247,23 @@ public class Ec2QueryHandler {
         return tags;
     }
 
+    private List<Tag> parseLaunchTemplateDataTagsForResource(MultivaluedMap<String, String> p, String resourceType) {
+        List<Tag> tags = new ArrayList<>();
+        for (int i = 1; ; i++) {
+            String resType = p.getFirst("LaunchTemplateData.TagSpecification." + i + ".ResourceType");
+            if (resType == null) break;
+            if (resourceType.equals(resType)) {
+                for (int j = 1; ; j++) {
+                    String key = p.getFirst("LaunchTemplateData.TagSpecification." + i + ".Tag." + j + ".Key");
+                    if (key == null) break;
+                    String value = p.getFirst("LaunchTemplateData.TagSpecification." + i + ".Tag." + j + ".Value");
+                    tags.add(new Tag(key, value));
+                }
+            }
+        }
+        return tags;
+    }
+
     private Response xmlResponse(String xml) {
         return Response.ok(xml).type(MediaType.APPLICATION_XML).build();
     }
@@ -277,8 +297,7 @@ public class Ec2QueryHandler {
             userData = decodeUserData(userDataEncoded);
         }
 
-        // IamInstanceProfile
-        String iamInstanceProfileArn = p.getFirst("IamInstanceProfile.Arn");
+        String iamInstanceProfileArn = resolveIamInstanceProfileArn(p);
 
         // Parse TagSpecifications
         List<Tag> instanceTags = new ArrayList<>();
@@ -1378,7 +1397,8 @@ public class Ec2QueryHandler {
                 p.getFirst("LaunchTemplateData.KeyName"),
                 parseLaunchTemplateSecurityGroupIds(p),
                 decodeUserData(p.getFirst("LaunchTemplateData.UserData")),
-                parseTagsForResource(p, "launch-template"));
+                parseTagsForResource(p, "launch-template"),
+                parseLaunchTemplateDataTagsForResource(p, "instance"));
         XmlBuilder xml = new XmlBuilder()
                 .start("CreateLaunchTemplateResponse", AwsNamespaces.EC2)
                 .elem("requestId", UUID.randomUUID().toString())
@@ -1392,12 +1412,13 @@ public class Ec2QueryHandler {
                 region,
                 p.getFirst("LaunchTemplateId"),
                 p.getFirst("LaunchTemplateName"),
+                p.getFirst("SourceVersion"),
                 p.getFirst("LaunchTemplateData.ImageId"),
                 p.getFirst("LaunchTemplateData.InstanceType"),
                 p.getFirst("LaunchTemplateData.KeyName"),
                 parseLaunchTemplateSecurityGroupIds(p),
                 decodeUserData(p.getFirst("LaunchTemplateData.UserData")),
-                p.getFirst("SourceVersion"));
+                parseLaunchTemplateDataTagsForResource(p, "instance"));
         XmlBuilder xml = new XmlBuilder()
                 .start("CreateLaunchTemplateVersionResponse", AwsNamespaces.EC2)
                 .elem("requestId", UUID.randomUUID().toString())
@@ -1691,6 +1712,18 @@ public class Ec2QueryHandler {
         return xml.build();
     }
 
+    private String resolveIamInstanceProfileArn(MultivaluedMap<String, String> p) {
+        String arn = p.getFirst("IamInstanceProfile.Arn");
+        if (arn != null && !arn.isBlank()) {
+            return arn;
+        }
+        String name = p.getFirst("IamInstanceProfile.Name");
+        if (name == null || name.isBlank()) {
+            return null;
+        }
+        return "arn:aws:iam::" + config.defaultAccountId() + ":instance-profile/" + name;
+    }
+
     private String vpcXml(Vpc vpc) {
         XmlBuilder xml = new XmlBuilder()
                 .elem("vpcId", vpc.getVpcId())
@@ -1868,8 +1901,16 @@ public class Ec2QueryHandler {
         for (String securityGroupId : launchTemplate.getSecurityGroupIds()) {
             xml.elem("item", securityGroupId);
         }
-        xml.end("securityGroupIdSet")
-                .end("launchTemplateData");
+        xml.end("securityGroupIdSet");
+        if (launchTemplate.getInstanceTags() != null && !launchTemplate.getInstanceTags().isEmpty()) {
+            xml.start("tagSpecificationSet")
+                    .start("item")
+                    .elem("resourceType", "instance")
+                    .raw(tagSetXml(launchTemplate.getInstanceTags()))
+                    .end("item")
+                    .end("tagSpecificationSet");
+        }
+        xml.end("launchTemplateData");
         return xml.build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -61,6 +61,7 @@ import io.github.hectorvent.floci.services.ec2.model.VolumeAttachment;
 import io.github.hectorvent.floci.services.ec2.model.Vpc;
 import io.github.hectorvent.floci.services.ec2.model.VpcCidrBlockAssociation;
 import io.github.hectorvent.floci.services.ec2.model.VpcEndpoint;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -156,6 +157,37 @@ public class Ec2Service {
         this.vpcEndpoints = vpcEndpoints;
         this.natGateways = natGateways;
         this.tags = tags;
+    }
+
+    @PostConstruct
+    void restoreMetadataRegistrations() {
+        if (config.services().ec2().mock()) {
+            return;
+        }
+
+        int restored = 0;
+        for (String key : instances.keys()) {
+            Instance instance = instances.get(key).orElse(null);
+            if (!needsMetadataRegistration(instance)) {
+                continue;
+            }
+            if (containerManager.restoreMetadataRegistration(instance)) {
+                instances.put(key, instance);
+                restored++;
+            }
+        }
+        if (restored > 0) {
+            LOG.infov("Restored IMDS metadata registration for {0} EC2 container(s)", restored);
+        }
+    }
+
+    private static boolean needsMetadataRegistration(Instance instance) {
+        if (instance == null || instance.getDockerContainerId() == null) {
+            return false;
+        }
+        String state = instance.getState() != null ? instance.getState().getName() : null;
+        return state == null
+                || (!"shutting-down".equals(state) && !"terminated".equals(state) && !"stopping".equals(state));
     }
 
     // ─── Default resource seeding ──────────────────────────────────────────────
@@ -440,7 +472,10 @@ public class Ec2Service {
         if (config.services().ec2().mock()) {
             instances.scan(k -> true).stream()
                     .filter(i -> i.getRegion().equals(region) && "pending".equals(i.getState().getName()))
-                    .forEach(i -> i.setState(InstanceState.running()));
+                    .forEach(i -> {
+                        i.setState(InstanceState.running());
+                        instances.put(key(i.getRegion(), i.getInstanceId()), i);
+                    });
         }
         List<Instance> matched = instances.scan(k -> true).stream()
                 .filter(i -> i.getRegion().equals(region))
@@ -578,7 +613,10 @@ public class Ec2Service {
             instances.scan(k -> true).stream()
                     .filter(i -> i.getRegion().equals(region) && "pending".equals(i.getState().getName()))
                     .filter(i -> instanceIds.isEmpty() || instanceIds.contains(i.getInstanceId()))
-                    .forEach(i -> i.setState(InstanceState.running()));
+                    .forEach(i -> {
+                        i.setState(InstanceState.running());
+                        instances.put(key(i.getRegion(), i.getInstanceId()), i);
+                    });
         }
         return instances.scan(k -> true).stream()
                 .filter(i -> i.getRegion().equals(region))
@@ -1070,7 +1108,15 @@ public class Ec2Service {
 
     public boolean isInstanceContainerRunning(String instanceId) {
         Instance instance = findInstanceById(instanceId);
-        return instance != null && containerManager.isContainerRunning(instance.getDockerContainerId());
+        if (instance == null) {
+            return false;
+        }
+        if (config.services().ec2().mock()) {
+            String state = instance.getState() != null ? instance.getState().getName() : null;
+            return state == null
+                    || (!"shutting-down".equals(state) && !"terminated".equals(state) && !"stopping".equals(state));
+        }
+        return containerManager.isContainerRunning(instance.getDockerContainerId());
     }
 
     public KeyPair findKeyPair(String region, String keyName) {
@@ -1104,7 +1150,7 @@ public class Ec2Service {
     public LaunchTemplate createLaunchTemplate(String region, String name, String imageId,
                                                String instanceType, String keyName,
                                                List<String> securityGroupIds, String userData,
-                                               List<Tag> launchTemplateTags) {
+                                               List<Tag> launchTemplateTags, List<Tag> instanceTags) {
         ensureDefaultResources(region);
         if (name == null || name.isBlank()) {
             throw new AwsException("MissingParameter", "The request must contain the parameter LaunchTemplateName", 400);
@@ -1133,17 +1179,22 @@ public class Ec2Service {
             launchTemplate.setTags(new ArrayList<>(launchTemplateTags));
             tags.put(launchTemplate.getLaunchTemplateId(), new ArrayList<>(launchTemplateTags));
         }
+        if (instanceTags != null && !instanceTags.isEmpty()) {
+            launchTemplate.setInstanceTags(new ArrayList<>(instanceTags));
+        }
         launchTemplate.getVersions().put("1", dataFrom(launchTemplate));
         launchTemplates.put(key(region, launchTemplate.getLaunchTemplateId()), launchTemplate);
         return launchTemplate;
     }
 
     public LaunchTemplate createLaunchTemplateVersion(String region, String id, String name,
+                                                      String sourceVersion,
                                                       String imageId, String instanceType, String keyName,
                                                       List<String> securityGroupIds, String userData,
-                                                      String sourceVersion) {
+                                                      List<Tag> instanceTags) {
         ensureDefaultResources(region);
         LaunchTemplate launchTemplate = findLaunchTemplate(region, id, name);
+        ensureLaunchTemplateVersions(launchTemplate);
         int latestVersion = parseLaunchTemplateVersion(launchTemplate.getLatestVersionNumber()) + 1;
         LaunchTemplateData data = new LaunchTemplateData(versionData(launchTemplate,
                 resolveLaunchTemplateVersion(launchTemplate, sourceVersion, launchTemplate.getLatestVersionNumber())));
@@ -1163,8 +1214,12 @@ public class Ec2Service {
         if (securityGroupIds != null && !securityGroupIds.isEmpty()) {
             data.setSecurityGroupIds(securityGroupIds);
         }
+        if (instanceTags != null && !instanceTags.isEmpty()) {
+            data.setInstanceTags(instanceTags);
+        }
         launchTemplate.getVersions().put(String.valueOf(latestVersion), data);
         applyData(launchTemplate, data);
+        launchTemplates.put(key(region, launchTemplate.getLaunchTemplateId()), launchTemplate);
         return launchTemplate;
     }
 
@@ -1192,6 +1247,7 @@ public class Ec2Service {
     public LaunchTemplate modifyLaunchTemplate(String region, String id, String name, String defaultVersion) {
         ensureDefaultResources(region);
         LaunchTemplate launchTemplate = findLaunchTemplate(region, id, name);
+        ensureLaunchTemplateVersions(launchTemplate);
         if (defaultVersion != null && !defaultVersion.isBlank()) {
             String resolved = switch (defaultVersion) {
                 case "$Latest" -> launchTemplate.getLatestVersionNumber();
@@ -1200,12 +1256,14 @@ public class Ec2Service {
             };
             int requested = parseLaunchTemplateVersion(resolved);
             int latest = parseLaunchTemplateVersion(launchTemplate.getLatestVersionNumber());
-            if (requested < 1 || requested > latest) {
+            if (requested < 1 || requested > latest
+                    || !launchTemplate.getVersions().containsKey(String.valueOf(requested))) {
                 throw new AwsException("InvalidLaunchTemplateVersion.NotFound",
                         "The specified launch template version does not exist.", 400);
             }
             launchTemplate.setDefaultVersionNumber(String.valueOf(requested));
         }
+        launchTemplates.put(key(region, launchTemplate.getLaunchTemplateId()), launchTemplate);
         return launchTemplate;
     }
 
@@ -1254,11 +1312,17 @@ public class Ec2Service {
         }
     }
 
+    private void ensureLaunchTemplateVersions(LaunchTemplate launchTemplate) {
+        if (!launchTemplate.getVersions().isEmpty()) {
+            return;
+        }
+        launchTemplate.getVersions().put(launchTemplate.getLatestVersionNumber(), dataFrom(launchTemplate));
+        launchTemplates.put(key(launchTemplate.getRegion(), launchTemplate.getLaunchTemplateId()), launchTemplate);
+    }
+
     private String resolveLaunchTemplateVersion(LaunchTemplate launchTemplate, String requestedVersion,
                                                 String defaultWhenMissing) {
-        if (launchTemplate.getVersions().isEmpty()) {
-            launchTemplate.getVersions().put(launchTemplate.getLatestVersionNumber(), dataFrom(launchTemplate));
-        }
+        ensureLaunchTemplateVersions(launchTemplate);
         String candidate = requestedVersion == null || requestedVersion.isBlank() ? defaultWhenMissing : requestedVersion;
         String resolved = switch (candidate) {
             case "$Latest" -> launchTemplate.getLatestVersionNumber();
@@ -1285,6 +1349,7 @@ public class Ec2Service {
         data.setKeyName(launchTemplate.getKeyName());
         data.setUserData(launchTemplate.getUserData());
         data.setSecurityGroupIds(launchTemplate.getSecurityGroupIds());
+        data.setInstanceTags(launchTemplate.getInstanceTags());
         return data;
     }
 
@@ -1294,6 +1359,7 @@ public class Ec2Service {
         launchTemplate.setKeyName(data.getKeyName());
         launchTemplate.setUserData(data.getUserData());
         launchTemplate.setSecurityGroupIds(new ArrayList<>(data.getSecurityGroupIds()));
+        launchTemplate.setInstanceTags(data.getInstanceTags());
     }
 
     private LaunchTemplate copyForVersion(LaunchTemplate source, String versionNumber) {
@@ -2030,6 +2096,8 @@ public class Ec2Service {
                 case "group-id" -> ni.getGroups().stream()
                         .anyMatch(g -> matchesValue(values, g.getGroupId()));
                 case "status" -> matchesValue(values, ni.getStatus());
+                case "attachment.instance-id" -> ni.getAttachment() != null
+                        && matchesValue(values, ni.getAttachment().getInstanceId());
                 case "private-ip-address" ->
                     matchesValue(values, ni.getPrivateIpAddress()) ||
                     ni.getPrivateIpAddresses().stream()

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/LaunchTemplate.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/LaunchTemplate.java
@@ -26,6 +26,7 @@ public class LaunchTemplate {
     private String userData;
     private List<String> securityGroupIds = new ArrayList<>();
     private List<Tag> tags = new ArrayList<>();
+    private List<Tag> instanceTags = new ArrayList<>();
     private Map<String, LaunchTemplateData> versions = new LinkedHashMap<>();
 
     public LaunchTemplate() {}
@@ -68,6 +69,11 @@ public class LaunchTemplate {
 
     public List<Tag> getTags() { return tags; }
     public void setTags(List<Tag> tags) { this.tags = tags; }
+
+    public List<Tag> getInstanceTags() { return instanceTags; }
+    public void setInstanceTags(List<Tag> instanceTags) {
+        this.instanceTags = instanceTags != null ? new ArrayList<>(instanceTags) : new ArrayList<>();
+    }
 
     public Map<String, LaunchTemplateData> getVersions() { return versions; }
     public void setVersions(Map<String, LaunchTemplateData> versions) {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/LaunchTemplateData.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/LaunchTemplateData.java
@@ -15,6 +15,7 @@ public class LaunchTemplateData {
     private String keyName;
     private String userData;
     private List<String> securityGroupIds = new ArrayList<>();
+    private List<Tag> instanceTags = new ArrayList<>();
 
     public LaunchTemplateData() {}
 
@@ -24,6 +25,7 @@ public class LaunchTemplateData {
         this.keyName = source.keyName;
         this.userData = source.userData;
         this.securityGroupIds = new ArrayList<>(source.securityGroupIds);
+        this.instanceTags = new ArrayList<>(source.instanceTags);
     }
 
     public String getImageId() { return imageId; }
@@ -41,5 +43,10 @@ public class LaunchTemplateData {
     public List<String> getSecurityGroupIds() { return securityGroupIds; }
     public void setSecurityGroupIds(List<String> securityGroupIds) {
         this.securityGroupIds = securityGroupIds != null ? new ArrayList<>(securityGroupIds) : new ArrayList<>();
+    }
+
+    public List<Tag> getInstanceTags() { return instanceTags; }
+    public void setInstanceTags(List<Tag> instanceTags) {
+        this.instanceTags = instanceTags != null ? new ArrayList<>(instanceTags) : new ArrayList<>();
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingIntegrationTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 @QuarkusTest
@@ -17,6 +18,8 @@ class AutoScalingIntegrationTest {
             "AWS4-HMAC-SHA256 Credential=test/20260501/us-east-1/autoscaling/aws4_request";
 
     private static String policyArn;
+    private static String instanceRefreshId;
+    private static String pagedInstanceRefreshId;
 
     // ── Launch Configurations ─────────────────────────────────────────────────
 
@@ -386,10 +389,216 @@ class AutoScalingIntegrationTest {
                 .body(containsString("DescribeScalingActivitiesResponse"));
     }
 
+    @Test
+    @Order(21)
+    void createAutoScalingGroupWithLaunchTemplateId() {
+        given()
+                .formParam("Action", "CreateAutoScalingGroup")
+                .formParam("AutoScalingGroupName", "my-lt-asg")
+                .formParam("LaunchTemplate.LaunchTemplateId", "lt-0123456789abcdef0")
+                .formParam("LaunchTemplate.Version", "$Latest")
+                .formParam("MinSize", "0")
+                .formParam("MaxSize", "1")
+                .formParam("DesiredCapacity", "0")
+                .formParam("AvailabilityZones.member.1", "us-east-1a")
+                .formParam("VPCZoneIdentifier", "subnet-12345678,subnet-87654321")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("CreateAutoScalingGroupResponse"));
+
+        given()
+                .formParam("Action", "CreateOrUpdateTags")
+                .formParam("Tags.member.1.ResourceId", "my-lt-asg")
+                .formParam("Tags.member.1.ResourceType", "auto-scaling-group")
+                .formParam("Tags.member.1.Key", "owner")
+                .formParam("Tags.member.1.Value", "sample-app")
+                .formParam("Tags.member.1.PropagateAtLaunch", "true")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("CreateOrUpdateTagsResponse"));
+    }
+
+    @Test
+    @Order(22)
+    void describeAutoScalingGroupWithLaunchTemplateId() {
+        given()
+                .formParam("Action", "DescribeAutoScalingGroups")
+                .formParam("AutoScalingGroupNames.member.1", "my-lt-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("my-lt-asg"))
+                .body(containsString("<LaunchTemplateId>lt-0123456789abcdef0</LaunchTemplateId>"))
+                .body(containsString("<Version>$Latest</Version>"))
+                .body(containsString("<VPCZoneIdentifier>subnet-12345678,subnet-87654321</VPCZoneIdentifier>"))
+                .body(containsString("owner"))
+                .body(containsString("sample-app"));
+
+        given()
+                .formParam("Action", "DeleteTags")
+                .formParam("Tags.member.1.ResourceId", "my-lt-asg")
+                .formParam("Tags.member.1.ResourceType", "auto-scaling-group")
+                .formParam("Tags.member.1.Key", "owner")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("DeleteTagsResponse"));
+
+        given()
+                .formParam("Action", "DescribeAutoScalingGroups")
+                .formParam("AutoScalingGroupNames.member.1", "my-lt-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(not(containsString("sample-app")));
+    }
+
+    @Test
+    @Order(23)
+    void startInstanceRefresh() {
+        instanceRefreshId = given()
+                .formParam("Action", "StartInstanceRefresh")
+                .formParam("AutoScalingGroupName", "my-lt-asg")
+                .formParam("Strategy", "Rolling")
+                .formParam("DesiredConfiguration.LaunchTemplate.LaunchTemplateId", "lt-0fedcba9876543210")
+                .formParam("DesiredConfiguration.LaunchTemplate.Version", "2")
+                .formParam("Preferences.MinHealthyPercentage", "90")
+                .formParam("Preferences.MaxHealthyPercentage", "120")
+                .formParam("Preferences.InstanceWarmup", "200")
+                .formParam("Preferences.SkipMatching", "true")
+                .formParam("Preferences.AutoRollback", "true")
+                .formParam("Preferences.CheckpointPercentages.member.1", "50")
+                .formParam("Preferences.CheckpointPercentages.member.2", "100")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("StartInstanceRefreshResponse"))
+                .body(containsString("InstanceRefreshId"))
+                .extract().xmlPath()
+                .getString("StartInstanceRefreshResponse.StartInstanceRefreshResult.InstanceRefreshId");
+
+        assertThat(instanceRefreshId, not(emptyOrNullString()));
+    }
+
+    @Test
+    @Order(24)
+    void describeInstanceRefreshes() {
+        String body = given()
+                .formParam("Action", "DescribeInstanceRefreshes")
+                .formParam("AutoScalingGroupName", "my-lt-asg")
+                .formParam("InstanceRefreshIds.member.1", instanceRefreshId)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("DescribeInstanceRefreshesResponse"))
+                .extract().body().asString();
+
+        assertThat(body, containsString(instanceRefreshId));
+        assertThat(body, containsString("<AutoScalingGroupName>my-lt-asg</AutoScalingGroupName>"));
+        assertThat(body, containsString("<Status>Successful</Status>"));
+        assertThat(body, containsString("<PercentageComplete>100</PercentageComplete>"));
+        assertThat(body, containsString("<InstancesToUpdate>0</InstancesToUpdate>"));
+        assertThat(body, containsString("<Strategy>Rolling</Strategy>"));
+        assertThat(body, containsString("<LaunchTemplateId>lt-0fedcba9876543210</LaunchTemplateId>"));
+        assertThat(body, containsString("<Version>2</Version>"));
+        assertThat(body, containsString("<MinHealthyPercentage>90</MinHealthyPercentage>"));
+        assertThat(body, containsString("<MaxHealthyPercentage>120</MaxHealthyPercentage>"));
+        assertThat(body, containsString("<InstanceWarmup>200</InstanceWarmup>"));
+        assertThat(body, containsString("<SkipMatching>true</SkipMatching>"));
+        assertThat(body, containsString("<AutoRollback>true</AutoRollback>"));
+        assertThat(body, containsString("<CheckpointPercentages>"));
+
+        given()
+                .formParam("Action", "DescribeAutoScalingGroups")
+                .formParam("AutoScalingGroupNames.member.1", "my-lt-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<LaunchTemplateId>lt-0fedcba9876543210</LaunchTemplateId>"))
+                .body(containsString("<Version>2</Version>"));
+    }
+
+    @Test
+    @Order(25)
+    void describeInstanceRefreshesPaginatesNewestFirst() {
+        pagedInstanceRefreshId = given()
+                .formParam("Action", "StartInstanceRefresh")
+                .formParam("AutoScalingGroupName", "my-lt-asg")
+                .formParam("Preferences.SkipMatching", "true")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract().xmlPath()
+                .getString("StartInstanceRefreshResponse.StartInstanceRefreshResult.InstanceRefreshId");
+
+        String firstPage = given()
+                .formParam("Action", "DescribeInstanceRefreshes")
+                .formParam("AutoScalingGroupName", "my-lt-asg")
+                .formParam("MaxRecords", "1")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<NextToken>1</NextToken>"))
+                .extract().body().asString();
+
+        assertThat(firstPage, containsString(pagedInstanceRefreshId));
+        assertThat(firstPage, not(containsString(instanceRefreshId)));
+
+        given()
+                .formParam("Action", "DescribeInstanceRefreshes")
+                .formParam("AutoScalingGroupName", "my-lt-asg")
+                .formParam("MaxRecords", "1")
+                .formParam("NextToken", "1")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString(instanceRefreshId))
+                .body(not(containsString("<NextToken>")));
+    }
+
+    @Test
+    @Order(26)
+    void deleteLaunchTemplateAutoScalingGroup() {
+        given()
+                .formParam("Action", "DeleteAutoScalingGroup")
+                .formParam("AutoScalingGroupName", "my-lt-asg")
+                .formParam("ForceDelete", "true")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("DeleteAutoScalingGroupResponse"));
+    }
+
     // ── Cleanup ───────────────────────────────────────────────────────────────
 
     @Test
-    @Order(21)
+    @Order(27)
     void deleteAutoScalingGroup() {
         given()
                 .formParam("Action", "DeleteAutoScalingGroup")
@@ -404,7 +613,7 @@ class AutoScalingIntegrationTest {
     }
 
     @Test
-    @Order(22)
+    @Order(28)
     void deleteLaunchConfiguration() {
         given()
                 .formParam("Action", "DeleteLaunchConfiguration")
@@ -418,7 +627,7 @@ class AutoScalingIntegrationTest {
     }
 
     @Test
-    @Order(23)
+    @Order(29)
     void describeAutoScalingGroupsEmpty() {
         given()
                 .formParam("Action", "DescribeAutoScalingGroups")

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandlerTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.autoscaling;
 
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.autoscaling.model.AsgInstance;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
@@ -76,5 +77,53 @@ class AutoScalingQueryHandlerTest {
         assertTrue(describeXml.contains("<Preferences>"));
         assertTrue(describeXml.contains("<MinHealthyPercentage>90</MinHealthyPercentage>"));
         assertTrue(describeXml.contains("<SkipMatching>true</SkipMatching>"));
+    }
+
+    @Test
+    void describeAutoScalingGroupsIncludesInstanceLaunchTemplateMetadata() {
+        AutoScalingService service = new AutoScalingService();
+        service.regionResolver = new RegionResolver(REGION, "000000000000");
+        service.createAutoScalingGroup(REGION,
+                "query-asg",
+                null,
+                "lt-current",
+                null,
+                "$Latest",
+                0,
+                3,
+                1,
+                300,
+                List.of("us-east-1a"),
+                List.of(),
+                List.of(),
+                List.of(),
+                "EC2",
+                0,
+                List.of("Default"),
+                java.util.Map.of());
+        AsgInstance instance = new AsgInstance();
+        instance.setInstanceId("i-current");
+        instance.setAvailabilityZone("us-east-1a");
+        instance.setLifecycleState("InService");
+        instance.setHealthStatus("Healthy");
+        instance.setLaunchTemplateId("lt-current");
+        instance.setLaunchTemplateVersion("7");
+        service.describeAutoScalingGroups(REGION, List.of("query-asg"))
+                .getFirst()
+                .getInstances()
+                .add(instance);
+
+        AutoScalingQueryHandler handler = new AutoScalingQueryHandler(service);
+        MultivaluedHashMap<String, String> params = new MultivaluedHashMap<>();
+        params.add("AutoScalingGroupNames.member.1", "query-asg");
+
+        Response response = handler.handle("DescribeAutoScalingGroups", params, REGION);
+
+        assertEquals(200, response.getStatus());
+        String xml = (String) response.getEntity();
+        assertTrue(xml.contains("<InstanceId>i-current</InstanceId>"));
+        assertTrue(xml.contains("<LaunchTemplate>"));
+        assertTrue(xml.contains("<LaunchTemplateId>lt-current</LaunchTemplateId>"));
+        assertTrue(xml.contains("<Version>7</Version>"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandlerTest.java
@@ -1,0 +1,80 @@
+package io.github.hectorvent.floci.services.autoscaling;
+
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AutoScalingQueryHandlerTest {
+
+    private static final String REGION = "us-east-1";
+
+    @Test
+    void startAndDescribeInstanceRefreshUseAwsQueryXmlShape() {
+        AutoScalingService service = new AutoScalingService();
+        service.regionResolver = new RegionResolver(REGION, "000000000000");
+        service.createAutoScalingGroup(REGION,
+                "query-asg",
+                null,
+                "lt-original",
+                null,
+                "1",
+                0,
+                3,
+                1,
+                300,
+                List.of("us-east-1a"),
+                List.of(),
+                List.of(),
+                List.of(),
+                "EC2",
+                0,
+                List.of("Default"),
+                java.util.Map.of());
+
+        AutoScalingQueryHandler handler = new AutoScalingQueryHandler(service);
+        MultivaluedHashMap<String, String> startParams = new MultivaluedHashMap<>();
+        startParams.add("AutoScalingGroupName", "query-asg");
+        startParams.add("DesiredConfiguration.LaunchTemplate.LaunchTemplateId", "lt-updated");
+        startParams.add("DesiredConfiguration.LaunchTemplate.Version", "2");
+        startParams.add("Preferences.MinHealthyPercentage", "90");
+        startParams.add("Preferences.SkipMatching", "true");
+
+        Response startResponse = handler.handle("StartInstanceRefresh", startParams, REGION);
+
+        assertEquals(200, startResponse.getStatus());
+        String startXml = (String) startResponse.getEntity();
+        assertTrue(startXml.contains("<StartInstanceRefreshResponse"));
+        assertTrue(startXml.contains("<StartInstanceRefreshResult>"));
+        assertTrue(startXml.contains("<InstanceRefreshId>"));
+        String refreshId = service.describeInstanceRefreshes(REGION, "query-asg", List.of(), null, null)
+                .instanceRefreshes().getFirst().getInstanceRefreshId();
+
+        MultivaluedHashMap<String, String> describeParams = new MultivaluedHashMap<>();
+        describeParams.add("AutoScalingGroupName", "query-asg");
+        describeParams.add("InstanceRefreshIds.member.1", refreshId);
+
+        Response describeResponse = handler.handle("DescribeInstanceRefreshes", describeParams, REGION);
+
+        assertEquals(200, describeResponse.getStatus());
+        String describeXml = (String) describeResponse.getEntity();
+        assertTrue(describeXml.contains("<DescribeInstanceRefreshesResponse"));
+        assertTrue(describeXml.contains("<InstanceRefreshes>"));
+        assertTrue(describeXml.contains("<InstanceRefreshId>" + refreshId + "</InstanceRefreshId>"));
+        assertTrue(describeXml.contains("<AutoScalingGroupName>query-asg</AutoScalingGroupName>"));
+        assertTrue(describeXml.contains("<Status>Successful</Status>"));
+        assertTrue(describeXml.contains("<PercentageComplete>100</PercentageComplete>"));
+        assertTrue(describeXml.contains("<InstancesToUpdate>0</InstancesToUpdate>"));
+        assertTrue(describeXml.contains("<DesiredConfiguration>"));
+        assertTrue(describeXml.contains("<LaunchTemplateId>lt-updated</LaunchTemplateId>"));
+        assertTrue(describeXml.contains("<Version>2</Version>"));
+        assertTrue(describeXml.contains("<Preferences>"));
+        assertTrue(describeXml.contains("<MinHealthyPercentage>90</MinHealthyPercentage>"));
+        assertTrue(describeXml.contains("<SkipMatching>true</SkipMatching>"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconcilerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconcilerTest.java
@@ -1,0 +1,182 @@
+package io.github.hectorvent.floci.services.autoscaling;
+
+import io.github.hectorvent.floci.services.autoscaling.model.AsgInstance;
+import io.github.hectorvent.floci.services.autoscaling.model.AutoScalingGroup;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.model.Instance;
+import io.github.hectorvent.floci.services.ec2.model.InstanceState;
+import io.github.hectorvent.floci.services.ec2.model.LaunchTemplate;
+import io.github.hectorvent.floci.services.ec2.model.Reservation;
+import io.github.hectorvent.floci.services.elbv2.ElbV2Service;
+import io.github.hectorvent.floci.services.elbv2.model.TargetDescription;
+import io.github.hectorvent.floci.services.elbv2.model.TargetHealth;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AutoScalingReconcilerTest {
+
+    @Test
+    void pendingInstancesCountAsActiveCapacity() {
+        AutoScalingGroup asg = new AutoScalingGroup();
+        asg.getInstances().add(instance("Pending"));
+        asg.getInstances().add(instance("InService"));
+        asg.getInstances().add(instance("Terminating"));
+        asg.getInstances().add(instance("Terminated"));
+        asg.getInstances().add(instance("Detached"));
+
+        assertEquals(2, AutoScalingReconciler.activeCapacity(asg));
+    }
+
+    @Test
+    void reconcileCompletesSettledInstanceRefreshes() {
+        AutoScalingService asgService = mock(AutoScalingService.class);
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        ElbV2Service elbV2Service = mock(ElbV2Service.class);
+        AutoScalingReconciler reconciler = new AutoScalingReconciler(asgService, ec2Service, elbV2Service);
+        AutoScalingGroup asg = new AutoScalingGroup();
+        asg.setRegion("us-east-1");
+        asg.setAutoScalingGroupName("app-asg");
+        asg.setDesiredCapacity(0);
+
+        reconciler.reconcile(asg);
+
+        verify(asgService).completeInstanceRefreshIfSettled("us-east-1", "app-asg");
+    }
+
+    @Test
+    void scaleOutUsesRequestedLaunchTemplateVersionData() {
+        AutoScalingService asgService = mock(AutoScalingService.class);
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        ElbV2Service elbV2Service = mock(ElbV2Service.class);
+        AutoScalingReconciler reconciler = new AutoScalingReconciler(asgService, ec2Service, elbV2Service);
+        AutoScalingGroup asg = new AutoScalingGroup();
+        asg.setRegion("us-east-1");
+        asg.setAutoScalingGroupName("app-asg");
+        asg.setDesiredCapacity(1);
+        asg.setLaunchTemplateId("lt-123");
+        asg.setLaunchTemplateVersion("1");
+
+        LaunchTemplate launchTemplate = new LaunchTemplate();
+        launchTemplate.setLaunchTemplateId("lt-123");
+        LaunchTemplate.LaunchTemplateVersion version = new LaunchTemplate.LaunchTemplateVersion();
+        version.setVersionNumber("1");
+        version.setImageId("ami-version-1");
+        version.setInstanceType("t3.micro");
+        when(ec2Service.describeLaunchTemplates("us-east-1", List.of("lt-123"), List.of(), Map.of()))
+                .thenReturn(List.of(launchTemplate));
+        when(ec2Service.resolveLaunchTemplateVersion("us-east-1", "lt-123", null, "1"))
+                .thenReturn(version);
+        Instance ec2Instance = new Instance();
+        ec2Instance.setInstanceId("i-launched");
+        Reservation reservation = new Reservation();
+        reservation.setInstances(List.of(ec2Instance));
+        when(ec2Service.runInstances(eq("us-east-1"), eq("ami-version-1"), eq("t3.micro"),
+                eq(1), eq(1), eq(null), eq(List.of()), eq(null), eq(null),
+                eq(List.of()), eq(null), eq(null))).thenReturn(reservation);
+
+        reconciler.reconcile(asg);
+
+        assertEquals(1, asg.getInstances().size());
+        assertEquals("i-launched", asg.getInstances().getFirst().getInstanceId());
+        assertEquals("lt-123", asg.getInstances().getFirst().getLaunchTemplateId());
+        assertEquals("1", asg.getInstances().getFirst().getLaunchTemplateVersion());
+        verify(ec2Service).runInstances(eq("us-east-1"), eq("ami-version-1"), eq("t3.micro"),
+                eq(1), eq(1), eq(null), eq(List.of()), eq(null), eq(null),
+                eq(List.of()), eq(null), eq(null));
+    }
+
+    @Test
+    void reconcileDeregistersTargetsThatAreNotActiveAsgInstances() {
+        AutoScalingService asgService = mock(AutoScalingService.class);
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        ElbV2Service elbV2Service = mock(ElbV2Service.class);
+        AutoScalingReconciler reconciler = new AutoScalingReconciler(asgService, ec2Service, elbV2Service);
+        AutoScalingGroup asg = new AutoScalingGroup();
+        asg.setRegion("us-east-1");
+        asg.setAutoScalingGroupName("app-asg");
+        asg.setDesiredCapacity(1);
+        asg.setTargetGroupARNs(List.of("arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/app/123"));
+        asg.getInstances().add(instance("i-active", "InService"));
+        when(ec2Service.isInstanceContainerRunning("i-active")).thenReturn(true);
+        when(elbV2Service.describeTargetHealth(asg.getRegion(), asg.getTargetGroupARNs().getFirst(), List.of()))
+                .thenReturn(List.of(targetHealth("i-active"), targetHealth("i-stale")));
+
+        reconciler.reconcile(asg);
+
+        ArgumentCaptor<List<TargetDescription>> targets = ArgumentCaptor.captor();
+        verify(elbV2Service).deregisterTargets(
+                eq(asg.getRegion()),
+                eq(asg.getTargetGroupARNs().getFirst()),
+                targets.capture());
+        assertEquals(1, targets.getValue().size());
+        assertEquals("i-stale", targets.getValue().getFirst().getId());
+        verify(asgService).saveAutoScalingGroup(asg);
+        verify(ec2Service, never()).terminateInstances(asg.getRegion(), List.of("i-active"));
+    }
+
+    @Test
+    void reconcilePromotesPendingAsgInstanceWhenEc2InstanceIsRunning() {
+        AutoScalingService asgService = mock(AutoScalingService.class);
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        ElbV2Service elbV2Service = mock(ElbV2Service.class);
+        AutoScalingReconciler reconciler = new AutoScalingReconciler(asgService, ec2Service, elbV2Service);
+        AutoScalingGroup asg = new AutoScalingGroup();
+        asg.setRegion("us-east-1");
+        asg.setAutoScalingGroupName("app-asg");
+        asg.setDesiredCapacity(1);
+        asg.getInstances().add(instance("i-pending", "Pending"));
+
+        Instance ec2Instance = new Instance();
+        ec2Instance.setInstanceId("i-pending");
+        ec2Instance.setState(InstanceState.running());
+        Reservation reservation = new Reservation();
+        reservation.setInstances(List.of(ec2Instance));
+        when(ec2Service.describeInstances(asg.getRegion(), List.of("i-pending"), null))
+                .thenReturn(List.of(reservation));
+        when(ec2Service.isInstanceContainerRunning("i-pending")).thenReturn(true);
+
+        reconciler.reconcile(asg);
+
+        assertEquals("InService", asg.getInstances().getFirst().getLifecycleState());
+        assertEquals("Healthy", asg.getInstances().getFirst().getHealthStatus());
+        verify(asgService).recordActivity(
+                eq(asg.getRegion()),
+                eq(asg.getAutoScalingGroupName()),
+                eq("Launching a new EC2 instance: i-pending"),
+                eq("An instance was started in response to a desired capacity change."),
+                eq("Successful"));
+        verify(asgService, times(2)).saveAutoScalingGroup(asg);
+    }
+
+    private static AsgInstance instance(String lifecycleState) {
+        AsgInstance instance = new AsgInstance();
+        instance.setLifecycleState(lifecycleState);
+        return instance;
+    }
+
+    private static AsgInstance instance(String instanceId, String lifecycleState) {
+        AsgInstance instance = instance(lifecycleState);
+        instance.setInstanceId(instanceId);
+        instance.setHealthStatus("Healthy");
+        return instance;
+    }
+
+    private static TargetHealth targetHealth(String instanceId) {
+        TargetDescription target = new TargetDescription();
+        target.setId(instanceId);
+        TargetHealth health = new TargetHealth();
+        health.setTarget(target);
+        return health;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconcilerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconcilerTest.java
@@ -69,14 +69,14 @@ class AutoScalingReconcilerTest {
 
         LaunchTemplate launchTemplate = new LaunchTemplate();
         launchTemplate.setLaunchTemplateId("lt-123");
-        LaunchTemplate.LaunchTemplateVersion version = new LaunchTemplate.LaunchTemplateVersion();
-        version.setVersionNumber("1");
+        LaunchTemplate version = new LaunchTemplate();
+        version.setLatestVersionNumber("1");
         version.setImageId("ami-version-1");
         version.setInstanceType("t3.micro");
         when(ec2Service.describeLaunchTemplates("us-east-1", List.of("lt-123"), List.of(), Map.of()))
                 .thenReturn(List.of(launchTemplate));
-        when(ec2Service.resolveLaunchTemplateVersion("us-east-1", "lt-123", null, "1"))
-                .thenReturn(version);
+        when(ec2Service.describeLaunchTemplateVersions("us-east-1", "lt-123", null, List.of("1")))
+                .thenReturn(List.of(version));
         Instance ec2Instance = new Instance();
         ec2Instance.setInstanceId("i-launched");
         Reservation reservation = new Reservation();
@@ -94,6 +94,43 @@ class AutoScalingReconcilerTest {
         verify(ec2Service).runInstances(eq("us-east-1"), eq("ami-version-1"), eq("t3.micro"),
                 eq(1), eq(1), eq(null), eq(List.of()), eq(null), eq(null),
                 eq(List.of()), eq(null), eq(null));
+    }
+
+    @Test
+    void scaleOutStoresResolvedLaunchTemplateVersionForAliases() {
+        AutoScalingService asgService = mock(AutoScalingService.class);
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        ElbV2Service elbV2Service = mock(ElbV2Service.class);
+        AutoScalingReconciler reconciler = new AutoScalingReconciler(asgService, ec2Service, elbV2Service);
+        AutoScalingGroup asg = new AutoScalingGroup();
+        asg.setRegion("us-east-1");
+        asg.setAutoScalingGroupName("app-asg");
+        asg.setDesiredCapacity(1);
+        asg.setLaunchTemplateId("lt-123");
+        asg.setLaunchTemplateVersion("$Latest");
+
+        LaunchTemplate launchTemplate = new LaunchTemplate();
+        launchTemplate.setLaunchTemplateId("lt-123");
+        LaunchTemplate version = new LaunchTemplate();
+        version.setLatestVersionNumber("7");
+        version.setImageId("ami-version-7");
+        version.setInstanceType("t3.micro");
+        when(ec2Service.describeLaunchTemplates("us-east-1", List.of("lt-123"), List.of(), Map.of()))
+                .thenReturn(List.of(launchTemplate));
+        when(ec2Service.describeLaunchTemplateVersions("us-east-1", "lt-123", null, List.of("$Latest")))
+                .thenReturn(List.of(version));
+        Instance ec2Instance = new Instance();
+        ec2Instance.setInstanceId("i-launched");
+        Reservation reservation = new Reservation();
+        reservation.setInstances(List.of(ec2Instance));
+        when(ec2Service.runInstances(eq("us-east-1"), eq("ami-version-7"), eq("t3.micro"),
+                eq(1), eq(1), eq(null), eq(List.of()), eq(null), eq(null),
+                eq(List.of()), eq(null), eq(null))).thenReturn(reservation);
+
+        reconciler.reconcile(asg);
+
+        assertEquals("$Latest", asg.getLaunchTemplateVersion());
+        assertEquals("7", asg.getInstances().getFirst().getLaunchTemplateVersion());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingServiceTest.java
@@ -1,0 +1,334 @@
+package io.github.hectorvent.floci.services.autoscaling;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.autoscaling.model.AsgInstance;
+import io.github.hectorvent.floci.services.autoscaling.model.InstanceRefresh;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class AutoScalingServiceTest {
+
+    private static final String REGION = "us-east-1";
+    private AutoScalingService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AutoScalingService();
+        service.regionResolver = new RegionResolver(REGION, "000000000000");
+        service.createAutoScalingGroup(REGION,
+                "test-asg",
+                null,
+                "lt-original",
+                null,
+                "1",
+                0,
+                3,
+                1,
+                300,
+                List.of("us-east-1a"),
+                List.of("subnet-12345678"),
+                List.of(),
+                List.of(),
+                "EC2",
+                0,
+                List.of("Default"),
+                java.util.Map.of());
+    }
+
+    @Test
+    void startInstanceRefreshStoresCompletedRefreshAndAppliesDesiredLaunchTemplate() {
+        InstanceRefresh request = new InstanceRefresh();
+        request.setStrategy("Rolling");
+        request.setDesiredLaunchTemplateId("lt-updated");
+        request.setDesiredLaunchTemplateVersion("2");
+        request.setMinHealthyPercentage(90);
+        request.setMaxHealthyPercentage(120);
+        request.setInstanceWarmup(200);
+        request.setSkipMatching(true);
+        request.setAutoRollback(true);
+        request.setCheckpointPercentages(List.of(50, 100));
+
+        InstanceRefresh refresh = service.startInstanceRefresh(REGION, "test-asg", request);
+
+        assertNotNull(refresh.getInstanceRefreshId());
+        assertEquals("test-asg", refresh.getAutoScalingGroupName());
+        assertEquals("Rolling", refresh.getStrategy());
+        assertEquals("Successful", refresh.getStatus());
+        assertEquals(100, refresh.getPercentageComplete());
+        assertEquals(0, refresh.getInstancesToUpdate());
+        assertEquals("lt-updated", refresh.getDesiredLaunchTemplateId());
+        assertEquals("2", refresh.getDesiredLaunchTemplateVersion());
+        assertEquals(90, refresh.getMinHealthyPercentage());
+        assertEquals(120, refresh.getMaxHealthyPercentage());
+        assertEquals(200, refresh.getInstanceWarmup());
+        assertEquals(Boolean.TRUE, refresh.getSkipMatching());
+        assertEquals(Boolean.TRUE, refresh.getAutoRollback());
+        assertEquals(List.of(50, 100), refresh.getCheckpointPercentages());
+
+        AutoScalingService.InstanceRefreshPage page =
+                service.describeInstanceRefreshes(REGION, "test-asg", List.of(refresh.getInstanceRefreshId()), null, null);
+        assertEquals(1, page.instanceRefreshes().size());
+        assertEquals(refresh.getInstanceRefreshId(), page.instanceRefreshes().getFirst().getInstanceRefreshId());
+        assertNull(page.nextToken());
+
+        var group = service.describeAutoScalingGroups(REGION, List.of("test-asg")).getFirst();
+        assertEquals("lt-updated", group.getLaunchTemplateId());
+        assertEquals("2", group.getLaunchTemplateVersion());
+        assertNull(group.getLaunchConfigurationName());
+    }
+
+    @Test
+    void describeInstanceRefreshesPaginatesNewestFirst() {
+        InstanceRefresh first = service.startInstanceRefresh(REGION, "test-asg", new InstanceRefresh());
+        InstanceRefresh second = service.startInstanceRefresh(REGION, "test-asg", new InstanceRefresh());
+
+        AutoScalingService.InstanceRefreshPage firstPage =
+                service.describeInstanceRefreshes(REGION, "test-asg", List.of(), 1, null);
+        assertEquals(1, firstPage.instanceRefreshes().size());
+        assertEquals(second.getInstanceRefreshId(), firstPage.instanceRefreshes().getFirst().getInstanceRefreshId());
+        assertEquals("1", firstPage.nextToken());
+
+        AutoScalingService.InstanceRefreshPage secondPage =
+                service.describeInstanceRefreshes(REGION, "test-asg", List.of(), 1, firstPage.nextToken());
+        assertEquals(1, secondPage.instanceRefreshes().size());
+        assertEquals(first.getInstanceRefreshId(), secondPage.instanceRefreshes().getFirst().getInstanceRefreshId());
+        assertNull(secondPage.nextToken());
+    }
+
+    @Test
+    void startInstanceRefreshMarksActiveInstancesForReplacement() {
+        AutoScalingGroupFixture.addInstance(service, REGION, "test-asg", "i-original", "InService", "lt-original", "1");
+
+        InstanceRefresh refresh = service.startInstanceRefresh(REGION, "test-asg", new InstanceRefresh());
+
+        assertEquals("InProgress", refresh.getStatus());
+        assertEquals("Instance refresh in progress.", refresh.getStatusReason());
+        assertEquals(0, refresh.getPercentageComplete());
+        assertEquals(1, refresh.getInstancesToUpdate());
+        assertNull(refresh.getEndTime());
+
+        AsgInstance instance = service.describeAutoScalingGroups(REGION, List.of("test-asg"))
+                .getFirst()
+                .getInstances()
+                .getFirst();
+        assertEquals("Terminating", instance.getLifecycleState());
+    }
+
+    @Test
+    void startInstanceRefreshRejectsSecondRefreshWhileFirstIsActive() {
+        AutoScalingGroupFixture.addInstance(service, REGION, "test-asg", "i-original", "InService", "lt-original", "1");
+        service.startInstanceRefresh(REGION, "test-asg", new InstanceRefresh());
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.startInstanceRefresh(REGION, "test-asg", new InstanceRefresh()));
+
+        assertEquals("InstanceRefreshInProgress", error.getErrorCode());
+        assertEquals(400, error.getHttpStatus());
+    }
+
+    @Test
+    void startInstanceRefreshSkipMatchingLeavesMatchingInstancesInService() {
+        AutoScalingGroupFixture.addInstance(service, REGION, "test-asg", "i-matching", "InService", "lt-original", "1");
+        InstanceRefresh request = new InstanceRefresh();
+        request.setSkipMatching(true);
+
+        service.startInstanceRefresh(REGION, "test-asg", request);
+
+        AsgInstance instance = service.describeAutoScalingGroups(REGION, List.of("test-asg"))
+                .getFirst()
+                .getInstances()
+                .getFirst();
+        assertEquals("InService", instance.getLifecycleState());
+    }
+
+    @Test
+    void startInstanceRefreshWithLaunchTemplateAliasDoesNotSkipExistingInstances() {
+        var group = service.describeAutoScalingGroups(REGION, List.of("test-asg")).getFirst();
+        group.setLaunchTemplateVersion("$Latest");
+        AutoScalingGroupFixture.addInstance(service, REGION, "test-asg", "i-original", "InService", "lt-original", "1");
+        InstanceRefresh request = new InstanceRefresh();
+        request.setSkipMatching(true);
+
+        InstanceRefresh refresh = service.startInstanceRefresh(REGION, "test-asg", request);
+
+        assertEquals("InProgress", refresh.getStatus());
+        assertEquals(1, refresh.getInstancesToUpdate());
+        AsgInstance original = group.getInstances().getFirst();
+        assertEquals("Terminating", original.getLifecycleState());
+
+        group.getInstances().clear();
+        AutoScalingGroupFixture.addInstance(service, REGION, "test-asg", "i-replacement", "InService", "lt-original", "2");
+        service.completeInstanceRefreshIfSettled(REGION, "test-asg");
+
+        InstanceRefresh completed = service.describeInstanceRefreshes(
+                        REGION, "test-asg", List.of(refresh.getInstanceRefreshId()), null, null)
+                .instanceRefreshes()
+                .getFirst();
+        assertEquals("Successful", completed.getStatus());
+        assertEquals(0, completed.getInstancesToUpdate());
+    }
+
+    @Test
+    void startInstanceRefreshWithDefaultLaunchTemplateAliasDoesNotSkipExistingInstances() {
+        var group = service.describeAutoScalingGroups(REGION, List.of("test-asg")).getFirst();
+        group.setLaunchTemplateVersion("$Default");
+        AutoScalingGroupFixture.addInstance(service, REGION, "test-asg", "i-original", "InService", "lt-original", "1");
+        InstanceRefresh request = new InstanceRefresh();
+        request.setSkipMatching(true);
+
+        InstanceRefresh refresh = service.startInstanceRefresh(REGION, "test-asg", request);
+
+        assertEquals("InProgress", refresh.getStatus());
+        assertEquals(1, refresh.getInstancesToUpdate());
+        AsgInstance original = group.getInstances().getFirst();
+        assertEquals("Terminating", original.getLifecycleState());
+
+        group.getInstances().clear();
+        AutoScalingGroupFixture.addInstance(service, REGION, "test-asg", "i-replacement", "InService", "lt-original", "2");
+        service.completeInstanceRefreshIfSettled(REGION, "test-asg");
+
+        InstanceRefresh completed = service.describeInstanceRefreshes(
+                        REGION, "test-asg", List.of(refresh.getInstanceRefreshId()), null, null)
+                .instanceRefreshes()
+                .getFirst();
+        assertEquals("Successful", completed.getStatus());
+        assertEquals(0, completed.getInstancesToUpdate());
+    }
+
+    @Test
+    void startInstanceRefreshWithDefaultLaunchTemplateVersionDoesNotSkipExistingInstances() {
+        var group = service.describeAutoScalingGroups(REGION, List.of("test-asg")).getFirst();
+        group.setLaunchTemplateVersion(null);
+        AutoScalingGroupFixture.addInstance(service, REGION, "test-asg", "i-original", "InService", "lt-original", "1");
+        InstanceRefresh request = new InstanceRefresh();
+        request.setSkipMatching(true);
+
+        InstanceRefresh refresh = service.startInstanceRefresh(REGION, "test-asg", request);
+
+        assertEquals("InProgress", refresh.getStatus());
+        assertEquals(1, refresh.getInstancesToUpdate());
+        AsgInstance original = group.getInstances().getFirst();
+        assertEquals("Terminating", original.getLifecycleState());
+    }
+
+    @Test
+    void startInstanceRefreshWithBlankLaunchTemplateVersionDoesNotSkipExistingInstances() {
+        var group = service.describeAutoScalingGroups(REGION, List.of("test-asg")).getFirst();
+        group.setLaunchTemplateVersion("");
+        AutoScalingGroupFixture.addInstance(service, REGION, "test-asg", "i-original", "InService", "lt-original", "1");
+        InstanceRefresh request = new InstanceRefresh();
+        request.setSkipMatching(true);
+
+        InstanceRefresh refresh = service.startInstanceRefresh(REGION, "test-asg", request);
+
+        assertEquals("InProgress", refresh.getStatus());
+        assertEquals(1, refresh.getInstancesToUpdate());
+        AsgInstance original = group.getInstances().getFirst();
+        assertEquals("Terminating", original.getLifecycleState());
+    }
+
+    @Test
+    void completeInstanceRefreshMarksSettledReplacementSuccessful() {
+        AutoScalingGroupFixture.addInstance(service, REGION, "test-asg", "i-original", "InService", "lt-original", "1");
+        InstanceRefresh request = new InstanceRefresh();
+        request.setDesiredLaunchTemplateId("lt-updated");
+        request.setDesiredLaunchTemplateVersion("2");
+        InstanceRefresh refresh = service.startInstanceRefresh(REGION, "test-asg", request);
+        var group = service.describeAutoScalingGroups(REGION, List.of("test-asg")).getFirst();
+        group.getInstances().clear();
+        AutoScalingGroupFixture.addInstance(service, REGION, "test-asg", "i-replacement", "InService", "lt-updated", "2");
+
+        service.completeInstanceRefreshIfSettled(REGION, "test-asg");
+
+        InstanceRefresh completed = service.describeInstanceRefreshes(
+                        REGION, "test-asg", List.of(refresh.getInstanceRefreshId()), null, null)
+                .instanceRefreshes()
+                .getFirst();
+        assertEquals("Successful", completed.getStatus());
+        assertEquals(100, completed.getPercentageComplete());
+        assertEquals(0, completed.getInstancesToUpdate());
+        assertNotNull(completed.getEndTime());
+    }
+
+    @Test
+    void completeInstanceRefreshWaitsForReplacementCapacity() {
+        AutoScalingGroupFixture.addInstance(service, REGION, "test-asg", "i-original", "InService", "lt-original", "1");
+        InstanceRefresh refresh = service.startInstanceRefresh(REGION, "test-asg", new InstanceRefresh());
+        var group = service.describeAutoScalingGroups(REGION, List.of("test-asg")).getFirst();
+        group.getInstances().clear();
+
+        service.completeInstanceRefreshIfSettled(REGION, "test-asg");
+
+        InstanceRefresh inProgress = service.describeInstanceRefreshes(
+                        REGION, "test-asg", List.of(refresh.getInstanceRefreshId()), null, null)
+                .instanceRefreshes()
+                .getFirst();
+        assertEquals("InProgress", inProgress.getStatus());
+        assertEquals(0, inProgress.getPercentageComplete());
+        assertEquals(1, inProgress.getInstancesToUpdate());
+        assertNull(inProgress.getEndTime());
+    }
+
+    @Test
+    void deleteAutoScalingGroupWithoutForceRejectsActiveInstances() {
+        AutoScalingGroupFixture.addInstance(service, REGION, "test-asg", "i-active", "InService", "lt-original", "1");
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.deleteAutoScalingGroup(REGION, "test-asg", false));
+
+        assertEquals("ResourceInUse", error.getErrorCode());
+    }
+
+    @Test
+    void forceDeleteAutoScalingGroupTerminatesActiveEc2Instances() {
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        service.ec2Service = ec2Service;
+        AutoScalingGroupFixture.addInstance(service, REGION, "test-asg", "i-active", "InService", "lt-original", "1");
+        AutoScalingGroupFixture.addInstance(service, REGION, "test-asg", "i-terminated", "Terminated", "lt-original", "1");
+
+        service.deleteAutoScalingGroup(REGION, "test-asg", true);
+
+        verify(ec2Service).terminateInstances(REGION, List.of("i-active"));
+        assertTrue(service.describeAutoScalingGroups(REGION, List.of("test-asg")).isEmpty());
+    }
+
+    @Test
+    void forceDeleteAutoScalingGroupIgnoresStaleEc2Membership() {
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        service.ec2Service = ec2Service;
+        AutoScalingGroupFixture.addInstance(service, REGION, "test-asg", "i-stale", "InService", "lt-original", "1");
+        doThrow(new AwsException("InvalidInstanceID.NotFound", "Instance i-stale was not found.", 400))
+                .when(ec2Service)
+                .terminateInstances(REGION, List.of("i-stale"));
+
+        service.deleteAutoScalingGroup(REGION, "test-asg", true);
+
+        verify(ec2Service).terminateInstances(REGION, List.of("i-stale"));
+        assertTrue(service.describeAutoScalingGroups(REGION, List.of("test-asg")).isEmpty());
+    }
+
+    private static final class AutoScalingGroupFixture {
+        private static void addInstance(AutoScalingService service, String region, String name, String instanceId,
+                String lifecycleState, String launchTemplateId, String launchTemplateVersion) {
+            AsgInstance instance = new AsgInstance();
+            instance.setInstanceId(instanceId);
+            instance.setLifecycleState(lifecycleState);
+            instance.setHealthStatus("Healthy");
+            instance.setLaunchTemplateId(launchTemplateId);
+            instance.setLaunchTemplateVersion(launchTemplateVersion);
+            service.describeAutoScalingGroups(region, List.of(name))
+                    .getFirst()
+                    .getInstances()
+                    .add(instance);
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
@@ -1,0 +1,436 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.command.CopyArchiveToContainerCmd;
+import com.github.dockerjava.api.command.ExecCreateCmd;
+import com.github.dockerjava.api.command.ExecCreateCmdResponse;
+import com.github.dockerjava.api.command.ExecStartCmd;
+import com.github.dockerjava.api.command.InspectContainerCmd;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.command.InspectExecCmd;
+import com.github.dockerjava.api.command.InspectExecResponse;
+import com.github.dockerjava.api.model.ContainerNetwork;
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.api.model.NetworkSettings;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
+import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
+import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
+import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
+import io.github.hectorvent.floci.core.common.docker.DockerHostResolver;
+import io.github.hectorvent.floci.core.common.docker.PortAllocator;
+import io.github.hectorvent.floci.services.ec2.model.Instance;
+import io.github.hectorvent.floci.services.ec2.model.InstanceNetworkInterface;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Answers.RETURNS_SELF;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+class Ec2ContainerManagerTest {
+
+    @org.junit.jupiter.api.AfterEach
+    void resetBridgeIpPolling() {
+        Ec2ContainerManager.containerBridgeIpAttempts = 30;
+        Ec2ContainerManager.containerBridgeIpPollMillis = 500;
+    }
+
+    @Test
+    void exposeReachablePrivateAddressUpdatesInstanceAndAttachedNetworkInterfaces() {
+        Instance instance = new Instance();
+        instance.setPrivateIpAddress("10.82.32.10");
+        instance.setPrivateDnsName("ip-10-82-32-10.ec2.internal");
+
+        InstanceNetworkInterface networkInterface = new InstanceNetworkInterface();
+        networkInterface.setPrivateIpAddress("10.82.32.10");
+        networkInterface.setPrivateDnsName("ip-10-82-32-10.ec2.internal");
+        instance.setNetworkInterfaces(List.of(networkInterface));
+
+        Ec2ContainerManager.exposeReachablePrivateAddress(instance, "192.168.215.21");
+
+        assertEquals("192.168.215.21", instance.getPrivateIpAddress());
+        assertEquals("ip-192-168-215-21.ec2.internal", instance.getPrivateDnsName());
+        assertEquals("192.168.215.21", networkInterface.getPrivateIpAddress());
+        assertEquals("ip-192-168-215-21.ec2.internal", networkInterface.getPrivateDnsName());
+    }
+
+    @Test
+    void restoreMetadataRegistrationRegistersRunningPersistedContainer() {
+        ContainerLifecycleManager lifecycleManager = mock(ContainerLifecycleManager.class);
+        when(lifecycleManager.isContainerRunning("container-1")).thenReturn(true);
+
+        DockerClient dockerClient = mock(DockerClient.class);
+        InspectContainerCmd inspect = mock(InspectContainerCmd.class);
+        InspectContainerResponse response = inspectResponse("192.168.215.42");
+        when(dockerClient.inspectContainerCmd("container-1")).thenReturn(inspect);
+        when(inspect.exec()).thenReturn(response);
+
+        Ec2MetadataServer metadataServer = mock(Ec2MetadataServer.class);
+        Ec2ContainerManager manager = new Ec2ContainerManager(
+                mock(ContainerBuilder.class),
+                lifecycleManager,
+                mock(ContainerLogStreamer.class),
+                mock(ContainerDetector.class),
+                mock(DockerHostResolver.class),
+                dockerClient,
+                mock(PortAllocator.class),
+                mock(EmulatorConfig.class),
+                metadataServer);
+
+        Instance instance = new Instance();
+        instance.setInstanceId("i-restored");
+        instance.setDockerContainerId("container-1");
+        instance.setContainerBridgeIp("192.168.215.7");
+
+        assertTrue(manager.restoreMetadataRegistration(instance));
+
+        assertEquals("192.168.215.42", instance.getContainerBridgeIp());
+        assertEquals("192.168.215.42", instance.getPrivateIpAddress());
+        verify(metadataServer).unregisterContainer("192.168.215.7", instance);
+        verify(metadataServer).registerContainer("192.168.215.42", "i-restored", instance);
+    }
+
+    @Test
+    void userDataExecutionCommandRunsScriptDirectlySoShebangIsHonored() {
+        assertArrayEquals(new String[]{"/tmp/user-data.sh"}, Ec2ContainerManager.userDataExecutionCommand());
+    }
+
+    @Test
+    void userDataShellScriptsPreservesRawShellScript() {
+        String script = "#!/bin/bash\nset -euo pipefail\necho ready\n";
+
+        assertEquals(List.of(script), Ec2ContainerManager.userDataShellScripts(script));
+    }
+
+    @Test
+    void userDataShellScriptsExtractsMimeShellscriptPartsInOrder() {
+        String userData = """
+                Content-Type: multipart/mixed; boundary="==SAMPLE-CLOUD-INIT=="
+                MIME-Version: 1.0
+
+                --==SAMPLE-CLOUD-INIT==
+                Content-Type: text/cloud-config; charset="us-ascii"
+
+                #cloud-config
+
+                --==SAMPLE-CLOUD-INIT==
+                Content-Type: text/x-shellscript; charset="us-ascii"
+
+                #!/bin/bash
+                echo first
+
+                --==SAMPLE-CLOUD-INIT==
+                Content-Type: text/x-shellscript
+
+                #!/bin/sh
+                echo second
+
+                --==SAMPLE-CLOUD-INIT==--
+                """;
+
+        assertEquals(
+                List.of(
+                        "#!/bin/bash\necho first\n",
+                        "#!/bin/sh\necho second\n"),
+                Ec2ContainerManager.userDataShellScripts(userData));
+    }
+
+    @Test
+    void userDataShellScriptsIgnoresCloudConfigWithoutShellscript() {
+        String userData = """
+                Content-Type: multipart/mixed; boundary=cloudinit
+                MIME-Version: 1.0
+
+                --cloudinit
+                Content-Type: text/cloud-config
+
+                #cloud-config
+
+                --cloudinit--
+                """;
+
+        assertTrue(Ec2ContainerManager.userDataShellScripts(userData).isEmpty());
+    }
+
+    @Test
+    void metadataProxyInstallCommandInstallsLinkLocalProxyDependencies() {
+        String[] command = Ec2ContainerManager.metadataProxyInstallCommand();
+
+        assertEquals("sh", command[0]);
+        assertTrue(command[2].contains("iproute2"));
+        assertTrue(command[2].contains("socat"));
+        assertTrue(command[2].contains("curl"));
+    }
+
+    @Test
+    void metadataProxyStartCommandBindsAwsLinkLocalMetadataAddress() {
+        String[] command = Ec2ContainerManager.metadataProxyStartCommand("floci", 9169);
+
+        assertEquals("sh", command[0]);
+        assertTrue(command[2].contains("169.254.169.254/32"));
+        assertTrue(command[2].contains("TCP-LISTEN:80,bind=169.254.169.254"));
+        assertTrue(command[2].contains("TCP:floci:9169"));
+        assertTrue(command[2].contains("http://169.254.169.254/latest/meta-data/instance-id"));
+    }
+
+    @Test
+    void localAwsEnvironmentProvidesCliCredentialsAndFlociEndpoint() {
+        assertEquals(
+                java.util.List.of(
+                        "AWS_EC2_METADATA_SERVICE_ENDPOINT=http://floci:9169",
+                        "AWS_ENDPOINT_URL=http://floci:4566",
+                        "AWS_DEFAULT_REGION=us-west-2",
+                        "AWS_REGION=us-west-2",
+                        "AWS_ACCESS_KEY_ID=test",
+                        "AWS_SECRET_ACCESS_KEY=test",
+                        "AWS_SESSION_TOKEN=test-session-token"),
+                Ec2ContainerManager.localAwsEnvironment(
+                        "us-west-2",
+                        "http://floci:4566",
+                        "http://floci:9169"));
+    }
+
+    @Test
+    void preferredMetadataSourceIpUsesConfiguredNetworkBeforeBridge() {
+        ContainerNetwork bridge = new ContainerNetwork();
+        bridge.withIpv4Address("172.17.0.8");
+        ContainerNetwork floci = new ContainerNetwork();
+        floci.withIpv4Address("192.168.215.10");
+
+        assertEquals(
+                "192.168.215.10",
+                Ec2ContainerManager.preferredMetadataSourceIp(Map.of(
+                        "bridge", bridge,
+                        "custom-floci-network", floci)).orElseThrow());
+    }
+
+    @Test
+    void preferredMetadataSourceIpFallsBackToBridge() {
+        ContainerNetwork bridge = new ContainerNetwork();
+        bridge.withIpv4Address("172.17.0.8");
+
+        assertEquals(
+                "172.17.0.8",
+                Ec2ContainerManager.preferredMetadataSourceIp(Map.of("bridge", bridge)).orElseThrow());
+    }
+
+    @Test
+    void preferredMetadataSourceIpIsEmptyWithoutUsableAddress() {
+        ContainerNetwork bridge = new ContainerNetwork();
+
+        assertTrue(Ec2ContainerManager.preferredMetadataSourceIp(Map.of("bridge", bridge)).isEmpty());
+    }
+
+    @Test
+    void launchWaitsForContainerBridgeIpBeforeRegisteringImds() throws Exception {
+        Ec2ContainerManager.containerBridgeIpAttempts = 3;
+        Ec2ContainerManager.containerBridgeIpPollMillis = 1;
+        LaunchHarness harness = launchHarness();
+        InspectContainerCmd inspect = mock(InspectContainerCmd.class);
+        InspectContainerResponse noIp = inspectResponse(null);
+        InspectContainerResponse withIp = inspectResponse("172.18.0.9");
+        when(harness.dockerClient.inspectContainerCmd("container-1")).thenReturn(inspect);
+        when(inspect.exec()).thenReturn(noIp).thenReturn(withIp);
+        harness.stubSuccessfulExecs(new CountDownLatch(0), new CountDownLatch(0));
+
+        Instance instance = instance("i-waitip");
+
+        harness.manager.launch(instance, "ubuntu:24.04", null, "us-west-2");
+
+        awaitUntil(() -> "running".equals(instance.getState().getName()), Duration.ofSeconds(2));
+        assertEquals("container-1", instance.getDockerContainerId());
+        assertEquals("172.18.0.9", instance.getContainerBridgeIp());
+        assertEquals("172.18.0.9", instance.getPrivateIpAddress());
+        verify(inspect, times(2)).exec();
+        verify(harness.metadataServer).registerContainer("172.18.0.9", "i-waitip", instance);
+    }
+
+    @Test
+    void launchTerminatesWhenContainerBridgeIpNeverAppears() throws Exception {
+        Ec2ContainerManager.containerBridgeIpAttempts = 2;
+        Ec2ContainerManager.containerBridgeIpPollMillis = 1;
+        LaunchHarness harness = launchHarness();
+        InspectContainerCmd inspect = mock(InspectContainerCmd.class);
+        InspectContainerResponse noIp = inspectResponse(null);
+        when(harness.dockerClient.inspectContainerCmd("container-1")).thenReturn(inspect);
+        when(inspect.exec()).thenReturn(noIp);
+
+        Instance instance = instance("i-noip");
+
+        harness.manager.launch(instance, "ubuntu:24.04", null, "us-west-2");
+
+        awaitUntil(() -> "terminated".equals(instance.getState().getName()), Duration.ofSeconds(2));
+        assertEquals("container-1", instance.getDockerContainerId());
+        verify(harness.metadataServer, never()).registerContainer(anyString(), anyString(), any());
+    }
+
+    @Test
+    void launchMarksInstanceRunningBeforeUserDataCompletes() throws Exception {
+        Ec2ContainerManager.containerBridgeIpAttempts = 2;
+        Ec2ContainerManager.containerBridgeIpPollMillis = 1;
+        LaunchHarness harness = launchHarness();
+        InspectContainerCmd inspect = mock(InspectContainerCmd.class);
+        InspectContainerResponse withIp = inspectResponse("172.18.0.10");
+        when(harness.dockerClient.inspectContainerCmd("container-1")).thenReturn(inspect);
+        when(inspect.exec()).thenReturn(withIp);
+        CountDownLatch userDataStarted = new CountDownLatch(1);
+        CountDownLatch finishUserData = new CountDownLatch(1);
+        harness.stubSuccessfulExecs(userDataStarted, finishUserData);
+        Instance instance = instance("i-userdata");
+        instance.setUserData("#!/bin/sh\necho ready\n");
+
+        harness.manager.launch(instance, "ubuntu:24.04", null, "us-west-2");
+
+        assertTrue(userDataStarted.await(2, TimeUnit.SECONDS), "user data should start");
+        assertEquals("running", instance.getState().getName());
+        assertFalse(finishUserData.await(10, TimeUnit.MILLISECONDS), "user data should still be blocked");
+        finishUserData.countDown();
+        awaitUntil(() -> "running".equals(instance.getState().getName()), Duration.ofSeconds(2));
+    }
+
+    private static LaunchHarness launchHarness() {
+        ContainerBuilder containerBuilder = mock(ContainerBuilder.class);
+        ContainerBuilder.Builder builder = mock(ContainerBuilder.Builder.class, withSettings().defaultAnswer(RETURNS_SELF));
+        when(containerBuilder.newContainer(anyString())).thenReturn(builder);
+        when(builder.build()).thenReturn(new ContainerSpec("ubuntu:24.04"));
+
+        ContainerLifecycleManager lifecycleManager = mock(ContainerLifecycleManager.class);
+        when(lifecycleManager.create(any(ContainerSpec.class))).thenReturn("container-1");
+        when(lifecycleManager.isContainerRunning("container-1")).thenReturn(true);
+
+        DockerHostResolver dockerHostResolver = mock(DockerHostResolver.class);
+        when(dockerHostResolver.resolve()).thenReturn("floci");
+        PortAllocator portAllocator = mock(PortAllocator.class);
+        when(portAllocator.allocate(anyInt(), anyInt())).thenReturn(2201);
+
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.Ec2ServiceConfig ec2 = mock(EmulatorConfig.Ec2ServiceConfig.class);
+        when(config.services()).thenReturn(services);
+        when(services.ec2()).thenReturn(ec2);
+        when(ec2.sshPortRangeStart()).thenReturn(2200);
+        when(ec2.sshPortRangeEnd()).thenReturn(2299);
+        when(ec2.imdsPort()).thenReturn(9169);
+
+        DockerClient dockerClient = mock(DockerClient.class);
+        Ec2MetadataServer metadataServer = mock(Ec2MetadataServer.class);
+        Ec2ContainerManager manager = new Ec2ContainerManager(
+                containerBuilder,
+                lifecycleManager,
+                mock(ContainerLogStreamer.class),
+                mock(ContainerDetector.class),
+                dockerHostResolver,
+                dockerClient,
+                portAllocator,
+                config,
+                metadataServer);
+        return new LaunchHarness(manager, dockerClient, metadataServer);
+    }
+
+    private static Instance instance(String instanceId) {
+        Instance instance = new Instance();
+        instance.setInstanceId(instanceId);
+        return instance;
+    }
+
+    private static InspectContainerResponse inspectResponse(String ipAddress) {
+        InspectContainerResponse inspect = mock(InspectContainerResponse.class);
+        NetworkSettings networkSettings = mock(NetworkSettings.class);
+        when(inspect.getNetworkSettings()).thenReturn(networkSettings);
+        if (ipAddress != null) {
+            ContainerNetwork bridge = new ContainerNetwork().withIpv4Address(ipAddress);
+            when(networkSettings.getNetworks()).thenReturn(Map.of("bridge", bridge));
+        }
+        return inspect;
+    }
+
+    private static void awaitUntil(BooleanSupplier condition, Duration timeout) throws InterruptedException {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (System.nanoTime() < deadline) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            Thread.sleep(10);
+        }
+        assertTrue(condition.getAsBoolean(), "condition was not met before timeout");
+    }
+
+    private record LaunchHarness(Ec2ContainerManager manager,
+                                 DockerClient dockerClient,
+                                 Ec2MetadataServer metadataServer) {
+        void stubSuccessfulExecs(CountDownLatch userDataStarted, CountDownLatch finishUserData) throws Exception {
+            AtomicReference<String[]> currentCommand = new AtomicReference<>();
+            ExecCreateCmd execCreate = mock(ExecCreateCmd.class, withSettings().defaultAnswer(RETURNS_SELF));
+            ExecCreateCmdResponse metadataExec = mock(ExecCreateCmdResponse.class);
+            ExecCreateCmdResponse userDataExec = mock(ExecCreateCmdResponse.class);
+            when(metadataExec.getId()).thenReturn("metadata-exec");
+            when(userDataExec.getId()).thenReturn("userdata-exec");
+            when(dockerClient.execCreateCmd("container-1")).thenReturn(execCreate);
+            when(execCreate.withCmd(any(String[].class))).thenAnswer(invocation -> {
+                Object[] args = invocation.getArguments();
+                if (args.length == 1 && args[0] instanceof String[] command) {
+                    currentCommand.set(command);
+                } else {
+                    currentCommand.set(Arrays.copyOf(args, args.length, String[].class));
+                }
+                return execCreate;
+            });
+            when(execCreate.exec()).thenAnswer(invocation -> {
+                String[] command = currentCommand.get();
+                if (command != null && command.length == 1 && "/tmp/user-data.sh".equals(command[0])) {
+                    return userDataExec;
+                }
+                return metadataExec;
+            });
+
+            when(dockerClient.execStartCmd(anyString())).thenAnswer(invocation -> {
+                String execId = invocation.getArgument(0);
+                ExecStartCmd execStart = mock(ExecStartCmd.class);
+                when(execStart.exec(any())).thenAnswer(startInvocation -> {
+                    @SuppressWarnings("unchecked")
+                    ResultCallback<Frame> callback = startInvocation.getArgument(0);
+                    if ("userdata-exec".equals(execId)) {
+                        userDataStarted.countDown();
+                        finishUserData.await(2, TimeUnit.SECONDS);
+                    }
+                    callback.onComplete();
+                    return callback;
+                });
+                return execStart;
+            });
+
+            InspectExecCmd inspectExec = mock(InspectExecCmd.class);
+            InspectExecResponse inspectExecResponse = mock(InspectExecResponse.class);
+            when(inspectExecResponse.getExitCodeLong()).thenReturn(0L);
+            when(inspectExec.exec()).thenReturn(inspectExecResponse);
+            when(dockerClient.inspectExecCmd(anyString())).thenReturn(inspectExec);
+
+            CopyArchiveToContainerCmd copy = mock(CopyArchiveToContainerCmd.class, withSettings().defaultAnswer(RETURNS_SELF));
+            when(dockerClient.copyArchiveToContainerCmd("container-1")).thenReturn(copy);
+            when(copy.withTarInputStream(any(InputStream.class))).thenReturn(copy);
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -646,6 +646,11 @@ class Ec2IntegrationTest {
             .formParam("LaunchTemplateData.KeyName", "test-key")
             .formParam("LaunchTemplateData.SecurityGroupId.1", securityGroupId)
             .formParam("LaunchTemplateData.UserData", gzipBase64("#!/bin/sh\necho launch-template\n"))
+            .formParam("LaunchTemplateData.TagSpecification.1.ResourceType", "instance")
+            .formParam("LaunchTemplateData.TagSpecification.1.Tag.1.Key", "example:ClusterId")
+            .formParam("LaunchTemplateData.TagSpecification.1.Tag.1.Value", "sample-template")
+            .formParam("LaunchTemplateData.TagSpecification.1.Tag.2.Key", "example:NodeType")
+            .formParam("LaunchTemplateData.TagSpecification.1.Tag.2.Value", "COORDINATOR")
             .formParam("TagSpecification.1.ResourceType", "launch-template")
             .formParam("TagSpecification.1.Tag.1.Key", "Name")
             .formParam("TagSpecification.1.Tag.1.Value", "sample-template")
@@ -696,7 +701,13 @@ class Ec2IntegrationTest {
             .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.instanceType",
                     equalTo("t3.micro"))
             .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.userData",
-                    equalTo("#!/bin/sh\necho launch-template\n"));
+                    equalTo("#!/bin/sh\necho launch-template\n"))
+            .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.tagSpecificationSet.item.resourceType",
+                    equalTo("instance"))
+            .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.tagSpecificationSet.item.tagSet.item.find { it.key == 'example:ClusterId' }.value",
+                    equalTo("sample-template"))
+            .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.tagSpecificationSet.item.tagSet.item.find { it.key == 'example:NodeType' }.value",
+                    equalTo("COORDINATOR"));
     }
 
     @Test
@@ -713,6 +724,9 @@ class Ec2IntegrationTest {
             .formParam("LaunchTemplateData.KeyName", "test-key")
             .formParam("LaunchTemplateData.SecurityGroupId.1", securityGroupId)
             .formParam("LaunchTemplateData.UserData", gzipBase64("#!/bin/sh\necho launch-template-version\n"))
+            .formParam("LaunchTemplateData.TagSpecification.1.ResourceType", "instance")
+            .formParam("LaunchTemplateData.TagSpecification.1.Tag.1.Key", "example:NodeType")
+            .formParam("LaunchTemplateData.TagSpecification.1.Tag.1.Value", "WORKER")
             .header("Authorization", AUTH_HEADER)
         .when()
             .post("/")
@@ -727,7 +741,9 @@ class Ec2IntegrationTest {
             .body("CreateLaunchTemplateVersionResponse.launchTemplateVersion.launchTemplateData.instanceType",
                     equalTo("t3.small"))
             .body("CreateLaunchTemplateVersionResponse.launchTemplateVersion.launchTemplateData.userData",
-                    equalTo("#!/bin/sh\necho launch-template-version\n"));
+                    equalTo("#!/bin/sh\necho launch-template-version\n"))
+            .body("CreateLaunchTemplateVersionResponse.launchTemplateVersion.launchTemplateData.tagSpecificationSet.item.tagSet.item.find { it.key == 'example:NodeType' }.value",
+                    equalTo("WORKER"));
 
         given()
             .formParam("Action", "DescribeLaunchTemplateVersions")
@@ -743,7 +759,11 @@ class Ec2IntegrationTest {
             .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.defaultVersion",
                     equalTo("true"))
             .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.instanceType",
-                    equalTo("t3.micro"));
+                    equalTo("t3.micro"))
+            .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.userData",
+                    equalTo("#!/bin/sh\necho launch-template\n"))
+            .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.tagSpecificationSet.item.tagSet.item.find { it.key == 'example:NodeType' }.value",
+                    equalTo("COORDINATOR"));
     }
 
     @Test
@@ -1246,6 +1266,8 @@ class Ec2IntegrationTest {
             .formParam("Action", "DescribeInstances")
             .formParam("Filter.1.Name", "instance-state-name")
             .formParam("Filter.1.Value.1", "running")
+            .formParam("Filter.2.Name", "instance-id")
+            .formParam("Filter.2.Value.1", instanceId)
             .header("Authorization", AUTH_HEADER)
         .when()
             .post("/")
@@ -1337,9 +1359,10 @@ class Ec2IntegrationTest {
     @Test
     @Order(79)
     void describeNetworkInterfacesBeforeRun() {
-        // Before any instances exist, the set should be empty
         given()
             .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("Filter.1.Name", "attachment.instance-id")
+            .formParam("Filter.1.Value.1", "i-00000000000000000")
             .header("Authorization", AUTH_HEADER)
         .when()
             .post("/")
@@ -1354,13 +1377,15 @@ class Ec2IntegrationTest {
     void describeNetworkInterfacesAfterRun() {
         networkInterfaceId = given()
             .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("Filter.1.Name", "attachment.instance-id")
+            .formParam("Filter.1.Value.1", instanceId)
             .header("Authorization", AUTH_HEADER)
         .when()
             .post("/")
         .then()
             .statusCode(200)
             .contentType("application/xml")
-            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item.size()", greaterThanOrEqualTo(1))
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item.size()", equalTo(1))
             .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].networkInterfaceId",
                     startsWith("eni-"))
             .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].vpcId", notNullValue())
@@ -1373,7 +1398,7 @@ class Ec2IntegrationTest {
             .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].attachment.deviceIndex",
                     equalTo("0"))
             .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].attachment.instanceId",
-                    notNullValue())
+                    equalTo(instanceId))
             .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].groupSet.item.size()",
                     greaterThanOrEqualTo(1))
             .extract().path("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].networkInterfaceId");
@@ -1576,13 +1601,15 @@ class Ec2IntegrationTest {
             .formParam("Action", "DescribeNetworkInterfaces")
             .formParam("Filter.1.Name", "status")
             .formParam("Filter.1.Value.1", "in-use")
+            .formParam("Filter.2.Name", "attachment.instance-id")
+            .formParam("Filter.2.Value.1", instanceId)
             .header("Authorization", AUTH_HEADER)
         .when()
             .post("/")
         .then()
             .statusCode(200)
             .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item.size()",
-                    greaterThanOrEqualTo(1))
+                    equalTo(1))
             .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].status",
                     equalTo("in-use"));
     }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2MetadataServerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2MetadataServerTest.java
@@ -1,0 +1,67 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import io.github.hectorvent.floci.services.ec2.model.Instance;
+import io.github.hectorvent.floci.services.ec2.model.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Ec2MetadataServerTest {
+
+    @Test
+    void instanceMetadataListsTagKeys() {
+        Instance instance = new Instance();
+        instance.setTags(List.of(
+                new Tag("Environment", "dev"),
+                new Tag("Service", "orders")));
+
+        assertEquals("Environment\nService", Ec2MetadataServer.instanceTagKeys(instance));
+    }
+
+    @Test
+    void instanceMetadataReturnsTagValue() {
+        Instance instance = new Instance();
+        instance.setTags(List.of(
+                new Tag("Environment", "dev"),
+                new Tag("Service", "orders")));
+
+        assertEquals("orders", Ec2MetadataServer.instanceTagValue(instance, "Service").orElseThrow());
+    }
+
+    @Test
+    void instanceMetadataReturnsEmptyValueForEmptyTag() {
+        Instance instance = new Instance();
+        instance.setTags(List.of(new Tag("Owner", null)));
+
+        assertTrue(Ec2MetadataServer.instanceTagValue(instance, "Owner").isPresent());
+        assertEquals("", Ec2MetadataServer.instanceTagValue(instance, "Owner").orElseThrow());
+    }
+
+    @Test
+    void instanceMetadataReturnsMissingForUnknownTag() {
+        Instance instance = new Instance();
+        instance.setTags(List.of(new Tag("Environment", "dev")));
+
+        assertTrue(Ec2MetadataServer.instanceTagValue(instance, "Missing").isEmpty());
+    }
+
+    @Test
+    void staleContainerUnregisterDoesNotRemoveCurrentRegistration() {
+        Ec2MetadataServer server = new Ec2MetadataServer(null, null);
+        Instance oldInstance = new Instance();
+        oldInstance.setInstanceId("i-old");
+        Instance currentInstance = new Instance();
+        currentInstance.setInstanceId("i-current");
+
+        server.registerContainer("192.168.215.7", oldInstance.getInstanceId(), oldInstance);
+        server.registerContainer("192.168.215.7", currentInstance.getInstanceId(), currentInstance);
+        server.unregisterContainer("192.168.215.7", oldInstance);
+
+        assertEquals(
+                currentInstance,
+                server.registeredContainer("192.168.215.7").orElseThrow());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2Phase2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2Phase2IntegrationTest.java
@@ -33,6 +33,7 @@ class Ec2Phase2IntegrationTest {
 
     private static String instanceWithUserData;
     private static String instanceWithProfile;
+    private static String instanceWithProfileName;
     private static String instanceForTerminate;
     private static String importedKeyName = "phase2-imported-key";
 
@@ -117,6 +118,46 @@ class Ec2Phase2IntegrationTest {
                     equalTo(instanceWithProfile))
             .body("DescribeInstancesResponse.reservationSet.item.instancesSet.item.instanceState.name",
                     equalTo("running"));
+    }
+
+    @Test
+    @Order(12)
+    void runInstancesWithIamInstanceProfileName() {
+        String profileName = "my-app-profile";
+
+        instanceWithProfileName = given()
+            .formParam("Action", "RunInstances")
+            .formParam("ImageId", "ami-ubuntu2204")
+            .formParam("InstanceType", "t3.micro")
+            .formParam("MinCount", "1")
+            .formParam("MaxCount", "1")
+            .formParam("IamInstanceProfile.Name", profileName)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("RunInstancesResponse.instancesSet.item.instanceId", startsWith("i-"))
+            .body("RunInstancesResponse.instancesSet.item.iamInstanceProfile.arn",
+                    equalTo("arn:aws:iam::000000000000:instance-profile/" + profileName))
+            .extract().path("RunInstancesResponse.instancesSet.item.instanceId");
+    }
+
+    @Test
+    @Order(13)
+    void describeInstanceWithProfileName() {
+        given()
+            .formParam("Action", "DescribeInstances")
+            .formParam("InstanceId.1", instanceWithProfileName)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeInstancesResponse.reservationSet.item.instancesSet.item.instanceId",
+                    equalTo(instanceWithProfileName))
+            .body("DescribeInstancesResponse.reservationSet.item.instancesSet.item.iamInstanceProfile.arn",
+                    equalTo("arn:aws:iam::000000000000:instance-profile/my-app-profile"));
     }
 
     // ─── SSH key import ────────────────────────────────────────────────────────

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -1,0 +1,86 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.ec2.model.LaunchTemplate;
+import io.github.hectorvent.floci.services.ec2.model.Reservation;
+import io.github.hectorvent.floci.services.ec2.model.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class Ec2ServiceTest {
+
+    @Test
+    void mockModeTreatsExistingNonTerminatedInstanceAsRunningContainer() {
+        Ec2ContainerManager containerManager = mock(Ec2ContainerManager.class);
+        Ec2Service service = new Ec2Service(mockConfig(true), containerManager,
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new InMemoryStorageFactory());
+        Reservation reservation = service.runInstances("us-east-1", "ami-1234567890abcdef0", "t3.micro",
+                1, 1, null, List.of(), null, null, List.of(), null, null);
+        String instanceId = reservation.getInstances().getFirst().getInstanceId();
+
+        assertTrue(service.isInstanceContainerRunning(instanceId));
+        service.terminateInstances("us-east-1", List.of(instanceId));
+        assertFalse(service.isInstanceContainerRunning(instanceId));
+        verifyNoInteractions(containerManager);
+    }
+
+    @Test
+    void launchTemplateVersionInheritsOmittedFieldsFromRequestedSourceVersion() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new InMemoryStorageFactory());
+        LaunchTemplate template = service.createLaunchTemplate("us-east-1", "app-template",
+                "ami-source", "t3.micro", "app-key", List.of("sg-source"),
+                "source-user-data", List.of(), List.of(new Tag("Role", "source")));
+
+        service.createLaunchTemplateVersion("us-east-1", template.getLaunchTemplateId(), null,
+                "1", null, "t3.small", null, List.of(), null, List.of());
+
+        LaunchTemplate version = service.describeLaunchTemplateVersions(
+                "us-east-1", template.getLaunchTemplateId(), null, List.of("2")).getFirst();
+        assertEquals("ami-source", version.getImageId());
+        assertEquals("t3.small", version.getInstanceType());
+        assertEquals("app-key", version.getKeyName());
+        assertEquals(List.of("sg-source"), version.getSecurityGroupIds());
+        assertEquals("source-user-data", version.getUserData());
+        assertEquals("2", version.getLatestVersionNumber());
+        assertEquals(1, version.getInstanceTags().size());
+        assertEquals("Role", version.getInstanceTags().getFirst().getKey());
+        assertEquals("source", version.getInstanceTags().getFirst().getValue());
+    }
+
+    private static EmulatorConfig mockConfig(boolean ec2Mock) {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.Ec2ServiceConfig ec2 = mock(EmulatorConfig.Ec2ServiceConfig.class);
+        when(config.defaultAccountId()).thenReturn("000000000000");
+        when(config.services()).thenReturn(services);
+        when(services.ec2()).thenReturn(ec2);
+        when(ec2.mock()).thenReturn(ec2Mock);
+        return config;
+    }
+
+    private static final class InMemoryStorageFactory extends StorageFactory {
+        private InMemoryStorageFactory() {
+            super(null, null);
+        }
+
+        @Override
+        public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+                                                    TypeReference<Map<String, V>> typeReference) {
+            return new InMemoryStorage<>();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- reconcile Auto Scaling desired capacity by launching and terminating EC2 instances
- add instance refresh state and replacement flow support
- align EC2 instance runtime behavior used by the reconciler, including container liveness and metadata restoration
- keep CloudFormation ASG provisioning wired to the expanded Auto Scaling service shape

## Tests
- ./mvnw -Dtest='AutoScalingQueryHandlerTest,AutoScalingReconcilerTest,AutoScalingServiceTest,AutoScalingIntegrationTest,Ec2ContainerManagerTest,Ec2MetadataServerTest,Ec2ServiceTest,Ec2IntegrationTest,Ec2Phase2IntegrationTest' test