### PR TITLE
fix(cloudformation): record REVIEW_IN_PROGRESS event on change-set creation

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
@@ -133,11 +133,22 @@ public class CloudFormationService {
                                      Map<String, String> tags, String region) {
         String resolvedTemplate = resolveTemplate(templateBody, templateUrl);
 
+        boolean isNewStack = !stacks.containsKey(key(stackName, region));
+
         Stack stack = stacks.computeIfAbsent(key(stackName, region), k -> {
             Stack s = newStack(stackName, region);
             if (tags != null) s.getTags().putAll(tags);
             return s;
         });
+
+        // A CREATE change set puts a brand-new stack into REVIEW_IN_PROGRESS. Record the matching
+        // stack-level event (as AWS and LocalStack do) so DescribeStackEvents is non-empty straight
+        // after change-set creation — tooling such as the AWS SAM CLI reads StackEvents[0] at that
+        // point and otherwise fails with an IndexError.
+        if (isNewStack && "REVIEW_IN_PROGRESS".equals(stack.getStatus())) {
+            addEvent(stack, stack.getStackName(), stack.getStackId(),
+                    "AWS::CloudFormation::Stack", "REVIEW_IN_PROGRESS", "User Initiated");
+        }
 
         ChangeSet cs = new ChangeSet();
         cs.setChangeSetId(AwsArnUtils.Arn.of("cloudformation", region, regionResolver.getAccountId(), "changeSet/" + changeSetName + "/" + UUID.randomUUID()).toString());

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
@@ -133,9 +133,12 @@ public class CloudFormationService {
                                      Map<String, String> tags, String region) {
         String resolvedTemplate = resolveTemplate(templateBody, templateUrl);
 
-        boolean isNewStack = !stacks.containsKey(key(stackName, region));
-
+        // Detect first creation atomically: the mapping function runs at most once per key, so the
+        // flag is only set for the thread that actually creates the stack (no double-recording under
+        // concurrent CreateChangeSet calls).
+        boolean[] stackCreated = {false};
         Stack stack = stacks.computeIfAbsent(key(stackName, region), k -> {
+            stackCreated[0] = true;
             Stack s = newStack(stackName, region);
             if (tags != null) s.getTags().putAll(tags);
             return s;
@@ -143,9 +146,10 @@ public class CloudFormationService {
 
         // A CREATE change set puts a brand-new stack into REVIEW_IN_PROGRESS. Record the matching
         // stack-level event (as AWS and LocalStack do) so DescribeStackEvents is non-empty straight
-        // after change-set creation — tooling such as the AWS SAM CLI reads StackEvents[0] at that
-        // point and otherwise fails with an IndexError.
-        if (isNewStack && "REVIEW_IN_PROGRESS".equals(stack.getStatus())) {
+        // after change-set creation — tooling such as the AWS SAM CLI reads StackEvents[0] there and
+        // otherwise fails with an IndexError. (CreateChangeSet defaults a null type to CREATE.)
+        boolean isCreateType = changeSetType == null || "CREATE".equalsIgnoreCase(changeSetType);
+        if (stackCreated[0] && isCreateType) {
             addEvent(stack, stack.getStackName(), stack.getStackId(),
                     "AWS::CloudFormation::Stack", "REVIEW_IN_PROGRESS", "User Initiated");
         }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -1013,6 +1013,48 @@ class CloudFormationIntegrationTest {
     }
 
     @Test
+    void createChangeSet_recordsReviewInProgressEvent() {
+        // A CREATE change set for a brand-new stack must record a REVIEW_IN_PROGRESS stack event,
+        // so DescribeStackEvents is non-empty right after CreateChangeSet (matching AWS/LocalStack).
+        // Tooling such as the AWS SAM CLI reads StackEvents[0] at this point.
+        String template = """
+            {
+              "Resources": {
+                "MyBucket": {
+                  "Type": "AWS::S3::Bucket",
+                  "Properties": { "BucketName": "review-event-bucket" }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateChangeSet")
+            .formParam("StackName", "review-event-stack")
+            .formParam("ChangeSetName", "cs1")
+            .formParam("ChangeSetType", "CREATE")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Before the change set is executed the stack is REVIEW_IN_PROGRESS and must already
+        // carry a matching stack-level event.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStackEvents")
+            .formParam("StackName", "review-event-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<ResourceType>AWS::CloudFormation::Stack</ResourceType>"))
+            .body(containsString("<ResourceStatus>REVIEW_IN_PROGRESS</ResourceStatus>"));
+    }
+
+    @Test
     void describeDeletedStackEvents_byArn_returnsDeleteCompleteEvents() throws Exception {
         String template = """
             {


### PR DESCRIPTION
Fixes #1429

## Problem

A `CREATE` change set puts a brand-new stack into `REVIEW_IN_PROGRESS`, but `createChangeSet` records **no stack event**, so `DescribeStackEvents` returns an empty list for that stack. AWS and LocalStack return at least the `REVIEW_IN_PROGRESS` stack event at this point.

Tooling that reads `StackEvents[0]` right after change-set creation hits this. In particular the AWS SAM CLI's `get_last_event_time` does:

```python
describe_stack_events(StackName=stack_name)["StackEvents"][0]["Timestamp"]
```

and only guards `except KeyError`, so floci's empty list raises an uncaught `IndexError` and `sam deploy` aborts before deploying anything.

Verified side-by-side (`create-change-set` CREATE → `describe-stack-events`):

| Emulator | StackStatus | `length(StackEvents)` |
|---|---|---|
| floci 1.5.25 | `REVIEW_IN_PROGRESS` | **0** |
| LocalStack 3.0.2 | `REVIEW_IN_PROGRESS` | **1** |

## Fix

In `CloudFormationService.createChangeSet`, when a `CREATE` change set creates a **new** stack (status `REVIEW_IN_PROGRESS`), record the matching `AWS::CloudFormation::Stack` `REVIEW_IN_PROGRESS` event — mirroring the event already recorded on execute (`executeChangeSet`). Scoped to the new-stack path; nested stacks (which go straight to `CREATE_IN_PROGRESS`) and update change sets are unaffected.

## Test

Added `createChangeSet_recordsReviewInProgressEvent` to `CloudFormationIntegrationTest`: after `CreateChangeSet` (CREATE), `DescribeStackEvents` now returns a `REVIEW_IN_PROGRESS` event for `AWS::CloudFormation::Stack`. Passes locally on JDK 25 (`Tests run: 1, BUILD SUCCESS`).

## Notes

Separate from the SAM `Globals` transform gap (#1426 / PR #1427). Together, these two fixes let `sam deploy` run end-to-end against floci with no client-side workarounds.