### PR TITLE
feat(ses): support v1 ConfigurationSet tracking and reputation-metrics options

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesConfigurationSetTrackingOptionsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesConfigurationSetTrackingOptionsTest.java
@@ -1,0 +1,198 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import software.amazon.awssdk.services.ses.SesClient;
+import software.amazon.awssdk.services.ses.model.ConfigurationSet;
+import software.amazon.awssdk.services.ses.model.ConfigurationSetAttribute;
+import software.amazon.awssdk.services.ses.model.ConfigurationSetDoesNotExistException;
+import software.amazon.awssdk.services.ses.model.CreateConfigurationSetRequest;
+import software.amazon.awssdk.services.ses.model.CreateConfigurationSetTrackingOptionsRequest;
+import software.amazon.awssdk.services.ses.model.DeleteConfigurationSetRequest;
+import software.amazon.awssdk.services.ses.model.DeleteConfigurationSetTrackingOptionsRequest;
+import software.amazon.awssdk.services.ses.model.DescribeConfigurationSetRequest;
+import software.amazon.awssdk.services.ses.model.DescribeConfigurationSetResponse;
+import software.amazon.awssdk.services.ses.model.InvalidTrackingOptionsException;
+import software.amazon.awssdk.services.ses.model.TrackingOptions;
+import software.amazon.awssdk.services.ses.model.TrackingOptionsAlreadyExistsException;
+import software.amazon.awssdk.services.ses.model.TrackingOptionsDoesNotExistException;
+import software.amazon.awssdk.services.ses.model.UpdateConfigurationSetReputationMetricsEnabledRequest;
+import software.amazon.awssdk.services.ses.model.UpdateConfigurationSetTrackingOptionsRequest;
+import software.amazon.awssdk.services.ses.model.VerifyDomainIdentityRequest;
+
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.GetConfigurationSetRequest;
+import software.amazon.awssdk.services.sesv2.model.GetConfigurationSetResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * SDK compatibility test for the SES v1 (Query) ConfigurationSet option APIs:
+ * {@code Create/Update/DeleteConfigurationSetTrackingOptions} and
+ * {@code UpdateConfigurationSetReputationMetricsEnabled}. Verifies AWS Java SDK v2
+ * marshalling of the SES v1 (Query) API, the modeled error types (verified domain
+ * requirement, lifecycle
+ * conflicts, unknown configuration set), and cross-API visibility of the
+ * reputation-metrics flag through the v2 GetConfigurationSet response.
+ */
+@DisplayName("SES v1 ConfigurationSet Tracking & Reputation Options")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesConfigurationSetTrackingOptionsTest {
+
+    private static final String CS = "compat-cs-v1-tracking";
+    private static final String DOMAIN = "track.compat.floci.test";
+    private static final String DOMAIN_2 = "track2.compat.floci.test";
+
+    private static SesClient sesV1;
+    private static SesV2Client sesV2;
+
+    @BeforeAll
+    static void setup() {
+        sesV1 = TestFixtures.sesClient();
+        sesV2 = TestFixtures.sesV2Client();
+        deleteCsQuietly();
+        sesV1.verifyDomainIdentity(VerifyDomainIdentityRequest.builder().domain(DOMAIN).build());
+        sesV1.verifyDomainIdentity(VerifyDomainIdentityRequest.builder().domain(DOMAIN_2).build());
+        sesV1.createConfigurationSet(CreateConfigurationSetRequest.builder()
+                .configurationSet(ConfigurationSet.builder().name(CS).build()).build());
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (sesV1 != null) {
+            deleteCsQuietly();
+            sesV1.close();
+        }
+        if (sesV2 != null) {
+            sesV2.close();
+        }
+    }
+
+    private static void deleteCsQuietly() {
+        try {
+            sesV1.deleteConfigurationSet(DeleteConfigurationSetRequest.builder()
+                    .configurationSetName(CS).build());
+        } catch (Exception ignored) {}
+    }
+
+    private static DescribeConfigurationSetResponse describe(ConfigurationSetAttribute attr) {
+        return sesV1.describeConfigurationSet(DescribeConfigurationSetRequest.builder()
+                .configurationSetName(CS)
+                .configurationSetAttributeNames(attr)
+                .build());
+    }
+
+    @Test
+    @Order(1)
+    void v1CreatedSet_reputationMetricsDefaultsDisabled() {
+        assertThat(describe(ConfigurationSetAttribute.REPUTATION_OPTIONS)
+                .reputationOptions().reputationMetricsEnabled()).isFalse();
+    }
+
+    @Test
+    @Order(2)
+    void createTrackingOptions_unverifiedDomain_throwsInvalidTrackingOptions() {
+        assertThatThrownBy(() -> sesV1.createConfigurationSetTrackingOptions(
+                CreateConfigurationSetTrackingOptionsRequest.builder()
+                        .configurationSetName(CS)
+                        .trackingOptions(TrackingOptions.builder()
+                                .customRedirectDomain("never-verified.example.com").build())
+                        .build()))
+                .isInstanceOf(InvalidTrackingOptionsException.class);
+    }
+
+    @Test
+    @Order(3)
+    void createTrackingOptions_verifiedDomain_stored() {
+        sesV1.createConfigurationSetTrackingOptions(CreateConfigurationSetTrackingOptionsRequest.builder()
+                .configurationSetName(CS)
+                .trackingOptions(TrackingOptions.builder().customRedirectDomain(DOMAIN).build())
+                .build());
+
+        assertThat(describe(ConfigurationSetAttribute.TRACKING_OPTIONS)
+                .trackingOptions().customRedirectDomain()).isEqualTo(DOMAIN);
+    }
+
+    @Test
+    @Order(4)
+    void createTrackingOptions_alreadyExists_throws() {
+        assertThatThrownBy(() -> sesV1.createConfigurationSetTrackingOptions(
+                CreateConfigurationSetTrackingOptionsRequest.builder()
+                        .configurationSetName(CS)
+                        .trackingOptions(TrackingOptions.builder().customRedirectDomain(DOMAIN).build())
+                        .build()))
+                .isInstanceOf(TrackingOptionsAlreadyExistsException.class);
+    }
+
+    @Test
+    @Order(5)
+    void updateTrackingOptions_changesDomain() {
+        sesV1.updateConfigurationSetTrackingOptions(UpdateConfigurationSetTrackingOptionsRequest.builder()
+                .configurationSetName(CS)
+                .trackingOptions(TrackingOptions.builder().customRedirectDomain(DOMAIN_2).build())
+                .build());
+
+        assertThat(describe(ConfigurationSetAttribute.TRACKING_OPTIONS)
+                .trackingOptions().customRedirectDomain()).isEqualTo(DOMAIN_2);
+    }
+
+    @Test
+    @Order(6)
+    void deleteTrackingOptions_removesThem() {
+        sesV1.deleteConfigurationSetTrackingOptions(DeleteConfigurationSetTrackingOptionsRequest.builder()
+                .configurationSetName(CS).build());
+
+        TrackingOptions options = describe(ConfigurationSetAttribute.TRACKING_OPTIONS).trackingOptions();
+        assertThat(options == null || options.customRedirectDomain() == null).isTrue();
+    }
+
+    @Test
+    @Order(7)
+    void deleteTrackingOptions_whenNoneSet_throws() {
+        assertThatThrownBy(() -> sesV1.deleteConfigurationSetTrackingOptions(
+                DeleteConfigurationSetTrackingOptionsRequest.builder().configurationSetName(CS).build()))
+                .isInstanceOf(TrackingOptionsDoesNotExistException.class);
+    }
+
+    @Test
+    @Order(8)
+    void updateReputationMetricsEnabled_visibleViaV1AndV2() {
+        sesV1.updateConfigurationSetReputationMetricsEnabled(
+                UpdateConfigurationSetReputationMetricsEnabledRequest.builder()
+                        .configurationSetName(CS).enabled(true).build());
+
+        assertThat(describe(ConfigurationSetAttribute.REPUTATION_OPTIONS)
+                .reputationOptions().reputationMetricsEnabled()).isTrue();
+
+        GetConfigurationSetResponse v2 = sesV2.getConfigurationSet(
+                GetConfigurationSetRequest.builder().configurationSetName(CS).build());
+        assertThat(v2.reputationOptions().reputationMetricsEnabled()).isTrue();
+    }
+
+    @Test
+    @Order(9)
+    void reputationMetrics_unknownConfigSet_throwsConfigurationSetDoesNotExist() {
+        assertThatThrownBy(() -> sesV1.updateConfigurationSetReputationMetricsEnabled(
+                UpdateConfigurationSetReputationMetricsEnabledRequest.builder()
+                        .configurationSetName("compat-cs-ghost").enabled(true).build()))
+                .isInstanceOf(ConfigurationSetDoesNotExistException.class);
+    }
+
+    @Test
+    @Order(10)
+    void createTrackingOptions_unknownConfigSet_throwsConfigurationSetDoesNotExist() {
+        assertThatThrownBy(() -> sesV1.createConfigurationSetTrackingOptions(
+                CreateConfigurationSetTrackingOptionsRequest.builder()
+                        .configurationSetName("compat-cs-ghost")
+                        .trackingOptions(TrackingOptions.builder().customRedirectDomain(DOMAIN).build())
+                        .build()))
+                .isInstanceOf(ConfigurationSetDoesNotExistException.class);
+    }
+}

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -46,6 +46,10 @@ Floci exposes the classic Amazon SES Query API used by `aws ses ...` commands an
 | `UpdateConfigurationSetEventDestination` | Update an existing event destination on a configuration set |
 | `DeleteConfigurationSetEventDestination` | Remove an event destination from a configuration set      |
 | `UpdateConfigurationSetSendingEnabled`   | Enable or disable email sending through a configuration set |
