### PR TITLE
fix(secretsmanager): register AWSPENDING version before invoking rotation Lambda

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
@@ -166,13 +166,19 @@ public class SecretsManagerService {
 
         if (clientRequestToken != null && secret.getVersions() != null && secret.getVersions().containsKey(clientRequestToken)) {
             SecretVersion existingVersion = secret.getVersions().get(clientRequestToken);
-            if (!Objects.equals(existingVersion.getSecretString(), secretString) ||
-                !Objects.equals(existingVersion.getSecretBinary(), secretBinary)) {
-                throw new AwsException("ResourceExistsException",
-                    "You can't use ClientRequestToken " + clientRequestToken
-                        + " because that value is already in use for a version of secret " + secret.getArn(), 400);
+            boolean isPendingPlaceholder = existingVersion.getSecretString() == null
+                    && existingVersion.getSecretBinary() == null
+                    && existingVersion.getVersionStages() != null
+                    && existingVersion.getVersionStages().contains("AWSPENDING");
+            if (!isPendingPlaceholder) {
+                if (!Objects.equals(existingVersion.getSecretString(), secretString) ||
+                    !Objects.equals(existingVersion.getSecretBinary(), secretBinary)) {
+                    throw new AwsException("ResourceExistsException",
+                        "You can't use ClientRequestToken " + clientRequestToken
+                            + " because that value is already in use for a version of secret " + secret.getArn(), 400);
+                }
+                return existingVersion;
             }
-            return existingVersion;
         }
 
         Instant now = Instant.now();
@@ -412,6 +418,24 @@ public class SecretsManagerService {
         }
 
         try {
+            if (!isExistingVersion) {
+                synchronized (lockFor(secretArn)) {
+                    Secret secret = resolveSecret(secretArn, region);
+                    if (secret.getVersions() != null && secret.getVersions().containsKey(clientRequestToken)) {
+                        isExistingVersion = true;
+                    } else {
+                        SecretVersion pendingVersion = new SecretVersion();
+                        pendingVersion.setVersionId(clientRequestToken);
+                        pendingVersion.setVersionStages(List.of("AWSPENDING"));
+                        pendingVersion.setCreatedDate(Instant.now());
+                        if (secret.getVersions() == null) {
+                            secret.setVersions(new java.util.HashMap<>());
+                        }
+                        secret.getVersions().put(clientRequestToken, pendingVersion);
+                        store.put(regionKey(region, secret.getName()), secret);
+                    }
+                }
+            }
             if (!isExistingVersion) {
                 invokeRotationLambda(secretArn, clientRequestToken, lambdaArn, "createSecret", region);
                 invokeRotationLambda(secretArn, clientRequestToken, lambdaArn, "setSecret", region);


### PR DESCRIPTION
## Summary

Register an `AWSPENDING` version before invoking the rotation Lambda in `RotateSecret`, and allow `PutSecretValue` to overwrite empty `AWSPENDING` placeholders.

Without this, standard rotation handlers (including the AWS-provided templates) call `DescribeSecret`, fail to find their `ClientRequestToken` in `VersionIdsToStages`, and raise an error. This matches the behavior of real AWS and [Moto](https://github.com/getmoto/moto/blob/master/moto/secretsmanager/models.py).

Closes #1518

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

`RotateSecret` was not registering the `ClientRequestToken` as an `AWSPENDING` version before invoking the Lambda. The Lambda's `createSecret` step would fail with:

```
ValueError: Secret version <token> has no stage for rotation.
```

Real AWS creates the `AWSPENDING` placeholder before Lambda invocation — confirmed by the `VersionId` field in the `RotateSecret` API response and by Moto's implementation.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
