### PR TITLE
fix(ui): register StatusResponse for native-image reflection

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/lifecycle/UiController.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/UiController.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.lifecycle;
 import io.github.hectorvent.floci.services.floci.ui.FlociUiManager;
 import io.github.hectorvent.floci.services.floci.ui.FlociUiManager.UiStatus;
 import io.github.hectorvent.floci.services.floci.ui.UiPages;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
@@ -40,6 +41,7 @@ public class UiController {
         return Response.ok(uiPages.startingHtml()).build();
     }
 
+    @RegisterForReflection
     public record StatusResponse(boolean ready, String url, String error) {}
 
     @GET


### PR DESCRIPTION
## Summary

The Floci UI never loads when running the **native image**. `GET /_floci/ui` serves an interstitial page that launches the `floci-ui` sidecar and then polls `GET /_floci/ui/status` until it returns `{ready:true,url:...}`, at which point it redirects the browser to the sidecar on port 4500.

In the native image that status endpoint returns **HTTP 500**, so the interstitial never redirects and the UI appears broken, even though the `floci-ui` container is up and healthy.

## Root cause

`UiController.StatusResponse` was not registered for reflection, so Jackson cannot serialize it in the native image:

```
ERROR NativeInvalidDefinitionExceptionMapper: Jackson was unable to serialize type
'io.github.hectorvent.floci.lifecycle.UiController$StatusResponse' ... No serializer found ...
This appears to be a native image, in which case you may need to configure reflection
```

This matches the project rule that controller return types must remain reflection-safe in native images.

## Fix

Annotate the response record with `@RegisterForReflection`, the same pattern used by other controller response types (e.g. `AwsErrorResponse`).

```java
@RegisterForReflection
public record StatusResponse(boolean ready, String url, String error) {}
```

## Testing

Reproduced against a locally built native image (`docker/Dockerfile.native`): before the change `GET /_floci/ui/status` returned `500` with the `NativeInvalidDefinitionException` above while the `floci-ui` sidecar was running; the loading page never redirected. The fix registers the record so the endpoint serializes normally. JVM mode was unaffected (Jackson reflects freely there), which is why this only surfaced in native builds.