### PR TITLE
fix(cloudformation): create stage from AWS::ApiGateway::Deployment inline StageName

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -2601,6 +2601,20 @@ public class CloudFormationResourceProvisioner {
 
         var deployment = apiGatewayService.createDeployment(region, apiId, req);
         r.setPhysicalId(deployment.id());
+
+        // AWS::ApiGateway::Deployment accepts an inline StageName: when present, AWS creates that
+        // stage pointing at this deployment, with no separate AWS::ApiGateway::Stage resource.
+        String stageName = resolveOptional(props, "StageName", engine);
+        if (stageName != null && !stageName.isBlank()) {
+            Map<String, Object> stageReq = new HashMap<>();
+            stageReq.put("stageName", stageName);
+            stageReq.put("deploymentId", deployment.id());
+            JsonNode stageDescription = props != null ? props.get("StageDescription") : null;
+            if (stageDescription != null && stageDescription.has("Description")) {
+                stageReq.put("description", resolveOptional(stageDescription, "Description", engine));
+            }
+            apiGatewayService.createStage(region, apiId, stageReq);
+        }
     }
 
     private void provisionApiGatewayStage(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -3971,6 +3971,78 @@ class CloudFormationIntegrationTest {
             .body("item[0].type", equalTo("TOKEN"));
     }
 
+    // ── Issue #1163: AWS::ApiGateway::Deployment with inline StageName creates the stage ──
+
+    @Test
+    void createStack_withApiGatewayDeploymentStageName_createsStage() {
+        // Regression test for issue #1163: a Deployment carrying an inline StageName created
+        // the deployment but never the stage, so `get-stages` returned empty and invoking
+        // .../{stage}/_user_request_/... returned "Stage not found".
+        String stackName = "cfn-apigw-deploy-stagename-stack";
+        String template = """
+            {
+              "Resources": {
+                "RestApi": {
+                  "Type": "AWS::ApiGateway::RestApi",
+                  "Properties": {
+                    "Name": "cfn-apigw-deploy-stagename-api"
+                  }
+                },
+                "Deployment": {
+                  "Type": "AWS::ApiGateway::Deployment",
+                  "Properties": {
+                    "RestApiId": {"Ref": "RestApi"},
+                    "StageName": "prod"
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        String resourcesXml = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStackResources")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().asString();
+
+        String apiId = physicalIdByLogicalId(resourcesXml, "RestApi");
+        String deploymentId = physicalIdByLogicalId(resourcesXml, "Deployment");
+
+        // The inline StageName must have produced a real stage bound to this deployment.
+        given()
+        .when()
+            .get("/restapis/" + apiId + "/stages")
+        .then()
+            .statusCode(200)
+            .body("item.size()", equalTo(1))
+            .body("item[0].stageName", equalTo("prod"))
+            .body("item[0].deploymentId", equalTo(deploymentId));
+    }
+
     @Test
     void createStack_withApiGatewayMethod_wiresAuthorizerIdViaRef() {
         // Core scenario from issue #788: `AuthorizationType: CUSTOM` plus


### PR DESCRIPTION
## Summary

`AWS::ApiGateway::Deployment` accepts an inline `StageName`. Previously Floci created the deployment but not the stage, so `get-stages` returned empty and invoking `.../{stage}/_user_request_/...` returned "Stage not found". The provisioner now creates the stage (picking up `StageDescription.Description` when present) bound to the new deployment.

This is the secondary CloudFormation gap from #1163. The primary half — `AWS::StepFunctions::StateMachine` not registering — is already resolved on `main`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: a Deployment with `StageName` created no stage. Verified with a regression integration test (`createStack_withApiGatewayDeploymentStageName_createsStage`): CreateStack -> `get-stages` returns the `prod` stage bound to the deployment.

## Checklist

- [x] Affected test passes locally (`CloudFormationIntegrationTest#createStack_withApiGatewayDeploymentStageName_createsStage`)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Refs #1163
