### PR TITLE
fix(cognito): align sign-up confirmation with AWS behavior

### DIFF
--- a/compatibility-tests/sdk-test-node/tests/cognito.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/cognito.test.ts
@@ -23,7 +23,7 @@ import {
   AdminRemoveUserFromGroupCommand,
   AdminListGroupsForUserCommand,
 } from '@aws-sdk/client-cognito-identity-provider';
-import { makeClient, uniqueName, ENDPOINT } from './setup';
+import { makeClient, uniqueName, fetchLatestSesVerificationCode } from './setup';
 
 describe('Cognito', () => {
   let cognito: CognitoIdentityProviderClient;
@@ -111,19 +111,21 @@ describe('Cognito', () => {
   });
 
   it('should sign up and confirm user', async () => {
+    const email = 'testuser2@example.com';
     await cognito.send(
       new SignUpCommand({
         ClientId: clientId,
         Username: 'testuser2',
         Password: 'Pass789!',
-        UserAttributes: [{ Name: 'email', Value: 'testuser2@example.com' }],
+        UserAttributes: [{ Name: 'email', Value: email }],
       })
     );
+    const confirmationCode = await fetchLatestSesVerificationCode(email);
     await cognito.send(
       new ConfirmSignUpCommand({
         ClientId: clientId,
         Username: 'testuser2',
-        ConfirmationCode: '123456',
+        ConfirmationCode: confirmationCode,
       })
     );
   });

--- a/compatibility-tests/sdk-test-node/tests/cognito.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/cognito.test.ts
@@ -23,7 +23,7 @@ import {
   AdminRemoveUserFromGroupCommand,
   AdminListGroupsForUserCommand,
 } from '@aws-sdk/client-cognito-identity-provider';
-import { makeClient, uniqueName, fetchLatestSesVerificationCode } from './setup';
+import { makeClient, uniqueName, ENDPOINT, fetchLatestSesVerificationCode } from './setup';
 
 describe('Cognito', () => {
   let cognito: CognitoIdentityProviderClient;
@@ -46,7 +46,10 @@ describe('Cognito', () => {
 
   it('should create user pool', async () => {
     const response = await cognito.send(
-      new CreateUserPoolCommand({ PoolName: `test-pool-${uniqueName()}` })
+      new CreateUserPoolCommand({
+        PoolName: `test-pool-${uniqueName()}`,
+        AutoVerifiedAttributes: ['email'],
+      })
     );
     poolId = response.UserPool!.Id!;
     expect(poolId).toBeTruthy();

--- a/compatibility-tests/sdk-test-node/tests/setup.ts
+++ b/compatibility-tests/sdk-test-node/tests/setup.ts
@@ -51,7 +51,11 @@ export async function fetchLatestSesVerificationCode(recipient: string): Promise
   const payload = (await response.json()) as {
     messages?: Array<{ Body?: { text_part?: string } }>;
   };
-  const body = payload.messages?.[0]?.Body?.text_part ?? '';
+  const firstMessage = payload.messages?.[0];
+  const body =
+    firstMessage?.Body?.text_part ??
+    (firstMessage?.Body as { html_part?: string } | undefined)?.html_part ??
+    '';
   const match = body.match(SIX_DIGIT_CODE);
   if (!match) {
     throw new Error('verification code email should contain a 6-digit code');

--- a/compatibility-tests/sdk-test-node/tests/setup.ts
+++ b/compatibility-tests/sdk-test-node/tests/setup.ts
@@ -38,6 +38,27 @@ export function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+const SIX_DIGIT_CODE = /\b(\d{6})\b/;
+
+export async function fetchLatestSesVerificationCode(recipient: string): Promise<string> {
+  const response = await fetch(
+    `${ENDPOINT}/_aws/ses?email=${encodeURIComponent(recipient)}`
+  );
+  if (!response.ok) {
+    throw new Error(`failed to fetch SES messages: ${response.status}`);
+  }
+
+  const payload = (await response.json()) as {
+    messages?: Array<{ Body?: { text_part?: string } }>;
+  };
+  const body = payload.messages?.[0]?.Body?.text_part ?? '';
+  const match = body.match(SIX_DIGIT_CODE);
+  if (!match) {
+    throw new Error('verification code email should contain a 6-digit code');
+  }
+  return match[1];
+}
+
 // Build a minimal ZIP file for Lambda functions
 export function buildMinimalZip(filename: string, content: Buffer): Buffer {
   const filenameBytes = Buffer.from(filename);

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -526,17 +526,23 @@ public class CognitoJsonHandler {
         ObjectNode response = objectMapper.createObjectNode();
         response.put("UserConfirmed", "CONFIRMED".equals(user.getUserStatus()));
         response.put("UserSub", user.getAttributes().get("sub"));
-        ObjectNode delivery = response.putObject("CodeDeliveryDetails");
-        delivery.put("AttributeName", "email");
-        delivery.put("DeliveryMedium", "EMAIL");
-        delivery.put("Destination", user.getAttributes().getOrDefault("email", "****"));
+        if (!"CONFIRMED".equals(user.getUserStatus())) {
+            Map<String, String> deliveryDetails = service.signUpCodeDeliveryDetails(user);
+            if (!deliveryDetails.isEmpty()) {
+                ObjectNode delivery = response.putObject("CodeDeliveryDetails");
+                delivery.put("AttributeName", deliveryDetails.get("AttributeName"));
+                delivery.put("DeliveryMedium", deliveryDetails.get("DeliveryMedium"));
+                delivery.put("Destination", deliveryDetails.get("Destination"));
+            }
+        }
         return Response.ok(response).build();
     }
 
     private Response handleConfirmSignUp(JsonNode request) {
         service.confirmSignUp(
                 request.path("ClientId").asText(),
-                request.path("Username").asText()
+                request.path("Username").asText(),
+                request.path("ConfirmationCode").asText()
         );
         return Response.ok(objectMapper.createObjectNode()).build();
     }

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -103,6 +103,19 @@ public class CognitoService {
                    String baseUrl,
                    RegionResolver regionResolver,
                    LambdaService lambdaService) {
+        this(poolStore, clientStore, resourceServerStore, userStore, groupStore, baseUrl,
+                regionResolver, lambdaService, null, null);
+    }
+
+    CognitoService(StorageBackend<String, UserPool> poolStore,
+            StorageBackend<String, UserPoolClient> clientStore,
+            StorageBackend<String, ResourceServer> resourceServerStore,
+            StorageBackend<String, CognitoUser> userStore,
+            StorageBackend<String, CognitoGroup> groupStore,
+            String baseUrl,
+            RegionResolver regionResolver, LambdaService lambdaService,
+            VerificationCodeService verificationCodeService,
+            CognitoMessageDispatcher messageDispatcher) {
         this.poolStore = poolStore;
         this.clientStore = clientStore;
         this.resourceServerStore = resourceServerStore;
@@ -112,8 +125,8 @@ public class CognitoService {
         this.baseUrl = baseUrl;
         this.regionResolver = regionResolver;
         this.lambdaService = lambdaService;
-        this.verificationCodeService = null;
-        this.messageDispatcher = null;
+        this.verificationCodeService = verificationCodeService;
+        this.messageDispatcher = messageDispatcher;
         this.authFlowHandler = new CognitoAuthFlowHandler(this, lambdaService, regionResolver);
     }
 
@@ -1034,7 +1047,8 @@ public class CognitoService {
 
     public CognitoUser signUp(String clientId, String username, String password, Map<String, String> attributes) {
         UserPoolClient client = clientStore.get(clientId)
-                .orElseThrow(() -> new AwsException("ResourceNotFoundException", "Client not found", 404));
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException", "Client not found",
+                        400));
         String userPoolId = client.getUserPoolId();
         UserPool pool = describeUserPool(userPoolId);
 
@@ -1071,9 +1085,37 @@ public class CognitoService {
             user.getAttributes().put("phone_number_verified", "true");
         }
 
+        DeliveryTarget deliveryTarget = null;
+        boolean requiresConfirmationCode =
+                !preSignUp.autoConfirmUser() && verificationCodeService != null
+                        && messageDispatcher != null && isSignUpConfirmationEnabled(pool);
+        if (requiresConfirmationCode) {
+            deliveryTarget = resolveSignUpDeliveryTarget(pool, user);
+            if (deliveryTarget == null) {
+                throw new AwsException("InvalidParameterException",
+                        "Cannot confirm user because email or phone_number is missing", 400);
+            }
+        }
+
         userStore.put(key, user);
         LOG.infov("Signed up user {0} in pool {1} (status={2})",
                 username, userPoolId, user.getUserStatus());
+
+        if (requiresConfirmationCode) {
+            try {
+                String code = verificationCodeService.issue(pool.getId(), user.getUsername(),
+                        VerificationCode.Purpose.SIGNUP_CONFIRMATION, Duration.ofHours(24));
+                messageDispatcher.dispatch(pool, user, VerificationCode.Purpose.SIGNUP_CONFIRMATION,
+                        code, List.of(deliveryTarget.deliveryMedium()));
+            } catch (VerificationCodeException e) {
+                rollbackSignUpConfirmationArtifacts(pool.getId(), user.getUsername(), key);
+                throw mapVerificationCodeException(e);
+            } catch (RuntimeException e) {
+                rollbackSignUpConfirmationArtifacts(pool.getId(), user.getUsername(), key);
+                throw new AwsException("CodeDeliveryFailureException",
+                        "Failed to deliver the message.", 400);
+            }
+        }
 
         // When PreSignUp auto-confirms, AWS Cognito also fires PostConfirmation.
         // See: docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-sign-up.html
@@ -1084,16 +1126,44 @@ public class CognitoService {
     }
 
     public void confirmSignUp(String clientId, String username) {
+        confirmSignUp(clientId, username, null);
+    }
+
+    public void confirmSignUp(String clientId, String username, String confirmationCode) {
         UserPoolClient client = clientStore.get(clientId)
-                .orElseThrow(() -> new AwsException("ResourceNotFoundException", "Client not found", 404));
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException", "Client not found",
+                        400));
         CognitoUser user = adminGetUser(client.getUserPoolId(), username);
+        if (verificationCodeService != null) {
+            try {
+                verificationCodeService.consume(client.getUserPoolId(), user.getUsername(),
+                        VerificationCode.Purpose.SIGNUP_CONFIRMATION,
+                        confirmationCode == null ? "" : confirmationCode);
+            } catch (VerificationCodeException e) {
+                throw mapVerificationCodeException(e);
+            }
+        }
         user.setUserStatus("CONFIRMED");
         user.setLastModifiedDate(System.currentTimeMillis() / 1000L);
         userStore.put(userKey(client.getUserPoolId(), user.getUsername()), user);
 
         UserPool pool = poolStore.get(client.getUserPoolId())
-                .orElseThrow(() -> new AwsException("ResourceNotFoundException", "User pool not found", 404));
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "User pool not found", 400));
         authFlowHandler.firePostConfirmation(pool, client, user, Map.of(), "PostConfirmation_ConfirmSignUp");
+    }
+
+    Map<String, String> signUpCodeDeliveryDetails(CognitoUser user) {
+        UserPool pool = describeUserPool(user.getUserPoolId());
+        if (!isSignUpConfirmationEnabled(pool)) {
+            return Map.of();
+        }
+        DeliveryTarget deliveryTarget = resolveSignUpDeliveryTarget(pool, user);
+        if (deliveryTarget == null) {
+            return Map.of();
+        }
+        return Map.of("AttributeName", deliveryTarget.attributeName(), "DeliveryMedium",
+                deliveryTarget.deliveryMedium(), "Destination", deliveryTarget.destination());
     }
 
     public void adminConfirmSignUp(String userPoolId, String username) {
@@ -2268,6 +2338,43 @@ public class CognitoService {
         throw new AwsException("InvalidParameterException",
                 "Cannot reset password for the user as there is no registered/verified email or phone_number",
                 400);
+    }
+
+    private boolean isSignUpConfirmationEnabled(UserPool pool) {
+        return pool.getAutoVerifiedAttributes() != null
+                && !pool.getAutoVerifiedAttributes().isEmpty();
+    }
+
+    private DeliveryTarget resolveSignUpDeliveryTarget(UserPool pool, CognitoUser user) {
+        Map<String, String> attributes = user.getAttributes();
+        List<String> autoVerifiedAttributes =
+                pool.getAutoVerifiedAttributes() != null ? pool.getAutoVerifiedAttributes()
+                        : List.of();
+        for (String attribute : autoVerifiedAttributes) {
+            if ("email".equals(attribute)) {
+                String email = blankToNull(attributes.get("email"));
+                if (email != null) {
+                    return new DeliveryTarget("email", "EMAIL", maskEmail(email));
+                }
+            }
+            if ("phone_number".equals(attribute)) {
+                String phoneNumber = blankToNull(attributes.get("phone_number"));
+                if (phoneNumber != null) {
+                    return new DeliveryTarget("phone_number", "SMS", maskPhoneNumber(phoneNumber));
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private void rollbackSignUpConfirmationArtifacts(String userPoolId, String username,
+            String userKey) {
+        userStore.delete(userKey);
+        if (verificationCodeService != null) {
+            verificationCodeService.invalidatePrevious(userPoolId, username,
+                    VerificationCode.Purpose.SIGNUP_CONFIRMATION);
+        }
     }
 
     private AwsException mapVerificationCodeException(VerificationCodeException e) {

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -1135,8 +1135,11 @@ public class CognitoService {
         UserPoolClient client = clientStore.get(clientId)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException", "Client not found",
                         400));
+        UserPool pool = poolStore.get(client.getUserPoolId())
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "User pool not found", 400));
         CognitoUser user = adminGetUser(client.getUserPoolId(), username);
-        if (verificationCodeService != null) {
+        if (verificationCodeService != null && isSignUpConfirmationEnabled(pool)) {
             try {
                 verificationCodeService.consume(client.getUserPoolId(), user.getUsername(),
                         VerificationCode.Purpose.SIGNUP_CONFIRMATION,
@@ -1148,10 +1151,6 @@ public class CognitoService {
         user.setUserStatus("CONFIRMED");
         user.setLastModifiedDate(System.currentTimeMillis() / 1000L);
         userStore.put(userKey(client.getUserPoolId(), user.getUsername()), user);
-
-        UserPool pool = poolStore.get(client.getUserPoolId())
-                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "User pool not found", 400));
         authFlowHandler.firePostConfirmation(pool, client, user, Map.of(), "PostConfirmation_ConfirmSignUp");
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -74,24 +74,25 @@ public class CognitoService {
     public CognitoService(StorageFactory storageFactory, EmulatorConfig emulatorConfig,
             RegionResolver regionResolver, LambdaService lambdaService, SesService sesService,
             SnsService snsService, Clock clock) {
-        this.poolStore = storageFactory.create("cognito", "cognito-pools.json",
-                new TypeReference<Map<String, UserPool>>() {});
-        this.clientStore = storageFactory.create("cognito", "cognito-clients.json",
-                new TypeReference<Map<String, UserPoolClient>>() {});
-        this.resourceServerStore = storageFactory.create("cognito", "cognito-resource-servers.json",
-                new TypeReference<Map<String, ResourceServer>>() {});
-        this.userStore = storageFactory.create("cognito", "cognito-users.json",
-                new TypeReference<Map<String, CognitoUser>>() {});
-        this.groupStore = storageFactory.create("cognito", "cognito-groups.json",
-                new TypeReference<Map<String, CognitoGroup>>() {});
-        this.revokedTokenStore = storageFactory.create("cognito", "cognito-revoked-tokens.json",
-                new TypeReference<Map<String, RevokedTokenInfo>>() {});
-        this.baseUrl = trimTrailingSlash(emulatorConfig.baseUrl());
-        this.regionResolver = regionResolver;
-        this.lambdaService = lambdaService;
-        this.verificationCodeService = new VerificationCodeService(storageFactory, clock);
-        this.messageDispatcher = new CognitoMessageDispatcher(sesService, snsService);
-        this.authFlowHandler = new CognitoAuthFlowHandler(this, lambdaService, regionResolver);
+        this(
+                storageFactory.create("cognito", "cognito-pools.json",
+                        new TypeReference<Map<String, UserPool>>() {}),
+                storageFactory.create("cognito", "cognito-clients.json",
+                        new TypeReference<Map<String, UserPoolClient>>() {}),
+                storageFactory.create("cognito", "cognito-resource-servers.json",
+                        new TypeReference<Map<String, ResourceServer>>() {}),
+                storageFactory.create("cognito", "cognito-users.json",
+                        new TypeReference<Map<String, CognitoUser>>() {}),
+                storageFactory.create("cognito", "cognito-groups.json",
+                        new TypeReference<Map<String, CognitoGroup>>() {}),
+                storageFactory.create("cognito", "cognito-revoked-tokens.json",
+                        new TypeReference<Map<String, RevokedTokenInfo>>() {}),
+                trimTrailingSlash(emulatorConfig.baseUrl()),
+                regionResolver,
+                lambdaService,
+                new VerificationCodeService(storageFactory, clock),
+                new CognitoMessageDispatcher(sesService, snsService)
+        );
     }
 
     CognitoService(StorageBackend<String, UserPool> poolStore,
@@ -103,7 +104,7 @@ public class CognitoService {
                    String baseUrl,
                    RegionResolver regionResolver,
                    LambdaService lambdaService) {
-        this(poolStore, clientStore, resourceServerStore, userStore, groupStore, baseUrl,
+        this(poolStore, clientStore, resourceServerStore, userStore, groupStore, revokedTokenStore, baseUrl,
                 regionResolver, lambdaService, null, null);
     }
 
@@ -112,6 +113,7 @@ public class CognitoService {
             StorageBackend<String, ResourceServer> resourceServerStore,
             StorageBackend<String, CognitoUser> userStore,
             StorageBackend<String, CognitoGroup> groupStore,
+            StorageBackend<String, RevokedTokenInfo> revokedTokenStore,
             String baseUrl,
             RegionResolver regionResolver, LambdaService lambdaService,
             VerificationCodeService verificationCodeService,
@@ -2455,7 +2457,7 @@ public class CognitoService {
         return value;
     }
 
-    private String trimTrailingSlash(String value) {
+    private static String trimTrailingSlash(String value) {
         if (value.endsWith("/")) {
             return value.substring(0, value.length() - 1);
         }

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
@@ -20,6 +20,8 @@ import java.security.KeyFactory;
 import java.security.PublicKey;
 import java.security.Signature;
 import java.security.spec.RSAPublicKeySpec;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.Base64;
 import java.util.List;
 import java.util.Spliterators;
@@ -40,6 +42,7 @@ class CognitoIntegrationTest {
 
     private static final String COGNITO_CONTENT_TYPE = "application/x-amz-json-1.1";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final Pattern SIX_DIGIT_CODE = Pattern.compile("\\b(\\d{6})\\b");
 
     private static String poolId;
     private static String clientId;
@@ -291,6 +294,126 @@ class CognitoIntegrationTest {
 
     @Test
     @Order(7)
+    void confirmSignUpRequiresValidConfirmationCode() throws Exception {
+        given().delete("/_aws/ses").then().statusCode(200);
+
+        JsonNode poolResponse = cognitoJson("CreateUserPool", """
+                {
+                  "PoolName": "ConfirmSignUpCodePool",
+                  "AutoVerifiedAttributes": ["email"]
+                }
+                """);
+        String signUpPoolId = poolResponse.path("UserPool").path("Id").asText();
+
+        JsonNode clientResponse = cognitoJson("CreateUserPoolClient", """
+                {
+                  "UserPoolId": "%s",
+                  "ClientName": "confirm-sign-up-client"
+                }
+                """.formatted(signUpPoolId));
+        String signUpClientId = clientResponse.path("UserPoolClient").path("ClientId").asText();
+
+        String signUpUsername = "signup+" + UUID.randomUUID() + "@example.com";
+        cognitoAction("SignUp", """
+                {
+                  "ClientId": "%s",
+                  "Username": "%s",
+                  "Password": "Passw0rd!",
+                  "UserAttributes": [
+                    { "Name": "email", "Value": "%s" }
+                  ]
+                }
+                """.formatted(signUpClientId, signUpUsername, signUpUsername))
+                .then()
+                .statusCode(200);
+
+        JsonNode unconfirmedUser = cognitoJson("AdminGetUser", """
+                {
+                  "UserPoolId": "%s",
+                  "Username": "%s"
+                }
+                """.formatted(signUpPoolId, signUpUsername));
+        assertEquals("UNCONFIRMED", unconfirmedUser.path("UserStatus").asText());
+
+        cognitoAction("ConfirmSignUp", """
+                {
+                  "ClientId": "%s",
+                  "Username": "%s",
+                  "ConfirmationCode": "000000"
+                }
+                """.formatted(signUpClientId, signUpUsername))
+                .then()
+                .statusCode(400)
+                .body("__type", org.hamcrest.Matchers.equalTo("CodeMismatchException"))
+                .body("message", org.hamcrest.Matchers.equalTo("Invalid verification code provided, please try again."));
+
+        JsonNode stillUnconfirmedUser = cognitoJson("AdminGetUser", """
+                {
+                  "UserPoolId": "%s",
+                  "Username": "%s"
+                }
+                """.formatted(signUpPoolId, signUpUsername));
+        assertEquals("UNCONFIRMED", stillUnconfirmedUser.path("UserStatus").asText());
+    }
+
+    @Test
+    @Order(8)
+    void confirmSignUpAcceptsIssuedConfirmationCode() throws Exception {
+        given().delete("/_aws/ses").then().statusCode(200);
+
+        JsonNode poolResponse = cognitoJson("CreateUserPool", """
+                {
+                  "PoolName": "ConfirmSignUpSuccessPool",
+                  "AutoVerifiedAttributes": ["email"]
+                }
+                """);
+        String signUpPoolId = poolResponse.path("UserPool").path("Id").asText();
+
+        JsonNode clientResponse = cognitoJson("CreateUserPoolClient", """
+                {
+                  "UserPoolId": "%s",
+                  "ClientName": "confirm-sign-up-success-client"
+                }
+                """.formatted(signUpPoolId));
+        String signUpClientId = clientResponse.path("UserPoolClient").path("ClientId").asText();
+
+        String signUpUsername = "signup+" + UUID.randomUUID() + "@example.com";
+        cognitoAction("SignUp", """
+                {
+                  "ClientId": "%s",
+                  "Username": "%s",
+                  "Password": "Passw0rd!",
+                  "UserAttributes": [
+                    { "Name": "email", "Value": "%s" }
+                  ]
+                }
+                """.formatted(signUpClientId, signUpUsername, signUpUsername))
+                .then()
+                .statusCode(200);
+
+        String confirmationCode = fetchLatestSesVerificationCode(signUpUsername);
+
+        cognitoAction("ConfirmSignUp", """
+                {
+                  "ClientId": "%s",
+                  "Username": "%s",
+                  "ConfirmationCode": "%s"
+                }
+                """.formatted(signUpClientId, signUpUsername, confirmationCode))
+                .then()
+                .statusCode(200);
+
+        JsonNode confirmedUser = cognitoJson("AdminGetUser", """
+                {
+                  "UserPoolId": "%s",
+                  "Username": "%s"
+                }
+                """.formatted(signUpPoolId, signUpUsername));
+        assertEquals("CONFIRMED", confirmedUser.path("UserStatus").asText());
+    }
+
+    @Test
+    @Order(8)
     void forgotPasswordRequiresVerifiedRecoveryDestination() throws Exception {
         JsonNode poolResponse = cognitoJson("CreateUserPool", """
                 {
@@ -1354,15 +1477,33 @@ class CognitoIntegrationTest {
     @Test
     @Order(91)
     void adminConfirmSignUp() throws Exception {
+        JsonNode poolResponse = cognitoJson("CreateUserPool", """
+                {
+                  "PoolName": "AdminConfirmSignUpPool"
+                }
+                """);
+        String localPoolId = poolResponse.path("UserPool").path("Id").asText();
+
+        JsonNode clientResponse = cognitoJson("CreateUserPoolClient", """
+                {
+                  "UserPoolId": "%s",
+                  "ClientName": "admin-confirm-sign-up-client"
+                }
+                """.formatted(localPoolId));
+        String localClientId = clientResponse.path("UserPoolClient").path("ClientId").asText();
+
         String testUser = "unconfirmed+" + UUID.randomUUID() + "@example.com";
         // SignUp user - initially UNCONFIRMED
         cognitoJson("SignUp", """
                 {
                   "ClientId": "%s",
                   "Username": "%s",
-                  "Password": "%s"
+                  "Password": "%s",
+                  "UserAttributes": [
+                    { "Name": "email", "Value": "%s" }
+                  ]
                 }
-                """.formatted(clientId, testUser, password));
+                """.formatted(localClientId, testUser, password, testUser));
 
         // Get user details to verify user status is UNCONFIRMED
         JsonNode userResp = cognitoJson("AdminGetUser", """
@@ -1370,7 +1511,7 @@ class CognitoIntegrationTest {
                   "UserPoolId": "%s",
                   "Username": "%s"
                 }
-                """.formatted(poolId, testUser));
+                """.formatted(localPoolId, testUser));
         assertEquals("UNCONFIRMED", userResp.path("UserStatus").asText());
 
         // Admin confirms user
@@ -1379,7 +1520,7 @@ class CognitoIntegrationTest {
                   "UserPoolId": "%s",
                   "Username": "%s"
                 }
-                """.formatted(poolId, testUser))
+                """.formatted(localPoolId, testUser))
                 .then()
                 .statusCode(200);
 
@@ -1389,7 +1530,7 @@ class CognitoIntegrationTest {
                   "UserPoolId": "%s",
                   "Username": "%s"
                 }
-                """.formatted(poolId, testUser));
+                """.formatted(localPoolId, testUser));
         assertEquals("CONFIRMED", userRespConfirmed.path("UserStatus").asText());
     }
 
@@ -2070,6 +2211,22 @@ class CognitoIntegrationTest {
                 }
                 """.formatted(clientId, username, password));
         return auth.path("AuthenticationResult").path("AccessToken").asText();
+    }
+
+    private static String fetchLatestSesVerificationCode(String recipient) throws Exception {
+        String response = given()
+                .queryParam("email", recipient)
+                .when()
+                .get("/_aws/ses")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+        JsonNode payload = OBJECT_MAPPER.readTree(response);
+        String body = payload.path("messages").get(0).path("Body").path("text_part").asText();
+        Matcher matcher = SIX_DIGIT_CODE.matcher(body);
+        assertTrue(matcher.find(), "verification code email should contain a 6-digit code");
+        return matcher.group(1);
     }
 
     private static String padBase64(String value) {

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
@@ -8,6 +8,9 @@ import io.github.hectorvent.floci.services.cognito.model.CognitoGroup;
 import io.github.hectorvent.floci.services.cognito.model.CognitoUser;
 import io.github.hectorvent.floci.services.cognito.model.UserPool;
 import io.github.hectorvent.floci.services.cognito.model.UserPoolClient;
+import io.github.hectorvent.floci.services.cognito.verification.CognitoMessageDispatcher;
+import io.github.hectorvent.floci.services.cognito.verification.VerificationCode;
+import io.github.hectorvent.floci.services.cognito.verification.VerificationCodeService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -20,6 +23,12 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class CognitoServiceTest {
 
@@ -1046,6 +1055,94 @@ class CognitoServiceTest {
         assertTrue(user.getAttributes().containsKey("sub"),
                 "signUp should auto-generate a sub attribute");
         assertFalse(user.getAttributes().get("sub").isBlank());
+    }
+
+    @Test
+    void signUpWithoutDeliveryTargetFailsBeforePersistingUser() {
+        VerificationCodeService verificationCodeService = mock(VerificationCodeService.class);
+        CognitoMessageDispatcher messageDispatcher = mock(CognitoMessageDispatcher.class);
+        CognitoService serviceWithVerification = new CognitoService(
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                "http://localhost:4566",
+                regionResolver,
+                null,
+                verificationCodeService,
+                messageDispatcher
+        );
+
+        UserPool pool = serviceWithVerification.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
+        pool.setAutoVerifiedAttributes(List.of("email"));
+        UserPoolClient client = serviceWithVerification.createUserPoolClient(pool.getId(), "test-client",
+                false, false, List.of(), List.of());
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                serviceWithVerification.signUp(client.getClientId(), "carol", "Pass1234!", Map.of()));
+        assertEquals("InvalidParameterException", ex.getErrorCode());
+
+        AwsException lookupEx = assertThrows(AwsException.class, () ->
+                serviceWithVerification.adminGetUser(pool.getId(), "carol"));
+        assertEquals("UserNotFoundException", lookupEx.getErrorCode());
+    }
+
+    @Test
+    void signUpRollsBackUserWhenDispatchFails() {
+        VerificationCodeService verificationCodeService = mock(VerificationCodeService.class);
+        CognitoMessageDispatcher messageDispatcher = mock(CognitoMessageDispatcher.class);
+        when(verificationCodeService.issue(any(), any(), eq(VerificationCode.Purpose.SIGNUP_CONFIRMATION), any()))
+                .thenReturn("123456");
+        doThrow(new RuntimeException("SES unavailable")).when(messageDispatcher)
+                .dispatch(any(), any(), eq(VerificationCode.Purpose.SIGNUP_CONFIRMATION), eq("123456"), any());
+
+        CognitoService serviceWithVerification = new CognitoService(
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                "http://localhost:4566",
+                regionResolver,
+                null,
+                verificationCodeService,
+                messageDispatcher
+        );
+
+        UserPool pool = serviceWithVerification.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
+        pool.setAutoVerifiedAttributes(List.of("email"));
+        UserPoolClient client = serviceWithVerification.createUserPoolClient(pool.getId(), "test-client",
+                false, false, List.of(), List.of());
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                serviceWithVerification.signUp(client.getClientId(), "carol", "Pass1234!",
+                        Map.of("email", "carol@example.com")));
+        assertEquals("CodeDeliveryFailureException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+        assertEquals("Failed to deliver the message.", ex.getMessage());
+
+        AwsException lookupEx = assertThrows(AwsException.class, () ->
+                serviceWithVerification.adminGetUser(pool.getId(), "carol"));
+        assertEquals("UserNotFoundException", lookupEx.getErrorCode());
+        verify(verificationCodeService).invalidatePrevious(pool.getId(), "carol",
+                VerificationCode.Purpose.SIGNUP_CONFIRMATION);
+    }
+
+    @Test
+    void signUpReturnsResourceNotFoundAsBadRequestWhenClientMissing() {
+        AwsException ex = assertThrows(AwsException.class, () ->
+                service.signUp("missing-client", "carol", "Pass1234!", Map.of("email", "carol@example.com")));
+        assertEquals("ResourceNotFoundException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+    }
+
+    @Test
+    void confirmSignUpReturnsResourceNotFoundAsBadRequestWhenClientMissing() {
+        AwsException ex = assertThrows(AwsException.class, () ->
+                service.confirmSignUp("missing-client", "carol", "123456"));
+        assertEquals("ResourceNotFoundException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
@@ -1067,6 +1067,7 @@ class CognitoServiceTest {
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
                 "http://localhost:4566",
                 regionResolver,
                 null,
@@ -1098,6 +1099,7 @@ class CognitoServiceTest {
                 .dispatch(any(), any(), eq(VerificationCode.Purpose.SIGNUP_CONFIRMATION), eq("123456"), any());
 
         CognitoService serviceWithVerification = new CognitoService(
+                new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),


### PR DESCRIPTION
## Summary

Align Cognito `SignUp` / `ConfirmSignUp` sign-up confirmation behavior with AWS-style verification-code handling. Closes #1487.

- make `ConfirmSignUp` read and validate `ConfirmationCode` instead of confirming users unconditionally
- issue sign-up confirmation codes only when the user pool enables Cognito-assisted verification through `AutoVerifiedAttributes`
- return AWS-style `CodeMismatchException` / `ExpiredCodeException` for invalid or expired confirmation codes
- return AWS-style `CodeDeliveryFailureException` when sign-up confirmation delivery fails
- return `ResourceNotFoundException` with HTTP 400 for missing `SignUp` / `ConfirmSignUp` clients or pools
- build `SignUp` `CodeDeliveryDetails` from the actual confirmation delivery target instead of a fixed email response
- add regression tests for invalid-code rejection, valid-code confirmation, missing delivery target rejection, delivery failure rollback, and missing-client status mapping
- update the Node compatibility test to fetch the issued confirmation code from the SES inspection endpoint instead of assuming a fixed `123456`

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Before this change, Floci accepted arbitrary `ConfirmationCode` values in `ConfirmSignUp`, confirmed users without verification, and did not model the Cognito sign-up confirmation-code flow consistently.

This PR aligns the public flow more closely with AWS Cognito by validating sign-up confirmation codes when the pool is configured to use Cognito-managed sign-up verification, issuing confirmation messages only when the pool auto-verifies contact attributes, mapping delivery failures to AWS-style errors, and returning delivery details that match the actual destination. The compatibility tests now also confirm users with the actual code issued through the SES inspection endpoint rather than a hard-coded placeholder value.

Follow-up items remain outside this PR's scope, including `ConfirmSignUp`-time verified-attribute updates, dual `email` + `phone_number` delivery-priority parity, and stale sign-up code invalidation after `AdminConfirmSignUp`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
