### PR TITLE
feat(cloudformation): generate implicit API Gateway from SAM Api events

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessor.java
@@ -64,6 +64,9 @@ class SamTransformProcessor {
             }
         });
 
+        // Collect implicit-API routes from function Api events before the functions are expanded.
+        List<ApiRoute> apiRoutes = collectApiRoutes(samLogicalIds, resources);
+
         for (String logicalId : samLogicalIds) {
             JsonNode resDef = resources.get(logicalId);
             String type = resDef.path("Type").asText();
@@ -80,7 +83,218 @@ class SamTransformProcessor {
             }
         }
 
+        // Synthesize the implicit REST API (RestApi + resources + methods + AWS_PROXY integrations +
+        // deployment + stage + lambda permissions) for functions that declare Api events without an
+        // explicit RestApiId — matching SAM's implicit-API behavior so the deployed service is reachable.
+        if (!apiRoutes.isEmpty()) {
+            generateImplicitApi(apiRoutes, globals(template), expandedResources);
+        }
+
         return expanded;
+    }
+
+    private JsonNode globals(JsonNode template) {
+        return template.path("Globals");
+    }
+
+    private record ApiRoute(String functionLogicalId, String path, String httpMethod) {}
+
+    private List<ApiRoute> collectApiRoutes(List<String> samLogicalIds, JsonNode resources) {
+        List<ApiRoute> routes = new ArrayList<>();
+        for (String logicalId : samLogicalIds) {
+            JsonNode resDef = resources.get(logicalId);
+            if (!"AWS::Serverless::Function".equals(resDef.path("Type").asText())) {
+                continue;
+            }
+            JsonNode events = resDef.path("Properties").path("Events");
+            if (!events.isObject()) {
+                continue;
+            }
+            Iterator<Map.Entry<String, JsonNode>> it = events.fields();
+            while (it.hasNext()) {
+                JsonNode ev = it.next().getValue();
+                if (!"Api".equals(ev.path("Type").asText())) {
+                    continue;
+                }
+                JsonNode p = ev.path("Properties");
+                JsonNode restApiId = p.path("RestApiId");
+                if (!restApiId.isMissingNode() && !restApiId.isNull()) {
+                    continue; // bound to an explicit API — not an implicit-API route (null == implicit)
+                }
+                String path = p.path("Path").asText(null);
+                if (path != null) {
+                    routes.add(new ApiRoute(logicalId, path, p.path("Method").asText("ANY")));
+                }
+            }
+        }
+        return routes;
+    }
+
+    private void generateImplicitApi(List<ApiRoute> routes, JsonNode globals, ObjectNode resources) {
+        // Collision-safe: reuse "ServerlessRestApi" when free, otherwise a suffixed id, so an existing
+        // resource with that logical id is never silently overwritten.
+        final String apiId = uniqueId("ServerlessRestApi", resources);
+
+        ObjectNode api = objectMapper.createObjectNode();
+        api.put("Type", "AWS::ApiGateway::RestApi");
+        ObjectNode apiProps = objectMapper.createObjectNode();
+        JsonNode globalName = globals.path("Api").path("Name");
+        if (globalName.isMissingNode() || globalName.isNull()) {
+            apiProps.put("Name", apiId);
+        } else {
+            apiProps.set("Name", globalName.deepCopy());
+        }
+        api.set("Properties", apiProps);
+        resources.set(apiId, api);
+
+        Map<String, String> pathToResource = new java.util.LinkedHashMap<>();
+        List<String> methodIds = new ArrayList<>();
+        java.util.Set<String> permissionFns = new java.util.LinkedHashSet<>();
+        java.util.Set<String> seenRoutes = new java.util.LinkedHashSet<>();
+
+        for (ApiRoute r : routes) {
+            String method = r.httpMethod().toUpperCase();
+            if (!seenRoutes.add(r.path() + " " + method)) {
+                continue; // API Gateway allows one method per verb per resource — skip duplicate (path, method)
+            }
+            String resourceId = ensureResourcePath(apiId, r.path(), pathToResource, resources);
+
+            String methodLogicalId = uniqueId(apiId + "Method" + sanitize(r.path()) + capitalize(method.toLowerCase()), resources);
+            ObjectNode m = objectMapper.createObjectNode();
+            m.put("Type", "AWS::ApiGateway::Method");
+            ObjectNode mp = objectMapper.createObjectNode();
+            mp.set("RestApiId", ref(apiId));
+            mp.set("ResourceId", resourceId == null ? getAtt(apiId, "RootResourceId") : ref(resourceId));
+            mp.put("HttpMethod", method);
+            mp.put("AuthorizationType", "NONE");
+            ObjectNode integ = objectMapper.createObjectNode();
+            integ.put("Type", "AWS_PROXY");
+            integ.put("IntegrationHttpMethod", "POST");
+            integ.set("Uri", lambdaInvokeUri(r.functionLogicalId()));
+            mp.set("Integration", integ);
+            m.set("Properties", mp);
+            resources.set(methodLogicalId, m);
+            methodIds.add(methodLogicalId);
+            permissionFns.add(r.functionLogicalId());
+        }
+
+        for (String fn : permissionFns) {
+            ObjectNode perm = objectMapper.createObjectNode();
+            perm.put("Type", "AWS::Lambda::Permission");
+            ObjectNode pp = objectMapper.createObjectNode();
+            pp.set("FunctionName", ref(fn));
+            pp.put("Action", "lambda:InvokeFunction");
+            pp.put("Principal", "apigateway.amazonaws.com");
+            perm.set("Properties", pp);
+            resources.set(uniqueId(fn + "ApiPermission", resources), perm);
+        }
+
+        String deploymentId = apiId + "Deployment";
+        ObjectNode dep = objectMapper.createObjectNode();
+        dep.put("Type", "AWS::ApiGateway::Deployment");
+        ObjectNode dp = objectMapper.createObjectNode();
+        dp.set("RestApiId", ref(apiId));
+        dep.set("Properties", dp);
+        ArrayNode dependsOn = objectMapper.createArrayNode();
+        methodIds.forEach(dependsOn::add);
+        dep.set("DependsOn", dependsOn);
+        resources.set(deploymentId, dep);
+
+        ObjectNode stage = objectMapper.createObjectNode();
+        stage.put("Type", "AWS::ApiGateway::Stage");
+        ObjectNode sp = objectMapper.createObjectNode();
+        sp.set("RestApiId", ref(apiId));
+        sp.set("DeploymentId", ref(deploymentId));
+        sp.put("StageName", "Prod");
+        stage.set("Properties", sp);
+        resources.set(apiId + "ProdStage", stage);
+    }
+
+    /** Builds the API Gateway resource chain for a path; returns the leaf resource logical id (null = root). */
+    private String ensureResourcePath(String apiId, String path, Map<String, String> pathToResource, ObjectNode resources) {
+        String trimmed = path.startsWith("/") ? path.substring(1) : path;
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        String cumulative = "";
+        String parentResourceId = null;
+        String leaf = null;
+        for (String segment : trimmed.split("/")) {
+            if (segment.isEmpty()) {
+                continue;
+            }
+            cumulative = cumulative + "/" + segment;
+            String resId = pathToResource.get(cumulative);
+            if (resId == null) {
+                resId = uniqueId(apiId + "Resource" + sanitize(cumulative), resources);
+                ObjectNode res = objectMapper.createObjectNode();
+                res.put("Type", "AWS::ApiGateway::Resource");
+                ObjectNode rp = objectMapper.createObjectNode();
+                rp.set("RestApiId", ref(apiId));
+                rp.set("ParentId", parentResourceId == null ? getAtt(apiId, "RootResourceId") : ref(parentResourceId));
+                rp.put("PathPart", segment);
+                res.set("Properties", rp);
+                resources.set(resId, res);
+                pathToResource.put(cumulative, resId);
+            }
+            parentResourceId = resId;
+            leaf = resId;
+        }
+        return leaf;
+    }
+
+    private ObjectNode ref(String logicalId) {
+        ObjectNode n = objectMapper.createObjectNode();
+        n.put("Ref", logicalId);
+        return n;
+    }
+
+    private ObjectNode getAtt(String logicalId, String attribute) {
+        ObjectNode n = objectMapper.createObjectNode();
+        ArrayNode a = objectMapper.createArrayNode();
+        a.add(logicalId);
+        a.add(attribute);
+        n.set("Fn::GetAtt", a);
+        return n;
+    }
+
+    /** Two-arg Fn::Sub producing the AWS_PROXY integration URI for a function (the form floci resolves). */
+    private ObjectNode lambdaInvokeUri(String functionLogicalId) {
+        ObjectNode sub = objectMapper.createObjectNode();
+        ArrayNode arr = objectMapper.createArrayNode();
+        arr.add("arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${FnArn}/invocations");
+        ObjectNode vars = objectMapper.createObjectNode();
+        vars.set("FnArn", getAtt(functionLogicalId, "Arn"));
+        arr.add(vars);
+        sub.set("Fn::Sub", arr);
+        return sub;
+    }
+
+    private String sanitize(String s) {
+        StringBuilder b = new StringBuilder();
+        boolean upper = true;
+        for (char c : s.toCharArray()) {
+            if (Character.isLetterOrDigit(c)) {
+                b.append(upper ? Character.toUpperCase(c) : c);
+                upper = false;
+            } else {
+                upper = true;
+            }
+        }
+        return b.length() == 0 ? "Root" : b.toString();
+    }
+
+    private String capitalize(String s) {
+        return s.isEmpty() ? s : Character.toUpperCase(s.charAt(0)) + s.substring(1);
+    }
+
+    private String uniqueId(String base, ObjectNode resources) {
+        String id = base;
+        int i = 2;
+        while (resources.has(id)) {
+            id = base + i++;
+        }
+        return id;
     }
 
     private void expandServerlessFunction(String logicalId, JsonNode properties, ObjectNode resources) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessor.java
