### PR TITLE
fix(auth,s3): resolve account context from X-Amz-Credential query param in presigned URLs

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/AccountContextFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AccountContextFilter.java
@@ -10,7 +10,8 @@ import jakarta.ws.rs.ext.Provider;
 
 /**
  * Populates {@link RequestContext} with the account ID and region derived from
- * the incoming AWS Authorization header. Runs at AUTHENTICATION priority so that
+ * the incoming AWS Authorization header or, for presigned URL requests, the
+ * X-Amz-Credential query parameter. Runs at AUTHENTICATION priority so that
  * downstream filters (e.g. IAM enforcement) can rely on the context being set.
  */
 @Provider
@@ -34,7 +35,18 @@ public class AccountContextFilter implements ContainerRequestFilter {
     @Override
     public void filter(ContainerRequestContext ctx) {
         String auth = ctx.getHeaderString("Authorization");
-        requestContext.setAccountId(accountResolver.resolve(auth));
-        requestContext.setRegion(regionResolver.resolveRegionFromAuth(auth));
+        if (auth != null && !auth.isEmpty()) {
+            requestContext.setAccountId(accountResolver.resolve(auth));
+            requestContext.setRegion(regionResolver.resolveRegionFromAuth(auth));
+        } else {
+            String credential = ctx.getUriInfo().getQueryParameters().getFirst("X-Amz-Credential");
+            if (credential != null && !credential.isEmpty()) {
+                requestContext.setAccountId(accountResolver.resolveFromPresignedCredential(credential));
+                requestContext.setRegion(regionResolver.resolveRegionFromPresignedCredential(credential));
+            } else {
+                requestContext.setAccountId(accountResolver.resolve(null));
+                requestContext.setRegion(regionResolver.resolveRegionFromAuth(null));
+            }
+        }
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/core/common/AccountResolver.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AccountResolver.java
@@ -19,6 +19,10 @@ public class AccountResolver {
         this.defaultAccountId = config.defaultAccountId();
     }
 
+    public AccountResolver(String defaultAccountId) {
+        this.defaultAccountId = defaultAccountId;
+    }
+
     /**
      * Returns the account ID for the given Authorization header.
      * When the access key ID is exactly 12 digits it is used directly as the account ID,
@@ -43,5 +47,26 @@ public class AccountResolver {
         }
         Matcher m = AKID_PATTERN.matcher(authorizationHeader);
         return m.find() ? m.group(1) : null;
+    }
+
+    /**
+     * Resolves the account ID from an X-Amz-Credential value found in
+     * presigned URL query parameters.
+     * Format: accessKeyID/date/region/service/aws4_request
+     * When the access key ID is exactly 12 digits it is used directly
+     * as the account ID, matching LocalStack's multi-account convention.
+     * Any other key format or missing/malformed value falls back to
+     * the configured default account.
+     */
+    public String resolveFromPresignedCredential(String credentialValue) {
+        if (credentialValue == null || credentialValue.isEmpty()) {
+            return defaultAccountId;
+        }
+        String[] parts = credentialValue.split("/");
+        String akid = parts[0];
+        if (akid.matches("\\d{12}")) {
+            return akid;
+        }
+        return defaultAccountId;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/core/common/RegionResolver.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/RegionResolver.java
@@ -49,6 +49,24 @@ public class RegionResolver {
         return matcher.find() ? matcher.group(1) : defaultRegion;
     }
 
+    /**
+     * Resolves the region from an X-Amz-Credential value found in
+     * presigned URL query parameters.
+     * Format: accessKeyID/date/region/service/aws4_request
+     * Falls back to the configured default region if the credential value
+     * is null, empty, or does not contain enough segments.
+     */
+    public String resolveRegionFromPresignedCredential(String credentialValue) {
+        if (credentialValue == null || credentialValue.isEmpty()) {
+            return defaultRegion;
+        }
+        String[] parts = credentialValue.split("/");
+        if (parts.length >= 3) {
+            return parts[2];
+        }
+        return defaultRegion;
+    }
+
     public String getDefaultRegion() {
         return defaultRegion;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/PreSignedUrlGenerator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/PreSignedUrlGenerator.java
@@ -1,7 +1,10 @@
 package io.github.hectorvent.floci.services.s3;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.RequestContext;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ContextNotActiveException;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
 import javax.crypto.Mac;
@@ -22,29 +25,54 @@ public class PreSignedUrlGenerator {
     private final int defaultExpiry;
     private final boolean validateSignatures;
     private final String defaultRegion;
+    private final String defaultAccountId;
+
+    // Field-injected so the package-private test constructors remain valid
+    @Inject
+    Instance<RequestContext> requestContextInstance;
 
     @Inject
     public PreSignedUrlGenerator(EmulatorConfig config) {
         this(config.auth().presignSecret(),
              config.services().s3().defaultPresignExpirySeconds(),
              config.auth().validateSignatures(),
-             config.defaultRegion());
+             config.defaultRegion(),
+             config.defaultAccountId());
     }
 
     /** Package-private constructor for testing. */
     PreSignedUrlGenerator(String secret, int defaultExpiry) {
-        this(secret, defaultExpiry, false, "us-east-1");
+        this(secret, defaultExpiry, false, "us-east-1", "000000000000");
     }
 
     PreSignedUrlGenerator(String secret, int defaultExpiry, boolean validateSignatures) {
-        this(secret, defaultExpiry, validateSignatures, "us-east-1");
+        this(secret, defaultExpiry, validateSignatures, "us-east-1", "000000000000");
     }
 
     PreSignedUrlGenerator(String secret, int defaultExpiry, boolean validateSignatures, String defaultRegion) {
+        this(secret, defaultExpiry, validateSignatures, defaultRegion, "000000000000");
+    }
+
+    PreSignedUrlGenerator(String secret, int defaultExpiry, boolean validateSignatures, String defaultRegion, String defaultAccountId) {
         this.secret = secret;
         this.defaultExpiry = defaultExpiry;
         this.validateSignatures = validateSignatures;
         this.defaultRegion = defaultRegion;
+        this.defaultAccountId = defaultAccountId;
+    }
+
+    private String resolveAccessKeyId() {
+        if (requestContextInstance != null) {
+            try {
+                String accountId = requestContextInstance.get().getAccountId();
+                if (accountId != null) {
+                    return accountId;
+                }
+            } catch (ContextNotActiveException ignored) {
+                // outside request scope — fall through to default
+            }
+        }
+        return defaultAccountId;
     }
 
     public boolean shouldValidateSignatures() {
@@ -55,7 +83,7 @@ public class PreSignedUrlGenerator {
                                          String method, int expiresSeconds) {
         int expiry = expiresSeconds > 0 ? expiresSeconds : defaultExpiry;
         String amzDate = AMZ_DATE_FORMAT.format(Instant.now());
-        String credential = "AKIAIOSFODNN7EXAMPLE/" + amzDate.substring(0, 8) + "/" + defaultRegion + "/s3/aws4_request";
+        String credential = resolveAccessKeyId() + "/" + amzDate.substring(0, 8) + "/" + defaultRegion + "/s3/aws4_request";
 
         String signature = computeSignature(method, bucket, key, amzDate, expiry);
 

--- a/src/test/java/io/github/hectorvent/floci/core/common/AccountContextFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/AccountContextFilterTest.java
@@ -1,0 +1,102 @@
+package io.github.hectorvent.floci.core.common;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.UriInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AccountContextFilterTest {
+
+    private static final String DEFAULT_ACCOUNT = "000000000000";
+    private static final String DEFAULT_REGION = "us-east-1";
+
+    private AccountResolver accountResolver;
+    private RegionResolver regionResolver;
+    private RequestContext requestContext;
+    private AccountContextFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        accountResolver = new AccountResolver(DEFAULT_ACCOUNT);
+        regionResolver = new RegionResolver(DEFAULT_REGION, DEFAULT_ACCOUNT);
+        requestContext = new RequestContext();
+        filter = new AccountContextFilter(accountResolver, regionResolver, requestContext);
+    }
+
+    @Test
+    void resolvesFromAuthHeaderWhenPresent() {
+        ContainerRequestContext ctx = mockContext(
+            "AWS4-HMAC-SHA256 Credential=000000000001/20260617/us-west-2/s3/aws4_request, SignedHeaders=host, Signature=abc",
+            null
+        );
+        filter.filter(ctx);
+        assertEquals("000000000001", requestContext.getAccountId());
+        assertEquals("us-west-2", requestContext.getRegion());
+    }
+
+    @Test
+    void resolvesFromPresignedCredentialWhenNoAuthHeader() {
+        ContainerRequestContext ctx = mockContext(null,
+            "000000000002/20260617/eu-west-1/s3/aws4_request");
+        filter.filter(ctx);
+        assertEquals("000000000002", requestContext.getAccountId());
+        assertEquals("eu-west-1", requestContext.getRegion());
+    }
+
+    @Test
+    void authHeaderTakesPrecedenceOverPresignedCredential() {
+        ContainerRequestContext ctx = mockContext(
+            "AWS4-HMAC-SHA256 Credential=000000000001/20260617/us-west-2/s3/aws4_request, SignedHeaders=host, Signature=abc",
+            "000000000002/20260617/eu-west-1/s3/aws4_request"
+        );
+        filter.filter(ctx);
+        assertEquals("000000000001", requestContext.getAccountId());
+        assertEquals("us-west-2", requestContext.getRegion());
+    }
+
+    @Test
+    void fallsBackToDefaultsWhenNoAuthInfo() {
+        ContainerRequestContext ctx = mockContext(null, null);
+        filter.filter(ctx);
+        assertEquals(DEFAULT_ACCOUNT, requestContext.getAccountId());
+        assertEquals(DEFAULT_REGION, requestContext.getRegion());
+    }
+
+    @Test
+    void emptyAuthHeaderFallsBackToPresignedCredential() {
+        ContainerRequestContext ctx = mockContext("",
+            "000000000002/20260617/eu-west-1/s3/aws4_request");
+        filter.filter(ctx);
+        assertEquals("000000000002", requestContext.getAccountId());
+        assertEquals("eu-west-1", requestContext.getRegion());
+    }
+
+    @Test
+    void emptyPresignedCredentialFallsBackToDefaults() {
+        ContainerRequestContext ctx = mockContext("", "");
+        filter.filter(ctx);
+        assertEquals(DEFAULT_ACCOUNT, requestContext.getAccountId());
+        assertEquals(DEFAULT_REGION, requestContext.getRegion());
+    }
+
+    private ContainerRequestContext mockContext(String authHeader, String xAmzCredential) {
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        when(ctx.getHeaderString("Authorization")).thenReturn(authHeader);
+
+        UriInfo uriInfo = mock(UriInfo.class);
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        if (xAmzCredential != null) {
+            queryParams.add("X-Amz-Credential", xAmzCredential);
+        }
+        when(uriInfo.getQueryParameters()).thenReturn(queryParams);
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+
+        return ctx;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/core/common/AccountResolverTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/AccountResolverTest.java
@@ -1,0 +1,59 @@
+package io.github.hectorvent.floci.core.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AccountResolverTest {
+
+    private static final String DEFAULT_ACCOUNT = "000000000000";
+    private final AccountResolver resolver = new AccountResolver(DEFAULT_ACCOUNT);
+
+    // --- resolve(String authorizationHeader) tests ---
+
+    @Test
+    void resolvesFrom12DigitAkidInAuthHeader() {
+        String auth = "AWS4-HMAC-SHA256 Credential=000000000001/20260617/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=abc";
+        assertEquals("000000000001", resolver.resolve(auth));
+    }
+
+    @Test
+    void fallsBackToDefaultForNon12DigitAkidInAuthHeader() {
+        String auth = "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260617/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=abc";
+        assertEquals(DEFAULT_ACCOUNT, resolver.resolve(auth));
+    }
+
+    @Test
+    void fallsBackToDefaultWhenNullAuthHeader() {
+        assertEquals(DEFAULT_ACCOUNT, resolver.resolve(null));
+    }
+
+    @Test
+    void fallsBackToDefaultWhenEmptyAuthHeader() {
+        assertEquals(DEFAULT_ACCOUNT, resolver.resolve(""));
+    }
+
+    // --- resolveFromPresignedCredential(String credentialValue) tests ---
+
+    @Test
+    void resolvesFromPresigned12DigitAkid() {
+        assertEquals("000000000001",
+                resolver.resolveFromPresignedCredential("000000000001/20260617/us-east-1/s3/aws4_request"));
+    }
+
+    @Test
+    void fallsBackToDefaultForPresignedNon12DigitAkid() {
+        assertEquals(DEFAULT_ACCOUNT,
+                resolver.resolveFromPresignedCredential("AKIAIOSFODNN7EXAMPLE/20260617/us-east-1/s3/aws4_request"));
+    }
+
+    @Test
+    void fallsBackToDefaultWhenPresignedCredentialNull() {
+        assertEquals(DEFAULT_ACCOUNT, resolver.resolveFromPresignedCredential(null));
+    }
+
+    @Test
+    void fallsBackToDefaultWhenPresignedCredentialEmpty() {
+        assertEquals(DEFAULT_ACCOUNT, resolver.resolveFromPresignedCredential(""));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/core/common/RegionResolverTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/RegionResolverTest.java
@@ -78,6 +78,35 @@ class RegionResolverTest {
         assertEquals("ap-southeast-1", custom.resolveRegion(null));
     }
 
+    // --- resolveRegionFromPresignedCredential(String credentialValue) tests ---
+
+    @Test
+    void resolveRegionFromPresignedCredential_validCredential_returnsRegion() {
+        assertEquals("us-west-2",
+                resolver.resolveRegionFromPresignedCredential("000000000001/20260617/us-west-2/s3/aws4_request"));
+    }
+
+    @Test
+    void resolveRegionFromPresignedCredential_differentRegion() {
+        assertEquals("eu-central-1",
+                resolver.resolveRegionFromPresignedCredential("AKID/20260617/eu-central-1/s3/aws4_request"));
+    }
+
+    @Test
+    void resolveRegionFromPresignedCredential_null_returnsDefault() {
+        assertEquals("us-east-1", resolver.resolveRegionFromPresignedCredential(null));
+    }
+
+    @Test
+    void resolveRegionFromPresignedCredential_empty_returnsDefault() {
+        assertEquals("us-east-1", resolver.resolveRegionFromPresignedCredential(""));
+    }
+
+    @Test
+    void resolveRegionFromPresignedCredential_malformedTooFewParts_returnsDefault() {
+        assertEquals("us-east-1", resolver.resolveRegionFromPresignedCredential("only-two/parts"));
+    }
+
     private static HttpHeaders stubHeaders(String authorizationValue) {
         return new HttpHeaders() {
             @Override public List<String> getRequestHeader(String name) {

--- a/src/test/java/io/github/hectorvent/floci/services/s3/PreSignedUrlAccountResolutionIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/PreSignedUrlAccountResolutionIntegrationTest.java
@@ -1,0 +1,171 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * End-to-end integration test verifying that presigned URL requests carrying
+ * credentials only in {@code X-Amz-Credential} (no Authorization header)
+ * correctly resolve the account ID and route to the right account's bucket.
+ *
+ * <p>This is the scenario that was previously broken: the AccountContextFilter
+ * now falls back to X-Amz-Credential query param when Authorization is absent,
+ * allowing presigned URL requests to be routed to the correct account's storage.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class PreSignedUrlAccountResolutionIntegrationTest {
+
+    private static final String BUCKET = "presigned-account-resolution-bucket";
+    private static final String KEY = "account-resolved-object.txt";
+    private static final String BODY = "content-for-account-000000000001";
+
+    // 12-digit numeric AKID → treated as account ID
+    private static final String ACCOUNT_1 = "000000000001";
+    private static final String ACCOUNT_2 = "000000000002";
+
+    private static final String AUTH_ACCOUNT_1 =
+            "AWS4-HMAC-SHA256 Credential=" + ACCOUNT_1 + "/20260617/us-east-1/s3/aws4_request";
+    private static final String AUTH_ACCOUNT_2 =
+            "AWS4-HMAC-SHA256 Credential=" + ACCOUNT_2 + "/20260617/us-east-1/s3/aws4_request";
+
+    private static final DateTimeFormatter AMZ_DATE_FMT =
+            DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'").withZone(ZoneOffset.UTC);
+
+    @Test
+    @Order(1)
+    void createBucketAndPutObjectUnderAccount1() {
+        // Create bucket under account 000000000001
+        given()
+            .header("Authorization", AUTH_ACCOUNT_1)
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+
+        // Put object under account 000000000001
+        given()
+            .header("Authorization", AUTH_ACCOUNT_1)
+            .body(BODY)
+            .contentType("text/plain")
+        .when()
+            .put("/" + BUCKET + "/" + KEY)
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void presignedUrlWithXAmzCredentialResolvesCorrectAccount() {
+        // Craft a presigned GET URL that carries credentials ONLY in X-Amz-Credential
+        // query parameter (no Authorization header). This is the scenario that was
+        // previously broken: AccountContextFilter must fall back to X-Amz-Credential
+        // when Authorization is absent.
+        String amzDate = AMZ_DATE_FMT.format(Instant.now());
+        String dateStamp = amzDate.substring(0, 8);
+        String credential = ACCOUNT_1 + "/" + dateStamp + "/us-east-1/s3/aws4_request";
+
+        String path = "/" + BUCKET + "/" + KEY
+                + "?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+                + "&X-Amz-Credential=" + URLEncoder.encode(credential, StandardCharsets.UTF_8)
+                + "&X-Amz-Date=" + amzDate
+                + "&X-Amz-Expires=3600"
+                + "&X-Amz-SignedHeaders=host"
+                + "&X-Amz-Signature=fakesig";
+
+        given()
+            .urlEncodingEnabled(false)
+        .when()
+            .get(path)
+        .then()
+            .statusCode(200)
+            .body(equalTo(BODY));
+    }
+
+    @Test
+    @Order(3)
+    void presignedUrlWithWrongAccountCannotAccessOtherAccountsBucket() {
+        // Verify isolation: when account 000000000002 tries to access a bucket
+        // that belongs to account 000000000001, it should get NoSuchBucket (404)
+        // because that bucket doesn't exist under account 2.
+        String amzDate = AMZ_DATE_FMT.format(Instant.now());
+        String dateStamp = amzDate.substring(0, 8);
+        String credential = ACCOUNT_2 + "/" + dateStamp + "/us-east-1/s3/aws4_request";
+
+        String path = "/" + BUCKET + "/" + KEY
+                + "?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+                + "&X-Amz-Credential=" + URLEncoder.encode(credential, StandardCharsets.UTF_8)
+                + "&X-Amz-Date=" + amzDate
+                + "&X-Amz-Expires=3600"
+                + "&X-Amz-SignedHeaders=host"
+                + "&X-Amz-Signature=fakesig";
+
+        given()
+            .urlEncodingEnabled(false)
+        .when()
+            .get(path)
+        .then()
+            .statusCode(404)
+            .body(containsString("NoSuchBucket"));
+    }
+
+    @Test
+    @Order(4)
+    void presignedUrlWithXAmzCredentialDoesNotFallBackToDefault() {
+        // Verify that a presigned URL with X-Amz-Credential does NOT fall back to
+        // the default account when the credential specifies a real 12-digit account.
+        // This re-validates after the wrong-account isolation test to confirm no
+        // state pollution occurred.
+        String amzDate = AMZ_DATE_FMT.format(Instant.now());
+        String dateStamp = amzDate.substring(0, 8);
+        String credential = ACCOUNT_1 + "/" + dateStamp + "/us-east-1/s3/aws4_request";
+
+        // A properly-credentialed presigned URL succeeds (re-validate after previous test)
+        String path = "/" + BUCKET + "/" + KEY
+                + "?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+                + "&X-Amz-Credential=" + URLEncoder.encode(credential, StandardCharsets.UTF_8)
+                + "&X-Amz-Date=" + amzDate
+                + "&X-Amz-Expires=3600"
+                + "&X-Amz-SignedHeaders=host"
+                + "&X-Amz-Signature=fakesig";
+
+        given()
+            .urlEncodingEnabled(false)
+        .when()
+            .get(path)
+        .then()
+            .statusCode(200)
+            .body(equalTo(BODY));
+    }
+
+    @Test
+    @Order(99)
+    void cleanUp() {
+        given()
+            .header("Authorization", AUTH_ACCOUNT_1)
+        .when()
+            .delete("/" + BUCKET + "/" + KEY)
+        .then()
+            .statusCode(204);
+
+        given()
+            .header("Authorization", AUTH_ACCOUNT_1)
+        .when()
+            .delete("/" + BUCKET)
+        .then()
+            .statusCode(204);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/s3/PreSignedUrlIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/PreSignedUrlIntegrationTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
@@ -70,6 +72,19 @@ class PreSignedUrlIntegrationTest {
         assertTrue(url.contains("X-Amz-Expires=300"));
         assertTrue(url.contains("X-Amz-SignedHeaders=host"));
         assertTrue(url.contains("X-Amz-Signature="));
+
+        // Verify X-Amz-Credential uses request-scoped account ID, not the hardcoded placeholder
+        assertFalse(url.contains("AKIAIOSFODNN7EXAMPLE"),
+                "X-Amz-Credential must not contain hardcoded AKIAIOSFODNN7EXAMPLE");
+
+        int credStart = url.indexOf("X-Amz-Credential=");
+        int credEnd = url.indexOf("&", credStart);
+        String encodedCredential = credEnd > 0
+                ? url.substring(credStart + "X-Amz-Credential=".length(), credEnd)
+                : url.substring(credStart + "X-Amz-Credential=".length());
+        String credential = URLDecoder.decode(encodedCredential, StandardCharsets.UTF_8);
+        assertTrue(credential.startsWith("000000000000/"),
+                "X-Amz-Credential should start with 12-digit account ID, got: " + credential);
     }
 
     @Test


### PR DESCRIPTION

## Summary

Presigned URL requests resolve the wrong account ID because `AccountContextFilter` only reads the `Authorization` header to determine account context. Presigned requests carry credentials in the `X-Amz-Credential` query parameter, not the `Authorization` header — so the filter resolves null and falls back to `defaultAccountId`, causing bucket lookups in the wrong account.

A secondary issue: `PreSignedUrlGenerator` hardcodes `AKIAIOSFODNN7EXAMPLE` as the access key when building the presigned credential string, so even internally-generated presigned URLs never contain the actual 12-digit account ID in `X-Amz-Credential`.

**Changes:**

- **`AccountResolver`** — added `resolveFromPresignedCredential(String)` that parses the AKID from an `X-Amz-Credential` value (e.g. `000000000001/20260617/us-east-1/s3/aws4_request`) and applies the same `\d{12}` convention as the existing `Authorization` header path.
- **`RegionResolver`** — added `resolveRegionFromPresignedCredential(String)` that extracts the region from the same credential string format.
- **`AccountContextFilter`** — when the `Authorization` header is absent, falls back to `X-Amz-Credential` in query parameters to resolve both account ID and region into `RequestContext`.
- **`PreSignedUrlGenerator`** — replaced hardcoded `AKIAIOSFODNN7EXAMPLE` with the request-scoped account ID from `RequestContext`, falling back to `defaultAccountId` outside request scope.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Presigned GET/PUT URLs generated by the AWS S3 SDK carry credentials exclusively in `X-Amz-Credential` query parameters — no `Authorization` header is present. Real AWS resolves the account from the access key ID embedded in that credential. Floci now matches this behavior: the access key ID (first component of `X-Amz-Credential`, before the first `/`) is extracted and, if it is a 12-digit numeric string, used directly as the account ID per LocalStack's multi-account convention.

Verified with AWS SDK v2 presigned GET/PUT requests where `X-Amz-Credential=000000000001/...` resolves to the correct account bucket instead of falling back to the default.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (PreSignedUrlAccountResolutionIntegrationTest)
- [x] Commit messages follow Conventional Commits
