### PR TITLE
feat(dynamodb): TableId, TableClass, OnDemandThroughput; fix deletion-protection error

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -175,6 +175,20 @@ public class DynamoDbJsonHandler {
             table.setBillingMode("PROVISIONED");
         }
 
+        if (request.has("TableClass")) {
+            table.setTableClass(request.get("TableClass").asText());
+        }
+
+        JsonNode onDemand = request.path("OnDemandThroughput");
+        if (onDemand.isObject()) {
+            if (onDemand.has("MaxReadRequestUnits")) {
+                table.setOnDemandMaxReadRequestUnits(onDemand.get("MaxReadRequestUnits").asInt());
+            }
+            if (onDemand.has("MaxWriteRequestUnits")) {
+                table.setOnDemandMaxWriteRequestUnits(onDemand.get("MaxWriteRequestUnits").asInt());
+            }
+        }
+
         // Store tags from CreateTable request
         JsonNode tagsNode = request.path("Tags");
         if (tagsNode.isArray()) {
@@ -209,8 +223,9 @@ public class DynamoDbJsonHandler {
         String tableName = request.path("TableName").asText();
         TableDefinition table = dynamoDbService.describeTable(tableName, region);
         if (table.isDeletionProtectionEnabled()) {
-            throw new AwsException("ResourceInUseException",
-                    "Table " + tableName + " can't be deleted while DeletionProtectionEnabled is set to true", 400);
+            throw new AwsException("ValidationException",
+                    "Table " + tableName + " is protected against deletion. To delete the table, "
+                    + "DeletionProtectionEnabled must be set to false.", 400);
         }
         ObjectNode response = objectMapper.createObjectNode();
         response.set("TableDescription", tableToNode(table));
@@ -1149,6 +1164,20 @@ public class DynamoDbJsonHandler {
             }
         }
 
+        if (request.has("TableClass")) {
+            table.setTableClass(request.get("TableClass").asText());
+        }
+
+        JsonNode onDemand = request.path("OnDemandThroughput");
+        if (onDemand.isObject()) {
+            if (onDemand.has("MaxReadRequestUnits")) {
+                table.setOnDemandMaxReadRequestUnits(onDemand.get("MaxReadRequestUnits").asInt());
+            }
+            if (onDemand.has("MaxWriteRequestUnits")) {
+                table.setOnDemandMaxWriteRequestUnits(onDemand.get("MaxWriteRequestUnits").asInt());
+            }
+        }
+
         JsonNode streamSpec = request.path("StreamSpecification");
         if (!streamSpec.isMissingNode()) {
             boolean streamEnabled = streamSpec.path("StreamEnabled").asBoolean(false);
@@ -1790,6 +1819,7 @@ public class DynamoDbJsonHandler {
     private ObjectNode tableToNode(TableDefinition table) {
         ObjectNode node = objectMapper.createObjectNode();
         node.put("TableName", table.getTableName());
+        node.put("TableId", table.getTableId());
         node.put("TableStatus", table.getTableStatus());
         node.put("TableArn", table.getTableArn());
         node.put("CreationDateTime", table.getCreationDateTime().getEpochSecond());
@@ -1803,6 +1833,24 @@ public class DynamoDbJsonHandler {
             billing.put("LastUpdateToPayPerRequestDateTime",
                     table.getCreationDateTime().getEpochSecond());
             node.set("BillingModeSummary", billing);
+        }
+
+        // TableClassSummary always present; defaults to STANDARD.
+        ObjectNode tableClassSummary = objectMapper.createObjectNode();
+        tableClassSummary.put("TableClass",
+                table.getTableClass() != null ? table.getTableClass() : "STANDARD");
+        node.set("TableClassSummary", tableClassSummary);
+
+        if (table.getOnDemandMaxReadRequestUnits() != null
+                || table.getOnDemandMaxWriteRequestUnits() != null) {
+            ObjectNode odt = objectMapper.createObjectNode();
+            if (table.getOnDemandMaxReadRequestUnits() != null) {
+                odt.put("MaxReadRequestUnits", table.getOnDemandMaxReadRequestUnits());
+            }
+            if (table.getOnDemandMaxWriteRequestUnits() != null) {
+                odt.put("MaxWriteRequestUnits", table.getOnDemandMaxWriteRequestUnits());
+            }
+            node.set("OnDemandThroughput", odt);
         }
 
         ObjectNode warmThroughput = objectMapper.createObjectNode();

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
@@ -43,6 +43,10 @@ public class TableDefinition {
     private String sseType;
     private String kmsMasterKeyArn;
     private List<KinesisStreamingDestination> kinesisStreamingDestinations;
+    private String tableId;
+    private String tableClass; // "STANDARD" or "STANDARD_INFREQUENT_ACCESS"
+    private Integer onDemandMaxReadRequestUnits;
+    private Integer onDemandMaxWriteRequestUnits;
 
     public TableDefinition() {
         this.keySchema = new ArrayList<>();
@@ -72,6 +76,7 @@ public class TableDefinition {
         this.itemCount = 0;
         this.tableSizeBytes = 0;
         this.tableArn = AwsArnUtils.Arn.of("dynamodb", region, accountId, "table/" + tableName).toString();
+        this.tableId = java.util.UUID.randomUUID().toString();
         this.provisionedThroughput = new ProvisionedThroughput(5, 5);
         this.tags = new HashMap<>();
         this.globalSecondaryIndexes = new ArrayList<>();
@@ -174,6 +179,21 @@ public class TableDefinition {
     }
 
     /** Returns the partition key attribute name. */
+    public String getTableId() {
+        if (tableId == null) tableId = java.util.UUID.randomUUID().toString();
+        return tableId;
+    }
+    public void setTableId(String tableId) { this.tableId = tableId; }
+
+    public String getTableClass() { return tableClass; }
+    public void setTableClass(String tableClass) { this.tableClass = tableClass; }
+
+    public Integer getOnDemandMaxReadRequestUnits() { return onDemandMaxReadRequestUnits; }
+    public void setOnDemandMaxReadRequestUnits(Integer v) { this.onDemandMaxReadRequestUnits = v; }
+
+    public Integer getOnDemandMaxWriteRequestUnits() { return onDemandMaxWriteRequestUnits; }
+    public void setOnDemandMaxWriteRequestUnits(Integer v) { this.onDemandMaxWriteRequestUnits = v; }
+
     public String getPartitionKeyName() {
         return keySchema.stream()
                 .filter(k -> "HASH".equals(k.getKeyType()))

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -2194,7 +2194,8 @@ given()
             .statusCode(200)
             .body("Table.DeletionProtectionEnabled", equalTo(true));
 
-        // DeleteTable is blocked
+        // DeleteTable is blocked. AWS returns a ValidationException (not
+        // ResourceInUseException) when deletion protection is enabled.
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
             .contentType(DYNAMODB_CONTENT_TYPE)
@@ -2204,7 +2205,7 @@ given()
         .when().post("/")
         .then()
             .statusCode(400)
-            .body("__type", equalTo("ResourceInUseException"));
+            .body("__type", equalTo("ValidationException"));
 
         // UpdateTable to disable deletion protection
         given()


### PR DESCRIPTION
## What
- Generates a stable **`TableId`** per table, returned by CreateTable/DescribeTable.
- Parses and round-trips **`TableClass`** (`TableClassSummary`) and **`OnDemandThroughput`** on Create/UpdateTable; `TableClassSummary` defaults to `STANDARD`.
- **DeleteTable under deletion protection** now returns `ValidationException` ("… is protected against deletion"), matching AWS, instead of `ResourceInUseException`.

## Why
Closes **7** conformance failures (CreateTable/DescribeTable TableId, config round-trips, UpdateTable changes, and the deletion-protection enforcement message).

## Stacking
Stacked on #1444. Merge in order; GitHub retargets to `main` as each parent merges.