### PR TITLE
docs: correct service count to 58 and add EMR, WAF v2, CloudTrail pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ LocalStack's community edition [sunset in March 2026](https://blog.localstack.cl
 | CodeBuild | Real Docker execution | No |
 | Native binary | ~40 MB | No |
 
-**54 AWS services. Broad coverage. Free forever.**
+**58 AWS services. Broad coverage. Free forever.**
 
 ## Architecture Overview
 
@@ -222,7 +222,8 @@ Floci supports local emulation for application services, data services, eventing
 | Events and workflows | EventBridge, EventBridge Pipes, EventBridge Scheduler, Step Functions, CloudWatch Logs, CloudWatch Metrics |
 | API and identity | API Gateway REST, API Gateway v2, AppSync, Cognito, ACM, Route53, Cloud Map |
 | Containers and compute | ECS, EC2, EKS, CodeBuild, CodeDeploy, Auto Scaling, ELB v2 |
-| Data and analytics | Athena, Glue, Firehose, OpenSearch, Textract, Transcribe |
+| Data and analytics | Athena, Glue, EMR, Firehose, OpenSearch, Textract, Transcribe |
+| Security and governance | WAF v2, CloudTrail |
 | Databases | RDS, RDS Data API, Neptune |
 | Messaging and transfer | SES, SES v2, Kinesis, Transfer Family |
 | Cost and billing | Pricing, Cost Explorer, Cost and Usage Reports, BCM Data Exports |
