### PR TITLE
feat(autoscaling): preserve policy and mixed instances parity

### DIFF
--- a/docs/services/autoscaling.md
+++ b/docs/services/autoscaling.md
@@ -24,9 +24,9 @@ Floci implements the EC2 Auto Scaling API — stored-state management for launch
 
 | Operation | Notes |
 |---|---|
-| `CreateAutoScalingGroup` | Creates a group with min/max/desired capacity, AZs, tags; starts capacity reconciliation loop |
-| `DescribeAutoScalingGroups` | Filtered by name list; returns all if no filter; includes current instance list with lifecycle state |
-| `UpdateAutoScalingGroup` | Updates capacity bounds, cooldown, launch configuration, AZs |
+| `CreateAutoScalingGroup` | Creates a group with min/max/desired capacity, AZs, tags, launch configuration, launch template, or mixed instances policy; starts capacity reconciliation loop |
+| `DescribeAutoScalingGroups` | Filtered by name list; returns all if no filter; includes current instance list with lifecycle state and mixed instances policy shape when configured |
+| `UpdateAutoScalingGroup` | Updates capacity bounds, cooldown, launch source, AZs |
 | `DeleteAutoScalingGroup` | `ForceDelete=true` terminates all instances before deletion |
 
 ### Instance Management
@@ -64,8 +64,8 @@ Floci implements the EC2 Auto Scaling API — stored-state management for launch
 
 | Operation | Notes |
 |---|---|
-| `PutScalingPolicy` | Creates or updates a policy: `SimpleScaling`, `AdjustmentType`, `ScalingAdjustment`, `Cooldown` |
-| `DescribePolicies` | Lists policies filtered by group or policy name |
+| `PutScalingPolicy` | Creates or updates a policy: `SimpleScaling` fields or `TargetTrackingScaling` with predefined metric, target value, and estimated warmup |
+| `DescribePolicies` | Lists policies filtered by group or policy name, including stored target tracking configuration |
 | `DeletePolicy` | Removes a scaling policy |
 
 ### Activities
@@ -92,6 +92,22 @@ Floci runs a background reconciler (10 s fixed rate) that keeps each group's InS
 - **Scale-out**: calls `RunInstances` with the group's launch configuration; new instances are tracked as `Pending` until the EC2 state transitions to `running`, at which point they move to `InService` and are registered with all attached ELB v2 target groups.
 - **Scale-in**: selects InService instances not protected from scale-in, deregisters them from target groups, then calls `TerminateInstances`.
 - Activity records are written on each scale-out and scale-in event.
