### PR TITLE
fix(dynamodb): invalid expressions throw 400 with exact error messages

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
@@ -148,8 +148,13 @@ final class ExpressionEvaluator {
                 continue;
             }
 
+            int nearStart = Math.max(0, i - 15);
+            int nearEnd = Math.min(expression.length(), i + 15);
+            
+            String near = expression.substring(nearStart, nearEnd);
+
             throw new IllegalArgumentException(
-                    "Unexpected character '%c' at position %d in expression: %s".formatted(c, i, expression));
+                    "token: \"%c\", near: \"%s\"".formatted(c, near));
         }
 
         tokens.add(new Token(TokenType.EOF, "", len));
@@ -389,14 +394,22 @@ final class ExpressionEvaluator {
     static void validateExpression(String expression, String exprType,
                                    JsonNode exprAttrNames, JsonNode exprAttrValues) {
         if (expression == null || expression.isBlank()) return;
-        List<Token> tokens = tokenize(expression.trim());
-        checkRedundantParentheses(tokens, exprType);
+        List<Token> tokens;
         Expr expr;
         try {
+            tokens = tokenize(expression.trim());
+            checkRedundantParentheses(tokens, exprType);
             expr = parse(expression);
         } catch (IllegalArgumentException e) {
-            // Other syntax errors are surfaced by the existing parse/evaluate paths.
-            return;
+            String detail = e.getMessage();
+            
+            if (detail.startsWith("token:")) {
+                throw new AwsException("ValidationException", 
+                    "Invalid " + exprType + ": Syntax error; " + detail, 400);
+            } else {
+                throw new AwsException("ValidationException", 
+                    "Invalid " + exprType + ": Syntax error", 400);
+            }
         }
         validateSemantics(expr, exprType, exprAttrNames, exprAttrValues);
     }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluatorTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import io.github.hectorvent.floci.core.common.AwsException;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class ExpressionEvaluatorTest {
@@ -569,6 +571,53 @@ class ExpressionEvaluatorTest {
         void blankExpressionMatchesAll() throws Exception {
             var i = item("{\"a\": {\"S\": \"1\"}}");
             assertTrue(ExpressionEvaluator.matches("  ", i, null, null));
+        }
+    }
+
+    // ── Validation tests ──
+
+    @Nested
+    class ValidationTests {
+
+        @Test
+        void exactAwsErrorFormatForLexicallyInvalidTokens() {
+            // Test various invalid characters that cause the tokenizer to fail
+            List<String> invalidChars = List.of("-", "+", "*", "/", "&", "|", "!", "@", "~", ";", "?");
+
+            for (String ch : invalidChars) {
+                String expression = "a " + ch + " b";
+                AwsException e = assertThrows(AwsException.class, () ->
+                                ExpressionEvaluator.validateExpression(expression, "ConditionExpression", null, null),
+                        "Expected exception for character: " + ch);
+
+                assertEquals("ValidationException", e.getErrorCode());
+                assertEquals(400, e.getHttpStatus());
+                assertEquals("Invalid ConditionExpression: Syntax error; token: \"" + ch + "\", near: \"a " + ch + " b\"", e.getMessage());
+            }
+        }
+
+        @Test
+        void missingOperandThrowsSyntaxError() {
+            AwsException e = assertThrows(AwsException.class, () ->
+                    ExpressionEvaluator.validateExpression("a =", "FilterExpression", null, null));
+            assertEquals("ValidationException", e.getErrorCode());
+            assertTrue(e.getMessage().contains("Invalid FilterExpression: Syntax error"), e.getMessage());
+        }
+
+        @Test
+        void redundantParenthesesThrowsSpecificError() {
+            AwsException e = assertThrows(AwsException.class, () ->
+                    ExpressionEvaluator.validateExpression("((a = b))", "KeyConditionExpression", null, null));
+            assertEquals("ValidationException", e.getErrorCode());
+            assertTrue(e.getMessage().contains("Invalid KeyConditionExpression: The expression has redundant parentheses;"), e.getMessage());
+        }
+
+        @Test
+        void unexpectedTokenThrowsSyntaxError() {
+            AwsException e = assertThrows(AwsException.class, () ->
+                    ExpressionEvaluator.validateExpression("a AND OR b", "ConditionExpression", null, null));
+            assertEquals("ValidationException", e.getErrorCode());
+            assertTrue(e.getMessage().contains("Invalid ConditionExpression: Syntax error"), e.getMessage());
         }
     }
 }


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->
This PR makes Floci return a 400 Validation Exception on invalid condition, filter, KeyCondition expressions, before it was returning 500 which is a retryable error which resulted into 3 api calls for one bad input

Closes #1512

## Type of change

- [X] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Floci returned HTTP 500 InternalFailure (instead of 400 validation exception) resulting into 3 api calls because its a retryable error

## Checklist

- [X] `./mvnw test` passes locally
- [X] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Local test note: All DynamoDB tests pass, full test suite run experienced unrelated local environmental timeouts and container initialization failures for ELB and cloudformation