### PR TITLE
fix(cloudformation): merge SAM Globals into resource properties

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessor.java
@@ -50,6 +50,12 @@ class SamTransformProcessor {
         ObjectNode expanded = template.deepCopy();
         expanded.remove("Transform");
 
+        // Globals is a SAM-only top-level section: capture it for merging into resources, then strip
+        // it from the emitted CloudFormation template up front so it is removed on every return path
+        // (including the early return below when Resources is absent or not an object).
+        JsonNode globals = expanded.path("Globals");
+        expanded.remove("Globals");
+
         JsonNode resources = expanded.path("Resources");
         if (!resources.isObject()) {
             return expanded;
@@ -74,11 +80,11 @@ class SamTransformProcessor {
 
             switch (type) {
                 case "AWS::Serverless::Function" ->
-                        expandServerlessFunction(logicalId, properties, expandedResources);
+                        expandServerlessFunction(logicalId, mergeGlobals(globals, "Function", properties), expandedResources);
                 case "AWS::Serverless::SimpleTable" ->
-                        expandServerlessSimpleTable(logicalId, properties, expandedResources);
+                        expandServerlessSimpleTable(logicalId, mergeGlobals(globals, "SimpleTable", properties), expandedResources);
                 case "AWS::Serverless::Api" ->
-                        expandServerlessApi(logicalId, properties, expandedResources);
+                        expandServerlessApi(logicalId, mergeGlobals(globals, "Api", properties), expandedResources);
                 default -> LOG.debugv("Unsupported SAM resource type: {0} ({1})", type, logicalId);
             }
         }
@@ -298,6 +304,46 @@ class SamTransformProcessor {
             id = base + i++;
         }
         return id;
+    }
+
+    /**
+     * Merges the matching {@code Globals.<section>} block into a resource's own {@code Properties},
+     * with the resource's own values taking precedence (per the SAM Globals specification). Returns
+     * {@code properties} unchanged when there is no matching globals block.
+     *
+     * <p>Nested objects (e.g. {@code Environment.Variables}, {@code Tags}) are merged key-wise, so a
+     * resource only overrides the individual keys it sets and global entries are preserved — matching
+     * SAM's map-merge behavior. Scalar and array-valued properties (e.g. {@code Policies},
+     * {@code Layers}) are overridden wholesale; SAM's additive list-append for those is not implemented.
+     */
+    private JsonNode mergeGlobals(JsonNode globals, String section, JsonNode properties) {
+        JsonNode sectionGlobals = globals.path(section);
+        if (!sectionGlobals.isObject()) {
+            return properties;
+        }
+        if (!properties.isObject()) {
+            return sectionGlobals.deepCopy();
+        }
+        return deepMerge((ObjectNode) sectionGlobals.deepCopy(), (ObjectNode) properties);
+    }
+
+    /**
+     * Recursively merges {@code override} into {@code base}: when both sides hold an object for the
+     * same key, the objects are merged key-wise; otherwise the override value replaces the base value.
+     * {@code base} is mutated and returned.
+     */
+    private ObjectNode deepMerge(ObjectNode base, ObjectNode override) {
+        override.fields().forEachRemaining(entry -> {
+            String key = entry.getKey();
+            JsonNode overrideValue = entry.getValue();
+            JsonNode baseValue = base.get(key);
+            if (baseValue != null && baseValue.isObject() && overrideValue.isObject()) {
+                base.set(key, deepMerge((ObjectNode) baseValue, (ObjectNode) overrideValue));
+            } else {
+                base.set(key, overrideValue.deepCopy());
+            }
+        });
+        return base;
     }
 
     private void expandServerlessFunction(String logicalId, JsonNode properties, ObjectNode resources) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessorTest.java
@@ -525,4 +525,121 @@ class SamTransformProcessorTest {
         }
         assertEquals(0, methods, "a route with a non-literal Path must not be registered");
     }
