### PR TITLE
feat(secretsmanager): support Filters for BatchGetSecretValue

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
@@ -69,8 +69,17 @@ public class SecretsManagerJsonHandler {
             request.path("SecretIdList").forEach(id -> secretIdList.add(id.asText()));
         }
 
-        // Filters are not fully implemented yet, but for now we only support SecretIdList
-        List<SecretsManagerService.BatchSecretValue> values = service.batchGetSecretValue(secretIdList, region);
+        List<SecretsManagerService.Filter> filters = new ArrayList<>();
+        if (request.has("Filters")) {
+            for (JsonNode filterNode : request.get("Filters")) {
+                String key = filterNode.path("Key").asText(null);
+                List<String> values = new ArrayList<>();
+                filterNode.path("Values").forEach(v -> values.add(v.asText()));
+                filters.add(new SecretsManagerService.Filter(key, values));
+            }
+        }
+
+        List<SecretsManagerService.BatchSecretValue> values = service.batchGetSecretValue(secretIdList, filters, region);
 
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode secretValues = objectMapper.createArrayNode();

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
@@ -25,8 +25,10 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -38,6 +40,19 @@ public class SecretsManagerService {
     private static final String AWSCURRENT = "AWSCURRENT";
     private static final String AWSPREVIOUS = "AWSPREVIOUS";
     private static final String ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+    static final String FILTER_KEY_NAME = "name";
+    static final String FILTER_KEY_DESCRIPTION = "description";
+    static final String FILTER_KEY_TAG_KEY = "tag-key";
+    static final String FILTER_KEY_TAG_VALUE = "tag-value";
+    static final String FILTER_KEY_PRIMARY_REGION = "primary-region";
+    static final String FILTER_KEY_OWNING_SERVICE = "owning-service";
+    static final String FILTER_KEY_ALL = "all";
+    private static final Set<String> ALLOWED_FILTER_KEYS = Set.of(
+            FILTER_KEY_NAME, FILTER_KEY_DESCRIPTION, FILTER_KEY_TAG_KEY,
+            FILTER_KEY_TAG_VALUE, FILTER_KEY_PRIMARY_REGION,
+            FILTER_KEY_OWNING_SERVICE, FILTER_KEY_ALL);
+    private static final String NEGATION_PREFIX = "!";
 
     private final StorageBackend<String, Secret> store;
     private final int defaultRecoveryWindowDays;
@@ -488,38 +503,153 @@ public class SecretsManagerService {
     }
 
     public List<BatchSecretValue> batchGetSecretValue(List<String> secretIdList, String region) {
+        return batchGetSecretValue(secretIdList, null, region);
+    }
+
+    public List<BatchSecretValue> batchGetSecretValue(List<String> secretIdList,
+                                                      List<Filter> filters,
+                                                      String region) {
+        boolean hasIds = secretIdList != null && !secretIdList.isEmpty();
+        boolean hasFilters = filters != null && !filters.isEmpty();
+        if (hasIds && hasFilters) {
+            throw new AwsException("InvalidParameterException",
+                    "Either SecretIdList or Filters must be provided, but not both.", 400);
+        }
+        if (hasFilters) {
+            validateFilters(filters);
+            return batchGetByFilters(filters, region);
+        }
+        return batchGetByIds(secretIdList, region);
+    }
+
+    private List<BatchSecretValue> batchGetByIds(List<String> secretIdList, String region) {
         List<BatchSecretValue> result = new ArrayList<>();
         if (secretIdList == null) {
             return result;
         }
-
         for (String secretId : secretIdList) {
-            try {
-                Secret secret = resolveSecret(secretId, region);
-                if (secret.getDeletedDate() != null) {
-                    continue;
-                }
-                SecretVersion version = findVersionByStage(secret, AWSCURRENT);
-                if (version != null) {
-                    result.add(new BatchSecretValue(
-                            secret.getArn(),
-                            secret.getName(),
-                            version.getSecretString(),
-                            version.getSecretBinary(),
-                            version.getVersionId(),
-                            version.getVersionStages(),
-                            version.getCreatedDate()
-                    ));
-                }
-            } catch (AwsException e) {
-                // AWS documentation says: "Secrets Manager doesn't return an error if a secret in the SecretIdList doesn't exist."
-                // Wait, let me re-check that. 
-                // Actually, "If any of the secrets in the SecretIdList don't exist, Secrets Manager returns an error."
-                // Let me verify this in the AWS docs.
-                throw e;
+            Secret secret = resolveSecret(secretId, region);
+            if (secret.getDeletedDate() != null) {
+                continue;
+            }
+            addCurrentVersion(result, secret);
+        }
+        return result;
+    }
+
+    private List<BatchSecretValue> batchGetByFilters(List<Filter> filters, String region) {
+        List<BatchSecretValue> result = new ArrayList<>();
+        String prefix = region + "::";
+        List<Secret> candidates = store.scan(key -> key.startsWith(prefix));
+        for (Secret secret : candidates) {
+            if (secret.getDeletedDate() != null) {
+                continue;
+            }
+            if (matchesAllFilters(secret, filters, region)) {
+                addCurrentVersion(result, secret);
             }
         }
         return result;
+    }
+
+    private void addCurrentVersion(List<BatchSecretValue> result, Secret secret) {
+        SecretVersion version = findVersionByStage(secret, AWSCURRENT);
+        if (version == null) {
+            return;
+        }
+        result.add(new BatchSecretValue(
+                secret.getArn(),
+                secret.getName(),
+                version.getSecretString(),
+                version.getSecretBinary(),
+                version.getVersionId(),
+                version.getVersionStages(),
+                version.getCreatedDate()
+        ));
+    }
+
+    private static void validateFilters(List<Filter> filters) {
+        for (Filter filter : filters) {
+            if (filter == null || filter.key() == null || filter.key().isEmpty()) {
+                throw new AwsException("InvalidParameterException",
+                        "Filter Key is required.", 400);
+            }
+            if (!ALLOWED_FILTER_KEYS.contains(filter.key())) {
+                throw new AwsException("ValidationException",
+                        "1 validation error detected: Value '" + filter.key()
+                                + "' at 'filters' failed to satisfy constraint: Member must satisfy enum value set: "
+                                + ALLOWED_FILTER_KEYS, 400);
+            }
+            if (filter.values() == null || filter.values().isEmpty()) {
+                throw new AwsException("InvalidParameterException",
+                        "Filter Values must not be empty for key '" + filter.key() + "'.", 400);
+            }
+        }
+    }
+
+    private static boolean matchesAllFilters(Secret secret, List<Filter> filters, String region) {
+        for (Filter filter : filters) {
+            if (!matchesFilter(secret, filter, region)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean matchesFilter(Secret secret, Filter filter, String region) {
+        for (String rawValue : filter.values()) {
+            if (rawValue == null) {
+                continue;
+            }
+            boolean negate = rawValue.startsWith(NEGATION_PREFIX);
+            String value = negate ? rawValue.substring(NEGATION_PREFIX.length()) : rawValue;
+            if (value.isEmpty()) {
+                continue;
+            }
+            boolean hit = matchesValue(secret, filter.key(), value, region);
+            if (negate ? !hit : hit) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean matchesValue(Secret secret, String key, String value, String region) {
+        return switch (key) {
+            case FILTER_KEY_NAME -> startsWithIgnoreCase(secret.getName(), value);
+            case FILTER_KEY_DESCRIPTION -> startsWithIgnoreCase(secret.getDescription(), value);
+            case FILTER_KEY_TAG_KEY -> anyTag(secret, tag -> startsWithIgnoreCase(tag.key(), value));
+            case FILTER_KEY_TAG_VALUE -> anyTag(secret, tag -> startsWithIgnoreCase(tag.value(), value));
+            case FILTER_KEY_PRIMARY_REGION -> startsWithIgnoreCase(region, value);
+            case FILTER_KEY_OWNING_SERVICE -> false;
+            case FILTER_KEY_ALL -> startsWithIgnoreCase(secret.getName(), value)
+                    || startsWithIgnoreCase(secret.getDescription(), value)
+                    || anyTag(secret, tag -> startsWithIgnoreCase(tag.key(), value))
+                    || anyTag(secret, tag -> startsWithIgnoreCase(tag.value(), value));
+            default -> false;
+        };
+    }
+
+    private static boolean anyTag(Secret secret, java.util.function.Predicate<Secret.Tag> predicate) {
+        if (secret.getTags() == null) {
+            return false;
+        }
+        for (Secret.Tag tag : secret.getTags()) {
+            if (tag != null && predicate.test(tag)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean startsWithIgnoreCase(String haystack, String needle) {
+        if (haystack == null || needle == null) {
+            return false;
+        }
+        return haystack.toLowerCase(Locale.ROOT).startsWith(needle.toLowerCase(Locale.ROOT));
+    }
+
+    public record Filter(String key, List<String> values) {
     }
 
     public Secret updateSecretVersionStage(String secretId, String moveToVersionId, String removeFromVersionId, String versionStage, String region) {

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.secretsmanager;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import jakarta.ws.rs.core.Response;
@@ -321,5 +322,62 @@ class SecretsManagerJsonHandlerTest {
         assertThat(body.has("RotationRules"), is(true));
         assertThat(body.get("RotationRules").get("AutomaticallyAfterDays").asInt(), is(45));
         assertThat(body.get("RotationRules").get("Duration").asText(), is("2h"));
+    }
+
+    @Test
+    void batchGetSecretValueByFilterReturnsMatchingSecrets() {
+        ObjectNode createReq1 = MAPPER.createObjectNode();
+        createReq1.put("Name", "production/db");
+        createReq1.put("SecretString", "prod-pass");
+        handler.handle("CreateSecret", createReq1, REGION);
+
+        ObjectNode createReq2 = MAPPER.createObjectNode();
+        createReq2.put("Name", "staging/db");
+        createReq2.put("SecretString", "stage-pass");
+        handler.handle("CreateSecret", createReq2, REGION);
+
+        ObjectNode batchReq = MAPPER.createObjectNode();
+        ArrayNode filters = batchReq.putArray("Filters");
+        ObjectNode nameFilter = filters.addObject();
+        nameFilter.put("Key", "name");
+        nameFilter.putArray("Values").add("production/");
+
+        Response response = handler.handle("BatchGetSecretValue", batchReq, REGION);
+
+        assertThat(response.getStatus(), is(200));
+        ObjectNode body = (ObjectNode) response.getEntity();
+        assertThat(body.get("SecretValues").size(), is(1));
+        assertThat(body.get("SecretValues").get(0).get("Name").asText(), is("production/db"));
+        assertThat(body.get("SecretValues").get(0).get("SecretString").asText(), is("prod-pass"));
+    }
+
+    @Test
+    void batchGetSecretValueByTagKeyFilterReturnsMatchingSecrets() {
+        ObjectNode createTagged = MAPPER.createObjectNode();
+        createTagged.put("Name", "tagged-secret");
+        createTagged.put("SecretString", "tagged-value");
+        ArrayNode tags = createTagged.putArray("Tags");
+        ObjectNode tag = tags.addObject();
+        tag.put("Key", "env");
+        tag.put("Value", "prod");
+        handler.handle("CreateSecret", createTagged, REGION);
+
+        ObjectNode createUntagged = MAPPER.createObjectNode();
+        createUntagged.put("Name", "untagged-secret");
+        createUntagged.put("SecretString", "untagged-value");
+        handler.handle("CreateSecret", createUntagged, REGION);
+
+        ObjectNode batchReq = MAPPER.createObjectNode();
+        ArrayNode filters = batchReq.putArray("Filters");
+        ObjectNode tagFilter = filters.addObject();
+        tagFilter.put("Key", "tag-key");
+        tagFilter.putArray("Values").add("env");
+
+        Response response = handler.handle("BatchGetSecretValue", batchReq, REGION);
+
+        assertThat(response.getStatus(), is(200));
+        ObjectNode body = (ObjectNode) response.getEntity();
+        assertThat(body.get("SecretValues").size(), is(1));
+        assertThat(body.get("SecretValues").get(0).get("Name").asText(), is("tagged-secret"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
@@ -362,6 +362,204 @@ class SecretsManagerServiceTest {
     }
 
     @Test
+    void batchGetSecretValueByNameFilterReturnsPrefixMatches() {
+        service.createSecret("production/db", "prod-pass", null, null, null, null, REGION);
+        service.createSecret("production/api", "prod-api", null, null, null, null, REGION);
+        service.createSecret("staging/db", "stage-pass", null, null, null, null, REGION);
+
+        List<SecretsManagerService.BatchSecretValue> values = service.batchGetSecretValue(
+                null,
+                List.of(new SecretsManagerService.Filter("name", List.of("production/"))),
+                REGION);
+
+        assertEquals(2, values.size());
+        assertTrue(values.stream().allMatch(v -> v.name().startsWith("production/")));
+    }
+
+    @Test
+    void batchGetSecretValueByNameFilterIsCaseInsensitive() {
+        service.createSecret("ProductionDb", "prod-pass", null, null, null, null, REGION);
+
+        List<SecretsManagerService.BatchSecretValue> values = service.batchGetSecretValue(
+                null,
+                List.of(new SecretsManagerService.Filter("name", List.of("PRODUCTION"))),
+                REGION);
+
+        assertEquals(1, values.size());
+        assertEquals("ProductionDb", values.getFirst().name());
+    }
+
+    @Test
+    void batchGetSecretValueByDescriptionFilter() {
+        service.createSecret("alpha", "v1", null, "Primary RDS credentials", null, null, REGION);
+        service.createSecret("beta", "v2", null, "Cache token", null, null, REGION);
+
+        List<SecretsManagerService.BatchSecretValue> values = service.batchGetSecretValue(
+                null,
+                List.of(new SecretsManagerService.Filter("description", List.of("Primary"))),
+                REGION);
+
+        assertEquals(1, values.size());
+        assertEquals("alpha", values.getFirst().name());
+    }
+
+    @Test
+    void batchGetSecretValueByTagKeyFilter() {
+        service.createSecret("tagged", "v1", null, null, null,
+                List.of(new Secret.Tag("env", "prod")), REGION);
+        service.createSecret("untagged", "v2", null, null, null, null, REGION);
+
+        List<SecretsManagerService.BatchSecretValue> values = service.batchGetSecretValue(
+                null,
+                List.of(new SecretsManagerService.Filter("tag-key", List.of("env"))),
+                REGION);
+
+        assertEquals(1, values.size());
+        assertEquals("tagged", values.getFirst().name());
+    }
+
+    @Test
+    void batchGetSecretValueByTagValueFilter() {
+        service.createSecret("prodSecret", "v1", null, null, null,
+                List.of(new Secret.Tag("env", "prod")), REGION);
+        service.createSecret("devSecret", "v2", null, null, null,
+                List.of(new Secret.Tag("env", "dev")), REGION);
+
+        List<SecretsManagerService.BatchSecretValue> values = service.batchGetSecretValue(
+                null,
+                List.of(new SecretsManagerService.Filter("tag-value", List.of("prod"))),
+                REGION);
+
+        assertEquals(1, values.size());
+        assertEquals("prodSecret", values.getFirst().name());
+    }
+
+    @Test
+    void batchGetSecretValueByAllFilterMatchesNameOrTag() {
+        service.createSecret("namedMatch", "v1", null, null, null, null, REGION);
+        service.createSecret("otherSecret", "v2", null, null, null,
+                List.of(new Secret.Tag("environment", "namedSomething")), REGION);
+        service.createSecret("unrelated", "v3", null, null, null, null, REGION);
+
+        List<SecretsManagerService.BatchSecretValue> values = service.batchGetSecretValue(
+                null,
+                List.of(new SecretsManagerService.Filter("all", List.of("named"))),
+                REGION);
+
+        assertEquals(2, values.size());
+        assertTrue(values.stream().anyMatch(v -> "namedMatch".equals(v.name())));
+        assertTrue(values.stream().anyMatch(v -> "otherSecret".equals(v.name())));
+    }
+
+    @Test
+    void batchGetSecretValueFilterValuesAreOrCombined() {
+        service.createSecret("prodApi", "v1", null, null, null, null, REGION);
+        service.createSecret("stagingApi", "v2", null, null, null, null, REGION);
+        service.createSecret("devApi", "v3", null, null, null, null, REGION);
+
+        List<SecretsManagerService.BatchSecretValue> values = service.batchGetSecretValue(
+                null,
+                List.of(new SecretsManagerService.Filter("name", List.of("prod", "staging"))),
+                REGION);
+
+        assertEquals(2, values.size());
+        assertTrue(values.stream().anyMatch(v -> "prodApi".equals(v.name())));
+        assertTrue(values.stream().anyMatch(v -> "stagingApi".equals(v.name())));
+    }
+
+    @Test
+    void batchGetSecretValueMultipleFiltersAreAndCombined() {
+        service.createSecret("prodWithTag", "v1", null, null, null,
+                List.of(new Secret.Tag("env", "prod")), REGION);
+        service.createSecret("prodNoTag", "v2", null, null, null, null, REGION);
+        service.createSecret("devWithTag", "v3", null, null, null,
+                List.of(new Secret.Tag("env", "dev")), REGION);
+
+        List<SecretsManagerService.BatchSecretValue> values = service.batchGetSecretValue(
+                null,
+                List.of(
+                        new SecretsManagerService.Filter("name", List.of("prod")),
+                        new SecretsManagerService.Filter("tag-key", List.of("env"))),
+                REGION);
+
+        assertEquals(1, values.size());
+        assertEquals("prodWithTag", values.getFirst().name());
+    }
+
+    @Test
+    void batchGetSecretValueNegationPrefixExcludes() {
+        service.createSecret("prodAlpha", "v1", null, null, null, null, REGION);
+        service.createSecret("stagingAlpha", "v2", null, null, null, null, REGION);
+
+        List<SecretsManagerService.BatchSecretValue> values = service.batchGetSecretValue(
+                null,
+                List.of(new SecretsManagerService.Filter("name", List.of("!prod"))),
+                REGION);
+
+        assertEquals(1, values.size());
+        assertEquals("stagingAlpha", values.getFirst().name());
+    }
+
+    @Test
+    void batchGetSecretValueFilterSkipsDeletedSecrets() {
+        service.createSecret("prodAlpha", "v1", null, null, null, null, REGION);
+        service.createSecret("prodBeta", "v2", null, null, null, null, REGION);
+        service.deleteSecret("prodAlpha", 7, false, REGION);
+
+        List<SecretsManagerService.BatchSecretValue> values = service.batchGetSecretValue(
+                null,
+                List.of(new SecretsManagerService.Filter("name", List.of("prod"))),
+                REGION);
+
+        assertEquals(1, values.size());
+        assertEquals("prodBeta", values.getFirst().name());
+    }
+
+    @Test
+    void batchGetSecretValueFilterIsScopedToRegion() {
+        service.createSecret("regional", "v1", null, null, null, null, REGION);
+        service.createSecret("regional", "v2", null, null, null, null, "eu-west-1");
+
+        List<SecretsManagerService.BatchSecretValue> values = service.batchGetSecretValue(
+                null,
+                List.of(new SecretsManagerService.Filter("name", List.of("regional"))),
+                REGION);
+
+        assertEquals(1, values.size());
+        assertEquals("v1", values.getFirst().secretString());
+    }
+
+    @Test
+    void batchGetSecretValueRejectsBothSecretIdListAndFilters() {
+        service.createSecret("alpha", "v1", null, null, null, null, REGION);
+        assertThrows(AwsException.class, () ->
+                service.batchGetSecretValue(
+                        List.of("alpha"),
+                        List.of(new SecretsManagerService.Filter("name", List.of("alpha"))),
+                        REGION));
+    }
+
+    @Test
+    void batchGetSecretValueRejectsUnknownFilterKey() {
+        service.createSecret("alpha", "v1", null, null, null, null, REGION);
+        assertThrows(AwsException.class, () ->
+                service.batchGetSecretValue(
+                        null,
+                        List.of(new SecretsManagerService.Filter("not-a-real-key", List.of("alpha"))),
+                        REGION));
+    }
+
+    @Test
+    void batchGetSecretValueRejectsEmptyFilterValues() {
+        service.createSecret("alpha", "v1", null, null, null, null, REGION);
+        assertThrows(AwsException.class, () ->
+                service.batchGetSecretValue(
+                        null,
+                        List.of(new SecretsManagerService.Filter("name", List.of())),
+                        REGION));
+    }
+
+    @Test
     void getSecretValueByPartialArnSucceeds() {
         Secret secret = service.createSecret("my-secret", "value", null, null, null, null, REGION);
         // Full ARN: arn:aws:secretsmanager:us-east-1:000000000000:secret:my-secret-XXXXXX


### PR DESCRIPTION
## What

`BatchGetSecretValue` previously accepted only `SecretIdList`; any `Filters` in the request were silently ignored (the handler had a `// Filters are not fully implemented yet` placeholder). This implements the documented `Filters` API.

Resolves issue 1267.

## Behavior

- Supported filter keys: `name`, `description`, `tag-key`, `tag-value`, `primary-region`, `owning-service`, `all`.
- Prefix match, case-insensitive (AWS semantics).
- `!` negation prefix on a value excludes matches.
- Values within one filter are **OR**-combined; multiple filters are **AND**-combined.
- `SecretIdList` and `Filters` are mutually exclusive → `InvalidParameterException`.
- Unknown filter keys and empty value lists are rejected.
- Results are scoped to the request region; deleted secrets are skipped.
- `owning-service` matches nothing (the emulator has no managed/service-owned secrets) — kept as a recognized key for API compatibility.

## Test verification (RED → GREEN)

16 new tests (13 service-level, 3 handler-level — name/description/tag-key/tag-value/all/region-scope/negation/OR/AND/deleted-skip/mutual-exclusion/unknown-key/empty-values).

**RED** — feature reverted (filtering disabled, API kept so tests compile):

```
[ERROR] Tests run: 25, Failures: 2 -- SecretsManagerJsonHandlerTest
[ERROR] Tests run: 63, Failures: 13 -- SecretsManagerServiceTest
  batchGetSecretValueByNameFilterReturnsPrefixMatches  expected: <2> but was: <0>
  batchGetSecretValueByTagKeyFilter                    expected: <1> but was: <0>
  batchGetSecretValueByAllFilterMatchesNameOrTag       expected: <2> but was: <0>
  batchGetSecretValueFilterIsScopedToRegion            expected: <1> but was: <0>
  ... (15 filter tests fail; all pre-existing tests still pass)
```

**GREEN** — with the fix:

```
[INFO] Tests run: 25, Failures: 0, Errors: 0, Skipped: 0 -- SecretsManagerJsonHandlerTest
[INFO] Tests run: 63, Failures: 0, Errors: 0, Skipped: 0 -- SecretsManagerServiceTest
[INFO] BUILD SUCCESS
```
