### PR TITLE
feat(dynamodb): TableId, TableClass, OnDemandThroughput; fix deletion-protection error

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -887,7 +887,8 @@ public class DynamoDbJsonHandler {
         }
 
         DynamoDbService.ScanResult result = dynamoDbService.scan(
-                tableName, filterExpr, exprAttrNames, exprAttrValues, scanFilter, limit, exclusiveStartKey, region);
+                tableName, filterExpr, exprAttrNames, exprAttrValues, scanFilter, limit,
+                exclusiveStartKey, indexNameScan, region);
 
         List<JsonNode> scanItems = result.items();
         // Apply parallel scan segment partitioning

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -175,6 +175,20 @@ public class DynamoDbJsonHandler {
             table.setBillingMode("PROVISIONED");
         }
 
+        if (request.has("TableClass")) {
+            table.setTableClass(request.get("TableClass").asText());
+        }
+
+        JsonNode onDemand = request.path("OnDemandThroughput");
+        if (onDemand.isObject()) {
+            if (onDemand.has("MaxReadRequestUnits")) {
+                table.setOnDemandMaxReadRequestUnits(onDemand.get("MaxReadRequestUnits").asInt());
+            }
+            if (onDemand.has("MaxWriteRequestUnits")) {
+                table.setOnDemandMaxWriteRequestUnits(onDemand.get("MaxWriteRequestUnits").asInt());
+            }
+        }
+
         // Store tags from CreateTable request
         JsonNode tagsNode = request.path("Tags");
         if (tagsNode.isArray()) {
@@ -209,8 +223,9 @@ public class DynamoDbJsonHandler {
         String tableName = request.path("TableName").asText();
         TableDefinition table = dynamoDbService.describeTable(tableName, region);
         if (table.isDeletionProtectionEnabled()) {
-            throw new AwsException("ResourceInUseException",
-                    "Table " + tableName + " can't be deleted while DeletionProtectionEnabled is set to true", 400);
+            throw new AwsException("ValidationException",
+                    "Table " + tableName + " is protected against deletion. To delete the table, "
+                    + "DeletionProtectionEnabled must be set to false.", 400);
         }
         ObjectNode response = objectMapper.createObjectNode();
         response.set("TableDescription", tableToNode(table));
@@ -1149,6 +1164,20 @@ public class DynamoDbJsonHandler {
             }
         }
 
+        if (request.has("TableClass")) {
+            table.setTableClass(request.get("TableClass").asText());
+        }
+
+        JsonNode onDemand = request.path("OnDemandThroughput");
+        if (onDemand.isObject()) {
+            if (onDemand.has("MaxReadRequestUnits")) {
+                table.setOnDemandMaxReadRequestUnits(onDemand.get("MaxReadRequestUnits").asInt());
+            }
+            if (onDemand.has("MaxWriteRequestUnits")) {
+                table.setOnDemandMaxWriteRequestUnits(onDemand.get("MaxWriteRequestUnits").asInt());
+            }
+        }
+
         JsonNode streamSpec = request.path("StreamSpecification");
         if (!streamSpec.isMissingNode()) {
             boolean streamEnabled = streamSpec.path("StreamEnabled").asBoolean(false);
@@ -1790,6 +1819,7 @@ public class DynamoDbJsonHandler {
     private ObjectNode tableToNode(TableDefinition table) {
         ObjectNode node = objectMapper.createObjectNode();
         node.put("TableName", table.getTableName());
+        node.put("TableId", table.getTableId());
         node.put("TableStatus", table.getTableStatus());
         node.put("TableArn", table.getTableArn());
         node.put("CreationDateTime", table.getCreationDateTime().getEpochSecond());
@@ -1803,6 +1833,24 @@ public class DynamoDbJsonHandler {
             billing.put("LastUpdateToPayPerRequestDateTime",
                     table.getCreationDateTime().getEpochSecond());
             node.set("BillingModeSummary", billing);
+        }
+
+        // TableClassSummary always present; defaults to STANDARD.
+        ObjectNode tableClassSummary = objectMapper.createObjectNode();
+        tableClassSummary.put("TableClass",
+                table.getTableClass() != null ? table.getTableClass() : "STANDARD");
+        node.set("TableClassSummary", tableClassSummary);
+
+        if (table.getOnDemandMaxReadRequestUnits() != null
+                || table.getOnDemandMaxWriteRequestUnits() != null) {
+            ObjectNode odt = objectMapper.createObjectNode();
+            if (table.getOnDemandMaxReadRequestUnits() != null) {
+                odt.put("MaxReadRequestUnits", table.getOnDemandMaxReadRequestUnits());
+            }
+            if (table.getOnDemandMaxWriteRequestUnits() != null) {
+                odt.put("MaxWriteRequestUnits", table.getOnDemandMaxWriteRequestUnits());
+            }
+            node.set("OnDemandThroughput", odt);
         }
 
         ObjectNode warmThroughput = objectMapper.createObjectNode();

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -800,6 +800,14 @@ public class DynamoDbService {
     public ScanResult scan(String tableName, String filterExpression,
                             JsonNode expressionAttrNames, JsonNode expressionAttrValues,
                             JsonNode scanFilter, Integer limit, JsonNode exclusiveStartKey, String region) {
+        return scan(tableName, filterExpression, expressionAttrNames, expressionAttrValues,
+                scanFilter, limit, exclusiveStartKey, null, region);
+    }
+
+    public ScanResult scan(String tableName, String filterExpression,
+                            JsonNode expressionAttrNames, JsonNode expressionAttrValues,
+                            JsonNode scanFilter, Integer limit, JsonNode exclusiveStartKey,
+                            String indexName, String region) {
         DynamoDbReservedWords.check(filterExpression, "FilterExpression");
         String canonicalTableName = canonicalTableName(region, tableName);
         String storageKey = regionKey(region, canonicalTableName);
@@ -809,10 +817,28 @@ public class DynamoDbService {
         var items = itemsByTable.get(storageKey);
         if (items == null) return new ScanResult(List.of(), 0, null);
 
-        // ConcurrentSkipListMap keeps items sorted by item key — no sort needed.
+        // ConcurrentSkipListMap keeps items sorted by base item key — no sort needed.
         // Use tailMap for O(log n) pagination instead of O(n) linear search.
         String pkName = table.getPartitionKeyName();
         String skName = table.getSortKeyName();
+
+        // When scanning a secondary index, the LastEvaluatedKey must carry the index key
+        // attributes in addition to the base table key. Cursor navigation still uses the
+        // (unique) base table key, which is a total order even when index sort keys tie.
+        boolean indexScan = indexName != null;
+        String lekPkName = pkName;
+        String lekSkName = skName;
+        if (indexScan) {
+            var gsi = table.findGsi(indexName);
+            var lsi = table.findLsi(indexName);
+            if (gsi.isPresent()) {
+                lekPkName = gsi.get().getPartitionKeyName();
+                lekSkName = gsi.get().getSortKeyName();
+            } else if (lsi.isPresent()) {
+                lekPkName = lsi.get().getPartitionKeyName();
+                lekSkName = lsi.get().getSortKeyName();
+            }
+        }
 
         var source = exclusiveStartKey != null
                 ? items.tailMap(buildItemKeyFromNode(exclusiveStartKey, pkName, skName), false).values()
@@ -820,36 +846,35 @@ public class DynamoDbService {
 
         int totalScanned = 0;
         List<JsonNode> results = new ArrayList<>();
-        for (JsonNode item : source) {
-            totalScanned++;
-            if (isExpired(item, table)) {
-                continue;
-            }
-            if (filterExpression != null
-                    && !matchesFilterExpression(item, filterExpression, expressionAttrNames, expressionAttrValues)) {
-                continue;
-            }
-            if (scanFilter != null && !matchesScanFilter(item, scanFilter)) {
-                continue;
-            }
-            results.add(item);
-        }
-
         JsonNode lastEvaluatedKey = null;
-        if (limit != null && limit > 0 && results.size() > limit) {
-            JsonNode lastItem = results.get(limit - 1);
-            lastEvaluatedKey = buildKeyNode(table, lastItem, pkName, skName);
-            results = results.subList(0, limit);
+        Iterator<JsonNode> it = source.iterator();
+        while (it.hasNext()) {
+            JsonNode item = it.next();
+            totalScanned++;
+            if (!isExpired(item, table)) {
+                boolean matched = (filterExpression == null
+                        || matchesFilterExpression(item, filterExpression, expressionAttrNames, expressionAttrValues))
+                        && (scanFilter == null || matchesScanFilter(item, scanFilter));
+                if (matched) results.add(item);
+            }
+            // Limit caps SCANNED items (those read), not matched items. Stop at the
+            // limit and surface a cursor when more items remain to be examined.
+            if (limit != null && limit > 0 && totalScanned >= limit) {
+                if (it.hasNext()) {
+                    lastEvaluatedKey = buildKeyNode(table, item, lekPkName, lekSkName, indexScan);
+                }
+                break;
+            }
         }
 
-        // Apply 1MB response size limit
+        // Apply 1MB response size limit (only when not already truncated by Limit)
         if (lastEvaluatedKey == null) {
             final int MAX_RESPONSE_BYTES = 1024 * 1024;
             int accSize = 0;
             for (int i = 0; i < results.size(); i++) {
                 int sz = DynamoDbItemSize.calculateItemSize(results.get(i));
                 if (accSize > 0 && accSize + sz > MAX_RESPONSE_BYTES) {
-                    lastEvaluatedKey = buildKeyNode(table, results.get(i - 1), pkName, skName);
+                    lastEvaluatedKey = buildKeyNode(table, results.get(i - 1), lekPkName, lekSkName, indexScan);
                     results = new ArrayList<>(results.subList(0, i));
                     break;
                 }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
@@ -43,6 +43,10 @@ public class TableDefinition {
     private String sseType;
     private String kmsMasterKeyArn;
     private List<KinesisStreamingDestination> kinesisStreamingDestinations;
+    private String tableId;
+    private String tableClass; // "STANDARD" or "STANDARD_INFREQUENT_ACCESS"
+    private Integer onDemandMaxReadRequestUnits;
+    private Integer onDemandMaxWriteRequestUnits;
 
     public TableDefinition() {
         this.keySchema = new ArrayList<>();
@@ -72,6 +76,7 @@ public class TableDefinition {
         this.itemCount = 0;
         this.tableSizeBytes = 0;
         this.tableArn = AwsArnUtils.Arn.of("dynamodb", region, accountId, "table/" + tableName).toString();
+        this.tableId = java.util.UUID.randomUUID().toString();
         this.provisionedThroughput = new ProvisionedThroughput(5, 5);
         this.tags = new HashMap<>();
         this.globalSecondaryIndexes = new ArrayList<>();
@@ -174,6 +179,21 @@ public class TableDefinition {
     }
 
     /** Returns the partition key attribute name. */
+    public String getTableId() {
+        if (tableId == null) tableId = java.util.UUID.randomUUID().toString();
+        return tableId;
+    }
+    public void setTableId(String tableId) { this.tableId = tableId; }
+
+    public String getTableClass() { return tableClass; }
+    public void setTableClass(String tableClass) { this.tableClass = tableClass; }
+
+    public Integer getOnDemandMaxReadRequestUnits() { return onDemandMaxReadRequestUnits; }
+    public void setOnDemandMaxReadRequestUnits(Integer v) { this.onDemandMaxReadRequestUnits = v; }
+
+    public Integer getOnDemandMaxWriteRequestUnits() { return onDemandMaxWriteRequestUnits; }
+    public void setOnDemandMaxWriteRequestUnits(Integer v) { this.onDemandMaxWriteRequestUnits = v; }
+
     public String getPartitionKeyName() {
         return keySchema.stream()
                 .filter(k -> "HASH".equals(k.getKeyType()))

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -499,7 +499,7 @@ public class AslExecutor {
                 Integer limit = input.has("Limit") ? input.get("Limit").asInt() : null;
                 JsonNode scanFilter = input.has("ScanFilter") ? input.get("ScanFilter") : null;
                 DynamoDbService.ScanResult scanResult = dynamoDbService.scan(
-                        tableName, filterExpression, exprAttrNames, exprAttrValues, scanFilter, limit, null, region);
+                        tableName, filterExpression, exprAttrNames, exprAttrValues, scanFilter, limit, null, null, region);
                 ObjectNode response = objectMapper.createObjectNode();
                 com.fasterxml.jackson.databind.node.ArrayNode items = objectMapper.createArrayNode();
                 scanResult.items().forEach(items::add);

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -2194,7 +2194,8 @@ given()
             .statusCode(200)
             .body("Table.DeletionProtectionEnabled", equalTo(true));
 
-        // DeleteTable is blocked
+        // DeleteTable is blocked. AWS returns a ValidationException (not
+        // ResourceInUseException) when deletion protection is enabled.
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
             .contentType(DYNAMODB_CONTENT_TYPE)
@@ -2204,7 +2205,7 @@ given()
         .when().post("/")
         .then()
             .statusCode(400)
-            .body("__type", equalTo("ResourceInUseException"));
+            .body("__type", equalTo("ValidationException"));
 
         // UpdateTable to disable deletion protection
         given()


### PR DESCRIPTION
Re-lands the table-metadata work, which did **not** reach `main` — the earlier #1445 was merged into its stacked base (`fix/dynamodb-pagination-limit`) rather than `main`.

## What
- Stable **`TableId`** per table, returned by CreateTable/DescribeTable.
- Round-trips **`TableClass`** (`TableClassSummary`, defaults `STANDARD`) and **`OnDemandThroughput`** on Create/UpdateTable.
- **DeleteTable under deletion protection** returns `ValidationException` ("… is protected against deletion") to match AWS.

Closes 7 conformance failures.
