### PR TITLE
fix: implement read APIs required by Steampipe resource collection

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
@@ -52,6 +52,7 @@ public class CloudWatchLogsHandler {
             case "PutSubscriptionFilter" -> handlePutSubscriptionFilter(request, region);
             case "DescribeSubscriptionFilters" -> handleDescribeSubscriptionFilters(request, region);
             case "DeleteSubscriptionFilter" -> handleDeleteSubscriptionFilter(request, region);
+            case "GetDataProtectionPolicy" -> handleGetDataProtectionPolicy(request, region);
             default -> Response.status(400)
                     .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                     .build();
@@ -309,6 +310,20 @@ public class CloudWatchLogsHandler {
         String filterName = request.path("filterName").asText();
         logsService.deleteSubscriptionFilter(logGroupName, filterName, region);
         return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleGetDataProtectionPolicy(JsonNode request, String region) {
+        // Data-protection policies are not modeled. Real AWS returns
+        // ResourceNotFoundException when a log group has no policy, but the Steampipe
+        // aws_cloudwatch_log_group hydrate does not tolerate errors, so return an
+        // empty policy (HTTP 200) to let per-group collection succeed.
+        String identifier = resolveLogGroupName(request);
+        ObjectNode response = objectMapper.createObjectNode();
+        if (identifier != null) {
+            response.put("logGroupIdentifier", identifier);
+        }
+        // policyDocument intentionally omitted -> no data-protection policy
+        return Response.ok(response).build();
     }
 
     private String resolveLogGroupName(JsonNode request) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
@@ -313,10 +313,10 @@ public class CloudWatchLogsHandler {
     }
 
     private Response handleGetDataProtectionPolicy(JsonNode request, String region) {
-        // Data-protection policies are not modeled. Real AWS returns
-        // ResourceNotFoundException when a log group has no policy, but the Steampipe
-        // aws_cloudwatch_log_group hydrate does not tolerate errors, so return an
-        // empty policy (HTTP 200) to let per-group collection succeed.
+        // Data-protection policies are not modeled. Return HTTP 200 with the resolved
+        // logGroupIdentifier and no policyDocument ("no policy set"). Real AWS returns
+        // ResourceNotFoundException (HTTP 400) when the resource does not exist — the
+        // 200-empty response is a deliberate Floci simplification for read-only callers.
         String identifier = resolveLogGroupName(request);
         ObjectNode response = objectMapper.createObjectNode();
         if (identifier != null) {

--- a/src/main/java/io/github/hectorvent/floci/services/ecr/EcrJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecr/EcrJsonHandler.java
@@ -102,10 +102,12 @@ public class EcrJsonHandler {
     }
 
     private Response handleBatchGetRepositoryScanningConfiguration(JsonNode request, String region) {
-        // Scanning configuration is not modeled. Reuse describeRepositories (which
-        // resolves names and throws RepositoryNotFoundException for misses) and return
-        // a wire-accurate scanning config so Steampipe per-repo hydration
-        // (aws_ecr_repository) succeeds instead of failing on UnsupportedOperation.
+        // Scanning configuration is not modeled. Resolve names via describeRepositories
+        // and synthesize a wire-accurate RepositoryScanningConfiguration per repo:
+        // scanFrequency derived from scanOnPush (AWS enum: SCAN_ON_PUSH|CONTINUOUS_SCAN|
+        // MANUAL), with empty appliedScanFilters. Note: real AWS reports unknown repos
+        // in the `failures` array; here describeRepositories throws
+        // RepositoryNotFoundException, failing the whole batch instead.
         List<String> names = parseStringList(request.path("repositoryNames"));
         String registryId = request.path("registryId").asText(null);
 

--- a/src/main/java/io/github/hectorvent/floci/services/ecr/EcrJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecr/EcrJsonHandler.java
@@ -42,6 +42,8 @@ public class EcrJsonHandler {
         return switch (action) {
             case "CreateRepository" -> handleCreateRepository(request, region);
             case "DescribeRepositories" -> handleDescribeRepositories(request, region);
+            case "BatchGetRepositoryScanningConfiguration" ->
+                    handleBatchGetRepositoryScanningConfiguration(request, region);
             case "DeleteRepository" -> handleDeleteRepository(request, region);
             case "GetAuthorizationToken" -> handleGetAuthorizationToken(request);
             case "ListImages" -> handleListImages(request, region);
@@ -96,6 +98,32 @@ public class EcrJsonHandler {
             arr.add(buildRepository(r));
         }
         response.set("repositories", arr);
+        return Response.ok(response).build();
+    }
+
+    private Response handleBatchGetRepositoryScanningConfiguration(JsonNode request, String region) {
+        // Scanning configuration is not modeled. Reuse describeRepositories (which
+        // resolves names and throws RepositoryNotFoundException for misses) and return
+        // a wire-accurate scanning config so Steampipe per-repo hydration
+        // (aws_ecr_repository) succeeds instead of failing on UnsupportedOperation.
+        List<String> names = parseStringList(request.path("repositoryNames"));
+        String registryId = request.path("registryId").asText(null);
+
+        List<Repository> repos = service.describeRepositories(names, registryId, region);
+
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode configs = objectMapper.createArrayNode();
+        for (Repository r : repos) {
+            ObjectNode cfg = objectMapper.createObjectNode();
+            cfg.put("repositoryArn", r.getRepositoryArn());
+            cfg.put("repositoryName", r.getRepositoryName());
+            cfg.put("scanOnPush", r.isScanOnPush());
+            cfg.put("scanFrequency", r.isScanOnPush() ? "SCAN_ON_PUSH" : "MANUAL");
+            cfg.set("appliedScanFilters", objectMapper.createArrayNode());
+            configs.add(cfg);
+        }
+        response.set("scanningConfigurations", configs);
+        response.set("failures", objectMapper.createArrayNode());
         return Response.ok(response).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
@@ -225,9 +225,9 @@ public class IamQueryHandler {
     }
 
     private Response handleListMFADevices(MultivaluedMap<String, String> params) {
-        // MFA device state is not modeled; return a wire-accurate empty list so that
-        // SDK/Steampipe per-user hydration (aws_iam_user) succeeds instead of failing
-        // on an UnsupportedOperation error.
+        // MFA device state is not modeled; return the wire-accurate empty result
+        // (MFADevices list + IsTruncated=false). Real AWS returns NoSuchEntity
+        // (HTTP 404) for an unknown user — Floci returns an empty list regardless.
         String result = new XmlBuilder()
                 .start("MFADevices").end("MFADevices")
                 .elem("IsTruncated", false)

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
@@ -56,6 +56,7 @@ public class IamQueryHandler {
             case "TagUser" -> handleTagUser(params);
             case "UntagUser" -> handleUntagUser(params);
             case "ListUserTags" -> handleListUserTags(params);
+            case "ListMFADevices" -> handleListMFADevices(params);
 
             // Groups
             case "CreateGroup" -> handleCreateGroup(params);
@@ -221,6 +222,17 @@ public class IamQueryHandler {
         String result = new XmlBuilder().start("Tags").raw(tagsXml(tags)).end("Tags")
                 .elem("IsTruncated", false).build();
         return Response.ok(AwsQueryResponse.envelope("ListUserTags", AwsNamespaces.IAM, result)).build();
+    }
+
+    private Response handleListMFADevices(MultivaluedMap<String, String> params) {
+        // MFA device state is not modeled; return a wire-accurate empty list so that
+        // SDK/Steampipe per-user hydration (aws_iam_user) succeeds instead of failing
+        // on an UnsupportedOperation error.
+        String result = new XmlBuilder()
+                .start("MFADevices").end("MFADevices")
+                .elem("IsTruncated", false)
+                .build();
+        return Response.ok(AwsQueryResponse.envelope("ListMFADevices", AwsNamespaces.IAM, result)).build();
     }
 
     // =========================================================================

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandlerTest.java
@@ -70,6 +70,32 @@ class CloudWatchLogsHandlerTest {
         assertEquals(STREAM, streams.get(0).path("logStreamName").asText());
     }
 
+    // ──────────────────────────── GetDataProtectionPolicy ────────────────────────────
+
+    @Test
+    void getDataProtectionPolicyReturnsEmptyPolicyWith200() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("logGroupIdentifier", GROUP);
+
+        Response response = handler.handle("GetDataProtectionPolicy", request, REGION);
+
+        assertEquals(200, response.getStatus());
+        JsonNode body = (JsonNode) response.getEntity();
+        assertEquals(GROUP, body.path("logGroupIdentifier").asText());
+        assertTrue(body.path("policyDocument").isMissingNode());
+    }
+
+    @Test
+    void getDataProtectionPolicyByNameAlsoSucceeds() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("logGroupName", GROUP);
+
+        Response response = handler.handle("GetDataProtectionPolicy", request, REGION);
+
+        assertEquals(200, response.getStatus());
+        assertEquals(GROUP, ((JsonNode) response.getEntity()).path("logGroupIdentifier").asText());
+    }
+
     @Test
     void describeLogStreamsByLogGroupIdentifierArnWithWildcardSuffix() {
         ObjectNode request = MAPPER.createObjectNode();

--- a/src/test/java/io/github/hectorvent/floci/services/ecr/EcrIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecr/EcrIntegrationTest.java
@@ -156,6 +156,27 @@ class EcrIntegrationTest {
 
     @Test
     @Order(8)
+    void batchGetRepositoryScanningConfiguration() {
+        given()
+            .header("X-Amz-Target", PREFIX + "BatchGetRepositoryScanningConfiguration")
+            .contentType(CT)
+            .body("""
+                { "repositoryNames": ["%s"] }
+                """.formatted(REPO))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("scanningConfigurations[0].repositoryName", equalTo(REPO))
+            .body("scanningConfigurations[0].repositoryArn", startsWith("arn:aws:ecr:"))
+            .body("scanningConfigurations[0].scanOnPush", equalTo(false))
+            .body("scanningConfigurations[0].scanFrequency", equalTo("MANUAL"))
+            .body("scanningConfigurations[0].appliedScanFilters", empty())
+            .body("failures", empty());
+    }
+
+    @Test
+    @Order(9)
     void deleteRepositoryForce() {
         given()
             .header("X-Amz-Target", PREFIX + "DeleteRepository")

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
@@ -370,6 +370,22 @@ class IamIntegrationTest {
     // =========================================================================
 
     @Test
+    @Order(50)
+    void listMfaDevicesReturnsEmptyList() {
+        given()
+            .formParam("Action", "ListMFADevices")
+            .formParam("UserName", "any-user")
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=test/20260227/us-east-1/iam/aws4_request")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("ListMFADevicesResponse.ListMFADevicesResult.IsTruncated", equalTo("false"));
+    }
+
+    @Test
     @Order(10)
     void createUser() {
         given()


### PR DESCRIPTION
## Summary
Implements three read-only AWS APIs that Floci previously rejected with `UnsupportedOperation` (HTTP 400) because they fell through to each service handler's `default` branch:
- IAM `ListMFADevices`
- ECR `BatchGetRepositoryScanningConfiguration`
- CloudWatch Logs `GetDataProtectionPolicy`

Each now returns a minimal, wire-accurate response matching the AWS API reference, so read-only clients (SDKs, IaC tools, resource collectors) that call these actions during read-back no longer fail.

## Type of change
- [x] Bug fix (`fix:`)

## AWS behavior implemented
- **IAM `ListMFADevices`** → empty `MFADevices` list, `IsTruncated=false`. *(Real AWS returns `NoSuchEntity` / HTTP 404 for an unknown user; Floci returns empty regardless, since MFA state isn't modeled.)*
- **ECR `BatchGetRepositoryScanningConfiguration`** → one `scanningConfigurations` entry per repo (`repositoryArn`, `repositoryName`, `scanOnPush`, `appliedScanFilters: []`) with `scanFrequency` derived from `scanOnPush` — `SCAN_ON_PUSH` when true, else `MANUAL` (both valid members of the AWS enum `SCAN_ON_PUSH | CONTINUOUS_SCAN | MANUAL`); empty `failures`. *(Deviation: real AWS reports unknown repos in the `failures[]` array; this reuses `describeRepositories`, which throws `RepositoryNotFoundException` and fails the whole batch.)*
- **CloudWatch Logs `GetDataProtectionPolicy`** → HTTP 200 with `logGroupIdentifier`, no `policyDocument`. *(Real AWS returns `ResourceNotFoundException` / HTTP 400 when the resource doesn't exist; 200-empty is a deliberate simplification for read-only callers.)*

## Checklist
- [ ] `./mvnw test` passes locally (focused tests pass; full suite optional)
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits