### PR TITLE
fix(elbv2): publish resolvable local ALB DNS names

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/ElbV2Test.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/ElbV2Test.java
@@ -84,6 +84,7 @@ class ElbV2Test {
     private static ElasticLoadBalancingV2Client elb;
 
     private static String lbArn;
+    private static String lbDnsName;
     private static String tgArn;
     private static String listenerArn;
     private static String ruleArn;
@@ -141,11 +142,24 @@ class ElbV2Test {
         LoadBalancer lb = resp.loadBalancers().get(0);
         assertThat(lb.loadBalancerName()).isEqualTo(LB_NAME);
         assertThat(lb.loadBalancerArn()).contains("elasticloadbalancing");
-        assertThat(lb.dnsName()).isNotBlank();
+        assertThat(lb.dnsName()).endsWith(expectedElbDnsSuffix());
         assertThat(lb.type()).isEqualTo(LoadBalancerTypeEnum.APPLICATION);
         assertThat(lb.scheme()).isEqualTo(LoadBalancerSchemeEnum.INTERNET_FACING);
         assertThat(lb.state().code()).isEqualTo(LoadBalancerStateEnum.PROVISIONING);
         lbArn = lb.loadBalancerArn();
+        lbDnsName = lb.dnsName();
+    }
+
+    private static String expectedElbDnsSuffix() {
+        String hostname = System.getenv("FLOCI_HOSTNAME");
+        if (hostname == null || hostname.isBlank()) {
+            hostname = TestFixtures.endpoint().getHost();
+        }
+        if (hostname == null || hostname.isBlank()
+                || "localhost".equals(hostname) || "127.0.0.1".equals(hostname)) {
+            hostname = "localhost.floci.io";
+        }
+        return ".elb." + hostname;
     }
 
     @Test
@@ -159,6 +173,7 @@ class ElbV2Test {
         LoadBalancer lb = resp.loadBalancers().get(0);
         assertThat(lb.loadBalancerArn()).isEqualTo(lbArn);
         assertThat(lb.loadBalancerName()).isEqualTo(LB_NAME);
+        assertThat(lb.dnsName()).isEqualTo(lbDnsName);
         assertThat(lb.state().code()).isEqualTo(LoadBalancerStateEnum.ACTIVE);
     }
 
@@ -171,6 +186,7 @@ class ElbV2Test {
 
         assertThat(resp.loadBalancers()).hasSize(1);
         assertThat(resp.loadBalancers().get(0).loadBalancerArn()).isEqualTo(lbArn);
+        assertThat(resp.loadBalancers().get(0).dnsName()).isEqualTo(lbDnsName);
     }
 
     @Test

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
@@ -1,9 +1,11 @@
 package io.github.hectorvent.floci.services.elbv2;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.dns.EmbeddedDnsServer;
 import io.github.hectorvent.floci.core.storage.StorageBackedMap;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
@@ -35,6 +37,9 @@ public class ElbV2Service {
 
     @Inject
     StorageFactory storageFactory;
+
+    @Inject
+    EmulatorConfig config;
 
     private static final String CANONICAL_HOSTED_ZONE_ID = "Z35SXDOTRQ7X7K";
 
@@ -157,7 +162,7 @@ public class ElbV2Service {
         String typePrefix = lbTypePrefix(lbType);
         String id = randomHex16();
         String arn = AwsArnUtils.Arn.of("elasticloadbalancing", region, regionResolver.getAccountId(), "loadbalancer/" + typePrefix + "/" + name + "/" + id).toString();
-        String dnsName = name + "-" + id + ".elb.localhost";
+        String dnsName = name + "-" + id + ".elb." + loadBalancerDnsSuffix();
         String vpcId = resolveSubnetVpcId(region, lbType, subnets);
 
         LoadBalancer lb = new LoadBalancer();
@@ -182,6 +187,13 @@ public class ElbV2Service {
             tags.put(arn, new LinkedHashMap<>(initialTags));
         }
         return lb;
+    }
+
+    private String loadBalancerDnsSuffix() {
+        if (config == null) {
+            return EmbeddedDnsServer.DEFAULT_SUFFIX;
+        }
+        return config.hostname().orElse(EmbeddedDnsServer.DEFAULT_SUFFIX);
     }
 
     public List<LoadBalancer> describeLoadBalancers(String region, List<String> arns, List<String> names,

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -5485,7 +5485,7 @@ class CloudFormationIntegrationTest {
         String albArn = cfnOutputValue(describeXml, "AlbRef");
         assertThat(albArn, startsWith(
                 "arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/app/cfn-alb/"));
-        assertThat(cfnOutputValue(describeXml, "AlbDns"), containsString(".elb.localhost"));
+        assertThat(cfnOutputValue(describeXml, "AlbDns"), containsString(".elb.localhost.floci.io"));
         assertThat(cfnOutputValue(describeXml, "AlbFullName"), startsWith("app/cfn-alb/"));
         assertThat(cfnOutputValue(describeXml, "AlbCanonical"), notNullValue());
         String tgArn = cfnOutputValue(describeXml, "TgRef");

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
@@ -57,7 +57,7 @@ class ElbV2IntegrationTest {
                 .body("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.AvailabilityZones.member.SubnetId",
                         hasItems("subnet-default-a", "subnet-default-b"))
                 .body("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.DNSName",
-                        containsString(".elb.localhost"))
+                        containsString(".elb.localhost.floci.io"))
                 .extract()
                 .path("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.LoadBalancerArn");
     }

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2ServiceTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.elbv2;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
@@ -24,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -38,6 +40,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ElbV2ServiceTest {
@@ -118,6 +121,19 @@ class ElbV2ServiceTest {
         verify(dataPlane).restartListener(any(Listener.class), eq(REGION), anyList());
         verify(dataPlane, never()).stopListener(anyString());
         verify(dataPlane, never()).startListener(any(Listener.class), anyString(), anyList());
+    }
+
+    @Test
+    void createLoadBalancerUsesConfiguredHostnameForDnsSuffix() {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        when(config.hostname()).thenReturn(Optional.of("floci"));
+        service.config = config;
+
+        String dnsName = service.createLoadBalancer(
+                REGION, "sample-lb", "internal", "application", "ipv4",
+                ALB_SUBNETS, List.of("sg-a"), Map.of()).getDnsName();
+
+        assertTrue(dnsName.endsWith(".elb.floci"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- publish ELBv2 load balancer DNS names under the embedded DNS suffix
- update Query and CloudFormation coverage for the new DNS shape
- add Java SDK round-trip assertions for CreateLoadBalancer and DescribeLoadBalancers

## Tests
- ./mvnw -Dtest='ElbV2IntegrationTest' test
- ./mvnw -Dtest='CloudFormationIntegrationTest#createStack_withElbV2LoadBalancerTargetGroupListenerRule' test
- mvn -q -DskipTests compile test-compile (compatibility-tests/sdk-test-java)
- ./mvnw package -DskipTests
- FLOCI_ENDPOINT=http://localhost:4566 mvn -Dtest=ElbV2Test test (compatibility-tests/sdk-test-java, against packaged local Floci)