### PR TITLE
refactor(floci): regroup UI and DuckDB under services.floci

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
@@ -7,7 +7,7 @@ import io.github.hectorvent.floci.lifecycle.inithook.InitializationHook;
 import io.github.hectorvent.floci.lifecycle.inithook.InitializationHooksRunner;
 import io.github.hectorvent.floci.services.ec2.Ec2MetadataServer;
 import io.github.hectorvent.floci.services.ecr.registry.EcrRegistryManager;
-import io.github.hectorvent.floci.services.ui.FlociUiManager;
+import io.github.hectorvent.floci.services.floci.ui.FlociUiManager;
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheContainerManager;
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheMemcachedContainerManager;
 import io.github.hectorvent.floci.services.elasticache.proxy.ElastiCacheProxyManager;

--- a/src/main/java/io/github/hectorvent/floci/lifecycle/UiController.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/UiController.java
@@ -1,8 +1,8 @@
 package io.github.hectorvent.floci.lifecycle;
 
-import io.github.hectorvent.floci.services.ui.FlociUiManager;
-import io.github.hectorvent.floci.services.ui.FlociUiManager.UiStatus;
-import io.github.hectorvent.floci.services.ui.UiPages;
+import io.github.hectorvent.floci.services.floci.ui.FlociUiManager;
+import io.github.hectorvent.floci.services.floci.ui.FlociUiManager.UiStatus;
+import io.github.hectorvent.floci.services.floci.ui.UiPages;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;

--- a/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
@@ -8,7 +8,7 @@ import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.athena.model.*;
 import io.github.hectorvent.floci.services.glue.model.Column;
-import io.github.hectorvent.floci.services.floci.FlociDuckClient;
+import io.github.hectorvent.floci.services.floci.duck.FlociDuckClient;
 import io.github.hectorvent.floci.services.glue.GlueService;
 import io.github.hectorvent.floci.services.glue.model.Database;
 import io.github.hectorvent.floci.services.glue.model.Table;

--- a/src/main/java/io/github/hectorvent/floci/services/cur/ParquetEmitter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cur/ParquetEmitter.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.UsageLine;
-import io.github.hectorvent.floci.services.floci.FlociDuckClient;
+import io.github.hectorvent.floci.services.floci.duck.FlociDuckClient;
 import io.github.hectorvent.floci.services.s3.S3Service;
 import io.github.hectorvent.floci.services.s3.model.Bucket;
 import jakarta.enterprise.context.ApplicationScoped;

--- a/src/main/java/io/github/hectorvent/floci/services/floci/duck/FlociDuckClient.java
+++ b/src/main/java/io/github/hectorvent/floci/services/floci/duck/FlociDuckClient.java
@@ -1,4 +1,4 @@
-package io.github.hectorvent.floci.services.floci;
+package io.github.hectorvent.floci.services.floci.duck;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/io/github/hectorvent/floci/services/floci/duck/FlociDuckManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/floci/duck/FlociDuckManager.java
@@ -1,4 +1,4 @@
-package io.github.hectorvent.floci.services.floci;
+package io.github.hectorvent.floci.services.floci.duck;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;

--- a/src/main/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManager.java
@@ -1,4 +1,4 @@
-package io.github.hectorvent.floci.services.ui;
+package io.github.hectorvent.floci.services.floci.ui;
 
 import java.io.Closeable;
 import java.net.HttpURLConnection;

