### PR TITLE
feat(ssm): add DescribePatchBaselines and GetDefaultPatchBaseline

### DIFF
--- a/docs/services/ssm.md
+++ b/docs/services/ssm.md
@@ -21,6 +21,8 @@
 | `AddTagsToResource` | Tag a parameter |
 | `ListTagsForResource` | List tags on a parameter |
 | `RemoveTagsFromResource` | Remove tags from a parameter |
+| `DescribePatchBaselines` | List AWS-owned predefined patch baselines (filter by `OWNER`, `OPERATING_SYSTEM`, `NAME_PREFIX`) |
+| `GetDefaultPatchBaseline` | Get the default patch baseline id for an operating system |
 
 ### Run Command
 

--- a/src/main/java/io/github/hectorvent/floci/services/ssm/SsmJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssm/SsmJsonHandler.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.services.ssm.model.CommandInvocation;
 import io.github.hectorvent.floci.services.ssm.model.InstanceInformation;
 import io.github.hectorvent.floci.services.ssm.model.Parameter;
 import io.github.hectorvent.floci.services.ssm.model.ParameterHistory;
+import io.github.hectorvent.floci.services.ssm.model.PatchBaselineIdentity;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -57,6 +58,9 @@ public class SsmJsonHandler {
             case "ListCommandInvocations" -> handleListCommandInvocations(request, region);
             case "CancelCommand" -> handleCancelCommand(request, region);
             case "DescribeInstanceInformation" -> handleDescribeInstanceInformation(request, region);
+            // Patch Manager (read-only: AWS-owned predefined baselines)
+            case "DescribePatchBaselines" -> handleDescribePatchBaselines(request, region);
+            case "GetDefaultPatchBaseline" -> handleGetDefaultPatchBaseline(request, region);
             // Agent registration (internal, not in public SDK)
             case "UpdateInstanceInformation" -> handleUpdateInstanceInformation(request, region);
             default -> Response.status(400)
@@ -197,6 +201,47 @@ public class SsmJsonHandler {
             parametersArray.add(node);
         }
         response.set("Parameters", parametersArray);
+        return Response.ok(response).build();
+    }
+
+    private Response handleDescribePatchBaselines(JsonNode request, String region) {
+        Map<String, List<String>> filters = new HashMap<>();
+        JsonNode filtersNode = request.path("Filters");
+        if (filtersNode.isArray()) {
+            for (JsonNode f : filtersNode) {
+                String key = f.path("Key").asText("");
+                List<String> values = new ArrayList<>();
+                f.path("Values").forEach(v -> values.add(v.asText()));
+                if (!key.isEmpty()) {
+                    filters.put(key, values);
+                }
+            }
+        }
+
+        List<PatchBaselineIdentity> baselines = ssmService.describePatchBaselines(filters);
+
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode identities = objectMapper.createArrayNode();
+        for (PatchBaselineIdentity b : baselines) {
+            ObjectNode node = objectMapper.createObjectNode();
+            node.put("BaselineId", b.baselineId());
+            node.put("BaselineName", b.baselineName());
+            node.put("OperatingSystem", b.operatingSystem());
+            node.put("BaselineDescription", b.baselineDescription());
+            node.put("DefaultBaseline", b.defaultBaseline());
+            identities.add(node);
+        }
+        response.set("BaselineIdentities", identities);
+        return Response.ok(response).build();
+    }
+
+    private Response handleGetDefaultPatchBaseline(JsonNode request, String region) {
+        String operatingSystem = request.has("OperatingSystem") ? request.path("OperatingSystem").asText() : null;
+        String baselineId = ssmService.getDefaultPatchBaseline(operatingSystem);
+
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("BaselineId", baselineId);
+        response.put("OperatingSystem", (operatingSystem == null || operatingSystem.isBlank()) ? "WINDOWS" : operatingSystem);
         return Response.ok(response).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ssm/SsmService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssm/SsmService.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ssm.model.Parameter;
 import io.github.hectorvent.floci.services.ssm.model.ParameterHistory;
+import io.github.hectorvent.floci.services.ssm.model.PatchBaselineIdentity;
 import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -239,6 +240,82 @@ public class SsmService {
             parameterStore.put(storageKey, param);
         }
         LOG.debugv("Removed tags from parameter: {0}", resourceId);
+    }
+
+    // ──────────────────────────── Patch Baselines ────────────────────────────
+    // AWS provides a fixed set of AWS-owned predefined patch baselines (one default per operating
+    // system). These are static reference data, not customer state, so they live in-memory only.
+
+    private static final List<PatchBaselineIdentity> PREDEFINED_BASELINES = buildPredefinedBaselines();
+
+    private static List<PatchBaselineIdentity> buildPredefinedBaselines() {
+        String[][] defs = {
+                {"WINDOWS", "AWS-DefaultPatchBaseline", "Windows"},
+                {"AMAZON_LINUX", "AWS-AmazonLinuxDefaultPatchBaseline", "Amazon Linux"},
+                {"AMAZON_LINUX_2", "AWS-AmazonLinux2DefaultPatchBaseline", "Amazon Linux 2"},
+                {"AMAZON_LINUX_2022", "AWS-AmazonLinux2022DefaultPatchBaseline", "Amazon Linux 2022"},
+                {"AMAZON_LINUX_2023", "AWS-AmazonLinux2023DefaultPatchBaseline", "Amazon Linux 2023"},
+                {"UBUNTU", "AWS-UbuntuDefaultPatchBaseline", "Ubuntu"},
+                {"REDHAT_ENTERPRISE_LINUX", "AWS-RedHatDefaultPatchBaseline", "Red Hat Enterprise Linux"},
+                {"SUSE", "AWS-SuseDefaultPatchBaseline", "SUSE Linux Enterprise Server"},
+                {"CENTOS", "AWS-CentOSDefaultPatchBaseline", "CentOS"},
+                {"ORACLE_LINUX", "AWS-OracleLinuxDefaultPatchBaseline", "Oracle Linux"},
+                {"DEBIAN", "AWS-DebianDefaultPatchBaseline", "Debian Server"},
+                {"MACOS", "AWS-MacOSDefaultPatchBaseline", "macOS"},
+                {"RASPBIAN", "AWS-RaspbianDefaultPatchBaseline", "Raspbian"},
+                {"ROCKY_LINUX", "AWS-RockyLinuxDefaultPatchBaseline", "Rocky Linux"},
+                {"ALMA_LINUX", "AWS-AlmaLinuxDefaultPatchBaseline", "AlmaLinux"},
+        };
+        List<PatchBaselineIdentity> baselines = new ArrayList<>();
+        for (String[] def : defs) {
+            String os = def[0];
+            String name = def[1];
+            String description = "Default Patch Baseline for " + def[2] + " Provided by AWS.";
+            baselines.add(new PatchBaselineIdentity(stableBaselineId(name), name, os, description, true));
+        }
+        return List.copyOf(baselines);
+    }
+
+    /** Deterministic AWS-style baseline id (pb-<17 hex>) derived from the baseline name. */
+    private static String stableBaselineId(String name) {
+        long h = 1125899906842597L;
+        for (int i = 0; i < name.length(); i++) {
+            h = 31 * h + name.charAt(i);
+        }
+        String hex = String.format("%016x", h & 0x0FFFFFFFFFFFFFFFL);
+        return "pb-0" + hex;
+    }
+
+    /**
+     * Return AWS-owned predefined patch baselines matching the given DescribePatchBaselines filters
+     * (supported keys: OWNER, OPERATING_SYSTEM, NAME_PREFIX). There are no customer-owned baselines.
+     */
+    public List<PatchBaselineIdentity> describePatchBaselines(Map<String, List<String>> filters) {
+        List<String> owners = filters.getOrDefault("OWNER", List.of());
+        // OWNER=Self matches only customer-owned baselines, of which there are none.
+        if (!owners.isEmpty() && !owners.contains("AWS") && !owners.contains("All")) {
+            return List.of();
+        }
+
+        List<String> operatingSystems = filters.getOrDefault("OPERATING_SYSTEM", List.of());
+        List<String> namePrefixes = filters.getOrDefault("NAME_PREFIX", List.of());
+
+        return PREDEFINED_BASELINES.stream()
+                .filter(b -> operatingSystems.isEmpty() || operatingSystems.contains(b.operatingSystem()))
+                .filter(b -> namePrefixes.isEmpty()
+                        || namePrefixes.stream().anyMatch(prefix -> b.baselineName().startsWith(prefix)))
+                .toList();
+    }
+
+    /** Return the default patch baseline id for an operating system (defaults to WINDOWS). */
+    public String getDefaultPatchBaseline(String operatingSystem) {
+        String os = (operatingSystem == null || operatingSystem.isBlank()) ? "WINDOWS" : operatingSystem;
+        return PREDEFINED_BASELINES.stream()
+                .filter(b -> b.operatingSystem().equals(os))
+                .findFirst()
+                .map(PatchBaselineIdentity::baselineId)
+                .orElseThrow(() -> new AwsException("DoesNotExistException",
+                        "No default patch baseline exists for operating system " + os, 400));
     }
 
     private static String regionKey(String region, String name) {

--- a/src/main/java/io/github/hectorvent/floci/services/ssm/model/PatchBaselineIdentity.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssm/model/PatchBaselineIdentity.java
@@ -1,0 +1,14 @@
+package io.github.hectorvent.floci.services.ssm.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * Identity of an AWS-owned predefined patch baseline, as returned by DescribePatchBaselines.
+ */
+@RegisterForReflection
+public record PatchBaselineIdentity(String baselineId,
+                                    String baselineName,
+                                    String operatingSystem,
+                                    String baselineDescription,
+                                    boolean defaultBaseline) {
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ssm/SsmIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssm/SsmIntegrationTest.java
@@ -233,6 +233,89 @@ class SsmIntegrationTest {
             .body("DeletedParameters.size()", equalTo(2));
     }
 
+    // ── Issue #956: DescribePatchBaselines / GetDefaultPatchBaseline (AWS-owned predefined) ──
+
+    @Test
+    void describePatchBaselines_filteredByOwnerAndOperatingSystem() {
+        given()
+            .header("X-Amz-Target", "AmazonSSM.DescribePatchBaselines")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                {
+                    "Filters": [
+                        {"Key": "OWNER", "Values": ["AWS"]},
+                        {"Key": "OPERATING_SYSTEM", "Values": ["AMAZON_LINUX_2"]}
+                    ]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("BaselineIdentities.size()", equalTo(1))
+            .body("BaselineIdentities[0].BaselineName", equalTo("AWS-AmazonLinux2DefaultPatchBaseline"))
+            .body("BaselineIdentities[0].OperatingSystem", equalTo("AMAZON_LINUX_2"))
+            .body("BaselineIdentities[0].DefaultBaseline", equalTo(true))
+            .body("BaselineIdentities[0].BaselineId", startsWith("pb-"));
+    }
+
+    @Test
+    void describePatchBaselines_byNamePrefixReturnsPredefined() {
+        given()
+            .header("X-Amz-Target", "AmazonSSM.DescribePatchBaselines")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                {
+                    "Filters": [
+                        {"Key": "NAME_PREFIX", "Values": ["AWS-"]}
+                    ]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("BaselineIdentities.size()", greaterThan(1))
+            .body("BaselineIdentities.BaselineName", everyItem(startsWith("AWS-")));
+    }
+
+    @Test
+    void describePatchBaselines_ownerSelfReturnsEmpty() {
+        given()
+            .header("X-Amz-Target", "AmazonSSM.DescribePatchBaselines")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                {
+                    "Filters": [
+                        {"Key": "OWNER", "Values": ["Self"]}
+                    ]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("BaselineIdentities.size()", equalTo(0));
+    }
+
+    @Test
+    void getDefaultPatchBaseline_windows() {
+        given()
+            .header("X-Amz-Target", "AmazonSSM.GetDefaultPatchBaseline")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                {
+                    "OperatingSystem": "WINDOWS"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("OperatingSystem", equalTo("WINDOWS"))
+            .body("BaselineId", startsWith("pb-"));
+    }
+
     @Test
     void unsupportedOperation() {
         given()


### PR DESCRIPTION
## Summary

Implements `DescribePatchBaselines` and `GetDefaultPatchBaseline` for SSM, returning AWS-owned predefined patch baselines (one default per operating system) so Terraform's `aws_ssm_patch_baseline` data source resolves. `DescribePatchBaselines` supports the `OWNER`, `OPERATING_SYSTEM` and `NAME_PREFIX` filters.

Addresses the SSM half of #956. (The EC2 `DescribeVpcEndpoints` half is already on `main`.)

Closes #956 

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

New actions. Wire shapes verified against the AWS SDK model (`ssm.json`): `DescribePatchBaselinesRequest.Filters`, `PatchBaselineIdentity` (`BaselineId`/`BaselineName`/`OperatingSystem`/`BaselineDescription`/`DefaultBaseline`), `GetDefaultPatchBaseline`. Verified end-to-end with AWS CLI v2 against a running instance.

## Notes

- Read-only predefined (AWS-owned) catalog only; customer `CreatePatchBaseline` / `GetPatchBaseline` detail / patch-group association are out of scope (follow-ups).

## Checklist

- [x] Affected tests pass locally (`SsmIntegrationTest`, 15 incl. 4 new)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Refs #956
