### PR TITLE
fix(autoscaling): validate MixedInstancesPolicy launch template

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
@@ -128,7 +128,8 @@ public class AutoScalingService {
         if (launchConfigName == null && launchTemplateId == null && launchTemplateName == null
                 && mixedInstancesPolicy == null) {
             throw new AwsException("ValidationError",
-                    "Either LaunchConfigurationName or LaunchTemplate must be specified.", 400);
+                    "Valid requests must contain either LaunchTemplate, LaunchConfigurationName, "
+                            + "InstanceId or MixedInstancesPolicy parameter.", 400);
         }
 
         AutoScalingGroup asg = new AutoScalingGroup();
@@ -642,6 +643,29 @@ public class AutoScalingService {
             throw new AwsException("ValidationError",
                     "LaunchConfigurationName, LaunchTemplate, and MixedInstancesPolicy are mutually exclusive.", 400);
         }
+        if (mixedInstancesPolicy != null && !hasUsableLaunchTemplate(mixedInstancesPolicy)) {
+            throw new AwsException("ValidationError",
+                    "A MixedInstancesPolicy must specify a LaunchTemplate with a LaunchTemplateId "
+                            + "or LaunchTemplateName.", 400);
+        }
+    }
+
+    private static boolean hasUsableLaunchTemplate(MixedInstancesPolicy mixedInstancesPolicy) {
+        MixedInstancesPolicy.LaunchTemplate launchTemplate = mixedInstancesPolicy.getLaunchTemplate();
+        if (launchTemplate == null) {
+            return false;
+        }
+        MixedInstancesPolicy.LaunchTemplateSpecification specification =
+                launchTemplate.getLaunchTemplateSpecification();
+        if (specification == null) {
+            return false;
+        }
+        return notBlank(specification.getLaunchTemplateId())
+                || notBlank(specification.getLaunchTemplateName());
+    }
+
+    private static boolean notBlank(String value) {
+        return value != null && !value.isBlank();
     }
 
     private static String instanceRefreshKey(String region, String asgName, String refreshId) {

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingServiceTest.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.services.autoscaling.model.AsgInstance;
 import io.github.hectorvent.floci.services.autoscaling.model.InstanceRefresh;
+import io.github.hectorvent.floci.services.autoscaling.model.MixedInstancesPolicy;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -315,6 +316,79 @@ class AutoScalingServiceTest {
 
         verify(ec2Service).terminateInstances(REGION, List.of("i-stale"));
         assertTrue(service.describeAutoScalingGroups(REGION, List.of("test-asg")).isEmpty());
+    }
+
+    @Test
+    void createAutoScalingGroupRejectsMixedInstancesPolicyWithoutLaunchTemplate() {
+        MixedInstancesPolicy policy = new MixedInstancesPolicy();
+        MixedInstancesPolicy.InstancesDistribution distribution =
+                new MixedInstancesPolicy.InstancesDistribution();
+        distribution.setOnDemandBaseCapacity(1);
+        policy.setInstancesDistribution(distribution);
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> createWithMixedInstancesPolicy("mixed-no-lt", policy));
+
+        assertEquals("ValidationError", error.getErrorCode());
+        assertEquals(400, error.getHttpStatus());
+    }
+
+    @Test
+    void createAutoScalingGroupRejectsMixedInstancesPolicyWithBlankLaunchTemplateIdentifiers() {
+        MixedInstancesPolicy policy = new MixedInstancesPolicy();
+        MixedInstancesPolicy.LaunchTemplate launchTemplate = new MixedInstancesPolicy.LaunchTemplate();
+        MixedInstancesPolicy.LaunchTemplateSpecification specification =
+                new MixedInstancesPolicy.LaunchTemplateSpecification();
+        specification.setLaunchTemplateId("");
+        specification.setLaunchTemplateName("  ");
+        launchTemplate.setLaunchTemplateSpecification(specification);
+        policy.setLaunchTemplate(launchTemplate);
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> createWithMixedInstancesPolicy("mixed-blank-lt", policy));
+
+        assertEquals("ValidationError", error.getErrorCode());
+        assertEquals(400, error.getHttpStatus());
+    }
+
+    @Test
+    void createAutoScalingGroupAcceptsMixedInstancesPolicyWithLaunchTemplate() {
+        MixedInstancesPolicy policy = new MixedInstancesPolicy();
+        MixedInstancesPolicy.LaunchTemplate launchTemplate = new MixedInstancesPolicy.LaunchTemplate();
+        MixedInstancesPolicy.LaunchTemplateSpecification specification =
+                new MixedInstancesPolicy.LaunchTemplateSpecification();
+        specification.setLaunchTemplateId("lt-mixed");
+        launchTemplate.setLaunchTemplateSpecification(specification);
+        policy.setLaunchTemplate(launchTemplate);
+
+        createWithMixedInstancesPolicy("mixed-with-lt", policy);
+
+        var group = service.describeAutoScalingGroups(REGION, List.of("mixed-with-lt")).getFirst();
+        assertEquals("lt-mixed",
+                group.getMixedInstancesPolicy().getLaunchTemplate()
+                        .getLaunchTemplateSpecification().getLaunchTemplateId());
+    }
+
+    private void createWithMixedInstancesPolicy(String name, MixedInstancesPolicy policy) {
+        service.createAutoScalingGroup(REGION,
+                name,
+                null,
+                null,
+                null,
+                null,
+                policy,
+                0,
+                3,
+                1,
+                300,
+                List.of("us-east-1a"),
+                List.of(),
+                List.of(),
+                List.of(),
+                "EC2",
+                0,
+                List.of("Default"),
+                java.util.Map.of());
     }
 
     private static final class AutoScalingGroupFixture {


### PR DESCRIPTION
## Summary

Follow-up to #1437. Tightens `MixedInstancesPolicy` validation so Floci matches AWS behavior on create/update.

- Reject a `MixedInstancesPolicy` that has no usable `LaunchTemplate` (neither `LaunchTemplateId` nor `LaunchTemplateName`) with a `ValidationError`. Previously such a request persisted an Auto Scaling group that the reconciler could never scale out ("no launch source found"), because the parser builds a non-null policy from any `MixedInstancesPolicy.*` key (e.g. distribution-only requests). Real AWS rejects this at create/update time.
- Update the missing-launch-source error message to mention all valid sources (`LaunchTemplate`, `LaunchConfigurationName`, `InstanceId`, `MixedInstancesPolicy`), matching AWS wording. The previous message only named `LaunchConfigurationName`/`LaunchTemplate`, which became misleading once `MixedInstancesPolicy` was added as a source.

Both items were raised in the Copilot review on #1437.

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

- `CreateAutoScalingGroup` / `UpdateAutoScalingGroup` now return `ValidationError` (HTTP 400) for a `MixedInstancesPolicy` without a resolvable launch template, instead of silently accepting an unscalable group.

## Verification

`./mvnw -Dtest="AutoScalingServiceTest,AutoScalingIntegrationTest,AutoScalingQueryHandlerTest,AutoScalingReconcilerTest" test` — 65 tests, 0 failures, 0 errors.

## Checklist

- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits