### PR TITLE
fix(cloudfront): honor configured domain-suffix for generated distribution domains

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontService.java
@@ -57,6 +57,7 @@ public class CloudFrontService {
     private final StorageBackend<String, FieldLevelEncryptionProfile> fleProfileStore;
     private final StorageBackend<String, MonitoringSubscription> monitoringStore;
     private final String accountId;
+    private final String domainSuffix;
 
     @Inject
     public CloudFrontService(StorageFactory factory, EmulatorConfig config) {
@@ -95,6 +96,7 @@ public class CloudFrontService {
         this.monitoringStore = factory.create("cloudfront", "cloudfront-monitoring-subscriptions.json",
                 new TypeReference<Map<String, MonitoringSubscription>>() {});
         this.accountId = config.defaultAccountId();
+        this.domainSuffix = config.services().cloudfront().domainSuffix();
     }
 
     // ── Distributions ─────────────────────────────────────────────────────────
@@ -103,7 +105,7 @@ public class CloudFrontService {
         String id = generateDistributionId();
         dist.setId(id);
         dist.setArn("arn:aws:cloudfront::" + accountId + ":distribution/" + id);
-        dist.setDomainName(id + ".cloudfront.net");
+        dist.setDomainName(id + "." + domainSuffix);
         dist.setStatus("Deployed");
         dist.setLastModifiedTime(Instant.now());
         dist.setEtag(UUID.randomUUID().toString());
@@ -817,7 +819,7 @@ public class CloudFrontService {
         String id = generateDistributionId();
         sd.setId(id);
         sd.setArn("arn:aws:cloudfront::" + accountId + ":streaming-distribution/" + id);
-        sd.setDomainName(id + ".cloudfront.net");
+        sd.setDomainName(id + "." + domainSuffix);
         sd.setStatus("Deployed");
         sd.setLastModifiedTime(Instant.now());
         sd.setEtag(UUID.randomUUID().toString());

--- a/src/test/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontServiceTest.java
@@ -1,0 +1,66 @@
+package io.github.hectorvent.floci.services.cloudfront;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.cloudfront.model.Distribution;
+import io.github.hectorvent.floci.services.cloudfront.model.StreamingDistribution;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+class CloudFrontServiceTest {
+
+    private static final String ACCOUNT = "000000000000";
+
+    private CloudFrontService serviceWithDomainSuffix(String domainSuffix) {
+        StorageFactory storageFactory = Mockito.mock(StorageFactory.class);
+        when(storageFactory.create(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
+                .thenReturn(new InMemoryStorage<>());
+
+        EmulatorConfig config = Mockito.mock(EmulatorConfig.class);
+        var servicesConfig = Mockito.mock(EmulatorConfig.ServicesConfig.class);
+        var cloudFrontConfig = Mockito.mock(EmulatorConfig.CloudFrontServiceConfig.class);
+
+        when(config.defaultAccountId()).thenReturn(ACCOUNT);
+        when(config.services()).thenReturn(servicesConfig);
+        when(servicesConfig.cloudfront()).thenReturn(cloudFrontConfig);
+        when(cloudFrontConfig.domainSuffix()).thenReturn(domainSuffix);
+
+        return new CloudFrontService(storageFactory, config);
+    }
+
+    @Test
+    void createDistributionUsesDefaultDomainSuffix() {
+        CloudFrontService service = serviceWithDomainSuffix("cloudfront.net");
+
+        Distribution dist = service.createDistribution(new Distribution(), Map.of());
+
+        assertTrue(dist.getDomainName().endsWith(".cloudfront.net"),
+                "Expected default suffix, got: " + dist.getDomainName());
+    }
+
+    @Test
+    void createDistributionHonorsConfiguredDomainSuffix() {
+        CloudFrontService service = serviceWithDomainSuffix("cloudfront.local");
+
+        Distribution dist = service.createDistribution(new Distribution(), Map.of());
+
+        assertTrue(dist.getDomainName().endsWith(".cloudfront.local"),
+                "Expected configured suffix, got: " + dist.getDomainName());
+    }
+
+    @Test
+    void createStreamingDistributionHonorsConfiguredDomainSuffix() {
+        CloudFrontService service = serviceWithDomainSuffix("cloudfront.local");
+
+        StreamingDistribution sd = service.createStreamingDistribution(new StreamingDistribution());
+
+        assertTrue(sd.getDomainName().endsWith(".cloudfront.local"),
+                "Expected configured suffix, got: " + sd.getDomainName());
+    }
+}


### PR DESCRIPTION
## Summary

`FLOCI_SERVICES_CLOUDFRONT_DOMAIN_SUFFIX` (config: `floci.services.cloudfront.domain-suffix`) was defined and documented but never actually consumed — `CloudFrontService` hardcoded the `.cloudfront.net` suffix when generating distribution domain names, so the env var had no effect.

This wires the existing config value through:

- Capture `config.services().cloudfront().domainSuffix()` into a `domainSuffix` field in the `CloudFrontService` constructor (which already receives `EmulatorConfig`).
- Use it in `createDistribution()` and `createStreamingDistribution()` in place of the hardcoded literal: `id + "." + domainSuffix`.

Default behaviour is unchanged — `domainSuffix()` defaults to `cloudfront.net` via `@WithDefault`, so existing setups still generate `<id>.cloudfront.net`. Users who set the env var (e.g. `cloudfront.local` to route distribution domains to a local emulator host) now get it honoured.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behaviour (bug fix):** The `domain-suffix` config property existed (`EmulatorConfig.CloudFrontServiceConfig.domainSuffix()`, default `cloudfront.net`) and was documented in `docs/services/cloudfront.md`, but `CloudFrontService` ignored it and always emitted `<id>.cloudfront.net` from both `createDistribution` and `createStreamingDistribution`. Setting `FLOCI_SERVICES_CLOUDFRONT_DOMAIN_SUFFIX` had no observable effect.

The default value remains `cloudfront.net`, matching real AWS CloudFront distribution domain names, so the AWS-compatible default is preserved; the suffix is only overridden when a user explicitly configures it (a local-emulation convenience, not an AWS wire-protocol change).

## Checklist

- [x] `./mvnw test` passes locally — ran the new test class: `./mvnw test -Dtest=CloudFrontServiceTest` → `Tests run: 3, Failures: 0, Errors: 0` (full suite delegated to CI)
- [x] New or updated integration test added — `CloudFrontServiceTest` with 3 cases: default suffix (`.cloudfront.net`), configured suffix for a distribution (`.cloudfront.local`), and configured suffix for a streaming distribution
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