@@ -121,10 +121,13 @@ class SamTransformProcessor {
                 if (!restApiId.isMissingNode() && !restApiId.isNull()) {
                     continue; // bound to an explicit API — not an implicit-API route (null == implicit)
                 }
-                String path = p.path("Path").asText(null);
-                if (path != null) {
-                    routes.add(new ApiRoute(logicalId, path, p.path("Method").asText("ANY")));
+                JsonNode pathNode = p.path("Path");
+                if (!pathNode.isTextual()) {
+                    continue; // implicit routing needs a literal path; skip intrinsics (Ref/Fn::Sub)
                 }
+                JsonNode methodNode = p.path("Method");
+                String method = methodNode.isTextual() ? methodNode.asText() : "ANY";
+                routes.add(new ApiRoute(logicalId, pathNode.asText(), method));
             }
         }
         return routes;
@@ -189,7 +192,7 @@ class SamTransformProcessor {
             resources.set(uniqueId(fn + "ApiPermission", resources), perm);
         }
 
-        String deploymentId = apiId + "Deployment";
+        String deploymentId = uniqueId(apiId + "Deployment", resources);
         ObjectNode dep = objectMapper.createObjectNode();
         dep.put("Type", "AWS::ApiGateway::Deployment");
         ObjectNode dp = objectMapper.createObjectNode();
