### PR TITLE
fix(lambda): propagate SQS FIFO system attributes to ESM event

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/SqsEventSourcePoller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/SqsEventSourcePoller.java
@@ -285,6 +285,15 @@ public class SqsEventSourcePoller {
                 attrs.put("SentTimestamp", String.valueOf(msg.getSentTimestamp().toEpochMilli()));
                 attrs.put("SenderId", AwsArnUtils.accountOrDefault(esm.getEventSourceArn(), "000000000000"));
                 attrs.put("ApproximateFirstReceiveTimestamp", String.valueOf(System.currentTimeMillis()));
+                if (msg.getSequenceNumber() > 0) {
+                    attrs.put("SequenceNumber", String.valueOf(msg.getSequenceNumber()));
+                }
+                if (msg.getMessageGroupId() != null) {
+                    attrs.put("MessageGroupId", msg.getMessageGroupId());
+                }
+                if (msg.getMessageDeduplicationId() != null) {
+                    attrs.put("MessageDeduplicationId", msg.getMessageDeduplicationId());
+                }
                 // Populate messageAttributes from the message model
                 ObjectNode msgAttrs = record.putObject("messageAttributes");
                 if (msg.getMessageAttributes() != null) {

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/SqsEventSourcePollerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/SqsEventSourcePollerTest.java
@@ -206,6 +206,46 @@ class SqsEventSourcePollerTest {
     }
 
     @Test
+    void buildSqsEventIncludesFifoSystemAttributes() throws Exception {
+        Message msg = new Message();
+        msg.setBody("hello-fifo");
+        msg.setSentTimestamp(Instant.parse("2026-01-15T10:30:00Z"));
+        msg.setMessageGroupId("groupA");
+        msg.setSequenceNumber(27);
+        msg.setMessageDeduplicationId("6e809cbda0732ac4845916a59016f954");
+
+        EventSourceMapping esm = new EventSourceMapping();
+        esm.setEventSourceArn("arn:aws:sqs:us-east-1:123456789012:my-queue.fifo");
+        esm.setRegion("us-east-1");
+
+        String event = poller.buildSqsEvent(List.of(msg), esm);
+        JsonNode attrs = OBJECT_MAPPER.readTree(event).get("Records").get(0).get("attributes");
+
+        assertEquals("groupA", attrs.get("MessageGroupId").asText());
+        assertEquals("27", attrs.get("SequenceNumber").asText());
+        assertEquals("6e809cbda0732ac4845916a59016f954",
+                attrs.get("MessageDeduplicationId").asText());
+    }
+
+    @Test
+    void buildSqsEventOmitsFifoSystemAttributesForStandardQueueMessages() throws Exception {
+        Message msg = new Message();
+        msg.setBody("hello");
+        msg.setSentTimestamp(Instant.parse("2026-01-15T10:30:00Z"));
+
+        EventSourceMapping esm = new EventSourceMapping();
+        esm.setEventSourceArn("arn:aws:sqs:us-east-1:123456789012:my-queue");
+        esm.setRegion("us-east-1");
+
+        String event = poller.buildSqsEvent(List.of(msg), esm);
+        JsonNode attrs = OBJECT_MAPPER.readTree(event).get("Records").get(0).get("attributes");
+
+        assertNull(attrs.get("MessageGroupId"));
+        assertNull(attrs.get("SequenceNumber"));
+        assertNull(attrs.get("MessageDeduplicationId"));
+    }
+
+    @Test
     void buildSqsEventUsesDefaultAccountWhenArnParsingFails() throws Exception {
         Message msg = new Message();
         msg.setBody("test");


### PR DESCRIPTION
## Summary

Closes #1526. When an SQS event source mapping invokes a Lambda from a FIFO queue, `SqsEventSourcePoller.buildSqsEvent()` now copies the FIFO system attributes (`MessageGroupId`, `SequenceNumber`, `MessageDeduplicationId`) into each record's `attributes` map, matching the values `ReceiveMessage` already returns. Standard-queue messages are unaffected since each attribute is only added when present.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Previously the ESM event only carried the four standard system attributes, so consumers relying on `MessageGroupId` to process FIFO messages in group order never received it. On real AWS the SQS→Lambda event includes these FIFO system attributes; the fix restores that behaviour.

## Checklist

- [x] `./mvnw test` passes locally (SqsEventSourcePollerTest, 7 tests)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