+
+    @Test
+    void expandSamTemplate_appliesGlobalsFunctionToFunction() throws Exception {
+        // Handler/Runtime defined only in Globals.Function (common SAM pattern, e.g. Go provided.al2023)
+        JsonNode template = objectMapper.readTree("""
+            {
+              "Transform": "AWS::Serverless-2016-10-31",
+              "Globals": {
+                "Function": {
+                  "Handler": "bootstrap",
+                  "Runtime": "provided.al2023"
+                }
+              },
+              "Resources": {
+                "MyFunc": {
+                  "Type": "AWS::Serverless::Function",
+                  "Properties": {
+                    "InlineCode": "bootstrap"
+                  }
+                }
+              }
+            }
+            """);
+
+        JsonNode expanded = processor.expandSamTemplate(template);
+
+        // Globals is a SAM-only section and must be stripped from the emitted CFN template
+        assertTrue(expanded.path("Globals").isMissingNode());
+
+        JsonNode lambdaProps = expanded.path("Resources").path("MyFunc").path("Properties");
+        assertEquals("AWS::Lambda::Function",
+                expanded.path("Resources").path("MyFunc").path("Type").asText());
+        // Handler/Runtime from Globals must be propagated onto the generated function
+        assertEquals("bootstrap", lambdaProps.path("Handler").asText());
+        assertEquals("provided.al2023", lambdaProps.path("Runtime").asText());
+    }
+
+    @Test
+    void expandSamTemplate_functionPropertiesOverrideGlobals() throws Exception {
+        JsonNode template = objectMapper.readTree("""
+            {
+              "Transform": "AWS::Serverless-2016-10-31",
+              "Globals": {
+                "Function": {
+                  "Handler": "bootstrap",
+                  "Runtime": "provided.al2023",
+                  "Timeout": 3
+                }
+              },
+              "Resources": {
+                "MyFunc": {
+                  "Type": "AWS::Serverless::Function",
+                  "Properties": {
+                    "Runtime": "nodejs20.x",
+                    "Handler": "index.handler",
+                    "InlineCode": "exports.handler = async () => ({});"
+                  }
+                }
+              }
+            }
+            """);
+
+        JsonNode lambdaProps = processor.expandSamTemplate(template)
+                .path("Resources").path("MyFunc").path("Properties");
+
+        // Function-level values win; Globals-only values still apply
+        assertEquals("index.handler", lambdaProps.path("Handler").asText());
+        assertEquals("nodejs20.x", lambdaProps.path("Runtime").asText());
+        assertEquals(3, lambdaProps.path("Timeout").asInt());
+    }
+
+    @Test
+    void expandSamTemplate_mergesNestedMapsFromGlobals() throws Exception {
+        // Environment.Variables must merge key-wise: globals-only keys preserved, function keys win on clash
+        JsonNode template = objectMapper.readTree("""
+            {
+              "Transform": "AWS::Serverless-2016-10-31",
+              "Globals": {
+                "Function": {
+                  "Handler": "bootstrap",
+                  "Runtime": "provided.al2023",
+                  "Environment": { "Variables": { "GLOBAL_VAR": "g", "SHARED": "from-globals" } }
+                }
+              },
+              "Resources": {
+                "MyFunc": {
+                  "Type": "AWS::Serverless::Function",
+                  "Properties": {
+                    "InlineCode": "bootstrap",
+                    "Environment": { "Variables": { "LOCAL_VAR": "l", "SHARED": "from-function" } }
+                  }
+                }
+              }
+            }
+            """);
+
+        JsonNode vars = processor.expandSamTemplate(template)
+                .path("Resources").path("MyFunc").path("Properties")
+                .path("Environment").path("Variables");
+
+        assertEquals("g", vars.path("GLOBAL_VAR").asText());          // globals-only key preserved
+        assertEquals("l", vars.path("LOCAL_VAR").asText());           // function-only key added
+        assertEquals("from-function", vars.path("SHARED").asText());  // clash resolved in favor of function
+    }
+
+    @Test
+    void expandSamTemplate_stripsGlobalsWhenResourcesAbsent() throws Exception {
+        // SAM-only Globals must be stripped even on the early return (no/!object Resources)
+        JsonNode template = objectMapper.readTree("""
+            {"Transform": "AWS::Serverless-2016-10-31", "Globals": {"Function": {"Runtime": "provided.al2023"}}}
+            """);
+
+        JsonNode expanded = processor.expandSamTemplate(template);
+
+        assertTrue(expanded.path("Transform").isMissingNode());
+        assertTrue(expanded.path("Globals").isMissingNode());
+    }
 }


### PR DESCRIPTION
Fixes #1426

## Problem

`SamTransformProcessor` builds each generated resource **only from the individual `AWS::Serverless::*` resource's own `Properties`** and never applies the template's top-level **`Globals:`** section. Any property declared in `Globals.Function` (Handler, Runtime, Timeout, Environment, …) is dropped during the transform.

For a Go / custom-runtime function that sets `Handler: bootstrap` + `Runtime: provided.al2023` in `Globals.Function` (a common SAM pattern), the generated `AWS::Lambda::Function` ends up with no Handler/Runtime, the handler defaults to `index`, and creation fails with:

```
Handler file 'index' not found in deployment package
```

The same templates deploy correctly on LocalStack, which applies Globals.

## Fix

- Capture the template's `Globals` node in `expandSamTemplate`.
- Merge `Globals.<section>` into each `AWS::Serverless::{Function,Api,SimpleTable}`'s `Properties` before expansion, with the resource's own properties taking precedence (per the SAM Globals spec), via a new `mergeGlobals` helper.
- Strip the SAM-only `Globals` key from the emitted CloudFormation template.

### Scope / follow-up
Property-level override only. The SAM spec additionally merges some list/map-valued properties (`Policies`, `Layers`, `Environment.Variables`) **additively**; that refinement is intentionally left out here and noted in a code comment.

## Tests

Added two unit tests in `SamTransformProcessorTest`:
1. `Handler`/`Runtime` defined only in `Globals.Function` propagate onto the generated Lambda (and `Globals` is stripped from the output).
2. Function-level properties override `Globals`, while Globals-only values still apply.

Full class run locally on JDK 25: `Tests run: 17, Failures: 0, Errors: 0` — `BUILD SUCCESS`.