### PR TITLE
test(ec2): stop describeDefaultSecurityGroup flaking on shared store

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -5284,6 +5284,15 @@ class CloudFormationIntegrationTest {
                 .formParam("TemplateBody", template)
                 .when().post("/")
                 .then().statusCode(200);
+
+        // Tear the recreated stack back down so the security group is not left behind in the
+        // shared in-memory EC2 store, where it would pollute other tests' DescribeSecurityGroups.
+        given()
+                .formParam("Action", "DeleteStack")
+                .formParam("Version", "2010-05-15")
+                .formParam("StackName", stackName)
+                .when().post("/")
+                .then().statusCode(200);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -92,8 +92,16 @@ class Ec2IntegrationTest {
     @Test
     @Order(3)
     void describeDefaultSecurityGroup() {
+        // Filter to the default VPC's default group rather than assuming it is item[0] of an
+        // unfiltered list: DescribeSecurityGroups returns groups in the store's iteration order,
+        // so any other group in this region (e.g. one left behind by another test class sharing
+        // the in-memory EC2 store) could otherwise land at item[0] and flake this assertion.
         given()
             .formParam("Action", "DescribeSecurityGroups")
+            .formParam("Filter.1.Name", "group-name")
+            .formParam("Filter.1.Value.1", "default")
+            .formParam("Filter.2.Name", "vpc-id")
+            .formParam("Filter.2.Value.1", "vpc-default")
             .header("Authorization", AUTH_HEADER)
         .when()
             .post("/")


### PR DESCRIPTION
## Summary

Two integration tests flaked because the in-memory EC2 store is shared across test classes:

- `Ec2IntegrationTest#describeDefaultSecurityGroup` assumed the default group was item[0] of an unfiltered `DescribeSecurityGroups` list. Groups are returned in the store's iteration order, so any group left behind by another test could land at item[0] and flake the assertion. It now filters by `group-name=default` + `vpc-id=vpc-default`.
- A CloudFormation test recreated a stack and left its security group behind in the shared store, polluting other tests. It now issues a `DeleteStack` to tear the recreated stack back down.

No runtime/production code changes — test-only robustness fixes.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore (test-only — `test(ec2):`; no dedicated checkbox in template)

## AWS Compatibility

No wire-protocol change. The new filters exercise the existing `DescribeSecurityGroups` `group-name`/`vpc-id` filter support.

## Checklist

- [x] `./mvnw test` passes locally (`Ec2IntegrationTest` + `CloudFormationIntegrationTest`: 200/200)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)