### PR TITLE
fix(elasticache): register Endpoint for reflection so HybridStorage can persist state

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/model/Endpoint.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/model/Endpoint.java
@@ -1,3 +1,6 @@
 package io.github.hectorvent.floci.services.elasticache.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public record Endpoint(String address, int port) {}


### PR DESCRIPTION
## Summary

In a native image, Jackson could not serialize `ReplicationGroup.configurationEndpoint` because the `Endpoint` record lacked reflection metadata. `HybridStorage` threw on every flush and never wrote `elasticache-groups.json`, so ElastiCache replication groups were lost on restart. Annotate `Endpoint` with `@RegisterForReflection` (matching its sibling models `ReplicationGroup`, `CacheCluster`, `ElastiCacheUser`).

Closes #1268

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: ElastiCache state failed to persist in the native image (`No serializer found for class ...Endpoint`). This fix restores persistence.

## Notes

- Native-image-only bug: under the JVM, Jackson serializes the record fine via runtime reflection, so a JVM test can't reproduce it (and would give false assurance) — no test added for that reason. Full confirmation needs a native build (`./mvnw clean package -Dnative`), not run locally.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added (see Notes)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
