### PR TITLE
feat(ses): support v2 dedicated IP pool APIs

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesDedicatedIpPoolTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesDedicatedIpPoolTest.java
@@ -1,0 +1,133 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.AlreadyExistsException;
+import software.amazon.awssdk.services.sesv2.model.BadRequestException;
+import software.amazon.awssdk.services.sesv2.model.CreateDedicatedIpPoolRequest;
+import software.amazon.awssdk.services.sesv2.model.DeleteDedicatedIpPoolRequest;
+import software.amazon.awssdk.services.sesv2.model.GetDedicatedIpPoolRequest;
+import software.amazon.awssdk.services.sesv2.model.GetDedicatedIpPoolResponse;
+import software.amazon.awssdk.services.sesv2.model.ListDedicatedIpPoolsResponse;
+import software.amazon.awssdk.services.sesv2.model.NotFoundException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * SDK compatibility test for the SES v2 dedicated IP pool APIs. Verifies the
+ * AWS Java SDK v2 marshalling of CreateDedicatedIpPool / GetDedicatedIpPool /
+ * ListDedicatedIpPools / DeleteDedicatedIpPool and the
+ * BadRequestException / AlreadyExistsException / NotFoundException errors,
+ * against a live Floci instance.
+ */
+@DisplayName("SES v2 Dedicated IP Pools")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesDedicatedIpPoolTest {
+
+    private static final String POOL = "compat-pool-alpha";
+    private static final String POOL_MANAGED = "compat-pool-managed";
+
+    private static SesV2Client sesV2;
+
+    @BeforeAll
+    static void setup() {
+        sesV2 = TestFixtures.sesV2Client();
+        deletePoolQuietly(POOL);
+        deletePoolQuietly(POOL_MANAGED);
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (sesV2 != null) {
+            deletePoolQuietly(POOL);
+            deletePoolQuietly(POOL_MANAGED);
+            sesV2.close();
+        }
+    }
+
+    private static void deletePoolQuietly(String name) {
+        try {
+            sesV2.deleteDedicatedIpPool(DeleteDedicatedIpPoolRequest.builder().poolName(name).build());
+        } catch (Exception ignored) {}
+    }
+
+    @Test
+    @Order(1)
+    void createDedicatedIpPool_defaultsToStandardScaling() {
+        sesV2.createDedicatedIpPool(CreateDedicatedIpPoolRequest.builder().poolName(POOL).build());
+
+        GetDedicatedIpPoolResponse response = sesV2.getDedicatedIpPool(
+                GetDedicatedIpPoolRequest.builder().poolName(POOL).build());
+        assertThat(response.dedicatedIpPool()).isNotNull();
+        assertThat(response.dedicatedIpPool().poolName()).isEqualTo(POOL);
+        assertThat(response.dedicatedIpPool().scalingModeAsString()).isEqualTo("STANDARD");
+    }
+
+    @Test
+    @Order(2)
+    void createDedicatedIpPool_managedScaling() {
+        sesV2.createDedicatedIpPool(CreateDedicatedIpPoolRequest.builder()
+                .poolName(POOL_MANAGED).scalingMode("MANAGED").build());
+
+        GetDedicatedIpPoolResponse response = sesV2.getDedicatedIpPool(
+                GetDedicatedIpPoolRequest.builder().poolName(POOL_MANAGED).build());
+        assertThat(response.dedicatedIpPool().scalingModeAsString()).isEqualTo("MANAGED");
+    }
+
+    @Test
+    @Order(3)
+    void createDedicatedIpPool_invalidScalingMode_throwsBadRequest() {
+        assertThatThrownBy(() -> sesV2.createDedicatedIpPool(CreateDedicatedIpPoolRequest.builder()
+                .poolName("compat-pool-bad").scalingMode("NONSENSE").build()))
+                .isInstanceOf(BadRequestException.class);
+    }
+
+    @Test
+    @Order(4)
+    void createDedicatedIpPool_duplicate_throwsAlreadyExists() {
+        assertThatThrownBy(() -> sesV2.createDedicatedIpPool(
+                CreateDedicatedIpPoolRequest.builder().poolName(POOL).build()))
+                .isInstanceOf(AlreadyExistsException.class);
+    }
+
+    @Test
+    @Order(5)
+    void getDedicatedIpPool_unknown_throwsNotFound() {
+        assertThatThrownBy(() -> sesV2.getDedicatedIpPool(
+                GetDedicatedIpPoolRequest.builder().poolName("compat-pool-ghost").build()))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @Order(6)
+    void listDedicatedIpPools_includesCreatedPools() {
+        ListDedicatedIpPoolsResponse response = sesV2.listDedicatedIpPools(r -> {});
+        assertThat(response.dedicatedIpPools()).contains(POOL, POOL_MANAGED);
+    }
+
+    @Test
+    @Order(7)
+    void deleteDedicatedIpPool_removesIt() {
+        sesV2.deleteDedicatedIpPool(DeleteDedicatedIpPoolRequest.builder().poolName(POOL).build());
+
+        assertThatThrownBy(() -> sesV2.getDedicatedIpPool(
+                GetDedicatedIpPoolRequest.builder().poolName(POOL).build()))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @Order(8)
+    void deleteDedicatedIpPool_unknown_throwsNotFound() {
+        assertThatThrownBy(() -> sesV2.deleteDedicatedIpPool(
+                DeleteDedicatedIpPoolRequest.builder().poolName("compat-pool-ghost").build()))
+                .isInstanceOf(NotFoundException.class);
+    }
+}

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -193,6 +193,10 @@ Alongside the classic Query API, Floci implements a subset of the SES v2 REST JS
 | `DELETE` | `/v2/email/configuration-sets/{name}/event-destinations/{eventDestinationName}` | `DeleteConfigurationSetEventDestination` |
 | `PUT` | `/v2/email/configuration-sets/{name}/suppression-options` | `PutConfigurationSetSuppressionOptions` |
 | `PUT` | `/v2/email/configuration-sets/{name}/sending` | `PutConfigurationSetSendingOptions` |
+| `POST` | `/v2/email/dedicated-ip-pools` | `CreateDedicatedIpPool` |
+| `GET` | `/v2/email/dedicated-ip-pools` | `ListDedicatedIpPools` |
+| `GET` | `/v2/email/dedicated-ip-pools/{PoolName}` | `GetDedicatedIpPool` |
+| `DELETE` | `/v2/email/dedicated-ip-pools/{PoolName}` | `DeleteDedicatedIpPool` |
 | `PUT` | `/v2/email/suppression/addresses` | `PutSuppressedDestination` |
 | `GET` | `/v2/email/suppression/addresses/{EmailAddress}` | `GetSuppressedDestination` |
 | `DELETE` | `/v2/email/suppression/addresses/{EmailAddress}` | `DeleteSuppressedDestination` |

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttribute
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntry;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.EventDestination;
 import io.github.hectorvent.floci.services.ses.model.Identity;
@@ -835,6 +836,70 @@ public class SesController {
         } catch (AwsException e) {
             throw remapV1Exception(e);
         }
+    }
+
+    // ──────────────────────── Dedicated IP Pools ────────────────────────
+
+    @POST
+    @Path("/dedicated-ip-pools")
+    public Response createDedicatedIpPool(@Context HttpHeaders headers, String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            if (body == null || body.isBlank()) {
+                throw new AwsException("BadRequestException", "Request body is required.", 400);
+            }
+            JsonNode request = objectMapper.readTree(body);
+            requireJsonObject(request);
+            String poolName = readRequiredStringField(request, "PoolName");
+            JsonNode scalingNode = request.path("ScalingMode");
+            String scalingMode;
+            if (scalingNode.isMissingNode() || scalingNode.isNull()) {
+                scalingMode = null;
+            } else if (!scalingNode.isTextual()) {
+                throw new AwsException("BadRequestException",
+                        "The ScalingMode parameter is invalid.", 400);
+            } else {
+                scalingMode = scalingNode.asText();
+            }
+            sesService.createDedicatedIpPool(poolName, scalingMode, region);
+            LOG.infov("SES V2 CreateDedicatedIpPool: {0}", poolName);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @GET
+    @Path("/dedicated-ip-pools")
+    public Response listDedicatedIpPools(@Context HttpHeaders headers) {
+        String region = regionResolver.resolveRegion(headers);
+        ObjectNode result = objectMapper.createObjectNode();
+        ArrayNode pools = result.putArray("DedicatedIpPools");
+        sesService.listDedicatedIpPools(region).forEach(pools::add);
+        return Response.ok(result).build();
+    }
+
+    @GET
+    @Path("/dedicated-ip-pools/{poolName}")
+    public Response getDedicatedIpPool(@Context HttpHeaders headers,
+                                       @PathParam("poolName") String poolName) {
+        String region = regionResolver.resolveRegion(headers);
+        DedicatedIpPool pool = sesService.getDedicatedIpPool(poolName, region);
+        ObjectNode result = objectMapper.createObjectNode();
+        result.set("DedicatedIpPool", objectMapper.valueToTree(pool));
+        return Response.ok(result).build();
+    }
+
+    @DELETE
+    @Path("/dedicated-ip-pools/{poolName}")
+    public Response deleteDedicatedIpPool(@Context HttpHeaders headers,
+                                          @PathParam("poolName") String poolName) {
+        String region = regionResolver.resolveRegion(headers);
+        sesService.deleteDedicatedIpPool(poolName, region);
+        LOG.infov("SES V2 DeleteDedicatedIpPool: {0}", poolName);
+        return Response.ok(objectMapper.createObjectNode()).build();
     }
 
     // ──────────────────────────── Account ────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -10,6 +10,7 @@ import io.github.hectorvent.floci.services.ses.model.BulkEmailEntry;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
 import io.github.hectorvent.floci.services.ses.model.CloudWatchDimensionConfiguration;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.EventDestination;
 import io.github.hectorvent.floci.services.ses.model.Identity;
@@ -67,6 +68,7 @@ public class SesService {
     private final StorageBackend<String, ConfigurationSet> configSetStore;
     private final StorageBackend<String, SuppressedDestination> suppressionStore;
     private final StorageBackend<String, AccountSuppressionAttributes> accountSuppressionStore;
+    private final StorageBackend<String, DedicatedIpPool> dedicatedIpPoolStore;
     private final SmtpRelay smtpRelay;
     private final ObjectMapper objectMapper;
     private final SesEventPublisher eventPublisher;
@@ -89,6 +91,8 @@ public class SesService {
                 new TypeReference<Map<String, SuppressedDestination>>() {});
         this.accountSuppressionStore = storageFactory.create("ses", "ses-account-suppression.json",
                 new TypeReference<Map<String, AccountSuppressionAttributes>>() {});
+        this.dedicatedIpPoolStore = storageFactory.create("ses", "ses-dedicated-ip-pools.json",
+                new TypeReference<Map<String, DedicatedIpPool>>() {});
         this.smtpRelay = smtpRelay;
         this.objectMapper = objectMapper;
         this.eventPublisher = eventPublisher;
@@ -102,6 +106,7 @@ public class SesService {
                StorageBackend<String, ConfigurationSet> configSetStore,
                StorageBackend<String, SuppressedDestination> suppressionStore,
                StorageBackend<String, AccountSuppressionAttributes> accountSuppressionStore,
+               StorageBackend<String, DedicatedIpPool> dedicatedIpPoolStore,
                SmtpRelay smtpRelay,
                ObjectMapper objectMapper) {
         this.identityStore = identityStore;
@@ -111,6 +116,7 @@ public class SesService {
         this.configSetStore = configSetStore;
         this.suppressionStore = suppressionStore;
         this.accountSuppressionStore = accountSuppressionStore;
+        this.dedicatedIpPoolStore = dedicatedIpPoolStore;
         this.smtpRelay = smtpRelay;
         this.objectMapper = objectMapper;
         this.eventPublisher = null;
@@ -689,6 +695,61 @@ public class SesService {
     private static String configSetKey(String region, String name) {
         validateConfigurationSetName(name);
         return "configSet::" + region + "::" + name;
+    }
+
+    // ──────────────────────── Dedicated IP Pools ────────────────────────
+
+    private static final java.util.Set<String> SCALING_MODES = java.util.Set.of("STANDARD", "MANAGED");
+
+    public DedicatedIpPool createDedicatedIpPool(String poolName, String scalingMode, String region) {
+        if (poolName == null || poolName.isBlank()) {
+            throw new AwsException("BadRequestException", "PoolName is required.", 400);
+        }
+        String effectiveScaling = (scalingMode == null || scalingMode.isBlank()) ? "STANDARD" : scalingMode;
+        if (!SCALING_MODES.contains(effectiveScaling)) {
+            throw new AwsException("BadRequestException", "The ScalingMode parameter is invalid.", 400);
+        }
+        String key = dedicatedIpPoolKey(region, poolName);
+        if (dedicatedIpPoolStore.get(key).isPresent()) {
+            throw new AwsException("AlreadyExistsException",
+                    "The pool <" + poolName + "> already exists.", 400);
+        }
+        DedicatedIpPool pool = new DedicatedIpPool(poolName, effectiveScaling);
+        dedicatedIpPoolStore.put(key, pool);
+        LOG.infov("Created SES dedicated IP pool: {0} in region {1}", poolName, region);
+        return pool;
+    }
+
+    public DedicatedIpPool getDedicatedIpPool(String poolName, String region) {
+        return dedicatedIpPoolStore.get(dedicatedIpPoolKey(region, poolName))
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "The requested pool <" + poolName + "> does not exist.", 404));
+    }
+
+    public boolean dedicatedIpPoolExists(String poolName, String region) {
+        return dedicatedIpPoolStore.get(dedicatedIpPoolKey(region, poolName)).isPresent();
+    }
+
+    public List<String> listDedicatedIpPools(String region) {
+        String prefix = "dedicatedIpPool::" + region + "::";
+        return dedicatedIpPoolStore.scan(k -> k.startsWith(prefix)).stream()
+                .map(DedicatedIpPool::getPoolName)
+                .sorted()
+                .toList();
+    }
+
+    public void deleteDedicatedIpPool(String poolName, String region) {
+        String key = dedicatedIpPoolKey(region, poolName);
+        if (dedicatedIpPoolStore.get(key).isEmpty()) {
+            throw new AwsException("NotFoundException",
+                    "The requested pool <" + poolName + "> does not exist.", 404);
+        }
+        dedicatedIpPoolStore.delete(key);
+        LOG.infov("Deleted SES dedicated IP pool: {0} in region {1}", poolName, region);
+    }
+
+    private static String dedicatedIpPoolKey(String region, String name) {
+        return "dedicatedIpPool::" + region + "::" + name;
     }
 
     static void validateConfigurationSetName(String name) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/DedicatedIpPool.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/DedicatedIpPool.java
@@ -1,0 +1,35 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * A SES V2 dedicated IP pool. Mirrors the AWS {@code DedicatedIpPool} shape:
+ * a pool name and its scaling mode ({@code STANDARD} or {@code MANAGED}).
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DedicatedIpPool {
+
+    @JsonProperty("PoolName")
+    private String poolName;
+
+    @JsonProperty("ScalingMode")
+    private String scalingMode;
+
+    public DedicatedIpPool() {}
+
+    public DedicatedIpPool(String poolName, String scalingMode) {
+        this.poolName = poolName;
+        this.scalingMode = scalingMode;
+    }
+
+    public String getPoolName() { return poolName; }
+    public void setPoolName(String poolName) { this.poolName = poolName; }
+
+    public String getScalingMode() { return scalingMode; }
+    public void setScalingMode(String scalingMode) { this.scalingMode = scalingMode; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesDedicatedIpPoolV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesDedicatedIpPoolV2IntegrationTest.java
@@ -1,0 +1,163 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+/**
+ * Integration tests for SES V2 dedicated IP pool endpoints under
+ * /v2/email/dedicated-ip-pools.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesDedicatedIpPoolV2IntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/ses/aws4_request";
+
+    @Test
+    @Order(1)
+    void createDedicatedIpPool_defaultScalingMode() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"PoolName\": \"v2-pool-alpha\"}")
+        .when().post("/v2/email/dedicated-ip-pools")
+        .then().statusCode(200);
+
+        // Default ScalingMode is STANDARD.
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/dedicated-ip-pools/v2-pool-alpha")
+        .then().statusCode(200)
+            .body("DedicatedIpPool.PoolName", equalTo("v2-pool-alpha"))
+            .body("DedicatedIpPool.ScalingMode", equalTo("STANDARD"));
+    }
+
+    @Test
+    @Order(2)
+    void createDedicatedIpPool_managedScalingMode() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"PoolName\": \"v2-pool-managed\", \"ScalingMode\": \"MANAGED\"}")
+        .when().post("/v2/email/dedicated-ip-pools")
+        .then().statusCode(200);
+
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/dedicated-ip-pools/v2-pool-managed")
+        .then().statusCode(200)
+            .body("DedicatedIpPool.ScalingMode", equalTo("MANAGED"));
+    }
+
+    @Test
+    @Order(3)
+    void createDedicatedIpPool_invalidScalingMode_returns400() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"PoolName\": \"v2-pool-bad\", \"ScalingMode\": \"NONSENSE\"}")
+        .when().post("/v2/email/dedicated-ip-pools")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("The ScalingMode parameter is invalid."));
+    }
+
+    @Test
+    @Order(4)
+    void createDedicatedIpPool_duplicate_returns400() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"PoolName\": \"v2-pool-alpha\"}")
+        .when().post("/v2/email/dedicated-ip-pools")
+        .then().statusCode(400)
+            .body("__type", equalTo("AlreadyExistsException"))
+            .body("message", equalTo("The pool <v2-pool-alpha> already exists."));
+    }
+
+    @Test
+    @Order(5)
+    void getDedicatedIpPool_unknown_returns404() {
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/dedicated-ip-pools/v2-pool-ghost")
+        .then().statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", equalTo("The requested pool <v2-pool-ghost> does not exist."));
+    }
+
+    @Test
+    @Order(6)
+    void listDedicatedIpPools() {
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/dedicated-ip-pools")
+        .then().statusCode(200)
+            .body("DedicatedIpPools", hasItem("v2-pool-alpha"))
+            .body("DedicatedIpPools", hasItem("v2-pool-managed"));
+    }
+
+    @Test
+    @Order(7)
+    void deleteDedicatedIpPool() {
+        given().header("Authorization", AUTH_HEADER)
+        .when().delete("/v2/email/dedicated-ip-pools/v2-pool-alpha")
+        .then().statusCode(200);
+
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/dedicated-ip-pools/v2-pool-alpha")
+        .then().statusCode(404);
+    }
+
+    @Test
+    @Order(8)
+    void deleteDedicatedIpPool_unknown_returns404() {
+        given().header("Authorization", AUTH_HEADER)
+        .when().delete("/v2/email/dedicated-ip-pools/v2-pool-ghost")
+        .then().statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", equalTo("The requested pool <v2-pool-ghost> does not exist."));
+    }
+
+    @Test
+    @Order(9)
+    void createDedicatedIpPool_emptyBody_returns400() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("")
+        .when().post("/v2/email/dedicated-ip-pools")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("Request body is required."));
+    }
+
+    @Test
+    @Order(10)
+    void createDedicatedIpPool_missingPoolName_returns400() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{}")
+        .when().post("/v2/email/dedicated-ip-pools")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("PoolName is required."));
+    }
+
+    @Test
+    @Order(11)
+    void createDedicatedIpPool_nullPoolName_returns400() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"PoolName\": null}")
+        .when().post("/v2/email/dedicated-ip-pools")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("PoolName is required."));
+    }
+
+    @Test
+    @Order(12)
+    void createDedicatedIpPool_nonTextualScalingMode_returns400() {
+        // A present-but-non-string ScalingMode must be rejected, not coerced to
+        // "" and silently defaulted to STANDARD.
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"PoolName\": \"v2-pool-objsm\", \"ScalingMode\": {}}")
+        .when().post("/v2/email/dedicated-ip-pools")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("The ScalingMode parameter is invalid."));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSmtpTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSmtpTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.SentEmail;
@@ -38,6 +39,7 @@ class SesServiceSmtpTest {
                 new InMemoryStorage<String, ConfigurationSet>(),
                 new InMemoryStorage<String, SuppressedDestination>(),
                 new InMemoryStorage<String, AccountSuppressionAttributes>(),
+                new InMemoryStorage<String, DedicatedIpPool>(),
                 smtpRelay,
                 new ObjectMapper());
     }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSuppressionLegacyKeyTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSuppressionLegacyKeyTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.SentEmail;
@@ -45,6 +46,7 @@ class SesServiceSuppressionLegacyKeyTest {
                 new InMemoryStorage<String, ConfigurationSet>(),
                 suppressionStore,
                 new InMemoryStorage<String, AccountSuppressionAttributes>(),
+                new InMemoryStorage<String, DedicatedIpPool>(),
                 mock(SmtpRelay.class),
                 new ObjectMapper());
     }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSuppressionReasonTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSuppressionReasonTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.SentEmail;
@@ -46,6 +47,7 @@ class SesServiceSuppressionReasonTest {
                 new InMemoryStorage<String, ConfigurationSet>(),
                 suppressionStore,
                 accountSuppressionStore,
+                new InMemoryStorage<String, DedicatedIpPool>(),
                 mock(SmtpRelay.class),
                 new ObjectMapper());
     }


### PR DESCRIPTION
## Summary

Adds SES v2 dedicated IP pool management, backed by a per-region store:

- `POST /v2/email/dedicated-ip-pools` — `CreateDedicatedIpPool`
- `GET /v2/email/dedicated-ip-pools` — `ListDedicatedIpPools`
- `GET /v2/email/dedicated-ip-pools/{PoolName}` — `GetDedicatedIpPool`
- `DELETE /v2/email/dedicated-ip-pools/{PoolName}` — `DeleteDedicatedIpPool`

This is the backing resource for a configuration set's `DeliveryOptions.SendingPoolName`; a follow-up will let that member reference a pool created here.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Validation and response shapes were verified against the live AWS SES V2 API using the AWS CLI v2 (`aws sesv2 ...`) on 2026-06-18:

- `ScalingMode` defaults to `STANDARD` and must be `STANDARD` or `MANAGED`, otherwise `BadRequestException: The ScalingMode parameter is invalid.`
- A duplicate pool returns `AlreadyExistsException: The pool <name> already exists.`
- An unknown pool (get/delete) returns `NotFoundException: The requested pool <name> does not exist.`
- `GetDedicatedIpPool` returns `{ "DedicatedIpPool": { "PoolName", "ScalingMode" } }`; `ListDedicatedIpPools` returns `{ "DedicatedIpPools": [names] }`.
- A missing/blank body returns `BadRequestException: Request body is required.` and a missing/non-textual `PoolName` returns `PoolName is required.`, matching the other SES v2 endpoints.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
