### PR TITLE
feat(ses): publish SNS notifications to identity feedback topics

### DIFF
--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -31,7 +31,7 @@ Floci exposes the classic Amazon SES Query API used by `aws ses ...` commands an
 | `UpdateAccountSendingEnabled`       | Enable or disable account-wide sending                    |
 | `ListVerifiedEmailAddresses`        | List verified email identities                            |
 | `DeleteVerifiedEmailAddress`        | Delete a verified email identity                          |
-| `SetIdentityNotificationTopic`      | Store SNS notification topic ARNs for an identity         |
+| `SetIdentityNotificationTopic`      | Set the SNS topic for an identity's bounce/complaint/delivery notifications |
 | `GetIdentityNotificationAttributes` | Read stored notification topic settings                   |
 | `SetIdentityFeedbackForwardingEnabled`     | Toggle feedback forwarding for an identity        |
 | `SetIdentityHeadersInNotificationsEnabled` | Toggle headers-in-notifications per notification type |
@@ -154,8 +154,7 @@ curl $AWS_ENDPOINT_URL/_aws/ses
 
 - Identity verification succeeds immediately; no real DNS or inbox verification flow is required.
 - `SendEmail` stores the text body or the HTML body as the captured message body.
-- `SetIdentityNotificationTopic` stores SNS topic ARNs and returns them via `GetIdentityNotificationAttributes`.
-- Notification topics are configuration metadata only; SES delivery, bounce, or complaint events are not emitted automatically.
+- `SetIdentityNotificationTopic` publishes to the configured topic on a Bounce/Complaint/Delivery event (triggered via the mailbox simulator addresses or the suppression list), independent of any configuration set. The payload uses the legacy format (`notificationType`, no `mail.tags`, headers only when `SetIdentityHeadersInNotificationsEnabled` is on).
 - For the REST JSON API see [SES v2](#v2) below.
 
 ## SES v2 (REST JSON) {#v2}

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesEventPayload.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesEventPayload.java
@@ -40,11 +40,56 @@ final class SesEventPayload {
                             List<String> suppressionComplaintRecipients,
                             String configurationSetName, List<MessageTag> emailTags,
                             List<MessageHeader> additionalHeaders, Instant timestamp) {
+        return buildRoot(mapper, "eventType", eventType, messageId, source, sourceArn,
+                sendingAccountId, subject, toAddresses, ccAddresses, bccAddresses,
+                envelopeDestinations, suppressionBounceRecipients, suppressionComplaintRecipients,
+                configurationSetName, emailTags, additionalHeaders, timestamp, true, true);
+    }
+
+    /**
+     * Builds the legacy Amazon SNS notification JSON delivered to the per-identity feedback
+     * topics configured through {@code SetIdentityNotificationTopic}, matching the format at
+     * https://docs.aws.amazon.com/ses/latest/dg/notification-contents.html. It shares the
+     * {@code mail}/{@code bounce}/{@code complaint}/{@code delivery} blocks with the
+     * event-publishing payload from {@link #build} but differs in three spec-mandated ways:
+     * the top-level discriminator is named {@code notificationType} rather than {@code eventType};
+     * the {@code mail} object never carries a {@code tags} field; and the original headers
+     * ({@code headers}/{@code commonHeaders}/{@code headersTruncated}) appear only when the
+     * identity has headers-in-notifications enabled for the type ({@code includeHeaders}). Only
+     * the {@code BOUNCE}, {@code COMPLAINT}, and {@code DELIVERY} event types are ever published
+     * through this path.
+     */
+    static ObjectNode buildIdentityNotification(ObjectMapper mapper, String eventType,
+                            String messageId, String source, String sourceArn,
+                            String sendingAccountId, String subject,
+                            List<String> toAddresses, List<String> ccAddresses,
+                            List<String> bccAddresses, List<String> envelopeDestinations,
+                            List<String> suppressionBounceRecipients,
+                            List<String> suppressionComplaintRecipients,
+                            List<MessageHeader> additionalHeaders, Instant timestamp,
+                            boolean includeHeaders) {
+        return buildRoot(mapper, "notificationType", eventType, messageId, source, sourceArn,
+                sendingAccountId, subject, toAddresses, ccAddresses, bccAddresses,
+                envelopeDestinations, suppressionBounceRecipients, suppressionComplaintRecipients,
+                null, null, additionalHeaders, timestamp, includeHeaders, false);
+    }
+
+    private static ObjectNode buildRoot(ObjectMapper mapper, String typeField, String eventType,
+                            String messageId, String source, String sourceArn,
+                            String sendingAccountId, String subject,
+                            List<String> toAddresses, List<String> ccAddresses,
+                            List<String> bccAddresses, List<String> envelopeDestinations,
+                            List<String> suppressionBounceRecipients,
+                            List<String> suppressionComplaintRecipients,
+                            String configurationSetName, List<MessageTag> emailTags,
+                            List<MessageHeader> additionalHeaders, Instant timestamp,
+                            boolean includeHeaders, boolean includeTags) {
         ObjectNode root = mapper.createObjectNode();
-        root.put("eventType", eventTypeLabel(eventType));
+        root.put(typeField, eventTypeLabel(eventType));
         root.set("mail", buildMail(mapper, messageId, source, sourceArn, sendingAccountId,
                 subject, toAddresses, ccAddresses, bccAddresses, envelopeDestinations,
-                configurationSetName, emailTags, additionalHeaders, timestamp));
+                configurationSetName, emailTags, additionalHeaders, timestamp,
+                includeHeaders, includeTags));
         root.set(blockName(eventType),
                 buildEventBlock(mapper, eventType, messageId, envelopeDestinations,
                         suppressionBounceRecipients, suppressionComplaintRecipients, timestamp));
