### PR TITLE
fix(floci-ui): resolve readiness probe URL from container endpoint

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManager.java
@@ -16,6 +16,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
 import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.EndpointInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
 import io.github.hectorvent.floci.core.common.docker.CurrentContainerNetworkResolver;
@@ -54,6 +55,15 @@ public class FlociUiManager {
     private volatile String containerId;
     private volatile Closeable logStream;
     private volatile String lastError;
+    /**
+     * URL the readiness probe connects to, resolved from the Docker API at start time.
+     * Published host ports (e.g. {@code -p 4500:4500}) only exist on the host's network
+     * namespace, so when Floci itself runs in a container it cannot reach the sidecar at
+     * {@code localhost:hostPort} — it must use the sidecar's container IP on the shared
+     * Docker network. {@link EndpointInfo} resolves the right address for both cases:
+     * {@code localhost:hostPort} natively, {@code <containerIp>:4500} in a container.
+     */
+    private volatile String probeUrl;
 
     private final ExecutorService starter = Executors.newSingleThreadExecutor(r -> {
         Thread t = new Thread(r, "floci-ui-starter");
@@ -124,6 +134,7 @@ public class FlociUiManager {
             ContainerInfo info = lifecycleManager.createAndStart(spec);
             this.containerId = info.containerId();
             this.hostPort = chosenPort;
+            this.probeUrl = resolveProbeUrl(info.getEndpoint(CONTAINER_INTERNAL_PORT), chosenPort);
             this.started = true;
             this.lastError = null;
             LOG.infov("Started floci-ui sidecar {0} on host port {1}", name, String.valueOf(chosenPort));
@@ -225,10 +236,26 @@ public class FlociUiManager {
         return Optional.empty();
     }
 
+    /**
+     * Resolves the URL the readiness probe should connect to from the sidecar's
+     * resolved endpoint. {@link EndpointInfo} already returns a Floci-reachable
+     * address — {@code localhost:hostPort} when Floci runs natively, or the
+     * sidecar's container IP on the shared Docker network when Floci runs in a
+     * container (where the published host port is not reachable from inside).
+     * Falls back to {@code localhost:hostPort} if the endpoint is unavailable.
+     */
+    String resolveProbeUrl(EndpointInfo endpoint, int fallbackHostPort) {
+        if (endpoint != null) {
+            return "http://" + endpoint.host() + ":" + endpoint.port() + "/";
+        }
+        return "http://localhost:" + fallbackHostPort + "/";
+    }
+
     private boolean probeReady() {
-        String url = containerDetector.isRunningInContainer()
-                ? "http://" + config.services().ui().containerName() + ":" + CONTAINER_INTERNAL_PORT + "/"
-                : "http://localhost:" + hostPort + "/";
+        String url = probeUrl;
+        if (url == null) {
+            return false;
+        }
         try {
             HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
             conn.setConnectTimeout(800);
@@ -246,10 +273,11 @@ public class FlociUiManager {
         this.containerId = existing.getId();
         try {
             ContainerInfo info = lifecycleManager.adopt(containerId, List.of(CONTAINER_INTERNAL_PORT));
-            var endpoint = info.getEndpoint(CONTAINER_INTERNAL_PORT);
+            EndpointInfo endpoint = info.getEndpoint(CONTAINER_INTERNAL_PORT);
             if (endpoint != null) {
                 this.hostPort = endpoint.port();
             }
+            this.probeUrl = resolveProbeUrl(endpoint, hostPort);
             this.started = true;
             this.lastError = null;
             LOG.infov("Adopted existing floci-ui sidecar {0} on host port {1}",

--- a/src/main/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManager.java
@@ -132,12 +132,13 @@ public class FlociUiManager {
 
             ContainerSpec spec = specBuilder.build();
             ContainerInfo info = lifecycleManager.createAndStart(spec);
+            EndpointInfo endpoint = info.getEndpoint(CONTAINER_INTERNAL_PORT);
             this.containerId = info.containerId();
-            this.hostPort = chosenPort;
-            this.probeUrl = resolveProbeUrl(info.getEndpoint(CONTAINER_INTERNAL_PORT), chosenPort);
+            this.hostPort = resolveHostPort(endpoint, chosenPort);
+            this.probeUrl = resolveProbeUrl(endpoint, hostPort);
             this.started = true;
             this.lastError = null;
-            LOG.infov("Started floci-ui sidecar {0} on host port {1}", name, String.valueOf(chosenPort));
+            LOG.infov("Started floci-ui sidecar {0} on host port {1}", name, String.valueOf(hostPort));
             attachLogStream();
         } catch (Exception e) {
             this.lastError = "Could not start the Floci UI from image '" + image + "': " + e.getMessage()
@@ -237,6 +238,20 @@ public class FlociUiManager {
     }
 
     /**
+     * The host port the browser-facing redirect ({@code /_floci/ui/status}) should target.
+     * In native mode the resolved {@link EndpointInfo} reflects the actual bound host port,
+     * which may differ from {@code configuredPort} when dynamic allocation ({@code port=0})
+     * is used — so prefer it. In container mode the endpoint reflects the sidecar's internal
+     * port (4500), not the host binding, so the configured published port is authoritative.
+     */
+    int resolveHostPort(EndpointInfo endpoint, int configuredPort) {
+        if (!containerDetector.isRunningInContainer() && endpoint != null) {
+            return endpoint.port();
+        }
+        return configuredPort;
+    }
+
+    /**
      * Resolves the URL the readiness probe should connect to from the sidecar's
      * resolved endpoint. {@link EndpointInfo} already returns a Floci-reachable
      * address — {@code localhost:hostPort} when Floci runs natively, or the
@@ -274,9 +289,7 @@ public class FlociUiManager {
         try {
             ContainerInfo info = lifecycleManager.adopt(containerId, List.of(CONTAINER_INTERNAL_PORT));
             EndpointInfo endpoint = info.getEndpoint(CONTAINER_INTERNAL_PORT);
-            if (endpoint != null) {
-                this.hostPort = endpoint.port();
-            }
+            this.hostPort = resolveHostPort(endpoint, config.services().ui().port());
             this.probeUrl = resolveProbeUrl(endpoint, hostPort);
             this.started = true;
             this.lastError = null;

--- a/src/test/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManagerTest.java
@@ -90,6 +90,33 @@ class FlociUiManagerTest {
     }
 
     @Test
+    void hostPortUsesBoundEndpointPortNatively() {
+        // Native mode: EndpointInfo carries the actual bound host port, which may differ
+        // from the requested port when dynamic allocation (port=0) is used.
+        when(containerDetector.isRunningInContainer()).thenReturn(false);
+        EndpointInfo endpoint = new EndpointInfo("localhost", 49160);
+
+        assertEquals(49160, newManager().resolveHostPort(endpoint, 0));
+    }
+
+    @Test
+    void hostPortKeepsConfiguredPublishedPortWhenContainerized() {
+        // Container mode: EndpointInfo carries the sidecar's internal port (4500), not the
+        // host binding, so the configured published port must win for the browser redirect.
+        when(containerDetector.isRunningInContainer()).thenReturn(true);
+        EndpointInfo endpoint = new EndpointInfo("10.88.0.20", 4500);
+
+        assertEquals(8080, newManager().resolveHostPort(endpoint, 8080));
+    }
+
+    @Test
+    void hostPortFallsBackToConfiguredWhenEndpointMissing() {
+        when(containerDetector.isRunningInContainer()).thenReturn(false);
+
+        assertEquals(4500, newManager().resolveHostPort(null, 4500));
+    }
+
+    @Test
     void usesHttpsSchemeWhenTlsEnabled() {
         when(containerDetector.isRunningInContainer()).thenReturn(false);
         when(config.port()).thenReturn(4566);

--- a/src/test/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManagerTest.java
@@ -5,6 +5,7 @@ import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
 import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.EndpointInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.CurrentContainerNetworkResolver;
 import io.github.hectorvent.floci.core.common.docker.DockerHostResolver;
@@ -65,6 +66,27 @@ class FlociUiManagerTest {
         when(dockerHostResolver.resolve()).thenReturn("host.docker.internal");
 
         assertEquals("http://host.docker.internal:4566", newManager().resolveFlociEndpoint());
+    }
+
+    @Test
+    void probeUsesSidecarContainerIpWhenContainerized() {
+        // In a container the published host port is not reachable via localhost; the
+        // probe must target the sidecar's container IP on the shared Docker network.
+        EndpointInfo endpoint = new EndpointInfo("10.88.0.20", 4500);
+
+        assertEquals("http://10.88.0.20:4500/", newManager().resolveProbeUrl(endpoint, 4500));
+    }
+
+    @Test
+    void probeUsesLocalhostHostPortNatively() {
+        EndpointInfo endpoint = new EndpointInfo("localhost", 4500);
+
+        assertEquals("http://localhost:4500/", newManager().resolveProbeUrl(endpoint, 4500));
+    }
+
+    @Test
+    void probeFallsBackToLocalhostWhenEndpointMissing() {
+        assertEquals("http://localhost:4500/", newManager().resolveProbeUrl(null, 4500));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Resolves the floci-ui readiness probe URL once at start/adopt time from the sidecar's resolved `EndpointInfo` rather than recomputing it on every probe by branching on container detection. `EndpointInfo` already yields a Floci-reachable address — `localhost:hostPort` natively, or the sidecar's container IP on the shared Docker network when Floci itself runs in a container, where the published host port is unreachable from inside. Closes #1459.

The browser-facing host port is derived from the same `EndpointInfo`: in native mode it reflects the actual bound host port (so dynamic `port=0` allocation redirects correctly), and in container mode the configured published port stays authoritative (the endpoint there carries the sidecar's internal port, not the host binding).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Not an AWS action change. Previously, when Floci ran in a container the probe relied on container-name DNS, and the native/container branch was re-evaluated on every call; the probe now uses the same endpoint-resolution mechanism used elsewhere for cross-container reachability.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Unit tests added/updated (`FlociUiManagerTest`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
