### PR TITLE
fix(kms): 🐛 wrap RSA DIGEST signatures in PKCS#1 DigestInfo

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -12,10 +12,15 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.bouncycastle.asn1.ASN1Integer;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.DERNull;
 import org.bouncycastle.asn1.DERSequenceGenerator;
+import org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.asn1.x509.DigestInfo;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.crypto.params.ECDomainParameters;
 import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
@@ -34,6 +39,7 @@ import org.jboss.logging.Logger;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -729,6 +735,12 @@ public class KmsService {
             if ("DIGEST".equals(messageType)) {
                 // If message is already a digest, we need a "NONEwith..." algorithm
                 jcaAlgo = "NONEwith" + (kmsKey.getCustomerMasterKeySpec().startsWith("RSA") ? "RSA" : "ECDSA");
+                if (algorithm.startsWith("RSASSA_PKCS1_V1_5")) {
+                    // RFC 8017 9.2: PKCS#1 v1.5 signs DigestInfo{hashOID, digest}, not the
+                    // bare digest, so the signature validates with external verifiers and
+                    // real KMS (NONEwithRSA only pads the bytes it is given).
+                    message = wrapInDigestInfo(message, algorithm);
+                }
             }
 
             if (isSecgP256k1(kmsKey.getCustomerMasterKeySpec())) {
@@ -759,6 +771,10 @@ public class KmsService {
             
             if ("DIGEST".equals(messageType)) {
                 jcaAlgo = "NONEwith" + (kmsKey.getCustomerMasterKeySpec().startsWith("RSA") ? "RSA" : "ECDSA");
+                if (algorithm.startsWith("RSASSA_PKCS1_V1_5")) {
+                    // Mirror sign(): verify against DigestInfo{hashOID, digest} (RFC 8017 9.2).
+                    message = wrapInDigestInfo(message, algorithm);
+                }
             }
 
             if (isSecgP256k1(kmsKey.getCustomerMasterKeySpec())) {
@@ -882,6 +898,29 @@ public class KmsService {
             return converter.generatePublic(SubjectPublicKeyInfo.getInstance(decoded));
         }
         return buildKeyFactory(spec).generatePublic(new X509EncodedKeySpec(decoded));
+    }
+
+    /**
+     * Wraps a pre-computed digest in the ASN.1 {@code DigestInfo} structure that PKCS#1
+     * v1.5 signing prepends before padding (RFC 8017 9.2). Needed for {@code MessageType=DIGEST}
+     * RSA signatures because {@code NONEwithRSA} pads only the bytes it is given.
+     */
+    private byte[] wrapInDigestInfo(byte[] digest, String algorithm) {
+        ASN1ObjectIdentifier hashOid;
+        if (algorithm.endsWith("SHA_256")) {
+            hashOid = NISTObjectIdentifiers.id_sha256;
+        } else if (algorithm.endsWith("SHA_384")) {
+            hashOid = NISTObjectIdentifiers.id_sha384;
+        } else if (algorithm.endsWith("SHA_512")) {
+            hashOid = NISTObjectIdentifiers.id_sha512;
+        } else {
+            throw new AwsException("InvalidSigningAlgorithmException", "Unsupported algorithm: " + algorithm, 400);
+        }
+        try {
+            return new DigestInfo(new AlgorithmIdentifier(hashOid, DERNull.INSTANCE), digest).getEncoded();
+        } catch (IOException e) {
+            throw new AwsException("InternalFailure", "Failed to encode DigestInfo: " + e.getMessage(), 500);
+        }
     }
 
     private String mapAlgorithm(String awsAlgo) {

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -15,7 +15,9 @@ import org.junit.jupiter.api.Test;
 import java.nio.charset.StandardCharsets;
 import java.security.Security;
 import java.security.KeyFactory;
+import java.security.MessageDigest;
 import java.security.PublicKey;
+import java.security.Signature;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
 import java.util.Base64;
@@ -778,6 +780,49 @@ class KmsServiceTest {
         byte[] sig = kmsService.sign(key.getKeyId(), message, "RSASSA_PKCS1_V1_5_SHA_256", REGION);
         assertNotNull(sig);
         assertTrue(kmsService.verify(key.getKeyId(), message, sig, "RSASSA_PKCS1_V1_5_SHA_256", REGION));
+    }
+
+    @Test
+    void signWithDigestMessageTypeVerifiesWithExternalVerifier() throws Exception {
+        KmsKey key = kmsService.createKey("rsa digest key", "SIGN_VERIFY", "RSA_2048", null, Map.of(), REGION);
+        byte[] message = "floci kms round-trip".getBytes(StandardCharsets.UTF_8);
+        byte[] digest = MessageDigest.getInstance("SHA-512").digest(message);
+
+        byte[] sig = kmsService.sign(key.getKeyId(), digest,
+                "RSASSA_PKCS1_V1_5_SHA_512", "DIGEST", REGION);
+
+        // floci's own Verify round-trips.
+        assertTrue(kmsService.verify(key.getKeyId(), digest, sig,
+                "RSASSA_PKCS1_V1_5_SHA_512", "DIGEST", REGION));
+
+        // External verifier (standard JCA, standing in for openssl/python) reconstructs
+        // DigestInfo from the message hash and must validate the DIGEST signature (#1345).
+        byte[] der = Base64.getDecoder().decode(kmsService.getPublicKey(key.getKeyId(), REGION).getPublicKeyEncoded());
+        PublicKey pub = KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(der));
+        Signature verifier = Signature.getInstance("SHA512withRSA");
+        verifier.initVerify(pub);
+        verifier.update(message);
+        assertTrue(verifier.verify(sig), "DIGEST signature must verify with standard SHA512withRSA");
+    }
+
+    @Test
+    void signWithDigestMessageTypeMatchesRawSignature() {
+        KmsKey key = kmsService.createKey("rsa digest key", "SIGN_VERIFY", "RSA_2048", null, Map.of(), REGION);
+        byte[] message = "deterministic pkcs1".getBytes(StandardCharsets.UTF_8);
+        byte[] digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256").digest(message);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        // PKCS#1 v1.5 is deterministic, so signing the digest (DIGEST) and signing the
+        // message (RAW) with the same algorithm must produce identical signatures.
+        byte[] digestSig = kmsService.sign(key.getKeyId(), digest,
+                "RSASSA_PKCS1_V1_5_SHA_256", "DIGEST", REGION);
+        byte[] rawSig = kmsService.sign(key.getKeyId(), message,
+                "RSASSA_PKCS1_V1_5_SHA_256", "RAW", REGION);
+        assertArrayEquals(rawSig, digestSig);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #1345

`Sign`/`Verify` with `MessageType=DIGEST` and an `RSASSA_PKCS1_V1_5_*` algorithm fed the bare digest to `NONEwithRSA`, which applies PKCS#1 v1.5 padding to exactly the bytes it is given. Real KMS (and any standard verifier) signs `DigestInfo{ hashOID, digest }` per [RFC 8017 §9.2](https://datatracker.ietf.org/doc/html/rfc8017#section-9.2), so floci's `DIGEST` signatures verified through floci's own `Verify` but failed against external tools (openssl, python `cryptography`).

Fix: wrap the digest in the ASN.1 `DigestInfo` structure (via BouncyCastle, already a dependency) before `NONEwithRSA`, on both `sign` and `verify`. ECDSA `DIGEST` (which has no `DigestInfo` wrapper) and the `RAW` path are unchanged.

Scope: this addresses the reported, reproducible `RSASSA_PKCS1_V1_5_*` case. `RSASSA_PSS_* + DIGEST` (noted as "likely also affects" in the issue) is left for a follow-up: signing a pre-computed digest under PSS isn't cleanly supported by the JDK/BouncyCastle high-level APIs and warrants its own change; this PR does not regress its current behavior.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: a `RSASSA_PKCS1_V1_5_SHA_512` signature produced with `MessageType=DIGEST` failed `pub.verify(sig, msg, PKCS1v15(), SHA512())` in python `cryptography` (and openssl), while real KMS produces a signature that validates. Verified against the reproduction in the issue: floci-`DIGEST` signatures now verify with a standard verifier.

Determinism check: because PKCS#1 v1.5 is deterministic, signing the digest (`DIGEST`) and signing the message (`RAW`) with the same algorithm now produce byte-identical signatures.

## Checklist

- [x] `./mvnw test` passes locally for the affected suites: `KmsServiceTest` (108) and `KmsIntegrationTest` (30). The full suite's only failures on this machine are the 16 Docker-dependent suites that fail identically on an unmodified `main` (no Docker available locally).
- [x] New or updated integration test added: `KmsServiceTest` gains `signWithDigestMessageTypeVerifiesWithExternalVerifier` (signs `DIGEST`, then verifies the signature with a standard JCA `SHA512withRSA` over the original message via the key's exported public key) and `signWithDigestMessageTypeMatchesRawSignature` (DIGEST == RAW signature).
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
