### PR TITLE
fix(floci-ui): report real sidecar-start failures instead of always blaming the image

### DIFF
--- a/docs/configuration/docker.md
+++ b/docs/configuration/docker.md
@@ -132,7 +132,7 @@ podman network create floci-net
 podman run -d --name floci \
   --network floci-net \
   -p 4566:4566 \
-  -v /run/user/$(id -u)/podman/podman.sock:/var/run/docker.sock:Z \
+  -v /run/user/$(id -u)/podman/podman.sock:/var/run/docker.sock:z \
   -e FLOCI_SERVICES_LAMBDA_DOCKER_NETWORK=floci-net \
   -e FLOCI_HOSTNAME=floci \
   floci/floci
@@ -147,9 +147,14 @@ What each setting does and why it is needed:
   Lambda containers it spawns to that same named network.
 - **`FLOCI_HOSTNAME=floci`** — gives Floci a stable name that Lambda containers
   resolve when calling back to the Runtime API.
-- **`:Z` on the socket mount** — relabels the Podman socket for SELinux. Without
-  it, Floci fails to talk to the Podman socket and Lambda container creation
-  errors with `java.io.IOException: Broken pipe`.
+- **`:z` on the socket mount** — relabels the Podman socket for SELinux. Without
+  it, Floci fails to talk to the Podman socket: Lambda/ECR container creation
+  errors with `java.io.IOException: Broken pipe`, and the **Floci UI** sidecar
+  fails to launch with `java.net.BindException: Permission denied`. Use the
+  lowercase `:z` (shared relabel) rather than `:Z` — the Podman API socket is
+  shared with the Podman service, and `:Z` applies a container-private SELinux
+  label that can break access. If `:z` is still not enough on your host, fall
+  back to `--security-opt label=disable`.
 
 !!! tip "When the Runtime API address is still unreachable"
     On some Podman network topologies the auto-detected Runtime API address

--- a/src/main/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManager.java
@@ -21,6 +21,8 @@ import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
 import io.github.hectorvent.floci.core.common.docker.CurrentContainerNetworkResolver;
 import io.github.hectorvent.floci.core.common.docker.DockerHostResolver;
+import com.github.dockerjava.api.exception.DockerClientException;
+import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.Container;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -141,9 +143,7 @@ public class FlociUiManager {
             LOG.infov("Started floci-ui sidecar {0} on host port {1}", name, String.valueOf(hostPort));
             attachLogStream();
         } catch (Exception e) {
-            this.lastError = "Could not start the Floci UI from image '" + image + "': " + e.getMessage()
-                    + ". Ensure the image is available (docker pull " + image
-                    + ", or build it from the floci-ui repo).";
+            this.lastError = describeStartFailure(image, e);
             LOG.errorv(e, "Failed to start floci-ui sidecar from image {0}", image);
         }
     }
