### PR TITLE
fix(cfn): delete EC2 security groups

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -426,6 +426,7 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::ElasticLoadBalancingV2::Listener" -> elbV2Service.deleteListener(region, physicalId);
                 case "AWS::ElasticLoadBalancingV2::ListenerRule" -> elbV2Service.deleteRule(region, physicalId);
                 case "AWS::KinesisFirehose::DeliveryStream" -> firehoseService.deleteDeliveryStream(physicalId);
+                case "AWS::EC2::SecurityGroup" -> ec2Service.deleteSecurityGroup(region, physicalId);
                 case "AWS::EC2::Instance" -> ec2Service.terminateInstances(region, List.of(physicalId));
                 case "AWS::RDS::DBInstance" -> rdsService.deleteDbInstance(physicalId);
                 case "AWS::RDS::DBCluster" -> rdsService.deleteDbCluster(physicalId);

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -5225,6 +5225,66 @@ class CloudFormationIntegrationTest {
             .body("services[0].taskDefinition",
                     equalTo("arn:aws:ecs:us-east-1:000000000000:task-definition/cfn-ecs-update-taskdef:2"));
     }
+    
+    @Test
+    void deleteStack_ec2SecurityGroup_leavesNoOrphans() {
+        String stackName = "sg-delete-cleanup-stack";
+        String groupName = "sg-delete-cleanup-group";
+
+        String template = """
+                {
+                  "Resources": {
+                    "AppSecurityGroup": {
+                      "Type": "AWS::EC2::SecurityGroup",
+                      "Properties": {
+                        "GroupName": "%s",
+                        "GroupDescription": "Security group created by CloudFormation",
+                        "VpcId": "vpc-default"
+                      }
+                    }
+                  }
+                }
+                """.formatted(groupName);
+
+        given()
+                .formParam("Action", "CreateStack")
+                .formParam("Version", "2010-05-15")
+                .formParam("StackName", stackName)
+                .formParam("TemplateBody", template)
+                .when().post("/")
+                .then().statusCode(200);
+
+        given()
+                .formParam("Action", "DescribeSecurityGroups")
+                .formParam("Version", "2016-11-15")
+                .formParam("GroupName.1", groupName)
+                .when().post("/")
+                .then().statusCode(200)
+                .body(containsString(groupName));
+
+        given()
+                .formParam("Action", "DeleteStack")
+                .formParam("Version", "2010-05-15")
+                .formParam("StackName", stackName)
+                .when().post("/")
+                .then().statusCode(200);
+
+        given()
+                .formParam("Action", "DescribeSecurityGroups")
+                .formParam("Version", "2016-11-15")
+                .formParam("GroupName.1", groupName)
+                .when().post("/")
+                .then().statusCode(200)
+                .body(not(containsString(groupName)));
+
+        given()
+                .formParam("Action", "CreateStack")
+                .formParam("Version", "2010-05-15")
+                .formParam("StackName", stackName)
+                .formParam("TemplateBody", template)
+                .when().post("/")
+                .then().statusCode(200);
+    }
 
     @Test
     void deleteStack_ecs_leavesNoOrphans() {


### PR DESCRIPTION
## Summary

Deletes stack-owned EC2 security groups when a CloudFormation stack is deleted.

Previously, `AWS::EC2::SecurityGroup` resources were provisioned by CloudFormation but not cleaned up during `DeleteStack`. This left orphaned security groups behind and caused stack recreation with the same `GroupName` to fail.

Closes #1468

## Type of change

* [x] Bug fix (`fix:`)
* [ ] New feature (`feat:`)
* [ ] Breaking change (`feat!:` or `fix!:`)
* [ ] Docs / chore

## AWS Compatibility

Incorrect behavior:

Deleting a CloudFormation stack containing an `AWS::EC2::SecurityGroup` left the EC2 security group behind.

Updated behavior:

`DeleteStack` now deletes the corresponding EC2 security group resource, allowing the same stack/security group name to be recreated successfully.

## Testing

* [x] `./mvnw test -Dtest=CloudFormationIntegrationTest#deleteStack_ec2SecurityGroup_leavesNoOrphans`
* [x] `./mvnw test -Dtest=CloudFormationIntegrationTest`
