### PR TITLE
fix(lambda): return {"status":"OK"} ack body from runtime invocation endpoints

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServer.java
@@ -36,6 +36,11 @@ public class RuntimeApiServer {
     private static final byte[] CONTAINER_STOPPED_PAYLOAD =
             "{\"errorMessage\":\"Container stopped\",\"errorType\":\"ContainerStopped\"}".getBytes();
 
+    // Acknowledgement body for the /response, /error and /init/error endpoints. Some
+    // runtime clients (e.g. .NET's Amazon.Lambda.RuntimeSupport) deserialize it and
+    // fail on an empty body.
+    private static final String STATUS_OK_BODY = "{\"status\":\"OK\"}";
+
     private final Vertx vertx;
     private final int port;
 
@@ -110,7 +115,7 @@ public class RuntimeApiServer {
                 InvokeResult result = new InvokeResult(200, null, payload, null, requestId);
                 invocation.getResultFuture().complete(result);
             }
-            ctx.response().setStatusCode(202).end();
+            sendStatusOk(ctx);
         });
 
         // POST /runtime/invocation/{requestId}/error — failure
@@ -124,13 +129,13 @@ public class RuntimeApiServer {
                 InvokeResult result = new InvokeResult(200, functionError, payload, null, requestId);
                 invocation.getResultFuture().complete(result);
             }
-            ctx.response().setStatusCode(202).end();
+            sendStatusOk(ctx);
         });
 
         // POST /runtime/init/error — runtime initialization failure
         router.post(INIT_ERROR_PATH).handler(ctx -> {
             LOG.warnv("Lambda runtime reported init error on port {0}", String.valueOf(port));
-            ctx.response().setStatusCode(202).end();
+            sendStatusOk(ctx);
         });
 
         long deadline = System.currentTimeMillis() + 5000;
@@ -235,6 +240,13 @@ public class RuntimeApiServer {
                     new InvokeResult(200, "Unhandled", CONTAINER_STOPPED_PAYLOAD, null, invocation.getRequestId()));
         }
         return invocation.getResultFuture();
+    }
+
+    private void sendStatusOk(RoutingContext ctx) {
+        ctx.response()
+                .setStatusCode(202)
+                .putHeader("Content-Type", "application/json")
+                .end(STATUS_OK_BODY);
     }
 
     private void sendInvocation(RoutingContext ctx, PendingInvocation invocation) {

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServerTest.java
@@ -138,6 +138,70 @@ class RuntimeApiServerTest {
         assertEquals("req-parked", response.headers().firstValue("Lambda-Runtime-Aws-Request-Id").orElse(""));
     }
 
+    /**
+     * The /error endpoint must return HTTP 202 with a {@code {"status":"OK"}} body, not
+     * an empty body. The AWS .NET runtime client (Amazon.Lambda.RuntimeSupport)
+     * deserializes the acknowledgement and crashes the runtime process with "Could not
+     * deserialize the response body" when it is empty.
+     */
+    @Test
+    @Timeout(15)
+    void errorEndpoint_returns202WithStatusOkBody() throws Exception {
+        PendingInvocation invocation = new PendingInvocation(
+                "req-error", "{}".getBytes(), System.currentTimeMillis() + 60_000,
+                "arn:aws:lambda:us-east-1:000000000000:function:test",
+                new CompletableFuture<>());
+        server.enqueue(invocation);
+
+        // Deliver the invocation to a /next poller so it moves to inFlight.
+        httpClient.send(HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + port + "/2018-06-01/runtime/invocation/next"))
+                        .GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        HttpResponse<String> response = httpClient.send(HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + port
+                                + "/2018-06-01/runtime/invocation/req-error/error"))
+                        .header("Lambda-Runtime-Function-Error-Type", "Function.Handled")
+                        .POST(HttpRequest.BodyPublishers.ofString(
+                                "{\"errorMessage\":\"intentional failure\"}"))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(202, response.statusCode());
+        assertEquals("{\"status\":\"OK\"}", response.body(),
+                "/error must return a JSON ack body so the .NET runtime client can deserialize it");
+    }
+
+    /**
+     * The /response acknowledgement carries the same {@code {"status":"OK"}} body as
+     * /error so runtime clients that deserialize it succeed.
+     */
+    @Test
+    @Timeout(15)
+    void responseEndpoint_returns202WithStatusOkBody() throws Exception {
+        PendingInvocation invocation = new PendingInvocation(
+                "req-response", "{}".getBytes(), System.currentTimeMillis() + 60_000,
+                "arn:aws:lambda:us-east-1:000000000000:function:test",
+                new CompletableFuture<>());
+        server.enqueue(invocation);
+
+        httpClient.send(HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + port + "/2018-06-01/runtime/invocation/next"))
+                        .GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        HttpResponse<String> response = httpClient.send(HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:" + port
+                                + "/2018-06-01/runtime/invocation/req-response/response"))
+                        .POST(HttpRequest.BodyPublishers.ofString("\"result\""))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+
+        assertEquals(202, response.statusCode());
+        assertEquals("{\"status\":\"OK\"}", response.body());
+    }
+
     @Test
     @Timeout(15)
     void stopCompletesInFlightWithContainerStopped() throws Exception {

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServerTest.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.lambda.runtime;
 import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
 import io.github.hectorvent.floci.services.lambda.model.PendingInvocation;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -169,7 +170,9 @@ class RuntimeApiServerTest {
                 HttpResponse.BodyHandlers.ofString());
 
         assertEquals(202, response.statusCode());
-        assertEquals("{\"status\":\"OK\"}", response.body(),
+        assertEquals("application/json",
+                response.headers().firstValue("Content-Type").orElse(""));
+        assertEquals("OK", new JsonObject(response.body()).getString("status"),
                 "/error must return a JSON ack body so the .NET runtime client can deserialize it");
     }
 
@@ -199,7 +202,9 @@ class RuntimeApiServerTest {
                 HttpResponse.BodyHandlers.ofString());
 
         assertEquals(202, response.statusCode());
-        assertEquals("{\"status\":\"OK\"}", response.body());
+        assertEquals("application/json",
+                response.headers().firstValue("Content-Type").orElse(""));
+        assertEquals("OK", new JsonObject(response.body()).getString("status"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

The Lambda Runtime API `/response`, `/error` and `/init/error` endpoints replied with `HTTP 202` and an empty body. Runtime clients that deserialize the acknowledgement — notably the .NET `Amazon.Lambda.RuntimeSupport` client — throw `Could not deserialize the response body` on an empty body, crashing the runtime process after every failed invocation and tearing down the warm container. This returns the AWS-documented `{"status":"OK"}` JSON body from those endpoints instead. Closes #1417.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The Lambda Runtime API returns `HTTP 202` with `{"status":"OK"}` from the invocation `/response`, `/error` and `/init/error` endpoints. Previously floci returned `202` with an empty body, so `Amazon.Lambda.RuntimeSupport` (which deserializes the ack into a `StatusResponse`) crashed the `dotnet8` runtime on every error path, including SQS `ReportBatchItemFailures`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