@@ -207,7 +210,7 @@ class SamTransformProcessor {
         sp.set("DeploymentId", ref(deploymentId));
         sp.put("StageName", "Prod");
         stage.set("Properties", sp);
-        resources.set(apiId + "ProdStage", stage);
+        resources.set(uniqueId(apiId + "ProdStage", resources), stage);
     }
 
     /** Builds the API Gateway resource chain for a path; returns the leaf resource logical id (null = root). */

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessorTest.java
@@ -491,4 +491,38 @@ class SamTransformProcessorTest {
         }
         assertEquals(1, methods, "duplicate (path, method) routes must collapse to a single Method");
     }
+
+    @Test
+    void expandSamTemplate_skipsApiRouteWithNonLiteralPath() throws Exception {
+        // A Path given as an intrinsic (Ref/Fn::Sub) can't be turned into a literal API Gateway
+        // resource path, so the route must be skipped rather than registered as the API root.
+        JsonNode template = objectMapper.readTree("""
+            {
+              "Transform": "AWS::Serverless-2016-10-31",
+              "Resources": {
+                "Fn": {
+                  "Type": "AWS::Serverless::Function",
+                  "Properties": {
+                    "Handler": "bootstrap",
+                    "Runtime": "provided.al2023",
+                    "InlineCode": "x",
+                    "Events": {
+                      "A": { "Type": "Api", "Properties": { "Path": { "Ref": "SomePath" }, "Method": "GET" } }
+                    }
+                  }
+                }
+              }
+            }
+            """);
+
+        JsonNode resources = processor.expandSamTemplate(template).path("Resources");
+        int methods = 0;
+        Iterator<Map.Entry<String, JsonNode>> it = resources.fields();
+        while (it.hasNext()) {
+            if ("AWS::ApiGateway::Method".equals(it.next().getValue().path("Type").asText())) {
+                methods++;
+            }
+        }
+        assertEquals(0, methods, "a route with a non-literal Path must not be registered");
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessorTest.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Iterator;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -394,5 +397,98 @@ class SamTransformProcessorTest {
         assertEquals("arn:aws:sqs:us-east-1:123456789012:my-queue",
                 esmProps.path("EventSourceArn").asText());
         assertEquals(10, esmProps.path("BatchSize").asInt());
+    }
+
+    @Test
+    void expandSamTemplate_generatesImplicitApiFromApiEvents() throws Exception {
+        // Functions with Api events and no explicit RestApiId must produce a full implicit REST API.
+        JsonNode template = objectMapper.readTree("""
+            {
+              "Transform": "AWS::Serverless-2016-10-31",
+              "Globals": { "Api": { "Name": "MyServiceApi" } },
+              "Resources": {
+                "Fn": {
+                  "Type": "AWS::Serverless::Function",
+                  "Properties": {
+                    "Handler": "bootstrap",
+                    "Runtime": "provided.al2023",
+                    "InlineCode": "x",
+                    "Events": {
+                      "Docs":  { "Type": "Api", "Properties": { "Path": "/docs",      "Method": "GET" } },
+                      "Proxy": { "Type": "Api", "Properties": { "Path": "/{proxy+}",  "Method": "ANY" } }
+                    }
+                  }
+                }
+              }
+            }
+            """);
+
+        JsonNode resources = processor.expandSamTemplate(template).path("Resources");
+
+        // RestApi created, with the name from Globals.Api
+        assertEquals("AWS::ApiGateway::RestApi", resources.path("ServerlessRestApi").path("Type").asText());
+        assertEquals("MyServiceApi", resources.path("ServerlessRestApi").path("Properties").path("Name").asText());
+
+        // Deployment + Prod stage
+        assertEquals("AWS::ApiGateway::Deployment", resources.path("ServerlessRestApiDeployment").path("Type").asText());
+        assertEquals("Prod", resources.path("ServerlessRestApiProdStage").path("Properties").path("StageName").asText());
+
+        // A /docs resource exists, and there is a Method with an AWS_PROXY integration + a Lambda permission
+        boolean hasDocsResource = false;
+        boolean hasProxyMethod = false;
+        boolean hasPermission = false;
+        Iterator<Map.Entry<String, JsonNode>> it = resources.fields();
+        while (it.hasNext()) {
+            JsonNode n = it.next().getValue();
+            String type = n.path("Type").asText();
+            if ("AWS::ApiGateway::Resource".equals(type) && "docs".equals(n.path("Properties").path("PathPart").asText())) {
+                hasDocsResource = true;
+            }
+            if ("AWS::ApiGateway::Method".equals(type)
+                    && "AWS_PROXY".equals(n.path("Properties").path("Integration").path("Type").asText())) {
+                hasProxyMethod = true;
+            }
+            if ("AWS::Lambda::Permission".equals(type)
+                    && "apigateway.amazonaws.com".equals(n.path("Properties").path("Principal").asText())) {
+                hasPermission = true;
+            }
+        }
+        assertTrue(hasDocsResource, "expected an API Gateway Resource for /docs");
+        assertTrue(hasProxyMethod, "expected an API Gateway Method with AWS_PROXY integration");
+        assertTrue(hasPermission, "expected a Lambda permission for apigateway.amazonaws.com");
+    }
+
+    @Test
+    void expandSamTemplate_dedupesDuplicateApiRoutes() throws Exception {
+        // Two events resolving to the same (path, method) must collapse to a single API Gateway Method.
+        JsonNode template = objectMapper.readTree("""
+            {
+              "Transform": "AWS::Serverless-2016-10-31",
+              "Resources": {
+                "Fn": {
+                  "Type": "AWS::Serverless::Function",
+                  "Properties": {
+                    "Handler": "bootstrap",
+                    "Runtime": "provided.al2023",
+                    "InlineCode": "x",
+                    "Events": {
+                      "A": { "Type": "Api", "Properties": { "Path": "/docs", "Method": "GET" } },
+                      "B": { "Type": "Api", "Properties": { "Path": "/docs", "Method": "GET" } }
+                    }
+                  }
+                }
+              }
+            }
+            """);
+
+        JsonNode resources = processor.expandSamTemplate(template).path("Resources");
+        int methods = 0;
+        Iterator<Map.Entry<String, JsonNode>> it = resources.fields();
+        while (it.hasNext()) {
+            if ("AWS::ApiGateway::Method".equals(it.next().getValue().path("Type").asText())) {
+                methods++;
+            }
+        }
+        assertEquals(1, methods, "duplicate (path, method) routes must collapse to a single Method");
     }
 }


