### PR TITLE
fix(athena): Add partition keys to table metadata response

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
@@ -480,14 +480,22 @@ public class AthenaService {
         metadata.put("TableType", table.getTableType() != null ? table.getTableType() : "EXTERNAL_TABLE");
         metadata.put("Columns", athenaColumns(table));
         metadata.put("Parameters", table.getParameters() != null ? table.getParameters() : Map.of());
+        metadata.put("PartitionKeys", athenaColumns(table.getPartitionKeys()));
         return metadata;
     }
 
     private List<Map<String, String>> athenaColumns(Table table) {
-        if (table.getStorageDescriptor() == null || table.getStorageDescriptor().getColumns() == null) {
+        if (table.getStorageDescriptor() == null) {
             return List.of();
         }
-        return table.getStorageDescriptor().getColumns().stream()
+        return athenaColumns(table.getStorageDescriptor().getColumns());
+    }
+
+    private List<Map<String, String>> athenaColumns(List<Column> columns) {
+        if (columns == null) {
+            return List.of();
+        }
+        return columns.stream()
                 .map(column -> Map.of(
                         "Name", column.getName(),
                         "Type", glueTypeToAthena(column)

--- a/src/test/java/io/github/hectorvent/floci/services/athena/AthenaIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/athena/AthenaIntegrationTest.java
@@ -190,11 +190,77 @@ class AthenaIntegrationTest {
             .body("TableMetadata.Name", equalTo("orders"))
             .body("TableMetadata.Columns[0].Name", equalTo("id"))
             .body("TableMetadata.Columns[0].Type", equalTo("varchar"))
-            .body("TableMetadata.Columns[1].Type", equalTo("varchar"));
+            .body("TableMetadata.Columns[1].Type", equalTo("varchar"))
+            .body("TableMetadata.PartitionKeys", empty());
     }
 
     @Test
     @Order(8)
+    void listsGlueDatabasesAndTablesAsAthenaMetadataHasPartitionKeys() {
+        given()
+                .header("X-Amz-Target", "AWSGlue.CreateDatabase")
+                .contentType(CONTENT_TYPE)
+                .body("{ \"DatabaseInput\": { \"Name\": \"analytics_test2\" } }")
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+
+        given()
+                .header("X-Amz-Target", "AWSGlue.CreateTable")
+                .contentType(CONTENT_TYPE)
+                .body("""
+                {
+                  "DatabaseName": "analytics_test2",
+                  "TableInput": {
+                    "Name": "orders",
+                    "TableType": "EXTERNAL_TABLE",
+                    "StorageDescriptor": {
+                      "Location": "s3://bucket/orders",
+                      "Columns": [
+                        { "Name": "id", "Type": "string" },
+                        { "Name": "payload", "Type": "struct<id:string>" }
+                      ]
+                    },
+                    "PartitionKeys": [
+                      { "Name": "pkey", "Type": "string" }
+                    ]
+                  }
+                }
+                """)
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+
+        given()
+                .header("X-Amz-Target", "AmazonAthena.ListDatabases")
+                .contentType(CONTENT_TYPE)
+                .body("{ \"CatalogName\": \"AwsDataCatalog\" }")
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .body("DatabaseList.Name", hasItem("analytics_test2"));
+
+        given()
+                .header("X-Amz-Target", "AmazonAthena.GetTableMetadata")
+                .contentType(CONTENT_TYPE)
+                .body("{ \"CatalogName\": \"AwsDataCatalog\", \"DatabaseName\": \"analytics_test2\", \"TableName\": \"orders\" }")
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .body("TableMetadata.Name", equalTo("orders"))
+                .body("TableMetadata.Columns[0].Name", equalTo("id"))
+                .body("TableMetadata.Columns[0].Type", equalTo("varchar"))
+                .body("TableMetadata.Columns[1].Type", equalTo("varchar"))
+                .body("TableMetadata.PartitionKeys[0].Name", equalTo("pkey"))
+                .body("TableMetadata.PartitionKeys[0].Type", equalTo("varchar"));
+    }
+
+    @Test
+    @Order(9)
     void deleteWorkGroup() {
         given()
             .header("X-Amz-Target", "AmazonAthena.DeleteWorkGroup")
@@ -208,7 +274,7 @@ class AthenaIntegrationTest {
     }
 
     @Test
-    @Order(9)
+    @Order(10)
     void deleteWorkGroupMissingOrBlank() {
         given()
             .header("X-Amz-Target", "AmazonAthena.DeleteWorkGroup")
@@ -256,7 +322,7 @@ class AthenaIntegrationTest {
     }
 
     @Test
-    @Order(10)
+    @Order(11)
     void deletePrimaryWorkGroup() {
         given()
             .header("X-Amz-Target", "AmazonAthena.DeleteWorkGroup")


### PR DESCRIPTION
## Summary

The PartitionKeys field has been added to the responses of GetTableMetadata and ListTableMetadata.

Closes https://github.com/floci-io/floci/issues/1423

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

If a partition key was registered when the table was created, ListTableMetadata and GetTableMetadata should return a list of partition keys, but there were no entries at all.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
