### PR TITLE
feat(ses): support v2 dedicated IP pools and configuration-set option groups

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesConfigurationSetOptionsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesConfigurationSetOptionsTest.java
@@ -14,8 +14,10 @@ import software.amazon.awssdk.services.sesv2.model.BadRequestException;
 import software.amazon.awssdk.services.sesv2.model.DashboardOptions;
 import software.amazon.awssdk.services.sesv2.model.GuardianOptions;
 import software.amazon.awssdk.services.sesv2.model.CreateConfigurationSetRequest;
+import software.amazon.awssdk.services.sesv2.model.CreateDedicatedIpPoolRequest;
 import software.amazon.awssdk.services.sesv2.model.CreateEmailIdentityRequest;
 import software.amazon.awssdk.services.sesv2.model.DeleteConfigurationSetRequest;
+import software.amazon.awssdk.services.sesv2.model.DeleteDedicatedIpPoolRequest;
 import software.amazon.awssdk.services.sesv2.model.DeleteEmailIdentityRequest;
 import software.amazon.awssdk.services.sesv2.model.DeliveryOptions;
 import software.amazon.awssdk.services.sesv2.model.GetConfigurationSetRequest;
@@ -244,5 +246,21 @@ class SesConfigurationSetOptionsTest {
         assertThat(response.vdmOptions()).isNotNull();
         assertThat(response.vdmOptions().dashboardOptions().engagementMetricsAsString()).isEqualTo("ENABLED");
         assertThat(response.vdmOptions().guardianOptions().optimizedSharedDeliveryAsString()).isEqualTo("DISABLED");
+    }
+
+    @Test
+    @Order(12)
+    void putDeliveryOptions_existingSendingPool_roundTrips() {
+        String pool = "compat-cs-options-pool";
+        sesV2.createDedicatedIpPool(CreateDedicatedIpPoolRequest.builder().poolName(pool).build());
+        try {
+            sesV2.putConfigurationSetDeliveryOptions(PutConfigurationSetDeliveryOptionsRequest.builder()
+                    .configurationSetName(CS_NAME)
+                    .sendingPoolName(pool)
+                    .build());
+            assertThat(getConfigSet().deliveryOptions().sendingPoolName()).isEqualTo(pool);
+        } finally {
+            sesV2.deleteDedicatedIpPool(DeleteDedicatedIpPoolRequest.builder().poolName(pool).build());
+        }
     }
 }

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesConfigurationSetOptionsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesConfigurationSetOptionsTest.java
@@ -1,0 +1,248 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.ArchivingOptions;
+import software.amazon.awssdk.services.sesv2.model.BadRequestException;
+import software.amazon.awssdk.services.sesv2.model.DashboardOptions;
+import software.amazon.awssdk.services.sesv2.model.GuardianOptions;
+import software.amazon.awssdk.services.sesv2.model.CreateConfigurationSetRequest;
+import software.amazon.awssdk.services.sesv2.model.CreateEmailIdentityRequest;
+import software.amazon.awssdk.services.sesv2.model.DeleteConfigurationSetRequest;
+import software.amazon.awssdk.services.sesv2.model.DeleteEmailIdentityRequest;
+import software.amazon.awssdk.services.sesv2.model.DeliveryOptions;
+import software.amazon.awssdk.services.sesv2.model.GetConfigurationSetRequest;
+import software.amazon.awssdk.services.sesv2.model.GetConfigurationSetResponse;
+import software.amazon.awssdk.services.sesv2.model.NotFoundException;
+import software.amazon.awssdk.services.sesv2.model.PutConfigurationSetArchivingOptionsRequest;
+import software.amazon.awssdk.services.sesv2.model.PutConfigurationSetDeliveryOptionsRequest;
+import software.amazon.awssdk.services.sesv2.model.PutConfigurationSetReputationOptionsRequest;
+import software.amazon.awssdk.services.sesv2.model.PutConfigurationSetTrackingOptionsRequest;
+import software.amazon.awssdk.services.sesv2.model.ReputationOptions;
+import software.amazon.awssdk.services.sesv2.model.PutConfigurationSetVdmOptionsRequest;
+import software.amazon.awssdk.services.sesv2.model.TrackingOptions;
+import software.amazon.awssdk.services.sesv2.model.VdmOptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * SDK compatibility test for the per-configuration-set option groups added to
+ * the SES v2 surface. Verifies the AWS Java SDK v2 marshalling of:
+ *   - {@code putConfigurationSetReputationOptions} / {@code ReputationOptions}
+ *   - {@code putConfigurationSetTrackingOptions}   / {@code TrackingOptions}
+ *   - {@code putConfigurationSetDeliveryOptions}   / {@code DeliveryOptions}
+ *   - {@code putConfigurationSetArchivingOptions}  / {@code ArchivingOptions}
+ * and the {@code GetConfigurationSet} response carrying each block, plus the
+ * server-side validation errors surfaced as {@link BadRequestException} /
+ * {@link NotFoundException}.
+ */
+@DisplayName("SES v2 Configuration-Set Option Groups")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesConfigurationSetOptionsTest {
+
+    private static final String CS_NAME = "compat-cs-options";
+    private static final String CREATE_CS = "compat-cs-options-create";
+    private static final String CREATE_CS_BAD = "compat-cs-options-create-bad";
+    private static final String TRACK_DOMAIN = "compat-track.example.com";
+    private static final String ARCHIVE_ARN =
+            "arn:aws:ses:us-east-1:123456789012:mailmanager-archive/a-abcdefghijklmnopqrstuvwx";
+
+    private static SesV2Client sesV2;
+
+    @BeforeAll
+    static void setup() {
+        sesV2 = TestFixtures.sesV2Client();
+        deleteConfigSetQuietly(CS_NAME);
+        deleteConfigSetQuietly(CREATE_CS);
+        deleteConfigSetQuietly(CREATE_CS_BAD);
+        sesV2.createConfigurationSet(CreateConfigurationSetRequest.builder()
+                .configurationSetName(CS_NAME).build());
+        // CustomRedirectDomain must be a verified domain identity.
+        try {
+            sesV2.createEmailIdentity(CreateEmailIdentityRequest.builder()
+                    .emailIdentity(TRACK_DOMAIN).build());
+        } catch (Exception ignored) {}
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (sesV2 != null) {
+            deleteConfigSetQuietly(CS_NAME);
+            deleteConfigSetQuietly(CREATE_CS);
+            deleteConfigSetQuietly(CREATE_CS_BAD);
+            try {
+                sesV2.deleteEmailIdentity(DeleteEmailIdentityRequest.builder()
+                        .emailIdentity(TRACK_DOMAIN).build());
+            } catch (Exception ignored) {}
+            sesV2.close();
+        }
+    }
+
+    private static void deleteConfigSetQuietly(String name) {
+        try {
+            sesV2.deleteConfigurationSet(DeleteConfigurationSetRequest.builder()
+                    .configurationSetName(name).build());
+        } catch (Exception ignored) {}
+    }
+
+    private static GetConfigurationSetResponse getConfigSet() {
+        return sesV2.getConfigurationSet(GetConfigurationSetRequest.builder()
+                .configurationSetName(CS_NAME).build());
+    }
+
+    @Test
+    @Order(1)
+    void getConfigurationSet_reputationDefaultsToEnabled() {
+        assertThat(getConfigSet().reputationOptions()).isNotNull();
+        assertThat(getConfigSet().reputationOptions().reputationMetricsEnabled()).isTrue();
+    }
+
+    @Test
+    @Order(2)
+    void putReputationOptions_disables() {
+        sesV2.putConfigurationSetReputationOptions(PutConfigurationSetReputationOptionsRequest.builder()
+                .configurationSetName(CS_NAME)
+                .reputationMetricsEnabled(false)
+                .build());
+        assertThat(getConfigSet().reputationOptions().reputationMetricsEnabled()).isFalse();
+    }
+
+    @Test
+    @Order(3)
+    void putDeliveryOptions_roundTrips() {
+        sesV2.putConfigurationSetDeliveryOptions(PutConfigurationSetDeliveryOptionsRequest.builder()
+                .configurationSetName(CS_NAME)
+                .tlsPolicy("REQUIRE")
+                .maxDeliverySeconds(600L)
+                .build());
+        GetConfigurationSetResponse response = getConfigSet();
+        assertThat(response.deliveryOptions()).isNotNull();
+        assertThat(response.deliveryOptions().tlsPolicyAsString()).isEqualTo("REQUIRE");
+        assertThat(response.deliveryOptions().maxDeliverySeconds()).isEqualTo(600L);
+    }
+
+    @Test
+    @Order(4)
+    void putDeliveryOptions_nonExistentSendingPool_throwsBadRequest() {
+        assertThatThrownBy(() -> sesV2.putConfigurationSetDeliveryOptions(
+                PutConfigurationSetDeliveryOptionsRequest.builder()
+                        .configurationSetName(CS_NAME)
+                        .sendingPoolName("compat-ghost-pool")
+                        .build()))
+                .isInstanceOf(BadRequestException.class);
+    }
+
+    @Test
+    @Order(5)
+    void putTrackingOptions_verifiedDomain_roundTrips() {
+        sesV2.putConfigurationSetTrackingOptions(PutConfigurationSetTrackingOptionsRequest.builder()
+                .configurationSetName(CS_NAME)
+                .customRedirectDomain(TRACK_DOMAIN)
+                .httpsPolicy("REQUIRE")
+                .build());
+        GetConfigurationSetResponse response = getConfigSet();
+        assertThat(response.trackingOptions()).isNotNull();
+        assertThat(response.trackingOptions().customRedirectDomain()).isEqualTo(TRACK_DOMAIN);
+        assertThat(response.trackingOptions().httpsPolicyAsString()).isEqualTo("REQUIRE");
+    }
+
+    @Test
+    @Order(6)
+    void putTrackingOptions_unverifiedDomain_throwsBadRequest() {
+        assertThatThrownBy(() -> sesV2.putConfigurationSetTrackingOptions(
+                PutConfigurationSetTrackingOptionsRequest.builder()
+                        .configurationSetName(CS_NAME)
+                        .customRedirectDomain("compat-unverified.example.com")
+                        .httpsPolicy("REQUIRE")
+                        .build()))
+                .isInstanceOf(BadRequestException.class);
+    }
+
+    @Test
+    @Order(7)
+    void putArchivingOptions_roundTrips() {
+        sesV2.putConfigurationSetArchivingOptions(PutConfigurationSetArchivingOptionsRequest.builder()
+                .configurationSetName(CS_NAME)
+                .archiveArn(ARCHIVE_ARN)
+                .build());
+        GetConfigurationSetResponse response = getConfigSet();
+        assertThat(response.archivingOptions()).isNotNull();
+        assertThat(response.archivingOptions().archiveArn()).isEqualTo(ARCHIVE_ARN);
+    }
+
+    @Test
+    @Order(8)
+    void putReputationOptions_unknownConfigurationSet_throwsNotFound() {
+        assertThatThrownBy(() -> sesV2.putConfigurationSetReputationOptions(
+                PutConfigurationSetReputationOptionsRequest.builder()
+                        .configurationSetName("compat-cs-options-missing")
+                        .reputationMetricsEnabled(false)
+                        .build()))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @Order(9)
+    void createConfigurationSet_withInlineOptions_roundTrips() {
+        sesV2.createConfigurationSet(CreateConfigurationSetRequest.builder()
+                .configurationSetName(CREATE_CS)
+                .reputationOptions(ReputationOptions.builder().reputationMetricsEnabled(false).build())
+                .trackingOptions(TrackingOptions.builder()
+                        .customRedirectDomain(TRACK_DOMAIN).httpsPolicy("REQUIRE").build())
+                .deliveryOptions(DeliveryOptions.builder()
+                        .tlsPolicy("REQUIRE").maxDeliverySeconds(900L).build())
+                .archivingOptions(ArchivingOptions.builder().archiveArn(ARCHIVE_ARN).build())
+                .build());
+
+        GetConfigurationSetResponse response = sesV2.getConfigurationSet(
+                GetConfigurationSetRequest.builder().configurationSetName(CREATE_CS).build());
+        assertThat(response.reputationOptions().reputationMetricsEnabled()).isFalse();
+        assertThat(response.trackingOptions().customRedirectDomain()).isEqualTo(TRACK_DOMAIN);
+        assertThat(response.trackingOptions().httpsPolicyAsString()).isEqualTo("REQUIRE");
+        assertThat(response.deliveryOptions().tlsPolicyAsString()).isEqualTo("REQUIRE");
+        assertThat(response.deliveryOptions().maxDeliverySeconds()).isEqualTo(900L);
+        assertThat(response.archivingOptions().archiveArn()).isEqualTo(ARCHIVE_ARN);
+    }
+
+    @Test
+    @Order(10)
+    void createConfigurationSet_withInvalidInlineTracking_throwsAndDoesNotCreate() {
+        assertThatThrownBy(() -> sesV2.createConfigurationSet(CreateConfigurationSetRequest.builder()
+                .configurationSetName(CREATE_CS_BAD)
+                .trackingOptions(TrackingOptions.builder()
+                        .customRedirectDomain("compat-create-unverified.example.com")
+                        .httpsPolicy("REQUIRE")
+                        .build())
+                .build()))
+                .isInstanceOf(BadRequestException.class);
+
+        // Validation runs before the store write, so the set must not exist.
+        assertThatThrownBy(() -> sesV2.getConfigurationSet(
+                GetConfigurationSetRequest.builder().configurationSetName(CREATE_CS_BAD).build()))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @Order(11)
+    void putVdmOptions_roundTrips() {
+        sesV2.putConfigurationSetVdmOptions(PutConfigurationSetVdmOptionsRequest.builder()
+                .configurationSetName(CS_NAME)
+                .vdmOptions(VdmOptions.builder()
+                        .dashboardOptions(DashboardOptions.builder().engagementMetrics("ENABLED").build())
+                        .guardianOptions(GuardianOptions.builder().optimizedSharedDelivery("DISABLED").build())
+                        .build())
+                .build());
+        GetConfigurationSetResponse response = getConfigSet();
+        assertThat(response.vdmOptions()).isNotNull();
+        assertThat(response.vdmOptions().dashboardOptions().engagementMetricsAsString()).isEqualTo("ENABLED");
+        assertThat(response.vdmOptions().guardianOptions().optimizedSharedDeliveryAsString()).isEqualTo("DISABLED");
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesDedicatedIpPoolTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesDedicatedIpPoolTest.java
@@ -1,0 +1,133 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.AlreadyExistsException;
+import software.amazon.awssdk.services.sesv2.model.BadRequestException;
+import software.amazon.awssdk.services.sesv2.model.CreateDedicatedIpPoolRequest;
+import software.amazon.awssdk.services.sesv2.model.DeleteDedicatedIpPoolRequest;
+import software.amazon.awssdk.services.sesv2.model.GetDedicatedIpPoolRequest;
+import software.amazon.awssdk.services.sesv2.model.GetDedicatedIpPoolResponse;
+import software.amazon.awssdk.services.sesv2.model.ListDedicatedIpPoolsResponse;
+import software.amazon.awssdk.services.sesv2.model.NotFoundException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * SDK compatibility test for the SES v2 dedicated IP pool APIs. Verifies the
+ * AWS Java SDK v2 marshalling of CreateDedicatedIpPool / GetDedicatedIpPool /
+ * ListDedicatedIpPools / DeleteDedicatedIpPool and the
+ * BadRequestException / AlreadyExistsException / NotFoundException errors,
+ * against a live Floci instance.
+ */
+@DisplayName("SES v2 Dedicated IP Pools")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesDedicatedIpPoolTest {
+
+    private static final String POOL = "compat-pool-alpha";
+    private static final String POOL_MANAGED = "compat-pool-managed";
+
+    private static SesV2Client sesV2;
+
+    @BeforeAll
+    static void setup() {
+        sesV2 = TestFixtures.sesV2Client();
+        deletePoolQuietly(POOL);
+        deletePoolQuietly(POOL_MANAGED);
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (sesV2 != null) {
+            deletePoolQuietly(POOL);
+            deletePoolQuietly(POOL_MANAGED);
+            sesV2.close();
+        }
+    }
+
+    private static void deletePoolQuietly(String name) {
+        try {
+            sesV2.deleteDedicatedIpPool(DeleteDedicatedIpPoolRequest.builder().poolName(name).build());
+        } catch (Exception ignored) {}
+    }
+
+    @Test
+    @Order(1)
+    void createDedicatedIpPool_defaultsToStandardScaling() {
+        sesV2.createDedicatedIpPool(CreateDedicatedIpPoolRequest.builder().poolName(POOL).build());
+
+        GetDedicatedIpPoolResponse response = sesV2.getDedicatedIpPool(
+                GetDedicatedIpPoolRequest.builder().poolName(POOL).build());
+        assertThat(response.dedicatedIpPool()).isNotNull();
+        assertThat(response.dedicatedIpPool().poolName()).isEqualTo(POOL);
+        assertThat(response.dedicatedIpPool().scalingModeAsString()).isEqualTo("STANDARD");
+    }
+
+    @Test
+    @Order(2)
+    void createDedicatedIpPool_managedScaling() {
+        sesV2.createDedicatedIpPool(CreateDedicatedIpPoolRequest.builder()
+                .poolName(POOL_MANAGED).scalingMode("MANAGED").build());
+
+        GetDedicatedIpPoolResponse response = sesV2.getDedicatedIpPool(
+                GetDedicatedIpPoolRequest.builder().poolName(POOL_MANAGED).build());
+        assertThat(response.dedicatedIpPool().scalingModeAsString()).isEqualTo("MANAGED");
+    }
+
+    @Test
+    @Order(3)
+    void createDedicatedIpPool_invalidScalingMode_throwsBadRequest() {
+        assertThatThrownBy(() -> sesV2.createDedicatedIpPool(CreateDedicatedIpPoolRequest.builder()
+                .poolName("compat-pool-bad").scalingMode("NONSENSE").build()))
+                .isInstanceOf(BadRequestException.class);
+    }
+
+    @Test
+    @Order(4)
+    void createDedicatedIpPool_duplicate_throwsAlreadyExists() {
+        assertThatThrownBy(() -> sesV2.createDedicatedIpPool(
+                CreateDedicatedIpPoolRequest.builder().poolName(POOL).build()))
+                .isInstanceOf(AlreadyExistsException.class);
+    }
+
+    @Test
+    @Order(5)
+    void getDedicatedIpPool_unknown_throwsNotFound() {
+        assertThatThrownBy(() -> sesV2.getDedicatedIpPool(
+                GetDedicatedIpPoolRequest.builder().poolName("compat-pool-ghost").build()))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @Order(6)
+    void listDedicatedIpPools_includesCreatedPools() {
+        ListDedicatedIpPoolsResponse response = sesV2.listDedicatedIpPools(r -> {});
+        assertThat(response.dedicatedIpPools()).contains(POOL, POOL_MANAGED);
+    }
+
+    @Test
+    @Order(7)
+    void deleteDedicatedIpPool_removesIt() {
+        sesV2.deleteDedicatedIpPool(DeleteDedicatedIpPoolRequest.builder().poolName(POOL).build());
+
+        assertThatThrownBy(() -> sesV2.getDedicatedIpPool(
+                GetDedicatedIpPoolRequest.builder().poolName(POOL).build()))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @Order(8)
+    void deleteDedicatedIpPool_unknown_throwsNotFound() {
+        assertThatThrownBy(() -> sesV2.deleteDedicatedIpPool(
+                DeleteDedicatedIpPoolRequest.builder().poolName("compat-pool-ghost").build()))
+                .isInstanceOf(NotFoundException.class);
+    }
+}

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -193,6 +193,10 @@ Alongside the classic Query API, Floci implements a subset of the SES v2 REST JS
 | `DELETE` | `/v2/email/configuration-sets/{name}/event-destinations/{eventDestinationName}` | `DeleteConfigurationSetEventDestination` |
 | `PUT` | `/v2/email/configuration-sets/{name}/suppression-options` | `PutConfigurationSetSuppressionOptions` |
 | `PUT` | `/v2/email/configuration-sets/{name}/sending` | `PutConfigurationSetSendingOptions` |
+| `POST` | `/v2/email/dedicated-ip-pools` | `CreateDedicatedIpPool` |
+| `GET` | `/v2/email/dedicated-ip-pools` | `ListDedicatedIpPools` |
+| `GET` | `/v2/email/dedicated-ip-pools/{PoolName}` | `GetDedicatedIpPool` |
+| `DELETE` | `/v2/email/dedicated-ip-pools/{PoolName}` | `DeleteDedicatedIpPool` |
 | `PUT` | `/v2/email/suppression/addresses` | `PutSuppressedDestination` |
 | `GET` | `/v2/email/suppression/addresses/{EmailAddress}` | `GetSuppressedDestination` |
 | `DELETE` | `/v2/email/suppression/addresses/{EmailAddress}` | `DeleteSuppressedDestination` |

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -193,6 +193,11 @@ Alongside the classic Query API, Floci implements a subset of the SES v2 REST JS
 | `DELETE` | `/v2/email/configuration-sets/{name}/event-destinations/{eventDestinationName}` | `DeleteConfigurationSetEventDestination` |
 | `PUT` | `/v2/email/configuration-sets/{name}/suppression-options` | `PutConfigurationSetSuppressionOptions` |
 | `PUT` | `/v2/email/configuration-sets/{name}/sending` | `PutConfigurationSetSendingOptions` |
+| `PUT` | `/v2/email/configuration-sets/{name}/reputation-options` | `PutConfigurationSetReputationOptions` |
+| `PUT` | `/v2/email/configuration-sets/{name}/tracking-options` | `PutConfigurationSetTrackingOptions` |
+| `PUT` | `/v2/email/configuration-sets/{name}/delivery-options` | `PutConfigurationSetDeliveryOptions` |
+| `PUT` | `/v2/email/configuration-sets/{name}/archiving-options` | `PutConfigurationSetArchivingOptions` |
+| `PUT` | `/v2/email/configuration-sets/{name}/vdm-options` | `PutConfigurationSetVdmOptions` |
 | `POST` | `/v2/email/dedicated-ip-pools` | `CreateDedicatedIpPool` |
 | `GET` | `/v2/email/dedicated-ip-pools` | `ListDedicatedIpPools` |
 | `GET` | `/v2/email/dedicated-ip-pools/{PoolName}` | `GetDedicatedIpPool` |

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttribute
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntry;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.EventDestination;
 import io.github.hectorvent.floci.services.ses.model.Identity;
@@ -835,6 +836,70 @@ public class SesController {
         } catch (AwsException e) {
             throw remapV1Exception(e);
         }
+    }
+
+    // ──────────────────────── Dedicated IP Pools ────────────────────────
+
+    @POST
+    @Path("/dedicated-ip-pools")
+    public Response createDedicatedIpPool(@Context HttpHeaders headers, String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            if (body == null || body.isBlank()) {
+                throw new AwsException("BadRequestException", "Request body is required.", 400);
+            }
+            JsonNode request = objectMapper.readTree(body);
+            requireJsonObject(request);
+            String poolName = readRequiredStringField(request, "PoolName");
+            JsonNode scalingNode = request.path("ScalingMode");
+            String scalingMode;
+            if (scalingNode.isMissingNode() || scalingNode.isNull()) {
+                scalingMode = null;
+            } else if (!scalingNode.isTextual()) {
+                throw new AwsException("BadRequestException",
+                        "The ScalingMode parameter is invalid.", 400);
+            } else {
+                scalingMode = scalingNode.asText();
+            }
+            sesService.createDedicatedIpPool(poolName, scalingMode, region);
+            LOG.infov("SES V2 CreateDedicatedIpPool: {0}", poolName);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @GET
+    @Path("/dedicated-ip-pools")
+    public Response listDedicatedIpPools(@Context HttpHeaders headers) {
+        String region = regionResolver.resolveRegion(headers);
+        ObjectNode result = objectMapper.createObjectNode();
+        ArrayNode pools = result.putArray("DedicatedIpPools");
+        sesService.listDedicatedIpPools(region).forEach(pools::add);
+        return Response.ok(result).build();
+    }
+
+    @GET
+    @Path("/dedicated-ip-pools/{poolName}")
+    public Response getDedicatedIpPool(@Context HttpHeaders headers,
+                                       @PathParam("poolName") String poolName) {
+        String region = regionResolver.resolveRegion(headers);
+        DedicatedIpPool pool = sesService.getDedicatedIpPool(poolName, region);
+        ObjectNode result = objectMapper.createObjectNode();
+        result.set("DedicatedIpPool", objectMapper.valueToTree(pool));
+        return Response.ok(result).build();
+    }
+
+    @DELETE
+    @Path("/dedicated-ip-pools/{poolName}")
+    public Response deleteDedicatedIpPool(@Context HttpHeaders headers,
+                                          @PathParam("poolName") String poolName) {
+        String region = regionResolver.resolveRegion(headers);
+        sesService.deleteDedicatedIpPool(poolName, region);
+        LOG.infov("SES V2 DeleteDedicatedIpPool: {0}", poolName);
+        return Response.ok(objectMapper.createObjectNode()).build();
     }
 
     // ──────────────────────────── Account ────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -3,10 +3,14 @@ package io.github.hectorvent.floci.services.ses;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
+import io.github.hectorvent.floci.services.ses.model.ArchivingOptions;
+import io.github.hectorvent.floci.services.ses.model.DashboardOptions;
+import io.github.hectorvent.floci.services.ses.model.GuardianOptions;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntry;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
+import io.github.hectorvent.floci.services.ses.model.DeliveryOptions;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.EventDestination;
 import io.github.hectorvent.floci.services.ses.model.Identity;
@@ -15,6 +19,8 @@ import io.github.hectorvent.floci.services.ses.model.MessageTag;
 import io.github.hectorvent.floci.services.ses.model.SuppressedDestination;
 import io.github.hectorvent.floci.services.ses.model.SuppressionOptions;
 import io.github.hectorvent.floci.services.ses.model.Tag;
+import io.github.hectorvent.floci.services.ses.model.TrackingOptions;
+import io.github.hectorvent.floci.services.ses.model.VdmOptions;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -632,6 +638,30 @@ public class SesController {
                 }
                 cs.setSendingEnabled(parseSendingEnabled(sendingNode.path("SendingEnabled")));
             }
+            JsonNode reputationNode = request.path("ReputationOptions");
+            if (!reputationNode.isMissingNode() && !reputationNode.isNull()) {
+                requireOptionObject(reputationNode);
+                Boolean rme = parseReputationMetricsEnabled(reputationNode.path("ReputationMetricsEnabled"));
+                if (rme != null) {
+                    cs.setReputationMetricsEnabled(rme);
+                }
+            }
+            JsonNode trackingNode = request.path("TrackingOptions");
+            if (!trackingNode.isMissingNode() && !trackingNode.isNull()) {
+                cs.setTrackingOptions(parseTrackingOptions(trackingNode));
+            }
+            JsonNode deliveryNode = request.path("DeliveryOptions");
+            if (!deliveryNode.isMissingNode() && !deliveryNode.isNull()) {
+                cs.setDeliveryOptions(parseDeliveryOptions(deliveryNode));
+            }
+            JsonNode archivingNode = request.path("ArchivingOptions");
+            if (!archivingNode.isMissingNode() && !archivingNode.isNull()) {
+                cs.setArchivingOptions(parseArchivingOptions(archivingNode));
+            }
+            JsonNode vdmNode = request.path("VdmOptions");
+            if (!vdmNode.isMissingNode() && !vdmNode.isNull()) {
+                cs.setVdmOptions(parseVdmOptions(vdmNode));
+            }
             sesService.createConfigurationSet(cs, region);
             LOG.infov("SES V2 CreateConfigurationSet: {0}", name);
             return Response.ok(objectMapper.createObjectNode()).build();
@@ -680,6 +710,23 @@ public class SesController {
             }
             ObjectNode sendingNode = result.putObject("SendingOptions");
             sendingNode.put("SendingEnabled", cs.isSendingEnabledEffective());
+            // AWS always returns ReputationOptions (true by default), like SendingOptions.
+            ObjectNode reputationNode = result.putObject("ReputationOptions");
+            reputationNode.put("ReputationMetricsEnabled", cs.isReputationMetricsEnabledEffective());
+            // The option models carry @JsonProperty/@JsonInclude(NON_NULL), so let
+            // Jackson shape the response and omit unset members.
+            if (cs.getTrackingOptions() != null) {
+                result.set("TrackingOptions", objectMapper.valueToTree(cs.getTrackingOptions()));
+            }
+            if (cs.getDeliveryOptions() != null) {
+                result.set("DeliveryOptions", objectMapper.valueToTree(cs.getDeliveryOptions()));
+            }
+            if (cs.getArchivingOptions() != null) {
+                result.set("ArchivingOptions", objectMapper.valueToTree(cs.getArchivingOptions()));
+            }
+            if (cs.getVdmOptions() != null) {
+                result.set("VdmOptions", objectMapper.valueToTree(cs.getVdmOptions()));
+            }
             return Response.ok(result).build();
         } catch (AwsException e) {
             throw remapV1Exception(e);
@@ -733,6 +780,210 @@ public class SesController {
         } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
             throw new AwsException("BadRequestException", e.getMessage(), 400);
         }
+    }
+
+    @PUT
+    @Path("/configuration-sets/{configurationSetName}/reputation-options")
+    public Response putConfigurationSetReputationOptions(@Context HttpHeaders headers,
+                                                         @PathParam("configurationSetName") String name,
+                                                         String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode request = readOptionBody(body);
+            Boolean enabled = parseReputationMetricsEnabled(request.path("ReputationMetricsEnabled"));
+            boolean effectiveEnabled = enabled != null && enabled;
+            sesService.setConfigurationSetReputationOptions(name, effectiveEnabled, region);
+            LOG.infov("SES V2 PutConfigurationSetReputationOptions: {0} on {1}", effectiveEnabled, name);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        }
+    }
+
+    @PUT
+    @Path("/configuration-sets/{configurationSetName}/tracking-options")
+    public Response putConfigurationSetTrackingOptions(@Context HttpHeaders headers,
+                                                       @PathParam("configurationSetName") String name,
+                                                       String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode request = readOptionBody(body);
+            sesService.setConfigurationSetTrackingOptions(name, parseTrackingOptions(request), region);
+            LOG.infov("SES V2 PutConfigurationSetTrackingOptions on {0}", name);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        }
+    }
+
+    @PUT
+    @Path("/configuration-sets/{configurationSetName}/delivery-options")
+    public Response putConfigurationSetDeliveryOptions(@Context HttpHeaders headers,
+                                                       @PathParam("configurationSetName") String name,
+                                                       String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode request = readOptionBody(body);
+            sesService.setConfigurationSetDeliveryOptions(name, parseDeliveryOptions(request), region);
+            LOG.infov("SES V2 PutConfigurationSetDeliveryOptions on {0}", name);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        }
+    }
+
+    @PUT
+    @Path("/configuration-sets/{configurationSetName}/archiving-options")
+    public Response putConfigurationSetArchivingOptions(@Context HttpHeaders headers,
+                                                        @PathParam("configurationSetName") String name,
+                                                        String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode request = readOptionBody(body);
+            sesService.setConfigurationSetArchivingOptions(name, parseArchivingOptions(request), region);
+            LOG.infov("SES V2 PutConfigurationSetArchivingOptions on {0}", name);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        }
+    }
+
+    @PUT
+    @Path("/configuration-sets/{configurationSetName}/vdm-options")
+    public Response putConfigurationSetVdmOptions(@Context HttpHeaders headers,
+                                                  @PathParam("configurationSetName") String name,
+                                                  String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode request = readOptionBody(body);
+            JsonNode vdmNode = request.path("VdmOptions");
+            VdmOptions options = (vdmNode.isMissingNode() || vdmNode.isNull())
+                    ? null : parseVdmOptions(vdmNode);
+            sesService.setConfigurationSetVdmOptions(name, options, region);
+            LOG.infov("SES V2 PutConfigurationSetVdmOptions on {0}", name);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        }
+    }
+
+    /** Reject a non-object option block, mirroring the AWS deserialization layer. */
+    private static void requireOptionObject(JsonNode node) {
+        if (!node.isObject()) {
+            throw new AwsException("SerializationException", "Expected null", 400);
+        }
+    }
+
+    /** Parse a configuration-set option PUT body into a JSON object, treating an empty body as {}. */
+    private JsonNode readOptionBody(String body) {
+        try {
+            JsonNode request = (body == null || body.isBlank())
+                    ? objectMapper.createObjectNode()
+                    : objectMapper.readTree(body);
+            requireJsonObject(request);
+            return request;
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    private static Boolean parseReputationMetricsEnabled(JsonNode node) {
+        if (node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        if (!node.isBoolean()) {
+            throw new AwsException("BadRequestException",
+                    "ReputationMetricsEnabled must be a boolean.", 400);
+        }
+        return node.booleanValue();
+    }
+
+    /** Read an optional string member, rejecting a non-string value the way the AWS deserialization layer does. */
+    private static String parseOptionString(JsonNode node, String field) {
+        if (node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        if (!node.isTextual()) {
+            throw new AwsException("BadRequestException", field + " must be a JSON string.", 400);
+        }
+        return node.asText();
+    }
+
+    private static TrackingOptions parseTrackingOptions(JsonNode node) {
+        requireOptionObject(node);
+        TrackingOptions t = new TrackingOptions();
+        t.setCustomRedirectDomain(parseOptionString(node.path("CustomRedirectDomain"), "CustomRedirectDomain"));
+        t.setHttpsPolicy(parseOptionString(node.path("HttpsPolicy"), "HttpsPolicy"));
+        // An all-null block (e.g. an empty PUT body) clears the options rather
+        // than persisting an empty object that GetConfigurationSet would echo.
+        if (t.getCustomRedirectDomain() == null && t.getHttpsPolicy() == null) {
+            return null;
+        }
+        return t;
+    }
+
+    private static DeliveryOptions parseDeliveryOptions(JsonNode node) {
+        requireOptionObject(node);
+        DeliveryOptions d = new DeliveryOptions();
+        d.setTlsPolicy(parseOptionString(node.path("TlsPolicy"), "TlsPolicy"));
+        d.setSendingPoolName(parseOptionString(node.path("SendingPoolName"), "SendingPoolName"));
+        JsonNode max = node.path("MaxDeliverySeconds");
+        if (!max.isMissingNode() && !max.isNull()) {
+            if (!max.isNumber()) {
+                throw new AwsException("BadRequestException",
+                        "MaxDeliverySeconds must be a number.", 400);
+            }
+            if (!max.isIntegralNumber()) {
+                throw new AwsException("BadRequestException",
+                        "MaxDeliverySeconds must be an integer.", 400);
+            }
+            d.setMaxDeliverySeconds(max.asLong());
+        }
+        if (d.getTlsPolicy() == null && d.getSendingPoolName() == null && d.getMaxDeliverySeconds() == null) {
+            return null;
+        }
+        return d;
+    }
+
+    private static ArchivingOptions parseArchivingOptions(JsonNode node) {
+        requireOptionObject(node);
+        ArchivingOptions a = new ArchivingOptions();
+        a.setArchiveArn(parseOptionString(node.path("ArchiveArn"), "ArchiveArn"));
+        if (a.getArchiveArn() == null) {
+            return null;
+        }
+        return a;
+    }
+
+    private static VdmOptions parseVdmOptions(JsonNode node) {
+        requireOptionObject(node);
+        VdmOptions v = new VdmOptions();
+        JsonNode dashboard = node.path("DashboardOptions");
+        if (!dashboard.isMissingNode() && !dashboard.isNull()) {
+            requireOptionObject(dashboard);
+            String engagementMetrics = parseOptionString(dashboard.path("EngagementMetrics"), "EngagementMetrics");
+            if (engagementMetrics != null) {
+                DashboardOptions d = new DashboardOptions();
+                d.setEngagementMetrics(engagementMetrics);
+                v.setDashboardOptions(d);
+            }
+        }
+        JsonNode guardian = node.path("GuardianOptions");
+        if (!guardian.isMissingNode() && !guardian.isNull()) {
+            requireOptionObject(guardian);
+            String optimized = parseOptionString(guardian.path("OptimizedSharedDelivery"), "OptimizedSharedDelivery");
+            if (optimized != null) {
+                GuardianOptions g = new GuardianOptions();
+                g.setOptimizedSharedDelivery(optimized);
+                v.setGuardianOptions(g);
+            }
+        }
+        // An all-null block (e.g. an empty PUT body) clears the options rather
+        // than persisting an empty object that GetConfigurationSet would echo.
+        if (v.getDashboardOptions() == null && v.getGuardianOptions() == null) {
+            return null;
+        }
+        return v;
     }
 
     @DELETE

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -10,6 +10,7 @@ import io.github.hectorvent.floci.services.ses.model.BulkEmailEntry;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
 import io.github.hectorvent.floci.services.ses.model.CloudWatchDimensionConfiguration;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.EventDestination;
 import io.github.hectorvent.floci.services.ses.model.Identity;
@@ -67,6 +68,7 @@ public class SesService {
     private final StorageBackend<String, ConfigurationSet> configSetStore;
     private final StorageBackend<String, SuppressedDestination> suppressionStore;
     private final StorageBackend<String, AccountSuppressionAttributes> accountSuppressionStore;
+    private final StorageBackend<String, DedicatedIpPool> dedicatedIpPoolStore;
     private final SmtpRelay smtpRelay;
     private final ObjectMapper objectMapper;
     private final SesEventPublisher eventPublisher;
@@ -89,6 +91,8 @@ public class SesService {
                 new TypeReference<Map<String, SuppressedDestination>>() {});
         this.accountSuppressionStore = storageFactory.create("ses", "ses-account-suppression.json",
                 new TypeReference<Map<String, AccountSuppressionAttributes>>() {});
+        this.dedicatedIpPoolStore = storageFactory.create("ses", "ses-dedicated-ip-pools.json",
+                new TypeReference<Map<String, DedicatedIpPool>>() {});
         this.smtpRelay = smtpRelay;
         this.objectMapper = objectMapper;
         this.eventPublisher = eventPublisher;
@@ -102,6 +106,7 @@ public class SesService {
                StorageBackend<String, ConfigurationSet> configSetStore,
                StorageBackend<String, SuppressedDestination> suppressionStore,
                StorageBackend<String, AccountSuppressionAttributes> accountSuppressionStore,
+               StorageBackend<String, DedicatedIpPool> dedicatedIpPoolStore,
                SmtpRelay smtpRelay,
                ObjectMapper objectMapper) {
         this.identityStore = identityStore;
@@ -111,6 +116,7 @@ public class SesService {
         this.configSetStore = configSetStore;
         this.suppressionStore = suppressionStore;
         this.accountSuppressionStore = accountSuppressionStore;
+        this.dedicatedIpPoolStore = dedicatedIpPoolStore;
         this.smtpRelay = smtpRelay;
         this.objectMapper = objectMapper;
         this.eventPublisher = null;
@@ -689,6 +695,61 @@ public class SesService {
     private static String configSetKey(String region, String name) {
         validateConfigurationSetName(name);
         return "configSet::" + region + "::" + name;
+    }
+
+    // ──────────────────────── Dedicated IP Pools ────────────────────────
+
+    private static final java.util.Set<String> SCALING_MODES = java.util.Set.of("STANDARD", "MANAGED");
+
+    public DedicatedIpPool createDedicatedIpPool(String poolName, String scalingMode, String region) {
+        if (poolName == null || poolName.isBlank()) {
+            throw new AwsException("BadRequestException", "PoolName is required.", 400);
+        }
+        String effectiveScaling = (scalingMode == null || scalingMode.isBlank()) ? "STANDARD" : scalingMode;
+        if (!SCALING_MODES.contains(effectiveScaling)) {
+            throw new AwsException("BadRequestException", "The ScalingMode parameter is invalid.", 400);
+        }
+        String key = dedicatedIpPoolKey(region, poolName);
+        if (dedicatedIpPoolStore.get(key).isPresent()) {
+            throw new AwsException("AlreadyExistsException",
+                    "The pool <" + poolName + "> already exists.", 400);
+        }
+        DedicatedIpPool pool = new DedicatedIpPool(poolName, effectiveScaling);
+        dedicatedIpPoolStore.put(key, pool);
+        LOG.infov("Created SES dedicated IP pool: {0} in region {1}", poolName, region);
+        return pool;
+    }
+
+    public DedicatedIpPool getDedicatedIpPool(String poolName, String region) {
+        return dedicatedIpPoolStore.get(dedicatedIpPoolKey(region, poolName))
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "The requested pool <" + poolName + "> does not exist.", 404));
+    }
+
+    public boolean dedicatedIpPoolExists(String poolName, String region) {
+        return dedicatedIpPoolStore.get(dedicatedIpPoolKey(region, poolName)).isPresent();
+    }
+
+    public List<String> listDedicatedIpPools(String region) {
+        String prefix = "dedicatedIpPool::" + region + "::";
+        return dedicatedIpPoolStore.scan(k -> k.startsWith(prefix)).stream()
+                .map(DedicatedIpPool::getPoolName)
+                .sorted()
+                .toList();
+    }
+
+    public void deleteDedicatedIpPool(String poolName, String region) {
+        String key = dedicatedIpPoolKey(region, poolName);
+        if (dedicatedIpPoolStore.get(key).isEmpty()) {
+            throw new AwsException("NotFoundException",
+                    "The requested pool <" + poolName + "> does not exist.", 404);
+        }
+        dedicatedIpPoolStore.delete(key);
+        LOG.infov("Deleted SES dedicated IP pool: {0} in region {1}", poolName, region);
+    }
+
+    private static String dedicatedIpPoolKey(String region, String name) {
+        return "dedicatedIpPool::" + region + "::" + name;
     }
 
     static void validateConfigurationSetName(String name) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -658,7 +658,6 @@ public class SesService {
         }
         validateTrackingOptions(configSet.getTrackingOptions(), region);
         validateDeliveryOptions(configSet.getDeliveryOptions(), region);
-        validateArchivingOptions(configSet.getArchivingOptions());
         validateVdmOptions(configSet.getVdmOptions());
         if (configSetStore.get(key).isPresent()) {
             throw new AwsException("ConfigurationSetAlreadyExists",
@@ -698,7 +697,6 @@ public class SesService {
 
     public void setConfigurationSetArchivingOptions(String configSetName, ArchivingOptions options, String region) {
         ConfigurationSet cs = getConfigurationSet(configSetName, region);
-        validateArchivingOptions(options);
         cs.setArchivingOptions(options);
         configSetStore.put(configSetKey(region, configSetName), cs);
         LOG.infov("Updated ArchivingOptions on configuration set {0} in region {1}", configSetName, region);
@@ -739,8 +737,6 @@ public class SesService {
     private static final java.util.Set<String> HTTPS_POLICIES =
             java.util.Set.of("REQUIRE", "REQUIRE_OPEN_ONLY", "OPTIONAL");
     private static final java.util.Set<String> TLS_POLICIES = java.util.Set.of("REQUIRE", "OPTIONAL");
-    private static final java.util.regex.Pattern ARCHIVE_ARN_PATTERN = java.util.regex.Pattern.compile(
-            "arn:(aws|aws-[a-z-]+):ses:[a-z]{2,4}-[a-z-]+-[0-9]:[0-9]{1,20}:mailmanager-archive/a-[a-z0-9]{24,62}");
 
     private void validateTrackingOptions(TrackingOptions options, String region) {
         if (options == null) {
@@ -807,21 +803,6 @@ public class SesService {
                         "1 validation error detected: Value at 'maxDeliverySeconds' failed to satisfy constraint: "
                                 + "Member must have value less than or equal to 50400", 400);
             }
-        }
-    }
-
-    private void validateArchivingOptions(ArchivingOptions options) {
-        if (options == null || options.getArchiveArn() == null) {
-            return;
-        }
-        // Validate the ARN format (verified against real AWS 2026-06-17). The
-        // archive's existence / account ownership is not checked — Floci does not
-        // model Mail Manager archives — so a well-formed ARN is accepted.
-        if (!ARCHIVE_ARN_PATTERN.matcher(options.getArchiveArn()).matches()) {
-            throw new AwsException("BadRequestException",
-                    "1 validation error detected: Value at 'archiveArn' failed to satisfy constraint: "
-                            + "Member must satisfy regular expression pattern: " + ARCHIVE_ARN_PATTERN.pattern(),
-                    400);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -6,16 +6,20 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
+import io.github.hectorvent.floci.services.ses.model.ArchivingOptions;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntry;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
 import io.github.hectorvent.floci.services.ses.model.CloudWatchDimensionConfiguration;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
+import io.github.hectorvent.floci.services.ses.model.DeliveryOptions;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.EventDestination;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.MessageHeader;
 import io.github.hectorvent.floci.services.ses.model.MessageTag;
+import io.github.hectorvent.floci.services.ses.model.TrackingOptions;
+import io.github.hectorvent.floci.services.ses.model.VdmOptions;
 import io.github.hectorvent.floci.services.ses.model.SentEmail;
 import io.github.hectorvent.floci.services.ses.model.SuppressedDestination;
 import io.github.hectorvent.floci.services.ses.model.SuppressionOptions;
@@ -652,6 +656,10 @@ public class SesService {
                 }
             }
         }
+        validateTrackingOptions(configSet.getTrackingOptions(), region);
+        validateDeliveryOptions(configSet.getDeliveryOptions());
+        validateArchivingOptions(configSet.getArchivingOptions());
+        validateVdmOptions(configSet.getVdmOptions());
         if (configSetStore.get(key).isPresent()) {
             throw new AwsException("ConfigurationSetAlreadyExists",
                     "Configuration set " + configSet.getName() + " already exists.", 400);
@@ -662,6 +670,157 @@ public class SesService {
         configSetStore.put(key, configSet);
         LOG.infov("Created SES configuration set: {0} in region {1}", configSet.getName(), region);
         return configSet;
+    }
+
+    public void setConfigurationSetTrackingOptions(String configSetName, TrackingOptions options, String region) {
+        ConfigurationSet cs = getConfigurationSet(configSetName, region);
+        validateTrackingOptions(options, region);
+        cs.setTrackingOptions(options);
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Updated TrackingOptions on configuration set {0} in region {1}", configSetName, region);
+    }
+
+    public void setConfigurationSetDeliveryOptions(String configSetName, DeliveryOptions options, String region) {
+        ConfigurationSet cs = getConfigurationSet(configSetName, region);
+        validateDeliveryOptions(options);
+        cs.setDeliveryOptions(options);
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Updated DeliveryOptions on configuration set {0} in region {1}", configSetName, region);
+    }
+
+    public void setConfigurationSetReputationOptions(String configSetName, boolean metricsEnabled, String region) {
+        ConfigurationSet cs = getConfigurationSet(configSetName, region);
+        cs.setReputationMetricsEnabled(metricsEnabled);
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Updated ReputationMetricsEnabled on configuration set {0} in region {1}: {2}",
+                configSetName, region, metricsEnabled);
+    }
+
+    public void setConfigurationSetArchivingOptions(String configSetName, ArchivingOptions options, String region) {
+        ConfigurationSet cs = getConfigurationSet(configSetName, region);
+        validateArchivingOptions(options);
+        cs.setArchivingOptions(options);
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Updated ArchivingOptions on configuration set {0} in region {1}", configSetName, region);
+    }
+
+    private static final java.util.Set<String> VDM_FEATURE_STATES = java.util.Set.of("ENABLED", "DISABLED");
+
+    public void setConfigurationSetVdmOptions(String configSetName, VdmOptions options, String region) {
+        ConfigurationSet cs = getConfigurationSet(configSetName, region);
+        validateVdmOptions(options);
+        cs.setVdmOptions(options);
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Updated VdmOptions on configuration set {0} in region {1}", configSetName, region);
+    }
+
+    private void validateVdmOptions(VdmOptions options) {
+        if (options == null) {
+            return;
+        }
+        // Enum values verified against real AWS 2026-06-19; messages use the
+        // nested member path and the [ENABLED, DISABLED] value set.
+        if (options.getDashboardOptions() != null
+                && options.getDashboardOptions().getEngagementMetrics() != null
+                && !VDM_FEATURE_STATES.contains(options.getDashboardOptions().getEngagementMetrics())) {
+            throw new AwsException("BadRequestException",
+                    "1 validation error detected: Value at 'vdmOptions.dashboardOptions.engagementMetrics' "
+                            + "failed to satisfy constraint: Member must satisfy enum value set: [ENABLED, DISABLED]", 400);
+        }
+        if (options.getGuardianOptions() != null
+                && options.getGuardianOptions().getOptimizedSharedDelivery() != null
+                && !VDM_FEATURE_STATES.contains(options.getGuardianOptions().getOptimizedSharedDelivery())) {
+            throw new AwsException("BadRequestException",
+                    "1 validation error detected: Value at 'vdmOptions.guardianOptions.optimizedSharedDelivery' "
+                            + "failed to satisfy constraint: Member must satisfy enum value set: [ENABLED, DISABLED]", 400);
+        }
+    }
+
+    private static final java.util.Set<String> HTTPS_POLICIES =
+            java.util.Set.of("REQUIRE", "REQUIRE_OPEN_ONLY", "OPTIONAL");
+    private static final java.util.Set<String> TLS_POLICIES = java.util.Set.of("REQUIRE", "OPTIONAL");
+    private static final java.util.regex.Pattern ARCHIVE_ARN_PATTERN = java.util.regex.Pattern.compile(
+            "arn:(aws|aws-[a-z-]+):ses:[a-z]{2,4}-[a-z-]+-[0-9]:[0-9]{1,20}:mailmanager-archive/a-[a-z0-9]{24,62}");
+
+    private void validateTrackingOptions(TrackingOptions options, String region) {
+        if (options == null) {
+            return;
+        }
+        String domain = options.getCustomRedirectDomain();
+        String httpsPolicy = options.getHttpsPolicy();
+        // AWS validation order (verified against real AWS 2026-06-17): a present
+        // CustomRedirectDomain must be non-blank, and it is required whenever
+        // HttpsPolicy is set; then the domain must be a verified domain identity
+        // (checked even without HttpsPolicy); then HttpsPolicy must be a valid enum.
+        if ((domain != null && domain.isBlank()) || (httpsPolicy != null && domain == null)) {
+            throw new AwsException("BadRequestException",
+                    "CustomRedirectDomain must be specified.", 400);
+        }
+        if (domain != null) {
+            Identity identity = getIdentityVerificationAttributes(domain, region);
+            if (identity == null || !"Success".equals(identity.getVerificationStatus())
+                    || !"Domain".equals(identity.getIdentityType())) {
+                throw new AwsException("BadRequestException",
+                        "Domain <" + domain + "> is not verified under this account.", 400);
+            }
+        }
+        if (httpsPolicy != null && !HTTPS_POLICIES.contains(httpsPolicy)) {
+            throw new AwsException("BadRequestException",
+                    "1 validation error detected: Value at 'httpsPolicy' failed to satisfy constraint: "
+                            + "Member must satisfy enum value set: [OPTIONAL, REQUIRE, REQUIRE_OPEN_ONLY]", 400);
+        }
+    }
+
+    private void validateDeliveryOptions(DeliveryOptions options) {
+        if (options == null) {
+            return;
+        }
+        if (options.getTlsPolicy() != null && !TLS_POLICIES.contains(options.getTlsPolicy())) {
+            throw new AwsException("BadRequestException",
+                    "1 validation error detected: Value at 'tlsPolicy' failed to satisfy constraint: "
+                            + "Member must satisfy enum value set: [OPTIONAL, REQUIRE]", 400);
+        }
+        // AWS rejects a blank SendingPoolName outright, and Floci has no
+        // dedicated-IP pools so any other provided pool reference is unknown
+        // (both verified against real AWS 2026-06-17).
+        if (options.getSendingPoolName() != null) {
+            if (options.getSendingPoolName().isBlank()) {
+                throw new AwsException("BadRequestException",
+                        "sendingPoolName can't be blank.", 400);
+            }
+            throw new AwsException("BadRequestException",
+                    "SendingPool <" + options.getSendingPoolName() + "> doesn't exist", 400);
+        }
+        // AWS constrains MaxDeliverySeconds to [300, 50400] (max verified against
+        // real AWS 2026-06-17; min follows the same smithy range-constraint shape).
+        if (options.getMaxDeliverySeconds() != null) {
+            long maxDeliverySeconds = options.getMaxDeliverySeconds();
+            if (maxDeliverySeconds < 300) {
+                throw new AwsException("BadRequestException",
+                        "1 validation error detected: Value at 'maxDeliverySeconds' failed to satisfy constraint: "
+                                + "Member must have value greater than or equal to 300", 400);
+            }
+            if (maxDeliverySeconds > 50400) {
+                throw new AwsException("BadRequestException",
+                        "1 validation error detected: Value at 'maxDeliverySeconds' failed to satisfy constraint: "
+                                + "Member must have value less than or equal to 50400", 400);
+            }
+        }
+    }
+
+    private void validateArchivingOptions(ArchivingOptions options) {
+        if (options == null || options.getArchiveArn() == null) {
+            return;
+        }
+        // Validate the ARN format (verified against real AWS 2026-06-17). The
+        // archive's existence / account ownership is not checked — Floci does not
+        // model Mail Manager archives — so a well-formed ARN is accepted.
+        if (!ARCHIVE_ARN_PATTERN.matcher(options.getArchiveArn()).matches()) {
+            throw new AwsException("BadRequestException",
+                    "1 validation error detected: Value at 'archiveArn' failed to satisfy constraint: "
+                            + "Member must satisfy regular expression pattern: " + ARCHIVE_ARN_PATTERN.pattern(),
+                    400);
+        }
     }
 
     public ConfigurationSet getConfigurationSet(String name, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -657,7 +657,7 @@ public class SesService {
             }
         }
         validateTrackingOptions(configSet.getTrackingOptions(), region);
-        validateDeliveryOptions(configSet.getDeliveryOptions());
+        validateDeliveryOptions(configSet.getDeliveryOptions(), region);
         validateArchivingOptions(configSet.getArchivingOptions());
         validateVdmOptions(configSet.getVdmOptions());
         if (configSetStore.get(key).isPresent()) {
@@ -682,7 +682,7 @@ public class SesService {
 
     public void setConfigurationSetDeliveryOptions(String configSetName, DeliveryOptions options, String region) {
         ConfigurationSet cs = getConfigurationSet(configSetName, region);
-        validateDeliveryOptions(options);
+        validateDeliveryOptions(options, region);
         cs.setDeliveryOptions(options);
         configSetStore.put(configSetKey(region, configSetName), cs);
         LOG.infov("Updated DeliveryOptions on configuration set {0} in region {1}", configSetName, region);
@@ -771,7 +771,7 @@ public class SesService {
         }
     }
 
-    private void validateDeliveryOptions(DeliveryOptions options) {
+    private void validateDeliveryOptions(DeliveryOptions options, String region) {
         if (options == null) {
             return;
         }
@@ -780,16 +780,18 @@ public class SesService {
                     "1 validation error detected: Value at 'tlsPolicy' failed to satisfy constraint: "
                             + "Member must satisfy enum value set: [OPTIONAL, REQUIRE]", 400);
         }
-        // AWS rejects a blank SendingPoolName outright, and Floci has no
-        // dedicated-IP pools so any other provided pool reference is unknown
-        // (both verified against real AWS 2026-06-17).
+        // AWS rejects a blank SendingPoolName outright, and a non-existent
+        // dedicated IP pool (both verified against real AWS 2026-06-17). The
+        // pool must have been created via CreateDedicatedIpPool.
         if (options.getSendingPoolName() != null) {
             if (options.getSendingPoolName().isBlank()) {
                 throw new AwsException("BadRequestException",
                         "sendingPoolName can't be blank.", 400);
             }
-            throw new AwsException("BadRequestException",
-                    "SendingPool <" + options.getSendingPoolName() + "> doesn't exist", 400);
+            if (!dedicatedIpPoolExists(options.getSendingPoolName(), region)) {
+                throw new AwsException("BadRequestException",
+                        "SendingPool <" + options.getSendingPoolName() + "> doesn't exist", 400);
+            }
         }
         // AWS constrains MaxDeliverySeconds to [300, 50400] (max verified against
         // real AWS 2026-06-17; min follows the same smithy range-constraint shape).

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/ArchivingOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/ArchivingOptions.java
@@ -1,0 +1,25 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * Per-configuration-set archiving override. Mirrors the AWS SES V2
+ * {@code ArchivingOptions} shape: the ARN of the Mail Manager archive that
+ * sends through the configuration set are written to.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ArchivingOptions {
+
+    @JsonProperty("ArchiveArn")
+    private String archiveArn;
+
+    public ArchivingOptions() {}
+
+    public String getArchiveArn() { return archiveArn; }
+    public void setArchiveArn(String archiveArn) { this.archiveArn = archiveArn; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/ConfigurationSet.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/ConfigurationSet.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.ses.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.runtime.annotations.RegisterForReflection;
@@ -29,6 +30,21 @@ public class ConfigurationSet {
 
     @JsonProperty("SendingEnabled")
     private Boolean sendingEnabled;
+
+    @JsonProperty("ReputationMetricsEnabled")
+    private Boolean reputationMetricsEnabled;
+
+    @JsonProperty("TrackingOptions")
+    private TrackingOptions trackingOptions;
+
+    @JsonProperty("DeliveryOptions")
+    private DeliveryOptions deliveryOptions;
+
+    @JsonProperty("ArchivingOptions")
+    private ArchivingOptions archivingOptions;
+
+    @JsonProperty("VdmOptions")
+    private VdmOptions vdmOptions;
 
     public ConfigurationSet() {}
 
@@ -66,8 +82,44 @@ public class ConfigurationSet {
      * implicitly enabled. Use this anywhere v1/v2 read or enforce the toggle
      * so the default rule stays consistent across surfaces.
      */
-    @com.fasterxml.jackson.annotation.JsonIgnore
+    @JsonIgnore
     public boolean isSendingEnabledEffective() {
         return sendingEnabled == null || sendingEnabled;
+    }
+
+    public Boolean getReputationMetricsEnabled() { return reputationMetricsEnabled; }
+    public void setReputationMetricsEnabled(Boolean reputationMetricsEnabled) {
+        this.reputationMetricsEnabled = reputationMetricsEnabled;
+    }
+
+    /**
+     * Effective reputation-metrics flag with the AWS default applied — an unset
+     * (null) field reads as enabled, matching AWS where GetConfigurationSet
+     * always returns {@code ReputationOptions.ReputationMetricsEnabled} (true by
+     * default) for a configuration set with no explicit override.
+     */
+    @JsonIgnore
+    public boolean isReputationMetricsEnabledEffective() {
+        return reputationMetricsEnabled == null || reputationMetricsEnabled;
+    }
+
+    public TrackingOptions getTrackingOptions() { return trackingOptions; }
+    public void setTrackingOptions(TrackingOptions trackingOptions) {
+        this.trackingOptions = trackingOptions;
+    }
+
+    public DeliveryOptions getDeliveryOptions() { return deliveryOptions; }
+    public void setDeliveryOptions(DeliveryOptions deliveryOptions) {
+        this.deliveryOptions = deliveryOptions;
+    }
+
+    public ArchivingOptions getArchivingOptions() { return archivingOptions; }
+    public void setArchivingOptions(ArchivingOptions archivingOptions) {
+        this.archivingOptions = archivingOptions;
+    }
+
+    public VdmOptions getVdmOptions() { return vdmOptions; }
+    public void setVdmOptions(VdmOptions vdmOptions) {
+        this.vdmOptions = vdmOptions;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/DashboardOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/DashboardOptions.java
@@ -1,0 +1,26 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * VDM dashboard settings for a configuration set. Mirrors the AWS SES V2
+ * {@code DashboardOptions} shape: whether engagement metrics are collected.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DashboardOptions {
+
+    @JsonProperty("EngagementMetrics")
+    private String engagementMetrics;
+
+    public DashboardOptions() {}
+
+    public String getEngagementMetrics() { return engagementMetrics; }
+    public void setEngagementMetrics(String engagementMetrics) {
+        this.engagementMetrics = engagementMetrics;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/DedicatedIpPool.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/DedicatedIpPool.java
@@ -1,0 +1,35 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * A SES V2 dedicated IP pool. Mirrors the AWS {@code DedicatedIpPool} shape:
+ * a pool name and its scaling mode ({@code STANDARD} or {@code MANAGED}).
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DedicatedIpPool {
+
+    @JsonProperty("PoolName")
+    private String poolName;
+
+    @JsonProperty("ScalingMode")
+    private String scalingMode;
+
+    public DedicatedIpPool() {}
+
+    public DedicatedIpPool(String poolName, String scalingMode) {
+        this.poolName = poolName;
+        this.scalingMode = scalingMode;
+    }
+
+    public String getPoolName() { return poolName; }
+    public void setPoolName(String poolName) { this.poolName = poolName; }
+
+    public String getScalingMode() { return scalingMode; }
+    public void setScalingMode(String scalingMode) { this.scalingMode = scalingMode; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/DeliveryOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/DeliveryOptions.java
@@ -1,0 +1,37 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * Per-configuration-set delivery override. Mirrors the AWS SES V2
+ * {@code DeliveryOptions} shape: the TLS policy, an optional dedicated-IP
+ * sending pool, and the maximum delivery time.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DeliveryOptions {
+
+    @JsonProperty("TlsPolicy")
+    private String tlsPolicy;
+
+    @JsonProperty("SendingPoolName")
+    private String sendingPoolName;
+
+    @JsonProperty("MaxDeliverySeconds")
+    private Long maxDeliverySeconds;
+
+    public DeliveryOptions() {}
+
+    public String getTlsPolicy() { return tlsPolicy; }
+    public void setTlsPolicy(String tlsPolicy) { this.tlsPolicy = tlsPolicy; }
+
+    public String getSendingPoolName() { return sendingPoolName; }
+    public void setSendingPoolName(String sendingPoolName) { this.sendingPoolName = sendingPoolName; }
+
+    public Long getMaxDeliverySeconds() { return maxDeliverySeconds; }
+    public void setMaxDeliverySeconds(Long maxDeliverySeconds) { this.maxDeliverySeconds = maxDeliverySeconds; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/GuardianOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/GuardianOptions.java
@@ -1,0 +1,26 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * VDM Guardian settings for a configuration set. Mirrors the AWS SES V2
+ * {@code GuardianOptions} shape: whether optimized shared delivery is applied.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GuardianOptions {
+
+    @JsonProperty("OptimizedSharedDelivery")
+    private String optimizedSharedDelivery;
+
+    public GuardianOptions() {}
+
+    public String getOptimizedSharedDelivery() { return optimizedSharedDelivery; }
+    public void setOptimizedSharedDelivery(String optimizedSharedDelivery) {
+        this.optimizedSharedDelivery = optimizedSharedDelivery;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/TrackingOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/TrackingOptions.java
@@ -1,0 +1,33 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * Per-configuration-set open/click tracking override. Mirrors the AWS SES V2
+ * {@code TrackingOptions} shape: a custom redirect domain (which must be a
+ * verified identity) and the HTTPS policy applied to tracking links.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TrackingOptions {
+
+    @JsonProperty("CustomRedirectDomain")
+    private String customRedirectDomain;
+
+    @JsonProperty("HttpsPolicy")
+    private String httpsPolicy;
+
+    public TrackingOptions() {}
+
+    public String getCustomRedirectDomain() { return customRedirectDomain; }
+    public void setCustomRedirectDomain(String customRedirectDomain) {
+        this.customRedirectDomain = customRedirectDomain;
+    }
+
+    public String getHttpsPolicy() { return httpsPolicy; }
+    public void setHttpsPolicy(String httpsPolicy) { this.httpsPolicy = httpsPolicy; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/VdmOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/VdmOptions.java
@@ -1,0 +1,35 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * Per-configuration-set Virtual Deliverability Manager override. Mirrors the
+ * AWS SES V2 {@code VdmOptions} shape: nested {@code DashboardOptions} and
+ * {@code GuardianOptions}.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class VdmOptions {
+
+    @JsonProperty("DashboardOptions")
+    private DashboardOptions dashboardOptions;
+
+    @JsonProperty("GuardianOptions")
+    private GuardianOptions guardianOptions;
+
+    public VdmOptions() {}
+
+    public DashboardOptions getDashboardOptions() { return dashboardOptions; }
+    public void setDashboardOptions(DashboardOptions dashboardOptions) {
+        this.dashboardOptions = dashboardOptions;
+    }
+
+    public GuardianOptions getGuardianOptions() { return guardianOptions; }
+    public void setGuardianOptions(GuardianOptions guardianOptions) {
+        this.guardianOptions = guardianOptions;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV2IntegrationTest.java
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Integration tests for SES V2 ConfigurationSet endpoints under /v2/email/configuration-sets.
@@ -663,5 +665,480 @@ class SesConfigurationSetV2IntegrationTest {
             .statusCode(400)
             .body("__type", equalTo("SerializationException"))
             .body("message", equalTo("Expected null"));
+    }
+
+    // ─────────── Reputation / Tracking / Delivery / Archiving options ───────────
+    // Behavior verified against real AWS SES V2 on 2026-06-17.
+
+    @Test
+    @Order(30)
+    void getConfigurationSet_reputationOptions_defaultsEnabled() {
+        putConfigSet("v2-cs-rep-default");
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/configuration-sets/v2-cs-rep-default")
+        .then().statusCode(200)
+            .body("ReputationOptions.ReputationMetricsEnabled", equalTo(true));
+    }
+
+    @Test
+    @Order(31)
+    void putReputationOptions_disables_andEchoes() {
+        putConfigSet("v2-cs-rep");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"ReputationMetricsEnabled\": false}")
+        .when().put("/v2/email/configuration-sets/v2-cs-rep/reputation-options")
+        .then().statusCode(200);
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/configuration-sets/v2-cs-rep")
+        .then().statusCode(200)
+            .body("ReputationOptions.ReputationMetricsEnabled", equalTo(false));
+    }
+
+    @Test
+    @Order(32)
+    void createConfigurationSet_inlineReputation_echoed() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("""
+                {"ConfigurationSetName": "v2-cs-rep-inline",
+                 "ReputationOptions": {"ReputationMetricsEnabled": false}}
+                """)
+        .when().post("/v2/email/configuration-sets").then().statusCode(200);
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/configuration-sets/v2-cs-rep-inline")
+        .then().statusCode(200)
+            .body("ReputationOptions.ReputationMetricsEnabled", equalTo(false));
+    }
+
+    @Test
+    @Order(33)
+    void putDeliveryOptions_echoed() {
+        putConfigSet("v2-cs-delivery");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"TlsPolicy\": \"REQUIRE\", \"MaxDeliverySeconds\": 300}")
+        .when().put("/v2/email/configuration-sets/v2-cs-delivery/delivery-options")
+        .then().statusCode(200);
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/configuration-sets/v2-cs-delivery")
+        .then().statusCode(200)
+            .body("DeliveryOptions.TlsPolicy", equalTo("REQUIRE"))
+            .body("DeliveryOptions.MaxDeliverySeconds", equalTo(300));
+    }
+
+    @Test
+    @Order(34)
+    void putDeliveryOptions_nonexistentPool_returns400() {
+        putConfigSet("v2-cs-delivery-pool");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"TlsPolicy\": \"OPTIONAL\", \"SendingPoolName\": \"ghost-pool\"}")
+        .when().put("/v2/email/configuration-sets/v2-cs-delivery-pool/delivery-options")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("SendingPool <ghost-pool> doesn't exist"));
+    }
+
+    @Test
+    @Order(35)
+    void putArchivingOptions_validArn_echoed() {
+        putConfigSet("v2-cs-archiving");
+        String arn = "arn:aws:ses:us-east-1:123456789012:mailmanager-archive/a-abcdefghijklmnopqrstuvwx";
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"ArchiveArn\": \"" + arn + "\"}")
+        .when().put("/v2/email/configuration-sets/v2-cs-archiving/archiving-options")
+        .then().statusCode(200);
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/configuration-sets/v2-cs-archiving")
+        .then().statusCode(200)
+            .body("ArchivingOptions.ArchiveArn", equalTo(arn));
+    }
+
+    @Test
+    @Order(36)
+    void putArchivingOptions_malformedArn_returns400() {
+        putConfigSet("v2-cs-archiving-bad");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"ArchiveArn\": \"arn:aws:ses:us-east-1:123456789012:mailmanager-archive/a-short\"}")
+        .when().put("/v2/email/configuration-sets/v2-cs-archiving-bad/archiving-options")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("failed to satisfy constraint"));
+    }
+
+    @Test
+    @Order(37)
+    void putTrackingOptions_verifiedDomain_echoed() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"EmailIdentity\": \"track.floci.test\"}")
+        .when().post("/v2/email/identities").then().statusCode(200);
+        putConfigSet("v2-cs-tracking");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"CustomRedirectDomain\": \"track.floci.test\", \"HttpsPolicy\": \"REQUIRE\"}")
+        .when().put("/v2/email/configuration-sets/v2-cs-tracking/tracking-options")
+        .then().statusCode(200);
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/configuration-sets/v2-cs-tracking")
+        .then().statusCode(200)
+            .body("TrackingOptions.CustomRedirectDomain", equalTo("track.floci.test"))
+            .body("TrackingOptions.HttpsPolicy", equalTo("REQUIRE"));
+    }
+
+    @Test
+    @Order(38)
+    void putTrackingOptions_unverifiedDomain_returns400() {
+        putConfigSet("v2-cs-tracking-unverified");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"CustomRedirectDomain\": \"never-verified.example.com\", \"HttpsPolicy\": \"REQUIRE\"}")
+        .when().put("/v2/email/configuration-sets/v2-cs-tracking-unverified/tracking-options")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("Domain <never-verified.example.com> is not verified under this account."));
+    }
+
+    @Test
+    @Order(39)
+    void putTrackingOptions_invalidHttpsPolicy_returns400() {
+        // AWS validates the HttpsPolicy enum only after CustomRedirectDomain
+        // presence and verification, so the domain must be verified to reach it.
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"EmailIdentity\": \"track-enum.floci.test\"}")
+        .when().post("/v2/email/identities").then().statusCode(200);
+        putConfigSet("v2-cs-tracking-enum");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"CustomRedirectDomain\": \"track-enum.floci.test\", \"HttpsPolicy\": \"BOGUS\"}")
+        .when().put("/v2/email/configuration-sets/v2-cs-tracking-enum/tracking-options")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("1 validation error detected: Value at "
+                    + "'httpsPolicy' failed to satisfy constraint: "
+                    + "Member must satisfy enum value set: [OPTIONAL, REQUIRE, REQUIRE_OPEN_ONLY]"));
+    }
+
+    @Test
+    @Order(40)
+    void putReputationOptions_emptyBody_disables() {
+        // AWS treats a PutConfigurationSetReputationOptions with no
+        // ReputationMetricsEnabled member as "false" (verified against real AWS
+        // SES V2 on 2026-06-17) — it is not required and does not error.
+        putConfigSet("v2-cs-rep-empty");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{}")
+        .when().put("/v2/email/configuration-sets/v2-cs-rep-empty/reputation-options")
+        .then().statusCode(200);
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/configuration-sets/v2-cs-rep-empty")
+        .then().statusCode(200)
+            .body("ReputationOptions.ReputationMetricsEnabled", equalTo(false));
+    }
+
+    @Test
+    @Order(41)
+    void putDeliveryOptions_invalidTlsPolicy_returns400() {
+        putConfigSet("v2-cs-delivery-tls");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"TlsPolicy\": \"MAYBE\"}")
+        .when().put("/v2/email/configuration-sets/v2-cs-delivery-tls/delivery-options")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("1 validation error detected: Value at "
+                    + "'tlsPolicy' failed to satisfy constraint: "
+                    + "Member must satisfy enum value set: [OPTIONAL, REQUIRE]"));
+    }
+
+    @Test
+    @Order(42)
+    void putDeliveryOptions_nonNumericMaxDeliverySeconds_returns400() {
+        putConfigSet("v2-cs-delivery-max");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"TlsPolicy\": \"REQUIRE\", \"MaxDeliverySeconds\": \"soon\"}")
+        .when().put("/v2/email/configuration-sets/v2-cs-delivery-max/delivery-options")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("MaxDeliverySeconds must be a number."));
+    }
+
+    @Test
+    @Order(43)
+    void putTrackingOptions_nonStringHttpsPolicy_returns400() {
+        putConfigSet("v2-cs-tracking-type");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"HttpsPolicy\": 123}")
+        .when().put("/v2/email/configuration-sets/v2-cs-tracking-type/tracking-options")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("HttpsPolicy must be a JSON string."));
+    }
+
+    @Test
+    @Order(44)
+    void putArchivingOptions_nonStringArn_returns400() {
+        putConfigSet("v2-cs-archiving-type");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"ArchiveArn\": true}")
+        .when().put("/v2/email/configuration-sets/v2-cs-archiving-type/archiving-options")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("ArchiveArn must be a JSON string."));
+    }
+
+    @Test
+    @Order(48)
+    void putDeliveryOptions_fractionalMaxDeliverySeconds_returns400() {
+        // MaxDeliverySeconds is an integer; a fractional value must not be
+        // silently truncated.
+        putConfigSet("v2-cs-delivery-frac");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"TlsPolicy\": \"REQUIRE\", \"MaxDeliverySeconds\": 1.5}")
+        .when().put("/v2/email/configuration-sets/v2-cs-delivery-frac/delivery-options")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("MaxDeliverySeconds must be an integer."));
+    }
+
+    @Test
+    @Order(45)
+    void putTrackingOptions_httpsPolicyWithoutDomain_returns400() {
+        // AWS requires CustomRedirectDomain whenever HttpsPolicy is set
+        // (verified against real AWS 2026-06-17); an empty body is accepted.
+        putConfigSet("v2-cs-tracking-nodomain");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"HttpsPolicy\": \"REQUIRE\"}")
+        .when().put("/v2/email/configuration-sets/v2-cs-tracking-nodomain/tracking-options")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("CustomRedirectDomain must be specified."));
+    }
+
+    @Test
+    @Order(46)
+    void putTrackingOptions_unverifiedDomainPrecedesEnum_returns400() {
+        // AWS checks domain verification before the HttpsPolicy enum, so an
+        // unverified domain wins over an invalid enum value.
+        putConfigSet("v2-cs-tracking-order");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"CustomRedirectDomain\": \"unverified-order.example.com\", \"HttpsPolicy\": \"BOGUS\"}")
+        .when().put("/v2/email/configuration-sets/v2-cs-tracking-order/tracking-options")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("Domain <unverified-order.example.com> is not verified under this account."));
+    }
+
+    @Test
+    @Order(47)
+    void putTrackingOptions_verifiedEmailIdentityAsDomain_returns400() {
+        // CustomRedirectDomain must be a verified *domain* identity; a verified
+        // email-address identity does not qualify.
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"EmailIdentity\": \"redirect@floci.test\"}")
+        .when().post("/v2/email/identities").then().statusCode(200);
+        putConfigSet("v2-cs-tracking-email-id");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"CustomRedirectDomain\": \"redirect@floci.test\", \"HttpsPolicy\": \"REQUIRE\"}")
+        .when().put("/v2/email/configuration-sets/v2-cs-tracking-email-id/tracking-options")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("Domain <redirect@floci.test> is not verified under this account."));
+    }
+
+    @Test
+    @Order(49)
+    void putTrackingOptions_blankDomain_returns400() {
+        // AWS rejects a present-but-blank CustomRedirectDomain rather than
+        // storing it (verified against real AWS 2026-06-17), even with no
+        // HttpsPolicy set.
+        putConfigSet("v2-cs-tracking-blank");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"CustomRedirectDomain\": \"   \"}")
+        .when().put("/v2/email/configuration-sets/v2-cs-tracking-blank/tracking-options")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("CustomRedirectDomain must be specified."));
+    }
+
+    @Test
+    @Order(50)
+    void putTrackingOptions_unverifiedDomainWithoutHttpsPolicy_returns400() {
+        // AWS verifies CustomRedirectDomain even when HttpsPolicy is omitted.
+        putConfigSet("v2-cs-tracking-nopolicy");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"CustomRedirectDomain\": \"never-verified-nopolicy.example.com\"}")
+        .when().put("/v2/email/configuration-sets/v2-cs-tracking-nopolicy/tracking-options")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("Domain <never-verified-nopolicy.example.com> is not verified under this account."));
+    }
+
+    @Test
+    @Order(51)
+    void putTrackingOptions_emptyBody_clears() {
+        // An empty PUT body clears tracking options rather than persisting an
+        // empty block that GetConfigurationSet would echo as {}.
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"EmailIdentity\": \"clear.floci.test\"}")
+        .when().post("/v2/email/identities").then().statusCode(200);
+        putConfigSet("v2-cs-tracking-clear");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"CustomRedirectDomain\": \"clear.floci.test\", \"HttpsPolicy\": \"REQUIRE\"}")
+        .when().put("/v2/email/configuration-sets/v2-cs-tracking-clear/tracking-options")
+        .then().statusCode(200);
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/configuration-sets/v2-cs-tracking-clear")
+        .then().statusCode(200).body("TrackingOptions.HttpsPolicy", equalTo("REQUIRE"));
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{}")
+        .when().put("/v2/email/configuration-sets/v2-cs-tracking-clear/tracking-options")
+        .then().statusCode(200);
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/configuration-sets/v2-cs-tracking-clear")
+        .then().statusCode(200).body("TrackingOptions", nullValue());
+    }
+
+    @Test
+    @Order(52)
+    void putDeliveryOptions_emptyBody_clears() {
+        putConfigSet("v2-cs-delivery-clear");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"TlsPolicy\": \"REQUIRE\"}")
+        .when().put("/v2/email/configuration-sets/v2-cs-delivery-clear/delivery-options")
+        .then().statusCode(200);
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/configuration-sets/v2-cs-delivery-clear")
+        .then().statusCode(200).body("DeliveryOptions.TlsPolicy", equalTo("REQUIRE"));
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{}")
+        .when().put("/v2/email/configuration-sets/v2-cs-delivery-clear/delivery-options")
+        .then().statusCode(200);
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/configuration-sets/v2-cs-delivery-clear")
+        .then().statusCode(200).body("DeliveryOptions", nullValue());
+    }
+
+    @Test
+    @Order(53)
+    void putDeliveryOptions_blankSendingPool_returns400() {
+        // AWS rejects a blank SendingPoolName with a distinct message (verified
+        // against real AWS 2026-06-17), separate from the non-existent-pool case.
+        putConfigSet("v2-cs-delivery-blankpool");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"SendingPoolName\": \"   \"}")
+        .when().put("/v2/email/configuration-sets/v2-cs-delivery-blankpool/delivery-options")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("sendingPoolName can't be blank."));
+    }
+
+    @Test
+    @Order(54)
+    void putDeliveryOptions_maxDeliverySecondsBelowMinimum_returns400() {
+        putConfigSet("v2-cs-delivery-min");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"MaxDeliverySeconds\": 5}")
+        .when().put("/v2/email/configuration-sets/v2-cs-delivery-min/delivery-options")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("1 validation error detected: Value at "
+                    + "'maxDeliverySeconds' failed to satisfy constraint: "
+                    + "Member must have value greater than or equal to 300"));
+    }
+
+    @Test
+    @Order(55)
+    void putDeliveryOptions_maxDeliverySecondsAboveMaximum_returns400() {
+        putConfigSet("v2-cs-delivery-overmax");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"MaxDeliverySeconds\": 999999}")
+        .when().put("/v2/email/configuration-sets/v2-cs-delivery-overmax/delivery-options")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("1 validation error detected: Value at "
+                    + "'maxDeliverySeconds' failed to satisfy constraint: "
+                    + "Member must have value less than or equal to 50400"));
+    }
+
+    @Test
+    @Order(56)
+    void putVdmOptions_echoed() {
+        putConfigSet("v2-cs-vdm");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"VdmOptions\": {\"DashboardOptions\": {\"EngagementMetrics\": \"ENABLED\"}, "
+                    + "\"GuardianOptions\": {\"OptimizedSharedDelivery\": \"DISABLED\"}}}")
+        .when().put("/v2/email/configuration-sets/v2-cs-vdm/vdm-options")
+        .then().statusCode(200);
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/configuration-sets/v2-cs-vdm")
+        .then().statusCode(200)
+            .body("VdmOptions.DashboardOptions.EngagementMetrics", equalTo("ENABLED"))
+            .body("VdmOptions.GuardianOptions.OptimizedSharedDelivery", equalTo("DISABLED"));
+    }
+
+    @Test
+    @Order(57)
+    void putVdmOptions_invalidEngagementMetrics_returns400() {
+        putConfigSet("v2-cs-vdm-bad");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"VdmOptions\": {\"DashboardOptions\": {\"EngagementMetrics\": \"NONSENSE\"}}}")
+        .when().put("/v2/email/configuration-sets/v2-cs-vdm-bad/vdm-options")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("1 validation error detected: Value at "
+                    + "'vdmOptions.dashboardOptions.engagementMetrics' failed to satisfy constraint: "
+                    + "Member must satisfy enum value set: [ENABLED, DISABLED]"));
+    }
+
+    @Test
+    @Order(58)
+    void createConfigurationSet_inlineVdm_echoed() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"ConfigurationSetName\": \"v2-cs-vdm-inline\", "
+                    + "\"VdmOptions\": {\"DashboardOptions\": {\"EngagementMetrics\": \"DISABLED\"}}}")
+        .when().post("/v2/email/configuration-sets").then().statusCode(200);
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/configuration-sets/v2-cs-vdm-inline")
+        .then().statusCode(200)
+            .body("VdmOptions.DashboardOptions.EngagementMetrics", equalTo("DISABLED"));
+    }
+
+    @Test
+    @Order(59)
+    void putVdmOptions_emptyBody_clears() {
+        putConfigSet("v2-cs-vdm-clear");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"VdmOptions\": {\"DashboardOptions\": {\"EngagementMetrics\": \"ENABLED\"}}}")
+        .when().put("/v2/email/configuration-sets/v2-cs-vdm-clear/vdm-options")
+        .then().statusCode(200);
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/configuration-sets/v2-cs-vdm-clear")
+        .then().statusCode(200).body("VdmOptions.DashboardOptions.EngagementMetrics", equalTo("ENABLED"));
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{}")
+        .when().put("/v2/email/configuration-sets/v2-cs-vdm-clear/vdm-options")
+        .then().statusCode(200);
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/configuration-sets/v2-cs-vdm-clear")
+        .then().statusCode(200).body("VdmOptions", nullValue());
+    }
+
+    @Test
+    @Order(60)
+    void createConfigurationSet_invalidInlineVdm_returns400_andDoesNotCreate() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"ConfigurationSetName\": \"v2-cs-vdm-inline-bad\", "
+                    + "\"VdmOptions\": {\"DashboardOptions\": {\"EngagementMetrics\": \"NONSENSE\"}}}")
+        .when().post("/v2/email/configuration-sets")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("1 validation error detected: Value at "
+                    + "'vdmOptions.dashboardOptions.engagementMetrics' failed to satisfy constraint: "
+                    + "Member must satisfy enum value set: [ENABLED, DISABLED]"));
+
+        // Validation happens before the store write, so the set must not exist.
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/configuration-sets/v2-cs-vdm-inline-bad")
+        .then().statusCode(404)
+            .body("__type", equalTo("NotFoundException"));
+    }
+
+    private static void putConfigSet(String name) {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"ConfigurationSetName\": \"" + name + "\"}")
+        .when().post("/v2/email/configuration-sets").then().statusCode(200);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV2IntegrationTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
@@ -753,14 +752,20 @@ class SesConfigurationSetV2IntegrationTest {
 
     @Test
     @Order(36)
-    void putArchivingOptions_malformedArn_returns400() {
-        putConfigSet("v2-cs-archiving-bad");
+    void putArchivingOptions_arbitraryArn_accepted() {
+        // Floci does not model Mail Manager archives, so the ArchiveArn is not
+        // validated — any value is stored and echoed (matching the store-only
+        // behaviour of other local AWS emulators).
+        String arn = "not-an-arn";
+        putConfigSet("v2-cs-archiving-any");
         given().contentType("application/json").header("Authorization", AUTH_HEADER)
-            .body("{\"ArchiveArn\": \"arn:aws:ses:us-east-1:123456789012:mailmanager-archive/a-short\"}")
-        .when().put("/v2/email/configuration-sets/v2-cs-archiving-bad/archiving-options")
-        .then().statusCode(400)
-            .body("__type", equalTo("BadRequestException"))
-            .body("message", containsString("failed to satisfy constraint"));
+            .body("{\"ArchiveArn\": \"" + arn + "\"}")
+        .when().put("/v2/email/configuration-sets/v2-cs-archiving-any/archiving-options")
+        .then().statusCode(200);
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/configuration-sets/v2-cs-archiving-any")
+        .then().statusCode(200)
+            .body("ArchivingOptions.ArchiveArn", equalTo(arn));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV2IntegrationTest.java
@@ -1136,6 +1136,26 @@ class SesConfigurationSetV2IntegrationTest {
             .body("__type", equalTo("NotFoundException"));
     }
 
+    @Test
+    @Order(61)
+    void putDeliveryOptions_existingSendingPool_roundTrips() {
+        // A SendingPoolName that refers to a dedicated IP pool created via
+        // CreateDedicatedIpPool is accepted and echoed (verified against real
+        // AWS 2026-06-18).
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"PoolName\": \"v2-cs-pool-ref\"}")
+        .when().post("/v2/email/dedicated-ip-pools").then().statusCode(200);
+        putConfigSet("v2-cs-delivery-poolref");
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"TlsPolicy\": \"REQUIRE\", \"SendingPoolName\": \"v2-cs-pool-ref\"}")
+        .when().put("/v2/email/configuration-sets/v2-cs-delivery-poolref/delivery-options")
+        .then().statusCode(200);
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/configuration-sets/v2-cs-delivery-poolref")
+        .then().statusCode(200)
+            .body("DeliveryOptions.SendingPoolName", equalTo("v2-cs-pool-ref"));
+    }
+
     private static void putConfigSet(String name) {
         given().contentType("application/json").header("Authorization", AUTH_HEADER)
             .body("{\"ConfigurationSetName\": \"" + name + "\"}")

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesDedicatedIpPoolV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesDedicatedIpPoolV2IntegrationTest.java
@@ -1,0 +1,163 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+/**
+ * Integration tests for SES V2 dedicated IP pool endpoints under
+ * /v2/email/dedicated-ip-pools.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesDedicatedIpPoolV2IntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/ses/aws4_request";
+
+    @Test
+    @Order(1)
+    void createDedicatedIpPool_defaultScalingMode() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"PoolName\": \"v2-pool-alpha\"}")
+        .when().post("/v2/email/dedicated-ip-pools")
+        .then().statusCode(200);
+
+        // Default ScalingMode is STANDARD.
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/dedicated-ip-pools/v2-pool-alpha")
+        .then().statusCode(200)
+            .body("DedicatedIpPool.PoolName", equalTo("v2-pool-alpha"))
+            .body("DedicatedIpPool.ScalingMode", equalTo("STANDARD"));
+    }
+
+    @Test
+    @Order(2)
+    void createDedicatedIpPool_managedScalingMode() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"PoolName\": \"v2-pool-managed\", \"ScalingMode\": \"MANAGED\"}")
+        .when().post("/v2/email/dedicated-ip-pools")
+        .then().statusCode(200);
+
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/dedicated-ip-pools/v2-pool-managed")
+        .then().statusCode(200)
+            .body("DedicatedIpPool.ScalingMode", equalTo("MANAGED"));
+    }
+
+    @Test
+    @Order(3)
+    void createDedicatedIpPool_invalidScalingMode_returns400() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"PoolName\": \"v2-pool-bad\", \"ScalingMode\": \"NONSENSE\"}")
+        .when().post("/v2/email/dedicated-ip-pools")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("The ScalingMode parameter is invalid."));
+    }
+
+    @Test
+    @Order(4)
+    void createDedicatedIpPool_duplicate_returns400() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"PoolName\": \"v2-pool-alpha\"}")
+        .when().post("/v2/email/dedicated-ip-pools")
+        .then().statusCode(400)
+            .body("__type", equalTo("AlreadyExistsException"))
+            .body("message", equalTo("The pool <v2-pool-alpha> already exists."));
+    }
+
+    @Test
+    @Order(5)
+    void getDedicatedIpPool_unknown_returns404() {
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/dedicated-ip-pools/v2-pool-ghost")
+        .then().statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", equalTo("The requested pool <v2-pool-ghost> does not exist."));
+    }
+
+    @Test
+    @Order(6)
+    void listDedicatedIpPools() {
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/dedicated-ip-pools")
+        .then().statusCode(200)
+            .body("DedicatedIpPools", hasItem("v2-pool-alpha"))
+            .body("DedicatedIpPools", hasItem("v2-pool-managed"));
+    }
+
+    @Test
+    @Order(7)
+    void deleteDedicatedIpPool() {
+        given().header("Authorization", AUTH_HEADER)
+        .when().delete("/v2/email/dedicated-ip-pools/v2-pool-alpha")
+        .then().statusCode(200);
+
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/dedicated-ip-pools/v2-pool-alpha")
+        .then().statusCode(404);
+    }
+
+    @Test
+    @Order(8)
+    void deleteDedicatedIpPool_unknown_returns404() {
+        given().header("Authorization", AUTH_HEADER)
+        .when().delete("/v2/email/dedicated-ip-pools/v2-pool-ghost")
+        .then().statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", equalTo("The requested pool <v2-pool-ghost> does not exist."));
+    }
+
+    @Test
+    @Order(9)
+    void createDedicatedIpPool_emptyBody_returns400() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("")
+        .when().post("/v2/email/dedicated-ip-pools")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("Request body is required."));
+    }
+
+    @Test
+    @Order(10)
+    void createDedicatedIpPool_missingPoolName_returns400() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{}")
+        .when().post("/v2/email/dedicated-ip-pools")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("PoolName is required."));
+    }
+
+    @Test
+    @Order(11)
+    void createDedicatedIpPool_nullPoolName_returns400() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"PoolName\": null}")
+        .when().post("/v2/email/dedicated-ip-pools")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("PoolName is required."));
+    }
+
+    @Test
+    @Order(12)
+    void createDedicatedIpPool_nonTextualScalingMode_returns400() {
+        // A present-but-non-string ScalingMode must be rejected, not coerced to
+        // "" and silently defaulted to STANDARD.
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"PoolName\": \"v2-pool-objsm\", \"ScalingMode\": {}}")
+        .when().post("/v2/email/dedicated-ip-pools")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("The ScalingMode parameter is invalid."));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSmtpTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSmtpTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.SentEmail;
@@ -38,6 +39,7 @@ class SesServiceSmtpTest {
                 new InMemoryStorage<String, ConfigurationSet>(),
                 new InMemoryStorage<String, SuppressedDestination>(),
                 new InMemoryStorage<String, AccountSuppressionAttributes>(),
+                new InMemoryStorage<String, DedicatedIpPool>(),
                 smtpRelay,
                 new ObjectMapper());
     }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSuppressionLegacyKeyTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSuppressionLegacyKeyTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.SentEmail;
@@ -45,6 +46,7 @@ class SesServiceSuppressionLegacyKeyTest {
                 new InMemoryStorage<String, ConfigurationSet>(),
                 suppressionStore,
                 new InMemoryStorage<String, AccountSuppressionAttributes>(),
+                new InMemoryStorage<String, DedicatedIpPool>(),
                 mock(SmtpRelay.class),
                 new ObjectMapper());
     }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSuppressionReasonTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSuppressionReasonTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.SentEmail;
@@ -46,6 +47,7 @@ class SesServiceSuppressionReasonTest {
                 new InMemoryStorage<String, ConfigurationSet>(),
                 suppressionStore,
                 accountSuppressionStore,
+                new InMemoryStorage<String, DedicatedIpPool>(),
                 mock(SmtpRelay.class),
                 new ObjectMapper());
     }


### PR DESCRIPTION
## Summary

Adds two related SES v2 features in one PR (the configuration-set delivery option depends on the pool feature):

1. **Dedicated IP pool management**, backed by a per-region store.
2. **ConfigurationSet option groups** — `ReputationOptions`, `TrackingOptions`, `DeliveryOptions`, `ArchivingOptions`, and `VdmOptions` — each settable via its dedicated `Put...Options` endpoint or supplied inline to `CreateConfigurationSet`, and read back through `GetConfigurationSet`.

- New REST JSON endpoints (pools): `CreateDedicatedIpPool`, `ListDedicatedIpPools`, `GetDedicatedIpPool`, `DeleteDedicatedIpPool`.
- New REST JSON endpoints (config-set options): `PutConfigurationSet{Reputation,Tracking,Delivery,Archiving,Vdm}Options`.
- Inline parsing of the option groups in `CreateConfigurationSet` (validated before the set is stored) and echoing in `GetConfigurationSet`. An all-null block clears the options; `ReputationOptions` is always returned.
- `DeliveryOptions.SendingPoolName` is validated against the dedicated IP pool store: a pool created via `CreateDedicatedIpPool` is accepted, an unknown pool is rejected.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Validation and response shapes were verified against the live AWS SES V2 API using the AWS CLI v2 (`aws sesv2 ...`) on 2026-06-17–20:

- **Dedicated IP pools** — `ScalingMode` defaults to `STANDARD` and must be `STANDARD`/`MANAGED`; a duplicate pool returns `AlreadyExistsException`, an unknown pool `NotFoundException`; `GetDedicatedIpPool` returns `{ "DedicatedIpPool": { "PoolName", "ScalingMode" } }`.
- **TrackingOptions** — `HttpsPolicy` enum; a present `CustomRedirectDomain` must be non-blank and a verified domain identity, is required when `HttpsPolicy` is set, and is validated before the enum.
- **DeliveryOptions** — `TlsPolicy` enum; `MaxDeliverySeconds` integer in `[300, 50400]`; `SendingPoolName` must reference an existing dedicated IP pool (`sendingPoolName can't be blank.` for a blank value, `SendingPool <name> doesn't exist` for an unknown one).
- **ReputationOptions** — always returned by `GetConfigurationSet` (enabled by default); an empty-body PUT disables it.
- **VdmOptions** — nested `DashboardOptions`/`GuardianOptions` `[ENABLED, DISABLED]` enums; accepted independently of account-level VDM.
- **ArchivingOptions** — `ArchiveArn` is stored and echoed without format validation, since Floci does not model Mail Manager archives.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
