### PR TITLE
feat(core): add opt-in Private Network Access for CORS preflights

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -33,6 +33,7 @@ Floci is configured exclusively through environment variables. Every option belo
 | `FLOCI_SECURITY_EXTRA_CORS_ALLOWED_HEADERS` | _(none)_ | Additional header names to include in `Access-Control-Allow-Headers`. Alias: `EXTRA_CORS_ALLOWED_HEADERS` |
 | `FLOCI_SECURITY_EXTRA_CORS_EXPOSE_HEADERS` | _(none)_ | Additional header names to include in `Access-Control-Expose-Headers`. Alias: `EXTRA_CORS_EXPOSE_HEADERS` |
 | `FLOCI_SECURITY_DISABLE_CORS_HEADERS` | `false` | Disable Floci's global CORS response headers. Alias: `DISABLE_CORS_HEADERS` |
+| `FLOCI_SECURITY_CORS_ALLOW_PRIVATE_NETWORK` | `false` | Answer Private Network Access preflights with `Access-Control-Allow-Private-Network: true`, letting a page on a public/secure origin reach this loopback backend. Only applies after the origin passes the allow-list above. |
 
 ---
 

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -126,6 +126,18 @@ public interface EmulatorConfig {
 
         @WithDefault("false")
         boolean disableCorsHeaders();
+
+        /**
+         * Whether to grant Private Network Access preflights (respond with
+         * {@code Access-Control-Allow-Private-Network: true}) when the browser asks.
+         * Only takes effect after the origin already passes the CORS allow-list, so a
+         * page served from a public/secure origin can reach this loopback backend.
+         *
+         * <p>Off by default: it lets a public origin reach the private network, so it
+         * must be opted into explicitly.</p>
+         */
+        @WithDefault("false")
+        boolean corsAllowPrivateNetwork();
     }
 
     interface StorageConfig {

--- a/src/main/java/io/github/hectorvent/floci/core/common/GlobalCorsFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/GlobalCorsFilter.java
@@ -28,6 +28,11 @@ import java.util.stream.Collectors;
  * {@code FLOCI_SECURITY_EXTRA_CORS_ALLOWED_ORIGINS}). Service-level CORS
  * responses, such as S3 bucket CORS rules or API Gateway integrations, keep
  * precedence because this filter only fills missing CORS headers.</p>
+ *
+ * <p>Preflights that request Private Network Access (Chrome's
+ * {@code Access-Control-Request-Private-Network}) are granted only when opted in
+ * via {@code FLOCI_SECURITY_CORS_ALLOW_PRIVATE_NETWORK}, letting a UI served from a
+ * public/secure origin reach a loopback backend.</p>
  */
 @Provider
 @PreMatching
@@ -37,6 +42,8 @@ public class GlobalCorsFilter implements ContainerRequestFilter, ContainerRespon
     private static final String ORIGIN = "Origin";
     private static final String REQUEST_METHOD = "Access-Control-Request-Method";
     private static final String REQUEST_HEADERS = "Access-Control-Request-Headers";
+    private static final String REQUEST_PRIVATE_NETWORK = "Access-Control-Request-Private-Network";
+    private static final String ALLOW_PRIVATE_NETWORK = "Access-Control-Allow-Private-Network";
     private static final String ALLOW_ORIGIN = "Access-Control-Allow-Origin";
     private static final String ALLOW_METHODS = "Access-Control-Allow-Methods";
     private static final String ALLOW_HEADERS = "Access-Control-Allow-Headers";
@@ -96,6 +103,14 @@ public class GlobalCorsFilter implements ContainerRequestFilter, ContainerRespon
                     .header(MAX_AGE, "86400")
                     .header(VARY, ORIGIN);
 
+            // Private Network Access: a public/secure page (e.g. an HTTPS-hosted UI)
+            // probing a loopback/private-network backend sends this on the preflight;
+            // grant it (unless disabled) so the browser doesn't block the follow-up request.
+            if (s.allowPrivateNetwork()
+                    && "true".equalsIgnoreCase(requestContext.getHeaderString(REQUEST_PRIVATE_NETWORK))) {
+                builder.header(ALLOW_PRIVATE_NETWORK, "true");
+            }
+
             s.exposeHeaders().ifPresent(value -> builder.header(EXPOSE_HEADERS, value));
             requestContext.abortWith(builder.build());
         }
