### PR TITLE
fix(sqs): message processing from non-default account

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.sqs;
 
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.services.sqs.model.Message;
 
@@ -266,6 +267,33 @@ class GuardedMessageQueue {
         if (closed || messageStore == null || storageKey == null) {
             return;
         }
+        if (messageStore instanceof AccountAwareStorageBackend<List<Message>> aware) {
+            String accountId = extractAccountFromStorageKey(storageKey);
+            if (accountId != null) {
+                aware.putForAccount(accountId, storageKey, new ArrayList<>(messages));
+                return;
+            }
+        }
         messageStore.put(storageKey, new ArrayList<>(messages));
+    }
+
+    /**
+     * Extracts the 12-digit account ID from a storage key of the form
+     * {@code region::/accountId/queueName}.
+     */
+    private static String extractAccountFromStorageKey(String storageKey) {
+        if (storageKey == null) {
+            return null;
+        }
+        // storageKey format: "us-east-1::/000000000001/my-queue"
+        int separator = storageKey.indexOf("::");
+        if (separator < 0) {
+            return null;
+        }
+        String path = storageKey.substring(separator + 2); // "/000000000001/my-queue"
+        String trimmed = path.startsWith("/") ? path.substring(1) : path;
+        int slash = trimmed.indexOf('/');
+        String candidate = slash > 0 ? trimmed.substring(0, slash) : trimmed;
+        return candidate.matches("\\d{12}") ? candidate : null;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -611,7 +611,7 @@ public class SqsService {
                 // to the new queue's consumers.
                 return Collections.emptyList();
             }
-            List<Message> result = doReceiveMessage(storageKey, maxMessages, visibilityTimeout, region);
+            List<Message> result = doReceiveMessage(storageKey, queueUrl, maxMessages, visibilityTimeout, region);
             if (!result.isEmpty() || maxWait <= 0) {
                 if (!result.isEmpty() && LOG.isTraceEnabled()) {
                     for (Message m : result) {
@@ -657,8 +657,8 @@ public class SqsService {
         });
     }
 
-    private List<Message> doReceiveMessage(String storageKey, int maxMessages, int visibilityTimeout, String region) {
-        Queue queue = queueStore.get(storageKey).orElse(null);
+    private List<Message> doReceiveMessage(String storageKey, String queueUrl, int maxMessages, int visibilityTimeout, String region) {
+        Queue queue = getQueueByUrl(storageKey, queueUrl).orElse(null);
         if (queue == null) {
             return Collections.emptyList();
         }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/EsmIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/EsmIntegrationTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  * Integration tests for Lambda Event Source Mapping (ESM) endpoints.
  * Requires an SQS queue and Lambda function to be created first.
@@ -27,6 +29,13 @@ class EsmIntegrationTest {
             "arn:aws:sqs:" + REGION + ":" + ACCOUNT_ID + ":" + QUEUE_NAME;
     private static final String FUNCTION_ARN =
             "arn:aws:lambda:" + REGION + ":" + ACCOUNT_ID + ":function:" + FUNCTION_NAME;
+    private static final String NON_DEFAULT_ACCOUNT = "000000000001";
+    private static final String MULTI_ACCOUNT_QUEUE_NAME = "esm-multi-account-queue";
+    private static final String MULTI_ACCOUNT_FUNCTION_NAME = "esm-multi-account-fn";
+    private static final String MULTI_ACCOUNT_QUEUE_ARN =
+            "arn:aws:sqs:" + REGION + ":" + NON_DEFAULT_ACCOUNT + ":" + MULTI_ACCOUNT_QUEUE_NAME;
+    private static final String MULTI_ACCOUNT_QUEUE_URL =
+            "http://localhost:4566/" + NON_DEFAULT_ACCOUNT + "/" + MULTI_ACCOUNT_QUEUE_NAME;
 
     private static String esmUuid;
 
@@ -585,5 +594,175 @@ class EsmIntegrationTest {
             .body("$", not(hasKey("ScalingConfig")));
 
         given().delete(LAMBDA_BASE + "/event-source-mappings/" + uuid).then().statusCode(202);
+    }
+
+    /**
+     * Builds a SigV4 Authorization header whose access key ID is the given
+     * 12-digit account ID. Floci's AccountResolver treats a 12-digit AKID as
+     * the account ID directly (LocalStack multi-account convention). The full
+     * header form (SignedHeaders + Signature) mirrors AccountIsolationIntegrationTest.
+     */
+    private static String authForAccount(String accountId, String service) {
+        return "AWS4-HMAC-SHA256 Credential=" + accountId
+                + "/20260101/us-east-1/" + service + "/aws4_request, SignedHeaders=host, Signature=abc";
+    }
+
+    /**
+     * Returns the raw GetQueueAttributes (Query protocol) response body for the
+     * queue, queried as the given account. Only ApproximateNumberOfMessagesNotVisible
+     * is requested, so the body contains exactly one {@code <Value>} element.
+     */
+    private static String getQueueAttributesBody(String queueUrl, String auth) {
+        return given()
+                .header("Authorization", auth)
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "GetQueueAttributes")
+                .formParam("QueueUrl", queueUrl)
+                .formParam("AttributeName.1", "ApproximateNumberOfMessagesNotVisible")
+                .formParam("Version", "2012-11-05")
+            .when().post(SQS_BASE)
+            .then().statusCode(200)
+            .extract().asString();
+    }
+
+    /**
+     * Parses the single ApproximateNumberOfMessagesNotVisible value out of a
+     * GetQueueAttributes response body. Uses direct substring extraction (not
+     * XmlPath) so the result is independent of XML-path library quirks.
+     */
+    private static int parseNotVisible(String body) {
+        int start = body.indexOf("<Value>");
+        int end = body.indexOf("</Value>");
+        if (start < 0 || end <= start) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(body.substring(start + "<Value>".length(), end).trim());
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    // ──────────────────────────── Multi-account ESM ────────────────────────────
+
+    /**
+     * Regression test for the SQS ESM poller account-aware lookup bug (M1/M2).
+     *
+     * The poller runs on a Vert.x timer thread outside CDI request scope. Before
+     * the fix, doReceiveMessage() looked up the queue under the default account
+     * and never found queues created under another account, so Lambda never fired.
+     *
+     * Creates a queue, function, and ESM under account 000000000001 (via a
+     * 12-digit AKID in the SigV4 credential), sends a message, and asserts the
+     * poller claims it (ApproximateNumberOfMessagesNotVisible > 0).
+     */
+    @Test
+    @Order(60)
+    void esmPollerReceivesMessagesFromNonDefaultAccount() throws Exception {
+        String sqsAuth = authForAccount(NON_DEFAULT_ACCOUNT, "sqs");
+        String lambdaAuth = authForAccount(NON_DEFAULT_ACCOUNT, "lambda");
+        String esmUuid = null;
+        try {
+            // 1. Create the queue under account 000000000001
+            given()
+                .header("Authorization", sqsAuth)
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "CreateQueue")
+                .formParam("QueueName", MULTI_ACCOUNT_QUEUE_NAME)
+                .formParam("Version", "2012-11-05")
+            .when().post(SQS_BASE)
+            .then().statusCode(200)
+                .body(containsString(NON_DEFAULT_ACCOUNT + "/" + MULTI_ACCOUNT_QUEUE_NAME));
+
+            // 2. Create the Lambda function under account 000000000001
+            given()
+                .header("Authorization", lambdaAuth)
+                .contentType("application/json")
+                .body("""
+                    {
+                        "FunctionName": "%s",
+                        "Runtime": "nodejs20.x",
+                        "Role": "arn:aws:iam::000000000001:role/lambda-role",
+                        "Handler": "index.handler"
+                    }
+                    """.formatted(MULTI_ACCOUNT_FUNCTION_NAME))
+            .when().post(LAMBDA_BASE + "/functions")
+            .then().statusCode(201)
+                .body("FunctionName", equalTo(MULTI_ACCOUNT_FUNCTION_NAME));
+
+            // 3. Create the ESM linking the queue to the function (both account 000000000001)
+            esmUuid = given()
+                .header("Authorization", lambdaAuth)
+                .contentType("application/json")
+                .body("""
+                    {
+                        "FunctionName": "%s",
+                        "EventSourceArn": "%s",
+                        "BatchSize": 1
+                    }
+                    """.formatted(MULTI_ACCOUNT_FUNCTION_NAME, MULTI_ACCOUNT_QUEUE_ARN))
+            .when().post(LAMBDA_BASE + "/event-source-mappings")
+            .then().statusCode(202)
+                .body("State", equalTo("Enabled"))
+                .body("EventSourceArn", equalTo(MULTI_ACCOUNT_QUEUE_ARN))
+            .extract().path("UUID");
+
+            // 4. Send a message to the queue
+            given()
+                .header("Authorization", sqsAuth)
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "SendMessage")
+                .formParam("QueueUrl", MULTI_ACCOUNT_QUEUE_URL)
+                .formParam("MessageBody", "esm-multi-account-payload")
+                .formParam("Version", "2012-11-05")
+            .when().post(SQS_BASE)
+            .then().statusCode(200);
+
+            // 5. Wait for the poller to claim the message. Poll interval is 1000ms;
+            //    a claimed message becomes in-flight (NotVisible > 0), proving the
+            //    poller resolved the queue under account 000000000001 and received it.
+            long deadline = System.currentTimeMillis() + 8_000;
+            int notVisible = 0;
+            String lastBody = "";
+            while (System.currentTimeMillis() < deadline) {
+                lastBody = getQueueAttributesBody(MULTI_ACCOUNT_QUEUE_URL, sqsAuth);
+                notVisible = parseNotVisible(lastBody);
+                if (notVisible > 0) {
+                    break;
+                }
+                Thread.sleep(250);
+            }
+            assertTrue(notVisible > 0,
+                    "ESM poller never claimed the message under account " + NON_DEFAULT_ACCOUNT
+                            + " (ApproximateNumberOfMessagesNotVisible stayed 0) — "
+                            + "account-aware queue lookup in doReceiveMessage is broken. "
+                            + "Last GetQueueAttributes body: " + lastBody);
+
+        } finally {
+            // Best-effort cleanup so the test is re-runnable and leaks no state.
+            // Each cleanup is isolated so a missing resource doesn't abort the others.
+            try {
+                if (esmUuid != null) {
+                    given().header("Authorization", lambdaAuth)
+                        .when().delete(LAMBDA_BASE + "/event-source-mappings/" + esmUuid);
+                }
+            } catch (Exception ignored) {
+            }
+            try {
+                given().header("Authorization", sqsAuth)
+                    .contentType("application/x-www-form-urlencoded")
+                    .formParam("Action", "DeleteQueue")
+                    .formParam("QueueUrl", MULTI_ACCOUNT_QUEUE_URL)
+                    .formParam("Version", "2012-11-05")
+                    .when().post(SQS_BASE);
+            } catch (Exception ignored) {
+            }
+            try {
+                given().header("Authorization", lambdaAuth)
+                    .contentType("application/json")
+                    .when().delete(LAMBDA_BASE + "/functions/" + MULTI_ACCOUNT_FUNCTION_NAME);
+            } catch (Exception ignored) {
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

The Lambda SQS Event Source Mapping poller runs on a Vert.x periodic timer thread with no CDI request scope. When polling a queue owned by a non-default account (e.g. `000000000001`), `doReceiveMessage()` called `queueStore.get(storageKey)`, which went through `AccountAwareStorageBackend.prefix()`. That method caught `ContextNotActiveException` and fell back to `defaultAccountId` (`000000000000`), causing a key mismatch — the queue was stored under one account prefix but looked up under another. Result: queue not found, empty receive, Lambda never fires.

Additionally, `GuardedMessageQueue.persist()` called `messageStore.put(storageKey, ...)` which had the same account-prefix problem, corrupting message state persistence (visibility changes, deletions) when they originated from the poller's async thread.

Three targeted fixes:

1. **`SqsService.doReceiveMessage()`** — now accepts `queueUrl` and uses the existing `getQueueByUrl(storageKey, queueUrl)` helper (extracts account from URL path, bypasses request-context dependency) instead of `queueStore.get(storageKey)`. Mirrors how `sendMessage` and `deleteMessage` already resolve accounts.

2. **`GuardedMessageQueue.persist()`** — when the message store is `AccountAwareStorageBackend`, extracts the account ID from the storage key (`region::/accountId/queueName`) via a new `extractAccountFromStorageKey()` helper and calls `putForAccount(accountId, storageKey, messages)` instead of `put()`. Falls back to the existing `put()` path when the store is not account-aware or the account cannot be extracted.

3. **`EsmIntegrationTest`** — new `esmPollerReceivesMessagesFromNonDefaultAccount` test that creates a queue, Lambda function, and ESM under account `000000000001` (using SigV4 `Credential=000000000001/...` per the LocalStack 12-digit AKID convention), sends a message, and asserts `ApproximateNumberOfMessagesNotVisible > 0` within a timeout — proving the poller successfully receives from a non-default account's queue.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

SQS `ReceiveMessage` called from the Lambda ESM poller now correctly resolves the queue's account from the queue URL rather than from the CDI request context (which is absent on background threads). This matches AWS behaviour where a queue URL like `https://sqs.us-east-1.amazonaws.com/000000000001/my-queue` unambiguously identifies the account. No changes to request or response wire formats. The `GuardedMessageQueue` persistence fix ensures message state transitions (visibility timeout, deletion) are stored under the correct account, matching how they were originally created.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