@@ -266,6 +267,7 @@ For operation-level compatibility, see the [Services Overview](https://floci.io/
 | MSK | Real Docker | Kafka-compatible broker via Redpanda |
 | Athena | In-process with DuckDB sidecar | Real SQL execution over S3 and Glue-backed views |
 | Glue | In-process | Data Catalog, Schema Registry, tables consumed by Athena |
+| EMR | In-process | Cluster (job flow) lifecycle, instance groups and fleets, steps, security configurations, tagging |
 | Data Firehose | In-process | Streaming delivery, NDJSON flush to S3 |
 | ECS | Real Docker | Clusters, task definitions, tasks, services, capacity providers, task sets |
 | EC2 | Real Docker | RunInstances launches containers, SSH key injection, UserData, IMDS, VPC resources |
@@ -285,6 +287,8 @@ For operation-level compatibility, see the [Services Overview](https://floci.io/
 | Auto Scaling | In-process with reconciler | Launch configs, ASGs, desired capacity reconciliation, lifecycle hooks |
 | AWS Backup | In-process | Vaults, backup plans, selections, simulated job lifecycle, recovery points |
 | AWS Config | In-process | Config rules, configuration recorders, delivery channels, conformance packs, tagging |
+| CloudTrail | In-process | Trail lifecycle, event selectors, logging status; management API only |
+| WAF v2 | In-process | Web ACLs, IP sets, regex pattern sets, rule groups, logging configs, resource associations, tagging (REGIONAL and CLOUDFRONT scopes) |
 | Route53 | In-process | Hosted zones, SOA and NS records, resource record sets, change tracking, tagging |
 | Cloud Map | In-process | HTTP and DNS namespaces, services, instance registration, discovery queries, operations, tagging |
 | Transfer Family | In-process | Server lifecycle, user management, SSH key import, tagging |

--- a/docs/getting-started/migrate-from-localstack.md
+++ b/docs/getting-started/migrate-from-localstack.md
@@ -68,7 +68,7 @@ The port (`4566`), credentials (`test` / `test`), and AWS SDK configuration are 
 | `LAMBDA_REMOVE_CONTAINERS=1` | `FLOCI_SERVICES_LAMBDA_EPHEMERAL=true` | Remove Lambda containers after invocation |
 | `USE_SSL=1` | `FLOCI_TLS_ENABLED=true` | Enable TLS/HTTPS — see [TLS / HTTPS](../configuration/tls.md) |
 | `CUSTOM_SSL_CERT_PATH` | `FLOCI_TLS_CERT_PATH` + `FLOCI_TLS_KEY_PATH` | LocalStack accepts a single combined PEM; Floci accepts it in both fields |
-| `SERVICES` | _(not needed)_ | Floci starts all 41 services instantly; no selection required |
+| `SERVICES` | _(not needed)_ | Floci starts all 58 services instantly; no selection required |
 | `LAMBDA_EXECUTOR` | _(not needed)_ | Floci always runs Lambda in Docker containers |
 | `LAMBDA_REMOTE_DOCKER` | _(not supported)_ | Use per-function `S3Bucket=hot-reload` instead — see [Lambda](../services/lambda.md) |
 
@@ -250,6 +250,6 @@ See [S3 → Virtual-Hosted Style](../services/s3.md#virtual-hosted-style) for fu
 |---|---|---|
 | Lambda executor | Configurable (`LAMBDA_EXECUTOR`) | Always Docker containers |
 | `LAMBDA_REMOTE_DOCKER` | Supported | Not supported — use per-function `S3Bucket=hot-reload` instead |
-| Service selection | `SERVICES=sqs,s3,...` | All 41 services start automatically; no selection |
+| Service selection | `SERVICES=sqs,s3,...` | All 58 services start automatically; no selection |
 | Data directory | `/var/lib/localstack` | `/app/data` |
 | Log variable | `LS_LOG` / `DEBUG` | `QUARKUS_LOG_LEVEL` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Floci is a fast, free, and open-source local AWS service emulator built for deve
 
 ## Supported Services
 
-Floci emulates 55 AWS services. See the [Services Overview](services/index.md) for per-service operation counts, endpoints, and full protocol details.
+Floci emulates 58 AWS services. See the [Services Overview](services/index.md) for per-service operation counts, endpoints, and full protocol details.
 
 | Service | Protocol |
 |---|---|
@@ -106,7 +106,7 @@ docker compose up -d
 aws --endpoint-url http://localhost:4566 s3 mb s3://my-bucket
 ```
 
-All 54 AWS services are immediately available at `http://localhost:4566`.
+All 58 AWS services are immediately available at `http://localhost:4566`.
 
 [Get started →](getting-started/quick-start.md){ .md-button .md-button--primary }
 [View services →](services/index.md){ .md-button }

--- a/docs/services/cloudtrail.md
+++ b/docs/services/cloudtrail.md
@@ -1,0 +1,37 @@
+# CloudTrail
+
+**Protocol:** JSON 1.1
+**Endpoint:** `http://localhost:4566/`
+**Target prefix:** `X-Amz-Target: com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.*`
+
+Floci emulates the AWS CloudTrail management API. Trails, their event selectors, and logging status are persisted in Floci's storage backend so you can create and manage trails and validate IaC locally. Floci does not record live API activity into trails.
+
+## Supported Actions
+
+| Action | Description |
+|---|---|
+| `CreateTrail` | Creates a trail and returns its ARN |
+| `UpdateTrail` | Updates the settings of an existing trail |
+| `DeleteTrail` | Deletes a trail |
+| `DescribeTrails` | Returns the settings for one or more trails |
+| `GetTrailStatus` | Returns the logging status of a trail |
+| `StartLogging` | Starts logging for a trail |
+| `StopLogging` | Stops logging for a trail |
+| `PutEventSelectors` | Configures the event selectors for a trail |
+
+## Example
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:4566
+
+# A trail needs a destination S3 bucket
+aws s3 mb s3://my-trail-bucket
+
+aws cloudtrail create-trail \
+  --name demo-trail \
+  --s3-bucket-name my-trail-bucket
+
+aws cloudtrail start-logging --name demo-trail
+aws cloudtrail get-trail-status --name demo-trail
+aws cloudtrail describe-trails
+```

--- a/docs/services/emr.md
+++ b/docs/services/emr.md
@@ -1,0 +1,60 @@
+# EMR
+
+**Protocol:** JSON 1.1
+**Endpoint:** `http://localhost:4566/`
+**Target prefix:** `X-Amz-Target: ElasticMapReduce.*`
+
+Floci emulates the Amazon EMR (Elastic MapReduce) management API. Clusters (job flows), instance groups and fleets, steps, security configurations, and tags are tracked in Floci's storage backend so the AWS CLI and SDK clients can drive the full cluster lifecycle locally. EMR does not launch real Hadoop/Spark clusters — clusters transition through their lifecycle states as a state machine.
+
+## Supported Actions
+
+| Action | Description |
+|---|---|
+| `RunJobFlow` | Creates a new cluster (job flow) and returns its `JobFlowId` |
+| `DescribeCluster` | Returns the configuration and status of a cluster |
+| `ListClusters` | Lists clusters, filterable by state and creation time |
+| `ModifyCluster` | Updates cluster-level settings such as step concurrency |
+| `TerminateJobFlows` | Terminates one or more clusters |
+| `SetTerminationProtection` | Enables or disables termination protection |
+| `SetKeepJobFlowAliveWhenNoSteps` | Controls auto-termination when steps complete |
+| `SetVisibleToAllUsers` | Sets cluster visibility for the account |
+| `SetUnhealthyNodeReplacement` | Toggles unhealthy-node replacement |
+| `AddInstanceGroups` | Adds instance groups to a running cluster |
+| `ListInstanceGroups` | Lists the instance groups of a cluster |
+| `AddInstanceFleet` | Adds an instance fleet to a cluster |
+| `ListInstanceFleets` | Lists the instance fleets of a cluster |
+| `ListInstances` | Lists the EC2 instances of a cluster |
+| `AddJobFlowSteps` | Adds one or more steps to a cluster |
+| `ListSteps` | Lists the steps of a cluster, filterable by state |
+| `DescribeStep` | Returns the detail and status of a single step |
+| `CancelSteps` | Cancels pending steps |
+| `CreateSecurityConfiguration` | Creates a named security configuration |
+| `DescribeSecurityConfiguration` | Returns a security configuration |
+| `DeleteSecurityConfiguration` | Deletes a security configuration |
+| `ListSecurityConfigurations` | Lists all security configurations |
+| `AddTags` | Adds tags to a cluster |
+| `RemoveTags` | Removes tags from a cluster |
+
+## Example
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:4566
+
+# Create a cluster
+CLUSTER_ID=$(aws emr run-job-flow \
+  --name "demo-cluster" \
+  --release-label emr-7.0.0 \
+  --instances InstanceGroups='[{InstanceCount=1,InstanceGroupType=MASTER,InstanceType=m5.xlarge}]' \
+  --query 'JobFlowId' --output text)
+
+# Inspect it
+aws emr describe-cluster --cluster-id "$CLUSTER_ID"
+aws emr list-clusters
+
+# Add a step
+aws emr add-steps --cluster-id "$CLUSTER_ID" \
+  --steps Type=CUSTOM_JAR,Name=demo,Jar=command-runner.jar,Args=[echo,hello]
+
+# Terminate
+aws emr terminate-clusters --cluster-ids "$CLUSTER_ID"
+```

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -1,6 +1,6 @@
 # Services Overview
 
-Floci emulates 55 AWS services on a single port (`4566`). All services use the real AWS wire protocol, your existing AWS CLI commands and SDK clients work without modification.
+Floci emulates 58 AWS services on a single port (`4566`). All services use the real AWS wire protocol, your existing AWS CLI commands and SDK clients work without modification.
 
 This page is the canonical reference for supported service and operation counts. Some services expose separate control-plane and data-plane rows below. Other docs (and the README) should link here rather than duplicating the table.
 
@@ -39,6 +39,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [Athena](athena.md) | `POST /` + `X-Amz-Target: AmazonAthena.*` | JSON 1.1 | 4 |
 | [Glue](glue.md) | `POST /` + `X-Amz-Target: AWSGlue.*` | JSON 1.1 | 38 |
 | [Neptune](neptune.md) | `POST /` with `Action=` param + Gremlin TCP proxy | Query + WebSocket | 8 |
+| [EMR](emr.md) | `POST /` + `X-Amz-Target: ElasticMapReduce.*` | JSON 1.1 | 24 |
 | [Data Firehose](firehose.md) | `POST /` + `X-Amz-Target: Firehose_20150804.*` | JSON 1.1 | 6 |
 | [ECS](ecs.md) | `POST /` + `X-Amz-Target: AmazonEC2ContainerServiceV20141113.*` | JSON 1.1 | 58 |
 | [EC2](ec2.md) | `POST /` with `Action=` param | EC2 Query | 78 |
@@ -54,6 +55,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [Bedrock Runtime](bedrock-runtime.md) | `/model/{modelId}/converse`, `/model/{modelId}/invoke` | REST JSON | 2 (stub; streaming returns 501) |
 | [EKS](eks.md) | `/clusters`, `/clusters/{name}`, `/tags/{resourceArn}` | REST JSON | 7 |
 | [ELB v2](elb.md) | `POST /` with `Action=` param | Query | 34 |
+| [WAF v2](wafv2.md) | `POST /` + `X-Amz-Target: AWSWAF_20190729.*` | JSON 1.1 | 35 |
 | [Auto Scaling](autoscaling.md) | `POST /` with `Action=` param | Query | 33 |
 | [CodeBuild](codebuild.md) | `POST /` + `X-Amz-Target: CodeBuild_20161006.*` | JSON 1.1 | 20 |
 | [AWS Batch](batch.md) | `/v1/...` | REST JSON | 10 |
@@ -63,6 +65,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [Route53](route53.md) | `/2013-04-01/hostedzone/*`, `/2013-04-01/healthcheck/*`, `/2013-04-01/change/*` | REST XML | 17 |
 | [Cloud Map](cloudmap.md) | `POST /` + `X-Amz-Target: Route53AutoNaming_v20170314.*` | JSON 1.1 | 22 |
 | [AWS Config](config.md) | `POST /` + `X-Amz-Target: StarlingDoveService.*` | JSON 1.1 | 20 |
+| [CloudTrail](cloudtrail.md) | `POST /` + `X-Amz-Target: com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.*` | JSON 1.1 | 8 |
 | [Textract](textract.md) | `POST /` + `X-Amz-Target: Textract.*` | JSON 1.1 | 6 |
 | [Transcribe](transcribe.md) | `POST /` + `X-Amz-Target: Transcribe.*` | JSON 1.1 | 8 |
 | [Pricing](pricing.md) | `POST /` + `X-Amz-Target: AWSPriceListService.*` | JSON 1.1 | 5 |

--- a/docs/services/wafv2.md
+++ b/docs/services/wafv2.md
@@ -1,0 +1,71 @@
+# WAF v2
+
+**Protocol:** JSON 1.1
+**Endpoint:** `http://localhost:4566/`
+**Target prefix:** `X-Amz-Target: AWSWAF_20190729.*`
+
+Floci emulates the AWS WAF v2 management API. Web ACLs, IP sets, regex pattern sets, rule groups, logging configurations, permission policies, tags, and resource associations are persisted in Floci's storage backend. Floci does not inspect or filter live traffic — this surface lets you create, read, update, and delete WAF resources and validate IaC (CloudFormation/CDK/Terraform) locally.
+
+## Supported Actions
+
+| Action | Description |
+|---|---|
+| `CreateWebACL` | Creates a web ACL |
+| `GetWebACL` | Returns a web ACL by name/id/scope |
+| `UpdateWebACL` | Updates a web ACL (requires the current `LockToken`) |
+| `DeleteWebACL` | Deletes a web ACL |
+| `ListWebACLs` | Lists web ACLs for a scope |
+| `GetWebACLForResource` | Returns the web ACL associated with a resource |
+| `AssociateWebACL` | Associates a web ACL with a resource |
+| `DisassociateWebACL` | Removes a web ACL association from a resource |
+| `ListResourcesForWebACL` | Lists resources associated with a web ACL |
+| `CreateIPSet` | Creates an IP set |
+| `GetIPSet` | Returns an IP set |
+| `UpdateIPSet` | Updates an IP set |
+| `DeleteIPSet` | Deletes an IP set |
+| `ListIPSets` | Lists IP sets for a scope |
+| `CreateRegexPatternSet` | Creates a regex pattern set |
+| `GetRegexPatternSet` | Returns a regex pattern set |
+| `UpdateRegexPatternSet` | Updates a regex pattern set |
+| `DeleteRegexPatternSet` | Deletes a regex pattern set |
+| `ListRegexPatternSets` | Lists regex pattern sets for a scope |
+| `CreateRuleGroup` | Creates a rule group |
+| `GetRuleGroup` | Returns a rule group |
+| `UpdateRuleGroup` | Updates a rule group |
+| `DeleteRuleGroup` | Deletes a rule group |
+| `ListRuleGroups` | Lists rule groups for a scope |
+| `CheckCapacity` | Returns the WCU capacity required for a set of rules |
+| `PutLoggingConfiguration` | Sets the logging configuration for a web ACL |
+| `GetLoggingConfiguration` | Returns the logging configuration for a web ACL |
+| `DeleteLoggingConfiguration` | Removes a logging configuration |
+| `ListLoggingConfigurations` | Lists logging configurations for a scope |
+| `PutPermissionPolicy` | Attaches an IAM-style policy to a rule group |
+| `GetPermissionPolicy` | Returns the policy attached to a rule group |
+| `DeletePermissionPolicy` | Removes the policy from a rule group |
+| `TagResource` | Adds tags to a WAF resource |
+| `UntagResource` | Removes tags from a WAF resource |
+| `ListTagsForResource` | Lists tags for a WAF resource |
+
+## Scope
+
+WAF v2 resources are partitioned by `Scope`: `REGIONAL` (ALB, API Gateway, AppSync) or `CLOUDFRONT`. Pass `--scope` on every call; `CLOUDFRONT`-scoped requests must target `us-east-1` as on real AWS.
+
+## Example
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:4566
+
+# Create an IP set
+aws wafv2 create-ip-set \
+  --name blocklist --scope REGIONAL \
+  --ip-address-version IPV4 \
+  --addresses 192.0.2.0/24
+
+# Create a web ACL that allows by default
+aws wafv2 create-web-acl \
+  --name demo-acl --scope REGIONAL \
+  --default-action Allow={} \
+  --visibility-config SampledRequestsEnabled=true,CloudWatchMetricsEnabled=true,MetricName=demo
+
+aws wafv2 list-web-acls --scope REGIONAL
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,6 +123,9 @@ nav:
     - AppSync: services/appsync.md
     - Transfer Family: services/transfer.md
     - AWS Config: services/config.md
+    - CloudTrail: services/cloudtrail.md
+    - EMR: services/emr.md
+    - WAF v2: services/wafv2.md
     - Textract: services/textract.md
     - Transcribe: services/transcribe.md
     - Pricing: services/pricing.md


### PR DESCRIPTION
## Summary

Documentation only. Corrects the service count (previously stated inconsistently as 55/54/41) to 58 distinct services, and adds the three services that were emulated but undocumented: EMR, WAF v2, and CloudTrail (new `docs/services/*.md` pages, Service Matrix rows, mkdocs nav entries, and README service tables).

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

N/A — documentation only, no code changes.

## Checklist

- [ ] `./mvnw test` passes locally (N/A — docs only)
- [ ] New or updated integration test added (N/A — docs only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
