### PR TITLE
feat(iot): add MQTT broker with custom authorizer and HTTP publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Floci supports local emulation for application services, data services, eventing
 | Containers and compute | ECS, EC2, EKS, ECR, CodeBuild, CodeDeploy, CodePipeline, AWS Batch, Auto Scaling, ELB v2 |
 | Data, analytics, and AI | Athena, Glue, EMR, Firehose, OpenSearch, S3 Vectors, Textract, Transcribe, Bedrock Runtime |
 | Databases and caching | RDS, RDS Data API, Neptune, DocumentDB, MemoryDB, ElastiCache |
-| Messaging and transfer | SES, Kinesis, MSK, Transfer Family |
+| Messaging and transfer | SES, Kinesis, MSK, Transfer Family, IoT Core |
 | Security and governance | WAF v2, CloudTrail, CloudFront, Resource Groups Tagging API |
 | Cost and billing | Pricing, Cost Explorer, Cost and Usage Reports, BCM Data Exports |
 | Backup and config | AWS Backup, AWS Config, AppConfig, AppConfigData, CloudFormation |
@@ -295,6 +295,7 @@ For operation-level compatibility, see the [Services Overview](https://floci.io/
 | Route53 | In-process | Hosted zones, SOA and NS records, resource record sets, change tracking, tagging |
 | Cloud Map | In-process | HTTP and DNS namespaces, services, instance registration, discovery queries, operations, tagging |
 | Transfer Family | In-process | Server lifecycle, user management, SSH key import, tagging |
+| IoT Core | In-process + embedded MQTT broker | Embedded MQTT/WebSocket broker (Moquette) over plain and TLS (`tcp`/`ws`/`ssl`/`wss`) with token-based custom authorizers that invoke your authorizer Lambda and enforce the returned IAM policy for connect/publish/subscribe; HTTP publish, endpoint discovery, presence/lifecycle events (`$aws/events/presence/*`) and Last Will & Testament |
 | Textract | In-process stub | API-compatible stubs, dummy block data, async job simulation |
 | Transcribe | In-process stub | Transcription jobs and custom vocabularies; jobs complete immediately, no real audio processing |
 | Pricing | In-process with static snapshot | Product discovery, attributes, price list files, pagination |

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -1,6 +1,6 @@
 # Services Overview
 
-Floci emulates 59 AWS services on a single port (`4566`). All services use the real AWS wire protocol, your existing AWS CLI commands and SDK clients work without modification.
+Floci emulates 60 AWS services on a single port (`4566`). All services use the real AWS wire protocol, your existing AWS CLI commands and SDK clients work without modification.
 
 This page is the canonical reference for supported service and operation counts. Some services expose separate control-plane and data-plane rows below. Other docs (and the README) should link here rather than duplicating the table.
 
@@ -76,6 +76,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [Cost and Usage Reports](cur.md) | `POST /` + `X-Amz-Target: AWSOrigamiServiceGatewayService.*` | JSON 1.1 | 6 |
 | [BCM Data Exports](bcm-data-exports.md) | `POST /` + `X-Amz-Target: AWSBillingAndCostManagementDataExports.*` | JSON 1.1 | 7 |
 | [Transfer Family](transfer.md) | `POST /` + `X-Amz-Target: TransferService.*` | JSON 1.1 | 17 |
+| [IoT Core](iot.md) | `/authorizer/*`, `/topics/*`, `/endpoint` + MQTT broker (`tcp`/`ws`/`ssl`/`wss`) | REST JSON + MQTT | 9 + MQTT data plane |
 
 **Lambda, ElastiCache, RDS, MSK, ECS, EKS, and OpenSearch** spin up real Docker containers and support IAM authentication and SigV4 request signing, the same auth flow as production AWS. **RDS Data API** executes SQL against the local RDS containers through AWS-compatible REST JSON routes.
 

--- a/docs/services/iot.md
+++ b/docs/services/iot.md
@@ -1,0 +1,200 @@
+# AWS IoT Core
+
+**Protocol:** REST JSON (control) + MQTT (data plane)  
+**Endpoint:** `http://localhost:4566/`
+
+AWS IoT Core data plane with token-based custom authentication. An embedded MQTT broker (Moquette) lets devices connect, publish, and subscribe over MQTT and MQTT-over-WebSocket, in plain and TLS variants (`tcp://`, `ws://`, `ssl://`, `wss://`). Every connection is authenticated by a token-based custom authorizer: Floci invokes your authorizer Lambda at CONNECT and enforces the IAM policy it returns for `iot:Connect`, `iot:Publish`, `iot:Subscribe`, and `iot:Receive`.
+
+## Supported Actions
+
+### Custom Authorizers
+
+| Action | Description |
+|---|---|
+| `CreateAuthorizer` | Register a token-based custom authorizer (Lambda ARN, token key, signing keys) |
+| `DescribeAuthorizer` | Get authorizer configuration |
+| `UpdateAuthorizer` | Update function ARN, token key, signing keys, or status |
+| `DeleteAuthorizer` | Delete an authorizer (not while it is the default) |
+| `ListAuthorizers` | Paginated list of authorizers, optionally filtered by status |
+| `SetDefaultAuthorizer` | Set the account default authorizer |
+| `TestInvokeAuthorizer` | Invoke the authorizer Lambda and return its authentication result and policy |
+
+### Data Plane
+
+| Action | Description |
+|---|---|
+| `Publish` | Publish a message (request body) to a topic via `POST /topics/{topicName}` (optional `?qos=0\|1`) |
+| `DescribeEndpoint` | Return the broker address for the requested `endpointType` |
+
+## Custom Authentication
+
+The broker routes every CONNECT through a custom authorizer. Custom-auth parameters are read from the MQTT CONNECT username, encoded as a query string — the format the AWS IoT Device SDK v2 produces and which mqtt.js can replicate:
+
+```
+<username>?x-amz-customauthorizer-name=<authorizerName>&x-amz-customauthorizer-signature=<sig>&<tokenKeyName>=<tokenValue>
+```
+
+`x-amz-customauthorizer-name` is optional when a default authorizer is set. The signature is required unless the authorizer was created with `signingDisabled`; when required it is verified (RSA `SHA256withRSA`) against the registered `tokenSigningPublicKeys` before the Lambda is invoked. `TestInvokeAuthorizer` exercises the same path without a device, returning `{ isAuthenticated, principalId, policyDocuments, disconnectAfterInSeconds, refreshAfterInSeconds }`.
+
+!!! note "Self-signed TLS certificate"
+    TLS listeners use an auto-generated self-signed certificate for `localhost` (or a keystore you supply via `FLOCI_SERVICES_IOT_BROKER_TLS_KEYSTORE_PATH`). There is no public CA chain locally, so clients must trust it — for example `rejectUnauthorized: false` in mqtt.js, or a permissive trust store in the AWS IoT Device SDK.
+
+### Lifecycle (presence) events
+
+On connect and disconnect the broker publishes an AWS-shaped event to the reserved presence topics, so other clients can track device presence:
+
+```
+$aws/events/presence/connected/{clientId}
+$aws/events/presence/disconnected/{clientId}
+```
+
+```json
+{
+  "clientId": "device-1",
+  "timestamp": 1782314873926,
+  "eventType": "connected",
+  "sessionIdentifier": "e8940d94-5cda-48d2-a586-790cb743a636",
+  "principalIdentifier": "device-principal",
+  "versionNumber": 0
+}
+```
+
+Disconnect events additionally include `clientInitiatedDisconnect` and `disconnectReason` (`CLIENT_INITIATED_DISCONNECT` or `CONNECTION_LOST`); each disconnect yields exactly one event. Subscribers need a policy that allows `iot:Subscribe` / `iot:Receive` on the `$aws/events/presence/#` topics. Disable with `FLOCI_SERVICES_IOT_BROKER_LIFECYCLE_EVENTS_ENABLED=false`.
+
+### Last Will & Testament
+
+Standard MQTT LWT is supported: set a will on CONNECT and the broker publishes it to the will topic when the client drops ungracefully. A clean DISCONNECT discards the will, per the MQTT specification.
+
+## Configuration
+
+| Environment variable | Default | Description |
+|---|---|---|
+| `FLOCI_SERVICES_IOT_ENABLED` | `true` | Enable or disable AWS IoT Core |
+| `FLOCI_SERVICES_IOT_BROKER_ENABLED` | `true` | Start the embedded MQTT broker |
+| `FLOCI_SERVICES_IOT_BROKER_HOST` | `0.0.0.0` | Broker bind host |
+| `FLOCI_SERVICES_IOT_BROKER_TCP_BASE_PORT` | `1883` | First port in the MQTT (TCP) range |
+| `FLOCI_SERVICES_IOT_BROKER_TCP_MAX_PORT` | `1899` | Last port in the MQTT (TCP) range |
+| `FLOCI_SERVICES_IOT_BROKER_WS_BASE_PORT` | `8083` | First port in the MQTT-over-WebSocket range |
+| `FLOCI_SERVICES_IOT_BROKER_WS_MAX_PORT` | `8099` | Last port in the MQTT-over-WebSocket range |
+| `FLOCI_SERVICES_IOT_BROKER_WS_PATH` | `/mqtt` | WebSocket path |
+| `FLOCI_SERVICES_IOT_BROKER_TLS_ENABLED` | `true` | Start TLS listeners (`ssl://` and `wss://`) |
+| `FLOCI_SERVICES_IOT_BROKER_MQTTS_BASE_PORT` | `8883` | First port in the secure MQTT (TLS) range |
+| `FLOCI_SERVICES_IOT_BROKER_MQTTS_MAX_PORT` | `8899` | Last port in the secure MQTT (TLS) range |
+| `FLOCI_SERVICES_IOT_BROKER_WSS_BASE_PORT` | `8443` | First port in the secure WebSocket (WSS) range |
+| `FLOCI_SERVICES_IOT_BROKER_WSS_MAX_PORT` | `8459` | Last port in the secure WebSocket (WSS) range |
+| `FLOCI_SERVICES_IOT_BROKER_TLS_KEYSTORE_PATH` | *(auto)* | PKCS12 keystore; a self-signed certificate is generated if unset |
+| `FLOCI_SERVICES_IOT_BROKER_TLS_KEYSTORE_PASSWORD` | `floci-iot` | Keystore password |
+| `FLOCI_SERVICES_IOT_BROKER_LIFECYCLE_EVENTS_ENABLED` | `true` | Publish `$aws/events/presence/*` connect/disconnect events |
+
+## ARN Format
+
+```
+arn:aws:iot:{region}:{accountId}:authorizer/{authorizerName}
+```
+
+## Examples
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:4566
+
+# Register a token-based custom authorizer (its Lambda must already be deployed)
+aws iot create-authorizer \
+  --authorizer-name device-auth \
+  --authorizer-function-arn arn:aws:lambda:us-east-1:000000000000:function:my-authorizer \
+  --token-key-name MyAuthToken \
+  --signing-disabled
+
+# Validate the authorizer without a device
+aws iot test-invoke-authorizer \
+  --authorizer-name device-auth \
+  --token "my-token" \
+  --mqtt-context '{"clientId":"device-1"}'
+
+# Resolve the broker endpoint that devices connect to over wss://
+aws iot describe-endpoint --endpoint-type iot:Data-ATS
+
+# Publish a message over HTTP
+aws iot-data publish \
+  --topic devices/sensor-1/data \
+  --cli-binary-format raw-in-base64-out \
+  --payload '{"temp":22.5}'
+```
+
+## Java SDK Example
+
+The management plane and HTTP publish use the standard AWS SDK (`IotClient` and
+`IotDataPlaneClient`):
+
+```java
+IotClient iot = IotClient.builder()
+    .endpointOverride(URI.create("http://localhost:4566"))
+    .region(Region.US_EAST_1)
+    .credentialsProvider(StaticCredentialsProvider.create(
+        AwsBasicCredentials.create("test", "test")))
+    .build();
+
+// Register a token-based custom authorizer
+iot.createAuthorizer(r -> r
+    .authorizerName("device-auth")
+    .authorizerFunctionArn("arn:aws:lambda:us-east-1:000000000000:function:my-authorizer")
+    .tokenKeyName("MyAuthToken")
+    .signingDisabled(true)
+    .status(AuthorizerStatus.ACTIVE));
+
+// Validate it without a device
+TestInvokeAuthorizerResponse result = iot.testInvokeAuthorizer(r -> r
+    .authorizerName("device-auth")
+    .token("my-token")
+    .mqttContext(m -> m.clientId("device-1")));
+System.out.println(result.isAuthenticated());
+
+// Resolve the broker endpoint
+String endpoint = iot.describeEndpoint(r -> r.endpointType("iot:Data-ATS")).endpointAddress();
+
+// Publish a message over HTTP
+IotDataPlaneClient data = IotDataPlaneClient.builder()
+    .endpointOverride(URI.create("http://localhost:4566"))
+    .region(Region.US_EAST_1)
+    .credentialsProvider(StaticCredentialsProvider.create(
+        AwsBasicCredentials.create("test", "test")))
+    .build();
+
+data.publish(r -> r
+    .topic("devices/sensor-1/data")
+    .qos(1)
+    .payload(SdkBytes.fromUtf8String("{\"temp\":22.5}")));
+```
+
+## Connecting Devices over MQTT
+
+Connect with the **AWS IoT Device SDK v2** (or any MQTT client), supplying the custom-auth
+parameters and pointing the endpoint at the address returned by `DescribeEndpoint`:
+
+```java
+try (AwsIotMqttConnectionBuilder builder = AwsIotMqttConnectionBuilder.newDefaultBuilder()) {
+    builder.withCustomAuthorizer(
+            null,            // username
+            "device-auth",   // authorizerName
+            null,            // tokenSignature (null when the authorizer is signingDisabled)
+            "unused",        // password
+            "MyAuthToken",   // tokenKeyName
+            "my-token");     // tokenValue
+    builder.withEndpoint("localhost").withPort(8443).withClientId("device-1");
+    try (MqttClientConnection connection = builder.build()) {
+        connection.connect().get();
+        connection.publish(new MqttMessage(
+            "devices/sensor-1/data",
+            "{\"temp\":22.5}".getBytes(StandardCharsets.UTF_8),
+            QualityOfService.AT_LEAST_ONCE));
+        connection.disconnect().get();
+    }
+}
+```
+
+Any generic MQTT client works the same way — encode the authorizer name, signature, and token
+into the CONNECT username as shown under [Custom Authentication](#custom-authentication).
+
+## Notes
+
+- HTTP `Publish` is unauthenticated; MQTT publish/subscribe remain policy-enforced.
+- The thing registry (things, thing types, thing groups, IoT policies), X.509 certificate-based client authentication, jobs, and device shadows are not implemented.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -135,6 +135,7 @@ nav:
     - Cost Explorer: services/ce.md
     - Cost and Usage Reports: services/cur.md
     - BCM Data Exports: services/bcm-data-exports.md
+    - IoT Core: services/iot.md
   - Testcontainers:
     - Overview: testcontainers/index.md
     - Java: testcontainers/java.md

--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,25 @@
             <version>5.28.5</version>
             <scope>test</scope>
         </dependency>
+        <!-- Embedded MQTT broker for AWS IoT Core data plane -->
+        <dependency>
+            <groupId>io.moquette</groupId>
+            <artifactId>moquette-broker</artifactId>
+            <version>0.17</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- MQTT client for IoT broker integration tests -->
+        <dependency>
+            <groupId>org.eclipse.paho</groupId>
+            <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+            <version>1.2.5</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -437,6 +437,56 @@ public interface EmulatorConfig {
         BatchServiceConfig batch();
         UiServiceConfig ui();
         S3VectorsServiceConfig s3vectors();
+        IotServiceConfig iot();
+    }
+
+    interface IotServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
+
+        @WithDefault("true")
+        boolean brokerEnabled();
+
+        @WithDefault("0.0.0.0")
+        String brokerHost();
+
+        @WithDefault("1883")
+        int brokerTcpBasePort();
+
+        @WithDefault("1899")
+        int brokerTcpMaxPort();
+
+        @WithDefault("8083")
+        int brokerWsBasePort();
+
+        @WithDefault("8099")
+        int brokerWsMaxPort();
+
+        @WithDefault("/mqtt")
+        String brokerWsPath();
+
+        @WithDefault("true")
+        boolean brokerTlsEnabled();
+
+        @WithDefault("8883")
+        int brokerMqttsBasePort();
+
+        @WithDefault("8899")
+        int brokerMqttsMaxPort();
+
+        @WithDefault("8443")
+        int brokerWssBasePort();
+
+        @WithDefault("8459")
+        int brokerWssMaxPort();
+
+        Optional<String> brokerTlsKeystorePath();
+
+        @WithDefault("floci-iot")
+        String brokerTlsKeystorePassword();
+
+        @WithDefault("true")
+        boolean brokerLifecycleEventsEnabled();
     }
 
     interface CloudTrailServiceConfig {

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -18,6 +18,8 @@ import io.github.hectorvent.floci.services.ses.SesController;
 import io.github.hectorvent.floci.services.appsync.AppSyncController;
 import io.github.hectorvent.floci.services.rdsdata.RdsDataController;
 import io.github.hectorvent.floci.services.s3vectors.S3VectorsController;
+import io.github.hectorvent.floci.services.iot.IotController;
+import io.github.hectorvent.floci.services.iot.IotAuthorizerController;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -340,7 +342,12 @@ public class ResolvedServiceCatalog {
                         "s3vectors", storageMode(config.storage().services().s3vectors().mode(), config.storage().mode()),
                         config.storage().services().s3vectors().flushIntervalMs(), null, ServiceProtocol.REST_JSON,
                         protocols(ServiceProtocol.REST_JSON),
-                        Set.of(), Set.of("s3vectors"), Set.of(), Set.of(S3VectorsController.class))
+                        Set.of(), Set.of("s3vectors"), Set.of(), Set.of(S3VectorsController.class)),
+                descriptor("iot", "iot", config.services().iot().enabled(), true,
+                        "iot", config.storage().mode(), 5000L, null, ServiceProtocol.REST_JSON,
+                        protocols(ServiceProtocol.REST_JSON),
+                        Set.of(), Set.of("iot"), Set.of(),
+                        Set.of(IotController.class, IotAuthorizerController.class))
         ));
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/iot/CustomAuthParams.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/CustomAuthParams.java
@@ -1,0 +1,67 @@
+package io.github.hectorvent.floci.services.iot;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Parses AWS IoT custom-authorizer parameters out of the MQTT CONNECT username.
+ *
+ * <p>The AWS IoT Device SDK v2 (and clients like mqtt.js configured the same way) encode the
+ * authorizer name, token, and token signature into the username as a query string appended to
+ * the real username, for example:
+ *
+ * <pre>
+ *   myuser?x-amz-customauthorizer-name=MyAuthorizer&amp;x-amz-customauthorizer-signature=SIG&amp;MyTokenKey=TOKEN
+ * </pre>
+ *
+ * @param baseUsername the username portion before the {@code ?} (may be empty)
+ * @param params       decoded query parameters (authorizer name, signature, and the token key)
+ */
+public record CustomAuthParams(String baseUsername, Map<String, String> params) {
+
+    public static final String AUTHORIZER_NAME_KEY = "x-amz-customauthorizer-name";
+    public static final String SIGNATURE_KEY = "x-amz-customauthorizer-signature";
+
+    public static CustomAuthParams parse(String username) {
+        if (username == null) {
+            return new CustomAuthParams("", Map.of());
+        }
+        int q = username.indexOf('?');
+        if (q < 0) {
+            return new CustomAuthParams(username, Map.of());
+        }
+        String base = username.substring(0, q);
+        String query = username.substring(q + 1);
+        Map<String, String> params = new HashMap<>();
+        for (String pair : query.split("&")) {
+            if (pair.isEmpty()) {
+                continue;
+            }
+            int eq = pair.indexOf('=');
+            if (eq < 0) {
+                params.put(decode(pair), "");
+            } else {
+                params.put(decode(pair.substring(0, eq)), decode(pair.substring(eq + 1)));
+            }
+        }
+        return new CustomAuthParams(base, params);
+    }
+
+    public String authorizerName() {
+        return params.get(AUTHORIZER_NAME_KEY);
+    }
+
+    public String signature() {
+        return params.get(SIGNATURE_KEY);
+    }
+
+    public String token(String tokenKeyName) {
+        return tokenKeyName == null ? null : params.get(tokenKeyName);
+    }
+
+    private static String decode(String value) {
+        return URLDecoder.decode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotAuthorizerController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotAuthorizerController.java
@@ -1,0 +1,197 @@
+package io.github.hectorvent.floci.services.iot;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.iot.model.AuthorizerResult;
+import io.github.hectorvent.floci.services.iot.model.IotAuthorizer;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.io.IOException;
+
+import static io.github.hectorvent.floci.services.iot.IotJson.putEpoch;
+import static io.github.hectorvent.floci.services.iot.IotJson.putToken;
+import static io.github.hectorvent.floci.services.iot.IotJson.readStringMap;
+import static io.github.hectorvent.floci.services.iot.IotJson.text;
+
+/**
+ * AWS IoT custom-authorizer control plane (REST JSON) plus {@code TestInvokeAuthorizer},
+ * which exercises the full auth loop (invoke authorizer Lambda + evaluate its policy)
+ * without requiring an MQTT connection.
+ */
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class IotAuthorizerController {
+
+    private final IotAuthorizerService service;
+    private final RegionResolver regionResolver;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public IotAuthorizerController(IotAuthorizerService service, RegionResolver regionResolver,
+                                   ObjectMapper objectMapper) {
+        this.service = service;
+        this.regionResolver = regionResolver;
+        this.objectMapper = objectMapper;
+    }
+
+    @POST
+    @Path("/authorizer/{authorizerName}")
+    public Response createAuthorizer(@Context HttpHeaders headers,
+                                     @PathParam("authorizerName") String authorizerName,
+                                     String body) throws IOException {
+        String region = regionResolver.resolveRegion(headers);
+        JsonNode req = parseBody(body);
+        IotAuthorizer authorizer = service.createAuthorizer(
+                authorizerName,
+                text(req, "authorizerFunctionArn"),
+                text(req, "tokenKeyName"),
+                readStringMap(req.path("tokenSigningPublicKeys")),
+                text(req, "status"),
+                req.path("signingDisabled").asBoolean(false),
+                req.path("enableCachingForHttp").asBoolean(false),
+                region);
+        ObjectNode resp = objectMapper.createObjectNode();
+        resp.put("authorizerName", authorizer.getAuthorizerName());
+        resp.put("authorizerArn", authorizer.getAuthorizerArn());
+        return Response.ok(resp).build();
+    }
+
+    @GET
+    @Path("/authorizer/{authorizerName}")
+    public Response describeAuthorizer(@PathParam("authorizerName") String authorizerName) {
+        IotAuthorizer authorizer = service.getAuthorizer(authorizerName);
+        ObjectNode resp = objectMapper.createObjectNode();
+        resp.set("authorizerDescription", authorizerNode(authorizer));
+        return Response.ok(resp).build();
+    }
+
+    @PUT
+    @Path("/authorizer/{authorizerName}")
+    public Response updateAuthorizer(@PathParam("authorizerName") String authorizerName, String body) throws IOException {
+        JsonNode req = parseBody(body);
+        IotAuthorizer authorizer = service.updateAuthorizer(
+                authorizerName,
+                text(req, "authorizerFunctionArn"),
+                text(req, "tokenKeyName"),
+                req.path("tokenSigningPublicKeys").isMissingNode() ? null : readStringMap(req.path("tokenSigningPublicKeys")),
+                text(req, "status"));
+        ObjectNode resp = objectMapper.createObjectNode();
+        resp.put("authorizerName", authorizer.getAuthorizerName());
+        resp.put("authorizerArn", authorizer.getAuthorizerArn());
+        return Response.ok(resp).build();
+    }
+
+    @DELETE
+    @Path("/authorizer/{authorizerName}")
+    public Response deleteAuthorizer(@PathParam("authorizerName") String authorizerName) {
+        service.deleteAuthorizer(authorizerName);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    @GET
+    @Path("/authorizers")
+    public Response listAuthorizers(@QueryParam("status") String status,
+                                    @QueryParam("marker") String marker,
+                                    @QueryParam("pageSize") Integer pageSize,
+                                    @QueryParam("ascendingOrder") Boolean ascendingOrder) {
+        IotPaging.Page<IotAuthorizer> page = service.listAuthorizers(status, marker, pageSize,
+                ascendingOrder == null || ascendingOrder);
+        ObjectNode resp = objectMapper.createObjectNode();
+        ArrayNode authorizers = resp.putArray("authorizers");
+        page.items().forEach(authorizer -> {
+            ObjectNode node = authorizers.addObject();
+            node.put("authorizerName", authorizer.getAuthorizerName());
+            node.put("authorizerArn", authorizer.getAuthorizerArn());
+        });
+        putToken(resp, "nextMarker", page.nextToken());
+        return Response.ok(resp).build();
+    }
+
+    @POST
+    @Path("/default-authorizer")
+    public Response setDefaultAuthorizer(String body) throws IOException {
+        JsonNode req = parseBody(body);
+        String authorizerName = text(req, "authorizerName");
+        service.setDefaultAuthorizer(authorizerName);
+        ObjectNode resp = objectMapper.createObjectNode();
+        resp.put("authorizerName", authorizerName);
+        resp.put("authorizerArn", service.getAuthorizer(authorizerName).getAuthorizerArn());
+        return Response.ok(resp).build();
+    }
+
+    @POST
+    @Path("/authorizer/{authorizerName}/test")
+    public Response testInvokeAuthorizer(@Context HttpHeaders headers,
+                                         @PathParam("authorizerName") String authorizerName,
+                                         String body) throws IOException {
+        String region = regionResolver.resolveRegion(headers);
+        JsonNode req = parseBody(body);
+        IotAuthorizer authorizer = service.resolveAuthorizer(authorizerName);
+        JsonNode mqtt = req.path("mqttContext");
+        IotAuthorizerService.AuthInput input = new IotAuthorizerService.AuthInput(
+                text(req, "token"),
+                text(req, "tokenSignature"),
+                text(mqtt, "clientId"),
+                text(mqtt, "username"),
+                text(mqtt, "password"));
+        AuthorizerResult result = service.invokeAuthorizer(authorizer, region, input);
+
+        ObjectNode resp = objectMapper.createObjectNode();
+        resp.put("isAuthenticated", result.isAuthenticated());
+        if (result.principalId() != null) {
+            resp.put("principalId", result.principalId());
+        }
+        ArrayNode docs = resp.putArray("policyDocuments");
+        for (String doc : result.policyDocuments()) {
+            docs.add(doc);
+        }
+        if (result.disconnectAfterSeconds() != null) {
+            resp.put("disconnectAfterInSeconds", result.disconnectAfterSeconds());
+        }
+        if (result.refreshAfterSeconds() != null) {
+            resp.put("refreshAfterInSeconds", result.refreshAfterSeconds());
+        }
+        return Response.ok(resp).build();
+    }
+
+    // ──────────────────────────── Helpers ────────────────────────────
+
+    private ObjectNode authorizerNode(IotAuthorizer authorizer) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("authorizerName", authorizer.getAuthorizerName());
+        node.put("authorizerArn", authorizer.getAuthorizerArn());
+        node.put("authorizerFunctionArn", authorizer.getAuthorizerFunctionArn());
+        if (authorizer.getTokenKeyName() != null) {
+            node.put("tokenKeyName", authorizer.getTokenKeyName());
+        }
+        ObjectNode keys = node.putObject("tokenSigningPublicKeys");
+        authorizer.getTokenSigningPublicKeys().forEach(keys::put);
+        node.put("status", authorizer.getStatus());
+        node.put("signingDisabled", authorizer.isSigningDisabled());
+        node.put("enableCachingForHttp", authorizer.isEnableCachingForHttp());
+        putEpoch(node, "creationDate", authorizer.getCreationDate());
+        putEpoch(node, "lastModifiedDate", authorizer.getLastModifiedDate());
+        return node;
+    }
+
+    private JsonNode parseBody(String body) throws IOException {
+        return IotJson.parseBody(objectMapper, body);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotAuthorizerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotAuthorizerService.java
@@ -1,0 +1,319 @@
+package io.github.hectorvent.floci.services.iot;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.iam.IamPolicyEvaluator;
+import io.github.hectorvent.floci.services.iot.model.AuthorizerResult;
+import io.github.hectorvent.floci.services.iot.model.IotAuthorizer;
+import io.github.hectorvent.floci.services.lambda.LambdaService;
+import io.github.hectorvent.floci.services.lambda.model.InvocationType;
+import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.spec.X509EncodedKeySpec;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * AWS IoT custom-authorizer registry and evaluation.
+ *
+ * <p>Stores authorizer configuration (control plane) and, given a connection's token,
+ * invokes the authorizer Lambda via Floci's in-process {@link LambdaService}, then
+ * evaluates the returned IAM-style policy with {@link IamPolicyEvaluator}. This is the
+ * shared auth core used by both {@code TestInvokeAuthorizer} and the MQTT broker.
+ */
+@ApplicationScoped
+public class IotAuthorizerService {
+
+    private static final Logger LOG = Logger.getLogger(IotAuthorizerService.class);
+    private static final String DEFAULT_KEY = "default";
+
+    private final StorageBackend<String, IotAuthorizer> authorizerStore;
+    private final StorageBackend<String, String> defaultStore;
+    private final LambdaService lambdaService;
+    private final IamPolicyEvaluator policyEvaluator;
+    private final RegionResolver regionResolver;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public IotAuthorizerService(StorageFactory storageFactory,
+                                LambdaService lambdaService,
+                                IamPolicyEvaluator policyEvaluator,
+                                RegionResolver regionResolver,
+                                ObjectMapper objectMapper) {
+        this.authorizerStore = storageFactory.create("iot", "iot-authorizers.json", new TypeReference<>() {});
+        this.defaultStore = storageFactory.create("iot", "iot-default-authorizer.json", new TypeReference<>() {});
+        this.lambdaService = lambdaService;
+        this.policyEvaluator = policyEvaluator;
+        this.regionResolver = regionResolver;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Connection-time inputs presented by a device (or by {@code TestInvokeAuthorizer}).
+     */
+    public record AuthInput(String token, String tokenSignature, String clientId,
+                            String username, String password) {
+    }
+
+    // ──────────────────────────── Registry (control plane) ────────────────────────────
+
+    public synchronized IotAuthorizer createAuthorizer(String authorizerName, String authorizerFunctionArn,
+                                                       String tokenKeyName, Map<String, String> tokenSigningPublicKeys,
+                                                       String status, boolean signingDisabled,
+                                                       boolean enableCachingForHttp, String region) {
+        if (authorizerName == null || authorizerName.isBlank()) {
+            throw new AwsException("InvalidRequestException", "authorizerName is required.", 400);
+        }
+        if (authorizerFunctionArn == null || authorizerFunctionArn.isBlank()) {
+            throw new AwsException("InvalidRequestException", "authorizerFunctionArn is required.", 400);
+        }
+        if (!signingDisabled && (tokenSigningPublicKeys == null || tokenSigningPublicKeys.isEmpty())) {
+            throw new AwsException("InvalidRequestException",
+                    "tokenSigningPublicKeys is required unless signingDisabled is true.", 400);
+        }
+        if (authorizerStore.get(authorizerName).isPresent()) {
+            throw new AwsException("ResourceAlreadyExistsException",
+                    "Authorizer " + authorizerName + " already exists.", 409);
+        }
+        Instant now = Instant.now();
+        IotAuthorizer authorizer = new IotAuthorizer();
+        authorizer.setAuthorizerName(authorizerName);
+        authorizer.setAuthorizerArn(authorizerArn(region, authorizerName));
+        authorizer.setAuthorizerFunctionArn(authorizerFunctionArn);
+        authorizer.setTokenKeyName(tokenKeyName);
+        if (tokenSigningPublicKeys != null) {
+            authorizer.setTokenSigningPublicKeys(new HashMap<>(tokenSigningPublicKeys));
+        }
+        authorizer.setStatus(status == null || status.isBlank() ? "ACTIVE" : status);
+        authorizer.setSigningDisabled(signingDisabled);
+        authorizer.setEnableCachingForHttp(enableCachingForHttp);
+        authorizer.setCreationDate(now);
+        authorizer.setLastModifiedDate(now);
+        authorizerStore.put(authorizerName, authorizer);
+        LOG.infov("Created IoT authorizer {0}", authorizerName);
+        return authorizer;
+    }
+
+    public IotAuthorizer getAuthorizer(String authorizerName) {
+        return authorizerStore.get(authorizerName)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "Authorizer " + authorizerName + " does not exist.", 404));
+    }
+
+    public synchronized IotAuthorizer updateAuthorizer(String authorizerName, String authorizerFunctionArn,
+                                                       String tokenKeyName, Map<String, String> tokenSigningPublicKeys,
+                                                       String status) {
+        IotAuthorizer authorizer = getAuthorizer(authorizerName);
+        if (authorizerFunctionArn != null) {
+            authorizer.setAuthorizerFunctionArn(authorizerFunctionArn);
+        }
+        if (tokenKeyName != null) {
+            authorizer.setTokenKeyName(tokenKeyName);
+        }
+        if (tokenSigningPublicKeys != null) {
+            authorizer.setTokenSigningPublicKeys(new HashMap<>(tokenSigningPublicKeys));
+        }
+        if (status != null && !status.isBlank()) {
+            authorizer.setStatus(status);
+        }
+        authorizer.setLastModifiedDate(Instant.now());
+        authorizerStore.put(authorizerName, authorizer);
+        return authorizer;
+    }
+
+    public synchronized void deleteAuthorizer(String authorizerName) {
+        IotAuthorizer authorizer = getAuthorizer(authorizerName);
+        if (authorizerName.equals(getDefaultAuthorizerName().orElse(null))) {
+            throw new AwsException("InvalidRequestException",
+                    "Cannot delete the default authorizer; set a different default first.", 400);
+        }
+        authorizerStore.delete(authorizer.getAuthorizerName());
+    }
+
+    public IotPaging.Page<IotAuthorizer> listAuthorizers(String status, String marker,
+                                                         Integer pageSize, boolean ascendingOrder) {
+        List<IotAuthorizer> authorizers = new ArrayList<>(authorizerStore.scan(k -> true));
+        if (status != null && !status.isBlank()) {
+            authorizers.removeIf(a -> !status.equalsIgnoreCase(a.getStatus()));
+        }
+        authorizers.sort(Comparator.comparing(IotAuthorizer::getAuthorizerName));
+        if (!ascendingOrder) {
+            authorizers.sort(Comparator.comparing(IotAuthorizer::getAuthorizerName).reversed());
+        }
+        return IotPaging.paginate(authorizers, marker, pageSize);
+    }
+
+    public synchronized void setDefaultAuthorizer(String authorizerName) {
+        getAuthorizer(authorizerName);
+        defaultStore.put(DEFAULT_KEY, authorizerName);
+    }
+
+    public Optional<String> getDefaultAuthorizerName() {
+        return defaultStore.get(DEFAULT_KEY);
+    }
+
+    /**
+     * Resolves the authorizer to use for a connection: the named one if provided, otherwise
+     * the account default. Throws when none is available or the resolved authorizer is inactive.
+     */
+    public IotAuthorizer resolveAuthorizer(String authorizerName) {
+        String name = (authorizerName == null || authorizerName.isBlank())
+                ? getDefaultAuthorizerName().orElse(null)
+                : authorizerName;
+        if (name == null) {
+            throw new AwsException("InvalidRequestException",
+                    "No authorizer specified and no default authorizer is set.", 400);
+        }
+        IotAuthorizer authorizer = getAuthorizer(name);
+        if (!"ACTIVE".equalsIgnoreCase(authorizer.getStatus())) {
+            throw new AwsException("InvalidRequestException",
+                    "Authorizer " + name + " is not ACTIVE.", 400);
+        }
+        return authorizer;
+    }
+
+    // ──────────────────────────── Evaluation (shared with the broker) ────────────────────────────
+
+    /**
+     * Verifies the token signature, invokes the authorizer Lambda, and returns its parsed result.
+     */
+    public AuthorizerResult invokeAuthorizer(IotAuthorizer authorizer, String region, AuthInput input) {
+        boolean signatureVerified = authorizer.isSigningDisabled()
+                || verifyTokenSignature(authorizer, input.token(), input.tokenSignature());
+
+        byte[] payload = buildEvent(input, signatureVerified);
+        InvokeResult result = lambdaService.invoke(region, authorizer.getAuthorizerFunctionArn(),
+                payload, InvocationType.RequestResponse);
+        if (result.getFunctionError() != null) {
+            throw new AwsException("InvalidResponseException",
+                    "Authorizer function returned an error: " + result.getFunctionError(), 400);
+        }
+        return parseResponse(result.getPayload());
+    }
+
+    byte[] buildEvent(AuthInput input, boolean signatureVerified) {
+        ObjectNode event = objectMapper.createObjectNode();
+        event.put("token", input.token());
+        event.put("signatureVerified", signatureVerified);
+        ArrayNode protocols = event.putArray("protocols");
+        protocols.add("mqtt");
+        ObjectNode protocolData = event.putObject("protocolData");
+        ObjectNode mqtt = protocolData.putObject("mqtt");
+        if (input.username() != null) {
+            mqtt.put("username", input.username());
+        }
+        if (input.password() != null) {
+            mqtt.put("password", Base64.getEncoder()
+                    .encodeToString(input.password().getBytes(StandardCharsets.UTF_8)));
+        }
+        if (input.clientId() != null) {
+            mqtt.put("clientId", input.clientId());
+        }
+        try {
+            return objectMapper.writeValueAsBytes(event);
+        } catch (Exception e) {
+            throw new AwsException("InvalidRequestException", "Failed to build authorizer event.", 400);
+        }
+    }
+
+    AuthorizerResult parseResponse(byte[] payload) {
+        if (payload == null || payload.length == 0) {
+            throw new AwsException("InvalidResponseException", "Authorizer returned an empty response.", 400);
+        }
+        JsonNode node;
+        try {
+            node = objectMapper.readTree(payload);
+        } catch (Exception e) {
+            throw new AwsException("InvalidResponseException", "Authorizer returned invalid JSON.", 400);
+        }
+        boolean authenticated = node.path("isAuthenticated").asBoolean(false);
+        String principalId = node.path("principalId").isMissingNode() ? null : node.path("principalId").asText();
+        List<String> policyDocuments = new ArrayList<>();
+        JsonNode docs = node.path("policyDocuments");
+        if (docs.isArray()) {
+            for (JsonNode doc : docs) {
+                policyDocuments.add(doc.isTextual() ? doc.asText() : doc.toString());
+            }
+        }
+        Integer disconnectAfter = node.has("disconnectAfterInSeconds")
+                ? node.get("disconnectAfterInSeconds").asInt() : null;
+        Integer refreshAfter = node.has("refreshAfterInSeconds")
+                ? node.get("refreshAfterInSeconds").asInt() : null;
+        return new AuthorizerResult(authenticated, principalId, policyDocuments, disconnectAfter, refreshAfter);
+    }
+
+    /**
+     * Evaluates whether the authorizer's returned policy allows the given IoT action on a resource.
+     */
+    public boolean isAllowed(AuthorizerResult result, String action, String resource, Map<String, String> conditionCtx) {
+        if (result.policyDocuments() == null || result.policyDocuments().isEmpty()) {
+            return false;
+        }
+        return policyEvaluator.simulateCustomPolicy(result.policyDocuments(), action, resource, conditionCtx)
+                == IamPolicyEvaluator.Decision.ALLOW;
+    }
+
+    boolean verifyTokenSignature(IotAuthorizer authorizer, String token, String signatureB64) {
+        if (token == null || signatureB64 == null || signatureB64.isBlank()) {
+            return false;
+        }
+        Map<String, String> keys = authorizer.getTokenSigningPublicKeys();
+        if (keys == null || keys.isEmpty()) {
+            return false;
+        }
+        byte[] signatureBytes;
+        try {
+            signatureBytes = Base64.getDecoder().decode(signatureB64);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+        for (String pem : keys.values()) {
+            if (verifyWithKey(pem, token, signatureBytes)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean verifyWithKey(String pem, String token, byte[] signatureBytes) {
+        try {
+            String base64 = pem.replaceAll("-----BEGIN (?:RSA )?PUBLIC KEY-----", "")
+                    .replaceAll("-----END (?:RSA )?PUBLIC KEY-----", "")
+                    .replaceAll("\\s", "");
+            byte[] keyBytes = Base64.getDecoder().decode(base64);
+            PublicKey publicKey = KeyFactory.getInstance("RSA")
+                    .generatePublic(new X509EncodedKeySpec(keyBytes));
+            Signature verifier = Signature.getInstance("SHA256withRSA");
+            verifier.initVerify(publicKey);
+            verifier.update(token.getBytes(StandardCharsets.UTF_8));
+            return verifier.verify(signatureBytes);
+        } catch (Exception e) {
+            LOG.debugv("Token signature verification failed: {0}", e.getMessage());
+            return false;
+        }
+    }
+
+    private String authorizerArn(String region, String authorizerName) {
+        return regionResolver.buildArn("iot", region, "authorizer/" + authorizerName);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotBrokerEndpoint.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotBrokerEndpoint.java
@@ -1,0 +1,75 @@
+package io.github.hectorvent.floci.services.iot;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Shared holder for the running MQTT broker's reachable address.
+ *
+ * <p>Set by {@link IotMqttBroker} on startup and read by {@code DescribeEndpoint} so clients
+ * are pointed at the real local broker rather than a synthetic AWS hostname.
+ */
+@ApplicationScoped
+public class IotBrokerEndpoint {
+
+    private volatile boolean running;
+    private volatile String host;
+    private volatile int wsPort;
+    private volatile int tcpPort;
+    private volatile int wssPort = -1;
+    private volatile int mqttsPort = -1;
+    private volatile String wsPath = "/mqtt";
+
+    public boolean isRunning() {
+        return running;
+    }
+
+    public void set(String host, int wsPort, int tcpPort, String wsPath) {
+        this.host = host;
+        this.wsPort = wsPort;
+        this.tcpPort = tcpPort;
+        this.wsPath = wsPath;
+        this.running = true;
+    }
+
+    public void setTlsPorts(int wssPort, int mqttsPort) {
+        this.wssPort = wssPort;
+        this.mqttsPort = mqttsPort;
+    }
+
+    public void clear() {
+        this.running = false;
+        this.wssPort = -1;
+        this.mqttsPort = -1;
+    }
+
+    /**
+     * Host clients should connect to. {@code 0.0.0.0} is advertised as {@code localhost}.
+     */
+    public String advertisedHost() {
+        return (host == null || host.equals("0.0.0.0")) ? "localhost" : host;
+    }
+
+    public int wsPort() {
+        return wsPort;
+    }
+
+    public int tcpPort() {
+        return tcpPort;
+    }
+
+    public int wssPort() {
+        return wssPort;
+    }
+
+    public int mqttsPort() {
+        return mqttsPort;
+    }
+
+    public boolean tlsEnabled() {
+        return wssPort > 0;
+    }
+
+    public String wsPath() {
+        return wsPath;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotBrokerKeystore.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotBrokerKeystore.java
@@ -1,0 +1,63 @@
+package io.github.hectorvent.floci.services.iot;
+
+import io.github.hectorvent.floci.services.acm.CertificateGenerator;
+import io.github.hectorvent.floci.services.acm.model.KeyAlgorithm;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.Security;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+/**
+ * Builds (and caches on disk) a self-signed PKCS#12 keystore for the MQTT broker's TLS/WSS
+ * listeners. Reuses the repository's {@link CertificateGenerator} for the certificate and key.
+ *
+ * <p>The certificate is self-signed for {@code localhost} / {@code 127.0.0.1}; clients must trust
+ * it (e.g. {@code rejectUnauthorized: false} in mqtt.js, or a permissive trust store in the AWS
+ * IoT Device SDK) since there is no public CA chain locally.
+ */
+final class IotBrokerKeystore {
+
+    static final String ALIAS = "floci-iot";
+
+    private IotBrokerKeystore() {
+    }
+
+    /**
+     * Returns the keystore path, generating a self-signed keystore at {@code path} if absent.
+     */
+    static Path ensure(Path path, String password) throws Exception {
+        if (Files.exists(path)) {
+            return path;
+        }
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+        CertificateGenerator generator = new CertificateGenerator();
+        CertificateGenerator.GeneratedCertificate generated = generator.generateCertificate(
+                "localhost", List.of("localhost", "127.0.0.1"), KeyAlgorithm.RSA_2048);
+
+        X509Certificate certificate = generator.parseCertificate(generated.certificatePem());
+        PrivateKey privateKey = generator.parsePrivateKey(generated.privateKeyPem());
+
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        keyStore.load(null, null);
+        keyStore.setKeyEntry(ALIAS, privateKey, password.toCharArray(),
+                new Certificate[]{certificate});
+
+        Path parent = path.toAbsolutePath().getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+        try (OutputStream out = Files.newOutputStream(path)) {
+            keyStore.store(out, password.toCharArray());
+        }
+        return path;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotController.java
@@ -1,0 +1,85 @@
+package io.github.hectorvent.floci.services.iot;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * AWS IoT Core data-plane REST endpoints: endpoint discovery ({@code DescribeEndpoint}) and the
+ * HTTP {@code Publish} action ({@code POST /topics/{topicName}}), which injects a message into the
+ * embedded MQTT broker.
+ */
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+public class IotController {
+
+    private final IotMqttBroker broker;
+    private final IotBrokerEndpoint brokerEndpoint;
+    private final RegionResolver regionResolver;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public IotController(IotMqttBroker broker, IotBrokerEndpoint brokerEndpoint,
+                         RegionResolver regionResolver, ObjectMapper objectMapper) {
+        this.broker = broker;
+        this.brokerEndpoint = brokerEndpoint;
+        this.regionResolver = regionResolver;
+        this.objectMapper = objectMapper;
+    }
+
+    @GET
+    @Path("/endpoint")
+    public Response describeEndpoint(@Context HttpHeaders headers,
+                                     @QueryParam("endpointType") String endpointType) {
+        String region = regionResolver.resolveRegion(headers);
+        ObjectNode resp = objectMapper.createObjectNode();
+        resp.put("endpointAddress", resolveEndpointAddress(endpointType, region));
+        return Response.ok(resp).build();
+    }
+
+    @POST
+    @Path("/topics/{topic: .+}")
+    @Consumes(MediaType.WILDCARD)
+    public Response publish(@PathParam("topic") String topic,
+                            @QueryParam("qos") Integer qos,
+                            byte[] body) {
+        broker.publish(topic, body, qos == null ? 0 : qos);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private String resolveEndpointAddress(String endpointType, String region) {
+        String type = (endpointType == null || endpointType.isBlank()) ? "iot:Data-ATS" : endpointType;
+        // Data-plane endpoints point at the running local MQTT broker so clients can connect.
+        if (brokerEndpoint.isRunning() && (type.equals("iot:Data-ATS") || type.equals("iot:Data"))) {
+            int port = brokerEndpoint.tlsEnabled() ? brokerEndpoint.wssPort() : brokerEndpoint.wsPort();
+            return brokerEndpoint.advertisedHost() + ":" + port;
+        }
+        String prefix = endpointPrefix();
+        return switch (type) {
+            case "iot:Data" -> prefix + ".iot." + region + ".amazonaws.com";
+            case "iot:CredentialProvider" -> prefix + ".credentials.iot." + region + ".amazonaws.com";
+            case "iot:Jobs" -> prefix + ".jobs.iot." + region + ".amazonaws.com";
+            default -> prefix + "-ats.iot." + region + ".amazonaws.com";
+        };
+    }
+
+    private String endpointPrefix() {
+        String digits = regionResolver.getAccountId().replaceAll("\\D", "");
+        if (digits.length() < 12) {
+            digits = (digits + "000000000000").substring(0, 12);
+        }
+        return "a" + digits.substring(0, 11);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotJson.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotJson.java
@@ -1,0 +1,68 @@
+package io.github.hectorvent.floci.services.iot;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared JSON request-parsing and response-building helpers for the IoT REST controllers.
+ */
+final class IotJson {
+
+    private IotJson() {
+    }
+
+    static JsonNode parseBody(ObjectMapper objectMapper, String body) throws IOException {
+        if (body == null || body.isBlank()) {
+            return objectMapper.createObjectNode();
+        }
+        return objectMapper.readTree(body);
+    }
+
+    static String text(JsonNode node, String field) {
+        JsonNode child = node.path(field);
+        return (child.isMissingNode() || child.isNull()) ? null : child.asText();
+    }
+
+    static Long optionalLong(JsonNode node, String field) {
+        JsonNode child = node.path(field);
+        return (child.isMissingNode() || child.isNull()) ? null : child.asLong();
+    }
+
+    static List<String> readStringList(JsonNode node) {
+        List<String> values = new ArrayList<>();
+        if (node != null && node.isArray()) {
+            node.forEach(n -> values.add(n.asText()));
+        }
+        return values;
+    }
+
+    static Map<String, String> readStringMap(JsonNode node) {
+        Map<String, String> map = new HashMap<>();
+        if (node != null && node.isObject()) {
+            node.fields().forEachRemaining(e -> map.put(e.getKey(), e.getValue().asText()));
+        }
+        return map;
+    }
+
+    static void putToken(ObjectNode node, String field, String token) {
+        if (token != null) {
+            node.put(field, token);
+        } else {
+            node.putNull(field);
+        }
+    }
+
+    static void putEpoch(ObjectNode node, String field, Instant instant) {
+        if (instant != null) {
+            node.put(field, instant.toEpochMilli() / 1000.0);
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotMqttBroker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotMqttBroker.java
@@ -1,0 +1,391 @@
+package io.github.hectorvent.floci.services.iot;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.services.iot.model.AuthorizerResult;
+import io.github.hectorvent.floci.services.iot.model.IotAuthorizer;
+import io.moquette.BrokerConstants;
+import io.moquette.broker.Server;
+import io.moquette.broker.config.IConfig;
+import io.moquette.broker.config.MemoryConfig;
+import io.moquette.broker.security.IAuthenticator;
+import io.moquette.broker.security.IAuthorizatorPolicy;
+import io.moquette.broker.subscriptions.Topic;
+import io.moquette.interception.AbstractInterceptHandler;
+import io.moquette.interception.messages.InterceptConnectMessage;
+import io.moquette.interception.messages.InterceptConnectionLostMessage;
+import io.moquette.interception.messages.InterceptDisconnectMessage;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Embedded MQTT broker (Moquette) implementing the AWS IoT data plane with token-based
+ * custom-authorizer enforcement.
+ *
+ * <p>At CONNECT, custom-auth parameters are extracted from the MQTT username, the authorizer
+ * Lambda is invoked via {@link IotAuthorizerService}, and the returned IAM policy is evaluated
+ * for {@code iot:Connect}. Per-session policies are cached and re-evaluated for
+ * {@code iot:Publish} / {@code iot:Subscribe} / {@code iot:Receive} on every publish/subscribe.
+ */
+@ApplicationScoped
+public class IotMqttBroker {
+
+    private static final Logger LOG = Logger.getLogger(IotMqttBroker.class);
+
+    private static final String INTERNAL_PUBLISHER = "floci-iot-broker";
+
+    private final EmulatorConfig config;
+    private final IotAuthorizerService authorizerService;
+    private final RegionResolver regionResolver;
+    private final IotBrokerEndpoint endpoint;
+    private final IotWebSocketBridge webSocketBridge;
+    private final ObjectMapper objectMapper;
+
+    private final Map<String, AuthorizerResult> sessionPolicies = new ConcurrentHashMap<>();
+    private volatile boolean lifecycleEventsEnabled;
+    private Server server;
+
+    @Inject
+    public IotMqttBroker(EmulatorConfig config,
+                         IotAuthorizerService authorizerService,
+                         RegionResolver regionResolver,
+                         IotBrokerEndpoint endpoint,
+                         IotWebSocketBridge webSocketBridge,
+                         ObjectMapper objectMapper) {
+        this.config = config;
+        this.authorizerService = authorizerService;
+        this.regionResolver = regionResolver;
+        this.endpoint = endpoint;
+        this.objectMapper = objectMapper;
+        this.webSocketBridge = webSocketBridge;
+    }
+
+    void onStart(@Observes StartupEvent ignored) {
+        EmulatorConfig.IotServiceConfig iot = config.services().iot();
+        if (!iot.enabled() || !iot.brokerEnabled()) {
+            LOG.debug("IoT MQTT broker disabled by configuration");
+            return;
+        }
+        this.lifecycleEventsEnabled = iot.brokerLifecycleEventsEnabled();
+        int tcpPort = findFreePort(iot.brokerTcpBasePort(), iot.brokerTcpMaxPort());
+        int wsPort = findFreePort(iot.brokerWsBasePort(), iot.brokerWsMaxPort());
+        if (tcpPort < 0 || wsPort < 0) {
+            LOG.warnv("IoT MQTT broker not started: no free ports in TCP {0}-{1} / WS {2}-{3}",
+                    iot.brokerTcpBasePort(), iot.brokerTcpMaxPort(),
+                    iot.brokerWsBasePort(), iot.brokerWsMaxPort());
+            return;
+        }
+
+        Properties props = new Properties();
+        props.setProperty(BrokerConstants.HOST_PROPERTY_NAME, iot.brokerHost());
+        props.setProperty(BrokerConstants.PORT_PROPERTY_NAME, String.valueOf(tcpPort));
+        props.setProperty(BrokerConstants.PERSISTENCE_ENABLED_PROPERTY_NAME, "false");
+        props.setProperty(BrokerConstants.ENABLE_TELEMETRY_NAME, "false");
+        // Force every connection through the custom authorizer (no anonymous access).
+        props.setProperty(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, "false");
+
+        // WebSocket transport (ws/wss) is handled by IotWebSocketBridge, not Moquette's own
+        // WebSocket listener, which mis-frames packets from mqtt.js / the AWS IoT Device SDK.
+        int wssPort = -1;
+        int mqttsPort = -1;
+        String keystorePath = null;
+        String keystorePassword = iot.brokerTlsKeystorePassword();
+        if (iot.brokerTlsEnabled()) {
+            keystorePath = resolveKeystorePath(iot);
+            if (keystorePath != null) {
+                mqttsPort = findFreePort(iot.brokerMqttsBasePort(), iot.brokerMqttsMaxPort());
+                wssPort = findFreePort(iot.brokerWssBasePort(), iot.brokerWssMaxPort());
+                if (mqttsPort > 0) {
+                    // Moquette serves MQTT-over-TLS (mqtts) directly; TLS-over-TCP frames fine.
+                    props.setProperty(BrokerConstants.SSL_PORT_PROPERTY_NAME, String.valueOf(mqttsPort));
+                    props.setProperty(BrokerConstants.JKS_PATH_PROPERTY_NAME, keystorePath);
+                    props.setProperty(BrokerConstants.KEY_STORE_TYPE, "pkcs12");
+                    props.setProperty(BrokerConstants.KEY_STORE_PASSWORD_PROPERTY_NAME, keystorePassword);
+                    props.setProperty(BrokerConstants.KEY_MANAGER_PASSWORD_PROPERTY_NAME, keystorePassword);
+                }
+            } else {
+                LOG.warn("IoT MQTT broker TLS disabled: could not build keystore");
+            }
+        }
+
+        IConfig brokerConfig = new MemoryConfig(props);
+        Server srv = new Server();
+        try {
+            srv.startServer(brokerConfig, List.of(new LifecycleHandler()), null,
+                    new IotAuthenticator(), new IotAuthorizator());
+        } catch (IOException e) {
+            LOG.errorv("Failed to start IoT MQTT broker: {0}", e.getMessage());
+            return;
+        }
+        this.server = srv;
+
+        // Bridge ws:// (+ wss:// when TLS is on) to the Moquette TCP listener.
+        webSocketBridge.start(iot.brokerHost(), wsPort, wssPort, tcpPort, keystorePath, keystorePassword);
+
+        endpoint.set(iot.brokerHost(), wsPort, tcpPort, iot.brokerWsPath());
+        if (wssPort > 0) {
+            endpoint.setTlsPorts(wssPort, mqttsPort);
+            LOG.infov("IoT MQTT broker started — mqtt tcp://{0}:{1}, ws://{0}:{2}{3}, "
+                            + "mqtts ssl://{0}:{4}, wss://{0}:{5}{3}",
+                    endpoint.advertisedHost(), String.valueOf(tcpPort), String.valueOf(wsPort),
+                    iot.brokerWsPath(), String.valueOf(mqttsPort), String.valueOf(wssPort));
+        } else {
+            LOG.infov("IoT MQTT broker started — mqtt tcp://{0}:{1}, ws://{0}:{2}{3} (TLS disabled)",
+                    endpoint.advertisedHost(), String.valueOf(tcpPort), String.valueOf(wsPort),
+                    iot.brokerWsPath());
+        }
+    }
+
+    private String resolveKeystorePath(EmulatorConfig.IotServiceConfig iot) {
+        try {
+            String configuredPath = iot.brokerTlsKeystorePath().orElse(null);
+            Path keystorePath = (configuredPath == null || configuredPath.isBlank())
+                    ? Path.of(System.getProperty("java.io.tmpdir"), "floci-iot-broker-keystore.p12")
+                    : Path.of(configuredPath);
+            IotBrokerKeystore.ensure(keystorePath, iot.brokerTlsKeystorePassword());
+            return keystorePath.toAbsolutePath().toString();
+        } catch (Exception e) {
+            LOG.warnv("Failed to build IoT broker TLS keystore: {0}", e.getMessage());
+            return null;
+        }
+    }
+
+    void onStop(@Observes ShutdownEvent ignored) {
+        endpoint.clear();
+        webSocketBridge.stop();
+        if (server != null) {
+            server.stopServer();
+            server = null;
+            LOG.info("IoT MQTT broker stopped");
+        }
+        sessionPolicies.clear();
+    }
+
+    private String region() {
+        return regionResolver.getDefaultRegion();
+    }
+
+    private String iotArn(String resourceType, String resource) {
+        return regionResolver.buildArn("iot", region(), resourceType + "/" + resource);
+    }
+
+    private static Map<String, String> conditionContext(String clientId) {
+        return clientId == null ? Map.of() : Map.of("iot:ClientId", clientId);
+    }
+
+    // ──────────────────────────── Presence / lifecycle events ────────────────────────────
+
+    private void publishConnected(String clientId) {
+        if (!lifecycleEventsEnabled || clientId == null) {
+            return;
+        }
+        ObjectNode event = baseLifecycleEvent(clientId, "connected");
+        publishLifecycle("$aws/events/presence/connected/" + clientId, event);
+    }
+
+    private void publishDisconnected(String clientId, boolean clientInitiated) {
+        if (!lifecycleEventsEnabled || clientId == null) {
+            return;
+        }
+        ObjectNode event = baseLifecycleEvent(clientId, "disconnected");
+        event.put("clientInitiatedDisconnect", clientInitiated);
+        event.put("disconnectReason", clientInitiated ? "CLIENT_INITIATED_DISCONNECT" : "CONNECTION_LOST");
+        publishLifecycle("$aws/events/presence/disconnected/" + clientId, event);
+    }
+
+    private ObjectNode baseLifecycleEvent(String clientId, String eventType) {
+        AuthorizerResult session = sessionPolicies.get(clientId);
+        String principal = (session != null && session.principalId() != null)
+                ? session.principalId() : regionResolver.getAccountId();
+        ObjectNode event = objectMapper.createObjectNode();
+        event.put("clientId", clientId);
+        event.put("timestamp", Instant.now().toEpochMilli());
+        event.put("eventType", eventType);
+        event.put("sessionIdentifier", UUID.randomUUID().toString());
+        event.put("principalIdentifier", principal);
+        event.put("versionNumber", 0);
+        return event;
+    }
+
+    /**
+     * Publishes a message to a topic via the data-plane HTTP {@code Publish} action.
+     */
+    public void publish(String topic, byte[] payload, int qos) {
+        Server srv = this.server;
+        if (srv == null) {
+            throw new AwsException("ServiceUnavailableException", "IoT MQTT broker is not running.", 503);
+        }
+        MqttQoS mqttQos = qos == 1 ? MqttQoS.AT_LEAST_ONCE : MqttQoS.AT_MOST_ONCE;
+        MqttPublishMessage message = MqttMessageBuilders.publish()
+                .topicName(topic)
+                .retained(false)
+                .qos(mqttQos)
+                .payload(Unpooled.copiedBuffer(payload == null ? new byte[0] : payload))
+                .build();
+        srv.internalPublish(message, INTERNAL_PUBLISHER);
+    }
+
+    private void publishLifecycle(String topic, ObjectNode event) {
+        Server srv = this.server;
+        if (srv == null) {
+            return;
+        }
+        try {
+            byte[] payload = objectMapper.writeValueAsBytes(event);
+            MqttPublishMessage message = MqttMessageBuilders.publish()
+                    .topicName(topic)
+                    .retained(false)
+                    .qos(MqttQoS.AT_MOST_ONCE)
+                    .payload(Unpooled.copiedBuffer(payload))
+                    .build();
+            srv.internalPublish(message, INTERNAL_PUBLISHER);
+        } catch (Exception e) {
+            LOG.debugv("Failed to publish IoT lifecycle event to {0}: {1}", topic, e.getMessage());
+        }
+    }
+
+    private static int findFreePort(int basePort, int maxPort) {
+        for (int port = basePort; port <= maxPort; port++) {
+            try (ServerSocket socket = new ServerSocket(port)) {
+                socket.setReuseAddress(true);
+                return port;
+            } catch (IOException e) {
+                // port busy, try next
+            }
+        }
+        return -1;
+    }
+
+    // ──────────────────────────── Auth enforcement ────────────────────────────
+
+    /**
+     * Resolves the custom authorizer and invokes its Lambda at CONNECT time.
+     */
+    final class IotAuthenticator implements IAuthenticator {
+        @Override
+        public boolean checkValid(String clientId, String username, byte[] password) {
+            if (username == null) {
+                LOG.debugv("Rejecting MQTT CONNECT for {0}: no username/custom-auth params", clientId);
+                return false;
+            }
+            try {
+                CustomAuthParams params = CustomAuthParams.parse(username);
+                IotAuthorizer authorizer = authorizerService.resolveAuthorizer(params.authorizerName());
+                String token = params.token(authorizer.getTokenKeyName());
+                String passwordStr = password == null ? null : new String(password, StandardCharsets.UTF_8);
+                IotAuthorizerService.AuthInput input = new IotAuthorizerService.AuthInput(
+                        token, params.signature(), clientId, params.baseUsername(), passwordStr);
+
+                AuthorizerResult result = authorizerService.invokeAuthorizer(authorizer, region(), input);
+                if (!result.isAuthenticated()) {
+                    LOG.debugv("Authorizer denied authentication for client {0}", clientId);
+                    return false;
+                }
+                String resource = iotArn("client", clientId);
+                if (!authorizerService.isAllowed(result, "iot:Connect", resource, conditionContext(clientId))) {
+                    LOG.debugv("Authorizer policy denies iot:Connect for client {0}", clientId);
+                    return false;
+                }
+                sessionPolicies.put(clientId, result);
+                LOG.debugv("Client {0} authenticated via authorizer {1}", clientId, authorizer.getAuthorizerName());
+                return true;
+            } catch (AwsException e) {
+                LOG.debugv("MQTT CONNECT rejected for {0}: {1}", clientId, e.getMessage());
+                return false;
+            } catch (RuntimeException e) {
+                LOG.warnv("MQTT CONNECT error for {0}: {1}", clientId, e.getMessage());
+                return false;
+            }
+        }
+    }
+
+    /**
+     * Evaluates the cached authorizer policy for publish/subscribe operations.
+     */
+    final class IotAuthorizator implements IAuthorizatorPolicy {
+        @Override
+        public boolean canWrite(Topic topic, String user, String client) {
+            AuthorizerResult result = sessionPolicies.get(client);
+            if (result == null) {
+                return false;
+            }
+            String resource = iotArn("topic", topic.toString());
+            return authorizerService.isAllowed(result, "iot:Publish", resource, conditionContext(client));
+        }
+
+        @Override
+        public boolean canRead(Topic topic, String user, String client) {
+            AuthorizerResult result = sessionPolicies.get(client);
+            if (result == null) {
+                return false;
+            }
+            Map<String, String> ctx = conditionContext(client);
+            return authorizerService.isAllowed(result, "iot:Subscribe", iotArn("topicfilter", topic.toString()), ctx)
+                    || authorizerService.isAllowed(result, "iot:Receive", iotArn("topic", topic.toString()), ctx);
+        }
+    }
+
+    /**
+     * Publishes AWS IoT presence/lifecycle events and drops the cached session policy when a
+     * client disconnects. The cached policy is removed only after the disconnect event (and any
+     * Last Will message) is published, so will/lifecycle authorization still sees it.
+     */
+    final class LifecycleHandler extends AbstractInterceptHandler {
+        @Override
+        public String getID() {
+            return "floci-iot-lifecycle";
+        }
+
+        @Override
+        public void onConnect(InterceptConnectMessage msg) {
+            publishConnected(msg.getClientID());
+        }
+
+        @Override
+        public void onDisconnect(InterceptDisconnectMessage msg) {
+            // Graceful DISCONNECT. Moquette also fires onConnectionLost as the channel closes;
+            // the session-policy guard there prevents a duplicate disconnected event.
+            String clientId = msg.getClientID();
+            publishDisconnected(clientId, true);
+            sessionPolicies.remove(clientId);
+        }
+
+        @Override
+        public void onConnectionLost(InterceptConnectionLostMessage msg) {
+            // Only emit when no graceful DISCONNECT already handled this client (i.e. an abrupt
+            // drop), so each disconnect yields exactly one lifecycle event.
+            String clientId = msg.getClientID();
+            if (sessionPolicies.containsKey(clientId)) {
+                publishDisconnected(clientId, false);
+                sessionPolicies.remove(clientId);
+            }
+        }
+
+        @Override
+        public void onSessionLoopError(Throwable error) {
+            LOG.warnv("IoT MQTT session loop error: {0}", error == null ? "unknown" : error.getMessage());
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotPaging.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotPaging.java
@@ -1,0 +1,54 @@
+package io.github.hectorvent.floci.services.iot;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * Token-based pagination shared by the IoT REST endpoints.
+ */
+final class IotPaging {
+
+    private IotPaging() {
+    }
+
+    record Page<T>(List<T> items, String nextToken) {
+    }
+
+    static <T> Page<T> paginate(List<T> items, String nextToken, Integer maxResults) {
+        int start = decodeToken(nextToken);
+        if (start < 0 || start > items.size()) {
+            throw new AwsException("InvalidRequestException", "Invalid token.", 400);
+        }
+        if (maxResults != null && maxResults < 0) {
+            throw new AwsException("InvalidRequestException", "maxResults must be non-negative.", 400);
+        }
+        int limit = (maxResults == null || maxResults <= 0)
+                ? items.size() - start
+                : Math.min(maxResults, items.size() - start);
+        int end = Math.min(items.size(), start + limit);
+        List<T> sliced = new ArrayList<>(items.subList(start, end));
+        String next = (end < items.size()) ? encodeToken(end) : null;
+        return new Page<>(sliced, next);
+    }
+
+    private static String encodeToken(int offset) {
+        return Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(Integer.toString(offset).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static int decodeToken(String token) {
+        if (token == null || token.isEmpty()) {
+            return 0;
+        }
+        try {
+            byte[] decoded = Base64.getUrlDecoder().decode(token);
+            return Integer.parseInt(new String(decoded, StandardCharsets.UTF_8));
+        } catch (IllegalArgumentException e) {
+            return -1;
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotWebSocketBridge.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotWebSocketBridge.java
@@ -1,0 +1,127 @@
+package io.github.hectorvent.floci.services.iot;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.ServerWebSocket;
+import io.vertx.core.net.NetClient;
+import io.vertx.core.net.NetSocket;
+import io.vertx.core.net.PfxOptions;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Terminates MQTT-over-WebSocket (ws:// and wss://) in Vert.x and pipes the raw MQTT byte
+ * stream to the Moquette broker's plain TCP listener.
+ *
+ * <p>Moquette's own WebSocket transport mis-frames packets from common clients (mqtt.js, the
+ * AWS IoT Device SDK); Vert.x WebSocket support interoperates with them correctly. Each
+ * WebSocket connection is backed by a dedicated TCP socket to {@code 127.0.0.1:<brokerPort>},
+ * so all authentication and authorization still happen inside Moquette via the custom authorizer.
+ */
+@ApplicationScoped
+public class IotWebSocketBridge {
+
+    private static final Logger LOG = Logger.getLogger(IotWebSocketBridge.class);
+    private static final long CLOSE_GRACE_MS = 200;
+
+    private final Vertx vertx;
+
+    private NetClient netClient;
+    private HttpServer plainServer;
+    private HttpServer tlsServer;
+
+    @Inject
+    public IotWebSocketBridge(Vertx vertx) {
+        this.vertx = vertx;
+    }
+
+    void start(String host, int wsPort, int wssPort, int targetTcpPort,
+               String keystorePath, String keystorePassword) {
+        this.netClient = vertx.createNetClient();
+        plainServer = listen(host, wsPort, targetTcpPort, null, null);
+        if (wssPort > 0 && keystorePath != null) {
+            tlsServer = listen(host, wssPort, targetTcpPort, keystorePath, keystorePassword);
+        }
+    }
+
+    void stop() {
+        if (plainServer != null) {
+            plainServer.close();
+            plainServer = null;
+        }
+        if (tlsServer != null) {
+            tlsServer.close();
+            tlsServer = null;
+        }
+        if (netClient != null) {
+            netClient.close();
+            netClient = null;
+        }
+    }
+
+    private HttpServer listen(String host, int port, int targetTcpPort,
+                              String keystorePath, String keystorePassword) {
+        HttpServerOptions options = new HttpServerOptions()
+                .addWebSocketSubProtocol("mqtt")
+                .addWebSocketSubProtocol("mqttv3.1")
+                .setPerMessageWebSocketCompressionSupported(false)
+                .setPerFrameWebSocketCompressionSupported(false);
+        if (keystorePath != null) {
+            options.setSsl(true).setPfxKeyCertOptions(
+                    new PfxOptions().setPath(keystorePath).setPassword(keystorePassword));
+        }
+        HttpServer server = vertx.createHttpServer(options)
+                .webSocketHandler(ws -> bridge(ws, targetTcpPort));
+        try {
+            server.listen(port, host).toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            LOG.warnv("IoT WebSocket bridge failed to bind {0}:{1}: {2}", host, port, e.getMessage());
+        }
+        return server;
+    }
+
+    private void bridge(ServerWebSocket ws, int targetTcpPort) {
+        ws.pause();
+        netClient.connect(targetTcpPort, "127.0.0.1").onComplete(ar -> {
+            if (ar.failed()) {
+                LOG.debugv("IoT WS bridge could not reach broker TCP port {0}: {1}",
+                        targetTcpPort, ar.cause().getMessage());
+                ws.close();
+                return;
+            }
+            NetSocket socket = ar.result();
+            // Track the last outbound write so a backend close (e.g. CONNACK-then-disconnect on
+            // an auth failure) flushes the final frame to the client before the WebSocket closes.
+            AtomicReference<Future<Void>> lastWrite = new AtomicReference<>(Future.succeededFuture());
+            // Clients (mqtt.js, the AWS IoT Device SDK) fragment the MQTT byte stream across many
+            // small WebSocket frames. Reassemble whole MQTT packets before writing to Moquette's
+            // TCP listener so the broker always decodes well-formed packets. The accumulator is
+            // only touched from the WebSocket's event loop, where frames arrive in order.
+            MqttPacketAssembler assembler = new MqttPacketAssembler();
+            ws.frameHandler(frame -> {
+                Buffer data = frame.binaryData();
+                if (data != null && data.length() > 0) {
+                    assembler.append(data).forEach(packet -> socket.write(packet));
+                }
+            });
+            socket.handler(buf -> lastWrite.set(ws.writeBinaryMessage(buf.copy())));
+            // When the broker closes (e.g. CONNACK-refused then disconnect on an auth failure),
+            // flush the final frame and give the client a brief grace window to read it before
+            // tearing down the WebSocket — strict clients drop unread data on an abrupt close.
+            Runnable closeWebSocket = () -> lastWrite.get().onComplete(
+                    ignored -> vertx.setTimer(CLOSE_GRACE_MS, t -> ws.close()));
+            ws.closeHandler(v -> socket.close());
+            socket.closeHandler(v -> closeWebSocket.run());
+            ws.exceptionHandler(t -> socket.close());
+            socket.exceptionHandler(t -> closeWebSocket.run());
+            ws.resume();
+        });
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/iot/MqttPacketAssembler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/MqttPacketAssembler.java
@@ -1,0 +1,65 @@
+package io.github.hectorvent.floci.services.iot;
+
+import io.vertx.core.buffer.Buffer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reassembles complete MQTT control packets from an arbitrarily chunked byte stream.
+ *
+ * <p>WebSocket clients fragment the MQTT stream across many small frames; this accumulator
+ * buffers incoming bytes and emits each whole MQTT packet (fixed header + variable-length
+ * "remaining length" + payload) once fully available. Not thread-safe — drive it from a single
+ * event loop per connection.
+ */
+final class MqttPacketAssembler {
+
+    private Buffer pending = Buffer.buffer();
+
+    /**
+     * Appends bytes and returns any complete MQTT packets now available, in order.
+     */
+    List<Buffer> append(Buffer data) {
+        pending.appendBuffer(data);
+        List<Buffer> packets = new ArrayList<>();
+        int packetLength;
+        while ((packetLength = nextPacketLength()) > 0) {
+            packets.add(pending.getBuffer(0, packetLength));
+            pending = pending.getBuffer(packetLength, pending.length());
+        }
+        return packets;
+    }
+
+    /**
+     * Returns the byte length of the leading complete packet in {@code pending}, or -1 if a full
+     * packet is not yet buffered.
+     */
+    private int nextPacketLength() {
+        int len = pending.length();
+        if (len < 2) {
+            return -1;
+        }
+        int multiplier = 1;
+        int remaining = 0;
+        int pos = 1;
+        int digit;
+        do {
+            if (pos >= len) {
+                return -1; // remaining-length field not fully received yet
+            }
+            digit = pending.getByte(pos) & 0xff;
+            remaining += (digit & 0x7f) * multiplier;
+            multiplier *= 128;
+            pos++;
+        } while ((digit & 0x80) != 0 && pos <= 4);
+
+        if ((digit & 0x80) != 0) {
+            // Malformed remaining length (> 4 bytes); drop the buffer to resync.
+            pending = Buffer.buffer();
+            return -1;
+        }
+        int total = pos + remaining;
+        return pending.length() >= total ? total : -1;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/iot/model/AuthorizerResult.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/model/AuthorizerResult.java
@@ -1,0 +1,20 @@
+package io.github.hectorvent.floci.services.iot.model;
+
+import java.util.List;
+
+/**
+ * Parsed response from a custom-authorizer Lambda.
+ *
+ * @param isAuthenticated         whether the device is allowed to connect
+ * @param principalId             principal identifier returned by the authorizer
+ * @param policyDocuments         raw IAM-style policy documents (JSON strings) to evaluate for pub/sub
+ * @param disconnectAfterSeconds  connection lifetime hint (nullable)
+ * @param refreshAfterSeconds     policy refresh hint (nullable)
+ */
+public record AuthorizerResult(
+        boolean isAuthenticated,
+        String principalId,
+        List<String> policyDocuments,
+        Integer disconnectAfterSeconds,
+        Integer refreshAfterSeconds) {
+}

--- a/src/main/java/io/github/hectorvent/floci/services/iot/model/IotAuthorizer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/model/IotAuthorizer.java
@@ -1,0 +1,109 @@
+package io.github.hectorvent.floci.services.iot.model;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An AWS IoT custom authorizer (token-based).
+ *
+ * <p>Holds the configuration the broker uses at connect time: the Lambda to invoke,
+ * the request key that carries the token, the public keys used to verify the token
+ * signature, and whether signature verification is required.
+ */
+public class IotAuthorizer {
+
+    private String authorizerName;
+    private String authorizerArn;
+    private String authorizerFunctionArn;
+    private String tokenKeyName;
+    private Map<String, String> tokenSigningPublicKeys = new HashMap<>();
+    private String status = "ACTIVE";
+    private boolean signingDisabled = false;
+    private boolean enableCachingForHttp = false;
+    private Instant creationDate;
+    private Instant lastModifiedDate;
+
+    public IotAuthorizer() {
+    }
+
+    public String getAuthorizerName() {
+        return authorizerName;
+    }
+
+    public void setAuthorizerName(String authorizerName) {
+        this.authorizerName = authorizerName;
+    }
+
+    public String getAuthorizerArn() {
+        return authorizerArn;
+    }
+
+    public void setAuthorizerArn(String authorizerArn) {
+        this.authorizerArn = authorizerArn;
+    }
+
+    public String getAuthorizerFunctionArn() {
+        return authorizerFunctionArn;
+    }
+
+    public void setAuthorizerFunctionArn(String authorizerFunctionArn) {
+        this.authorizerFunctionArn = authorizerFunctionArn;
+    }
+
+    public String getTokenKeyName() {
+        return tokenKeyName;
+    }
+
+    public void setTokenKeyName(String tokenKeyName) {
+        this.tokenKeyName = tokenKeyName;
+    }
+
+    public Map<String, String> getTokenSigningPublicKeys() {
+        return tokenSigningPublicKeys;
+    }
+
+    public void setTokenSigningPublicKeys(Map<String, String> tokenSigningPublicKeys) {
+        this.tokenSigningPublicKeys = tokenSigningPublicKeys;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public boolean isSigningDisabled() {
+        return signingDisabled;
+    }
+
+    public void setSigningDisabled(boolean signingDisabled) {
+        this.signingDisabled = signingDisabled;
+    }
+
+    public boolean isEnableCachingForHttp() {
+        return enableCachingForHttp;
+    }
+
+    public void setEnableCachingForHttp(boolean enableCachingForHttp) {
+        this.enableCachingForHttp = enableCachingForHttp;
+    }
+
+    public Instant getCreationDate() {
+        return creationDate;
+    }
+
+    public void setCreationDate(Instant creationDate) {
+        this.creationDate = creationDate;
+    }
+
+    public Instant getLastModifiedDate() {
+        return lastModifiedDate;
+    }
+
+    public void setLastModifiedDate(Instant lastModifiedDate) {
+        this.lastModifiedDate = lastModifiedDate;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -373,3 +373,20 @@ floci:
       enabled: true
     s3vectors:
       enabled: true
+    iot:
+      enabled: true
+      broker-enabled: true
+      broker-host: 0.0.0.0
+      broker-tcp-base-port: 1883
+      broker-tcp-max-port: 1899
+      broker-ws-base-port: 8083
+      broker-ws-max-port: 8099
+      broker-ws-path: /mqtt
+      broker-tls-enabled: true
+      broker-mqtts-base-port: 8883
+      broker-mqtts-max-port: 8899
+      broker-wss-base-port: 8443
+      broker-wss-max-port: 8459
+      # broker-tls-keystore-path:          # Optional PKCS12 keystore; auto-generated self-signed if unset
+      broker-tls-keystore-password: floci-iot
+      broker-lifecycle-events-enabled: true

--- a/src/test/java/io/github/hectorvent/floci/services/iot/CustomAuthParamsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/CustomAuthParamsTest.java
@@ -1,0 +1,55 @@
+package io.github.hectorvent.floci.services.iot;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CustomAuthParamsTest {
+
+    @Test
+    void parsesAwsDeviceSdkStyleUsername() {
+        String username = "mydevice?x-amz-customauthorizer-name=MyAuthorizer"
+                + "&x-amz-customauthorizer-signature=ABC%2BDEF%3D&MyTokenKey=the-token-value";
+        CustomAuthParams params = CustomAuthParams.parse(username);
+
+        assertEquals("mydevice", params.baseUsername());
+        assertEquals("MyAuthorizer", params.authorizerName());
+        assertEquals("ABC+DEF=", params.signature());
+        assertEquals("the-token-value", params.token("MyTokenKey"));
+    }
+
+    @Test
+    void parsesUsernameWithoutBaseSegment() {
+        String username = "?x-amz-customauthorizer-name=A&Tok=t";
+        CustomAuthParams params = CustomAuthParams.parse(username);
+
+        assertEquals("", params.baseUsername());
+        assertEquals("A", params.authorizerName());
+        assertEquals("t", params.token("Tok"));
+    }
+
+    @Test
+    void plainUsernameHasNoParams() {
+        CustomAuthParams params = CustomAuthParams.parse("plainuser");
+
+        assertEquals("plainuser", params.baseUsername());
+        assertNull(params.authorizerName());
+        assertNull(params.signature());
+        assertNull(params.token("anything"));
+    }
+
+    @Test
+    void nullUsernameYieldsEmpty() {
+        CustomAuthParams params = CustomAuthParams.parse(null);
+
+        assertEquals("", params.baseUsername());
+        assertNull(params.authorizerName());
+    }
+
+    @Test
+    void tokenLookupRequiresKeyName() {
+        CustomAuthParams params = CustomAuthParams.parse("u?x-amz-customauthorizer-name=A&K=v");
+        assertNull(params.token(null));
+        assertEquals("v", params.token("K"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotAuthorizerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotAuthorizerIntegrationTest.java
@@ -1,0 +1,162 @@
+package io.github.hectorvent.floci.services.iot;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class IotAuthorizerIntegrationTest {
+
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/iot/aws4_request";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    @Order(10)
+    void createAuthorizer() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "authorizerFunctionArn": "arn:aws:lambda:us-east-1:000000000000:function:my-authorizer",
+                  "tokenKeyName": "MyAuthToken",
+                  "signingDisabled": true,
+                  "status": "ACTIVE"
+                }
+                """)
+        .when()
+            .post("/authorizer/device-auth")
+        .then()
+            .statusCode(200)
+            .body("authorizerName", equalTo("device-auth"))
+            .body("authorizerArn", endsWith(":authorizer/device-auth"));
+    }
+
+    @Test
+    @Order(11)
+    void describeAuthorizer() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/authorizer/device-auth")
+        .then()
+            .statusCode(200)
+            .body("authorizerDescription.authorizerName", equalTo("device-auth"))
+            .body("authorizerDescription.authorizerFunctionArn",
+                    equalTo("arn:aws:lambda:us-east-1:000000000000:function:my-authorizer"))
+            .body("authorizerDescription.tokenKeyName", equalTo("MyAuthToken"))
+            .body("authorizerDescription.signingDisabled", equalTo(true))
+            .body("authorizerDescription.status", equalTo("ACTIVE"));
+    }
+
+    @Test
+    @Order(12)
+    void createAuthorizerWithoutSigningKeysRejected() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "authorizerFunctionArn": "arn:aws:lambda:us-east-1:000000000000:function:my-authorizer",
+                  "tokenKeyName": "MyAuthToken",
+                  "signingDisabled": false
+                }
+                """)
+        .when()
+            .post("/authorizer/needs-keys")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(13)
+    void updateAuthorizerStatus() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("{\"status\": \"INACTIVE\"}")
+        .when()
+            .put("/authorizer/device-auth")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/authorizer/device-auth")
+        .then()
+            .statusCode(200)
+            .body("authorizerDescription.status", equalTo("INACTIVE"));
+
+        // restore to ACTIVE for the default-authorizer test
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("{\"status\": \"ACTIVE\"}")
+        .when()
+            .put("/authorizer/device-auth")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(14)
+    void listAuthorizers() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/authorizers")
+        .then()
+            .statusCode(200)
+            .body("authorizers.authorizerName", hasItem("device-auth"));
+    }
+
+    @Test
+    @Order(15)
+    void setDefaultAuthorizer() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("{\"authorizerName\": \"device-auth\"}")
+        .when()
+            .post("/default-authorizer")
+        .then()
+            .statusCode(200)
+            .body("authorizerName", equalTo("device-auth"));
+    }
+
+    @Test
+    @Order(16)
+    void cannotDeleteDefaultAuthorizer() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/authorizer/device-auth")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
+    @Order(17)
+    void describeMissingAuthorizerReturns404() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .get("/authorizer/ghost")
+        .then()
+            .statusCode(404);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotAuthorizerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotAuthorizerServiceTest.java
@@ -1,0 +1,129 @@
+package io.github.hectorvent.floci.services.iot;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.services.iot.model.AuthorizerResult;
+import io.github.hectorvent.floci.services.iot.model.IotAuthorizer;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Signature;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Exercises the custom-authorizer auth core (event construction, Lambda-response parsing,
+ * policy evaluation, and token-signature verification) without an MQTT connection or a
+ * deployed Lambda. The end-to-end {@code TestInvokeAuthorizer} path additionally requires
+ * a running Lambda container and is covered manually.
+ */
+@QuarkusTest
+class IotAuthorizerServiceTest {
+
+    @Inject
+    IotAuthorizerService service;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Test
+    void buildEventProducesTokenBasedShape() throws Exception {
+        IotAuthorizerService.AuthInput input =
+                new IotAuthorizerService.AuthInput("the-token", null, "client-1", "user", "secret");
+        byte[] payload = service.buildEvent(input, true);
+
+        JsonNode event = objectMapper.readTree(payload);
+        assertEquals("the-token", event.get("token").asText());
+        assertTrue(event.get("signatureVerified").asBoolean());
+        assertEquals("mqtt", event.get("protocols").get(0).asText());
+        JsonNode mqtt = event.get("protocolData").get("mqtt");
+        assertEquals("client-1", mqtt.get("clientId").asText());
+        assertEquals("user", mqtt.get("username").asText());
+        assertEquals("secret",
+                new String(Base64.getDecoder().decode(mqtt.get("password").asText()), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void parseResponseReadsAuthorizerFields() {
+        String body = """
+            {
+              "isAuthenticated": true,
+              "principalId": "device-123",
+              "disconnectAfterInSeconds": 3600,
+              "refreshAfterInSeconds": 300,
+              "policyDocuments": [
+                "{\\"Version\\":\\"2012-10-17\\",\\"Statement\\":[{\\"Effect\\":\\"Allow\\",\\"Action\\":\\"iot:Connect\\",\\"Resource\\":\\"*\\"}]}"
+              ]
+            }
+            """;
+        AuthorizerResult result = service.parseResponse(body.getBytes(StandardCharsets.UTF_8));
+        assertTrue(result.isAuthenticated());
+        assertEquals("device-123", result.principalId());
+        assertEquals(3600, result.disconnectAfterSeconds());
+        assertEquals(300, result.refreshAfterSeconds());
+        assertEquals(1, result.policyDocuments().size());
+    }
+
+    @Test
+    void parseResponseAcceptsInlinePolicyObjects() {
+        String body = """
+            {
+              "isAuthenticated": true,
+              "policyDocuments": [
+                {"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"iot:Publish","Resource":"*"}]}
+              ]
+            }
+            """;
+        AuthorizerResult result = service.parseResponse(body.getBytes(StandardCharsets.UTF_8));
+        assertTrue(result.isAuthenticated());
+        assertEquals(1, result.policyDocuments().size());
+        assertTrue(service.isAllowed(result, "iot:Publish",
+                "arn:aws:iot:us-east-1:000000000000:topic/devices/1/data", Map.of()));
+    }
+
+    @Test
+    void isAllowedEvaluatesReturnedPolicy() {
+        String policy = """
+            {"Version":"2012-10-17","Statement":[
+              {"Effect":"Allow","Action":["iot:Connect","iot:Subscribe"],
+               "Resource":"arn:aws:iot:us-east-1:000000000000:topicfilter/devices/*"}
+            ]}
+            """;
+        AuthorizerResult result = new AuthorizerResult(true, "p", List.of(policy), null, null);
+
+        assertTrue(service.isAllowed(result, "iot:Subscribe",
+                "arn:aws:iot:us-east-1:000000000000:topicfilter/devices/floor3", Map.of()));
+        assertFalse(service.isAllowed(result, "iot:Publish",
+                "arn:aws:iot:us-east-1:000000000000:topic/devices/floor3", Map.of()));
+    }
+
+    @Test
+    void verifyTokenSignatureAcceptsValidRsaSignature() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair keyPair = generator.generateKeyPair();
+
+        String token = "my-auth-token";
+        Signature signer = Signature.getInstance("SHA256withRSA");
+        signer.initSign(keyPair.getPrivate());
+        signer.update(token.getBytes(StandardCharsets.UTF_8));
+        String signatureB64 = Base64.getEncoder().encodeToString(signer.sign());
+
+        String pem = "-----BEGIN PUBLIC KEY-----\n"
+                + Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded())
+                + "\n-----END PUBLIC KEY-----";
+
+        IotAuthorizer authorizer = new IotAuthorizer();
+        authorizer.setTokenSigningPublicKeys(Map.of("KEY1", pem));
+
+        assertTrue(service.verifyTokenSignature(authorizer, token, signatureB64));
+        assertFalse(service.verifyTokenSignature(authorizer, "tampered", signatureB64));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttBrokerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttBrokerIntegrationTest.java
@@ -1,0 +1,179 @@
+package io.github.hectorvent.floci.services.iot;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the embedded MQTT broker starts with plain and TLS listeners, advertises its
+ * (TLS) address via {@code DescribeEndpoint}, and routes every CONNECT through the custom
+ * authorizer. A successful end-to-end connect additionally requires a deployed authorizer
+ * Lambda (Docker) and is exercised manually — see docs/services/iot.md.
+ */
+@QuarkusTest
+@TestProfile(IotMqttBrokerIntegrationTest.BrokerEnabledProfile.class)
+class IotMqttBrokerIntegrationTest {
+
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/iot/aws4_request";
+
+    @Inject
+    IotBrokerEndpoint brokerEndpoint;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void brokerIsRunningWithTlsListeners() {
+        assertTrue(brokerEndpoint.isRunning(), "broker should be running under the broker-enabled profile");
+        assertTrue(brokerEndpoint.wsPort() > 0);
+        assertTrue(brokerEndpoint.tcpPort() > 0);
+        assertTrue(brokerEndpoint.tlsEnabled(), "TLS listeners should be active");
+        assertTrue(brokerEndpoint.wssPort() > 0);
+        assertTrue(brokerEndpoint.mqttsPort() > 0);
+    }
+
+    @Test
+    void describeEndpointReturnsSecureBrokerAddress() {
+        String expected = brokerEndpoint.advertisedHost() + ":" + brokerEndpoint.wssPort();
+        given()
+            .header("Authorization", AUTH)
+            .queryParam("endpointType", "iot:Data-ATS")
+        .when()
+            .get("/endpoint")
+        .then()
+            .statusCode(200)
+            .body("endpointAddress", equalTo(expected));
+    }
+
+    @Test
+    void publishViaRestReturns200() {
+        // HTTP data-plane Publish: POST /topics/{topic} injects the message into the broker.
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/octet-stream")
+            .queryParam("qos", 1)
+            .body("{\"temp\":22.5}".getBytes(java.nio.charset.StandardCharsets.UTF_8))
+        .when()
+            .post("/topics/devices/sensor-1/data")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    void plainConnectWithoutValidAuthorizerIsRejected() {
+        MqttException ex = assertThrows(MqttException.class,
+                () -> connect("tcp://localhost:" + brokerEndpoint.tcpPort(), null));
+        assertAuthRefused(ex);
+    }
+
+    @Test
+    void tlsConnectCompletesHandshakeThenAuthRefuses() throws Exception {
+        MqttException ex = assertThrows(MqttException.class,
+                () -> connect("ssl://localhost:" + brokerEndpoint.mqttsPort(), trustAllSocketFactory()));
+        // A reason code of bad-credentials / not-authorized proves the TLS handshake succeeded
+        // and the broker reached the custom-authorizer stage (rather than failing at TLS).
+        assertAuthRefused(ex);
+    }
+
+    @Test
+    void webSocketConnectThroughBridgeIsRefused() {
+        // Exercises the Vert.x ws->tcp bridge end to end: the MQTT CONNECT is reassembled and
+        // delivered to Moquette + the custom authorizer, which refuses the unknown authorizer, so
+        // the connection does not succeed. (The exact CONNACK reason code over a WebSocket that the
+        // broker closes immediately is client-specific; the authenticated success path and the
+        // precise deny code are verified with mqtt.js — see docs/services/iot.md.)
+        assertThrows(MqttException.class,
+                () -> connect("ws://localhost:" + brokerEndpoint.wsPort() + "/mqtt", null));
+    }
+
+    @Test
+    void secureWebSocketConnectThroughBridgeIsRefused() throws Exception {
+        var factory = trustAllSocketFactory();
+        assertThrows(MqttException.class,
+                () -> connect("wss://localhost:" + brokerEndpoint.wssPort() + "/mqtt", factory));
+    }
+
+    private void connect(String url, javax.net.ssl.SSLSocketFactory socketFactory) throws MqttException {
+        MqttConnectOptions options = new MqttConnectOptions();
+        options.setConnectionTimeout(5);
+        options.setUserName("dev?x-amz-customauthorizer-name=ghost-authorizer&MyToken=abc");
+        options.setPassword("pw".toCharArray());
+        if (socketFactory != null) {
+            options.setSocketFactory(socketFactory);
+        }
+        MqttClient client = new MqttClient(url, MqttClient.generateClientId(), new MemoryPersistence());
+        try {
+            client.connect(options);
+        } finally {
+            client.close();
+        }
+    }
+
+    private static void assertAuthRefused(MqttException ex) {
+        int code = ex.getReasonCode();
+        assertTrue(code == MqttException.REASON_CODE_FAILED_AUTHENTICATION
+                        || code == MqttException.REASON_CODE_NOT_AUTHORIZED,
+                "expected an auth-refused reason code (4 or 5) but was " + code);
+    }
+
+    private static javax.net.ssl.SSLSocketFactory trustAllSocketFactory() throws Exception {
+        TrustManager[] trustAll = {
+            new X509TrustManager() {
+                @Override
+                public void checkClientTrusted(X509Certificate[] chain, String authType) {
+                }
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] chain, String authType) {
+                }
+
+                @Override
+                public X509Certificate[] getAcceptedIssuers() {
+                    return new X509Certificate[0];
+                }
+            }
+        };
+        SSLContext ctx = SSLContext.getInstance("TLS");
+        ctx.init(null, trustAll, new SecureRandom());
+        return ctx.getSocketFactory();
+    }
+
+    public static final class BrokerEnabledProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "floci.services.iot.broker-enabled", "true",
+                    "floci.services.iot.broker-tcp-base-port", "11883",
+                    "floci.services.iot.broker-tcp-max-port", "11899",
+                    "floci.services.iot.broker-ws-base-port", "18083",
+                    "floci.services.iot.broker-ws-max-port", "18099",
+                    "floci.services.iot.broker-mqtts-base-port", "18883",
+                    "floci.services.iot.broker-mqtts-max-port", "18899",
+                    "floci.services.iot.broker-wss-base-port", "18443",
+                    "floci.services.iot.broker-wss-max-port", "18459");
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iot/MqttPacketAssemblerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/MqttPacketAssemblerTest.java
@@ -1,0 +1,81 @@
+package io.github.hectorvent.floci.services.iot;
+
+import io.vertx.core.buffer.Buffer;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MqttPacketAssemblerTest {
+
+    // A small CONNECT-shaped packet: header 0x10, remaining length 3, then 3 payload bytes.
+    private static Buffer packet(int header, byte... payload) {
+        Buffer b = Buffer.buffer();
+        b.appendByte((byte) header);
+        b.appendByte((byte) payload.length);
+        b.appendBytes(payload);
+        return b;
+    }
+
+    @Test
+    void emitsWholePacketDeliveredAtOnce() {
+        MqttPacketAssembler a = new MqttPacketAssembler();
+        Buffer p = packet(0x10, (byte) 1, (byte) 2, (byte) 3);
+        List<Buffer> out = a.append(p);
+        assertEquals(1, out.size());
+        assertEquals(p, out.get(0));
+    }
+
+    @Test
+    void reassemblesPacketFragmentedByteByByte() {
+        MqttPacketAssembler a = new MqttPacketAssembler();
+        Buffer p = packet(0x82, (byte) 0xaa, (byte) 0xbb, (byte) 0xcc, (byte) 0xdd);
+        List<Buffer> collected = new java.util.ArrayList<>();
+        for (int i = 0; i < p.length(); i++) {
+            collected.addAll(a.append(Buffer.buffer().appendByte(p.getByte(i))));
+        }
+        assertEquals(1, collected.size());
+        assertEquals(p, collected.get(0));
+    }
+
+    @Test
+    void splitsMultiplePacketsInOneChunk() {
+        MqttPacketAssembler a = new MqttPacketAssembler();
+        Buffer p1 = packet(0x10, (byte) 1, (byte) 2);
+        Buffer p2 = packet(0x82, (byte) 3, (byte) 4, (byte) 5);
+        List<Buffer> out = a.append(Buffer.buffer().appendBuffer(p1).appendBuffer(p2));
+        assertEquals(2, out.size());
+        assertEquals(p1, out.get(0));
+        assertEquals(p2, out.get(1));
+    }
+
+    @Test
+    void handlesMultiByteRemainingLength() {
+        // remaining length 200 -> encoded as two bytes: 0xC8 0x01
+        Buffer b = Buffer.buffer();
+        b.appendByte((byte) 0x30);
+        b.appendByte((byte) 0xC8);
+        b.appendByte((byte) 0x01);
+        byte[] payload = new byte[200];
+        b.appendBytes(payload);
+
+        MqttPacketAssembler a = new MqttPacketAssembler();
+        // feed in two chunks split inside the payload
+        List<Buffer> out = a.append(b.getBuffer(0, 50));
+        assertTrue(out.isEmpty());
+        out = a.append(b.getBuffer(50, b.length()));
+        assertEquals(1, out.size());
+        assertEquals(203, out.get(0).length());
+    }
+
+    @Test
+    void waitsForIncompletePacket() {
+        MqttPacketAssembler a = new MqttPacketAssembler();
+        Buffer header = Buffer.buffer().appendByte((byte) 0x10).appendByte((byte) 5).appendByte((byte) 1);
+        assertTrue(a.append(header).isEmpty());
+        List<Buffer> out = a.append(Buffer.buffer().appendBytes(new byte[]{2, 3, 4, 5}));
+        assertEquals(1, out.size());
+        assertEquals(7, out.get(0).length());
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -240,3 +240,6 @@ floci:
       enabled: true
     s3vectors:
       enabled: true
+    iot:
+      enabled: true
+      broker-enabled: false


### PR DESCRIPTION
## Summary

Adds an **AWS IoT Core data plane** to Floci, backed by an embedded MQTT broker (Moquette), with **token-based custom authentication**. This lets devices connect, publish, and subscribe locally against the same custom-authorizer flow as production AWS.

- **Custom authorizers** — `CreateAuthorizer` / `DescribeAuthorizer` / `UpdateAuthorizer` / `DeleteAuthorizer` / `ListAuthorizers` / `SetDefaultAuthorizer` / `TestInvokeAuthorizer`. The broker invokes your authorizer Lambda at CONNECT (via the in-process Lambda runtime) and enforces the IAM policy it returns for `iot:Connect` / `iot:Publish` / `iot:Subscribe` / `iot:Receive` (via `IamPolicyEvaluator`). Token signatures are verified (`SHA256withRSA`) against the registered signing keys unless `signingDisabled`.
- **Embedded MQTT broker** — MQTT and MQTT-over-WebSocket, plain and TLS (`tcp://`, `ws://`, `ssl://`, `wss://`). WebSocket transports are fronted by a Vert.x bridge that reassembles MQTT packets so mqtt.js and the AWS IoT Device SDK interoperate cleanly; TLS uses an auto-generated self-signed cert (or a supplied keystore).
- **Presence / lifecycle events** — `$aws/events/presence/{connected,disconnected}/{clientId}`.
- **Last Will & Testament** — standard MQTT LWT.
- **Data plane** — HTTP `Publish` (`POST /topics/{topicName}`) and `DescribeEndpoint` (returns the running broker address).

Registered in `ResolvedServiceCatalog`, configured via `EmulatorConfig` + `application.yml`, and documented under `docs/services/iot.md` (service count 59 → 60).

New runtime dependency: **`io.moquette:moquette-broker`** (broker engine: subscription routing, retained messages, QoS, LWT, the auth SPI, and connect/disconnect interceptors). Flagging it explicitly for review.

The **thing registry** (things, thing types, thing groups, IoT policies) is intentionally **out of scope** here and will follow as a separate, dependency-free PR.

Refs #1038

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified end-to-end against a running Floci container (Docker socket mounted so the authorizer Lambda runs for real):

- **AWS CLI v2.33.3** — `iot create-authorizer`, `iot test-invoke-authorizer`, `iot describe-endpoint`, `iot-data publish`, plus `lambda create-function` / `invoke` for the authorizer.
- **MQTT clients** — mqtt.js 5.15.1 and Eclipse Paho 1.2.5 over `tcp`/`ws`/`ssl`/`wss`.
- Confirmed end-to-end: CONNECT → authorizer Lambda invoked → returned IAM policy enforced for publish/subscribe; HTTP publish delivered to subscribers; presence connect/disconnect events; and LWT on ungraceful disconnect.

Custom-auth parameters are read from the MQTT CONNECT username (the encoding the AWS IoT Device SDK v2 produces), so the standard device SDK and generic MQTT clients both work.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