@@ -134,7 +149,8 @@ public class GlobalCorsFilter implements ContainerRequestFilter, ContainerRespon
     private record CorsSettings(boolean disabled,
                                 Set<String> allowedOrigins,
                                 Set<String> extraAllowedHeaders,
-                                Set<String> extraExposeHeaders) {
+                                Set<String> extraExposeHeaders,
+                                boolean allowPrivateNetwork) {
 
         static CorsSettings from(EmulatorConfig.SecurityConfig security) {
             Set<String> origins = security.extraCorsAllowedOrigins()
@@ -146,7 +162,8 @@ public class GlobalCorsFilter implements ContainerRequestFilter, ContainerRespon
             Set<String> exposeHeaders = security.extraCorsExposeHeaders()
                     .map(list -> (Set<String>) new LinkedHashSet<>(list))
                     .orElse(Set.of());
-            return new CorsSettings(security.disableCorsHeaders(), origins, allowedHeaders, exposeHeaders);
+            return new CorsSettings(security.disableCorsHeaders(), origins, allowedHeaders, exposeHeaders,
+                    security.corsAllowPrivateNetwork());
         }
 
         boolean enabled() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -141,6 +141,9 @@ floci:
     # extra-cors-allowed-headers:
     # extra-cors-expose-headers:
     disable-cors-headers: false
+    # Grant Private Network Access preflights (Access-Control-Allow-Private-Network)
+    # so a page on a public/secure origin can reach this loopback backend.
+    cors-allow-private-network: false
 
   tls:
     enabled: false                     # FLOCI_TLS_ENABLED (default: false)

--- a/src/test/java/io/github/hectorvent/floci/core/common/GlobalCorsFilterIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/GlobalCorsFilterIntegrationTest.java
@@ -42,6 +42,32 @@ class GlobalCorsFilterIntegrationTest {
     }
 
     @Test
+    void preflightRequestingPrivateNetworkAccessIsGranted() {
+        given()
+            .header("Origin", "http://localhost:3000")
+            .header("Access-Control-Request-Method", "POST")
+            .header("Access-Control-Request-Private-Network", "true")
+        .when()
+            .options("/")
+        .then()
+            .statusCode(204)
+            .header("Access-Control-Allow-Origin", equalTo("http://localhost:3000"))
+            .header("Access-Control-Allow-Private-Network", equalTo("true"));
+    }
+
+    @Test
+    void preflightWithoutPrivateNetworkRequestOmitsAllowHeader() {
+        given()
+            .header("Origin", "http://localhost:3000")
+            .header("Access-Control-Request-Method", "POST")
+        .when()
+            .options("/")
+        .then()
+            .statusCode(204)
+            .header("Access-Control-Allow-Private-Network", nullValue());
+    }
+
+    @Test
     void actualRequestFromExtraAllowedOriginGetsCorsHeaders() {
         given()
             .header("Origin", "https://ui.example.test")
@@ -77,7 +103,40 @@ class GlobalCorsFilterIntegrationTest {
             return Map.of(
                     "floci.security.extra-cors-allowed-origins", "http://localhost:3000,https://ui.example.test",
                     "floci.security.extra-cors-allowed-headers", "x-added-header",
-                    "floci.security.extra-cors-expose-headers", "x-visible-header");
+                    "floci.security.extra-cors-expose-headers", "x-visible-header",
+                    "floci.security.cors-allow-private-network", "true");
+        }
+    }
+
+    @QuarkusTest
+    @TestProfile(PrivateNetworkDefaultOffTest.CorsPnaDefaultProfile.class)
+    static class PrivateNetworkDefaultOffTest {
+
+        @BeforeAll
+        static void configureRestAssured() {
+            RestAssuredJsonUtils.configureAwsContentTypes();
+        }
+
+        @Test
+        void privateNetworkAccessNotGrantedByDefault() {
+            given()
+                .header("Origin", "http://localhost:3000")
+                .header("Access-Control-Request-Method", "POST")
+                .header("Access-Control-Request-Private-Network", "true")
+            .when()
+                .options("/")
+            .then()
+                .statusCode(204)
+                .header("Access-Control-Allow-Origin", equalTo("http://localhost:3000"))
+                .header("Access-Control-Allow-Private-Network", nullValue());
+        }
+
+        // Only origins set — cors-allow-private-network left at its (off) default.
+        public static final class CorsPnaDefaultProfile implements QuarkusTestProfile {
+            @Override
+            public Map<String, String> getConfigOverrides() {
+                return Map.of("floci.security.extra-cors-allowed-origins", "http://localhost:3000");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds an opt-in `FLOCI_SECURITY_CORS_ALLOW_PRIVATE_NETWORK` flag (default `false`). When enabled, `GlobalCorsFilter` answers a browser's Private Network Access preflight with `Access-Control-Allow-Private-Network: true` — but only after the request's `Origin` already passes the existing CORS allow-list.

This unblocks a real case: a UI served from a public/secure origin (e.g. an HTTPS-hosted console) calling a Floci on `localhost`. Chromium gates that public→loopback request behind a [Private Network Access](https://developer.chrome.com/blog/private-network-access-preflight/) preflight, and without the response header the browser blocks the follow-up request even when CORS is otherwise correct.

**Motivation / parity:** Floci is used as a LocalStack drop-in, and LocalStack already returns `Access-Control-Allow-Private-Network: true` for this preflight — so a browser console that works against LocalStack on localhost currently breaks when pointed at Floci. This change closes that gap, while keeping it default-off so existing setups see no behavior change and no new exposure.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Not an AWS wire-protocol action — this is a browser/CORS concern on the global filter, so there is no SDK action to verify. The trigger and response follow the Private Network Access spec (`Access-Control-Request-Private-Network` → `Access-Control-Allow-Private-Network`). Verified by probing the preflight:

```
curl -i -X OPTIONS http://localhost:4566/ \
  -H 'Origin: https://example.test' \
  -H 'Access-Control-Request-Method: GET' \
  -H 'Access-Control-Request-Private-Network: true'
```

With the flag on (and the origin allow-listed) the response carries `Access-Control-Allow-Private-Network: true`; with it off the header is absent. This matches the header LocalStack returns for the same probe.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added <!-- granted / not-requested / default-off cases in GlobalCorsFilterIntegrationTest -->
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