--- a/src/main/java/io/github/hectorvent/floci/services/floci/ui/UiPages.java
+++ b/src/main/java/io/github/hectorvent/floci/services/floci/ui/UiPages.java
@@ -1,4 +1,4 @@
-package io.github.hectorvent.floci.services.ui;
+package io.github.hectorvent.floci.services.floci.ui;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -87,13 +87,13 @@ public class S3Controller {
     private final S3SelectService s3SelectService;
     private final RegionResolver regionResolver;
     private final io.quarkus.vertx.http.runtime.CurrentVertxRequest currentVertxRequest;
-    private final io.github.hectorvent.floci.services.ui.UiPages uiPages;
+    private final io.github.hectorvent.floci.services.floci.ui.UiPages uiPages;
 
     @Inject
     public S3Controller(S3Service s3Service, S3SelectService s3SelectService,
                         RegionResolver regionResolver,
                         io.quarkus.vertx.http.runtime.CurrentVertxRequest currentVertxRequest,
-                        io.github.hectorvent.floci.services.ui.UiPages uiPages) {
+                        io.github.hectorvent.floci.services.floci.ui.UiPages uiPages) {
         this.s3Service = s3Service;
         this.s3SelectService = s3SelectService;
         this.regionResolver = regionResolver;

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3SelectService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3SelectService.java
@@ -2,7 +2,7 @@ package io.github.hectorvent.floci.services.s3;
 
 import io.github.hectorvent.floci.core.common.AwsEventStreamEncoder;
 import io.github.hectorvent.floci.core.common.XmlParser;
-import io.github.hectorvent.floci.services.floci.FlociDuckClient;
+import io.github.hectorvent.floci.services.floci.duck.FlociDuckClient;
 import io.github.hectorvent.floci.services.s3.model.S3Object;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.enterprise.context.ApplicationScoped;

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
@@ -65,7 +65,7 @@ class EmulatorLifecycleTest {
     @Mock private PipesService pipesService;
     @Mock private Ec2MetadataServer ec2MetadataServer;
     @Mock private EcrRegistryManager ecrRegistryManager;
-    @Mock private io.github.hectorvent.floci.services.ui.FlociUiManager flociUiManager;
+    @Mock private io.github.hectorvent.floci.services.floci.ui.FlociUiManager flociUiManager;
     @Mock private InitLifecycleState initLifecycleState;
     @Mock private EmulatorConfig.TlsConfig tlsConfig;
 

--- a/src/test/java/io/github/hectorvent/floci/services/cur/CurEmissionIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cur/CurEmissionIntegrationTest.java
@@ -1,6 +1,6 @@
 package io.github.hectorvent.floci.services.cur;
 
-import io.github.hectorvent.floci.services.floci.FlociDuckClient;
+import io.github.hectorvent.floci.services.floci.duck.FlociDuckClient;
 import io.github.hectorvent.floci.services.s3.S3Service;
 import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;

--- a/src/test/java/io/github/hectorvent/floci/services/cur/ParquetEmitterIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cur/ParquetEmitterIntegrationTest.java
@@ -1,7 +1,7 @@
 package io.github.hectorvent.floci.services.cur;
 
 import io.github.hectorvent.floci.core.common.UsageLine;
-import io.github.hectorvent.floci.services.floci.FlociDuckClient;
+import io.github.hectorvent.floci.services.floci.duck.FlociDuckClient;
 import io.github.hectorvent.floci.services.s3.S3Service;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;

--- a/src/test/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManagerTest.java
@@ -1,4 +1,4 @@
-package io.github.hectorvent.floci.services.ui;
+package io.github.hectorvent.floci.services.floci.ui;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.RegionResolver;

--- a/src/test/java/io/github/hectorvent/floci/services/floci/ui/UiLandingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/floci/ui/UiLandingIntegrationTest.java
@@ -1,4 +1,4 @@
-package io.github.hectorvent.floci.services.ui;
+package io.github.hectorvent.floci.services.floci.ui;
 
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Summary

Pure package reorganization, no behavior change. The UI service classes (`FlociUiManager`, `UiPages`) move to `services.floci.ui`, and the DuckDB helper (`FlociDuckClient`, `FlociDuckManager`) moves to `services.floci.duck`. Tests are moved to mirror their classes; all importers updated (`EmulatorLifecycle`, `UiController`, `S3Controller`, `S3SelectService`, `AthenaService`, `ParquetEmitter`, and the CUR tests).

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore  (refactor — no version bump)

## AWS Compatibility

No wire-protocol surface changes. No request/response shapes, routes, or error codes are touched; only Java package locations and imports.

## Checklist

- [ ] `./mvnw test` passes locally (ran `test-compile` + S3/UI suites locally; full suite via CI)
- [ ] New or updated integration test added (N/A — existing tests moved, no behavior change)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
