### PR TITLE
fix(acm): restore ACM certificates after restart by ignoring computed getters (#1428)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/acm/model/Certificate.java
+++ b/src/main/java/io/github/hectorvent/floci/services/acm/model/Certificate.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.services.acm.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
@@ -15,6 +17,7 @@ import java.util.Map;
  * @see <a href="https://docs.aws.amazon.com/acm/latest/APIReference/API_CertificateDetail.html">AWS ACM CertificateDetail</a>
  */
 @RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Certificate {
     private String arn;
     private String domainName;
@@ -250,10 +253,12 @@ public class Certificate {
         this.idempotencyToken = idempotencyToken;
     }
 
+    @JsonIgnore
     public boolean isExpired() {
         return notAfter != null && Instant.now().isAfter(notAfter);
     }
 
+    @JsonIgnore
     public boolean canExport() {
         return type == CertificateType.PRIVATE ||
                type == CertificateType.IMPORTED ||

--- a/src/test/java/io/github/hectorvent/floci/services/acm/AcmImportExportTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/acm/AcmImportExportTest.java
@@ -45,8 +45,8 @@ class AcmImportExportTest {
             KeyAlgorithm.RSA_2048
         );
 
-        validTestCertificate = generated.certificatePem();
-        validTestPrivateKey = generated.privateKeyPem();
+        validTestCertificate = generated.certificatePem().replace("\r\n", "\n");
+        validTestPrivateKey = generated.privateKeyPem().replace("\r\n", "\n");
     }
 
     // ==================== ImportCertificate Tests ====================

--- a/src/test/java/io/github/hectorvent/floci/services/acm/AcmServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/acm/AcmServicePersistenceTest.java
@@ -1,0 +1,84 @@
+package io.github.hectorvent.floci.services.acm;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.PersistentStorage;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.services.acm.model.Certificate;
+import io.github.hectorvent.floci.services.acm.model.KeyAlgorithm;
+import io.github.hectorvent.floci.services.acm.model.ValidationMethod;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.security.Security;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AcmServicePersistenceTest {
+
+    private static final String REGION = "us-east-1";
+    private static CertificateGenerator generator;
+
+    @BeforeAll
+    static void setup() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+        generator = new CertificateGenerator();
+    }
+
+    @Test
+    void certificateSurvivesRestart(@TempDir Path dir) {
+        // Step 1: Create a service with a persistent backend and create a certificate
+        AcmService first = newService(dir);
+        Certificate cert = first.requestCertificate(
+                "example.com",
+                List.of("www.example.com"),
+                ValidationMethod.DNS,
+                "idempotency-token-123",
+                KeyAlgorithm.RSA_2048,
+                null,
+                null,
+                Map.of("Env", "test"),
+                REGION
+        );
+        assertNotNull(cert);
+        String arn = cert.getArn();
+
+        // Step 2: Create a second service instance sharing the same storage directory (simulating restart)
+        AcmService restarted = newService(dir);
+        Certificate loaded = restarted.describeCertificate(arn, REGION);
+
+        // Step 3: Validate that the certificate was correctly restored and properties match
+        assertNotNull(loaded);
+        assertEquals(arn, loaded.getArn());
+        assertEquals("example.com", loaded.getDomainName());
+        assertEquals(List.of("example.com", "www.example.com"), loaded.getSubjectAlternativeNames());
+        assertEquals("test", loaded.getTags().get("Env"));
+    }
+
+    private AcmService newService(Path dir) {
+        RegionResolver regionResolver = mock(RegionResolver.class);
+        when(regionResolver.getAccountId()).thenReturn("000000000000");
+
+        StorageBackend<String, Certificate> store = load(dir, "acm-certificates.json");
+        return new AcmService(store, generator, regionResolver, 0);
+    }
+
+    private StorageBackend<String, Certificate> load(Path dir, String file) {
+        PersistentStorage<String, Certificate> backend = new PersistentStorage<>(
+                dir.resolve(file),
+                new TypeReference<Map<String, Certificate>>() {}
+        );
+        backend.load();
+        return backend;
+    }
+}


### PR DESCRIPTION
The computed getters isExpired() and canExport() in Certificate.java were being serialized by Jackson as 'expired' and 'canExport', causing deserialization failure on restart because FAIL_ON_UNKNOWN_PROPERTIES is active. The fix annotates those getters with @JsonIgnore and adds @JsonIgnoreProperties(ignoreUnknown = true) to the Certificate class.

Closes #1428