### PR DESCRIPTION
Re-opens #1433 with a clean history (single commit, no co-author trailer), per @hectorvent's request. Same change, fully re-tested on current `main`.

Fixes #1434.

## What

SAM functions that declare `Events` of `Type: Api` with no explicit `AWS::Serverless::Api` rely on the **implicit** API Gateway that SAM/CloudFormation synthesizes. floci's SAM transform expanded the functions but never generated that API, so such templates deployed but couldn't be invoked over HTTP.

This adds generation of the implicit API from the function `Api` events:
- `AWS::ApiGateway::RestApi` (collision-safe logical id — `ServerlessRestApi`, suffixed if taken)
- `Resource` per path segment, `Method` per `(path, httpMethod)` — deduped so each verb maps to a single method
- `AWS_PROXY` `Integration` (two-arg `Fn::Sub` + `Fn::GetAtt FunctionArn`), plus `Deployment` and a `Prod` `Stage`

A route whose `RestApiId` is explicitly set (and non-null) is left untouched.

## Tests

`SamTransformProcessorTest` — 17 tests, including implicit-API generation and `(path, method)` dedup. Green on current `main` (JDK 25, `BUILD SUCCESS`).

## Context

This is the third of three complementary fixes (#1427 Globals merge, #1431 REVIEW_IN_PROGRESS event — merged, this one) that together let floci deploy **and serve** a standard SAM service using a Go `provided.al2023` runtime. Verified end-to-end: full stack `CREATE_COMPLETE` and `GET /docs` through the generated API returns **HTTP 200** from the lambda.