@@ -308,5 +308,63 @@ public class FlociUiManager {
         String logStreamName = logStreamer.generateLogStreamName(shortId);
         String region = regionResolver.getDefaultRegion();
         this.logStream = logStreamer.attach(containerId, logGroup, logStreamName, region, "floci:ui");
+    }
+
+    /**
+     * Builds the user-facing message for a failed sidecar start. Only a genuinely
+     * unavailable image gets the {@code docker pull} guidance — every other failure
+     * (an unreachable container runtime, a port clash, a daemon error) is reported
+     * as itself, so users are not sent to pull an image that is already present.
+     *
+     * <p>The previous behaviour blamed a missing image for <em>every</em> failure,
+     * which is especially misleading on Podman/SELinux hosts where the real cause is
+     * usually the bind-mounted Docker socket being unreachable.
+     */
+    static String describeStartFailure(String image, Throwable e) {
+        String detail = messageOf(e);
+        if (isImageUnavailable(e)) {
+            return "Could not start the Floci UI: image '" + image + "' is unavailable (" + detail
+                    + "). Pull it with 'docker pull " + image + "', or build it from the floci-ui repo.";
+        }
+        if (isRuntimeUnreachable(e)) {
+            return "Could not start the Floci UI: Floci could not reach the container runtime (" + detail
+                    + "). Check that the Docker/Podman socket is mounted into the Floci container and "
+                    + "accessible — on SELinux hosts the socket bind-mount may need relabeling "
+                    + "(e.g. ':z') or '--security-opt label=disable'.";
+        }
+        return "Could not start the Floci UI from image '" + image + "': " + detail + ".";
+    }
+
+    /** True when the failure chain indicates the image itself is missing locally and in the registry. */
+    private static boolean isImageUnavailable(Throwable e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t instanceof NotFoundException) {
+                return true;
+            }
+            String msg = t.getMessage();
+            // docker-java's pull callback rewraps a daemon pull failure (missing image, auth)
+            // as DockerClientException("Could not pull image: ...").
+            if (t instanceof DockerClientException && msg != null && msg.startsWith("Could not pull image: ")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** True when the failure chain indicates Floci could not reach the container runtime socket. */
+    private static boolean isRuntimeUnreachable(Throwable e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            // BindException and ConnectException both extend SocketException; the docker-java
+            // Apache transport surfaces a refused/denied Unix-socket connect this way.
+            if (t instanceof java.net.SocketException || t instanceof java.net.UnknownHostException) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String messageOf(Throwable e) {
+        String msg = e.getMessage();
+        return (msg == null || msg.isBlank()) ? e.getClass().getSimpleName() : msg;
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManagerTest.java
@@ -9,11 +9,16 @@ import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.E
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.CurrentContainerNetworkResolver;
 import io.github.hectorvent.floci.core.common.docker.DockerHostResolver;
+import com.github.dockerjava.api.exception.DockerClientException;
+import com.github.dockerjava.api.exception.NotFoundException;
 import org.junit.jupiter.api.Test;
 
+import java.net.BindException;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -114,6 +119,53 @@ class FlociUiManagerTest {
         when(containerDetector.isRunningInContainer()).thenReturn(false);
 
         assertEquals(4500, newManager().resolveHostPort(null, 4500));
+    }
+
+    @Test
+    void startFailureFromMissingImageKeepsPullGuidance() {
+        // A genuinely missing image (docker-java's pull-callback wrapper) — keep "docker pull".
+        Exception e = new DockerClientException("Could not pull image: not found");
+
+        String msg = FlociUiManager.describeStartFailure("floci/floci-ui:latest", e);
+
+        assertTrue(msg.contains("docker pull floci/floci-ui:latest"),
+                "missing-image failure should still suggest docker pull, was: " + msg);
+        assertTrue(msg.contains("unavailable"));
+    }
+
+    @Test
+    void startFailureFromMissingImageNotFoundKeepsPullGuidance() {
+        Exception e = new NotFoundException("no such image");
+
+        String msg = FlociUiManager.describeStartFailure("floci/floci-ui:latest", e);
+
+        assertTrue(msg.contains("docker pull floci/floci-ui:latest"), msg);
+    }
+
+    @Test
+    void startFailureFromUnreachableSocketDoesNotBlameImage() {
+        // The Podman/SELinux symptom: docker-java's Apache transport wraps a denied
+        // Unix-socket connect as RuntimeException -> BindException. Must NOT suggest a pull.
+        Exception e = new RuntimeException(new BindException("Permission denied"));
+
+        String msg = FlociUiManager.describeStartFailure("floci/floci-ui:latest", e);
+
+        assertFalse(msg.contains("docker pull"),
+                "socket-permission failure must not be reported as a missing image, was: " + msg);
+        assertTrue(msg.contains("could not reach the container runtime"), msg);
+        assertTrue(msg.contains("Permission denied"), msg);
+    }
+
+    @Test
+    void startFailureFromPortConflictDoesNotBlameImage() {
+        // Daemon error (e.g. port already in use) — report it as-is, no pull guidance.
+        Exception e = new RuntimeException(
+                "Status 500: listen tcp :4500: bind: address already in use");
+
+        String msg = FlociUiManager.describeStartFailure("floci/floci-ui:latest", e);
+
+        assertFalse(msg.contains("docker pull"), msg);
+        assertTrue(msg.contains("address already in use"), msg);
     }
 
     @Test


### PR DESCRIPTION
## What & why

Fixes #1543.

Pressing **Open Floci UI** under Podman (Docker-socket compat / docker-out-of-docker) reports **every** sidecar-start failure as a missing image and tells the user to `docker pull floci/floci-ui` — even when the image is already present. The real cause is hidden.

I reproduced this end-to-end against the real `floci/floci` + `floci/floci-ui` images under Podman and saw the **same** misleading message for three different root causes, all with the image present:

- `java.net.BindException: Permission denied` — the floci container couldn't reach the bind-mounted Podman socket (SELinux)
- `Status 500: ... listen tcp :4500: bind: address already in use` — host port clash
- `Status 500: ... listen tcp4 :4577: bind: address already in use` — host port clash

The sidecar launch is also the first thing that actually *uses* the Docker socket (other services are in-process), so a pre-existing socket problem surfaces here for the first time — making the wrong "pull the image" guidance especially costly.

## Changes

- **`FlociUiManager.describeStartFailure(...)`** classifies the failure instead of assuming a missing image:
  - only a genuinely unavailable image (`NotFoundException`, or docker-java's `Could not pull image: ...` wrapper) keeps the `docker pull` guidance;
  - an unreachable runtime (`SocketException`/`BindException`/`ConnectException`, `UnknownHostException`) points at the socket mount + SELinux relabeling;
  - any other daemon error is surfaced as-is (e.g. `address already in use`).
- **Podman docs** (`docs/configuration/docker.md`): use `:z` (shared relabel) rather than `:Z` on the *shared* Podman API socket — `:Z` applies a container-private SELinux label that can break access; note it applies to the UI sidecar too; mention the `--security-opt label=disable` fallback.
- **Tests**: 4 new unit tests covering the missing-image (2 forms), unreachable-socket, and port-conflict classifications.

## Testing

`./mvnw -o -Dtest=FlociUiManagerTest test` → `Tests run: 14, Failures: 0, Errors: 0`.

Manually verified under Podman: once the socket is reachable and the port is free, the sidecar launches, `/_floci/ui/status` returns `{"ready":true,...}`, and the UI page loads (HTTP 200). When it fails, the message now names the actual cause.

## Notes / out of scope

This PR fixes diagnosability (issue #1543, part 1) and the docs. The underlying SELinux socket-access behavior on some Podman hosts (part 2) is addressed via the docs change here; if maintainers want deeper handling (e.g. auto-detecting an unreachable socket at startup) that can be a follow-up.
