### PR TITLE
fix(ssm): reject send-command timeouts below AWS minimum

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SsmTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SsmTest.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.services.ssm.model.PutParameterResponse;
 import software.amazon.awssdk.services.ssm.model.RemoveTagsFromResourceRequest;
 import software.amazon.awssdk.services.ssm.model.SendCommandRequest;
 import software.amazon.awssdk.services.ssm.model.SendCommandResponse;
+import software.amazon.awssdk.services.ssm.model.SsmException;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -244,6 +245,25 @@ class SsmTest {
 
     @Test
     @Order(13)
+    void sendCommandRejectsTimeoutBelowAwsMinimum() {
+        assertThatThrownBy(() -> ssm.sendCommand(SendCommandRequest.builder()
+                .documentName("AWS-RunShellScript")
+                .instanceIds(COMMAND_INSTANCE_ID)
+                .parameters(Map.of("commands", List.of("echo floci-sdk")))
+                .timeoutSeconds(1)
+                .build()))
+                .isInstanceOfSatisfying(SsmException.class, error -> {
+                    assertThat(error.statusCode()).isEqualTo(400);
+                    assertThat(error.awsErrorDetails().serviceName()).isEqualTo("Ssm");
+                    assertThat(error.awsErrorDetails().errorCode()).isEqualTo("ValidationException");
+                    assertThat(error.awsErrorDetails().errorMessage())
+                            .contains("Value '1' at 'timeoutSeconds' failed to satisfy constraint")
+                            .contains("greater than or equal to 30");
+                });
+    }
+
+    @Test
+    @Order(14)
     void sendCommandCreatesPendingInvocation() {
         SendCommandResponse response = ssm.sendCommand(SendCommandRequest.builder()
                 .documentName("AWS-RunShellScript")
@@ -269,7 +289,7 @@ class SsmTest {
     }
 
     @Test
-    @Order(14)
+    @Order(15)
     void listRunCommandsAndInvocations() {
         ListCommandsResponse commands = ssm.listCommands(
                 ListCommandsRequest.builder().commandId(commandId).build());
@@ -296,7 +316,7 @@ class SsmTest {
     }
 
     @Test
-    @Order(15)
+    @Order(16)
     void cancelCommandUpdatesInvocationStatus() {
         ssm.cancelCommand(CancelCommandRequest.builder()
                 .commandId(commandId)

--- a/src/main/java/io/github/hectorvent/floci/services/ssm/SsmCommandService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssm/SsmCommandService.java
@@ -40,6 +40,7 @@ import java.util.concurrent.Executors;
 public class SsmCommandService {
 
     private static final Logger LOG = Logger.getLogger(SsmCommandService.class);
+    private static final int MIN_TIMEOUT_SECONDS = 30;
     private static final int MAX_STDOUT_CHARS = 24000;
     private static final int MAX_STDERR_CHARS = 8000;
 
@@ -129,6 +130,7 @@ public class SsmCommandService {
         Map<String, List<String>> parameters = parseParameters(request.path("Parameters"));
         String comment = request.path("Comment").asText("");
         int timeoutSeconds = request.path("TimeoutSeconds").asInt(3600);
+        validateTimeoutSeconds(timeoutSeconds);
         String documentVersion = request.path("DocumentVersion").asText("$DEFAULT");
         String outputS3Bucket = request.path("OutputS3BucketName").asText("");
         String outputS3Prefix = request.path("OutputS3KeyPrefix").asText("");
@@ -196,6 +198,15 @@ public class SsmCommandService {
                     region);
         }
         return response;
+    }
+
+    private static void validateTimeoutSeconds(int timeoutSeconds) {
+        if (timeoutSeconds < MIN_TIMEOUT_SECONDS) {
+            throw new AwsException(
+                    "ValidationException",
+                    "1 validation error detected: Value '" + timeoutSeconds + "' at 'timeoutSeconds' failed to satisfy constraint: Member must have value greater than or equal to 30",
+                    400);
+        }
     }
 
     public CommandInvocation getCommandInvocation(String commandId, String instanceId, String region) {

--- a/src/test/java/io/github/hectorvent/floci/services/ssm/SsmCommandServiceDirectExecutionTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssm/SsmCommandServiceDirectExecutionTest.java
@@ -102,11 +102,11 @@ class SsmCommandServiceDirectExecutionTest {
     void directTimeoutMarksCommandTimedOut() throws Exception {
         SsmDirectCommandExecutor executor = mock(SsmDirectCommandExecutor.class);
         Instant start = Instant.parse("2026-06-07T00:00:00Z");
-        Instant end = Instant.parse("2026-06-07T00:00:05Z");
+        Instant end = Instant.parse("2026-06-07T00:00:30Z");
         when(executor.supports(eq("i-timeout"), eq("AWS-RunShellScript"))).thenReturn(true);
-        when(executor.executeIfSupported(eq("i-timeout"), eq("AWS-RunShellScript"), any(), eq(5)))
+        when(executor.executeIfSupported(eq("i-timeout"), eq("AWS-RunShellScript"), any(), eq(30)))
                 .thenReturn(Optional.of(new SsmDirectCommandExecutor.ExecutionResult(
-                        "TimedOut", "", "Timed out after 5s", -1, start, end)));
+                        "TimedOut", "", "Timed out after 30s", -1, start, end)));
 
         SsmCommandService service = new SsmCommandService(
                 new InMemoryStorageFactory(),
@@ -121,7 +121,7 @@ class SsmCommandServiceDirectExecutionTest {
                   "Parameters": {
                     "commands": ["sleep 100"]
                   },
-                  "TimeoutSeconds": 5
+                  "TimeoutSeconds": 30
                 }
                 """), "us-west-2");
 
@@ -133,7 +133,7 @@ class SsmCommandServiceDirectExecutionTest {
         assertEquals("TimedOut", invocation.getStatus());
         assertEquals("Execution Timed Out", invocation.getStatusDetails());
         assertEquals(-1, invocation.getResponseCode());
-        assertEquals("Timed out after 5s", invocation.getStandardErrorContent());
+        assertEquals("Timed out after 30s", invocation.getStandardErrorContent());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ssm/SsmSendCommandIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssm/SsmSendCommandIntegrationTest.java
@@ -95,6 +95,31 @@ class SsmSendCommandIntegrationTest {
 
     @Test
     @Order(3)
+    void sendCommandRejectsTimeoutBelowAwsMinimum() {
+        given()
+            .header("X-Amz-Target", "AmazonSSM.SendCommand")
+            .contentType(SSM_CT)
+            .body("""
+                {
+                    "InstanceIds": ["%s"],
+                    "DocumentName": "AWS-RunShellScript",
+                    "Parameters": {
+                        "commands": ["echo hello"]
+                    },
+                    "TimeoutSeconds": 1
+                }
+                """.formatted(INSTANCE_ID))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", containsString("Value '1' at 'timeoutSeconds' failed to satisfy constraint"))
+            .body("message", containsString("greater than or equal to 30"));
+    }
+
+    @Test
+    @Order(4)
     void sendCommandCreatesCommandRecord() {
         String response = given()
             .header("X-Amz-Target", "AmazonSSM.SendCommand")
@@ -124,7 +149,7 @@ class SsmSendCommandIntegrationTest {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     void listCommandsReturnsCreatedCommand() {
         given()
             .header("X-Amz-Target", "AmazonSSM.ListCommands")
@@ -139,7 +164,7 @@ class SsmSendCommandIntegrationTest {
     }
 
     @Test
-    @Order(5)
+    @Order(6)
     void listCommandInvocationsReturnsInvocation() {
         given()
             .header("X-Amz-Target", "AmazonSSM.ListCommandInvocations")
@@ -159,7 +184,7 @@ class SsmSendCommandIntegrationTest {
     // ── ec2messages agent protocol ─────────────────────────────────────────
 
     @Test
-    @Order(6)
+    @Order(7)
     void agentGetsEndpoint() {
         given()
             .header("X-Amz-Target", "AmazonSSMMessageDeliveryService.GetEndpoint")
@@ -179,7 +204,7 @@ class SsmSendCommandIntegrationTest {
     }
 
     @Test
-    @Order(7)
+    @Order(8)
     void agentPollsAndGetsMessage() {
         given()
             .header("X-Amz-Target", "AmazonSSMMessageDeliveryService.GetMessages")
@@ -202,7 +227,7 @@ class SsmSendCommandIntegrationTest {
     }
 
     @Test
-    @Order(8)
+    @Order(9)
     void agentAcknowledgesMessage() {
         // First poll to get the message ID
         String msgId = given()
@@ -267,7 +292,7 @@ class SsmSendCommandIntegrationTest {
     }
 
     @Test
-    @Order(9)
+    @Order(10)
     void agentSendsReplyAndCommandStatusUpdates() {
         // Send a fresh command
         String resp = given()
@@ -337,7 +362,7 @@ class SsmSendCommandIntegrationTest {
     }
 
     @Test
-    @Order(10)
+    @Order(11)
     void cancelCommandUpdatesStatus() {
         String resp = given()
             .header("X-Amz-Target", "AmazonSSM.SendCommand")
@@ -379,7 +404,7 @@ class SsmSendCommandIntegrationTest {
     }
 
     @Test
-    @Order(11)
+    @Order(12)
     void sendCommandDirectlyExecutesForContainerBackedInstance() {
         Instant start = Instant.parse("2026-06-07T00:00:00Z");
         Instant end = Instant.parse("2026-06-07T00:00:01Z");


### PR DESCRIPTION
## Summary
- reject SendCommand requests with TimeoutSeconds below the AWS minimum of 30
- return a ValidationException with an AWS-shaped constraint message
- add root JSON integration coverage and Java SDK compatibility coverage

## Tests
- ./mvnw -Dtest='SsmSendCommandIntegrationTest' test
- mvn -q -DskipTests compile test-compile (compatibility-tests/sdk-test-java)
- ./mvnw package -DskipTests
- FLOCI_ENDPOINT=http://localhost:4566 mvn -Dtest=SsmTest test (compatibility-tests/sdk-test-java, against packaged local Floci)