### PR TITLE
fix(dynamodb): Limit caps scanned items and index scans carry a full cursor

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -887,7 +887,8 @@ public class DynamoDbJsonHandler {
         }
 
         DynamoDbService.ScanResult result = dynamoDbService.scan(
-                tableName, filterExpr, exprAttrNames, exprAttrValues, scanFilter, limit, exclusiveStartKey, region);
+                tableName, filterExpr, exprAttrNames, exprAttrValues, scanFilter, limit,
+                exclusiveStartKey, indexNameScan, region);
 
         List<JsonNode> scanItems = result.items();
         // Apply parallel scan segment partitioning

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -800,6 +800,14 @@ public class DynamoDbService {
     public ScanResult scan(String tableName, String filterExpression,
                             JsonNode expressionAttrNames, JsonNode expressionAttrValues,
                             JsonNode scanFilter, Integer limit, JsonNode exclusiveStartKey, String region) {
+        return scan(tableName, filterExpression, expressionAttrNames, expressionAttrValues,
+                scanFilter, limit, exclusiveStartKey, null, region);
+    }
+
+    public ScanResult scan(String tableName, String filterExpression,
+                            JsonNode expressionAttrNames, JsonNode expressionAttrValues,
+                            JsonNode scanFilter, Integer limit, JsonNode exclusiveStartKey,
+                            String indexName, String region) {
         DynamoDbReservedWords.check(filterExpression, "FilterExpression");
         String canonicalTableName = canonicalTableName(region, tableName);
         String storageKey = regionKey(region, canonicalTableName);
@@ -809,10 +817,28 @@ public class DynamoDbService {
         var items = itemsByTable.get(storageKey);
         if (items == null) return new ScanResult(List.of(), 0, null);
 
-        // ConcurrentSkipListMap keeps items sorted by item key — no sort needed.
+        // ConcurrentSkipListMap keeps items sorted by base item key — no sort needed.
         // Use tailMap for O(log n) pagination instead of O(n) linear search.
         String pkName = table.getPartitionKeyName();
         String skName = table.getSortKeyName();
+
+        // When scanning a secondary index, the LastEvaluatedKey must carry the index key
+        // attributes in addition to the base table key. Cursor navigation still uses the
+        // (unique) base table key, which is a total order even when index sort keys tie.
+        boolean indexScan = indexName != null;
+        String lekPkName = pkName;
+        String lekSkName = skName;
+        if (indexScan) {
+            var gsi = table.findGsi(indexName);
+            var lsi = table.findLsi(indexName);
+            if (gsi.isPresent()) {
+                lekPkName = gsi.get().getPartitionKeyName();
+                lekSkName = gsi.get().getSortKeyName();
+            } else if (lsi.isPresent()) {
+                lekPkName = lsi.get().getPartitionKeyName();
+                lekSkName = lsi.get().getSortKeyName();
+            }
+        }
 
         var source = exclusiveStartKey != null
                 ? items.tailMap(buildItemKeyFromNode(exclusiveStartKey, pkName, skName), false).values()
@@ -820,36 +846,35 @@ public class DynamoDbService {
 
         int totalScanned = 0;
         List<JsonNode> results = new ArrayList<>();
-        for (JsonNode item : source) {
-            totalScanned++;
-            if (isExpired(item, table)) {
-                continue;
-            }
-            if (filterExpression != null
-                    && !matchesFilterExpression(item, filterExpression, expressionAttrNames, expressionAttrValues)) {
-                continue;
-            }
-            if (scanFilter != null && !matchesScanFilter(item, scanFilter)) {
-                continue;
-            }
-            results.add(item);
-        }
-
         JsonNode lastEvaluatedKey = null;
-        if (limit != null && limit > 0 && results.size() > limit) {
-            JsonNode lastItem = results.get(limit - 1);
-            lastEvaluatedKey = buildKeyNode(table, lastItem, pkName, skName);
-            results = results.subList(0, limit);
+        Iterator<JsonNode> it = source.iterator();
+        while (it.hasNext()) {
+            JsonNode item = it.next();
+            totalScanned++;
+            if (!isExpired(item, table)) {
+                boolean matched = (filterExpression == null
+                        || matchesFilterExpression(item, filterExpression, expressionAttrNames, expressionAttrValues))
+                        && (scanFilter == null || matchesScanFilter(item, scanFilter));
+                if (matched) results.add(item);
+            }
+            // Limit caps SCANNED items (those read), not matched items. Stop at the
+            // limit and surface a cursor when more items remain to be examined.
+            if (limit != null && limit > 0 && totalScanned >= limit) {
+                if (it.hasNext()) {
+                    lastEvaluatedKey = buildKeyNode(table, item, lekPkName, lekSkName, indexScan);
+                }
+                break;
+            }
         }
 
-        // Apply 1MB response size limit
+        // Apply 1MB response size limit (only when not already truncated by Limit)
         if (lastEvaluatedKey == null) {
             final int MAX_RESPONSE_BYTES = 1024 * 1024;
             int accSize = 0;
             for (int i = 0; i < results.size(); i++) {
                 int sz = DynamoDbItemSize.calculateItemSize(results.get(i));
                 if (accSize > 0 && accSize + sz > MAX_RESPONSE_BYTES) {
-                    lastEvaluatedKey = buildKeyNode(table, results.get(i - 1), pkName, skName);
+                    lastEvaluatedKey = buildKeyNode(table, results.get(i - 1), lekPkName, lekSkName, indexScan);
                     results = new ArrayList<>(results.subList(0, i));
                     break;
                 }

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -499,7 +499,7 @@ public class AslExecutor {
                 Integer limit = input.has("Limit") ? input.get("Limit").asInt() : null;
                 JsonNode scanFilter = input.has("ScanFilter") ? input.get("ScanFilter") : null;
                 DynamoDbService.ScanResult scanResult = dynamoDbService.scan(
-                        tableName, filterExpression, exprAttrNames, exprAttrValues, scanFilter, limit, null, region);
+                        tableName, filterExpression, exprAttrNames, exprAttrValues, scanFilter, limit, null, null, region);
                 ObjectNode response = objectMapper.createObjectNode();
                 com.fasterxml.jackson.databind.node.ArrayNode items = objectMapper.createArrayNode();
                 scanResult.items().forEach(items::add);


### PR DESCRIPTION
## What
- **Scan `Limit` semantics** — `Limit` now bounds the number of items *scanned* (read), not *matched*. A filtered scan that matches nothing under its limit still returns the correct `ScannedCount` and a `LastEvaluatedKey` when items remain.
- **Index-scan cursor** — when scanning a secondary index, `scan()` takes an `indexName` and builds a `LastEvaluatedKey` that includes the **index key attributes alongside the base table key**, so paging across tied index sort keys walks every item exactly once (no skips/repeats).

## Why
Closes **2** conformance failures (filtered-Limit pagination + GSI pagination across tied sort keys).

## Note on the `scan()` signature
Adding the `indexName` parameter changes `DynamoDbService.scan(...)`. To keep every caller compiling, this PR also **restores the prior arity as a delegating overload** and updates the one Step Functions caller (`AslExecutor`). So `main` stays green at this commit — the signature change and its compile-fix land together, not in separate PRs.

## Stacking
Stacked on #1443. Merge in order.