### PR TITLE
fix(dynamodb): reject redundant parens, contains() dup operand, begins_with non-string

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -313,6 +313,8 @@ public class DynamoDbJsonHandler {
                     "ExpressionAttributeValues can only be specified when using expressions: ConditionExpression is null", 400);
         }
 
+        ExpressionEvaluator.validateExpression(conditionExpression, "ConditionExpression", exprAttrNames, exprAttrValues);
+
         validateItemSets(item);
 
         JsonNode oldItem = null;
@@ -417,6 +419,8 @@ public class DynamoDbJsonHandler {
                     + String.join("; ", delValidationErrors), 400);
         }
 
+        ExpressionEvaluator.validateExpression(conditionExpression, "ConditionExpression", exprAttrNames, exprAttrValues);
+
         JsonNode expectedDel = request.has("Expected") ? request.get("Expected") : null;
         String condOpDel = request.has("ConditionalOperator")
                 ? request.get("ConditionalOperator").asText() : "AND";
@@ -481,6 +485,8 @@ public class DynamoDbJsonHandler {
                     "Can not use both expression and non-expression parameters in the same request: "
                     + "Non-expression parameters: {AttributeUpdates} Expression parameters: {UpdateExpression}", 400);
         }
+
+        ExpressionEvaluator.validateExpression(conditionExpression, "ConditionExpression", exprAttrNames, exprAttrValues);
 
         if (conditionExpression != null && expectedUpd != null) {
             throw new AwsException("ValidationException",
@@ -708,6 +714,9 @@ public class DynamoDbJsonHandler {
                     "Invalid KeyConditionExpression: The expression can not be empty;", 400);
         }
 
+        ExpressionEvaluator.validateExpression(keyConditionExpr, "KeyConditionExpression", exprAttrNames, exprAttrValues);
+        ExpressionEvaluator.validateExpression(filterExpr, "FilterExpression", exprAttrNames, exprAttrValues);
+
         if (select != null && !VALID_SELECT.contains(select)) {
             throw new AwsException("ValidationException",
                     "1 validation error detected: Value '" + select + "' at 'select' failed to satisfy constraint: "
@@ -836,6 +845,8 @@ public class DynamoDbJsonHandler {
                     "The Segment parameter is zero-based and must be less than parameter TotalSegments: "
                     + "Segment: " + segment + " is not less than TotalSegments: " + totalSegments, 400);
         }
+
+        ExpressionEvaluator.validateExpression(filterExpr, "FilterExpression", exprAttrNames, exprAttrValues);
 
         String projectionExpressionScan = request.has("ProjectionExpression")
                 ? request.get("ProjectionExpression").asText() : null;

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.dynamodb;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -371,6 +372,134 @@ final class ExpressionEvaluator {
                             .formatted(parser.peek().value(), parser.peek().pos()));
         }
         return expr;
+    }
+
+    // ── Structural / semantic validation ──
+
+    /**
+     * Validates an expression for the structural and semantic errors that DynamoDB rejects
+     * at parse time with a ValidationException, independent of the item being evaluated:
+     *   - redundant parentheses, e.g. {@code ((a = b))}
+     *   - {@code contains(x, x)} where the first operand is not distinct from the second
+     *   - {@code begins_with(path, value)} where the value operand is not a string/binary
+     *
+     * {@code exprType} is the label used in the {@code "Invalid <exprType>: ..."} prefix
+     * (e.g. "ConditionExpression", "FilterExpression", "KeyConditionExpression").
+     */
+    static void validateExpression(String expression, String exprType,
+                                   JsonNode exprAttrNames, JsonNode exprAttrValues) {
+        if (expression == null || expression.isBlank()) return;
+        List<Token> tokens = tokenize(expression.trim());
+        checkRedundantParentheses(tokens, exprType);
+        Expr expr;
+        try {
+            expr = parse(expression);
+        } catch (IllegalArgumentException e) {
+            // Other syntax errors are surfaced by the existing parse/evaluate paths.
+            return;
+        }
+        validateSemantics(expr, exprType, exprAttrNames, exprAttrValues);
+    }
+
+    // A pair of parentheses is redundant when its entire content is itself a single
+    // parenthesised group — i.e. "( ( ... ) )". Single wraps "(x)" and full wraps
+    // "(a AND b)" are legal; only the doubled form is rejected.
+    private static void checkRedundantParentheses(List<Token> tokens, String exprType) {
+        for (int i = 0; i + 1 < tokens.size(); i++) {
+            if (tokens.get(i).type() == TokenType.LPAREN
+                    && tokens.get(i + 1).type() == TokenType.LPAREN) {
+                int innerClose = matchingParen(tokens, i + 1);
+                if (innerClose >= 0 && innerClose + 1 < tokens.size()
+                        && tokens.get(innerClose + 1).type() == TokenType.RPAREN) {
+                    throw new AwsException("ValidationException",
+                            "Invalid " + exprType + ": The expression has redundant parentheses;", 400);
+                }
+            }
+        }
+    }
+
+    // Index of the RPAREN that matches the LPAREN at openIdx (function-call parens included).
+    private static int matchingParen(List<Token> tokens, int openIdx) {
+        int depth = 0;
+        for (int i = openIdx; i < tokens.size(); i++) {
+            if (tokens.get(i).type() == TokenType.LPAREN) depth++;
+            else if (tokens.get(i).type() == TokenType.RPAREN) {
+                if (--depth == 0) return i;
+            }
+        }
+        return -1;
+    }
+
+    private static void validateSemantics(Expr expr, String exprType,
+                                          JsonNode names, JsonNode values) {
+        if (expr == null) return;
+        switch (expr) {
+            case AndExpr a -> a.operands().forEach(o -> validateSemantics(o, exprType, names, values));
+            case OrExpr o -> o.operands().forEach(x -> validateSemantics(x, exprType, names, values));
+            case NotExpr n -> validateSemantics(n.operand(), exprType, names, values);
+            case FunctionCallExpr f -> validateFunction(f, exprType, names, values);
+            default -> {}
+        }
+    }
+
+    private static void validateFunction(FunctionCallExpr f, String exprType,
+                                         JsonNode names, JsonNode values) {
+        String name = f.functionName().toLowerCase();
+        if (name.equals("contains") && f.args().size() >= 2
+                && operandsIdentical(f.args().get(0), f.args().get(1), names)) {
+            throw new AwsException("ValidationException",
+                    "Invalid " + exprType + ": The first operand must be distinct from the remaining operands "
+                    + "for this operator or function; operator: contains, first operand: "
+                    + displayOperand(f.args().get(0), names), 400);
+        }
+        if (name.equals("begins_with") && f.args().size() >= 2) {
+            String type = operandValueType(f.args().get(1), values);
+            if (type != null && !type.equals("S") && !type.equals("B")) {
+                throw new AwsException("ValidationException",
+                        "Invalid " + exprType + ": Incorrect operand type for operator or function; "
+                        + "operator or function: begins_with, operand type: " + type, 400);
+            }
+        }
+    }
+
+    private static boolean operandsIdentical(Operand a, Operand b, JsonNode names) {
+        if (a instanceof PathOperand pa && b instanceof PathOperand pb) {
+            return resolvePathString(pa, names).equals(resolvePathString(pb, names));
+        }
+        if (a instanceof PlaceholderOperand xa && b instanceof PlaceholderOperand xb) {
+            return xa.name().equals(xb.name());
+        }
+        return false;
+    }
+
+    // The DynamoDB type code (S, N, B, ...) of a placeholder value operand, or null
+    // when the operand is a document path whose type can only be known at runtime.
+    private static String operandValueType(Operand operand, JsonNode values) {
+        if (operand instanceof PlaceholderOperand p && values != null) {
+            JsonNode v = values.get(p.name());
+            if (v != null && v.isObject() && v.fieldNames().hasNext()) {
+                return v.fieldNames().next();
+            }
+        }
+        return null;
+    }
+
+    // Renders a path operand the way DynamoDB does in operand errors, e.g. "[data]" or "[a, b]".
+    private static String displayOperand(Operand operand, JsonNode names) {
+        if (operand instanceof PathOperand path) {
+            var parts = new ArrayList<String>();
+            for (String seg : path.segments()) {
+                if (seg.startsWith("[")) {
+                    if (!parts.isEmpty()) parts.set(parts.size() - 1, parts.getLast() + seg);
+                    else parts.add(seg);
+                } else {
+                    parts.add(resolveAttributeName(seg, names));
+                }
+            }
+            return "[" + String.join(", ", parts) + "]";
+        }
+        if (operand instanceof PlaceholderOperand p) return p.name();
+        return operand.toString();
     }
 
     // ── Key condition splitting ──

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbFilterExpressionIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbFilterExpressionIntegrationTest.java
@@ -223,14 +223,22 @@ class DynamoDbFilterExpressionIntegrationTest {
 
     @Test
     void scanFilterDoubleNestedParens() {
-        // ((category = :a)) should work like category = :a → u1, u3
-        scanWithFilter(
-                "((category = :a))",
-                """
-                {":a": {"S": "A"}}
-                """,
-                null,
-                2);
+        // AWS DynamoDB rejects redundant (doubled) parentheses such as ((category = :a))
+        // with a ValidationException at parse time — verified against moto/AWS DDB parity,
+        // where ((a < b)) fails but ((a = :b) OR (c = :d)) is allowed.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Scan")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "%s", "FilterExpression": "((category = :a))", \
+"ExpressionAttributeValues": {":a": {"S": "A"}}}
+                """.formatted(TABLE_NAME))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body(containsString("redundant parentheses"));
     }
 
     // ---- Parenthesized BETWEEN in KeyConditionExpression ----


### PR DESCRIPTION
## What
Adds structural/semantic validation that DynamoDB performs at parse time for Condition / Filter / KeyCondition expressions, via a new `ExpressionEvaluator.validateExpression`, wired into the Put / Delete / Update / Query / Scan handlers:

- **Redundant parentheses** — `((a = b))` is rejected (`Invalid <ExprType>: The expression has redundant parentheses;`), while legitimate per-condition and full-wrap parens still parse.
- **`contains()` distinct operands** — `contains(#a, #a)` is rejected (`The first operand must be distinct …; operator: contains, first operand: [data]`).
- **`begins_with` operand type** — a non-string/binary prefix (e.g. `{N}`) is rejected with the exact operand-type error.

Each error carries the correct `Invalid <ExpressionType>:` prefix.

## Why
Real DynamoDB rejects these at parse time; a lenient emulator silently accepts them. Closes **11** independent-conformance failures across the tier-1 paren tests and the tier-3 exact-error-message tests.

## Notes
First of a stacked series of DynamoDB conformance fixes — base `main`.