### PR TITLE
fix(cognito): add missing UserPoolClient validation

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -304,30 +304,52 @@ public class CognitoService {
             Boolean enableTokenRevocation) {
         describeUserPool(userPoolId);
         String clientId = UUID.randomUUID().toString().replace("-", "").substring(0, 26);
+        List<String> normalizedAllowedOAuthFlows = normalizeStringList(allowedOAuthFlows);
+        List<String> normalizedAllowedOAuthScopes = normalizeStringList(allowedOAuthScopes);
+        List<String> normalizedCallbackUrls = normalizeStringList(callbackURLs);
+        String normalizedDefaultRedirectUri = normalizeOptionalString(defaultRedirectURI);
+        List<String> normalizedExplicitAuthFlows = normalizeStringList(explicitAuthFlows);
+        List<String> normalizedLogoutUrls = normalizeStringList(logoutURLs);
+        List<String> normalizedReadAttributes = normalizeStringList(readAttributes);
+        List<String> normalizedSupportedIdentityProviders = normalizeStringList(supportedIdentityProviders);
+        Map<String, String> copiedTokenValidityUnits = copyStringMap(tokenValidityUnits);
+        List<String> normalizedWriteAttributes = normalizeStringList(writeAttributes);
+
+        validateUserPoolClientConfiguration(
+                allowedOAuthFlowsUserPoolClient,
+                normalizedAllowedOAuthFlows,
+                normalizedAllowedOAuthScopes,
+                normalizedCallbackUrls,
+                normalizedDefaultRedirectUri,
+                accessTokenValidity,
+                idTokenValidity,
+                refreshTokenValidity,
+                copiedTokenValidityUnits
+        );
+
         UserPoolClient client = new UserPoolClient();
         client.setClientId(clientId);
         client.setUserPoolId(userPoolId);
         client.setClientName(clientName);
         client.setGenerateSecret(generateSecret);
         client.setAllowedOAuthFlowsUserPoolClient(allowedOAuthFlowsUserPoolClient);
-        client.setAllowedOAuthFlows(normalizeStringList(allowedOAuthFlows));
-        client.setAllowedOAuthScopes(normalizeStringList(allowedOAuthScopes));
+        client.setAllowedOAuthFlows(normalizedAllowedOAuthFlows);
+        client.setAllowedOAuthScopes(normalizedAllowedOAuthScopes);
         client.setAnalyticsConfiguration(copyObjectMap(analyticsConfiguration));
-        client.setCallbackURLs(normalizeStringList(callbackURLs));
-        client.setDefaultRedirectURI(defaultRedirectURI);
-        client.setExplicitAuthFlows(normalizeStringList(explicitAuthFlows));
+        client.setCallbackURLs(normalizedCallbackUrls);
+        client.setDefaultRedirectURI(normalizedDefaultRedirectUri);
+        client.setExplicitAuthFlows(normalizedExplicitAuthFlows);
         client.setAccessTokenValidity(accessTokenValidity);
         client.setIdTokenValidity(idTokenValidity);
-        client.setLogoutURLs(normalizeStringList(logoutURLs));
+        client.setLogoutURLs(normalizedLogoutUrls);
         client.setPreventUserExistenceErrors(preventUserExistenceErrors);
-        client.setReadAttributes(normalizeStringList(readAttributes));
+        client.setReadAttributes(normalizedReadAttributes);
         client.setRefreshTokenValidity(refreshTokenValidity);
-        List<String> normalizedSupportedIdentityProviders = normalizeStringList(supportedIdentityProviders);
         client.setSupportedIdentityProviders(normalizedSupportedIdentityProviders.isEmpty()
                 ? List.of("COGNITO")
                 : normalizedSupportedIdentityProviders);
-        client.setTokenValidityUnits(copyStringMap(tokenValidityUnits));
-        client.setWriteAttributes(normalizeStringList(writeAttributes));
+        client.setTokenValidityUnits(copiedTokenValidityUnits);
+        client.setWriteAttributes(normalizedWriteAttributes);
         client.setRefreshTokenRotation(copyObjectMap(refreshTokenRotation));
         client.setEnableTokenRevocation(enableTokenRevocation != null ? enableTokenRevocation : Boolean.TRUE);
         if (generateSecret) {
@@ -420,24 +442,64 @@ public class CognitoService {
                                                Map<String, Object> refreshTokenRotation,
                                                Boolean enableTokenRevocation) {
         UserPoolClient client = describeUserPoolClient(userPoolId, clientId);
+        boolean effectiveAllowedOAuthFlowsUserPoolClient = allowedOAuthFlowsUserPoolClient != null
+                ? allowedOAuthFlowsUserPoolClient
+                : client.isAllowedOAuthFlowsUserPoolClient();
+        List<String> effectiveAllowedOAuthFlows = allowedOAuthFlows != null
+                ? normalizeStringList(allowedOAuthFlows)
+                : client.getAllowedOAuthFlows();
+        List<String> effectiveAllowedOAuthScopes = allowedOAuthScopes != null
+                ? normalizeStringList(allowedOAuthScopes)
+                : client.getAllowedOAuthScopes();
+        List<String> effectiveCallbackUrls = callbackURLs != null
+                ? normalizeStringList(callbackURLs)
+                : client.getCallbackURLs();
+        String effectiveDefaultRedirectUri = defaultRedirectURI != null
+                ? normalizeOptionalString(defaultRedirectURI)
+                : client.getDefaultRedirectURI();
+        Integer effectiveAccessTokenValidity = accessTokenValidity != null
+                ? accessTokenValidity
+                : client.getAccessTokenValidity();
+        Integer effectiveIdTokenValidity = idTokenValidity != null
+                ? idTokenValidity
+                : client.getIdTokenValidity();
+        Integer effectiveRefreshTokenValidity = refreshTokenValidity != null
+                ? refreshTokenValidity
+                : client.getRefreshTokenValidity();
+        Map<String, String> effectiveTokenValidityUnits = tokenValidityUnits != null
+                ? copyStringMap(tokenValidityUnits)
+                : client.getTokenValidityUnits();
+
+        validateUserPoolClientConfiguration(
+                effectiveAllowedOAuthFlowsUserPoolClient,
+                effectiveAllowedOAuthFlows,
+                effectiveAllowedOAuthScopes,
+                effectiveCallbackUrls,
+                effectiveDefaultRedirectUri,
+                effectiveAccessTokenValidity,
+                effectiveIdTokenValidity,
+                effectiveRefreshTokenValidity,
+                effectiveTokenValidityUnits
+        );
+
         if (clientName != null) client.setClientName(clientName);
         if (allowedOAuthFlowsUserPoolClient != null) {
             client.setAllowedOAuthFlowsUserPoolClient(allowedOAuthFlowsUserPoolClient);
         }
         if (allowedOAuthFlows != null) {
-            client.setAllowedOAuthFlows(normalizeStringList(allowedOAuthFlows));
+            client.setAllowedOAuthFlows(effectiveAllowedOAuthFlows);
         }
         if (allowedOAuthScopes != null) {
-            client.setAllowedOAuthScopes(normalizeStringList(allowedOAuthScopes));
+            client.setAllowedOAuthScopes(effectiveAllowedOAuthScopes);
         }
         if (analyticsConfiguration != null) {
             client.setAnalyticsConfiguration(copyObjectMap(analyticsConfiguration));
         }
         if (callbackURLs != null) {
-            client.setCallbackURLs(normalizeStringList(callbackURLs));
+            client.setCallbackURLs(effectiveCallbackUrls);
         }
         if (defaultRedirectURI != null) {
-            client.setDefaultRedirectURI(defaultRedirectURI);
+            client.setDefaultRedirectURI(effectiveDefaultRedirectUri);
         }
         if (explicitAuthFlows != null) {
             client.setExplicitAuthFlows(normalizeStringList(explicitAuthFlows));
@@ -464,7 +526,7 @@ public class CognitoService {
             client.setSupportedIdentityProviders(normalizeStringList(supportedIdentityProviders));
         }
         if (tokenValidityUnits != null) {
-            client.setTokenValidityUnits(copyStringMap(tokenValidityUnits));
+            client.setTokenValidityUnits(effectiveTokenValidityUnits);
         }
         if (writeAttributes != null) {
             client.setWriteAttributes(normalizeStringList(writeAttributes));
@@ -1476,6 +1538,73 @@ public class CognitoService {
         return new LinkedHashMap<>(source);
     }
 
+    private void validateUserPoolClientConfiguration(boolean allowedOAuthFlowsUserPoolClient,
+                                                     List<String> allowedOAuthFlows,
+                                                     List<String> allowedOAuthScopes,
+                                                     List<String> callbackURLs,
+                                                     String defaultRedirectURI,
+                                                     Integer accessTokenValidity,
+                                                     Integer idTokenValidity,
+                                                     Integer refreshTokenValidity,
+                                                     Map<String, String> tokenValidityUnits) {
+        validateTokenValidityUnits(tokenValidityUnits);
+        validateTokenValidityValue("AccessTokenValidity", accessTokenValidity);
+        validateTokenValidityValue("IdTokenValidity", idTokenValidity);
+        validateTokenValidityValue("RefreshTokenValidity", refreshTokenValidity);
+
+        List<String> effectiveFlows = allowedOAuthFlows != null ? allowedOAuthFlows : List.of();
+        List<String> effectiveScopes = allowedOAuthScopes != null ? allowedOAuthScopes : List.of();
+        List<String> effectiveCallbackUrls = callbackURLs != null ? callbackURLs : List.of();
+
+        if (!allowedOAuthFlowsUserPoolClient) {
+            if (!effectiveFlows.isEmpty() || !effectiveScopes.isEmpty()
+                    || !effectiveCallbackUrls.isEmpty() || defaultRedirectURI != null) {
+                throw new AwsException("InvalidParameterException",
+                        "To use authorization server features, set AllowedOAuthFlowsUserPoolClient to true.",
+                        400);
+            }
+            return;
+        }
+
+        if (defaultRedirectURI != null && !effectiveCallbackUrls.contains(defaultRedirectURI)) {
+            throw new AwsException("InvalidParameterException",
+                    "DefaultRedirectURI must be in the CallbackURLs list.", 400);
+        }
+
+        if ((effectiveFlows.contains("code") || effectiveFlows.contains("implicit"))
+                && effectiveCallbackUrls.isEmpty()) {
+            throw new AwsException("InvalidParameterException",
+                    "CallbackURLs must contain at least one URI when code or implicit OAuth flows are enabled.",
+                    400);
+        }
+    }
+
+    private void validateTokenValidityUnits(Map<String, String> tokenValidityUnits) {
+        if (tokenValidityUnits == null || tokenValidityUnits.isEmpty()) {
+            return;
+        }
+
+        Set<String> supportedKeys = Set.of("AccessToken", "IdToken", "RefreshToken");
+        Set<String> supportedUnits = Set.of("seconds", "minutes", "hours", "days");
+        for (Map.Entry<String, String> entry : tokenValidityUnits.entrySet()) {
+            if (!supportedKeys.contains(entry.getKey())) {
+                throw new AwsException("InvalidParameterException",
+                        "TokenValidityUnits contains an unsupported key: " + entry.getKey() + ".", 400);
+            }
+            String normalizedUnit = normalizeOptionalString(entry.getValue());
+            if (normalizedUnit == null || !supportedUnits.contains(normalizedUnit.toLowerCase(Locale.ROOT))) {
+                throw new AwsException("InvalidParameterException",
+                        "TokenValidityUnits contains an unsupported unit value: " + entry.getValue() + ".", 400);
+            }
+        }
+    }
+
+    private void validateTokenValidityValue(String fieldName, Integer value) {
+        if (value != null && value <= 0) {
+            throw new AwsException("InvalidParameterException", fieldName + " must be greater than 0.", 400);
+        }
+    }
+
     private List<ResourceServerScope> normalizeScopes(List<ResourceServerScope> scopes) {
         if (scopes == null || scopes.isEmpty()) {
             return List.of();
@@ -1515,6 +1644,14 @@ public class CognitoService {
             }
         }
         return normalized;
+    }
+
+    private String normalizeOptionalString(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
     private boolean isBuiltInScope(String scope) {

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -24,6 +24,7 @@ import java.util.*;
 
 @ApplicationScoped
 public class CognitoService {
+    private static final int DEFAULT_REFRESH_TOKEN_VALIDITY_DAYS = 30;
 
     private static final Logger LOG = Logger.getLogger(CognitoService.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -314,6 +315,7 @@ public class CognitoService {
         List<String> normalizedSupportedIdentityProviders = normalizeStringList(supportedIdentityProviders);
         Map<String, String> copiedTokenValidityUnits = copyStringMap(tokenValidityUnits);
         List<String> normalizedWriteAttributes = normalizeStringList(writeAttributes);
+        Integer normalizedRefreshTokenValidity = normalizeRefreshTokenValidity(refreshTokenValidity);
 
         validateUserPoolClientConfiguration(
                 allowedOAuthFlowsUserPoolClient,
@@ -323,7 +325,8 @@ public class CognitoService {
                 normalizedDefaultRedirectUri,
                 accessTokenValidity,
                 idTokenValidity,
-                refreshTokenValidity,
+                normalizedRefreshTokenValidity,
+                normalizedLogoutUrls,
                 copiedTokenValidityUnits
         );
 
@@ -344,7 +347,7 @@ public class CognitoService {
         client.setLogoutURLs(normalizedLogoutUrls);
         client.setPreventUserExistenceErrors(preventUserExistenceErrors);
         client.setReadAttributes(normalizedReadAttributes);
-        client.setRefreshTokenValidity(refreshTokenValidity);
+        client.setRefreshTokenValidity(normalizedRefreshTokenValidity);
         client.setSupportedIdentityProviders(normalizedSupportedIdentityProviders.isEmpty()
                 ? List.of("COGNITO")
                 : normalizedSupportedIdentityProviders);
@@ -464,11 +467,14 @@ public class CognitoService {
                 ? idTokenValidity
                 : client.getIdTokenValidity();
         Integer effectiveRefreshTokenValidity = refreshTokenValidity != null
-                ? refreshTokenValidity
+                ? normalizeRefreshTokenValidity(refreshTokenValidity)
                 : client.getRefreshTokenValidity();
         Map<String, String> effectiveTokenValidityUnits = tokenValidityUnits != null
                 ? copyStringMap(tokenValidityUnits)
                 : client.getTokenValidityUnits();
+        List<String> effectiveLogoutUrls = logoutURLs != null
+                ? normalizeStringList(logoutURLs)
+                : client.getLogoutURLs();
 
         validateUserPoolClientConfiguration(
                 effectiveAllowedOAuthFlowsUserPoolClient,
@@ -479,6 +485,7 @@ public class CognitoService {
                 effectiveAccessTokenValidity,
                 effectiveIdTokenValidity,
                 effectiveRefreshTokenValidity,
+                effectiveLogoutUrls,
                 effectiveTokenValidityUnits
         );
 
@@ -511,7 +518,7 @@ public class CognitoService {
             client.setIdTokenValidity(idTokenValidity);
         }
         if (logoutURLs != null) {
-            client.setLogoutURLs(normalizeStringList(logoutURLs));
+            client.setLogoutURLs(effectiveLogoutUrls);
         }
         if (preventUserExistenceErrors != null) {
             client.setPreventUserExistenceErrors(preventUserExistenceErrors);
@@ -520,7 +527,7 @@ public class CognitoService {
             client.setReadAttributes(normalizeStringList(readAttributes));
         }
         if (refreshTokenValidity != null) {
-            client.setRefreshTokenValidity(refreshTokenValidity);
+            client.setRefreshTokenValidity(effectiveRefreshTokenValidity);
         }
         if (supportedIdentityProviders != null) {
             client.setSupportedIdentityProviders(normalizeStringList(supportedIdentityProviders));
@@ -1546,19 +1553,22 @@ public class CognitoService {
                                                      Integer accessTokenValidity,
                                                      Integer idTokenValidity,
                                                      Integer refreshTokenValidity,
+                                                     List<String> logoutURLs,
                                                      Map<String, String> tokenValidityUnits) {
         validateTokenValidityUnits(tokenValidityUnits);
         validateTokenValidityValue("AccessTokenValidity", accessTokenValidity);
         validateTokenValidityValue("IdTokenValidity", idTokenValidity);
-        validateTokenValidityValue("RefreshTokenValidity", refreshTokenValidity);
+        validateRefreshTokenValidityValue(refreshTokenValidity);
 
         List<String> effectiveFlows = allowedOAuthFlows != null ? allowedOAuthFlows : List.of();
         List<String> effectiveScopes = allowedOAuthScopes != null ? allowedOAuthScopes : List.of();
         List<String> effectiveCallbackUrls = callbackURLs != null ? callbackURLs : List.of();
+        List<String> effectiveLogoutUrls = logoutURLs != null ? logoutURLs : List.of();
 
         if (!allowedOAuthFlowsUserPoolClient) {
             if (!effectiveFlows.isEmpty() || !effectiveScopes.isEmpty()
-                    || !effectiveCallbackUrls.isEmpty() || defaultRedirectURI != null) {
+                    || !effectiveCallbackUrls.isEmpty() || !effectiveLogoutUrls.isEmpty()
+                    || defaultRedirectURI != null) {
                 throw new AwsException("InvalidParameterException",
                         "To use authorization server features, set AllowedOAuthFlowsUserPoolClient to true.",
                         400);
@@ -1592,7 +1602,7 @@ public class CognitoService {
                         "TokenValidityUnits contains an unsupported key: " + entry.getKey() + ".", 400);
             }
             String normalizedUnit = normalizeOptionalString(entry.getValue());
-            if (normalizedUnit == null || !supportedUnits.contains(normalizedUnit.toLowerCase(Locale.ROOT))) {
+            if (normalizedUnit == null || !supportedUnits.contains(normalizedUnit)) {
                 throw new AwsException("InvalidParameterException",
                         "TokenValidityUnits contains an unsupported unit value: " + entry.getValue() + ".", 400);
             }
@@ -1603,6 +1613,19 @@ public class CognitoService {
         if (value != null && value <= 0) {
             throw new AwsException("InvalidParameterException", fieldName + " must be greater than 0.", 400);
         }
+    }
+
+    private void validateRefreshTokenValidityValue(Integer value) {
+        if (value != null && value < 0) {
+            throw new AwsException("InvalidParameterException", "RefreshTokenValidity must be greater than or equal to 0.", 400);
+        }
+    }
+
+    private Integer normalizeRefreshTokenValidity(Integer value) {
+        if (value != null && value == 0) {
+            return DEFAULT_REFRESH_TOKEN_VALIDITY_DAYS;
+        }
+        return value;
     }
 
     private List<ResourceServerScope> normalizeScopes(List<ResourceServerScope> scopes) {

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
@@ -573,8 +573,11 @@ class CognitoIntegrationTest {
                   "UserPoolId": "%s",
                   "ClientName": "secret-client",
                   "GenerateSecret": true,
+                  "AllowedOAuthFlowsUserPoolClient": true,
                   "AllowedOAuthFlows": ["code"],
-                  "AllowedOAuthScopes": ["openid"]
+                  "AllowedOAuthScopes": ["openid"],
+                  "CallbackURLs": ["https://example.com/callback"],
+                  "DefaultRedirectURI": "https://example.com/callback"
                 }
                 """.formatted(poolId));
         String secretClientId = secretClient.path("UserPoolClient").path("ClientId").asText();
@@ -646,7 +649,9 @@ class CognitoIntegrationTest {
                   "ClientName": "updated-name",
                   "AllowedOAuthFlowsUserPoolClient": true,
                   "AllowedOAuthFlows": ["code", "implicit"],
-                  "AllowedOAuthScopes": ["email", "openid"]
+                  "AllowedOAuthScopes": ["email", "openid"],
+                  "CallbackURLs": ["https://example.com/callback"],
+                  "DefaultRedirectURI": "https://example.com/callback"
                 }
                 """.formatted(poolId, cid));
 
@@ -1600,7 +1605,7 @@ class CognitoIntegrationTest {
                 {
                   "UserPoolId": "%s",
                   "ClientId": "%s",
-                  "AllowedOAuthFlowsUserPoolClient": false,
+                  "AllowedOAuthFlowsUserPoolClient": true,
                   "AllowedOAuthFlows": ["implicit"],
                   "AllowedOAuthScopes": ["email"],
                   "AnalyticsConfiguration": {
@@ -1641,7 +1646,7 @@ class CognitoIntegrationTest {
                 """.formatted(extendedPoolId, extendedClientId));
         JsonNode described = describeResp.path("UserPoolClient");
 
-        assertFalse(described.path("AllowedOAuthFlowsUserPoolClient").asBoolean());
+        assertTrue(described.path("AllowedOAuthFlowsUserPoolClient").asBoolean());
         assertEquals(1, described.path("AllowedOAuthFlows").size());
         assertEquals("implicit", described.path("AllowedOAuthFlows").get(0).asText());
         assertEquals(1, described.path("AllowedOAuthScopes").size());
@@ -1675,6 +1680,84 @@ class CognitoIntegrationTest {
 
     @Test
     @Order(96)
+    void createUserPoolClientRejectsInvalidTokenValidityConfiguration() throws Exception {
+        JsonNode poolResponse = cognitoJson("CreateUserPool", """
+                {
+                  "PoolName": "InvalidTokenValidityPool"
+                }
+                """);
+        String invalidPoolId = poolResponse.path("UserPool").path("Id").asText();
+
+        cognitoAction("CreateUserPoolClient", """
+                {
+                  "UserPoolId": "%s",
+                  "ClientName": "invalid-token-validity-client",
+                  "AccessTokenValidity": -1,
+                  "IdTokenValidity": 0,
+                  "RefreshTokenValidity": -7,
+                  "TokenValidityUnits": {
+                    "AccessToken": "weeks",
+                    "IdToken": "minutes",
+                    "RefreshToken": "days"
+                  }
+                }
+                """.formatted(invalidPoolId))
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    @Order(97)
+    void createUserPoolClientRejectsInconsistentOAuthFlowConfiguration() throws Exception {
+        JsonNode poolResponse = cognitoJson("CreateUserPool", """
+                {
+                  "PoolName": "InvalidOauthClientPool"
+                }
+                """);
+        String invalidPoolId = poolResponse.path("UserPool").path("Id").asText();
+
+        cognitoAction("CreateUserPoolClient", """
+                {
+                  "UserPoolId": "%s",
+                  "ClientName": "invalid-oauth-client",
+                  "AllowedOAuthFlowsUserPoolClient": false,
+                  "AllowedOAuthFlows": ["code"],
+                  "AllowedOAuthScopes": ["openid"],
+                  "CallbackURLs": ["https://example.com/callback"],
+                  "DefaultRedirectURI": "https://example.com/callback"
+                }
+                """.formatted(invalidPoolId))
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    @Order(98)
+    void createUserPoolClientRejectsDefaultRedirectUriNotInCallbackUrls() throws Exception {
+        JsonNode poolResponse = cognitoJson("CreateUserPool", """
+                {
+                  "PoolName": "InvalidRedirectClientPool"
+                }
+                """);
+        String invalidPoolId = poolResponse.path("UserPool").path("Id").asText();
+
+        cognitoAction("CreateUserPoolClient", """
+                {
+                  "UserPoolId": "%s",
+                  "ClientName": "invalid-redirect-client",
+                  "AllowedOAuthFlowsUserPoolClient": true,
+                  "AllowedOAuthFlows": ["code"],
+                  "AllowedOAuthScopes": ["openid"],
+                  "CallbackURLs": ["https://example.com/callback"],
+                  "DefaultRedirectURI": "https://different.example.com/callback"
+                }
+                """.formatted(invalidPoolId))
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    @Order(99)
     void configuredTokenValidityControlsAuthResultAndJwtExpiry() throws Exception {
         JsonNode poolResponse = cognitoJson("CreateUserPool", """
                 {

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
@@ -299,6 +299,109 @@ class CognitoServiceTest {
     }
 
     @Test
+    void createUserPoolClientAcceptsRefreshTokenValidityZeroAndCoercesToDefault() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "ClientPool"), "us-east-1");
+
+        UserPoolClient client = service.createUserPoolClient(
+                pool.getId(),
+                "refresh-default-client",
+                false,
+                false,
+                List.of(),
+                List.of(),
+                null,
+                List.of(),
+                null,
+                List.of(),
+                null,
+                null,
+                List.of(),
+                null,
+                List.of(),
+                0,
+                List.of(),
+                null,
+                List.of(),
+                null,
+                null
+        );
+
+        assertEquals(30, client.getRefreshTokenValidity());
+    }
+
+    @Test
+    void createUserPoolClientRejectsLogoutUrlsWhenOAuthFlowsUserPoolClientIsFalse() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "ClientPool"), "us-east-1");
+
+        AwsException exception = assertThrows(
+                AwsException.class,
+                () -> service.createUserPoolClient(
+                        pool.getId(),
+                        "invalid-logout-client",
+                        false,
+                        false,
+                        List.of(),
+                        List.of(),
+                        null,
+                        List.of(),
+                        null,
+                        List.of(),
+                        null,
+                        null,
+                        List.of("https://example.com/logout"),
+                        null,
+                        List.of(),
+                        null,
+                        List.of(),
+                        null,
+                        List.of(),
+                        null,
+                        null
+                )
+        );
+
+        assertEquals("InvalidParameterException", exception.getErrorCode());
+    }
+
+    @Test
+    void createUserPoolClientRejectsMixedCaseTokenValidityUnits() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "ClientPool"), "us-east-1");
+
+        AwsException exception = assertThrows(
+                AwsException.class,
+                () -> service.createUserPoolClient(
+                        pool.getId(),
+                        "invalid-token-unit-client",
+                        false,
+                        false,
+                        List.of(),
+                        List.of(),
+                        null,
+                        List.of(),
+                        null,
+                        List.of(),
+                        1,
+                        1,
+                        List.of(),
+                        null,
+                        List.of(),
+                        7,
+                        List.of(),
+                        Map.of(
+                                "AccessToken", "Hours",
+                                "IdToken", "minutes",
+                                "RefreshToken", "days"
+                        ),
+                        List.of(),
+                        null,
+                        null
+                )
+        );
+
+        assertEquals("InvalidParameterException", exception.getErrorCode());
+    }
+
+    @Test
     void createUserPoolClientRejectsInconsistentOAuthFlowConfiguration() {
         UserPool pool = service.createUserPool(Map.of("PoolName", "ClientPool"), "us-east-1");
 
@@ -425,6 +528,61 @@ class CognitoServiceTest {
         assertEquals(List.of(), updated.getReadAttributes());
         assertEquals(List.of(), updated.getSupportedIdentityProviders());
         assertEquals(List.of(), updated.getWriteAttributes());
+    }
+
+    @Test
+    void updateUserPoolClientAcceptsRefreshTokenValidityZeroAndCoercesToDefault() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "ClientPool"), "us-east-1");
+
+        UserPoolClient client = service.createUserPoolClient(
+                pool.getId(),
+                "client",
+                false,
+                false,
+                List.of(),
+                List.of(),
+                null,
+                List.of(),
+                null,
+                List.of(),
+                null,
+                null,
+                List.of(),
+                null,
+                List.of(),
+                7,
+                List.of(),
+                null,
+                List.of(),
+                null,
+                null
+        );
+
+        UserPoolClient updated = service.updateUserPoolClient(
+                pool.getId(),
+                client.getClientId(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                0,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        assertEquals(30, updated.getRefreshTokenValidity());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
@@ -207,7 +207,22 @@ class CognitoServiceTest {
                 true,
                 true,
                 List.of(" code ", "code", "implicit", "", "implicit"),
-                new ArrayList<>(java.util.Arrays.asList(" openid ", "openid", "email", null, "email"))
+                new ArrayList<>(java.util.Arrays.asList(" openid ", "openid", "email", null, "email")),
+                null,
+                List.of("https://example.com/callback"),
+                "https://example.com/callback",
+                List.of(),
+                null,
+                null,
+                List.of(),
+                null,
+                List.of(),
+                null,
+                List.of(),
+                null,
+                List.of(),
+                null,
+                null
         );
 
         assertNotNull(client.getClientId());
@@ -246,6 +261,112 @@ class CognitoServiceTest {
     }
 
     @Test
+    void createUserPoolClientRejectsInvalidTokenValidityConfiguration() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "ClientPool"), "us-east-1");
+
+        AwsException exception = assertThrows(
+                AwsException.class,
+                () -> service.createUserPoolClient(
+                        pool.getId(),
+                        "invalid-token-validity-client",
+                        false,
+                        false,
+                        List.of(),
+                        List.of(),
+                        null,
+                        List.of(),
+                        null,
+                        List.of(),
+                        -1,
+                        0,
+                        List.of(),
+                        null,
+                        List.of(),
+                        -7,
+                        List.of(),
+                        Map.of(
+                                "AccessToken", "weeks",
+                                "IdToken", "minutes",
+                                "RefreshToken", "days"
+                        ),
+                        List.of(),
+                        null,
+                        null
+                )
+        );
+
+        assertEquals("InvalidParameterException", exception.getErrorCode());
+    }
+
+    @Test
+    void createUserPoolClientRejectsInconsistentOAuthFlowConfiguration() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "ClientPool"), "us-east-1");
+
+        AwsException exception = assertThrows(
+                AwsException.class,
+                () -> service.createUserPoolClient(
+                        pool.getId(),
+                        "invalid-oauth-client",
+                        false,
+                        false,
+                        List.of("code"),
+                        List.of("openid"),
+                        null,
+                        List.of("https://example.com/callback"),
+                        "https://example.com/callback",
+                        List.of(),
+                        null,
+                        null,
+                        List.of(),
+                        null,
+                        List.of(),
+                        null,
+                        List.of(),
+                        null,
+                        List.of(),
+                        null,
+                        null
+                )
+        );
+
+        assertEquals("InvalidParameterException", exception.getErrorCode());
+    }
+
+    @Test
+    void createUserPoolClientRejectsDefaultRedirectUriNotInCallbackUrls() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "ClientPool"), "us-east-1");
+
+        AwsException exception = assertThrows(
+                AwsException.class,
+                () -> service.createUserPoolClient(
+                        pool.getId(),
+                        "invalid-redirect-client",
+                        false,
+                        true,
+                        List.of("code"),
+                        List.of("openid"),
+                        null,
+                        List.of("https://example.com/callback"),
+                        "https://different.example.com/callback",
+                        List.of(),
+                        null,
+                        null,
+                        List.of(),
+                        null,
+                        List.of(),
+                        null,
+                        List.of(),
+                        null,
+                        List.of(),
+                        null,
+                        null
+                )
+        );
+
+        assertEquals("InvalidParameterException", exception.getErrorCode());
+    }
+
+    @Test
     void updateUserPoolClientAllowsClearingListFieldsWithEmptyArrays() {
         UserPool pool = service.createUserPool(Map.of("PoolName", "ClientPool"), "us-east-1");
 
@@ -253,9 +374,9 @@ class CognitoServiceTest {
                 pool.getId(),
                 "client",
                 false,
-                false,
-                List.of(),
-                List.of(),
+                true,
+                List.of("code"),
+                List.of("openid"),
                 null,
                 List.of("https://example.com"),
                 "https://example.com",
@@ -277,12 +398,12 @@ class CognitoServiceTest {
                 pool.getId(),
                 client.getClientId(),
                 null,
-                null,
-                null,
-                null,
-                null,
+                false,
+                List.of(),
                 List.of(),
                 null,
+                List.of(),
+                "",
                 List.of(),
                 null,
                 null,


### PR DESCRIPTION
## Summary

Add missing `UserPoolClient` validation and tests to better align Cognito behavior with AWS.

The previous `UserPoolClient` implementation accepted invalid OAuth and token validity settings that should have been rejected.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

This bug fix adds validation for `UserPoolClient` settings that were previously accepted incorrectly.

Aligned behavior includes:
- rejecting invalid `TokenValidityUnits` keys and unit values
- rejecting non-positive token validity values
- rejecting OAuth settings when `AllowedOAuthFlowsUserPoolClient` is `false`
- rejecting `DefaultRedirectURI` values that aren't included in `CallbackURLs`

Error messages were adjusted to follow AWS documentation wording for `CreateUserPoolClient` and `UpdateUserPoolClient`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