+
+## Launch Source Compatibility
+
+Auto Scaling groups preserve either a launch configuration, a top-level launch template, or a `MixedInstancesPolicy`. These launch sources are mutually exclusive in create/update requests. When a mixed instances policy is supplied, Floci stores and returns:
+
+- `LaunchTemplate.LaunchTemplateSpecification.LaunchTemplateId`
+- `LaunchTemplate.LaunchTemplateSpecification.LaunchTemplateName`
+- `LaunchTemplate.LaunchTemplateSpecification.Version`
+- `LaunchTemplate.Overrides.member.N.InstanceType`
+- `InstancesDistribution.OnDemandBaseCapacity`
+- `InstancesDistribution.OnDemandPercentageAboveBaseCapacity`
+- `InstancesDistribution.SpotAllocationStrategy`
+
+## Scaling Policy Compatibility
+
+Target tracking policies preserve `TargetTrackingConfiguration` for predefined metrics. `DescribePolicies` returns `PredefinedMetricSpecification.PredefinedMetricType`, `TargetValue`, and `EstimatedInstanceWarmup` when present.
 
 ## Configuration
 

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java
@@ -678,7 +678,9 @@ public class AutoScalingQueryHandler {
                 p.getFirst("PolicyType"),
                 p.getFirst("AdjustmentType"),
                 intParam(p, "ScalingAdjustment", 0),
-                intParam(p, "Cooldown", 300));
+                intParam(p, "Cooldown", 300),
+                nullableIntParam(p, "EstimatedInstanceWarmup"),
+                parseTargetTrackingConfiguration(p));
         return ok(new XmlBuilder()
                 .start("PutScalingPolicyResponse", NS)
                   .start("PutScalingPolicyResult")
@@ -713,6 +715,10 @@ public class AutoScalingQueryHandler {
                .elem("ScalingAdjustment", String.valueOf(policy.getScalingAdjustment()))
                .elem("Cooldown", String.valueOf(policy.getCooldown()));
             if (policy.getAdjustmentType() != null) { xml.elem("AdjustmentType", policy.getAdjustmentType()); }
+            if (policy.getEstimatedInstanceWarmup() != null) {
+                xml.elem("EstimatedInstanceWarmup", String.valueOf(policy.getEstimatedInstanceWarmup()));
+            }
+            appendTargetTrackingConfigurationXml(xml, policy.getTargetTrackingConfiguration());
             xml.end("member");
         }
         xml.end("ScalingPolicies")
@@ -720,6 +726,44 @@ public class AutoScalingQueryHandler {
            .raw(AwsQueryResponse.responseMetadata())
            .end("DescribePoliciesResponse");
         return ok(xml.build());
+    }
+
+    private static ScalingPolicy.TargetTrackingConfiguration parseTargetTrackingConfiguration(MultivaluedMap<String, String> p) {
+        String predefinedMetricType = p.getFirst("TargetTrackingConfiguration.PredefinedMetricSpecification.PredefinedMetricType");
+        Double targetValue = nullableDoubleParam(p, "TargetTrackingConfiguration.TargetValue");
+        if (predefinedMetricType == null && targetValue == null) {
+            return null;
+        }
+        ScalingPolicy.TargetTrackingConfiguration configuration = new ScalingPolicy.TargetTrackingConfiguration();
+        if (predefinedMetricType != null) {
+            ScalingPolicy.PredefinedMetricSpecification specification =
+                    new ScalingPolicy.PredefinedMetricSpecification();
+            specification.setPredefinedMetricType(predefinedMetricType);
+            configuration.setPredefinedMetricSpecification(specification);
+        }
+        configuration.setTargetValue(targetValue);
+        return configuration;
+    }
+
+    private static void appendTargetTrackingConfigurationXml(
+            XmlBuilder xml, ScalingPolicy.TargetTrackingConfiguration configuration) {
+        if (configuration == null) {
+            return;
+        }
+        xml.start("TargetTrackingConfiguration");
+        ScalingPolicy.PredefinedMetricSpecification predefinedMetric =
+                configuration.getPredefinedMetricSpecification();
+        if (predefinedMetric != null) {
+            xml.start("PredefinedMetricSpecification");
+            if (predefinedMetric.getPredefinedMetricType() != null) {
+                xml.elem("PredefinedMetricType", predefinedMetric.getPredefinedMetricType());
+            }
+            xml.end("PredefinedMetricSpecification");
+        }
+        if (configuration.getTargetValue() != null) {
+            xml.elem("TargetValue", String.valueOf(configuration.getTargetValue()));
+        }
+        xml.end("TargetTrackingConfiguration");
     }
 
     // ── Activities ────────────────────────────────────────────────────────────
@@ -932,6 +976,12 @@ public class AutoScalingQueryHandler {
         String val = p.getFirst(key);
         if (val == null || val.isBlank()) { return null; }
         try { return Integer.parseInt(val); } catch (NumberFormatException e) { return null; }
+    }
+
+    private static Double nullableDoubleParam(MultivaluedMap<String, String> p, String key) {
+        String val = p.getFirst(key);
+        if (val == null || val.isBlank()) { return null; }
+        try { return Double.parseDouble(val); } catch (NumberFormatException e) { return null; }
     }
 
     private Boolean nullableBoolParam(MultivaluedMap<String, String> p, String key) {

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java
@@ -156,6 +156,7 @@ public class AutoScalingQueryHandler {
                 p.getFirst("LaunchTemplate.LaunchTemplateId"),
                 p.getFirst("LaunchTemplate.LaunchTemplateName"),
                 p.getFirst("LaunchTemplate.Version"),
+                parseMixedInstancesPolicy(p),
                 intParam(p, "MinSize", 0),
                 intParam(p, "MaxSize", 0),
                 intParam(p, "DesiredCapacity", intParam(p, "MinSize", 0)),
@@ -184,6 +185,7 @@ public class AutoScalingQueryHandler {
                 p.getFirst("LaunchTemplate.LaunchTemplateId"),
                 p.getFirst("LaunchTemplate.LaunchTemplateName"),
                 p.getFirst("LaunchTemplate.Version"),
+                parseMixedInstancesPolicy(p),
                 p.getFirst("MinSize") != null ? Integer.parseInt(p.getFirst("MinSize")) : null,
                 p.getFirst("MaxSize") != null ? Integer.parseInt(p.getFirst("MaxSize")) : null,
                 p.getFirst("DesiredCapacity") != null ? Integer.parseInt(p.getFirst("DesiredCapacity")) : null,
@@ -255,6 +257,7 @@ public class AutoScalingQueryHandler {
             }
             xml.end("LaunchTemplate");
         }
+        appendMixedInstancesPolicyXml(xml, asg.getMixedInstancesPolicy());
 
         xml.start("AvailabilityZones");
         for (String az : asg.getAvailabilityZones()) { xml.elem("member", az); }
@@ -472,6 +475,64 @@ public class AutoScalingQueryHandler {
             xml.elem("Version", inst.getLaunchTemplateVersion());
         }
         xml.end("LaunchTemplate");
+    }
+
+    private static void appendMixedInstancesPolicyXml(XmlBuilder xml, MixedInstancesPolicy policy) {
+        if (policy == null) {
+            return;
+        }
+        xml.start("MixedInstancesPolicy");
+        MixedInstancesPolicy.LaunchTemplate launchTemplate = policy.getLaunchTemplate();
+        if (launchTemplate != null) {
+            xml.start("LaunchTemplate");
+            appendMixedLaunchTemplateSpecificationXml(xml, launchTemplate.getLaunchTemplateSpecification());
+            if (!launchTemplate.getOverrides().isEmpty()) {
+                xml.start("Overrides");
+                for (MixedInstancesPolicy.LaunchTemplateOverride override : launchTemplate.getOverrides()) {
+                    xml.start("member");
+                    if (override.getInstanceType() != null) {
+                        xml.elem("InstanceType", override.getInstanceType());
+                    }
+                    xml.end("member");
+                }
+                xml.end("Overrides");
+            }
+            xml.end("LaunchTemplate");
+        }
+        MixedInstancesPolicy.InstancesDistribution distribution = policy.getInstancesDistribution();
+        if (distribution != null) {
+            xml.start("InstancesDistribution");
+            if (distribution.getOnDemandBaseCapacity() != null) {
+                xml.elem("OnDemandBaseCapacity", String.valueOf(distribution.getOnDemandBaseCapacity()));
+            }
+            if (distribution.getOnDemandPercentageAboveBaseCapacity() != null) {
+                xml.elem("OnDemandPercentageAboveBaseCapacity",
+                        String.valueOf(distribution.getOnDemandPercentageAboveBaseCapacity()));
+            }
+            if (distribution.getSpotAllocationStrategy() != null) {
+                xml.elem("SpotAllocationStrategy", distribution.getSpotAllocationStrategy());
+            }
+            xml.end("InstancesDistribution");
+        }
+        xml.end("MixedInstancesPolicy");
+    }
+
+    private static void appendMixedLaunchTemplateSpecificationXml(
+            XmlBuilder xml, MixedInstancesPolicy.LaunchTemplateSpecification specification) {
+        if (specification == null) {
+            return;
+        }
+        xml.start("LaunchTemplateSpecification");
+        if (specification.getLaunchTemplateId() != null) {
+            xml.elem("LaunchTemplateId", specification.getLaunchTemplateId());
+        }
+        if (specification.getLaunchTemplateName() != null) {
+            xml.elem("LaunchTemplateName", specification.getLaunchTemplateName());
+        }
+        if (specification.getVersion() != null) {
+            xml.elem("Version", specification.getVersion());
+        }
+        xml.end("LaunchTemplateSpecification");
     }
 
     private Response handleAttachInstances(MultivaluedMap<String, String> p, String region) {
@@ -907,6 +968,71 @@ public class AutoScalingQueryHandler {
                 .map(String::trim)
                 .filter(item -> !item.isEmpty())
                 .toList();
+    }
+
+    private MixedInstancesPolicy parseMixedInstancesPolicy(MultivaluedMap<String, String> p) {
+        if (!hasAnyPrefix(p, "MixedInstancesPolicy.")) {
+            return null;
+        }
+        MixedInstancesPolicy policy = new MixedInstancesPolicy();
+
+        MixedInstancesPolicy.LaunchTemplate launchTemplate = new MixedInstancesPolicy.LaunchTemplate();
+        MixedInstancesPolicy.LaunchTemplateSpecification specification =
+                new MixedInstancesPolicy.LaunchTemplateSpecification();
+        specification.setLaunchTemplateId(p.getFirst(
+                "MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification.LaunchTemplateId"));
+        specification.setLaunchTemplateName(p.getFirst(
+                "MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification.LaunchTemplateName"));
+        specification.setVersion(p.getFirst(
+                "MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification.Version"));
+        if (specification.getLaunchTemplateId() != null
+                || specification.getLaunchTemplateName() != null
+                || specification.getVersion() != null) {
+            launchTemplate.setLaunchTemplateSpecification(specification);
+        }
+        launchTemplate.setOverrides(parseMixedLaunchTemplateOverrides(p));
+        if (launchTemplate.getLaunchTemplateSpecification() != null || !launchTemplate.getOverrides().isEmpty()) {
+            policy.setLaunchTemplate(launchTemplate);
+        }
+
+        MixedInstancesPolicy.InstancesDistribution distribution =
+                new MixedInstancesPolicy.InstancesDistribution();
+        distribution.setOnDemandBaseCapacity(nullableIntParam(
+                p, "MixedInstancesPolicy.InstancesDistribution.OnDemandBaseCapacity"));
+        distribution.setOnDemandPercentageAboveBaseCapacity(nullableIntParam(
+                p, "MixedInstancesPolicy.InstancesDistribution.OnDemandPercentageAboveBaseCapacity"));
+        distribution.setSpotAllocationStrategy(
+                p.getFirst("MixedInstancesPolicy.InstancesDistribution.SpotAllocationStrategy"));
+        if (distribution.getOnDemandBaseCapacity() != null
+                || distribution.getOnDemandPercentageAboveBaseCapacity() != null
+                || distribution.getSpotAllocationStrategy() != null) {
+            policy.setInstancesDistribution(distribution);
+        }
+        return policy;
+    }
+
+    private static boolean hasAnyPrefix(MultivaluedMap<String, String> p, String prefix) {
+        for (String key : p.keySet()) {
+            if (key.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<MixedInstancesPolicy.LaunchTemplateOverride> parseMixedLaunchTemplateOverrides(
+            MultivaluedMap<String, String> p) {
+        List<MixedInstancesPolicy.LaunchTemplateOverride> result = new ArrayList<>();
+        for (int i = 1; ; i++) {
+            String instanceType = p.getFirst("MixedInstancesPolicy.LaunchTemplate.Overrides.member."
+                    + i + ".InstanceType");
+            if (instanceType == null) { break; }
+            MixedInstancesPolicy.LaunchTemplateOverride override =
+                    new MixedInstancesPolicy.LaunchTemplateOverride();
+            override.setInstanceType(instanceType);
+            result.add(override);
+        }
+        return result;
     }
 
     private Map<String, String> parseTags(MultivaluedMap<String, String> p) {

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
@@ -128,8 +128,7 @@ public class AutoScalingReconciler {
 
     private void removeStaleInstances(AutoScalingGroup asg) {
         List<AsgInstance> staleInstances = asg.getInstances().stream()
-                .filter(instance -> isActiveLifecycleState(instance.getLifecycleState()))
-                .filter(instance -> !ec2Service.isInstanceContainerRunning(instance.getInstanceId()))
+                .filter(instance -> isStaleInstance(asg, instance))
                 .collect(Collectors.toList());
         if (staleInstances.isEmpty()) {
             return;
@@ -146,6 +145,42 @@ public class AutoScalingReconciler {
                 "Successful");
         LOG.infov("ASG {0}: removed stale instance reference(s) {1}",
                 asg.getAutoScalingGroupName(), instanceIds);
+    }
+
+    private boolean isStaleInstance(AutoScalingGroup asg, AsgInstance instance) {
+        String lifecycleState = instance.getLifecycleState();
+        if ("InService".equals(lifecycleState)) {
+            return !ec2Service.isInstanceContainerRunning(instance.getInstanceId());
+        }
+        if ("Pending".equals(lifecycleState)) {
+            return isMissingOrTerminalEc2Instance(asg, instance);
+        }
+        return false;
+    }
+
+    private boolean isMissingOrTerminalEc2Instance(AutoScalingGroup asg, AsgInstance instance) {
+        try {
+            List<Instance> ec2Instances = ec2Service
+                    .describeInstances(asg.getRegion(), List.of(instance.getInstanceId()), null)
+                    .stream()
+                    .flatMap(r -> r.getInstances().stream())
+                    .collect(Collectors.toList());
+            if (ec2Instances.isEmpty()) {
+                return true;
+            }
+            String state = ec2Instances.getFirst().getState() != null
+                    ? ec2Instances.getFirst().getState().getName()
+                    : null;
+            return "shutting-down".equals(state)
+                    || "terminated".equals(state)
+                    || "stopping".equals(state)
+                    || "stopped".equals(state);
+        }
+        catch (Exception e) {
+            LOG.debugv("ASG {0}: keeping pending instance {1} during stale check: {2}",
+                    asg.getAutoScalingGroupName(), instance.getInstanceId(), e.getMessage());
+            return false;
+        }
     }
 
     private void removeOrphanedTargetRegistrations(AutoScalingGroup asg) {
@@ -356,7 +391,7 @@ public class AutoScalingReconciler {
                     version.getInstanceType(),
                     version.getKeyName(),
                     version.getSecurityGroupIds(),
-                    List.of(),
+                    version.getInstanceTags(),
                     version.getUserData(),
                     null,
                     asg.getLaunchTemplateId(),

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.autoscaling;
 import io.github.hectorvent.floci.services.autoscaling.model.AsgInstance;
 import io.github.hectorvent.floci.services.autoscaling.model.AutoScalingGroup;
 import io.github.hectorvent.floci.services.autoscaling.model.LaunchConfiguration;
+import io.github.hectorvent.floci.services.autoscaling.model.MixedInstancesPolicy;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.ec2.model.Instance;
 import io.github.hectorvent.floci.services.ec2.model.LaunchTemplate;
@@ -399,6 +400,38 @@ public class AutoScalingReconciler {
                     resolvedVersion);
         }
 
+        MixedInstancesPolicy.LaunchTemplateSpecification specification =
+                mixedInstancesLaunchTemplateSpecification(asg);
+        if (specification != null) {
+            LaunchTemplate mixedLaunchTemplate = resolveMixedInstancesLaunchTemplate(asg, specification);
+            if (mixedLaunchTemplate != null) {
+                LaunchTemplate version = ec2Service.describeLaunchTemplateVersions(
+                        asg.getRegion(),
+                        mixedLaunchTemplate.getLaunchTemplateId(),
+                        null,
+                        specification.getVersion() == null ? List.of() : List.of(specification.getVersion()))
+                        .getFirst();
+                String resolvedVersion = version.getLatestVersionNumber() != null
+                        ? version.getLatestVersionNumber()
+                        : specification.getVersion();
+                String instanceType = mixedInstancesInstanceType(asg, version);
+                return new LaunchSource(
+                        null,
+                        version.getImageId(),
+                        instanceType,
+                        version.getKeyName(),
+                        version.getSecurityGroupIds(),
+                        version.getInstanceTags(),
+                        version.getUserData(),
+                        null,
+                        specification.getLaunchTemplateId() == null
+                                ? mixedLaunchTemplate.getLaunchTemplateId()
+                                : specification.getLaunchTemplateId(),
+                        specification.getLaunchTemplateName(),
+                        resolvedVersion);
+            }
+        }
+
         return null;
     }
 
@@ -424,6 +457,53 @@ public class AutoScalingReconciler {
                 ltName == null || ltName.isBlank() ? List.of() : List.of(ltName),
                 Map.of());
         return launchTemplates.isEmpty() ? null : launchTemplates.get(0);
+    }
+
+    private MixedInstancesPolicy.LaunchTemplateSpecification mixedInstancesLaunchTemplateSpecification(
+            AutoScalingGroup asg) {
+        MixedInstancesPolicy policy = asg.getMixedInstancesPolicy();
+        if (policy == null || policy.getLaunchTemplate() == null) {
+            return null;
+        }
+        MixedInstancesPolicy.LaunchTemplateSpecification specification =
+                policy.getLaunchTemplate().getLaunchTemplateSpecification();
+        if (specification == null) {
+            return null;
+        }
+        String ltId = specification.getLaunchTemplateId();
+        String ltName = specification.getLaunchTemplateName();
+        if ((ltId == null || ltId.isBlank()) && (ltName == null || ltName.isBlank())) {
+            return null;
+        }
+        return specification;
+    }
+
+    private LaunchTemplate resolveMixedInstancesLaunchTemplate(
+            AutoScalingGroup asg, MixedInstancesPolicy.LaunchTemplateSpecification specification) {
+        String ltId = specification.getLaunchTemplateId();
+        String ltName = specification.getLaunchTemplateName();
+        List<LaunchTemplate> launchTemplates = ec2Service.describeLaunchTemplates(
+                asg.getRegion(),
+                ltId == null || ltId.isBlank() ? List.of() : List.of(ltId),
+                ltName == null || ltName.isBlank() ? List.of() : List.of(ltName),
+                Map.of());
+        return launchTemplates.isEmpty() ? null : launchTemplates.get(0);
+    }
+
+    private String mixedInstancesInstanceType(AutoScalingGroup asg, LaunchTemplate version) {
+        MixedInstancesPolicy policy = asg.getMixedInstancesPolicy();
+        if (policy != null && policy.getLaunchTemplate() != null) {
+            List<MixedInstancesPolicy.LaunchTemplateOverride> overrides =
+                    policy.getLaunchTemplate().getOverrides();
+            if (overrides != null) {
+                for (MixedInstancesPolicy.LaunchTemplateOverride override : overrides) {
+                    if (override.getInstanceType() != null && !override.getInstanceType().isBlank()) {
+                        return override.getInstanceType();
+                    }
+                }
+            }
+        }
+        return version.getInstanceType();
     }
 
     private record LaunchSource(

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
@@ -111,6 +111,7 @@ public class AutoScalingService {
                                                     String launchConfigName,
                                                     String launchTemplateId, String launchTemplateName,
                                                     String launchTemplateVersion,
+                                                    MixedInstancesPolicy mixedInstancesPolicy,
                                                     int minSize, int maxSize, int desiredCapacity,
                                                     int defaultCooldown, List<String> availabilityZones,
                                                     List<String> subnetIds,
@@ -123,7 +124,9 @@ public class AutoScalingService {
             throw new AwsException("AlreadyExists",
                     "Auto Scaling group '" + name + "' already exists.", 400);
         }
-        if (launchConfigName == null && launchTemplateId == null && launchTemplateName == null) {
+        validateLaunchSource(launchConfigName, launchTemplateId, launchTemplateName, mixedInstancesPolicy);
+        if (launchConfigName == null && launchTemplateId == null && launchTemplateName == null
+                && mixedInstancesPolicy == null) {
             throw new AwsException("ValidationError",
                     "Either LaunchConfigurationName or LaunchTemplate must be specified.", 400);
         }
@@ -137,6 +140,7 @@ public class AutoScalingService {
         asg.setLaunchTemplateId(launchTemplateId);
         asg.setLaunchTemplateName(launchTemplateName);
         asg.setLaunchTemplateVersion(launchTemplateVersion);
+        asg.setMixedInstancesPolicy(mixedInstancesPolicy);
         asg.setMinSize(minSize);
         asg.setMaxSize(maxSize);
         asg.setDesiredCapacity(desiredCapacity);
@@ -161,19 +165,34 @@ public class AutoScalingService {
                                         String launchConfigName,
                                         String launchTemplateId, String launchTemplateName,
                                         String launchTemplateVersion,
+                                        MixedInstancesPolicy mixedInstancesPolicy,
                                         Integer minSize, Integer maxSize, Integer desiredCapacity,
                                         Integer defaultCooldown, List<String> availabilityZones,
                                         List<String> subnetIds,
                                         String healthCheckType, Integer healthCheckGracePeriod,
                                         List<String> terminationPolicies) {
         AutoScalingGroup asg = requireGroup(region, name);
+        validateLaunchSource(launchConfigName, launchTemplateId, launchTemplateName, mixedInstancesPolicy);
         if (launchConfigName != null) {
             asg.setLaunchConfigurationName(launchConfigName);
+            asg.setLaunchTemplateId(null);
+            asg.setLaunchTemplateName(null);
+            asg.setLaunchTemplateVersion(null);
+            asg.setMixedInstancesPolicy(null);
         }
         if (launchTemplateId != null || launchTemplateName != null) {
+            asg.setLaunchConfigurationName(null);
             asg.setLaunchTemplateId(launchTemplateId);
             asg.setLaunchTemplateName(launchTemplateName);
             asg.setLaunchTemplateVersion(launchTemplateVersion);
+            asg.setMixedInstancesPolicy(null);
+        }
+        if (mixedInstancesPolicy != null) {
+            asg.setLaunchConfigurationName(null);
+            asg.setLaunchTemplateId(null);
+            asg.setLaunchTemplateName(null);
+            asg.setLaunchTemplateVersion(null);
+            asg.setMixedInstancesPolicy(mixedInstancesPolicy);
         }
         if (minSize != null) { asg.setMinSize(minSize); }
         if (maxSize != null) { asg.setMaxSize(maxSize); }
@@ -603,6 +622,26 @@ public class AutoScalingService {
 
     private static String policyKey(String region, String asgName, String policyName) {
         return region + "::" + asgName + "::" + policyName;
+    }
+
+    private static void validateLaunchSource(String launchConfigName,
+                                             String launchTemplateId,
+                                             String launchTemplateName,
+                                             MixedInstancesPolicy mixedInstancesPolicy) {
+        int sources = 0;
+        if (launchConfigName != null) {
+            sources++;
+        }
+        if (launchTemplateId != null || launchTemplateName != null) {
+            sources++;
+        }
+        if (mixedInstancesPolicy != null) {
+            sources++;
+        }
+        if (sources > 1) {
+            throw new AwsException("ValidationError",
+                    "LaunchConfigurationName, LaunchTemplate, and MixedInstancesPolicy are mutually exclusive.", 400);
+        }
     }
 
     private static String instanceRefreshKey(String region, String asgName, String refreshId) {

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
@@ -506,7 +506,9 @@ public class AutoScalingService {
 
     public ScalingPolicy putScalingPolicy(String region, String asgName, String policyName,
                                            String policyType, String adjustmentType,
-                                           int scalingAdjustment, int cooldown) {
+                                           int scalingAdjustment, int cooldown,
+                                           Integer estimatedInstanceWarmup,
+                                           ScalingPolicy.TargetTrackingConfiguration targetTrackingConfiguration) {
         requireGroup(region, asgName);
         String key = policyKey(region, asgName, policyName);
         ScalingPolicy policy = policies.computeIfAbsent(key, k -> new ScalingPolicy());
@@ -518,6 +520,8 @@ public class AutoScalingService {
         policy.setAdjustmentType(adjustmentType);
         policy.setScalingAdjustment(scalingAdjustment);
         policy.setCooldown(cooldown);
+        policy.setEstimatedInstanceWarmup(estimatedInstanceWarmup);
+        policy.setTargetTrackingConfiguration(targetTrackingConfiguration);
         policy.setRegion(region);
         policies.put(key, policy);
         return policy;

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/AutoScalingGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/AutoScalingGroup.java
@@ -19,6 +19,7 @@ public class AutoScalingGroup {
     private String launchTemplateId;
     private String launchTemplateName;
     private String launchTemplateVersion;
+    private MixedInstancesPolicy mixedInstancesPolicy;
     private int minSize;
     private int maxSize;
     private int desiredCapacity;
@@ -55,6 +56,9 @@ public class AutoScalingGroup {
 
     public String getLaunchTemplateVersion() { return launchTemplateVersion; }
     public void setLaunchTemplateVersion(String v) { this.launchTemplateVersion = v; }
+
+    public MixedInstancesPolicy getMixedInstancesPolicy() { return mixedInstancesPolicy; }
+    public void setMixedInstancesPolicy(MixedInstancesPolicy v) { this.mixedInstancesPolicy = v; }
 
     public int getMinSize() { return minSize; }
     public void setMinSize(int v) { this.minSize = v; }

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/MixedInstancesPolicy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/MixedInstancesPolicy.java
@@ -1,0 +1,86 @@
+package io.github.hectorvent.floci.services.autoscaling.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MixedInstancesPolicy {
+    private LaunchTemplate launchTemplate;
+    private InstancesDistribution instancesDistribution;
+
+    public MixedInstancesPolicy() {}
+
+    public LaunchTemplate getLaunchTemplate() { return launchTemplate; }
+    public void setLaunchTemplate(LaunchTemplate v) { this.launchTemplate = v; }
+
+    public InstancesDistribution getInstancesDistribution() { return instancesDistribution; }
+    public void setInstancesDistribution(InstancesDistribution v) { this.instancesDistribution = v; }
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class LaunchTemplate {
+        private LaunchTemplateSpecification launchTemplateSpecification;
+        private List<LaunchTemplateOverride> overrides = new ArrayList<>();
+
+        public LaunchTemplate() {}
+
+        public LaunchTemplateSpecification getLaunchTemplateSpecification() { return launchTemplateSpecification; }
+        public void setLaunchTemplateSpecification(LaunchTemplateSpecification v) { this.launchTemplateSpecification = v; }
+
+        public List<LaunchTemplateOverride> getOverrides() { return overrides; }
+        public void setOverrides(List<LaunchTemplateOverride> v) { this.overrides = v; }
+    }
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class LaunchTemplateSpecification {
+        private String launchTemplateId;
+        private String launchTemplateName;
+        private String version;
+
+        public LaunchTemplateSpecification() {}
+
+        public String getLaunchTemplateId() { return launchTemplateId; }
+        public void setLaunchTemplateId(String v) { this.launchTemplateId = v; }
+
+        public String getLaunchTemplateName() { return launchTemplateName; }
+        public void setLaunchTemplateName(String v) { this.launchTemplateName = v; }
+
+        public String getVersion() { return version; }
+        public void setVersion(String v) { this.version = v; }
+    }
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class LaunchTemplateOverride {
+        private String instanceType;
+
+        public LaunchTemplateOverride() {}
+
+        public String getInstanceType() { return instanceType; }
+        public void setInstanceType(String v) { this.instanceType = v; }
+    }
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class InstancesDistribution {
+        private Integer onDemandBaseCapacity;
+        private Integer onDemandPercentageAboveBaseCapacity;
+        private String spotAllocationStrategy;
+
+        public InstancesDistribution() {}
+
+        public Integer getOnDemandBaseCapacity() { return onDemandBaseCapacity; }
+        public void setOnDemandBaseCapacity(Integer v) { this.onDemandBaseCapacity = v; }
+
+        public Integer getOnDemandPercentageAboveBaseCapacity() { return onDemandPercentageAboveBaseCapacity; }
+        public void setOnDemandPercentageAboveBaseCapacity(Integer v) { this.onDemandPercentageAboveBaseCapacity = v; }
+
+        public String getSpotAllocationStrategy() { return spotAllocationStrategy; }
+        public void setSpotAllocationStrategy(String v) { this.spotAllocationStrategy = v; }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/ScalingPolicy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/ScalingPolicy.java
@@ -15,6 +15,8 @@ public class ScalingPolicy {
     private int scalingAdjustment;
     private int cooldown;
     private String metricAggregationType;
+    private Integer estimatedInstanceWarmup;
+    private TargetTrackingConfiguration targetTrackingConfiguration;
     private String region;
 
     public ScalingPolicy() {}
@@ -43,6 +45,38 @@ public class ScalingPolicy {
     public String getMetricAggregationType() { return metricAggregationType; }
     public void setMetricAggregationType(String v) { this.metricAggregationType = v; }
 
+    public Integer getEstimatedInstanceWarmup() { return estimatedInstanceWarmup; }
+    public void setEstimatedInstanceWarmup(Integer v) { this.estimatedInstanceWarmup = v; }
+
+    public TargetTrackingConfiguration getTargetTrackingConfiguration() { return targetTrackingConfiguration; }
+    public void setTargetTrackingConfiguration(TargetTrackingConfiguration v) { this.targetTrackingConfiguration = v; }
+
     public String getRegion() { return region; }
     public void setRegion(String v) { this.region = v; }
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class TargetTrackingConfiguration {
+        private PredefinedMetricSpecification predefinedMetricSpecification;
+        private Double targetValue;
+
+        public TargetTrackingConfiguration() {}
+
+        public PredefinedMetricSpecification getPredefinedMetricSpecification() { return predefinedMetricSpecification; }
+        public void setPredefinedMetricSpecification(PredefinedMetricSpecification v) { this.predefinedMetricSpecification = v; }
+
+        public Double getTargetValue() { return targetValue; }
+        public void setTargetValue(Double v) { this.targetValue = v; }
+    }
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class PredefinedMetricSpecification {
+        private String predefinedMetricType;
+
+        public PredefinedMetricSpecification() {}
+
+        public String getPredefinedMetricType() { return predefinedMetricType; }
+        public void setPredefinedMetricType(String v) { this.predefinedMetricType = v; }
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -777,6 +777,7 @@ public class CloudFormationResourceProvisioner {
 
         var asg = autoScalingService.createAutoScalingGroup(region, name,
                 blankToNull(launchConfigName), null, blankToNull(launchTemplateName), blankToNull(launchTemplateVersion),
+                null,
                 parseIntProp(props, "MinSize", engine, 0),
                 parseIntProp(props, "MaxSize", engine, 0),
                 parseIntProp(props, "DesiredCapacity", engine, 0),

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingIntegrationTest.java
@@ -332,10 +332,51 @@ class AutoScalingIntegrationTest {
                 .body(not(containsString("scale-out")));
     }
 
+    @Test
+    @Order(17)
+    void putTargetTrackingScalingPolicy() {
+        given()
+                .formParam("Action", "PutScalingPolicy")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .formParam("PolicyName", "cpu-target")
+                .formParam("PolicyType", "TargetTrackingScaling")
+                .formParam("EstimatedInstanceWarmup", "180")
+                .formParam("TargetTrackingConfiguration.PredefinedMetricSpecification.PredefinedMetricType",
+                        "ASGAverageCPUUtilization")
+                .formParam("TargetTrackingConfiguration.TargetValue", "55.5")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("PolicyARN"));
+    }
+
+    @Test
+    @Order(18)
+    void describeTargetTrackingScalingPolicy() {
+        given()
+                .formParam("Action", "DescribePolicies")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .formParam("PolicyNames.member.1", "cpu-target")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<PolicyName>cpu-target</PolicyName>"))
+                .body(containsString("<PolicyType>TargetTrackingScaling</PolicyType>"))
+                .body(containsString("<EstimatedInstanceWarmup>180</EstimatedInstanceWarmup>"))
+                .body(containsString("<TargetTrackingConfiguration>"))
+                .body(containsString("<PredefinedMetricSpecification>"))
+                .body(containsString("<PredefinedMetricType>ASGAverageCPUUtilization</PredefinedMetricType>"))
+                .body(containsString("<TargetValue>55.5</TargetValue>"));
+    }
+
     // ── Metadata ──────────────────────────────────────────────────────────────
 
     @Test
-    @Order(17)
+    @Order(19)
     void describeTerminationPolicyTypes() {
         given()
                 .formParam("Action", "DescribeTerminationPolicyTypes")
@@ -349,7 +390,7 @@ class AutoScalingIntegrationTest {
     }
 
     @Test
-    @Order(18)
+    @Order(20)
     void describeAccountLimits() {
         given()
                 .formParam("Action", "DescribeAccountLimits")
@@ -362,7 +403,7 @@ class AutoScalingIntegrationTest {
     }
 
     @Test
-    @Order(19)
+    @Order(21)
     void describeLifecycleHookTypes() {
         given()
                 .formParam("Action", "DescribeLifecycleHookTypes")
@@ -376,7 +417,7 @@ class AutoScalingIntegrationTest {
     }
 
     @Test
-    @Order(20)
+    @Order(22)
     void describeScalingActivities() {
         given()
                 .formParam("Action", "DescribeScalingActivities")
@@ -390,7 +431,7 @@ class AutoScalingIntegrationTest {
     }
 
     @Test
-    @Order(21)
+    @Order(23)
     void createAutoScalingGroupWithLaunchTemplateId() {
         given()
                 .formParam("Action", "CreateAutoScalingGroup")
@@ -425,7 +466,7 @@ class AutoScalingIntegrationTest {
     }
 
     @Test
-    @Order(22)
+    @Order(24)
     void describeAutoScalingGroupWithLaunchTemplateId() {
         given()
                 .formParam("Action", "DescribeAutoScalingGroups")
@@ -466,7 +507,7 @@ class AutoScalingIntegrationTest {
     }
 
     @Test
-    @Order(23)
+    @Order(25)
     void startInstanceRefresh() {
         instanceRefreshId = given()
                 .formParam("Action", "StartInstanceRefresh")
@@ -495,7 +536,7 @@ class AutoScalingIntegrationTest {
     }
 
     @Test
-    @Order(24)
+    @Order(26)
     void describeInstanceRefreshes() {
         String body = given()
                 .formParam("Action", "DescribeInstanceRefreshes")
@@ -537,7 +578,7 @@ class AutoScalingIntegrationTest {
     }
 
     @Test
-    @Order(25)
+    @Order(27)
     void describeInstanceRefreshesPaginatesNewestFirst() {
         pagedInstanceRefreshId = given()
                 .formParam("Action", "StartInstanceRefresh")
@@ -581,7 +622,7 @@ class AutoScalingIntegrationTest {
     }
 
     @Test
-    @Order(26)
+    @Order(28)
     void deleteLaunchTemplateAutoScalingGroup() {
         given()
                 .formParam("Action", "DeleteAutoScalingGroup")
@@ -598,7 +639,7 @@ class AutoScalingIntegrationTest {
     // ── Cleanup ───────────────────────────────────────────────────────────────
 
     @Test
-    @Order(27)
+    @Order(29)
     void deleteAutoScalingGroup() {
         given()
                 .formParam("Action", "DeleteAutoScalingGroup")
@@ -613,7 +654,7 @@ class AutoScalingIntegrationTest {
     }
 
     @Test
-    @Order(28)
+    @Order(30)
     void deleteLaunchConfiguration() {
         given()
                 .formParam("Action", "DeleteLaunchConfiguration")
@@ -627,7 +668,7 @@ class AutoScalingIntegrationTest {
     }
 
     @Test
-    @Order(29)
+    @Order(31)
     void describeAutoScalingGroupsEmpty() {
         given()
                 .formParam("Action", "DescribeAutoScalingGroups")

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingIntegrationTest.java
@@ -623,6 +623,123 @@ class AutoScalingIntegrationTest {
 
     @Test
     @Order(28)
+    void createAutoScalingGroupWithMixedInstancesPolicy() {
+        given()
+                .formParam("Action", "CreateAutoScalingGroup")
+                .formParam("AutoScalingGroupName", "my-mixed-asg")
+                .formParam("MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification.LaunchTemplateId",
+                        "lt-mixed")
+                .formParam("MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification.Version", "3")
+                .formParam("MixedInstancesPolicy.LaunchTemplate.Overrides.member.1.InstanceType", "t4g.medium")
+                .formParam("MixedInstancesPolicy.LaunchTemplate.Overrides.member.2.InstanceType", "m7g.large")
+                .formParam("MixedInstancesPolicy.InstancesDistribution.OnDemandBaseCapacity", "1")
+                .formParam("MixedInstancesPolicy.InstancesDistribution.OnDemandPercentageAboveBaseCapacity", "25")
+                .formParam("MixedInstancesPolicy.InstancesDistribution.SpotAllocationStrategy", "capacity-optimized")
+                .formParam("MinSize", "0")
+                .formParam("MaxSize", "4")
+                .formParam("DesiredCapacity", "1")
+                .formParam("AvailabilityZones.member.1", "us-east-1a")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("CreateAutoScalingGroupResponse"));
+
+        given()
+                .formParam("Action", "DescribeAutoScalingGroups")
+                .formParam("AutoScalingGroupNames.member.1", "my-mixed-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<MixedInstancesPolicy>"))
+                .body(containsString("<LaunchTemplateSpecification>"))
+                .body(containsString("<LaunchTemplateId>lt-mixed</LaunchTemplateId>"))
+                .body(containsString("<Version>3</Version>"))
+                .body(containsString("<InstanceType>t4g.medium</InstanceType>"))
+                .body(containsString("<InstanceType>m7g.large</InstanceType>"))
+                .body(containsString("<OnDemandBaseCapacity>1</OnDemandBaseCapacity>"))
+                .body(containsString("<OnDemandPercentageAboveBaseCapacity>25</OnDemandPercentageAboveBaseCapacity>"))
+                .body(containsString("<SpotAllocationStrategy>capacity-optimized</SpotAllocationStrategy>"));
+    }
+
+    @Test
+    @Order(29)
+    void updateAutoScalingGroupFromLaunchTemplateToMixedInstancesPolicy() {
+        given()
+                .formParam("Action", "UpdateAutoScalingGroup")
+                .formParam("AutoScalingGroupName", "my-lt-asg")
+                .formParam("MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification.LaunchTemplateId",
+                        "lt-replacement")
+                .formParam("MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification.Version", "4")
+                .formParam("MixedInstancesPolicy.LaunchTemplate.Overrides.member.1.InstanceType", "c7g.large")
+                .formParam("MixedInstancesPolicy.InstancesDistribution.OnDemandBaseCapacity", "0")
+                .formParam("MixedInstancesPolicy.InstancesDistribution.OnDemandPercentageAboveBaseCapacity", "10")
+                .formParam("MixedInstancesPolicy.InstancesDistribution.SpotAllocationStrategy", "lowest-price")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("UpdateAutoScalingGroupResponse"));
+
+        given()
+                .formParam("Action", "DescribeAutoScalingGroups")
+                .formParam("AutoScalingGroupNames.member.1", "my-lt-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<MixedInstancesPolicy>"))
+                .body(containsString("<LaunchTemplateId>lt-replacement</LaunchTemplateId>"))
+                .body(containsString("<Version>4</Version>"))
+                .body(containsString("<InstanceType>c7g.large</InstanceType>"))
+                .body(containsString("<OnDemandBaseCapacity>0</OnDemandBaseCapacity>"))
+                .body(containsString("<OnDemandPercentageAboveBaseCapacity>10</OnDemandPercentageAboveBaseCapacity>"))
+                .body(containsString("<SpotAllocationStrategy>lowest-price</SpotAllocationStrategy>"));
+    }
+
+    @Test
+    @Order(30)
+    void updateMixedInstancesPolicyOverridesAndDistribution() {
+        given()
+                .formParam("Action", "UpdateAutoScalingGroup")
+                .formParam("AutoScalingGroupName", "my-mixed-asg")
+                .formParam("MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification.LaunchTemplateId",
+                        "lt-mixed")
+                .formParam("MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification.Version", "5")
+                .formParam("MixedInstancesPolicy.LaunchTemplate.Overrides.member.1.InstanceType", "r7g.large")
+                .formParam("MixedInstancesPolicy.InstancesDistribution.OnDemandBaseCapacity", "2")
+                .formParam("MixedInstancesPolicy.InstancesDistribution.OnDemandPercentageAboveBaseCapacity", "50")
+                .formParam("MixedInstancesPolicy.InstancesDistribution.SpotAllocationStrategy", "price-capacity-optimized")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("UpdateAutoScalingGroupResponse"));
+
+        given()
+                .formParam("Action", "DescribeAutoScalingGroups")
+                .formParam("AutoScalingGroupNames.member.1", "my-mixed-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<Version>5</Version>"))
+                .body(containsString("<InstanceType>r7g.large</InstanceType>"))
+                .body(not(containsString("<InstanceType>t4g.medium</InstanceType>")))
+                .body(containsString("<OnDemandBaseCapacity>2</OnDemandBaseCapacity>"))
+                .body(containsString("<OnDemandPercentageAboveBaseCapacity>50</OnDemandPercentageAboveBaseCapacity>"))
+                .body(containsString("<SpotAllocationStrategy>price-capacity-optimized</SpotAllocationStrategy>"));
+    }
+
+    @Test
+    @Order(31)
     void deleteLaunchTemplateAutoScalingGroup() {
         given()
                 .formParam("Action", "DeleteAutoScalingGroup")
@@ -639,7 +756,7 @@ class AutoScalingIntegrationTest {
     // ── Cleanup ───────────────────────────────────────────────────────────────
 
     @Test
-    @Order(29)
+    @Order(32)
     void deleteAutoScalingGroup() {
         given()
                 .formParam("Action", "DeleteAutoScalingGroup")
@@ -654,7 +771,22 @@ class AutoScalingIntegrationTest {
     }
 
     @Test
-    @Order(30)
+    @Order(33)
+    void deleteMixedInstancesAutoScalingGroup() {
+        given()
+                .formParam("Action", "DeleteAutoScalingGroup")
+                .formParam("AutoScalingGroupName", "my-mixed-asg")
+                .formParam("ForceDelete", "true")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("DeleteAutoScalingGroupResponse"));
+    }
+
+    @Test
+    @Order(34)
     void deleteLaunchConfiguration() {
         given()
                 .formParam("Action", "DeleteLaunchConfiguration")
@@ -668,7 +800,7 @@ class AutoScalingIntegrationTest {
     }
 
     @Test
-    @Order(31)
+    @Order(35)
     void describeAutoScalingGroupsEmpty() {
         given()
                 .formParam("Action", "DescribeAutoScalingGroups")

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandlerTest.java
@@ -25,6 +25,7 @@ class AutoScalingQueryHandlerTest {
                 "lt-original",
                 null,
                 "1",
+                null,
                 0,
                 3,
                 1,
@@ -89,6 +90,7 @@ class AutoScalingQueryHandlerTest {
                 "lt-current",
                 null,
                 "$Latest",
+                null,
                 0,
                 3,
                 1,
@@ -137,6 +139,7 @@ class AutoScalingQueryHandlerTest {
                 "lt-current",
                 null,
                 "$Latest",
+                null,
                 0,
                 3,
                 1,
@@ -180,5 +183,49 @@ class AutoScalingQueryHandlerTest {
         assertTrue(xml.contains("<PredefinedMetricSpecification>"));
         assertTrue(xml.contains("<PredefinedMetricType>ASGAverageCPUUtilization</PredefinedMetricType>"));
         assertTrue(xml.contains("<TargetValue>55.5</TargetValue>"));
+    }
+
+    @Test
+    void createAutoScalingGroupWithMixedInstancesPolicyUsesAwsQueryXmlShape() {
+        AutoScalingService service = new AutoScalingService();
+        service.regionResolver = new RegionResolver(REGION, "000000000000");
+        AutoScalingQueryHandler handler = new AutoScalingQueryHandler(service);
+
+        MultivaluedHashMap<String, String> createParams = new MultivaluedHashMap<>();
+        createParams.add("AutoScalingGroupName", "mixed-asg");
+        createParams.add("MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification.LaunchTemplateId",
+                "lt-mixed");
+        createParams.add("MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification.Version", "3");
+        createParams.add("MixedInstancesPolicy.LaunchTemplate.Overrides.member.1.InstanceType", "t4g.medium");
+        createParams.add("MixedInstancesPolicy.LaunchTemplate.Overrides.member.2.InstanceType", "m7g.large");
+        createParams.add("MixedInstancesPolicy.InstancesDistribution.OnDemandBaseCapacity", "1");
+        createParams.add("MixedInstancesPolicy.InstancesDistribution.OnDemandPercentageAboveBaseCapacity", "25");
+        createParams.add("MixedInstancesPolicy.InstancesDistribution.SpotAllocationStrategy", "capacity-optimized");
+        createParams.add("MinSize", "0");
+        createParams.add("MaxSize", "4");
+        createParams.add("DesiredCapacity", "1");
+        createParams.add("AvailabilityZones.member.1", "us-east-1a");
+
+        Response createResponse = handler.handle("CreateAutoScalingGroup", createParams, REGION);
+
+        assertEquals(200, createResponse.getStatus());
+
+        MultivaluedHashMap<String, String> describeParams = new MultivaluedHashMap<>();
+        describeParams.add("AutoScalingGroupNames.member.1", "mixed-asg");
+
+        Response describeResponse = handler.handle("DescribeAutoScalingGroups", describeParams, REGION);
+
+        assertEquals(200, describeResponse.getStatus());
+        String xml = (String) describeResponse.getEntity();
+        assertTrue(xml.contains("<MixedInstancesPolicy>"));
+        assertTrue(xml.contains("<LaunchTemplateSpecification>"));
+        assertTrue(xml.contains("<LaunchTemplateId>lt-mixed</LaunchTemplateId>"));
+        assertTrue(xml.contains("<Version>3</Version>"));
+        assertTrue(xml.contains("<Overrides>"));
+        assertTrue(xml.contains("<InstanceType>t4g.medium</InstanceType>"));
+        assertTrue(xml.contains("<InstanceType>m7g.large</InstanceType>"));
+        assertTrue(xml.contains("<OnDemandBaseCapacity>1</OnDemandBaseCapacity>"));
+        assertTrue(xml.contains("<OnDemandPercentageAboveBaseCapacity>25</OnDemandPercentageAboveBaseCapacity>"));
+        assertTrue(xml.contains("<SpotAllocationStrategy>capacity-optimized</SpotAllocationStrategy>"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandlerTest.java
@@ -126,4 +126,59 @@ class AutoScalingQueryHandlerTest {
         assertTrue(xml.contains("<LaunchTemplateId>lt-current</LaunchTemplateId>"));
         assertTrue(xml.contains("<Version>7</Version>"));
     }
+
+    @Test
+    void targetTrackingScalingPolicyUsesAwsQueryXmlShape() {
+        AutoScalingService service = new AutoScalingService();
+        service.regionResolver = new RegionResolver(REGION, "000000000000");
+        service.createAutoScalingGroup(REGION,
+                "target-tracking-asg",
+                null,
+                "lt-current",
+                null,
+                "$Latest",
+                0,
+                3,
+                1,
+                300,
+                List.of("us-east-1a"),
+                List.of(),
+                List.of(),
+                List.of(),
+                "EC2",
+                0,
+                List.of("Default"),
+                java.util.Map.of());
+
+        AutoScalingQueryHandler handler = new AutoScalingQueryHandler(service);
+        MultivaluedHashMap<String, String> putParams = new MultivaluedHashMap<>();
+        putParams.add("AutoScalingGroupName", "target-tracking-asg");
+        putParams.add("PolicyName", "cpu-target");
+        putParams.add("PolicyType", "TargetTrackingScaling");
+        putParams.add("EstimatedInstanceWarmup", "180");
+        putParams.add("TargetTrackingConfiguration.PredefinedMetricSpecification.PredefinedMetricType",
+                "ASGAverageCPUUtilization");
+        putParams.add("TargetTrackingConfiguration.TargetValue", "55.5");
+
+        Response putResponse = handler.handle("PutScalingPolicy", putParams, REGION);
+
+        assertEquals(200, putResponse.getStatus());
+        assertTrue(((String) putResponse.getEntity()).contains("<PolicyARN>"));
+
+        MultivaluedHashMap<String, String> describeParams = new MultivaluedHashMap<>();
+        describeParams.add("AutoScalingGroupName", "target-tracking-asg");
+        describeParams.add("PolicyNames.member.1", "cpu-target");
+
+        Response describeResponse = handler.handle("DescribePolicies", describeParams, REGION);
+
+        assertEquals(200, describeResponse.getStatus());
+        String xml = (String) describeResponse.getEntity();
+        assertTrue(xml.contains("<PolicyName>cpu-target</PolicyName>"));
+        assertTrue(xml.contains("<PolicyType>TargetTrackingScaling</PolicyType>"));
+        assertTrue(xml.contains("<EstimatedInstanceWarmup>180</EstimatedInstanceWarmup>"));
+        assertTrue(xml.contains("<TargetTrackingConfiguration>"));
+        assertTrue(xml.contains("<PredefinedMetricSpecification>"));
+        assertTrue(xml.contains("<PredefinedMetricType>ASGAverageCPUUtilization</PredefinedMetricType>"));
+        assertTrue(xml.contains("<TargetValue>55.5</TargetValue>"));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconcilerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconcilerTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.autoscaling;
 
 import io.github.hectorvent.floci.services.autoscaling.model.AsgInstance;
 import io.github.hectorvent.floci.services.autoscaling.model.AutoScalingGroup;
+import io.github.hectorvent.floci.services.autoscaling.model.MixedInstancesPolicy;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.ec2.model.Instance;
 import io.github.hectorvent.floci.services.ec2.model.InstanceState;
@@ -74,7 +75,7 @@ class AutoScalingReconcilerTest {
         version.setLatestVersionNumber("1");
         version.setImageId("ami-version-1");
         version.setInstanceType("t3.micro");
-        List<Tag> instanceTags = List.of(new Tag("io.iceguard.ClusterId", "development"));
+        List<Tag> instanceTags = List.of(new Tag("app.ClusterId", "development"));
         version.setInstanceTags(instanceTags);
         when(ec2Service.describeLaunchTemplates("us-east-1", List.of("lt-123"), List.of(), Map.of()))
                 .thenReturn(List.of(launchTemplate));
@@ -134,6 +135,61 @@ class AutoScalingReconcilerTest {
 
         assertEquals("$Latest", asg.getLaunchTemplateVersion());
         assertEquals("7", asg.getInstances().getFirst().getLaunchTemplateVersion());
+    }
+
+    @Test
+    void scaleOutUsesMixedInstancesLaunchTemplateSpecification() {
+        AutoScalingService asgService = mock(AutoScalingService.class);
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        ElbV2Service elbV2Service = mock(ElbV2Service.class);
+        AutoScalingReconciler reconciler = new AutoScalingReconciler(asgService, ec2Service, elbV2Service);
+        AutoScalingGroup asg = new AutoScalingGroup();
+        asg.setRegion("us-east-1");
+        asg.setAutoScalingGroupName("app-asg");
+        asg.setDesiredCapacity(1);
+        MixedInstancesPolicy policy = new MixedInstancesPolicy();
+        MixedInstancesPolicy.LaunchTemplate launchTemplatePolicy =
+                new MixedInstancesPolicy.LaunchTemplate();
+        MixedInstancesPolicy.LaunchTemplateSpecification specification =
+                new MixedInstancesPolicy.LaunchTemplateSpecification();
+        specification.setLaunchTemplateId("lt-123");
+        specification.setVersion("3");
+        launchTemplatePolicy.setLaunchTemplateSpecification(specification);
+        MixedInstancesPolicy.LaunchTemplateOverride override =
+                new MixedInstancesPolicy.LaunchTemplateOverride();
+        override.setInstanceType("t3.small");
+        launchTemplatePolicy.setOverrides(List.of(override));
+        policy.setLaunchTemplate(launchTemplatePolicy);
+        asg.setMixedInstancesPolicy(policy);
+
+        LaunchTemplate launchTemplate = new LaunchTemplate();
+        launchTemplate.setLaunchTemplateId("lt-123");
+        LaunchTemplate version = new LaunchTemplate();
+        version.setLatestVersionNumber("3");
+        version.setImageId("ami-version-3");
+        version.setInstanceType("t3.micro");
+        when(ec2Service.describeLaunchTemplates("us-east-1", List.of("lt-123"), List.of(), Map.of()))
+                .thenReturn(List.of(launchTemplate));
+        when(ec2Service.describeLaunchTemplateVersions("us-east-1", "lt-123", null, List.of("3")))
+                .thenReturn(List.of(version));
+        Instance ec2Instance = new Instance();
+        ec2Instance.setInstanceId("i-launched");
+        Reservation reservation = new Reservation();
+        reservation.setInstances(List.of(ec2Instance));
+        when(ec2Service.runInstances(eq("us-east-1"), eq("ami-version-3"), eq("t3.small"),
+                eq(1), eq(1), eq(null), eq(List.of()), eq(null), eq(null),
+                eq(List.of()), eq(null), eq(null))).thenReturn(reservation);
+
+        reconciler.reconcile(asg);
+
+        assertEquals(1, asg.getInstances().size());
+        assertEquals("i-launched", asg.getInstances().getFirst().getInstanceId());
+        assertEquals("lt-123", asg.getInstances().getFirst().getLaunchTemplateId());
+        assertEquals("3", asg.getInstances().getFirst().getLaunchTemplateVersion());
+        assertEquals("t3.small", asg.getInstances().getFirst().getInstanceType());
+        verify(ec2Service).runInstances(eq("us-east-1"), eq("ami-version-3"), eq("t3.small"),
+                eq(1), eq(1), eq(null), eq(List.of()), eq(null), eq(null),
+                eq(List.of()), eq(null), eq(null));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconcilerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconcilerTest.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.services.ec2.model.Instance;
 import io.github.hectorvent.floci.services.ec2.model.InstanceState;
 import io.github.hectorvent.floci.services.ec2.model.LaunchTemplate;
 import io.github.hectorvent.floci.services.ec2.model.Reservation;
+import io.github.hectorvent.floci.services.ec2.model.Tag;
 import io.github.hectorvent.floci.services.elbv2.ElbV2Service;
 import io.github.hectorvent.floci.services.elbv2.model.TargetDescription;
 import io.github.hectorvent.floci.services.elbv2.model.TargetHealth;
@@ -73,6 +74,8 @@ class AutoScalingReconcilerTest {
         version.setLatestVersionNumber("1");
         version.setImageId("ami-version-1");
         version.setInstanceType("t3.micro");
+        List<Tag> instanceTags = List.of(new Tag("io.iceguard.ClusterId", "development"));
+        version.setInstanceTags(instanceTags);
         when(ec2Service.describeLaunchTemplates("us-east-1", List.of("lt-123"), List.of(), Map.of()))
                 .thenReturn(List.of(launchTemplate));
         when(ec2Service.describeLaunchTemplateVersions("us-east-1", "lt-123", null, List.of("1")))
@@ -83,7 +86,7 @@ class AutoScalingReconcilerTest {
         reservation.setInstances(List.of(ec2Instance));
         when(ec2Service.runInstances(eq("us-east-1"), eq("ami-version-1"), eq("t3.micro"),
                 eq(1), eq(1), eq(null), eq(List.of()), eq(null), eq(null),
-                eq(List.of()), eq(null), eq(null))).thenReturn(reservation);
+                eq(instanceTags), eq(null), eq(null))).thenReturn(reservation);
 
         reconciler.reconcile(asg);
 
@@ -93,7 +96,7 @@ class AutoScalingReconcilerTest {
         assertEquals("1", asg.getInstances().getFirst().getLaunchTemplateVersion());
         verify(ec2Service).runInstances(eq("us-east-1"), eq("ami-version-1"), eq("t3.micro"),
                 eq(1), eq(1), eq(null), eq(List.of()), eq(null), eq(null),
-                eq(List.of()), eq(null), eq(null));
+                eq(instanceTags), eq(null), eq(null));
     }
 
     @Test
@@ -160,6 +163,77 @@ class AutoScalingReconcilerTest {
         assertEquals("i-stale", targets.getValue().getFirst().getId());
         verify(asgService).saveAutoScalingGroup(asg);
         verify(ec2Service, never()).terminateInstances(asg.getRegion(), List.of("i-active"));
+    }
+
+    @Test
+    void reconcileKeepsPendingInstancesWhileContainerLaunchIsStillInFlight() {
+        AutoScalingService asgService = mock(AutoScalingService.class);
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        ElbV2Service elbV2Service = mock(ElbV2Service.class);
+        AutoScalingReconciler reconciler = new AutoScalingReconciler(asgService, ec2Service, elbV2Service);
+        AutoScalingGroup asg = new AutoScalingGroup();
+        asg.setRegion("us-east-1");
+        asg.setAutoScalingGroupName("app-asg");
+        asg.setDesiredCapacity(1);
+        asg.getInstances().add(instance("i-pending", "Pending"));
+
+        Instance ec2Instance = new Instance();
+        ec2Instance.setInstanceId("i-pending");
+        ec2Instance.setState(InstanceState.pending());
+        Reservation reservation = new Reservation();
+        reservation.setInstances(List.of(ec2Instance));
+        when(ec2Service.describeInstances("us-east-1", List.of("i-pending"), null))
+                .thenReturn(List.of(reservation));
+        when(ec2Service.isInstanceContainerRunning("i-pending")).thenReturn(false);
+
+        reconciler.reconcile(asg);
+
+        assertEquals(1, asg.getInstances().size());
+        assertEquals("i-pending", asg.getInstances().getFirst().getInstanceId());
+        verify(ec2Service, never()).runInstances(
+                eq("us-east-1"),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyInt(),
+                org.mockito.ArgumentMatchers.anyInt(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void reconcilePrunesPendingInstancesWhenEc2InstanceIsTerminal() {
+        AutoScalingService asgService = mock(AutoScalingService.class);
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        ElbV2Service elbV2Service = mock(ElbV2Service.class);
+        AutoScalingReconciler reconciler = new AutoScalingReconciler(asgService, ec2Service, elbV2Service);
+        AutoScalingGroup asg = new AutoScalingGroup();
+        asg.setRegion("us-east-1");
+        asg.setAutoScalingGroupName("app-asg");
+        asg.setDesiredCapacity(0);
+        asg.getInstances().add(instance("i-dead", "Pending"));
+
+        Instance ec2Instance = new Instance();
+        ec2Instance.setInstanceId("i-dead");
+        ec2Instance.setState(InstanceState.terminated());
+        Reservation reservation = new Reservation();
+        reservation.setInstances(List.of(ec2Instance));
+        when(ec2Service.describeInstances("us-east-1", List.of("i-dead"), null))
+                .thenReturn(List.of(reservation));
+
+        reconciler.reconcile(asg);
+
+        assertEquals(0, asg.getInstances().size());
+        verify(asgService).recordActivity(
+                eq("us-east-1"),
+                eq("app-asg"),
+                eq("Removing stale EC2 instance reference(s): [i-dead]"),
+                eq("Persisted Auto Scaling state referenced instance containers that are no longer running."),
+                eq("Successful"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingServiceTest.java
@@ -30,6 +30,7 @@ class AutoScalingServiceTest {
                 "lt-original",
                 null,
                 "1",
+                null,
                 0,
                 3,
                 1,


### PR DESCRIPTION
## Summary

Adds Auto Scaling compatibility for target tracking scaling policies, mixed instances policies, and launch template capacity metadata used during reconciliation.

## Type of change

- [x] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

- `PutScalingPolicy` and `DescribePolicies` now round-trip `TargetTrackingScaling` configuration, including predefined metric type, target value, and estimated warmup.
- `CreateAutoScalingGroup`, `UpdateAutoScalingGroup`, and `DescribeAutoScalingGroups` now preserve `MixedInstancesPolicy`, including launch template specification, overrides, and instances distribution fields.
- Auto Scaling reconciliation now preserves capacity-relevant launch template metadata when launching instances from top-level or mixed-instances launch templates.

## Verification

- `./mvnw -Dtest="AutoScalingIntegrationTest,AutoScalingQueryHandlerTest,AutoScalingReconcilerTest,AutoScalingServiceTest" test` - 62 tests, 0 failures, 0 errors
- `./mvnw test` - 6094 tests, 0 failures, 0 errors, 8 skipped

## Checklist

- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits
