### PR TITLE
fix(athena): serialize timestamps as epoch seconds in GetWorkGroup and GetTableMetadata responses

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AthenaTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AthenaTest.java
@@ -3,10 +3,13 @@ package com.floci.test;
 import org.junit.jupiter.api.*;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.athena.model.*;
+import software.amazon.awssdk.services.glue.GlueClient;
 
-import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Athena Query Execution")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -106,4 +109,72 @@ class AthenaTest {
                         .build()))
                 .isInstanceOf(InvalidRequestException.class);
     }
+
+    /**
+     * Reproduces issue #1498: the AthenaClient fails to unmarshal the {@code CreationTime} field returned by Floci's
+     * {@code GetWorkGroup} response.
+     */
+    @Test
+    @Order(6)
+    @DisplayName("getWorkGroup must unmarshal creationTime successfully")
+    void getWorkGroupCreationTimeCanBeUnmarshalledBySdk() {
+        String groupName = UUID.randomUUID().toString();
+        athena.createWorkGroup(
+                CreateWorkGroupRequest.builder()
+                        .name(groupName)
+                        .build()
+        );
+
+        GetWorkGroupResponse response = athena.getWorkGroup(
+                GetWorkGroupRequest.builder()
+                        .workGroup(groupName)
+                        .build()
+        );
+
+        Instant creationTime = response.workGroup().creationTime();
+        assertThat(creationTime)
+                .as("creationTime must be parseable by the AWS SDK")
+                .isNotNull();
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("getTableMetadata must unmarshal timestamps successfully")
+    void getTableMetadataTimestampsCanBeUnmarshalledBySdk() {
+        GlueClient glue = TestFixtures.glueClient();
+        String dbName = "athena_ts_test_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        String tableName = "orders";
+
+        glue.createDatabase(r -> r.databaseInput(i -> i.name(dbName)));
+        glue.createTable(r -> r
+                .databaseName(dbName)
+                .tableInput(t -> t
+                        .name(tableName)
+                        .tableType("EXTERNAL_TABLE")
+                        .storageDescriptor(
+                                sd -> sd
+                                        .location("s3://test-bucket/" + dbName + "/")
+                                        .columns(c -> c.name("id").type("string"))
+                        )
+                )
+        );
+
+        GetTableMetadataResponse response = athena.getTableMetadata(
+                GetTableMetadataRequest.builder()
+                        .catalogName("AwsDataCatalog")
+                        .databaseName(dbName)
+                        .tableName(tableName)
+                        .build()
+        );
+
+        assertThat(response.tableMetadata().createTime())
+                .as("createTime must be parseable by the AWS SDK")
+                .isNotNull();
+        assertThat(response.tableMetadata().lastAccessTime())
+                .as("lastAccessTime must be parseable by the AWS SDK")
+                .isNotNull();
+
+        glue.close();
+    }
 }
+

