### PR TITLE
feat(cloudwatch): add Logs Insights query support

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudWatchLogsInsightsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudWatchLogsInsightsTest.java
@@ -1,0 +1,186 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.cloudwatchlogs.model.*;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * CloudWatch Logs Insights compatibility: StartQuery / GetQueryResults / StopQuery.
+ *
+ * <p>Seeds a log group with structured JSON events and exercises the same query shape real
+ * clients send — filter on a nested JSON field ({@code params.job_id}), drop a log level,
+ * sort by {@code @timestamp}, and dedup. StartQuery times are epoch <em>seconds</em> while
+ * event timestamps are millis.
+ */
+@DisplayName("CloudWatch Logs Insights")
+class CloudWatchLogsInsightsTest {
+
+    private static CloudWatchLogsClient logs;
+
+    private static final String GROUP = "/test/" + TestFixtures.uniqueName("insights");
+    private static final String STREAM = "stream-01";
+    private static String jobId;
+    private static long baseMs;
+
+    @BeforeAll
+    static void setUp() {
+        logs = TestFixtures.cloudWatchLogsClient();
+        logs.createLogGroup(b -> b.logGroupName(GROUP));
+        logs.createLogStream(b -> b.logGroupName(GROUP).logStreamName(STREAM));
+
+        baseMs = System.currentTimeMillis();
+        jobId = TestFixtures.uniqueName("job");
+        logs.putLogEvents(b -> b
+                .logGroupName(GROUP)
+                .logStreamName(STREAM)
+                .logEvents(
+                        InputLogEvent.builder().timestamp(baseMs - 3000).message(json("INFO", "job started", jobId)).build(),
+                        InputLogEvent.builder().timestamp(baseMs - 2000).message(json("TRACE", "verbose noise", jobId)).build(),
+                        InputLogEvent.builder().timestamp(baseMs - 1000).message(json("INFO", "unrelated", "other-job")).build(),
+                        InputLogEvent.builder().timestamp(baseMs).message(json("ERROR", "job boom", jobId)).build()
+                ));
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (logs != null) {
+            try {
+                logs.deleteLogGroup(b -> b.logGroupName(GROUP));
+            } catch (RuntimeException ignored) {
+                // best-effort cleanup
+            }
+            logs.close();
+        }
+    }
+
+    @Test
+    @DisplayName("StartQuery returns a queryId")
+    void startQueryReturnsQueryId() {
+        StartQueryResponse start = startTestQuery();
+        assertThat(start.queryId()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("GetQueryResults filters by JSON field, drops TRACE, sorts desc and dedups")
+    void getQueryResultsFiltersSortsDedups() {
+        // On real AWS, events are not queryable for several seconds after ingestion; retry the
+        // full start+poll cycle until rows appear or the ~60s deadline elapses.
+        GetQueryResultsResponse res = pollUntilComplete(startTestQuery().queryId());
+        long deadline = System.currentTimeMillis() + 60_000;
+        while (res.results().isEmpty() && System.currentTimeMillis() < deadline) {
+            res = pollUntilComplete(startTestQuery().queryId());
+        }
+
+        assertThat(res.status()).isEqualTo(QueryStatus.COMPLETE);
+
+        // job_id filter keeps 3 events; level != TRACE drops 1 -> 2 rows.
+        assertThat(res.results()).hasSize(2);
+
+        // Every row projects @timestamp and @message.
+        assertThat(res.results()).allSatisfy(row -> {
+            assertThat(row).anySatisfy(f -> assertThat(f.field()).isEqualTo("@timestamp"));
+            assertThat(row).anySatisfy(f -> assertThat(f.field()).isEqualTo("@message"));
+        });
+
+        // sort @timestamp desc -> newest (ERROR "job boom") first, then INFO "job started".
+        assertThat(messageOf(res.results().get(0))).contains("job boom");
+        assertThat(messageOf(res.results().get(1))).contains("job started");
+
+        // The TRACE line and the unrelated job must be excluded.
+        List<String> messages = res.results().stream()
+                .map(CloudWatchLogsInsightsTest::messageOf)
+                .toList();
+        assertThat(messages).noneMatch(m -> m.contains("verbose noise") || m.contains("unrelated"));
+    }
+
+    @Test
+    @DisplayName("StopQuery on a finished query fails with InvalidParameterException")
+    void stopFinishedQueryFailsNotRunning() {
+        StartQueryResponse start = startTestQuery();
+        pollUntilComplete(start.queryId()); // ensure the query has ended
+
+        // AWS: stopping a query that is not running returns an error ("...is not running").
+        assertThatThrownBy(() -> logs.stopQuery(b -> b.queryId(start.queryId())))
+                .isInstanceOfSatisfying(CloudWatchLogsException.class,
+                        e -> assertThat(e.awsErrorDetails().errorCode()).isEqualTo("InvalidParameterException"));
+    }
+
+    @Test
+    @DisplayName("StopQuery on a running query returns success")
+    void stopRunningQuerySucceeds() {
+        StartQueryResponse start = startTestQuery();
+
+        // Only meaningful where the server models an async Running window: real AWS, or Floci with a
+        // non-zero query-completion-delay (FLOCI_SERVICES_CLOUDWATCHLOGS_QUERY_COMPLETION_DELAY_MS=2000).
+        // With Floci's default (instant completion) there is no Running phase, so this case is skipped
+        // rather than asserted.
+        String status = logs.getQueryResults(b -> b.queryId(start.queryId())).statusAsString();
+        Assumptions.assumeTrue("Running".equals(status) || "Scheduled".equals(status),
+                "no Running window (instant completion) — nothing to stop");
+
+        // On real AWS the query can complete in the gap between the status check and the stop call;
+        // treat InvalidParameterException from stopQuery as a valid outcome rather than a failure.
+        try {
+            StopQueryResponse stop = logs.stopQuery(b -> b.queryId(start.queryId()));
+            assertThat(stop.success()).isTrue();
+        } catch (CloudWatchLogsException e) {
+            if ("InvalidParameterException".equals(e.awsErrorDetails().errorCode())) {
+                Assumptions.abort("query completed before stop");
+            }
+            throw e;
+        }
+    }
+
+    // ──────────────────────────── helpers ────────────────────────────
+
+    private static StartQueryResponse startTestQuery() {
+        long nowSec = baseMs / 1000;
+        return logs.startQuery(b -> b
+                .logGroupNames(GROUP)
+                .startTime(nowSec - 300)
+                .endTime(nowSec + 300)
+                .queryString(query()));
+    }
+
+    private static String query() {
+        return "fields @timestamp, @message"
+                + " | filter params.job_id = '" + jobId + "'"
+                + " | filter level != 'TRACE'"
+                + " | sort @timestamp desc"
+                + " | dedup @timestamp, @message";
+    }
+
+    private static GetQueryResultsResponse pollUntilComplete(String queryId) {
+        GetQueryResultsResponse res = null;
+        for (int i = 0; i < 75; i++) {   // ~15s budget; real AWS Insights queries run asynchronously
+            res = logs.getQueryResults(b -> b.queryId(queryId));
+            QueryStatus status = res.status();
+            if (status == QueryStatus.COMPLETE || status == QueryStatus.FAILED || status == QueryStatus.CANCELLED) {
+                break;
+            }
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        return res;
+    }
+
+    private static String messageOf(List<ResultField> row) {
+        return row.stream()
+                .filter(f -> "@message".equals(f.field()))
+                .map(ResultField::value)
+                .findFirst()
+                .orElse("");
+    }
+
+    private static String json(String level, String message, String job) {
+        return "{\"level\":\"" + level + "\",\"message\":\"" + message + "\",\"params\":{\"job_id\":\"" + job + "\"}}";
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -662,6 +662,15 @@ public interface EmulatorConfig {
 
         @WithDefault("10000")
         int maxEventsPerQuery();
+
+        /**
+         * Artificial Logs Insights query completion delay, in milliseconds. With the default 0,
+         * queries complete immediately (fast local dev). A positive value emulates the real
+         * asynchronous lifecycle — StartQuery → Running → Complete after this delay — which also
+         * makes StopQuery on a still-running query return {@code success=true}.
+         */
+        @WithDefault("0")
+        long queryCompletionDelayMs();
     }
 
     interface CloudWatchMetricsServiceConfig {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
@@ -15,6 +15,7 @@ import jakarta.ws.rs.core.Response;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -52,6 +53,9 @@ public class CloudWatchLogsHandler {
             case "PutSubscriptionFilter" -> handlePutSubscriptionFilter(request, region);
             case "DescribeSubscriptionFilters" -> handleDescribeSubscriptionFilters(request, region);
             case "DeleteSubscriptionFilter" -> handleDeleteSubscriptionFilter(request, region);
+            case "StartQuery" -> handleStartQuery(request, region);
+            case "GetQueryResults" -> handleGetQueryResults(request, region);
+            case "StopQuery" -> handleStopQuery(request, region);
             default -> Response.status(400)
                     .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                     .build();
@@ -192,6 +196,62 @@ public class CloudWatchLogsHandler {
         if (result.nextToken() != null) {
             response.put("nextToken", result.nextToken());
         }
+        return Response.ok(response).build();
+    }
+
+    // ──────────────────────────── Logs Insights Queries ────────────────────────────
+
+    private Response handleStartQuery(JsonNode request, String region) {
+        List<String> logGroupNames = new ArrayList<>();
+        request.path("logGroupNames").forEach(n -> logGroupNames.add(extractLogGroupNameFromArn(n.asText())));
+        if (request.has("logGroupName")) {
+            logGroupNames.add(extractLogGroupNameFromArn(request.path("logGroupName").asText()));
+        }
+        request.path("logGroupIdentifiers").forEach(n -> logGroupNames.add(extractLogGroupNameFromArn(n.asText())));
+
+        long startTime = request.path("startTime").asLong();
+        long endTime = request.path("endTime").asLong();
+        String queryString = request.path("queryString").asText("");
+        Integer limit = request.has("limit") ? request.path("limit").asInt() : null;
+
+        String queryId = logsService.startQuery(logGroupNames, startTime, endTime, queryString, limit, region);
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("queryId", queryId);
+        return Response.ok(response).build();
+    }
+
+    private Response handleGetQueryResults(JsonNode request, String region) {
+        String queryId = request.path("queryId").asText();
+        CloudWatchLogsService.QueryState state = logsService.getQueryResults(queryId);
+
+        ArrayNode results = objectMapper.createArrayNode();
+        for (LinkedHashMap<String, String> row : state.rows()) {
+            ArrayNode rowArray = objectMapper.createArrayNode();
+            row.forEach((field, value) -> {
+                ObjectNode fieldNode = objectMapper.createObjectNode();
+                fieldNode.put("field", field);
+                fieldNode.put("value", value);
+                rowArray.add(fieldNode);
+            });
+            results.add(rowArray);
+        }
+
+        ObjectNode response = objectMapper.createObjectNode();
+        response.set("results", results);
+        response.put("status", state.status());
+        ObjectNode statistics = objectMapper.createObjectNode();
+        statistics.put("recordsMatched", (double) state.recordsMatched());
+        statistics.put("recordsScanned", (double) state.recordsScanned());
+        statistics.put("bytesScanned", 0.0);
+        response.set("statistics", statistics);
+        return Response.ok(response).build();
+    }
+
+    private Response handleStopQuery(JsonNode request, String region) {
+        String queryId = request.path("queryId").asText();
+        boolean success = logsService.stopQuery(queryId);
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("success", success);
         return Response.ok(response).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
@@ -15,11 +15,14 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.LongSupplier;
 
 @ApplicationScoped
 public class CloudWatchLogsService {
@@ -32,6 +35,22 @@ public class CloudWatchLogsService {
     private final StorageBackend<String, SubscriptionFilter> subscriptionFilterStore;
     private final RegionResolver regionResolver;
     private final int maxEventsPerQuery;
+    private final long queryCompletionDelayMs;
+
+    // Wall-clock source of "now" for the query lifecycle, injected so tests can drive it deterministically.
+    // Non-monotonic: a backward NTP step could briefly flip a Complete query back to Running — a rare,
+    // self-healing emulator artifact we accept rather than complicate the injectable clock with nanoTime.
+    private final LongSupplier clock;
+
+    /** Cached Logs Insights queries keyed by queryId, bounded with LRU-style eviction. */
+    private static final int MAX_STORED_QUERIES = 100;
+    private final Map<String, QueryRecord> insightsQueries = Collections.synchronizedMap(
+            new LinkedHashMap<>(16, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, QueryRecord> eldest) {
+                    return size() > MAX_STORED_QUERIES;
+                }
+            });
 
     @Inject
     public CloudWatchLogsService(StorageFactory storageFactory,
@@ -47,7 +66,9 @@ public class CloudWatchLogsService {
                 storageFactory.create("cloudwatchlogs", "cwlogs-subscription-filters.json",
                         new TypeReference<>() {}),
                 config.services().cloudwatchlogs().maxEventsPerQuery(),
-                regionResolver
+                regionResolver,
+                config.services().cloudwatchlogs().queryCompletionDelayMs(),
+                System::currentTimeMillis
         );
     }
 
@@ -57,12 +78,27 @@ public class CloudWatchLogsService {
                            StorageBackend<String, SubscriptionFilter> subscriptionFilterStore,
                            int maxEventsPerQuery,
                            RegionResolver regionResolver) {
+        this(groupStore, streamStore, eventStore, subscriptionFilterStore,
+                maxEventsPerQuery, regionResolver, 0L, System::currentTimeMillis);
+    }
+
+    CloudWatchLogsService(StorageBackend<String, LogGroup> groupStore,
+                           StorageBackend<String, LogStream> streamStore,
+                           StorageBackend<String, LogEvent> eventStore,
+                           StorageBackend<String, SubscriptionFilter> subscriptionFilterStore,
+                           int maxEventsPerQuery,
+                           RegionResolver regionResolver,
+                           long queryCompletionDelayMs,
+                           LongSupplier clock) {
         this.groupStore = groupStore;
         this.streamStore = streamStore;
         this.eventStore = eventStore;
         this.subscriptionFilterStore = subscriptionFilterStore;
         this.maxEventsPerQuery = maxEventsPerQuery;
         this.regionResolver = regionResolver;
+        // A negative delay is meaningless; treat it as instant completion.
+        this.queryCompletionDelayMs = Math.max(0, queryCompletionDelayMs);
+        this.clock = clock;
     }
 
     // ──────────────────────────── Log Groups ────────────────────────────
@@ -357,6 +393,151 @@ public class CloudWatchLogsService {
 
         String nextToken = result.size() >= maxEvents ? UUID.randomUUID().toString() : null;
         return new FilteredLogEventsResult(result, nextToken);
+    }
+
+    // ──────────────────────────── Logs Insights Queries ────────────────────────────
+
+    /** A query's status and (once Complete) its projected rows — the AWS GetQueryResults shape. */
+    public record QueryState(String status, List<LinkedHashMap<String, String>> rows,
+                             long recordsScanned, long recordsMatched) {}
+
+    /** Lifecycle state of a stored Insights query; {@link #label()} is the AWS wire form. */
+    private enum InsightsQueryStatus {
+        RUNNING("Running"),
+        COMPLETE("Complete"),
+        CANCELLED("Cancelled");
+
+        private final String label;
+
+        InsightsQueryStatus(String label) {
+            this.label = label;
+        }
+
+        String label() {
+            return label;
+        }
+    }
+
+    /**
+     * A stored Insights query. Results are computed eagerly at StartQuery, but the query reports
+     * {@code Running} until {@code completeAtMs} (an artificial delay emulating AWS's asynchronous
+     * execution), then {@code Complete} — unless cancelled by StopQuery, after which it is
+     * {@code Cancelled}. State transitions are time-driven and computed on read. {@code recordsMatched}
+     * is captured at construction so it survives the Running/Cancelled row masking and the row-drop on cancel.
+     */
+    private static final class QueryRecord {
+        private List<LinkedHashMap<String, String>> rows;
+        private final long recordsScanned;
+        private final long recordsMatched;
+        private final long completeAtMs;
+        private boolean cancelled;
+
+        QueryRecord(List<LinkedHashMap<String, String>> rows, long recordsScanned, long completeAtMs) {
+            this.rows = rows;
+            this.recordsScanned = recordsScanned;
+            this.recordsMatched = rows.size();
+            this.completeAtMs = completeAtMs;
+        }
+
+        private InsightsQueryStatus status(long nowMs) {
+            if (cancelled) {
+                return InsightsQueryStatus.CANCELLED;
+            }
+            return nowMs >= completeAtMs ? InsightsQueryStatus.COMPLETE : InsightsQueryStatus.RUNNING;
+        }
+
+        /**
+         * Snapshot this query in the AWS GetQueryResults shape. Rows are exposed only once
+         * {@code Complete}, and always as a defensive copy (the cached list is never handed out); while
+         * Running or Cancelled the rows are masked empty, but {@code recordsMatched} still reports the
+         * full match count.
+         */
+        synchronized QueryState snapshot(long nowMs) {
+            InsightsQueryStatus status = status(nowMs);
+            List<LinkedHashMap<String, String>> visible =
+                    status == InsightsQueryStatus.COMPLETE ? List.copyOf(rows) : List.of();
+            return new QueryState(status.label(), visible, recordsScanned, recordsMatched);
+        }
+
+        /** Cancels the query iff still running, dropping its now-unreachable rows. Returns true if this call stopped it. */
+        synchronized boolean stopIfRunning(long nowMs) {
+            if (!cancelled && nowMs < completeAtMs) {
+                cancelled = true;
+                rows = List.of();
+                return true;
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Start a CloudWatch Logs Insights query and cache it under a new queryId. Results are computed
+     * eagerly (the scan is in-memory); the query then reports {@code Running} until the configured
+     * completion delay elapses (default 0 = immediate), emulating AWS's async execution.
+     * {@code startTimeSeconds}/{@code endTimeSeconds} are epoch <em>seconds</em> (the StartQuery
+     * contract); {@link LogEvent} timestamps are epoch millis, so they are scaled for comparison.
+     */
+    public String startQuery(List<String> logGroupNames, long startTimeSeconds, long endTimeSeconds,
+                             String queryString, Integer limit, String region) {
+        long startMs = startTimeSeconds * 1000L;
+        long endMs = endTimeSeconds * 1000L;
+
+        List<LogEvent> gathered = new ArrayList<>();
+        for (String groupName : logGroupNames) {
+            if (groupName == null || groupName.isBlank()) {
+                continue;
+            }
+            String prefix = region + "::" + groupName + "::";
+            for (LogEvent e : eventStore.scan(k -> k.startsWith(prefix))) {
+                if (e.getTimestamp() >= startMs && e.getTimestamp() <= endMs) {
+                    gathered.add(e);
+                }
+            }
+        }
+
+        int effectiveLimit = (limit != null && limit > 0) ? Math.min(limit, maxEventsPerQuery) : maxEventsPerQuery;
+        List<LinkedHashMap<String, String>> rows =
+                LogsInsightsQuery.parse(queryString).evaluate(gathered, effectiveLimit);
+
+        String queryId = UUID.randomUUID().toString();
+        long completeAtMs = clock.getAsLong() + queryCompletionDelayMs;
+        insightsQueries.put(queryId, new QueryRecord(rows, gathered.size(), completeAtMs));
+        LOG.infov("Logs Insights query {0}: scanned {1} event(s) across {2} group(s) -> {3} row(s)",
+                queryId, gathered.size(), logGroupNames.size(), rows.size());
+        return queryId;
+    }
+
+    /**
+     * Return a query's status and, once {@code Complete}, its rows. Mirrors AWS: while {@code Running}
+     * or after a StopQuery ({@code Cancelled}) the result set is empty (though {@code recordsMatched}
+     * still reports the full match count); only a Complete query exposes rows. An unknown queryId is an
+     * error on real AWS — and a query that has fallen out of the bounded LRU cache 404s the same way.
+     */
+    public QueryState getQueryResults(String queryId) {
+        QueryRecord rec = insightsQueries.get(queryId);
+        if (rec == null) {
+            throw new AwsException("ResourceNotFoundException",
+                    "The specified query does not exist.", 400);
+        }
+        return rec.snapshot(clock.getAsLong());
+    }
+
+    /**
+     * Stop an in-progress query. Mirrors AWS StopQuery: a running query is cancelled and returns
+     * {@code success=true}; an already-ended query throws {@code InvalidParameterException} ("not
+     * running"); an unknown queryId throws {@code ResourceNotFoundException}.
+     */
+    public boolean stopQuery(String queryId) {
+        QueryRecord rec = insightsQueries.get(queryId);
+        if (rec == null) {
+            throw new AwsException("ResourceNotFoundException",
+                    "The specified query does not exist.", 400);
+        }
+        if (rec.stopIfRunning(clock.getAsLong())) {
+            return true;
+        }
+        throw new AwsException("InvalidParameterException",
+                "The query you are trying to stop is not running.", 400);
     }
 
     // ──────────────────────────── Subscription Filters ────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/LogsInsightsQuery.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/LogsInsightsQuery.java
@@ -1,0 +1,275 @@
+package io.github.hectorvent.floci.services.cloudwatch.logs;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.services.cloudwatch.logs.model.LogEvent;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Minimal CloudWatch Logs Insights query engine.
+ *
+ * <p>Implements the subset of the Logs Insights query language that clients use in practice:
+ * <ul>
+ *   <li>{@code fields a, b, ...} — projection (defaults to {@code @timestamp, @message})</li>
+ *   <li>{@code filter <field> = 'v'} / {@code filter <field> != 'v'} — equality / inequality</li>
+ *   <li>{@code sort <field> [asc|desc]}</li>
+ *   <li>{@code dedup <field, ...>} — keep the first row per unique tuple (applied after sort)</li>
+ *   <li>{@code limit N}</li>
+ * </ul>
+ * Fields may be the synthetic {@code @timestamp} / {@code @message} / {@code @ingestionTime} /
+ * {@code @ptr}, or a dotted path into the JSON log message (e.g. {@code params.job_id}, {@code level}).
+ *
+ * <p>This is intentionally <em>not</em> a full Insights implementation: unsupported commands
+ * (e.g. {@code stats}, {@code parse}) are ignored with a warning, and pipe ({@code |}) characters
+ * inside string literals are not supported as they do not occur in the queries we target.
+ */
+final class LogsInsightsQuery {
+
+    private static final Logger LOG = Logger.getLogger(LogsInsightsQuery.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final DateTimeFormatter TS_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneOffset.UTC);
+
+    private final List<String> fields = new ArrayList<>();
+    private final List<Filter> filters = new ArrayList<>();
+    private String sortField;
+    private boolean sortDesc;
+    private List<String> dedupFields;
+    private Integer limit;
+
+    private record Filter(String field, boolean negate, String value) {}
+
+    private LogsInsightsQuery() {}
+
+    static LogsInsightsQuery parse(String queryString) {
+        LogsInsightsQuery q = new LogsInsightsQuery();
+        if (queryString != null && !queryString.isBlank()) {
+            for (String rawStage : queryString.split("\\|")) {
+                String stage = rawStage.trim();
+                if (stage.isEmpty()) {
+                    continue;
+                }
+                String[] parts = stage.split("\\s+", 2);
+                String cmd = parts[0].toLowerCase();
+                String args = parts.length > 1 ? parts[1].trim() : "";
+                q.applyStage(cmd, args);
+            }
+        }
+        if (q.fields.isEmpty()) {
+            q.fields.add("@timestamp");
+            q.fields.add("@message");
+        }
+        return q;
+    }
+
+    private void applyStage(String cmd, String args) {
+        switch (cmd) {
+            case "fields", "display" -> splitCsv(args, fields);
+            case "filter", "where" -> {
+                Filter f = parseFilter(args);
+                if (f != null) {
+                    filters.add(f);
+                }
+            }
+            case "sort", "order" -> {
+                String[] s = args.split("\\s+");
+                if (s.length > 0 && !s[0].isEmpty()) {
+                    sortField = s[0].trim();
+                    sortDesc = s.length > 1 && s[1].trim().equalsIgnoreCase("desc");
+                }
+            }
+            case "dedup" -> {
+                dedupFields = new ArrayList<>();
+                splitCsv(args, dedupFields);
+            }
+            case "limit" -> {
+                try {
+                    limit = Integer.parseInt(args.trim());
+                } catch (NumberFormatException e) {
+                    LOG.warnv("Ignoring invalid Logs Insights limit: {0}", args);
+                }
+            }
+            default -> LOG.warnv("Ignoring unsupported Logs Insights command: {0}", cmd);
+        }
+    }
+
+    private static void splitCsv(String args, List<String> target) {
+        for (String token : args.split(",")) {
+            String t = token.trim();
+            if (!t.isEmpty()) {
+                target.add(t);
+            }
+        }
+    }
+
+    private static Filter parseFilter(String expr) {
+        // '!=' must be checked before '=' so it is not mis-parsed as equality.
+        for (String op : new String[] {"!=", "==", "="}) {
+            int idx = expr.indexOf(op);
+            if (idx > 0) {
+                String field = expr.substring(0, idx).trim();
+                String value = unquote(expr.substring(idx + op.length()).trim());
+                return new Filter(field, op.equals("!="), value);
+            }
+        }
+        LOG.warnv("Ignoring unsupported Logs Insights filter: {0}", expr);
+        return null;
+    }
+
+    private static String unquote(String s) {
+        if (s.length() >= 2) {
+            char first = s.charAt(0);
+            char last = s.charAt(s.length() - 1);
+            if ((first == '\'' && last == '\'') || (first == '"' && last == '"')) {
+                return s.substring(1, s.length() - 1);
+            }
+        }
+        return s;
+    }
+
+    /**
+     * Evaluate the query against the given events.
+     *
+     * @return ordered result rows; each row maps a projected field name to its string value,
+     *         in the order declared by {@code fields}, with a synthetic {@code @ptr} appended.
+     */
+    List<LinkedHashMap<String, String>> evaluate(List<LogEvent> events, int defaultLimit) {
+        List<Row> rows = new ArrayList<>(events.size());
+        for (LogEvent e : events) {
+            rows.add(new Row(e, tryParse(e.getMessage())));
+        }
+
+        // filter (logical AND across all filter stages)
+        List<Row> matched = new ArrayList<>();
+        for (Row row : rows) {
+            if (passesFilters(row)) {
+                matched.add(row);
+            }
+        }
+
+        // sort
+        if (sortField != null) {
+            Comparator<Row> cmp = comparatorFor(sortField);
+            matched.sort(sortDesc ? cmp.reversed() : cmp);
+        }
+
+        // dedup (keep first occurrence per tuple, after sorting)
+        if (dedupFields != null && !dedupFields.isEmpty()) {
+            List<Row> deduped = new ArrayList<>();
+            Set<String> seen = new HashSet<>();
+            for (Row row : matched) {
+                StringBuilder key = new StringBuilder();
+                for (String df : dedupFields) {
+                    key.append(resolve(row, df)).append('\0');
+                }
+                if (seen.add(key.toString())) {
+                    deduped.add(row);
+                }
+            }
+            matched = deduped;
+        }
+
+        // limit
+        int max = limit != null ? Math.min(limit, defaultLimit) : defaultLimit;
+        if (max >= 0 && matched.size() > max) {
+            matched = matched.subList(0, max);
+        }
+
+        // project
+        List<LinkedHashMap<String, String>> out = new ArrayList<>(matched.size());
+        for (Row row : matched) {
+            LinkedHashMap<String, String> projected = new LinkedHashMap<>();
+            for (String field : fields) {
+                String value = resolve(row, field);
+                projected.put(field, value != null ? value : "");
+            }
+            projected.putIfAbsent("@ptr", row.event.getEventId());
+            out.add(projected);
+        }
+        return out;
+    }
+
+    private boolean passesFilters(Row row) {
+        for (Filter f : filters) {
+            String actual = resolve(row, f.field());
+            boolean equals = actual != null && actual.equals(f.value());
+            boolean fails = f.negate() ? equals : !equals;
+            if (fails) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private Comparator<Row> comparatorFor(String field) {
+        if ("@timestamp".equals(field)) {
+            return Comparator.comparingLong(r -> r.event.getTimestamp());
+        }
+        if ("@ingestionTime".equals(field)) {
+            return Comparator.comparingLong(r -> r.event.getIngestionTime());
+        }
+        return Comparator.comparing(r -> {
+            String v = resolve(r, field);
+            return v != null ? v : "";
+        });
+    }
+
+    private String resolve(Row row, String field) {
+        switch (field) {
+            case "@timestamp":
+                return TS_FORMAT.format(Instant.ofEpochMilli(row.event.getTimestamp()));
+            case "@ingestionTime":
+                return TS_FORMAT.format(Instant.ofEpochMilli(row.event.getIngestionTime()));
+            case "@message":
+                return row.event.getMessage();
+            case "@ptr":
+                return row.event.getEventId();
+            default:
+                if (row.json == null) {
+                    return null;
+                }
+                JsonNode node = row.json;
+                for (String seg : field.split("\\.")) {
+                    if (node == null) {
+                        return null;
+                    }
+                    node = node.get(seg);
+                }
+                if (node == null || node.isNull()) {
+                    return null;
+                }
+                return node.isValueNode() ? node.asText() : node.toString();
+        }
+    }
+
+    private static JsonNode tryParse(String message) {
+        if (message == null || message.isBlank()) {
+            return null;
+        }
+        try {
+            return MAPPER.readTree(message);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static final class Row {
+        final LogEvent event;
+        final JsonNode json;
+
+        Row(LogEvent event, JsonNode json) {
+            this.event = event;
+            this.json = json;
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsInsightsQueryTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsInsightsQueryTest.java
@@ -1,0 +1,191 @@
+package io.github.hectorvent.floci.services.cloudwatch.logs;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the CloudWatch Logs Insights subset ({@code StartQuery}/{@code GetQueryResults}/{@code StopQuery})
+ * against the exact query shape the reporting-studio web backend sends.
+ */
+class CloudWatchLogsInsightsQueryTest {
+
+    private static final String REGION = "us-east-1";
+    private static final String GROUP = "rs-reporting-studio-spark";
+    private static final String STREAM = "job-stream";
+    private static final long BASE_MS = 1_700_000_000_000L;
+
+    // The literal query the web backend builds (filter on a nested JSON field, drop TRACE, sort, dedup).
+    private static final String APP_QUERY = """
+            fields @timestamp, @message
+            | filter params.job_id = 'JOB-1'
+            | filter level != 'TRACE'
+            | sort @timestamp desc
+            | dedup @timestamp, @message
+            """;
+
+    private CloudWatchLogsService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CloudWatchLogsService(
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                10000,
+                new RegionResolver(REGION, "000000000000"));
+        seedGroupAndStream(service);
+    }
+
+    private void put(long timestampMs, String level, String jobId, String text) {
+        String message = String.format(
+                "{\"level\":\"%s\",\"message\":\"%s\",\"params\":{\"job_id\":\"%s\"}}",
+                level, text, jobId);
+        Map<String, Object> event = new LinkedHashMap<>();
+        event.put("timestamp", timestampMs);
+        event.put("message", message);
+        service.putLogEvents(GROUP, STREAM, List.of(event), REGION);
+    }
+
+    @Test
+    void startQueryFiltersSortsAndDedups() {
+        put(BASE_MS + 2000, "INFO", "JOB-1", "alpha");
+        put(BASE_MS + 3000, "TRACE", "JOB-1", "trace-line"); // excluded: level == TRACE
+        put(BASE_MS + 4000, "INFO", "JOB-2", "other-job");   // excluded: different job_id
+        put(BASE_MS + 2000, "INFO", "JOB-1", "alpha");        // duplicate @timestamp + @message
+        put(BASE_MS + 5000, "DEBUG", "JOB-1", "delta");
+
+        long startSec = BASE_MS / 1000 - 10;
+        long endSec = startSec + 86400;
+        String queryId = service.startQuery(List.of(GROUP), startSec, endSec, APP_QUERY, null, REGION);
+
+        CloudWatchLogsService.QueryState state = service.getQueryResults(queryId);
+        assertEquals("Complete", state.status());
+        assertEquals(2, state.rows().size(), "delta + alpha survive filter/dedup");
+
+        // sorted @timestamp desc: delta (BASE+5000) before alpha (BASE+2000)
+        assertTrue(state.rows().get(0).get("@message").contains("delta"));
+        assertTrue(state.rows().get(1).get("@message").contains("alpha"));
+
+        for (LinkedHashMap<String, String> row : state.rows()) {
+            assertTrue(row.containsKey("@timestamp"), "row has @timestamp");
+            assertTrue(row.containsKey("@message"), "row has @message");
+            assertNotNull(row.get("@ptr"), "row has @ptr");
+        }
+    }
+
+    @Test
+    void startQueryRespectsTimeWindow() {
+        put(BASE_MS + 2000, "INFO", "JOB-1", "in-window");
+
+        // window entirely before the event → nothing matches
+        long startSec = BASE_MS / 1000 - 1000;
+        long endSec = BASE_MS / 1000 - 100;
+        String queryId = service.startQuery(List.of(GROUP), startSec, endSec, APP_QUERY, null, REGION);
+
+        assertTrue(service.getQueryResults(queryId).rows().isEmpty());
+    }
+
+    @Test
+    void getQueryResultsUnknownIdThrowsResourceNotFound() {
+        AwsException ex = assertThrows(AwsException.class, () -> service.getQueryResults("does-not-exist"));
+        assertEquals("ResourceNotFoundException", ex.getErrorCode());
+    }
+
+    @Test
+    void stopCompletedQueryThrowsInvalidParameter() {
+        // The default service has zero completion delay, so the query is Complete immediately.
+        put(BASE_MS + 2000, "INFO", "JOB-1", "alpha");
+        long startSec = BASE_MS / 1000 - 10;
+        String queryId = service.startQuery(List.of(GROUP), startSec, startSec + 86400, APP_QUERY, null, REGION);
+        assertEquals("Complete", service.getQueryResults(queryId).status());
+
+        AwsException ex = assertThrows(AwsException.class, () -> service.stopQuery(queryId));
+        assertEquals("InvalidParameterException", ex.getErrorCode());
+    }
+
+    @Test
+    void stopUnknownQueryThrowsResourceNotFound() {
+        AwsException ex = assertThrows(AwsException.class, () -> service.stopQuery("does-not-exist"));
+        assertEquals("ResourceNotFoundException", ex.getErrorCode());
+    }
+
+    @Test
+    void asyncQueryReportsRunningThenCompleteAfterDelay() {
+        AtomicLong now = new AtomicLong(BASE_MS);
+        CloudWatchLogsService async = newAsyncService(now, 1000L);
+        String queryId = async.startQuery(List.of(GROUP), BASE_MS / 1000 - 10, BASE_MS / 1000 + 86400, APP_QUERY, null, REGION);
+
+        // Within the delay window: Running, with no rows exposed yet.
+        assertEquals("Running", async.getQueryResults(queryId).status());
+        assertTrue(async.getQueryResults(queryId).rows().isEmpty());
+        // recordsMatched reports the full match count even while Running (rows masked, statistics not).
+        assertEquals(1, async.getQueryResults(queryId).recordsMatched());
+
+        // Advance the clock past the completion delay: Complete, rows exposed.
+        now.addAndGet(1000);
+        CloudWatchLogsService.QueryState complete = async.getQueryResults(queryId);
+        assertEquals("Complete", complete.status());
+        assertEquals(1, complete.rows().size());
+    }
+
+    @Test
+    void stopRunningQueryCancelsIt() {
+        AtomicLong now = new AtomicLong(BASE_MS);
+        CloudWatchLogsService async = newAsyncService(now, 1000L);
+        String queryId = async.startQuery(List.of(GROUP), BASE_MS / 1000 - 10, BASE_MS / 1000 + 86400, APP_QUERY, null, REGION);
+        assertEquals("Running", async.getQueryResults(queryId).status());
+
+        // Stopping a running query succeeds and cancels it.
+        assertTrue(async.stopQuery(queryId));
+        CloudWatchLogsService.QueryState cancelled = async.getQueryResults(queryId);
+        assertEquals("Cancelled", cancelled.status());
+        assertTrue(cancelled.rows().isEmpty());
+
+        // Stopping again (already ended) throws InvalidParameterException.
+        AwsException ex = assertThrows(AwsException.class, () -> async.stopQuery(queryId));
+        assertEquals("InvalidParameterException", ex.getErrorCode());
+    }
+
+    @Test
+    void negativeCompletionDelayClampsToImmediateComplete() {
+        AtomicLong now = new AtomicLong(BASE_MS);
+        CloudWatchLogsService async = newAsyncService(now, -5000L);
+        String queryId = async.startQuery(List.of(GROUP), BASE_MS / 1000 - 10, BASE_MS / 1000 + 86400, APP_QUERY, null, REGION);
+
+        // A negative delay must not leave the query stuck Running — it clamps to instant completion.
+        CloudWatchLogsService.QueryState state = async.getQueryResults(queryId);
+        assertEquals("Complete", state.status());
+        assertEquals(1, state.rows().size());
+    }
+
+    private CloudWatchLogsService newAsyncService(AtomicLong clockMs, long delayMs) {
+        CloudWatchLogsService svc = new CloudWatchLogsService(
+                new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
+                10000, new RegionResolver(REGION, "000000000000"), delayMs, clockMs::get);
+        seedGroupAndStream(svc);
+        Map<String, Object> event = new LinkedHashMap<>();
+        event.put("timestamp", BASE_MS + 2000);
+        event.put("message", "{\"level\":\"INFO\",\"message\":\"x\",\"params\":{\"job_id\":\"JOB-1\"}}");
+        svc.putLogEvents(GROUP, STREAM, List.of(event), REGION);
+        return svc;
+    }
+
+    private static void seedGroupAndStream(CloudWatchLogsService svc) {
+        svc.createLogGroup(GROUP, null, null, REGION);
+        svc.createLogStream(GROUP, STREAM, REGION);
+    }
+}


### PR DESCRIPTION
Implement StartQuery/GetQueryResults/StopQuery for CloudWatch Logs so clients using Logs Insights (e.g. boto3 start_query + get_query_results) work against Floci instead of receiving UnsupportedOperation.

LogsInsightsQuery is a minimal engine covering the common subset: fields, filter (= / !=), sort, dedup, limit; it resolves @timestamp/@message and dotted JSON paths (e.g. params.job_id, level). StartQuery times are epoch seconds while event timestamps are millis, scaled accordingly.

Queries follow a time-driven lifecycle: results are computed eagerly, but a query reports Running until a configurable completion delay elapses (FLOCI_SERVICES_CLOUDWATCHLOGS_QUERY_COMPLETION_DELAY_MS, default 0 = instant for local dev), then Complete; StopQuery cancels a running query and otherwise returns AWS-faithful errors (InvalidParameterException when already ended, ResourceNotFoundException for an unknown id). Status is computed on read from an injectable clock, with no background threads. GetQueryResults returns ResourceNotFoundException for unknown ids, reports recordsMatched independent of the Running/Cancelled row masking, hands out a defensive copy of result rows, and drops rows once cancelled. Results are cached by queryId with LRU eviction.

Covered by unit tests and an AWS SDK v2 compatibility test exercising the full StartQuery/GetQueryResults/StopQuery lifecycle (stable against both instant and delayed completion).

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
