### PR TITLE
feat(s3): support bucket logging configuration

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -179,6 +179,10 @@ public class S3Controller {
             if (hasQueryParam(uriInfo, "website")) {
                 return handlePutBucketWebsite(bucket, body);
             }
+            if (hasQueryParam(uriInfo, "logging")) {
+                s3Service.putBucketLogging(bucket, new String(body, StandardCharsets.UTF_8));
+                return Response.ok().build();
+            }
             if (hasQueryParam(uriInfo, "policy")) {
                 s3Service.putBucketPolicy(bucket, new String(body, StandardCharsets.UTF_8));
                 return Response.ok().build();
@@ -329,6 +333,11 @@ public class S3Controller {
             }
             if (hasQueryParam(uriInfo, "website")) {
                 return handleGetBucketWebsite(bucket);
+            }
+            if (hasQueryParam(uriInfo, "logging")) {
+                return Response.ok(s3Service.getBucketLogging(bucket))
+                        .type("application/xml")
+                        .build();
             }
             if (hasQueryParam(uriInfo, "policy")) {
                 return Response.ok(s3Service.getBucketPolicy(bucket)).build();

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -206,6 +206,39 @@ public class S3Service {
         return bucketStore.scan(key -> true);
     }
 
+    public void putBucketLogging(String bucketName, String loggingConfigurationXml) {
+        Bucket bucket = bucketStore.get(bucketName)
+                .orElseThrow(() -> new AwsException("NoSuchBucket", "The specified bucket does not exist.", 404));
+
+        if (loggingConfigurationXml == null || loggingConfigurationXml.isBlank()) {
+            bucket.setLoggingConfiguration(null);
+        } else {
+            String targetBucket = XmlParser.extractFirst(loggingConfigurationXml, "TargetBucket", null);
+            if (targetBucket == null) {
+                bucket.setLoggingConfiguration(null);
+            } else {
+                bucket.setLoggingConfiguration(loggingConfigurationXml);
+            }
+        }
+
+        bucketStore.put(bucketName, bucket);
+    }
+
+    public String getBucketLogging(String bucketName) {
+        Bucket bucket = bucketStore.get(bucketName)
+                .orElseThrow(() -> new AwsException("NoSuchBucket", "The specified bucket does not exist.", 404));
+
+        if (bucket.getLoggingConfiguration() == null || bucket.getLoggingConfiguration().isBlank()) {
+            return new XmlBuilder()
+                    .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+                    .start("BucketLoggingStatus", AwsNamespaces.S3)
+                    .end("BucketLoggingStatus")
+                    .build();
+        }
+
+        return bucket.getLoggingConfiguration();
+    }
+
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata) {
         return putObject(bucketName, key, data, contentType, metadata, new PutObjectOptions());

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/Bucket.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/Bucket.java
@@ -14,6 +14,7 @@ public class Bucket {
     private String name;
     private Instant creationDate;
     private String versioningStatus; // null (never enabled), "Enabled", "Suspended"
+    private String loggingConfiguration;
     private Map<String, String> tags;
     private NotificationConfiguration notificationConfiguration;
     private boolean objectLockEnabled;
@@ -48,6 +49,14 @@ public class Bucket {
 
     public String getVersioningStatus() { return versioningStatus; }
     public void setVersioningStatus(String versioningStatus) { this.versioningStatus = versioningStatus; }
+
+    public String getLoggingConfiguration() {
+        return loggingConfiguration;
+    }
+
+    public void setLoggingConfiguration(String loggingConfiguration) {
+        this.loggingConfiguration = loggingConfiguration;
+    }
 
     public Map<String, String> getTags() { return tags; }
     public void setTags(Map<String, String> tags) { this.tags = tags; }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -2046,6 +2046,73 @@ class S3IntegrationTest {
             .body(equalTo(""));
     }
 
+    @Test
+    @Order(206)
+    void bucketLogging_roundTripAndDisable() {
+        String bucket = "bucket-logging-test";
+        String targetBucket = "bucket-logging-target";
+
+        given()
+                .when().put("/" + bucket)
+                .then().statusCode(200);
+
+        given()
+                .when().put("/" + targetBucket)
+                .then().statusCode(200);
+
+        given()
+                .queryParam("logging", "")
+                .when().get("/" + bucket)
+                .then()
+                .statusCode(200)
+                .body(containsString("BucketLoggingStatus"))
+                .body(not(containsString("LoggingEnabled")));
+
+        String loggingXml = """
+                <BucketLoggingStatus xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                  <LoggingEnabled xmlns:test="http://example.com/test" test:attr="value">
+                    <TargetBucket>%s</TargetBucket>
+                    <TargetPrefix>logs/</TargetPrefix>
+                  </LoggingEnabled>
+                </BucketLoggingStatus>
+                """.formatted(targetBucket);
+
+        given()
+                .queryParam("logging", "")
+                .body(loggingXml)
+                .when().put("/" + bucket)
+                .then()
+                .statusCode(200);
+
+        given()
+                .queryParam("logging", "")
+                .when().get("/" + bucket)
+                .then()
+                .statusCode(200)
+                .body(containsString("LoggingEnabled"))
+                .body(containsString(targetBucket))
+                .body(containsString("logs/"));
+
+        String disabledXml = """
+                <BucketLoggingStatus xmlns="http://s3.amazonaws.com/doc/2006-03-01/"/>
+                """;
+
+        given()
+                .queryParam("logging", "")
+                .body(disabledXml)
+                .when().put("/" + bucket)
+                .then()
+                .statusCode(200);
+
+        given()
+                .queryParam("logging", "")
+                .when().get("/" + bucket)
+                .then()
+                .statusCode(200)
+                .body(containsString("BucketLoggingStatus"))
+                .body(not(containsString("LoggingEnabled")));
+    }
+
     private static String customerKeyMd5(String customerKey) {
         try {
             byte[] md5 = MessageDigest.getInstance("MD5").digest(Base64.getDecoder().decode(customerKey));


### PR DESCRIPTION
## Summary

Adds basic S3 bucket logging configuration support.

This implements mock-style support for:

* `PutBucketLogging`
* `GetBucketLogging`
* storing logging configuration per bucket
* returning an empty `BucketLoggingStatus` when logging is not configured
* disabling logging by sending an empty `BucketLoggingStatus`

This does not implement actual access-log delivery.

Closes #1500

## Type of change

* [ ] Bug fix (`fix:`)
* [x] New feature (`feat:`)
* [ ] Breaking change (`feat!:` or `fix!:`)
* [ ] Docs / chore

## AWS Compatibility

Implemented basic S3 bucket logging configuration behavior:

* `GET /{bucket}?logging` returns the stored bucket logging configuration.
* If no logging configuration exists, it returns an empty `BucketLoggingStatus`.
* `PUT /{bucket}?logging` stores the provided `LoggingEnabled` configuration.
* `PUT /{bucket}?logging` with an empty `BucketLoggingStatus` disables logging.

Actual server access-log delivery is intentionally out of scope for this initial implementation.

## Testing

* [x] `./mvnw test -Dtest=S3IntegrationTest#bucketLogging_roundTripAndDisable`
* [x] `./mvnw test -Dtest=S3IntegrationTest`
