### PR TITLE
fix(ec2): VPC endpoint compatibility for AWS SDK/Terraform

### DIFF
--- a/docs/services/ec2.md
+++ b/docs/services/ec2.md
@@ -136,6 +136,9 @@ Floci seeds the following resources on first use in each region so Terraform, th
 ### Network ACLs
 `CreateNetworkAcl` · `DescribeNetworkAcls` · `DeleteNetworkAcl` · `CreateNetworkAclEntry` · `ReplaceNetworkAclEntry` · `DeleteNetworkAclEntry` · `ReplaceNetworkAclAssociation`
 
+### Prefix Lists
+`DescribePrefixLists`
+
 ### NAT Gateways
 `CreateNatGateway` · `DescribeNatGateways` · `DeleteNatGateway`
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -147,6 +147,7 @@ public class AwsQueryController {
             "RebootInstances", "DescribeInstanceStatus", "DescribeInstanceAttribute", "ModifyInstanceAttribute",
             "CreateVpc", "DescribeVpcs", "DeleteVpc", "ModifyVpcAttribute", "DescribeVpcAttribute",
             "DescribeVpcEndpointServices", "CreateVpcEndpoint", "DescribeVpcEndpoints", "DeleteVpcEndpoints",
+            "DescribePrefixLists",
             "CreateDefaultVpc", "AssociateVpcCidrBlock", "DisassociateVpcCidrBlock",
             "CreateSubnet", "DescribeSubnets", "DeleteSubnet", "ModifySubnetAttribute",
             "CreateSecurityGroup", "DescribeSecurityGroups", "DeleteSecurityGroup",

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -62,6 +62,7 @@ public class Ec2QueryHandler {
                 case "CreateVpcEndpoint" -> handleCreateVpcEndpoint(params, region);
                 case "DescribeVpcEndpoints" -> handleDescribeVpcEndpoints(params, region);
                 case "DeleteVpcEndpoints" -> handleDeleteVpcEndpoints(params, region);
+                case "DescribePrefixLists" -> handleDescribePrefixLists(params, region);
                 case "CreateDefaultVpc" -> handleCreateDefaultVpc(params, region);
                 case "AssociateVpcCidrBlock" -> handleAssociateVpcCidrBlock(params, region);
                 case "DisassociateVpcCidrBlock" -> handleDisassociateVpcCidrBlock(params, region);
@@ -683,6 +684,7 @@ public class Ec2QueryHandler {
                 getList(p, "RouteTableId"),
                 getList(p, "SubnetId"),
                 getList(p, "SecurityGroupId"),
+                p.getFirst("PrivateDnsEnabled") != null ? Boolean.valueOf(p.getFirst("PrivateDnsEnabled")) : null,
                 parseTagsForResource(p, "vpc-endpoint"));
         XmlBuilder xml = new XmlBuilder()
                 .start("CreateVpcEndpointResponse", AwsNamespaces.EC2)
@@ -704,6 +706,28 @@ public class Ec2QueryHandler {
             xml.start("item").raw(vpcEndpointXml(endpoint)).end("item");
         }
         xml.end("vpcEndpointSet").end("DescribeVpcEndpointsResponse");
+        return xmlResponse(xml.build());
+    }
+
+    private Response handleDescribePrefixLists(MultivaluedMap<String, String> p, String region) {
+        List<String> ids = getList(p, "PrefixListId");
+        Map<String, List<String>> filters = getFilters(p);
+        List<PrefixList> lists = service.describePrefixLists(region, ids, filters);
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribePrefixListsResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .start("prefixListSet");
+        for (PrefixList pl : lists) {
+            xml.start("item")
+                    .elem("prefixListId", pl.getPrefixListId())
+                    .elem("prefixListName", pl.getPrefixListName())
+                    .start("cidrSet");
+            for (String cidr : pl.getCidrs()) {
+                xml.elem("item", cidr);
+            }
+            xml.end("cidrSet").end("item");
+        }
+        xml.end("prefixListSet").end("DescribePrefixListsResponse");
         return xmlResponse(xml.build());
     }
 
@@ -2078,18 +2102,19 @@ public class Ec2QueryHandler {
                 .elem("vpcEndpointType", endpoint.getVpcEndpointType())
                 .elem("vpcId", endpoint.getVpcId())
                 .elem("serviceName", endpoint.getServiceName())
-                .elem("state", endpoint.getState());
+                .elem("state", endpoint.getState())
+                .elem("privateDnsEnabled", String.valueOf(endpoint.isPrivateDnsEnabled()));
         if (endpoint.getCreationTimestamp() != null) {
             xml.elem("creationTimestamp", ISO_FMT.format(endpoint.getCreationTimestamp()));
         }
         xml.start("routeTableIdSet");
         for (String routeTableId : endpoint.getRouteTableIds()) {
-            xml.start("item").elem("routeTableId", routeTableId).end("item");
+            xml.elem("item", routeTableId);
         }
         xml.end("routeTableIdSet")
                 .start("subnetIdSet");
         for (String subnetId : endpoint.getSubnetIds()) {
-            xml.start("item").elem("subnetId", subnetId).end("item");
+            xml.elem("item", subnetId);
         }
         xml.end("subnetIdSet")
                 .start("groupSet");

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -50,6 +50,7 @@ import io.github.hectorvent.floci.services.ec2.model.NatGateway;
 import io.github.hectorvent.floci.services.ec2.model.NetworkAcl;
 import io.github.hectorvent.floci.services.ec2.model.NetworkAclAssociation;
 import io.github.hectorvent.floci.services.ec2.model.NetworkAclEntry;
+import io.github.hectorvent.floci.services.ec2.model.PrefixList;
 import io.github.hectorvent.floci.services.ec2.model.Placement;
 import io.github.hectorvent.floci.services.ec2.model.Reservation;
 import io.github.hectorvent.floci.services.ec2.model.Route;
@@ -464,6 +465,25 @@ public class Ec2Service {
                     "The network ACL '" + networkAclId + "' has dependencies and cannot be deleted.", 400);
         }
         networkAcls.delete(key(region, networkAclId));
+    }
+
+    // AWS-managed prefix lists for the gateway-endpoint services (S3, DynamoDB). These are
+    // not user-created, so they're returned as static managed data per region. Querying any
+    // other service name (e.g. an interface endpoint) correctly yields no match.
+    public List<PrefixList> describePrefixLists(String region, List<String> ids, Map<String, List<String>> filters) {
+        List<PrefixList> managed = new ArrayList<>();
+        managed.add(new PrefixList("pl-63a5400a", "com.amazonaws." + region + ".s3",
+                new ArrayList<>(List.of("52.216.0.0/15", "54.231.0.0/16"))));
+        managed.add(new PrefixList("pl-02cd2c6b", "com.amazonaws." + region + ".dynamodb",
+                new ArrayList<>(List.of("3.218.182.0/24", "52.94.0.0/22"))));
+
+        List<String> names = filters.getOrDefault("prefix-list-name", List.of());
+        List<String> filterIds = filters.getOrDefault("prefix-list-id", List.of());
+        return managed.stream()
+                .filter(pl -> ids.isEmpty() || ids.contains(pl.getPrefixListId()))
+                .filter(pl -> filterIds.isEmpty() || filterIds.contains(pl.getPrefixListId()))
+                .filter(pl -> names.isEmpty() || names.contains(pl.getPrefixListName()))
+                .collect(Collectors.toList());
     }
 
     private String key(String region, String id) {
@@ -926,7 +946,7 @@ public class Ec2Service {
 
     public VpcEndpoint createVpcEndpoint(String region, String vpcId, String serviceName, String endpointType,
                                          List<String> routeTableIds, List<String> subnetIds,
-                                         List<String> securityGroupIds, List<Tag> endpointTags) {
+                                         List<String> securityGroupIds, Boolean privateDnsEnabled, List<Tag> endpointTags) {
         ensureDefaultResources(region);
         getRequiredVpc(region, vpcId);
         for (String routeTableId : routeTableIds) {
@@ -944,6 +964,8 @@ public class Ec2Service {
         endpoint.setVpcId(vpcId);
         endpoint.setServiceName(serviceName);
         endpoint.setVpcEndpointType(endpointType != null && !endpointType.isBlank() ? endpointType : "Gateway");
+        boolean isInterface = "Interface".equalsIgnoreCase(endpoint.getVpcEndpointType());
+        endpoint.setPrivateDnsEnabled(privateDnsEnabled != null ? privateDnsEnabled : isInterface);
         endpoint.setCreationTimestamp(Instant.now());
         endpoint.setRegion(region);
         endpoint.setRouteTableIds(new ArrayList<>(routeTableIds));

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/PrefixList.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/PrefixList.java
@@ -1,0 +1,33 @@
+package io.github.hectorvent.floci.services.ec2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PrefixList {
+
+    private String prefixListId;
+    private String prefixListName;
+    private List<String> cidrs = new ArrayList<>();
+
+    public PrefixList() {}
+
+    public PrefixList(String prefixListId, String prefixListName, List<String> cidrs) {
+        this.prefixListId = prefixListId;
+        this.prefixListName = prefixListName;
+        this.cidrs = cidrs;
+    }
+
+    public String getPrefixListId() { return prefixListId; }
+    public void setPrefixListId(String prefixListId) { this.prefixListId = prefixListId; }
+
+    public String getPrefixListName() { return prefixListName; }
+    public void setPrefixListName(String prefixListName) { this.prefixListName = prefixListName; }
+
+    public List<String> getCidrs() { return cidrs; }
+    public void setCidrs(List<String> cidrs) { this.cidrs = cidrs; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/VpcEndpoint.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/VpcEndpoint.java
@@ -21,6 +21,7 @@ public class VpcEndpoint {
     private List<String> routeTableIds = new ArrayList<>();
     private List<String> subnetIds = new ArrayList<>();
     private List<String> securityGroupIds = new ArrayList<>();
+    private boolean privateDnsEnabled;
     private List<Tag> tags = new ArrayList<>();
 
     public VpcEndpoint() {}
@@ -54,6 +55,9 @@ public class VpcEndpoint {
 
     public List<String> getSecurityGroupIds() { return securityGroupIds; }
     public void setSecurityGroupIds(List<String> securityGroupIds) { this.securityGroupIds = securityGroupIds; }
+
+    public boolean isPrivateDnsEnabled() { return privateDnsEnabled; }
+    public void setPrivateDnsEnabled(boolean privateDnsEnabled) { this.privateDnsEnabled = privateDnsEnabled; }
 
     public List<Tag> getTags() { return tags; }
     public void setTags(List<Tag> tags) { this.tags = tags; }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -1004,7 +1004,7 @@ class Ec2IntegrationTest {
             .statusCode(200)
             .body("CreateVpcEndpointResponse.vpcEndpoint.vpcEndpointId", startsWith("vpce-"))
             .body("CreateVpcEndpointResponse.vpcEndpoint.vpcId", equalTo(vpcId))
-            .body("CreateVpcEndpointResponse.vpcEndpoint.routeTableIdSet.item.routeTableId",
+            .body("CreateVpcEndpointResponse.vpcEndpoint.routeTableIdSet.item",
                     equalTo(routeTableId))
             .extract().path("CreateVpcEndpointResponse.vpcEndpoint.vpcEndpointId");
     }
@@ -2579,5 +2579,64 @@ class Ec2IntegrationTest {
         .when().post("/")
         .then().statusCode(400)
             .body("Response.Errors.Error.Code", equalTo("DependencyViolation"));
+    }
+
+    @Test
+    @Order(315)
+    void describePrefixListsReturnsManagedS3() {
+        String prefixListId = given()
+            .formParam("Action", "DescribePrefixLists")
+            .formParam("Filter.1.Name", "prefix-list-name")
+            .formParam("Filter.1.Value.1", "com.amazonaws.us-east-1.s3")
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribePrefixListsResponse.prefixListSet.item.prefixListName",
+                    equalTo("com.amazonaws.us-east-1.s3"))
+            .body("DescribePrefixListsResponse.prefixListSet.item.prefixListId", startsWith("pl-"))
+            .extract().path("DescribePrefixListsResponse.prefixListSet.item.prefixListId");
+
+        // The prefix-list-id filter must narrow results to the matching list only.
+        given()
+            .formParam("Action", "DescribePrefixLists")
+            .formParam("Filter.1.Name", "prefix-list-id")
+            .formParam("Filter.1.Value.1", prefixListId)
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribePrefixListsResponse.prefixListSet.item.prefixListId", equalTo(prefixListId))
+            .body("DescribePrefixListsResponse.prefixListSet.item.prefixListName",
+                    equalTo("com.amazonaws.us-east-1.s3"));
+    }
+
+    @Test
+    @Order(316)
+    void interfaceEndpointPrivateDnsEnabledByDefault() {
+        String vpc = newVpc("10.36.0.0/16");
+        String subnet = given()
+            .formParam("Action", "CreateSubnet")
+            .formParam("VpcId", vpc)
+            .formParam("CidrBlock", "10.36.1.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then().statusCode(200)
+            .extract().path("CreateSubnetResponse.subnet.subnetId");
+
+        given()
+            .formParam("Action", "CreateVpcEndpoint")
+            .formParam("VpcId", vpc)
+            .formParam("ServiceName", "com.amazonaws.us-east-1.ssm")
+            .formParam("VpcEndpointType", "Interface")
+            .formParam("SubnetId.1", subnet)
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body("CreateVpcEndpointResponse.vpcEndpoint.privateDnsEnabled", equalTo("true"))
+            // subnetIdSet item text must be the plain id (not a wrapped <subnetId> element),
+            // otherwise the AWS SDK for Go fails to deserialize interface endpoints.
+            .body("CreateVpcEndpointResponse.vpcEndpoint.subnetIdSet.item", equalTo(subnet));
     }
 }


### PR DESCRIPTION
 - Title (must be exactly this — CI validates it):
  fix(ec2): VPC endpoint compatibility for AWS SDK/Terraform
  - Body:
  Closes #1462

  Fixes three VPC-endpoint compatibility problems with the AWS SDK for Go (Terraform/OpenTofu):

  - **Malformed `*Set` XML** — `routeTableIdSet`/`subnetIdSet` now emit the id as the item text (`<item>rtb-…</item>`) instead of a wrapped
  `<item><routeTableId>…</routeTableId></item>`, which the strict Go SDK could not decode.
  - **`DescribePrefixLists`** — now supported, returning AWS-managed prefix lists (e.g. `com.amazonaws.us-east-1.s3`).
  - **`privateDnsEnabled`** — honored and defaults to `true` for interface endpoints, so `terraform plan` no longer shows a permanent false→true diff.

  ## Testing
  Ec2IntegrationTest covers all three: routeTableIdSet/subnetIdSet plain-text items, describePrefixListsReturnsManagedS3, and
  interfaceEndpointPrivateDnsEnabledByDefault. Full EC2 suite passes locally