+| `CreateConfigurationSetTrackingOptions`  | Set the custom open/click tracking redirect domain |
+| `UpdateConfigurationSetTrackingOptions`  | Change the custom tracking redirect domain |
+| `DeleteConfigurationSetTrackingOptions`  | Remove the custom tracking redirect domain |
+| `UpdateConfigurationSetReputationMetricsEnabled` | Enable or disable reputation metrics for a configuration set |
 
 ## Configuration
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -362,7 +362,11 @@ public class AwsQueryController {
             "CreateConfigurationSetEventDestination",
             "UpdateConfigurationSetEventDestination",
             "DeleteConfigurationSetEventDestination",
-            "UpdateConfigurationSetSendingEnabled"
+            "UpdateConfigurationSetSendingEnabled",
+            "CreateConfigurationSetTrackingOptions",
+            "UpdateConfigurationSetTrackingOptions",
+            "DeleteConfigurationSetTrackingOptions",
+            "UpdateConfigurationSetReputationMetricsEnabled"
     );
 
     private static final Set<String> COGNITO_ACTIONS = Set.of(

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
@@ -90,6 +90,14 @@ public class SesQueryHandler {
                         handleDeleteConfigurationSetEventDestination(params, region);
                 case "UpdateConfigurationSetSendingEnabled" ->
                         handleUpdateConfigurationSetSendingEnabled(params, region);
+                case "CreateConfigurationSetTrackingOptions" ->
+                        handleCreateConfigurationSetTrackingOptions(params, region);
+                case "UpdateConfigurationSetTrackingOptions" ->
+                        handleUpdateConfigurationSetTrackingOptions(params, region);
+                case "DeleteConfigurationSetTrackingOptions" ->
+                        handleDeleteConfigurationSetTrackingOptions(params, region);
+                case "UpdateConfigurationSetReputationMetricsEnabled" ->
+                        handleUpdateConfigurationSetReputationMetricsEnabled(params, region);
                 default -> AwsQueryResponse.error("UnsupportedOperation",
                         "Operation " + action + " is not supported by SES.", AwsNamespaces.SES, 400);
             };
@@ -549,7 +557,9 @@ public class SesQueryHandler {
         if (name == null || name.isBlank()) {
             throw new AwsException("InvalidParameterValue", "ConfigurationSet.Name is required.", 400);
         }
-        sesService.createConfigurationSet(new ConfigurationSet(name), region);
+        ConfigurationSet configSet = new ConfigurationSet(name);
+        configSet.setReputationMetricsEnabled(false);
+        sesService.createConfigurationSet(configSet, region);
         return Response.ok(AwsQueryResponse.envelopeEmptyResult("CreateConfigurationSet", AwsNamespaces.SES)).build();
     }
 
@@ -579,7 +589,14 @@ public class SesQueryHandler {
         if (attrs.contains("reputationOptions")) {
             xml.start("ReputationOptions")
                 .elem("SendingEnabled", String.valueOf(cs.isSendingEnabledEffective()))
+                .elem("ReputationMetricsEnabled", String.valueOf(cs.isReputationMetricsEnabledEffective()))
                .end("ReputationOptions");
+        }
+        if (attrs.contains("trackingOptions") && cs.getTrackingOptions() != null
+                && cs.getTrackingOptions().getCustomRedirectDomain() != null) {
+            xml.start("TrackingOptions")
+                .elem("CustomRedirectDomain", cs.getTrackingOptions().getCustomRedirectDomain())
+               .end("TrackingOptions");
         }
         return Response.ok(AwsQueryResponse.envelope("DescribeConfigurationSet",
                 AwsNamespaces.SES, xml.build())).build();
@@ -699,6 +716,41 @@ public class SesQueryHandler {
         sesService.setConfigurationSetSendingEnabled(configSet, enabled, region);
         return Response.ok(AwsQueryResponse.envelopeEmptyResult(
                 "UpdateConfigurationSetSendingEnabled", AwsNamespaces.SES)).build();
+    }
+
+    private Response handleCreateConfigurationSetTrackingOptions(MultivaluedMap<String, String> params,
+                                                                 String region) {
+        String configSet = requireParam(params, "ConfigurationSetName");
+        String domain = getParam(params, "TrackingOptions.CustomRedirectDomain");
+        sesService.createConfigurationSetTrackingOptions(configSet, domain, region);
+        return Response.ok(AwsQueryResponse.envelopeEmptyResult(
+                "CreateConfigurationSetTrackingOptions", AwsNamespaces.SES)).build();
+    }
+
+    private Response handleUpdateConfigurationSetTrackingOptions(MultivaluedMap<String, String> params,
+                                                                 String region) {
+        String configSet = requireParam(params, "ConfigurationSetName");
+        String domain = getParam(params, "TrackingOptions.CustomRedirectDomain");
+        sesService.updateConfigurationSetTrackingOptions(configSet, domain, region);
+        return Response.ok(AwsQueryResponse.envelopeEmptyResult(
+                "UpdateConfigurationSetTrackingOptions", AwsNamespaces.SES)).build();
+    }
+
+    private Response handleDeleteConfigurationSetTrackingOptions(MultivaluedMap<String, String> params,
+                                                                 String region) {
+        String configSet = requireParam(params, "ConfigurationSetName");
+        sesService.deleteConfigurationSetTrackingOptions(configSet, region);
+        return Response.ok(AwsQueryResponse.envelopeEmptyResult(
+                "DeleteConfigurationSetTrackingOptions", AwsNamespaces.SES)).build();
+    }
+
+    private Response handleUpdateConfigurationSetReputationMetricsEnabled(MultivaluedMap<String, String> params,
+                                                                          String region) {
+        String configSet = requireParam(params, "ConfigurationSetName");
+        boolean enabled = parseRequiredBoolean(params, "Enabled");
+        sesService.setConfigurationSetReputationOptions(configSet, enabled, region);
+        return Response.ok(AwsQueryResponse.envelopeEmptyResult(
+                "UpdateConfigurationSetReputationMetricsEnabled", AwsNamespaces.SES)).build();
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -695,6 +695,61 @@ public class SesService {
                 configSetName, region, metricsEnabled);
     }
 
+    private boolean isVerifiedDomainIdentity(String domain, String region) {
+        Identity identity = getIdentityVerificationAttributes(domain, region);
+        return identity != null && "Success".equals(identity.getVerificationStatus())
+                && "Domain".equals(identity.getIdentityType());
+    }
+
+    private void requireVerifiedRedirectDomain(String domain, String region) {
+        if (domain == null || domain.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "CustomRedirectDomain is required.", 400);
+        }
+        if (!isVerifiedDomainIdentity(domain, region)) {
+            throw new AwsException("InvalidTrackingOptions",
+                    "Domain <" + domain + "> is not verified under this account.", 400);
+        }
+    }
+
+    public void createConfigurationSetTrackingOptions(String configSetName, String customRedirectDomain,
+                                                      String region) {
+        requireVerifiedRedirectDomain(customRedirectDomain, region);
+        ConfigurationSet cs = getConfigurationSet(configSetName, region);
+        if (cs.getTrackingOptions() != null && cs.getTrackingOptions().getCustomRedirectDomain() != null) {
+            throw new AwsException("TrackingOptionsAlreadyExistsException",
+                    "Configuration set <" + configSetName + "> already has tracking options.", 400);
+        }
+        TrackingOptions options = new TrackingOptions();
+        options.setCustomRedirectDomain(customRedirectDomain);
+        cs.setTrackingOptions(options);
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Created TrackingOptions on configuration set {0} in region {1}", configSetName, region);
+    }
+
+    public void updateConfigurationSetTrackingOptions(String configSetName, String customRedirectDomain,
+                                                      String region) {
+        requireVerifiedRedirectDomain(customRedirectDomain, region);
+        ConfigurationSet cs = getConfigurationSet(configSetName, region);
+        if (cs.getTrackingOptions() == null || cs.getTrackingOptions().getCustomRedirectDomain() == null) {
+            throw new AwsException("TrackingOptionsDoesNotExistException",
+                    "There are no tracking options for configuration set <" + configSetName + ">", 400);
+        }
+        cs.getTrackingOptions().setCustomRedirectDomain(customRedirectDomain);
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Updated TrackingOptions on configuration set {0} in region {1}", configSetName, region);
+    }
+
+    public void deleteConfigurationSetTrackingOptions(String configSetName, String region) {
+        ConfigurationSet cs = getConfigurationSet(configSetName, region);
+        if (cs.getTrackingOptions() == null || cs.getTrackingOptions().getCustomRedirectDomain() == null) {
+            throw new AwsException("TrackingOptionsDoesNotExistException",
+                    "There are no tracking options for configuration set <" + configSetName + ">", 400);
+        }
+        cs.setTrackingOptions(null);
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Deleted TrackingOptions on configuration set {0} in region {1}", configSetName, region);
+    }
+
     public void setConfigurationSetArchivingOptions(String configSetName, ArchivingOptions options, String region) {
         ConfigurationSet cs = getConfigurationSet(configSetName, region);
         cs.setArchivingOptions(options);
@@ -752,13 +807,9 @@ public class SesService {
             throw new AwsException("BadRequestException",
                     "CustomRedirectDomain must be specified.", 400);
         }
-        if (domain != null) {
-            Identity identity = getIdentityVerificationAttributes(domain, region);
-            if (identity == null || !"Success".equals(identity.getVerificationStatus())
-                    || !"Domain".equals(identity.getIdentityType())) {
-                throw new AwsException("BadRequestException",
-                        "Domain <" + domain + "> is not verified under this account.", 400);
-            }
+        if (domain != null && !isVerifiedDomainIdentity(domain, region)) {
+            throw new AwsException("BadRequestException",
+                    "Domain <" + domain + "> is not verified under this account.", 400);
         }
         if (httpsPolicy != null && !HTTPS_POLICIES.contains(httpsPolicy)) {
             throw new AwsException("BadRequestException",

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -702,8 +702,14 @@ public class SesService {
     }
 
     private void requireVerifiedRedirectDomain(String domain, String region) {
-        if (domain == null || domain.isBlank()) {
-            throw new AwsException("InvalidParameterValue", "CustomRedirectDomain is required.", 400);
+        if (domain == null) {
+            throw new AwsException("ValidationError",
+                    "1 validation error detected: Value at 'trackingOptions' failed to satisfy constraint: "
+                            + "Member must not be null", 400);
+        }
+        if (domain.isBlank()) {
+            throw new AwsException("InvalidTrackingOptions",
+                    "At least one field of TrackingOptions must contain a value.", 400);
         }
         if (!isVerifiedDomainIdentity(domain, region)) {
             throw new AwsException("InvalidTrackingOptions",

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetTrackingOptionsV1IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetTrackingOptionsV1IntegrationTest.java
@@ -174,7 +174,7 @@ class SesConfigurationSetTrackingOptionsV1IntegrationTest {
     }
 
     @Test
-    @Order(13)
+    @Order(11)
     void createTrackingOptions_missingDomain_returnsValidationError() {
         // No TrackingOptions.CustomRedirectDomain param at all: AWS treats the
         // tracking-options member as null and returns a framework ValidationError.
@@ -187,7 +187,7 @@ class SesConfigurationSetTrackingOptionsV1IntegrationTest {
     }
 
     @Test
-    @Order(14)
+    @Order(12)
     void createTrackingOptions_blankDomain_returnsInvalidTrackingOptions() {
         // Present but empty CustomRedirectDomain: the structure is non-null but has
         // no usable field, so AWS reports InvalidTrackingOptions instead.
@@ -201,7 +201,7 @@ class SesConfigurationSetTrackingOptionsV1IntegrationTest {
     }
 
     @Test
-    @Order(11)
+    @Order(13)
     void updateReputationMetricsEnabled_togglesAndReflectsInDescribe() {
         query("UpdateConfigurationSetReputationMetricsEnabled")
             .formParam("ConfigurationSetName", CS)
@@ -219,7 +219,7 @@ class SesConfigurationSetTrackingOptionsV1IntegrationTest {
     }
 
     @Test
-    @Order(12)
+    @Order(14)
     void reputationMetrics_unknownConfigSet_returns400() {
         query("UpdateConfigurationSetReputationMetricsEnabled")
             .formParam("ConfigurationSetName", "v1-cs-ghost")

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetTrackingOptionsV1IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetTrackingOptionsV1IntegrationTest.java
@@ -1,0 +1,204 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Integration tests for the SES V1 Query-protocol ConfigurationSet option APIs that
+ * sit alongside event destinations: tracking options and reputation-metrics toggling.
+ *
+ * <p>Tracking options require a verified domain identity, matching real AWS (verified
+ * 2026-06-21): an unverified CustomRedirectDomain yields {@code InvalidTrackingOptions},
+ * and that check runs before configuration-set existence. Reputation metrics default to
+ * disabled for a V1-created set, unlike the V2 create path which leaves them enabled.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesConfigurationSetTrackingOptionsV1IntegrationTest {
+
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/email/aws4_request";
+    private static final String DOMAIN = "track-v1.floci.test";
+    private static final String CS = "v1-cs-tracking";
+
+    private static RequestSpecification query(String action) {
+        return given()
+                .contentType("application/x-www-form-urlencoded")
+                .header("Authorization", AUTH)
+                .formParam("Action", action);
+    }
+
+    @Test
+    @Order(1)
+    void setup_verifyDomain_andCreateConfigSet() {
+        query("VerifyDomainIdentity").formParam("Domain", DOMAIN)
+            .when().post("/").then().statusCode(200);
+        query("CreateConfigurationSet").formParam("ConfigurationSet.Name", CS)
+            .when().post("/").then().statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void v1CreatedSet_reputationMetricsDefaultsDisabled() {
+        query("DescribeConfigurationSet")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("ConfigurationSetAttributeNames.member.1", "reputationOptions")
+        .when().post("/")
+        .then().statusCode(200)
+            .body(containsString("<ReputationMetricsEnabled>false</ReputationMetricsEnabled>"));
+    }
+
+    @Test
+    @Order(3)
+    void createTrackingOptions_unverifiedDomain_returns400() {
+        query("CreateConfigurationSetTrackingOptions")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("TrackingOptions.CustomRedirectDomain", "never-verified-v1.example.com")
+        .when().post("/")
+        .then().statusCode(400)
+            .body(containsString("<Code>InvalidTrackingOptions</Code>"))
+            .body(containsString("is not verified under this account"));
+    }
+
+    @Test
+    @Order(4)
+    void createTrackingOptions_verifiedDomain_stored() {
+        query("CreateConfigurationSetTrackingOptions")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("TrackingOptions.CustomRedirectDomain", DOMAIN)
+        .when().post("/")
+        .then().statusCode(200)
+            .body(containsString("CreateConfigurationSetTrackingOptionsResponse"));
+
+        query("DescribeConfigurationSet")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("ConfigurationSetAttributeNames.member.1", "trackingOptions")
+        .when().post("/")
+        .then().statusCode(200)
+            .body(containsString("<CustomRedirectDomain>" + DOMAIN + "</CustomRedirectDomain>"));
+    }
+
+    @Test
+    @Order(5)
+    void createTrackingOptions_alreadyExists_returns400() {
+        query("CreateConfigurationSetTrackingOptions")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("TrackingOptions.CustomRedirectDomain", DOMAIN)
+        .when().post("/")
+        .then().statusCode(400)
+            .body(containsString("<Code>TrackingOptionsAlreadyExistsException</Code>"));
+    }
+
+    @Test
+    @Order(6)
+    void updateTrackingOptions_changesDomain() {
+        query("VerifyDomainIdentity").formParam("Domain", "other." + DOMAIN)
+            .when().post("/").then().statusCode(200);
+        query("UpdateConfigurationSetTrackingOptions")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("TrackingOptions.CustomRedirectDomain", "other." + DOMAIN)
+        .when().post("/")
+        .then().statusCode(200);
+
+        query("DescribeConfigurationSet")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("ConfigurationSetAttributeNames.member.1", "trackingOptions")
+        .when().post("/")
+        .then().statusCode(200)
+            .body(containsString("<CustomRedirectDomain>other." + DOMAIN + "</CustomRedirectDomain>"));
+    }
+
+    @Test
+    @Order(7)
+    void deleteTrackingOptions_removesThem() {
+        query("DeleteConfigurationSetTrackingOptions")
+            .formParam("ConfigurationSetName", CS)
+        .when().post("/")
+        .then().statusCode(200)
+            .body(containsString("DeleteConfigurationSetTrackingOptionsResponse"));
+
+        query("DescribeConfigurationSet")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("ConfigurationSetAttributeNames.member.1", "trackingOptions")
+        .when().post("/")
+        .then().statusCode(200)
+            .body(not(containsString("<TrackingOptions>")));
+    }
+
+    @Test
+    @Order(8)
+    void deleteTrackingOptions_whenNoneSet_returns400() {
+        query("DeleteConfigurationSetTrackingOptions")
+            .formParam("ConfigurationSetName", CS)
+        .when().post("/")
+        .then().statusCode(400)
+            .body(containsString("<Code>TrackingOptionsDoesNotExistException</Code>"));
+    }
+
+    @Test
+    @Order(9)
+    void updateTrackingOptions_whenNoneSet_returns400() {
+        query("UpdateConfigurationSetTrackingOptions")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("TrackingOptions.CustomRedirectDomain", DOMAIN)
+        .when().post("/")
+        .then().statusCode(400)
+            .body(containsString("<Code>TrackingOptionsDoesNotExistException</Code>"));
+    }
+
+    @Test
+    @Order(10)
+    void trackingOptions_unknownConfigSet_domainCheckedFirst() {
+        // Verified domain reaches the configuration-set lookup; unverified short-circuits first.
+        query("CreateConfigurationSetTrackingOptions")
+            .formParam("ConfigurationSetName", "v1-cs-ghost")
+            .formParam("TrackingOptions.CustomRedirectDomain", DOMAIN)
+        .when().post("/")
+        .then().statusCode(400)
+            .body(containsString("<Code>ConfigurationSetDoesNotExist</Code>"));
+
+        query("CreateConfigurationSetTrackingOptions")
+            .formParam("ConfigurationSetName", "v1-cs-ghost")
+            .formParam("TrackingOptions.CustomRedirectDomain", "never-verified-v1.example.com")
+        .when().post("/")
+        .then().statusCode(400)
+            .body(containsString("<Code>InvalidTrackingOptions</Code>"));
+    }
+
+    @Test
+    @Order(11)
+    void updateReputationMetricsEnabled_togglesAndReflectsInDescribe() {
+        query("UpdateConfigurationSetReputationMetricsEnabled")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("Enabled", "true")
+        .when().post("/")
+        .then().statusCode(200)
+            .body(containsString("UpdateConfigurationSetReputationMetricsEnabledResponse"));
+
+        query("DescribeConfigurationSet")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("ConfigurationSetAttributeNames.member.1", "reputationOptions")
+        .when().post("/")
+        .then().statusCode(200)
+            .body(containsString("<ReputationMetricsEnabled>true</ReputationMetricsEnabled>"));
+    }
+
+    @Test
+    @Order(12)
+    void reputationMetrics_unknownConfigSet_returns400() {
+        query("UpdateConfigurationSetReputationMetricsEnabled")
+            .formParam("ConfigurationSetName", "v1-cs-ghost")
+            .formParam("Enabled", "true")
+        .when().post("/")
+        .then().statusCode(400)
+            .body(containsString("<Code>ConfigurationSetDoesNotExist</Code>"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetTrackingOptionsV1IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetTrackingOptionsV1IntegrationTest.java
@@ -174,6 +174,33 @@ class SesConfigurationSetTrackingOptionsV1IntegrationTest {
     }
 
     @Test
+    @Order(13)
+    void createTrackingOptions_missingDomain_returnsValidationError() {
+        // No TrackingOptions.CustomRedirectDomain param at all: AWS treats the
+        // tracking-options member as null and returns a framework ValidationError.
+        query("CreateConfigurationSetTrackingOptions")
+            .formParam("ConfigurationSetName", CS)
+        .when().post("/")
+        .then().statusCode(400)
+            .body(containsString("<Code>ValidationError</Code>"))
+            .body(containsString("Member must not be null"));
+    }
+
+    @Test
+    @Order(14)
+    void createTrackingOptions_blankDomain_returnsInvalidTrackingOptions() {
+        // Present but empty CustomRedirectDomain: the structure is non-null but has
+        // no usable field, so AWS reports InvalidTrackingOptions instead.
+        query("CreateConfigurationSetTrackingOptions")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("TrackingOptions.CustomRedirectDomain", "")
+        .when().post("/")
+        .then().statusCode(400)
+            .body(containsString("<Code>InvalidTrackingOptions</Code>"))
+            .body(containsString("At least one field of TrackingOptions must contain a value"));
+    }
+
+    @Test
     @Order(11)
     void updateReputationMetricsEnabled_togglesAndReflectsInDescribe() {
         query("UpdateConfigurationSetReputationMetricsEnabled")


### PR DESCRIPTION
## Summary

Implements the SES v1 (Query) ConfigurationSet option operations that previously returned `UnsupportedOperation`: `CreateConfigurationSetTrackingOptions`, `UpdateConfigurationSetTrackingOptions`, `DeleteConfigurationSetTrackingOptions`, and `UpdateConfigurationSetReputationMetricsEnabled`.

This continues #1412, which added the v2 (REST JSON) ConfigurationSet option groups (reputation, tracking, delivery, archiving, VDM); this PR fills in the corresponding v1 (Query) tracking and reputation-metrics operations.

Tracking options require a verified domain identity, matching real AWS: an unverified `CustomRedirectDomain` yields `InvalidTrackingOptions`, checked before configuration-set existence. The domain-verification check is shared with the existing v2 `PutConfigurationSetTrackingOptions` path so the two surfaces stay aligned. Lifecycle conflicts surface as `TrackingOptionsAlreadyExistsException` / `TrackingOptionsDoesNotExistException`, matching the AWS SDK error mapping. A v1-created configuration set now defaults reputation metrics to disabled (the v2 create path leaves them enabled), and `DescribeConfigurationSet` returns `ReputationMetricsEnabled` and the `trackingOptions` block.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Wire protocol verified against real AWS SES (us-east-2) with the AWS SDK for Java 2.x (2.42.24 — the `ses` module for the v1/Query API and `sesv2` for the v2 API) and the AWS CLI: the verified-domain requirement and its precedence over configuration-set existence, the tracking-options delete error, and reputation metrics defaulting to disabled for a v1-created set while remaining enabled for a v2-created set. The exact wire error codes (`InvalidTrackingOptions`, `TrackingOptionsAlreadyExistsException`, `TrackingOptionsDoesNotExistException`) were taken from the `ses` module's modeled error mapping rather than the CLI output, since the CLI strips the `Exception` suffix.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)