--- a/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
@@ -369,7 +369,7 @@ public class AthenaService {
             detail.put("Description", workGroup.getDescription());
         }
         if (workGroup.getCreationTime() != null) {
-            detail.put("CreationTime", workGroup.getCreationTime());
+            detail.put("CreationTime", workGroup.getCreationTime().getEpochSecond());
         }
         if (workGroup.getConfiguration() != null) {
             detail.put("Configuration", workGroup.getConfiguration());
@@ -475,8 +475,8 @@ public class AthenaService {
     private Map<String, Object> tableMetadata(String catalog, String database, Table table) {
         Map<String, Object> metadata = new LinkedHashMap<>();
         metadata.put("Name", table.getName());
-        metadata.put("CreateTime", table.getCreateTime() != null ? table.getCreateTime() : Instant.now());
-        metadata.put("LastAccessTime", table.getLastAccessTime() != null ? table.getLastAccessTime() : Instant.now());
+        metadata.put("CreateTime", (table.getCreateTime() != null ? table.getCreateTime() : Instant.now()).getEpochSecond());
+        metadata.put("LastAccessTime", (table.getLastAccessTime() != null ? table.getLastAccessTime() : Instant.now()).getEpochSecond());
         metadata.put("TableType", table.getTableType() != null ? table.getTableType() : "EXTERNAL_TABLE");
         metadata.put("Columns", athenaColumns(table));
         metadata.put("Parameters", table.getParameters() != null ? table.getParameters() : Map.of());

--- a/src/test/java/io/github/hectorvent/floci/services/athena/AthenaGetWorkGroupIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/athena/AthenaGetWorkGroupIntegrationTest.java
@@ -6,8 +6,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 
 @QuarkusTest
 class AthenaGetWorkGroupIntegrationTest {
@@ -72,6 +71,38 @@ class AthenaGetWorkGroupIntegrationTest {
                     equalTo("s3://test-bucket/athena-results/"))
             .body("WorkGroup.Configuration.EngineVersion.EffectiveEngineVersion",
                     equalTo("Athena engine version 3"));
+    }
+
+    /**
+     * Reproduces issue #1498: the AthenaClient fails to unmarshal the {@code CreationTime} field returned by Floci's
+     * {@code GetWorkGroup} response.
+     */
+    @Test
+    void getWorkGroupCreationTimeIsSerializedAsEpochSecondsNumber() {
+        given()
+                .header("X-Amz-Target", "AmazonAthena.CreateWorkGroup")
+                .contentType(CONTENT_TYPE)
+                .body("""
+                        {
+                          "Name": "timestamp-format-bug-wg"
+                        }
+                        """)
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+
+        var response = given()
+                .header("X-Amz-Target", "AmazonAthena.GetWorkGroup")
+                .contentType(CONTENT_TYPE)
+                .body("{ \"WorkGroup\": \"timestamp-format-bug-wg\" }")
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .body("WorkGroup.Name", equalTo("timestamp-format-bug-wg"))
+                .body("WorkGroup.CreationTime", notNullValue())
+                .body("WorkGroup.CreationTime", instanceOf(Number.class));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/athena/AthenaIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/athena/AthenaIntegrationTest.java
@@ -2,11 +2,7 @@ package io.github.hectorvent.floci.services.athena;
 
 import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.*;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
@@ -334,5 +330,51 @@ class AthenaIntegrationTest {
             .statusCode(400)
             .body("__type", equalTo("InvalidRequestException"))
             .body("message", equalTo("The primary workgroup cannot be deleted."));
+    }
+
+    @Test
+    @Order(12)
+    void getTableMetadataTimestampsAreSerializedAsEpochSecondsNumbers() {
+        given()
+                .header("X-Amz-Target", "AWSGlue.CreateDatabase")
+                .contentType(CONTENT_TYPE)
+                .body("{ \"DatabaseInput\": { \"Name\": \"ts-format-test\" } }")
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+
+        given()
+                .header("X-Amz-Target", "AWSGlue.CreateTable")
+                .contentType(CONTENT_TYPE)
+                .body("""
+                        {
+                          "DatabaseName": "ts-format-test",
+                          "TableInput": {
+                            "Name": "events",
+                            "TableType": "EXTERNAL_TABLE",
+                            "StorageDescriptor": {
+                              "Location": "s3://bucket/events",
+                              "Columns": [ { "Name": "id", "Type": "string" } ]
+                            }
+                          }
+                        }
+                        """)
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+
+        given()
+                .header("X-Amz-Target", "AmazonAthena.GetTableMetadata")
+                .contentType(CONTENT_TYPE)
+                .body("{ \"CatalogName\": \"AwsDataCatalog\", \"DatabaseName\": \"ts-format-test\", \"TableName\": \"events\" }")
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .body("TableMetadata.Name", equalTo("events"))
+                .body("TableMetadata.CreateTime", instanceOf(Number.class))
+                .body("TableMetadata.LastAccessTime", instanceOf(Number.class));
     }
 }


### PR DESCRIPTION
## Summary

Closes #1498 

Change summary:
- Serialize timestamps explicitly as epoch seconds
- Add integration and compatibilty regression tests

 Affected fields:
    - `GetWorkGroup` - `WorkGroup.CreationTime`
    - `GetTableMetadata` - `TableMetadata.CreateTime`, `TableMetadata.LastAccessTime` - the fields were not reported in the original issue but were affected by the same problem

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

`GetWorkGroup` and `GetTableMetadata` returned timestamp fields as ISO 8601 strings (e.g. `"2026-06-22T08:48:19.861716+00:00"`). The AWS SDK enforces a 20 character limit on the timestamp strings and failed to unmarshall the response.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
