### PR TITLE
fix(docdb,neptune): stop containers and proxies on emulator shutdown

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
@@ -11,9 +11,12 @@ import io.github.hectorvent.floci.services.floci.ui.FlociUiManager;
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheContainerManager;
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheMemcachedContainerManager;
 import io.github.hectorvent.floci.services.elasticache.proxy.ElastiCacheProxyManager;
+import io.github.hectorvent.floci.services.docdb.container.DocDbContainerManager;
 import io.github.hectorvent.floci.services.lambda.DynamoDbStreamsEventSourcePoller;
 import io.github.hectorvent.floci.services.lambda.KinesisEventSourcePoller;
 import io.github.hectorvent.floci.services.lambda.SqsEventSourcePoller;
+import io.github.hectorvent.floci.services.neptune.container.NeptuneContainerManager;
+import io.github.hectorvent.floci.services.neptune.proxy.NeptuneProxyManager;
 import io.github.hectorvent.floci.services.pipes.PipesService;
 import io.github.hectorvent.floci.services.rds.RdsService;
 import io.github.hectorvent.floci.services.rds.container.RdsContainerManager;
@@ -59,6 +62,9 @@ public class EmulatorLifecycle {
     private final ElastiCacheProxyManager elastiCacheProxyManager;
     private final RdsContainerManager rdsContainerManager;
     private final RdsProxyManager rdsProxyManager;
+    private final DocDbContainerManager docDbContainerManager;
+    private final NeptuneContainerManager neptuneContainerManager;
+    private final NeptuneProxyManager neptuneProxyManager;
     private final RdsService rdsService;
     private final InitializationHooksRunner initializationHooksRunner;
     private final SqsEventSourcePoller sqsPoller;
@@ -78,6 +84,9 @@ public class EmulatorLifecycle {
                              ElastiCacheProxyManager elastiCacheProxyManager,
                              RdsContainerManager rdsContainerManager,
                              RdsProxyManager rdsProxyManager,
+                             DocDbContainerManager docDbContainerManager,
+                             NeptuneContainerManager neptuneContainerManager,
+                             NeptuneProxyManager neptuneProxyManager,
                              RdsService rdsService,
                              InitializationHooksRunner initializationHooksRunner,
                              SqsEventSourcePoller sqsPoller,
@@ -96,6 +105,9 @@ public class EmulatorLifecycle {
         this.elastiCacheProxyManager = elastiCacheProxyManager;
         this.rdsContainerManager = rdsContainerManager;
         this.rdsProxyManager = rdsProxyManager;
+        this.docDbContainerManager = docDbContainerManager;
+        this.neptuneContainerManager = neptuneContainerManager;
+        this.neptuneProxyManager = neptuneProxyManager;
         this.rdsService = rdsService;
         this.initializationHooksRunner = initializationHooksRunner;
         this.sqsPoller = sqsPoller;
@@ -218,9 +230,12 @@ public class EmulatorLifecycle {
         }
         elastiCacheProxyManager.stopAll();
         rdsProxyManager.stopAll();
+        neptuneProxyManager.stopAll();
         elastiCacheContainerManager.stopAll();
         elastiCacheMemcachedContainerManager.stopAll();
         rdsContainerManager.stopAll();
+        docDbContainerManager.stopAll();
+        neptuneContainerManager.stopAll();
         ecrRegistryManager.shutdown();
         flociUiManager.shutdown();
         storageFactory.shutdownAll();

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
@@ -9,6 +9,9 @@ import io.github.hectorvent.floci.lifecycle.inithook.InitializationHooksRunner;
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheContainerManager;
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheMemcachedContainerManager;
 import io.github.hectorvent.floci.services.elasticache.proxy.ElastiCacheProxyManager;
+import io.github.hectorvent.floci.services.docdb.container.DocDbContainerManager;
+import io.github.hectorvent.floci.services.neptune.container.NeptuneContainerManager;
+import io.github.hectorvent.floci.services.neptune.proxy.NeptuneProxyManager;
 import io.github.hectorvent.floci.services.lambda.DynamoDbStreamsEventSourcePoller;
 import io.github.hectorvent.floci.services.lambda.KinesisEventSourcePoller;
 import io.github.hectorvent.floci.services.lambda.SqsEventSourcePoller;
@@ -57,6 +60,9 @@ class EmulatorLifecycleTest {
     @Mock private ElastiCacheProxyManager elastiCacheProxyManager;
     @Mock private RdsContainerManager rdsContainerManager;
     @Mock private RdsProxyManager rdsProxyManager;
+    @Mock private DocDbContainerManager docDbContainerManager;
+    @Mock private NeptuneContainerManager neptuneContainerManager;
+    @Mock private NeptuneProxyManager neptuneProxyManager;
     @Mock private RdsService rdsService;
     @Mock private InitializationHooksRunner initializationHooksRunner;
     @Mock private SqsEventSourcePoller sqsPoller;
@@ -82,7 +88,8 @@ class EmulatorLifecycleTest {
         emulatorLifecycle = new EmulatorLifecycle(
                 storageFactory, serviceRegistry, config,
                 elastiCacheContainerManager, elastiCacheMemcachedContainerManager,
-                elastiCacheProxyManager, rdsContainerManager, rdsProxyManager, rdsService,
+                elastiCacheProxyManager, rdsContainerManager, rdsProxyManager,
+                docDbContainerManager, neptuneContainerManager, neptuneProxyManager, rdsService,
                 initializationHooksRunner, sqsPoller, kinesisPoller, dynamodbStreamsPoller,
                 pipesService, ec2MetadataServer, ecrRegistryManager, flociUiManager, initLifecycleState);
     }
@@ -197,6 +204,7 @@ class EmulatorLifecycleTest {
         verify(storageFactory, never()).shutdownAll();
         verify(elastiCacheProxyManager, never()).stopAll();
         verify(rdsProxyManager, never()).stopAll();
+        verify(neptuneProxyManager, never()).stopAll();
     }
 
     @Test
@@ -244,8 +252,11 @@ class EmulatorLifecycleTest {
 
         verify(elastiCacheProxyManager).stopAll();
         verify(rdsProxyManager).stopAll();
+        verify(neptuneProxyManager).stopAll();
         verify(elastiCacheContainerManager).stopAll();
         verify(rdsContainerManager).stopAll();
+        verify(docDbContainerManager).stopAll();
+        verify(neptuneContainerManager).stopAll();
         verify(storageFactory).shutdownAll();
         // Hooks are handled by onPreShutdown, never from ShutdownEvent.
         verify(initializationHooksRunner, never()).run(InitializationHook.STOP);
@@ -262,8 +273,11 @@ class EmulatorLifecycleTest {
         verify(initializationHooksRunner).run(InitializationHook.STOP);
         verify(elastiCacheProxyManager).stopAll();
         verify(rdsProxyManager).stopAll();
+        verify(neptuneProxyManager).stopAll();
         verify(elastiCacheContainerManager).stopAll();
         verify(rdsContainerManager).stopAll();
+        verify(docDbContainerManager).stopAll();
+        verify(neptuneContainerManager).stopAll();
         verify(storageFactory).shutdownAll();
     }
 


### PR DESCRIPTION
## Summary

  EmulatorLifecycle.onStop() is the single place that tears down each service's Docker containers and TCP proxies on shutdown, but it only stopped ElastiCache and RDS. DocDbContainerManager,
  NeptuneContainerManager, and NeptuneProxyManager all expose stopAll() that was never invoked (and they don't self-clean via @PreDestroy/@Observes ShutdownEvent), so on shutdown they could leave running
  containers and bound proxy ports — a resource leak that accumulates across repeated dev/test runs.

  This wires the three managers into EmulatorLifecycle via constructor injection and calls stopAll() in onStop(), proxies before containers, mirroring the existing ElastiCache/RDS wiring. DocumentDB is
  container-only (no proxy manager), so it adds a single container teardown; Neptune adds both a proxy and a container teardown.

  Surfaced while hardening MemoryDB; the MemoryDB shutdown wiring is the reference implementation. This is a focused sibling-service mirror.
## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Not a wire-protocol change — no AWS actions or responses are affected. This fixes local resource lifecycle only: the incorrect behavior was that DocumentDB/Neptune containers and the Neptune proxy port
survived emulator shutdown instead of being released.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
