### PR TITLE
fix(rds): fix PostgreSQL proxy ignoring requested database name

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandler.java
@@ -127,7 +127,7 @@ public class PostgresProtocolHandler {
         InputStream backendIn = backend.getInputStream();
         OutputStream backendOut = backend.getOutputStream();
 
-        String effectiveDbName = (dbName != null && !dbName.isBlank()) ? dbName : "postgres";
+        String effectiveDbName = resolveEffectiveDbName(startup.database(), dbName);
         String backendUser = (isIam || isMaster) ? masterUsername : clientUsername;
         String backendPass = (isIam || isMaster) ? masterPassword : clientPassword;
         sendStartupToBackend(backendOut, backendUser, effectiveDbName);
@@ -146,6 +146,16 @@ public class PostgresProtocolHandler {
         List<byte[]> bufferedMessages = readUntilReadyForQuery(backendIn);
 
         // Phase 6: Send AuthenticationOK to client, forward buffered messages, then bridge
+        if (endsWithErrorResponse(bufferedMessages)) {
+            for (byte[] msg : bufferedMessages) {
+                clientOut.write(msg);
+            }
+            clientOut.flush();
+            closeQuietly(client);
+            closeQuietly(backend);
+            return;
+        }
+
         sendMessage(clientOut, 'R', intBytes(0)); // AuthenticationOK
         for (byte[] msg : bufferedMessages) {
             clientOut.write(msg);
@@ -183,7 +193,9 @@ public class PostgresProtocolHandler {
             byte[] payload = new byte[length - 8];
             readFully(in, payload);
             Map<String, String> params = parseStartupParams(payload);
-            return new StartupMessage(currentSocket, params.getOrDefault("user", "postgres"));
+            return new StartupMessage(currentSocket,
+                    params.getOrDefault("user", "postgres"),
+                    params.get("database"));
         }
     }
 
@@ -257,7 +269,21 @@ public class PostgresProtocolHandler {
         return context;
     }
 
-    private record StartupMessage(Socket socket, String username) {}
+    private record StartupMessage(Socket socket, String username, String database) {}
+
+    static String resolveEffectiveDbName(String clientDatabase, String instanceDbName) {
+        if (clientDatabase != null && !clientDatabase.isBlank()) {
+            return clientDatabase;
+        }
+        if (instanceDbName != null && !instanceDbName.isBlank()) {
+            return instanceDbName;
+        }
+        return "postgres";
+    }
+
+    private static boolean endsWithErrorResponse(List<byte[]> messages) {
+        return !messages.isEmpty() && messages.get(messages.size() - 1)[0] == 'E';
+    }
 
     private static Map<String, String> parseStartupParams(byte[] data) {
         Map<String, String> params = new HashMap<>();

--- a/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java
@@ -1,25 +1,151 @@
 package io.github.hectorvent.floci.services.rds.proxy;
 
+import io.github.hectorvent.floci.testutil.IamServiceTestHelper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
+import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 class PostgresProtocolHandlerTest {
 
     private static final int SSL_REQUEST_CODE = 80877103;
+    private static final int STARTUP_PROTOCOL_VERSION = 196608;
+
+    @ParameterizedTest
+    @CsvSource({
+            "auth_db, postgres, auth_db",
+            "'', postgres, postgres",
+            "'', '', postgres",
+            "auth_db, '', auth_db"
+    })
+    void resolveEffectiveDbNamePrefersClientDatabase(String clientDb, String instanceDb, String expected) {
+        String clientDatabase = clientDb.isEmpty() ? null : clientDb;
+        String instanceDatabase = instanceDb.isEmpty() ? null : instanceDb;
+        assertEquals(expected, PostgresProtocolHandler.resolveEffectiveDbName(clientDatabase, instanceDatabase));
+    }
+
+    @Test
+    void forwardsClientDatabaseToBackendStartup() throws Exception {
+        AtomicReference<String> backendDatabase = new AtomicReference<>();
+
+        try (ServerSocket backendServer = new ServerSocket(0);
+             ServerSocket clientServer = new ServerSocket(0)) {
+
+            int backendPort = backendServer.getLocalPort();
+            Thread backendThread = Thread.ofVirtual().start(() -> {
+                try {
+                    mockBackendStartup(backendServer, backendDatabase, false);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            Socket proxyClient;
+            try (Socket ourClient = new Socket("localhost", clientServer.getLocalPort())) {
+                proxyClient = clientServer.accept();
+                Socket backend = new Socket("localhost", backendPort);
+
+                Thread authThread = Thread.ofVirtual().start(() -> {
+                    try {
+                        PostgresProtocolHandler.handleAuth(
+                                proxyClient, backend,
+                                "dbadmin", "adminpass", "postgres",
+                                false, testSigV4Validator(),
+                                (user, pass) -> true);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+
+                DataOutputStream clientOut = new DataOutputStream(ourClient.getOutputStream());
+                DataInputStream clientIn = new DataInputStream(ourClient.getInputStream());
+
+                writeStartup(clientOut, "dbadmin", "auth_db");
+                readCleartextPasswordChallenge(clientIn);
+                writePassword(clientOut, "adminpass");
+                readAuthenticationOk(clientIn);
+                readReadyForQuery(clientIn);
+
+                authThread.join(5_000);
+                backendThread.join(5_000);
+            }
+
+            assertEquals("auth_db", backendDatabase.get());
+        }
+    }
+
+    @Test
+    void doesNotSendAuthenticationOkWhenBackendStartupFails() throws Exception {
+        AtomicReference<String> backendDatabase = new AtomicReference<>();
+
+        try (ServerSocket backendServer = new ServerSocket(0);
+             ServerSocket clientServer = new ServerSocket(0)) {
+
+            int backendPort = backendServer.getLocalPort();
+            Thread backendThread = Thread.ofVirtual().start(() -> {
+                try {
+                    mockBackendStartup(backendServer, backendDatabase, true);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            Socket proxyClient;
+            try (Socket ourClient = new Socket("localhost", clientServer.getLocalPort())) {
+                proxyClient = clientServer.accept();
+                Socket backend = new Socket("localhost", backendPort);
+
+                Thread authThread = Thread.ofVirtual().start(() -> {
+                    try {
+                        PostgresProtocolHandler.handleAuth(
+                                proxyClient, backend,
+                                "dbadmin", "adminpass", "postgres",
+                                false, testSigV4Validator(),
+                                (user, pass) -> true);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+
+                DataOutputStream clientOut = new DataOutputStream(ourClient.getOutputStream());
+                DataInputStream clientIn = new DataInputStream(ourClient.getInputStream());
+
+                writeStartup(clientOut, "dbadmin", "missing_db");
+                readCleartextPasswordChallenge(clientIn);
+                writePassword(clientOut, "adminpass");
+
+                int firstResponse = clientIn.read();
+                assertEquals('E', firstResponse);
+                assertNotEquals('R', firstResponse);
+
+                authThread.join(5_000);
+                backendThread.join(5_000);
+            }
+
+            assertEquals("missing_db", backendDatabase.get());
+        }
+    }
 
     @Test
     void acceptsPostgresSslRequestAndUpgradesSocket() throws Exception {
@@ -65,6 +191,146 @@ class PostgresProtocolHandlerTest {
         }
 
         assertEquals(42, serverRead.poll(5, TimeUnit.SECONDS));
+    }
+
+    private static RdsSigV4Validator testSigV4Validator() {
+        return new RdsSigV4Validator(IamServiceTestHelper.iamServiceWithAccessKey("AKIATEST", "secret"));
+    }
+
+    private static void mockBackendStartup(ServerSocket server, AtomicReference<String> backendDatabase,
+                                           boolean failWithError) throws IOException {
+        try (Socket socket = server.accept()) {
+            DataInputStream in = new DataInputStream(socket.getInputStream());
+            DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+
+            int length = in.readInt();
+            int proto = in.readInt();
+            byte[] payload = in.readNBytes(length - 8);
+            backendDatabase.set(parseStartupParams(payload).get("database"));
+
+            out.writeByte('R');
+            out.writeInt(8);
+            out.writeInt(3);
+            out.flush();
+
+            assertEquals('p', in.readByte());
+            int pwLength = in.readInt();
+            in.readNBytes(pwLength - 4);
+
+            out.writeByte('R');
+            out.writeInt(8);
+            out.writeInt(0);
+            out.flush();
+
+            if (failWithError) {
+                writeErrorResponse(out, "FATAL", "3D000", "database \"missing_db\" does not exist");
+            } else {
+                out.writeByte('Z');
+                out.writeInt(5);
+                out.writeByte('I');
+                out.flush();
+            }
+        }
+    }
+
+    private static void writeStartup(DataOutputStream out, String user, String database) throws IOException {
+        byte[] userKey = "user".getBytes(StandardCharsets.UTF_8);
+        byte[] userVal = user.getBytes(StandardCharsets.UTF_8);
+        byte[] dbKey = "database".getBytes(StandardCharsets.UTF_8);
+        byte[] dbVal = database.getBytes(StandardCharsets.UTF_8);
+
+        int length = 4 + 4
+                + userKey.length + 1 + userVal.length + 1
+                + dbKey.length + 1 + dbVal.length + 1
+                + 1;
+
+        out.writeInt(length);
+        out.writeInt(STARTUP_PROTOCOL_VERSION);
+        out.write(userKey);
+        out.writeByte(0);
+        out.write(userVal);
+        out.writeByte(0);
+        out.write(dbKey);
+        out.writeByte(0);
+        out.write(dbVal);
+        out.writeByte(0);
+        out.writeByte(0);
+        out.flush();
+    }
+
+    private static void writePassword(DataOutputStream out, String password) throws IOException {
+        byte[] pw = password.getBytes(StandardCharsets.UTF_8);
+        out.writeByte('p');
+        out.writeInt(4 + pw.length + 1);
+        out.write(pw);
+        out.writeByte(0);
+        out.flush();
+    }
+
+    private static void readCleartextPasswordChallenge(DataInputStream in) throws IOException {
+        assertEquals('R', in.readByte());
+        assertEquals(8, in.readInt());
+        assertEquals(3, in.readInt());
+    }
+
+    private static void readAuthenticationOk(DataInputStream in) throws IOException {
+        assertEquals('R', in.readByte());
+        assertEquals(8, in.readInt());
+        assertEquals(0, in.readInt());
+    }
+
+    private static void readReadyForQuery(DataInputStream in) throws IOException {
+        assertEquals('Z', in.readByte());
+        assertEquals(5, in.readInt());
+        assertEquals('I', in.readByte());
+    }
+
+    private static void writeErrorResponse(DataOutputStream out, String severity, String sqlState,
+                                           String message) throws IOException {
+        ByteArrayOutputStream fields = new ByteArrayOutputStream();
+        fields.write('S');
+        fields.write(severity.getBytes(StandardCharsets.UTF_8));
+        fields.write(0);
+        fields.write('C');
+        fields.write(sqlState.getBytes(StandardCharsets.UTF_8));
+        fields.write(0);
+        fields.write('M');
+        fields.write(message.getBytes(StandardCharsets.UTF_8));
+        fields.write(0);
+        fields.write(0);
+
+        byte[] payload = fields.toByteArray();
+        out.writeByte('E');
+        out.writeInt(4 + payload.length);
+        out.write(payload);
+        out.flush();
+    }
+
+    private static Map<String, String> parseStartupParams(byte[] data) {
+        Map<String, String> params = new HashMap<>();
+        int i = 0;
+        while (i < data.length) {
+            int keyStart = i;
+            while (i < data.length && data[i] != 0) {
+                i++;
+            }
+            if (i >= data.length) {
+                break;
+            }
+            String key = new String(data, keyStart, i - keyStart, StandardCharsets.UTF_8);
+            i++;
+            if (key.isEmpty()) {
+                break;
+            }
+            int valStart = i;
+            while (i < data.length && data[i] != 0) {
+                i++;
+            }
+            String value = new String(data, valStart, i - valStart, StandardCharsets.UTF_8);
+            i++;
+            params.put(key, value);
+        }
+        return params;
     }
 
     private static SSLContext trustAllContext() throws Exception {

--- a/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java
@@ -209,6 +209,7 @@ assertEquals(false, backendThread.isAlive(), "backendThread did not terminate");
 
             int length = in.readInt();
             int proto = in.readInt();
+            assertEquals(STARTUP_PROTOCOL_VERSION, proto);
             byte[] payload = in.readNBytes(length - 8);
             backendDatabase.set(parseStartupParams(payload).get("database"));
 

--- a/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java
@@ -87,8 +87,10 @@ class PostgresProtocolHandlerTest {
                 readAuthenticationOk(clientIn);
                 readReadyForQuery(clientIn);
 
-                authThread.join(5_000);
-                backendThread.join(5_000);
+authThread.join(5_000);
+backendThread.join(5_000);
+assertEquals(false, authThread.isAlive(), "authThread did not terminate");
+assertEquals(false, backendThread.isAlive(), "backendThread did not terminate");
             }
 
             assertEquals("auth_db", backendDatabase.get());

--- a/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java
@@ -143,6 +143,8 @@ assertEquals(false, backendThread.isAlive(), "backendThread did not terminate");
 
                 authThread.join(5_000);
                 backendThread.join(5_000);
+                assertEquals(false, authThread.isAlive(), "authThread did not terminate");
+                assertEquals(false, backendThread.isAlive(), "backendThread did not terminate");
             }
 
             assertEquals("missing_db", backendDatabase.get());


### PR DESCRIPTION
Closes #1465 

This pull request enhances the Postgres protocol proxy by improving how the target database name is determined and by ensuring correct error handling during authentication. It also adds comprehensive tests to verify these behaviors. The main changes focus on selecting the correct database for backend connections, handling backend startup errors gracefully, and increasing test coverage for these scenarios.

**Database selection and error handling logic:**

* Added a new method `resolveEffectiveDbName` to determine the database name for backend connections, prioritizing the client-supplied database, then the instance default, and falling back to `"postgres"` if neither is provided. This logic replaces the previous inline conditional. (`src/main/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandler.java`) [[1]](diffhunk://#diff-5bd086538c70f537a54bce63be43ce51b92469e9fbeac6ea5c3686cca5396e4eL130-R130) [[2]](diffhunk://#diff-5bd086538c70f537a54bce63be43ce51b92469e9fbeac6ea5c3686cca5396e4eL260-R286)
* Updated the `StartupMessage` record to include the database name, and adjusted its construction to extract the `database` parameter from startup messages. (`src/main/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandler.java`) [[1]](diffhunk://#diff-5bd086538c70f537a54bce63be43ce51b92469e9fbeac6ea5c3686cca5396e4eL186-R198) [[2]](diffhunk://#diff-5bd086538c70f537a54bce63be43ce51b92469e9fbeac6ea5c3686cca5396e4eL260-R286)
* Improved error handling during authentication: if the backend responds with an error (detected by the new `endsWithErrorResponse` method), the error is forwarded to the client and the connection is closed without sending an `AuthenticationOK` message. (`src/main/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandler.java`) [[1]](diffhunk://#diff-5bd086538c70f537a54bce63be43ce51b92469e9fbeac6ea5c3686cca5396e4eR149-R158) [[2]](diffhunk://#diff-5bd086538c70f537a54bce63be43ce51b92469e9fbeac6ea5c3686cca5396e4eL260-R286)

**Testing and validation:**

* Added parameterized and scenario-based tests to verify the database selection logic and proper error forwarding when backend startup fails. These tests include utilities to mock backend behavior and parse protocol messages. (`src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java`) [[1]](diffhunk://#diff-9a487bb1a657f651f4c13c7af55317761a420ac08fcc4ade1e7faa989a17c6f9R3-R148) [[2]](diffhunk://#diff-9a487bb1a657f651f4c13c7af55317761a420ac08fcc4ade1e7faa989a17c6f9R196-R335)

Connect through the Floci endpoint explicitly asking for auth_db
<img width="726" height="120" alt="image" src="https://github.com/user-attachments/assets/b70b47ea-2177-4864-94e9-59f556d7ab72" />
Using \connect inside a session
<img width="722" height="154" alt="image" src="https://github.com/user-attachments/assets/bc8c0df8-3c06-4bc6-9109-b8ccd5c4e8b0" />
