### PR TITLE
fix(elbv2): omit terminal SSL policy marker

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/ElbV2Test.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/ElbV2Test.java
@@ -507,6 +507,7 @@ class ElbV2Test {
         boolean hasDefault = resp.sslPolicies().stream()
                 .anyMatch(p -> p.name().startsWith("ELBSecurityPolicy-"));
         assertThat(hasDefault).isTrue();
+        assertThat(resp.nextMarker()).isNull();
     }
 
     @Test

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2QueryHandler.java
@@ -760,7 +760,6 @@ public class ElbV2QueryHandler {
                .end("member");
         }
         xml.end("SslPolicies")
-           .elem("NextMarker", "")
            .end("DescribeSSLPoliciesResult")
            .raw(AwsQueryResponse.responseMetadata())
            .end("DescribeSSLPoliciesResponse");

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
@@ -935,7 +935,8 @@ class ElbV2IntegrationTest {
                 .body("DescribeSSLPoliciesResponse.DescribeSSLPoliciesResult.SslPolicies.member.size()",
                         greaterThanOrEqualTo(7))
                 .body("DescribeSSLPoliciesResponse.DescribeSSLPoliciesResult.SslPolicies.member.Name",
-                        hasItem("ELBSecurityPolicy-2016-08"));
+                        hasItem("ELBSecurityPolicy-2016-08"))
+                .body(not(containsString("NextMarker")));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes `DescribeSSLPolicies` pagination behavior by omitting the terminal `NextMarker` element when there are no more SSL policies to return. Previously Floci returned an empty `<NextMarker></NextMarker>`, which caused clients that check marker presence to continue paginating indefinitely.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Bug fix: `DescribeSSLPolicies` incorrectly returned an empty terminal `NextMarker`. AWS-compatible behavior is to omit `NextMarker` when the result is complete.

Verified with:
- Floci ELBv2 integration test for `DescribeSSLPolicies`
- Java AWS SDK compatibility test asserting `nextMarker()` is `null`

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)