@@ -58,7 +103,8 @@ final class SesEventPayload {
                                         List<String> envelopeDestinations,
                                         String configurationSetName, List<MessageTag> emailTags,
                                         List<MessageHeader> additionalHeaders,
-                                        Instant timestamp) {
+                                        Instant timestamp, boolean includeHeaders,
+                                        boolean includeTags) {
         ObjectNode mail = mapper.createObjectNode();
         mail.put("timestamp", ISO_MILLIS.format(timestamp));
         if (source != null && !source.isBlank()) {
@@ -73,70 +119,74 @@ final class SesEventPayload {
         for (String d : envelopeDestinations) {
             dest.add(d);
         }
-        mail.put("headersTruncated", false);
-        ArrayNode headers = mail.putArray("headers");
-        if (source != null && !source.isBlank()) {
-            addHeader(headers, mapper, "From", source);
-        }
-        if (toAddresses != null && !toAddresses.isEmpty()) {
-            addHeader(headers, mapper, "To", String.join(", ", toAddresses));
-        }
-        if (ccAddresses != null && !ccAddresses.isEmpty()) {
-            addHeader(headers, mapper, "Cc", String.join(", ", ccAddresses));
-        }
-        if (subject != null && !subject.isEmpty()) {
-            addHeader(headers, mapper, "Subject", subject);
-        }
-        if (additionalHeaders != null) {
-            for (MessageHeader h : additionalHeaders) {
-                if (h == null || h.name() == null || h.name().isBlank()) {
-                    continue;
+        if (includeHeaders) {
+            mail.put("headersTruncated", false);
+            ArrayNode headers = mail.putArray("headers");
+            if (source != null && !source.isBlank()) {
+                addHeader(headers, mapper, "From", source);
+            }
+            if (toAddresses != null && !toAddresses.isEmpty()) {
+                addHeader(headers, mapper, "To", String.join(", ", toAddresses));
+            }
+            if (ccAddresses != null && !ccAddresses.isEmpty()) {
+                addHeader(headers, mapper, "Cc", String.join(", ", ccAddresses));
+            }
+            if (subject != null && !subject.isEmpty()) {
+                addHeader(headers, mapper, "Subject", subject);
+            }
+            if (additionalHeaders != null) {
+                for (MessageHeader h : additionalHeaders) {
+                    if (h == null || h.name() == null || h.name().isBlank()) {
+                        continue;
+                    }
+                    addHeader(headers, mapper, h.name(), h.value() == null ? "" : h.value());
                 }
-                addHeader(headers, mapper, h.name(), h.value() == null ? "" : h.value());
             }
-        }
-        ObjectNode common = mail.putObject("commonHeaders");
-        common.put("messageId", messageId);
-        common.put("date", RFC_5322_DATE.format(timestamp));
-        ArrayNode fromArr = common.putArray("from");
-        if (source != null && !source.isBlank()) {
-            fromArr.add(source);
-        }
-        ArrayNode toArr = common.putArray("to");
-        if (toAddresses != null) {
-            for (String a : toAddresses) {
-                toArr.add(a);
+            ObjectNode common = mail.putObject("commonHeaders");
+            common.put("messageId", messageId);
+            common.put("date", RFC_5322_DATE.format(timestamp));
+            ArrayNode fromArr = common.putArray("from");
+            if (source != null && !source.isBlank()) {
+                fromArr.add(source);
             }
-        }
-        if (ccAddresses != null && !ccAddresses.isEmpty()) {
-            ArrayNode ccArr = common.putArray("cc");
-            for (String a : ccAddresses) {
-                ccArr.add(a);
-            }
-        }
-        if (bccAddresses != null && !bccAddresses.isEmpty()) {
-            ArrayNode bccArr = common.putArray("bcc");
-            for (String a : bccAddresses) {
-                bccArr.add(a);
-            }
-        }
-        if (subject != null && !subject.isEmpty()) {
-            common.put("subject", subject);
-        }
-        ObjectNode tags = mail.putObject("tags");
-        if (configurationSetName != null) {
-            ArrayNode csTag = tags.putArray("ses:configuration-set");
-            csTag.add(configurationSetName);
-        }
-        if (emailTags != null) {
-            for (MessageTag t : emailTags) {
-                if (t == null || t.name() == null) {
-                    continue;
+            ArrayNode toArr = common.putArray("to");
+            if (toAddresses != null) {
+                for (String a : toAddresses) {
+                    toArr.add(a);
                 }
-                ArrayNode arr = tags.has(t.name())
-                        ? (ArrayNode) tags.get(t.name())
-                        : tags.putArray(t.name());
-                arr.add(t.value() == null ? "" : t.value());
+            }
+            if (ccAddresses != null && !ccAddresses.isEmpty()) {
+                ArrayNode ccArr = common.putArray("cc");
+                for (String a : ccAddresses) {
+                    ccArr.add(a);
+                }
+            }
+            if (bccAddresses != null && !bccAddresses.isEmpty()) {
+                ArrayNode bccArr = common.putArray("bcc");
+                for (String a : bccAddresses) {
+                    bccArr.add(a);
+                }
+            }
+            if (subject != null && !subject.isEmpty()) {
+                common.put("subject", subject);
+            }
+        }
+        if (includeTags) {
+            ObjectNode tags = mail.putObject("tags");
+            if (configurationSetName != null) {
+                ArrayNode csTag = tags.putArray("ses:configuration-set");
+                csTag.add(configurationSetName);
+            }
+            if (emailTags != null) {
+                for (MessageTag t : emailTags) {
+                    if (t == null || t.name() == null) {
+                        continue;
+                    }
+                    ArrayNode arr = tags.has(t.name())
+                            ? (ArrayNode) tags.get(t.name())
+                            : tags.putArray(t.name());
+                    arr.add(t.value() == null ? "" : t.value());
+                }
             }
         }
         return mail;

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesEventPublisher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesEventPublisher.java
@@ -96,6 +96,33 @@ public class SesEventPublisher {
         }
     }
 
+    /**
+     * Publishes a legacy Amazon SNS feedback notification to a single topic configured for an
+     * identity through {@code SetIdentityNotificationTopic}. Unlike {@link #publish}, this path
+     * is independent of any {@link ConfigurationSet} event destination: a verified identity with
+     * a Bounce/Complaint/Delivery topic receives notifications even when the send carries no
+     * configuration set. The payload uses the legacy {@code notificationType} discriminator, omits
+     * {@code mail.tags}, and includes the original headers only when {@code includeHeaders} is set
+     * (i.e. the identity has headers-in-notifications enabled for the type).
+     */
+    public void publishIdentityNotification(String topicArn, boolean includeHeaders, String eventType,
+                        String messageId, String source, String sourceArn, String sendingAccountId,
+                        String subject, List<String> toAddresses, List<String> ccAddresses,
+                        List<String> bccAddresses, List<String> envelopeDestinations,
+                        List<String> suppressionBounceRecipients,
+                        List<String> suppressionComplaintRecipients,
+                        List<MessageHeader> additionalHeaders, Instant timestamp, String defaultRegion) {
+        if (topicArn == null || topicArn.isBlank()) {
+            return;
+        }
+        ObjectNode payload = SesEventPayload.buildIdentityNotification(objectMapper, eventType,
+                messageId, source, sourceArn, sendingAccountId, subject,
+                toAddresses, ccAddresses, bccAddresses, envelopeDestinations,
+                suppressionBounceRecipients, suppressionComplaintRecipients,
+                additionalHeaders, timestamp, includeHeaders);
+        publishSns(topicArn, payload.toString(), defaultRegion);
+    }
+
     private void dispatch(EventDestination ed, String eventType, String payloadJson,
                           String sourceArn, String configurationSetName,
                           List<MessageTag> emailTags, List<MessageHeader> additionalHeaders,

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -245,10 +245,15 @@ public class SesService {
         }
         validateConfigurationSet(configurationSetName, region);
         boolean hasExplicitDestinations = destinations != null && !destinations.isEmpty();
-        boolean willPublishEvents = configurationSetName != null && !configurationSetName.isBlank();
-        SmtpRelay.RawMessageHeaders headers = (hasExplicitDestinations && !willPublishEvents)
+        boolean sourceOmitted = source == null || source.isBlank();
+        boolean willPublishEvents = (configurationSetName != null && !configurationSetName.isBlank())
+                || !resolveIdentityNotificationTargets(source, region).isEmpty();
+        SmtpRelay.RawMessageHeaders headers = (hasExplicitDestinations && !willPublishEvents && !sourceOmitted)
                 ? null
                 : SmtpRelay.parseRawHeaders(rawMessage);
+        String effectiveSource = sourceOmitted && headers != null && !headers.from().isBlank()
+                ? headers.from()
+                : source;
         List<String> effectiveDestinations = hasExplicitDestinations
                 ? destinations
                 : allRecipients(headers.to(), headers.cc(), headers.bcc());
@@ -257,21 +262,21 @@ public class SesService {
                     "At least one destination address is required.", 400);
         }
         String messageId = UUID.randomUUID().toString();
-        SentEmail email = new SentEmail(messageId, region, source, effectiveDestinations, rawMessage);
+        SentEmail email = new SentEmail(messageId, region, effectiveSource, effectiveDestinations, rawMessage);
         emailStore.put("email::" + region + "::" + messageId, email);
 
         Map<String, String> suppressedReasons = collectSuppressedReasons(effectiveDestinations, configurationSetName, region);
 
         List<String> relayedDestinations = filterUnsuppressed(effectiveDestinations, suppressedReasons);
         if (!relayedDestinations.isEmpty()) {
-            smtpRelay.relayRaw(source, relayedDestinations, rawMessage);
+            smtpRelay.relayRaw(effectiveSource, relayedDestinations, rawMessage);
         } else {
             LOG.infov("SES raw email accepted but not relayed (all recipients suppressed): messageId={0}",
                     messageId);
         }
 
-        LOG.infov("SES raw email sent: from={0}, messageId={1}", source, messageId);
-        publishSendEvents(configurationSetName, messageId, source,
+        LOG.infov("SES raw email sent: from={0}, messageId={1}", effectiveSource, messageId);
+        publishSendEvents(configurationSetName, messageId, effectiveSource,
                 headers != null ? headers.subject() : "",
                 headers != null ? headers.to() : List.of(),
                 headers != null ? headers.cc() : List.of(),
@@ -330,19 +335,22 @@ public class SesService {
                                    Map<String, String> suppressedReasons,
                                    List<MessageTag> emailTags,
                                    List<MessageHeader> additionalHeaders, String region) {
-        if (eventPublisher == null) {
+        if (eventPublisher == null || messageId == null) {
             return;
         }
-        if (configurationSetName == null || configurationSetName.isBlank() || messageId == null) {
-            return;
+        ConfigurationSet cs = null;
+        if (configurationSetName != null && !configurationSetName.isBlank()) {
+            cs = configSetStore.get(configSetKey(region, configurationSetName)).orElse(null);
+            if (cs == null) {
+                LOG.warnv("SES send references unknown ConfigurationSet <{0}>; configuration-set "
+                        + "events not published (identity notifications, if any, still apply).",
+                        configurationSetName);
+            }
         }
-        ConfigurationSet cs = configSetStore.get(configSetKey(region, configurationSetName)).orElse(null);
-        if (cs == null) {
-            LOG.warnv("SES send references unknown ConfigurationSet <{0}>; events not published.",
-                    configurationSetName);
-            return;
-        }
-        if (cs.getEventDestinations().isEmpty()) {
+        boolean configSetActive = cs != null && !cs.getEventDestinations().isEmpty();
+        Map<String, IdentityNotificationTarget> identityTargets =
+                resolveIdentityNotificationTargets(source, region);
+        if (!configSetActive && identityTargets.isEmpty()) {
             return;
         }
 
@@ -352,7 +360,8 @@ public class SesService {
         String sendingAccountId = defaultAccountId;
         String sourceArn = (source == null || source.isBlank())
                 ? null
-                : AwsArnUtils.Arn.of("ses", region, sendingAccountId, "identity/" + source).toString();
+                : AwsArnUtils.Arn.of("ses", region, sendingAccountId,
+                        "identity/" + extractEmailAddress(source)).toString();
 
         List<String> suppressionBounceRecipients = new ArrayList<>();
         List<String> suppressionComplaintRecipients = new ArrayList<>();
@@ -366,11 +375,81 @@ public class SesService {
 
         for (String eventType : determineSendEventTypes(envelope,
                 suppressionBounceRecipients, suppressionComplaintRecipients)) {
-            eventPublisher.publish(cs, eventType, messageId, source, sourceArn, sendingAccountId,
-                    subject, toAddresses, ccAddresses, bccAddresses, envelope,
-                    suppressionBounceRecipients, suppressionComplaintRecipients,
-                    emailTags, additionalHeaders, timestamp, region);
+            if (configSetActive) {
+                eventPublisher.publish(cs, eventType, messageId, source, sourceArn, sendingAccountId,
+                        subject, toAddresses, ccAddresses, bccAddresses, envelope,
+                        suppressionBounceRecipients, suppressionComplaintRecipients,
+                        emailTags, additionalHeaders, timestamp, region);
+            }
+            IdentityNotificationTarget target = identityTargets.get(eventType);
+            if (target != null) {
+                eventPublisher.publishIdentityNotification(target.topicArn(), target.includeHeaders(),
+                        eventType, messageId, source, sourceArn, sendingAccountId, subject,
+                        toAddresses, ccAddresses, bccAddresses, envelope, suppressionBounceRecipients,
+                        suppressionComplaintRecipients, additionalHeaders, timestamp, region);
+            }
         }
+    }
+
+    /**
+     * Resolves the SNS feedback notification target configured via {@code SetIdentityNotificationTopic}
+     * for the sending identity. The email-address identity's topic takes precedence over its parent
+     * domain identity's topic, per notification type; the headers-in-notifications flag is read from
+     * whichever identity supplied the topic. Returns a map keyed by the {@code SEND}-style event name
+     * ({@code BOUNCE}/{@code COMPLAINT}/{@code DELIVERY}) so it can be looked up directly against
+     * {@link #determineSendEventTypes}.
+     */
+    private Map<String, IdentityNotificationTarget> resolveIdentityNotificationTargets(String source,
+                                                                                       String region) {
+        Map<String, IdentityNotificationTarget> targets = new LinkedHashMap<>();
+        if (source == null || source.isBlank()) {
+            return targets;
+        }
+        String email = extractEmailAddress(source);
+        if (email.isBlank()) {
+            return targets;
+        }
+        Identity emailIdentity = identityStore.get(identityKey(region, email)).orElse(null);
+        Identity domainIdentity = null;
+        int at = email.indexOf('@');
+        if (at >= 0 && at < email.length() - 1) {
+            domainIdentity = identityStore.get(identityKey(region, email.substring(at + 1))).orElse(null);
+        }
+        for (String type : NOTIFICATION_TYPES) {
+            String topic = notificationTopicFor(emailIdentity, type);
+            Identity owner = emailIdentity;
+            if (topic == null) {
+                topic = notificationTopicFor(domainIdentity, type);
+                owner = domainIdentity;
+            }
+            if (topic == null) {
+                continue;
+            }
+            boolean includeHeaders = Boolean.TRUE.equals(
+                    owner.getHeadersInNotificationsEnabled().get(type));
+            targets.put(type.toUpperCase(Locale.ROOT),
+                    new IdentityNotificationTarget(topic, includeHeaders));
+        }
+        return targets;
+    }
+
+    private static String notificationTopicFor(Identity identity, String type) {
+        if (identity == null) {
+            return null;
+        }
+        String topic = identity.getNotificationAttributes().get(type + "Topic");
+        return topic != null && !topic.isBlank() ? topic : null;
+    }
+
+    private record IdentityNotificationTarget(String topicArn, boolean includeHeaders) {}
+
+    private static String extractEmailAddress(String source) {
+        int open = source.indexOf('<');
+        int close = source.indexOf('>', open + 1);
+        if (open >= 0 && close > open) {
+            return source.substring(open + 1, close).trim();
+        }
+        return source.trim();
     }
 
     private static List<String> determineSendEventTypes(List<String> destinations,

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SmtpRelay.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SmtpRelay.java
@@ -279,13 +279,14 @@ public class SmtpRelay {
     }
 
     /**
-     * Structured headers extracted from a raw RFC 5322 MIME message:
-     * subject and separate To / Cc / Bcc address lists. Empty fields when the
-     * corresponding header is missing.
+     * Structured headers extracted from a raw RFC 5322 MIME message: the From
+     * address, subject, and separate To / Cc / Bcc address lists. Empty fields
+     * when the corresponding header is missing.
      */
-    public record RawMessageHeaders(String subject, List<String> to, List<String> cc, List<String> bcc) {
+    public record RawMessageHeaders(String from, String subject,
+                                    List<String> to, List<String> cc, List<String> bcc) {
         public static RawMessageHeaders empty() {
-            return new RawMessageHeaders("", List.of(), List.of(), List.of());
+            return new RawMessageHeaders("", "", List.of(), List.of(), List.of());
         }
     }
 
@@ -303,13 +304,15 @@ public class SmtpRelay {
             var builder = new DefaultMessageBuilder();
             var message = builder.parseMessage(new ByteArrayInputStream(mimeBytes));
             String subject = message.getSubject() != null ? message.getSubject() : "";
+            List<String> from = message.getFrom() != null
+                    ? toMailboxAddresses(message.getFrom()) : List.of();
             List<String> to = message.getTo() != null
                     ? toMailboxAddresses(message.getTo().flatten()) : List.of();
             List<String> cc = message.getCc() != null
                     ? toMailboxAddresses(message.getCc().flatten()) : List.of();
             List<String> bcc = message.getBcc() != null
                     ? toMailboxAddresses(message.getBcc().flatten()) : List.of();
-            return new RawMessageHeaders(subject, to, cc, bcc);
+            return new RawMessageHeaders(from.isEmpty() ? "" : from.get(0), subject, to, cc, bcc);
         } catch (Exception e) {
             return RawMessageHeaders.empty();
         }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesIdentityNotificationTopicPublishV1IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesIdentityNotificationTopicPublishV1IntegrationTest.java
@@ -1,0 +1,389 @@
+package io.github.hectorvent.floci.services.ses;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end integration test for the legacy per-identity feedback notifications configured
+ * through {@code SetIdentityNotificationTopic}. A verified identity (or its parent domain) with
+ * a Bounce/Complaint/Delivery topic must receive an Amazon SNS notification when a matching
+ * event occurs on a send — independently of any configuration set. The delivered payload uses
+ * the legacy {@code notificationType} discriminator, not the event-publishing {@code eventType}.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesIdentityNotificationTopicPublishV1IntegrationTest {
+
+    private static final String SES_AUTH =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/ses/aws4_request";
+    private static final String SNS_AUTH =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/sns/aws4_request";
+    private static final String SQS_AUTH =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/sqs/aws4_request";
+    private static final String JSON_10 = "application/x-amz-json-1.0";
+    private static final String FORM = "application/x-www-form-urlencoded";
+
+    private static final String SENDER = "id-notif-sender@floci.test";
+    private static final String NO_TOPIC_SENDER = "id-notif-no-topic@floci.test";
+    private static final String FALLBACK_DOMAIN = "id-notif-domain.test";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static String queueUrl;
+    private static String queueArn;
+    private static String topicArn;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    @Order(1)
+    void setupQueueTopicAndSubscription() {
+        queueUrl = given()
+                .contentType(JSON_10)
+                .header("Authorization", SQS_AUTH)
+                .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+                .body("{\"QueueName\":\"ses-id-notif-queue\"}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200)
+                .extract().jsonPath().getString("QueueUrl");
+        assertNotNull(queueUrl);
+
+        queueArn = given()
+                .contentType(JSON_10)
+                .header("Authorization", SQS_AUTH)
+                .header("X-Amz-Target", "AmazonSQS.GetQueueAttributes")
+                .body("{\"QueueUrl\":\"" + queueUrl + "\",\"AttributeNames\":[\"All\"]}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200)
+                .extract().jsonPath().getString("Attributes.QueueArn");
+        assertNotNull(queueArn);
+
+        topicArn = given()
+                .contentType(JSON_10)
+                .header("Authorization", SNS_AUTH)
+                .header("X-Amz-Target", "SNS_20100331.CreateTopic")
+                .body("{\"Name\":\"ses-id-notif-topic\"}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200)
+                .extract().jsonPath().getString("TopicArn");
+        assertNotNull(topicArn);
+
+        given()
+                .contentType(JSON_10)
+                .header("Authorization", SNS_AUTH)
+                .header("X-Amz-Target", "SNS_20100331.Subscribe")
+                .body("{\"TopicArn\":\"" + topicArn + "\",\"Protocol\":\"sqs\",\"Endpoint\":\""
+                        + queueArn + "\"}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void setupIdentitiesAndNotificationTopics() {
+        verifyEmailIdentity(SENDER);
+        verifyEmailIdentity(NO_TOPIC_SENDER);
+        setIdentityNotificationTopic(SENDER, "Bounce", topicArn);
+        setIdentityNotificationTopic(SENDER, "Complaint", topicArn);
+
+        verifyDomainIdentity(FALLBACK_DOMAIN);
+        setIdentityNotificationTopic(FALLBACK_DOMAIN, "Bounce", topicArn);
+    }
+
+    @Test
+    @Order(3)
+    void bounceSimulator_publishesLegacyBounceNotificationToIdentityTopic() throws Exception {
+        drainQueue();
+        sendEmail(SENDER, "bounce@simulator.amazonses.com", "id-notif-bounce");
+
+        List<JsonNode> notifications = receiveNotifications(1);
+        assertEquals(1, notifications.size(), "expected one Bounce notification on the identity topic");
+        JsonNode bounce = notifications.get(0);
+        assertEquals("Bounce", bounce.path("notificationType").asText(),
+                "legacy identity notification must use notificationType, not eventType");
+        assertTrue(bounce.path("eventType").isMissingNode(),
+                "legacy identity notification must not carry the event-publishing eventType field");
+        JsonNode mail = bounce.path("mail");
+        assertEquals(SENDER, mail.path("source").asText());
+        assertEquals("bounce@simulator.amazonses.com",
+                bounce.path("bounce").path("bouncedRecipients").get(0).path("emailAddress").asText());
+        assertTrue(mail.path("tags").isMissingNode(),
+                "legacy identity notification mail object must never include a tags field");
+        assertTrue(mail.path("headers").isMissingNode(),
+                "headers must be omitted when headers-in-notifications is disabled (default)");
+        assertTrue(mail.path("commonHeaders").isMissingNode(),
+                "commonHeaders must be omitted when headers-in-notifications is disabled (default)");
+        assertTrue(mail.path("headersTruncated").isMissingNode(),
+                "headersTruncated must be omitted when headers-in-notifications is disabled (default)");
+    }
+
+    @Test
+    @Order(4)
+    void complaintSimulator_publishesLegacyComplaintNotificationToIdentityTopic() throws Exception {
+        drainQueue();
+        sendEmail(SENDER, "complaint@simulator.amazonses.com", "id-notif-complaint");
+
+        List<JsonNode> notifications = receiveNotifications(1);
+        assertEquals(1, notifications.size());
+        JsonNode complaint = notifications.get(0);
+        assertEquals("Complaint", complaint.path("notificationType").asText());
+        assertEquals("complaint@simulator.amazonses.com",
+                complaint.path("complaint").path("complainedRecipients").get(0).path("emailAddress").asText());
+    }
+
+    @Test
+    @Order(5)
+    void domainIdentityTopic_appliesToEmailWithoutItsOwnTopic() throws Exception {
+        drainQueue();
+        sendEmail("anyone@" + FALLBACK_DOMAIN, "bounce@simulator.amazonses.com", "id-notif-domain-fallback");
+
+        List<JsonNode> notifications = receiveNotifications(1);
+        assertEquals(1, notifications.size(),
+                "an unconfigured email identity must inherit its parent domain's Bounce topic");
+        assertEquals("Bounce", notifications.get(0).path("notificationType").asText());
+    }
+
+    @Test
+    @Order(6)
+    void identityWithoutTopic_andNoConfigSet_publishesNothing() throws Exception {
+        drainQueue();
+        sendEmail(NO_TOPIC_SENDER, "bounce@simulator.amazonses.com", "id-notif-none");
+
+        List<JsonNode> notifications = receiveNotifications(0);
+        assertTrue(notifications.isEmpty(),
+                "no identity topic and no configuration set should produce no notification");
+    }
+
+    @Test
+    @Order(7)
+    void headersInNotificationsEnabled_includesOriginalHeadersButStillNoTags() throws Exception {
+        setHeadersInNotificationsEnabled(SENDER, "Bounce", true);
+        drainQueue();
+        sendEmail(SENDER, "bounce@simulator.amazonses.com", "id-notif-with-headers");
+
+        List<JsonNode> notifications = receiveNotifications(1);
+        assertEquals(1, notifications.size());
+        JsonNode mail = notifications.get(0).path("mail");
+        assertFalse(mail.path("headers").isMissingNode(),
+                "headers must be present once headers-in-notifications is enabled for the type");
+        assertEquals("id-notif-with-headers", mail.path("commonHeaders").path("subject").asText());
+        assertFalse(mail.path("headersTruncated").asBoolean(true));
+        assertTrue(mail.path("tags").isMissingNode(),
+                "tags must never appear on a legacy identity notification, even with headers enabled");
+    }
+
+    @Test
+    @Order(8)
+    void displayNameSource_buildsSourceArnFromBareEmail() throws Exception {
+        drainQueue();
+        sendEmail("Sender Name <" + SENDER + ">", "bounce@simulator.amazonses.com", "id-notif-display-name");
+
+        List<JsonNode> notifications = receiveNotifications(1);
+        assertEquals(1, notifications.size());
+        assertEquals("arn:aws:ses:us-east-1:000000000000:identity/" + SENDER,
+                notifications.get(0).path("mail").path("sourceArn").asText(),
+                "sourceArn must be built from the bare email, not the display-name form");
+    }
+
+    @Test
+    @Order(9)
+    void sendRawEmailWithoutSource_resolvesIdentityFromMimeFrom() throws Exception {
+        drainQueue();
+        String raw = "From: " + SENDER + "\r\n"
+                + "To: bounce@simulator.amazonses.com\r\n"
+                + "Subject: id-notif-raw-from\r\n\r\nbody";
+        String rawB64 = Base64.getEncoder().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+        given()
+                .contentType(FORM)
+                .header("Authorization", SES_AUTH)
+                .body("Action=SendRawEmail"
+                        + "&RawMessage.Data=" + URLEncoder.encode(rawB64, StandardCharsets.UTF_8)
+                        + "&Version=2010-12-01")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200);
+
+        List<JsonNode> notifications = receiveNotifications(1);
+        assertEquals(1, notifications.size(),
+                "identity topic must fire even when Source is omitted and From comes from the MIME body");
+        JsonNode bounce = notifications.get(0);
+        assertEquals("Bounce", bounce.path("notificationType").asText());
+        assertEquals(SENDER, bounce.path("mail").path("source").asText());
+    }
+
+    private void verifyEmailIdentity(String email) {
+        given()
+                .contentType(FORM)
+                .header("Authorization", SES_AUTH)
+                .body("Action=VerifyEmailIdentity&EmailAddress="
+                        + URLEncoder.encode(email, StandardCharsets.UTF_8) + "&Version=2010-12-01")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200);
+    }
+
+    private void verifyDomainIdentity(String domain) {
+        given()
+                .contentType(FORM)
+                .header("Authorization", SES_AUTH)
+                .body("Action=VerifyDomainIdentity&Domain="
+                        + URLEncoder.encode(domain, StandardCharsets.UTF_8) + "&Version=2010-12-01")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200);
+    }
+
+    private void setIdentityNotificationTopic(String identity, String notificationType, String snsTopic) {
+        given()
+                .contentType(FORM)
+                .header("Authorization", SES_AUTH)
+                .body("Action=SetIdentityNotificationTopic"
+                        + "&Identity=" + URLEncoder.encode(identity, StandardCharsets.UTF_8)
+                        + "&NotificationType=" + notificationType
+                        + "&SnsTopic=" + URLEncoder.encode(snsTopic, StandardCharsets.UTF_8)
+                        + "&Version=2010-12-01")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200);
+    }
+
+    private void setHeadersInNotificationsEnabled(String identity, String notificationType, boolean enabled) {
+        given()
+                .contentType(FORM)
+                .header("Authorization", SES_AUTH)
+                .body("Action=SetIdentityHeadersInNotificationsEnabled"
+                        + "&Identity=" + URLEncoder.encode(identity, StandardCharsets.UTF_8)
+                        + "&NotificationType=" + notificationType
+                        + "&Enabled=" + enabled
+                        + "&Version=2010-12-01")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200);
+    }
+
+    private void sendEmail(String source, String to, String subject) {
+        given()
+                .contentType(FORM)
+                .header("Authorization", SES_AUTH)
+                .body("Action=SendEmail"
+                        + "&Source=" + URLEncoder.encode(source, StandardCharsets.UTF_8)
+                        + "&Destination.ToAddresses.member.1="
+                        + URLEncoder.encode(to, StandardCharsets.UTF_8)
+                        + "&Message.Subject.Data=" + URLEncoder.encode(subject, StandardCharsets.UTF_8)
+                        + "&Message.Body.Text.Data=hi"
+                        + "&Version=2010-12-01")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200);
+    }
+
+    private void drainQueue() {
+        for (int i = 0; i < 5; i++) {
+            Response r = given()
+                    .contentType(JSON_10)
+                    .header("Authorization", SQS_AUTH)
+                    .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+                    .body("{\"QueueUrl\":\"" + queueUrl
+                            + "\",\"MaxNumberOfMessages\":10,\"WaitTimeSeconds\":0}")
+            .when()
+                    .post("/")
+            .then()
+                    .statusCode(200)
+                    .extract().response();
+            List<String> handles = r.jsonPath().getList("Messages.ReceiptHandle");
+            if (handles == null || handles.isEmpty()) {
+                return;
+            }
+            deleteMessages(handles);
+        }
+    }
+
+    private List<JsonNode> receiveNotifications(int expectedAtLeast) throws Exception {
+        List<JsonNode> notifications = new ArrayList<>();
+        int maxAttempts = expectedAtLeast > 0 ? 10 : 2;
+        for (int attempt = 0; attempt < maxAttempts; attempt++) {
+            if (expectedAtLeast > 0 && notifications.size() >= expectedAtLeast) {
+                break;
+            }
+            Response r = given()
+                    .contentType(JSON_10)
+                    .header("Authorization", SQS_AUTH)
+                    .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+                    .body("{\"QueueUrl\":\"" + queueUrl
+                            + "\",\"MaxNumberOfMessages\":10,\"WaitTimeSeconds\":1}")
+            .when()
+                    .post("/")
+            .then()
+                    .statusCode(200)
+                    .extract().response();
+            List<String> bodies = r.jsonPath().getList("Messages.Body");
+            List<String> handles = r.jsonPath().getList("Messages.ReceiptHandle");
+            if (bodies == null || bodies.isEmpty()) {
+                continue;
+            }
+            for (String body : bodies) {
+                JsonNode snsWrapper = MAPPER.readTree(body);
+                notifications.add(MAPPER.readTree(snsWrapper.path("Message").asText()));
+            }
+            deleteMessages(handles);
+        }
+        return notifications;
+    }
+
+    private void deleteMessages(List<String> receiptHandles) {
+        StringBuilder entries = new StringBuilder();
+        for (int i = 0; i < receiptHandles.size(); i++) {
+            if (i > 0) {
+                entries.append(",");
+            }
+            entries.append("{\"Id\":\"m").append(i).append("\",\"ReceiptHandle\":\"")
+                    .append(receiptHandles.get(i)).append("\"}");
+        }
+        given()
+                .contentType(JSON_10)
+                .header("Authorization", SQS_AUTH)
+                .header("X-Amz-Target", "AmazonSQS.DeleteMessageBatch")
+                .body("{\"QueueUrl\":\"" + queueUrl + "\",\"Entries\":[" + entries + "]}")
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200);
+    }
+}


### PR DESCRIPTION
## Summary

`SetIdentityNotificationTopic` previously only stored the SNS topic ARN per identity and echoed it back via `GetIdentityNotificationAttributes` — no notification was ever published. This PR wires those topics into the send path: a verified identity (or its parent domain) with a Bounce/Complaint/Delivery topic now receives an Amazon SNS notification when a matching event occurs, independently of any configuration set.

- `SesEventPayload`: added `buildIdentityNotification(...)`, sharing the `mail`/`bounce`/`complaint`/`delivery` blocks with event publishing via a common `buildRoot(...)`, but emitting the legacy notification format.
- `SesEventPublisher`: added `publishIdentityNotification(...)`, independent of configuration-set event destinations.
- `SesService`: `publishSendEvents` now resolves the sending identity's topics (email-address identity taking precedence over its parent domain) and publishes alongside any configuration-set destinations, even when no configuration set is present. The sending identity is resolved from the bare email address (so a display-name `Source` yields a valid `identity/<email>` ARN), and `SendRawEmail` falls back to the MIME `From` header when `Source` is omitted.
- `docs/services/ses.md`: documented the behavior.

The legacy notification format differs from event publishing in three spec-mandated ways, all honored here: the top-level discriminator is `notificationType` (not `eventType`); the `mail` object omits the `tags` field; and the original headers (`headers`/`commonHeaders`/`headersTruncated`) are included only when the identity has headers-in-notifications enabled for that notification type (`SetIdentityHeadersInNotificationsEnabled`).

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The payload shape was verified against the AWS documentation for [Amazon SNS notification contents for Amazon SES](https://docs.aws.amazon.com/ses/latest/dg/notification-contents.html) and cross-checked against the [event publishing SNS contents](https://docs.aws.amazon.com/ses/latest/dg/event-publishing-retrieving-sns-contents.html) to isolate the three legacy-vs-event-publishing differences listed above. The integration test drives the classic SES (`2010-12-01`) Query API — `VerifyEmailIdentity`, `VerifyDomainIdentity`, `SetIdentityNotificationTopic`, `SetIdentityHeadersInNotificationsEnabled`, `SendEmail`, `SendRawEmail` — and asserts the legacy `notificationType` form is delivered, that `mail.tags` is never present, and that headers appear only once headers-in-notifications is enabled. Verified end-to-end against a running instance (SES SendEmail -> SNS topic -> SQS) for Bounce, Complaint, and Delivery, with no regression to configuration-set event publishing.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
