### PR TITLE
feat(ec2): add instance type metadata catalog

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2InstanceTypeCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2InstanceTypeCatalog.java
@@ -1,0 +1,136 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@ApplicationScoped
+public class Ec2InstanceTypeCatalog {
+
+    private static final String CATALOG_RESOURCE_NAME = "ec2/instance-type-catalog.yaml";
+    private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
+
+    private volatile Loaded loaded;
+
+    public Ec2InstanceTypeCatalog() {
+        // Load lazily so tests and mock-mode paths that do not need instance type
+        // metadata are not coupled to resource loading during bean construction.
+    }
+
+    Ec2InstanceTypeCatalog(Catalog catalog) {
+        this.loaded = new Loaded(catalog);
+    }
+
+    public List<CatalogInstanceType> instanceTypes() {
+        return loaded().instanceTypes;
+    }
+
+    public Optional<CatalogInstanceType> find(String instanceType) {
+        if (instanceType == null || instanceType.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(loaded().instanceTypesByName.get(instanceType));
+    }
+
+    private Loaded loaded() {
+        Loaded result = loaded;
+        if (result == null) {
+            synchronized (this) {
+                result = loaded;
+                if (result == null) {
+                    result = new Loaded(readResource(CATALOG_RESOURCE_NAME, Catalog.class));
+                    loaded = result;
+                }
+            }
+        }
+        return result;
+    }
+
+    private static <T> T readResource(String resourceName, Class<T> type) {
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        try (InputStream input = loader.getResourceAsStream(resourceName)) {
+            if (input == null) {
+                throw new IllegalStateException("Missing EC2 instance type catalog resource: " + resourceName);
+            }
+            return YAML_MAPPER.readValue(input, type);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load EC2 instance type catalog resource: " + resourceName, e);
+        }
+    }
+
+    private static final class Loaded {
+        private final List<CatalogInstanceType> instanceTypes;
+        private final Map<String, CatalogInstanceType> instanceTypesByName;
+
+        Loaded(Catalog catalog) {
+            this.instanceTypes = List.copyOf(catalog.instanceTypes == null ? List.of() : catalog.instanceTypes);
+            if (this.instanceTypes.isEmpty()) {
+                throw new IllegalStateException("EC2 instance type catalog has no instance types: " + CATALOG_RESOURCE_NAME);
+            }
+            this.instanceTypesByName = indexInstanceTypes(this.instanceTypes);
+        }
+    }
+
+    private static Map<String, CatalogInstanceType> indexInstanceTypes(List<CatalogInstanceType> instanceTypes) {
+        Map<String, CatalogInstanceType> index = new LinkedHashMap<>();
+        for (CatalogInstanceType instanceType : instanceTypes) {
+            String name = require(instanceType.instanceType, "instanceType");
+            if (instanceType.vcpu <= 0) {
+                throw new IllegalStateException("EC2 instance type catalog entry has invalid vcpu: " + name);
+            }
+            if (instanceType.memoryMib <= 0) {
+                throw new IllegalStateException("EC2 instance type catalog entry has invalid memoryMib: " + name);
+            }
+            if (instanceType.supportedArchitectures == null || instanceType.supportedArchitectures.isEmpty()) {
+                throw new IllegalStateException("EC2 instance type catalog entry is missing supportedArchitectures: " + name);
+            }
+            CatalogInstanceType previous = index.putIfAbsent(name, instanceType);
+            if (previous != null) {
+                throw new IllegalStateException("Duplicate EC2 instance type catalog entry: " + name);
+            }
+        }
+        return Map.copyOf(index);
+    }
+
+    private static String require(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException("EC2 instance type catalog entry is missing required field: " + field);
+        }
+        return value;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @RegisterForReflection
+    public static final class Catalog {
+        public List<CatalogInstanceType> instanceTypes = List.of();
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @RegisterForReflection
+    public static final class CatalogInstanceType {
+        public String instanceType;
+        public int vcpu;
+        public int memoryMib;
+        public List<String> supportedArchitectures = List.of();
+        public Boolean currentGeneration;
+
+        public Map<String, Object> toResponseMap() {
+            Map<String, Object> type = new LinkedHashMap<>();
+            type.put("instanceType", instanceType);
+            type.put("vcpu", vcpu);
+            type.put("memoryMib", memoryMib);
+            type.put("supportedArchitectures", List.copyOf(supportedArchitectures));
+            type.put("currentGeneration", currentGeneration == null || currentGeneration);
+            return type;
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -83,6 +83,7 @@ public class Ec2Service {
     private final Ec2ContainerManager containerManager;
     private final AmiImageResolver amiImageResolver;
     private final Ec2ImageCatalog imageCatalog;
+    private final Ec2InstanceTypeCatalog instanceTypeCatalog;
 
     // region::id → resource (persisted via StorageFactory so state survives a restart in
     // persistent/hybrid/wal modes; see #1297 — CloudFormation persists stacks/exports that
@@ -111,8 +112,8 @@ public class Ec2Service {
     @Inject
     public Ec2Service(EmulatorConfig config, Ec2ContainerManager containerManager,
                       AmiImageResolver amiImageResolver, Ec2ImageCatalog imageCatalog,
-                      StorageFactory storageFactory) {
-        this(config, containerManager, amiImageResolver, imageCatalog,
+                      Ec2InstanceTypeCatalog instanceTypeCatalog, StorageFactory storageFactory) {
+        this(config, containerManager, amiImageResolver, imageCatalog, instanceTypeCatalog,
                 storageFactory.create("ec2", "ec2-vpcs.json", new TypeReference<Map<String, Vpc>>() {}),
                 storageFactory.create("ec2", "ec2-subnets.json", new TypeReference<Map<String, Subnet>>() {}),
                 storageFactory.create("ec2", "ec2-security-groups.json", new TypeReference<Map<String, SecurityGroup>>() {}),
@@ -134,6 +135,7 @@ public class Ec2Service {
     // Package-private for hermetic tests (pass in-memory or temp-dir-backed StorageBackends directly).
     Ec2Service(EmulatorConfig config, Ec2ContainerManager containerManager,
                AmiImageResolver amiImageResolver, Ec2ImageCatalog imageCatalog,
+               Ec2InstanceTypeCatalog instanceTypeCatalog,
                StorageBackend<String, Vpc> vpcs,
                StorageBackend<String, Subnet> subnets,
                StorageBackend<String, SecurityGroup> securityGroups,
@@ -155,6 +157,7 @@ public class Ec2Service {
         this.containerManager = containerManager;
         this.amiImageResolver = amiImageResolver;
         this.imageCatalog = imageCatalog;
+        this.instanceTypeCatalog = instanceTypeCatalog;
         this.vpcs = vpcs;
         this.subnets = subnets;
         this.securityGroups = securityGroups;
@@ -2059,41 +2062,17 @@ public class Ec2Service {
     // ─── Instance Types ────────────────────────────────────────────────────────
 
     public List<Map<String, Object>> describeInstanceTypes(List<String> instanceTypeNames) {
-        List<Map<String, Object>> allTypes = new ArrayList<>();
-        allTypes.add(buildInstanceType("t2.micro", 1, 1024));
-        allTypes.add(buildInstanceType("t3.micro", 2, 1024));
-        allTypes.add(buildInstanceType("t3.small", 2, 2048));
-        allTypes.add(buildInstanceType("t3.medium", 2, 4096));
-        allTypes.add(buildInstanceType("m5.large", 2, 8192));
-        allTypes.add(buildInstanceType("t4g.micro", 2, 1024, List.of("arm64")));
-        allTypes.add(buildInstanceType("t4g.small", 2, 2048, List.of("arm64")));
-        allTypes.add(buildInstanceType("t4g.medium", 2, 4096, List.of("arm64")));
-        allTypes.add(buildInstanceType("m6gd.2xlarge", 8, 32768, List.of("arm64")));
-        allTypes.add(buildInstanceType("m7gd.2xlarge", 8, 32768, List.of("arm64")));
-        allTypes.add(buildInstanceType("m8gd.medium", 1, 4096, List.of("arm64")));
-        allTypes.add(buildInstanceType("m8gd.2xlarge", 8, 32768, List.of("arm64")));
-
         if (instanceTypeNames.isEmpty()) {
-            return allTypes;
+            return instanceTypeCatalog.instanceTypes().stream()
+                    .map(Ec2InstanceTypeCatalog.CatalogInstanceType::toResponseMap)
+                    .collect(Collectors.toList());
         }
-        return allTypes.stream()
-                .filter(t -> instanceTypeNames.contains(t.get("instanceType")))
+        return instanceTypeNames.stream()
+                .distinct()
+                .map(instanceTypeCatalog::find)
+                .flatMap(Optional::stream)
+                .map(Ec2InstanceTypeCatalog.CatalogInstanceType::toResponseMap)
                 .collect(Collectors.toList());
-    }
-
-    private Map<String, Object> buildInstanceType(String name, int vcpu, int memMib) {
-        return buildInstanceType(name, vcpu, memMib, List.of("x86_64"));
-    }
-
-    private Map<String, Object> buildInstanceType(String name, int vcpu, int memMib,
-                                                  List<String> supportedArchitectures) {
-        Map<String, Object> t = new LinkedHashMap<>();
-        t.put("instanceType", name);
-        t.put("vcpu", vcpu);
-        t.put("memoryMib", memMib);
-        t.put("supportedArchitectures", supportedArchitectures);
-        t.put("currentGeneration", true);
-        return t;
     }
 
     public List<Map<String, String>> describeInstanceTypeOfferings(String region, List<String> instanceTypeNames,

--- a/src/main/resources/ec2/instance-type-catalog.yaml
+++ b/src/main/resources/ec2/instance-type-catalog.yaml
@@ -1,0 +1,105 @@
+instanceTypes:
+  - instanceType: t2.micro
+    vcpu: 1
+    memoryMib: 1024
+    supportedArchitectures:
+      - x86_64
+    currentGeneration: true
+
+  - instanceType: t3.micro
+    vcpu: 2
+    memoryMib: 1024
+    supportedArchitectures:
+      - x86_64
+    currentGeneration: true
+
+  - instanceType: t3.small
+    vcpu: 2
+    memoryMib: 2048
+    supportedArchitectures:
+      - x86_64
+    currentGeneration: true
+
+  - instanceType: t3.medium
+    vcpu: 2
+    memoryMib: 4096
+    supportedArchitectures:
+      - x86_64
+    currentGeneration: true
+
+  - instanceType: m5.large
+    vcpu: 2
+    memoryMib: 8192
+    supportedArchitectures:
+      - x86_64
+    currentGeneration: true
+
+  - instanceType: t4g.micro
+    vcpu: 2
+    memoryMib: 1024
+    supportedArchitectures:
+      - arm64
+    currentGeneration: true
+
+  - instanceType: t4g.small
+    vcpu: 2
+    memoryMib: 2048
+    supportedArchitectures:
+      - arm64
+    currentGeneration: true
+
+  - instanceType: t4g.medium
+    vcpu: 2
+    memoryMib: 4096
+    supportedArchitectures:
+      - arm64
+    currentGeneration: true
+
+  - instanceType: m6gd.large
+    vcpu: 2
+    memoryMib: 8192
+    supportedArchitectures:
+      - arm64
+    currentGeneration: true
+
+  - instanceType: m6gd.2xlarge
+    vcpu: 8
+    memoryMib: 32768
+    supportedArchitectures:
+      - arm64
+    currentGeneration: true
+
+  - instanceType: m7gd.large
+    vcpu: 2
+    memoryMib: 8192
+    supportedArchitectures:
+      - arm64
+    currentGeneration: true
+
+  - instanceType: m7gd.2xlarge
+    vcpu: 8
+    memoryMib: 32768
+    supportedArchitectures:
+      - arm64
+    currentGeneration: true
+
+  - instanceType: m8gd.medium
+    vcpu: 1
+    memoryMib: 4096
+    supportedArchitectures:
+      - arm64
+    currentGeneration: true
+
+  - instanceType: m8gd.large
+    vcpu: 2
+    memoryMib: 8192
+    supportedArchitectures:
+      - arm64
+    currentGeneration: true
+
+  - instanceType: m8gd.2xlarge
+    vcpu: 8
+    memoryMib: 32768
+    supportedArchitectures:
+      - arm64
+    currentGeneration: true

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2InstanceTypeCatalogTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2InstanceTypeCatalogTest.java
@@ -1,0 +1,65 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class Ec2InstanceTypeCatalogTest {
+
+    @Inject
+    Ec2InstanceTypeCatalog instanceTypeCatalog;
+
+    @Test
+    void catalogContainsCurrentTypesAndLargeGravitonTypes() {
+        Set<String> instanceTypes = instanceTypeCatalog.instanceTypes().stream()
+                .map(instanceType -> instanceType.instanceType)
+                .collect(Collectors.toSet());
+
+        assertEquals(Set.of(
+                "t2.micro",
+                "t3.micro",
+                "t3.small",
+                "t3.medium",
+                "m5.large",
+                "t4g.micro",
+                "t4g.small",
+                "t4g.medium",
+                "m6gd.large",
+                "m6gd.2xlarge",
+                "m7gd.large",
+                "m7gd.2xlarge",
+                "m8gd.medium",
+                "m8gd.large",
+                "m8gd.2xlarge"), instanceTypes);
+    }
+
+    @Test
+    void largeGravitonTypesHaveExactMetadata() {
+        assertLargeGravitonType("m6gd.large");
+        assertLargeGravitonType("m7gd.large");
+        assertLargeGravitonType("m8gd.large");
+    }
+
+    @Test
+    void unknownInstanceTypeIsAbsent() {
+        assertFalse(instanceTypeCatalog.find("m8gd.xlarge").isPresent());
+    }
+
+    private void assertLargeGravitonType(String name) {
+        Ec2InstanceTypeCatalog.CatalogInstanceType instanceType = instanceTypeCatalog.find(name).orElseThrow();
+
+        assertEquals(2, instanceType.vcpu);
+        assertEquals(8192, instanceType.memoryMib);
+        assertEquals(List.of("arm64"), instanceType.supportedArchitectures);
+        assertTrue(instanceType.currentGeneration);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -245,6 +245,31 @@ class Ec2IntegrationTest {
 
     @Test
     @Order(18)
+    void describeLargeGravitonInstanceTypes() {
+        given()
+            .formParam("Action", "DescribeInstanceTypes")
+            .formParam("InstanceType.1", "m6gd.large")
+            .formParam("InstanceType.2", "m7gd.large")
+            .formParam("InstanceType.3", "m8gd.large")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("DescribeInstanceTypesResponse.instanceTypeSet.item.size()", equalTo(3))
+            .body("DescribeInstanceTypesResponse.instanceTypeSet.item.instanceType",
+                    containsInAnyOrder("m6gd.large", "m7gd.large", "m8gd.large"))
+            .body("DescribeInstanceTypesResponse.instanceTypeSet.item.vCpuInfo.defaultVCpus",
+                    everyItem(equalTo("2")))
+            .body("DescribeInstanceTypesResponse.instanceTypeSet.item.memoryInfo.sizeInMiB",
+                    everyItem(equalTo("8192")))
+            .body("DescribeInstanceTypesResponse.instanceTypeSet.item.supportedArchitectures.item.item",
+                    everyItem(equalTo("arm64")));
+    }
+
+    @Test
+    @Order(19)
     void describeInstanceTypeOfferings() {
         given()
             .formParam("Action", "DescribeInstanceTypeOfferings")
@@ -266,7 +291,7 @@ class Ec2IntegrationTest {
     }
 
     @Test
-    @Order(19)
+    @Order(20)
     void describeArmInstanceTypeOfferingByRegion() {
         given()
             .formParam("Action", "DescribeInstanceTypeOfferings")
@@ -288,7 +313,7 @@ class Ec2IntegrationTest {
     }
 
     @Test
-    @Order(20)
+    @Order(21)
     void describeModernGravitonInstanceTypeOfferingsByRegion() {
         given()
             .formParam("Action", "DescribeInstanceTypeOfferings")
@@ -307,6 +332,31 @@ class Ec2IntegrationTest {
             .body("DescribeInstanceTypeOfferingsResponse.instanceTypeOfferingSet.item.size()", equalTo(4))
             .body("DescribeInstanceTypeOfferingsResponse.instanceTypeOfferingSet.item.instanceType",
                     containsInAnyOrder("m8gd.2xlarge", "m7gd.2xlarge", "m6gd.2xlarge", "m8gd.medium"))
+            .body("DescribeInstanceTypeOfferingsResponse.instanceTypeOfferingSet.item.locationType",
+                    everyItem(equalTo("region")))
+            .body("DescribeInstanceTypeOfferingsResponse.instanceTypeOfferingSet.item.location",
+                    everyItem(equalTo("us-east-1")));
+    }
+
+    @Test
+    @Order(22)
+    void describeLargeGravitonInstanceTypeOfferingsByRegion() {
+        given()
+            .formParam("Action", "DescribeInstanceTypeOfferings")
+            .formParam("LocationType", "region")
+            .formParam("Filter.1.Name", "instance-type")
+            .formParam("Filter.1.Value.1", "m6gd.large")
+            .formParam("Filter.1.Value.2", "m7gd.large")
+            .formParam("Filter.1.Value.3", "m8gd.large")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("DescribeInstanceTypeOfferingsResponse.instanceTypeOfferingSet.item.size()", equalTo(3))
+            .body("DescribeInstanceTypeOfferingsResponse.instanceTypeOfferingSet.item.instanceType",
+                    containsInAnyOrder("m6gd.large", "m7gd.large", "m8gd.large"))
             .body("DescribeInstanceTypeOfferingsResponse.instanceTypeOfferingSet.item.locationType",
                     everyItem(equalTo("region")))
             .body("DescribeInstanceTypeOfferingsResponse.instanceTypeOfferingSet.item.location",

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServicePersistenceTest.java
@@ -68,7 +68,7 @@ class Ec2ServicePersistenceTest {
     private Ec2Service newService(Path dir) {
         EmulatorConfig config = mock(EmulatorConfig.class);
         when(config.defaultAccountId()).thenReturn("000000000000");
-        return new Ec2Service(config, null, null, null,
+        return new Ec2Service(config, null, null, null, new Ec2InstanceTypeCatalog(),
                 load(dir, "ec2-vpcs.json", new TypeReference<Map<String, Vpc>>() {}),
                 load(dir, "ec2-subnets.json", new TypeReference<Map<String, Subnet>>() {}),
                 load(dir, "ec2-security-groups.json", new TypeReference<Map<String, SecurityGroup>>() {}),

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -28,7 +28,8 @@ class Ec2ServiceTest {
     void mockModeTreatsExistingNonTerminatedInstanceAsRunningContainer() {
         Ec2ContainerManager containerManager = mock(Ec2ContainerManager.class);
         Ec2Service service = new Ec2Service(mockConfig(true), containerManager,
-                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new InMemoryStorageFactory());
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
         Reservation reservation = service.runInstances("us-east-1", "ami-1234567890abcdef0", "t3.micro",
                 1, 1, null, List.of(), null, null, List.of(), null, null);
         String instanceId = reservation.getInstances().getFirst().getInstanceId();
@@ -42,7 +43,8 @@ class Ec2ServiceTest {
     @Test
     void runInstancesRequiresImageIdInsteadOfDefaulting() {
         Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
-                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new InMemoryStorageFactory());
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
 
         AwsException error = assertThrows(AwsException.class, () -> service.runInstances(
                 "us-east-1", null, "t3.micro", 1, 1, null, List.of(), null, null,
@@ -56,7 +58,8 @@ class Ec2ServiceTest {
     @Test
     void launchTemplateVersionInheritsOmittedFieldsFromRequestedSourceVersion() {
         Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
-                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new InMemoryStorageFactory());
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
         LaunchTemplate template = service.createLaunchTemplate("us-east-1", "app-template",
                 "ami-source", "t3.micro", "app-key", List.of("sg-source"),
                 "source-user-data", List.of(), List.of(new Tag("Role", "source")));
@@ -82,7 +85,7 @@ class Ec2ServiceTest {
         Ec2ImageCatalog imageCatalog = new Ec2ImageCatalog();
         AmiImageResolver amiImageResolver = new AmiImageResolver(imageCatalog);
         Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
-                amiImageResolver, imageCatalog, new InMemoryStorageFactory());
+                amiImageResolver, imageCatalog, new Ec2InstanceTypeCatalog(), new InMemoryStorageFactory());
 
         assertTrue(service.describeImages("us-east-1", List.of(), List.of()).stream()
                 .anyMatch(image -> "ami-ubuntu2404-cloud-arm64".equals(image.getImageId())));
@@ -91,6 +94,21 @@ class Ec2ServiceTest {
         ResolvedAmiImage resolved = amiImageResolver.resolveImage("ami-ubuntu2404-cloud");
         assertEquals("floci/ami-ubuntu:24.04-arm64", resolved.dockerImage());
         assertTrue(resolved.systemd());
+    }
+
+    @Test
+    void describeInstanceTypesUsesExactCatalogMatches() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+
+        List<Map<String, Object>> types = service.describeInstanceTypes(List.of("m8gd.large", "m8gd.xlarge"));
+
+        assertEquals(1, types.size());
+        assertEquals("m8gd.large", types.getFirst().get("instanceType"));
+        assertEquals(2, types.getFirst().get("vcpu"));
+        assertEquals(8192, types.getFirst().get("memoryMib"));
+        assertEquals(List.of("arm64"), types.getFirst().get("supportedArchitectures"));
     }
 
     private static EmulatorConfig mockConfig(boolean ec2Mock) {


### PR DESCRIPTION
## Summary
- add a YAML-backed EC2 instance type metadata catalog
- move DescribeInstanceTypes and DescribeInstanceTypeOfferings to exact catalog lookup
- include m6gd.large, m7gd.large, and m8gd.large with arm64 metadata

## Tests
- ./mvnw -q -Dtest='Ec2InstanceTypeCatalogTest,Ec2ServiceTest,Ec2IntegrationTest' test
- git diff --check origin/main...HEAD
- rg -n '<project-specific names>' <changed member files>
- rg -n 'similar|fallback|approx' <changed member files>
