### PR TITLE
feat(ses): implement PutConfigurationSetDeliveryOptions for SES v1

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesConfigurationSetDeliveryOptionsV1Test.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesConfigurationSetDeliveryOptionsV1Test.java
@@ -1,0 +1,109 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import software.amazon.awssdk.services.ses.SesClient;
+import software.amazon.awssdk.services.ses.model.ConfigurationSet;
+import software.amazon.awssdk.services.ses.model.ConfigurationSetDoesNotExistException;
+import software.amazon.awssdk.services.ses.model.CreateConfigurationSetRequest;
+import software.amazon.awssdk.services.ses.model.DeleteConfigurationSetRequest;
+import software.amazon.awssdk.services.ses.model.DeliveryOptions;
+import software.amazon.awssdk.services.ses.model.PutConfigurationSetDeliveryOptionsRequest;
+
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.GetConfigurationSetRequest;
+import software.amazon.awssdk.services.sesv2.model.GetConfigurationSetResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * SDK compatibility test for the SES V1 (Query) {@code PutConfigurationSetDeliveryOptions}
+ * action. The V1 API names the TLS policy {@code Require}/{@code Optional} (PascalCase),
+ * while Floci stores the V2 canonical {@code REQUIRE}/{@code OPTIONAL}. A value written
+ * through the V1 {@link SesClient} must therefore read back as {@code REQUIRE} through the
+ * V2 {@code GetConfigurationSet} response — exercising both the action wiring and the
+ * PascalCase normalization end to end.
+ */
+@DisplayName("SES V1 PutConfigurationSetDeliveryOptions")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesConfigurationSetDeliveryOptionsV1Test {
+
+    private static SesClient sesV1;
+    private static SesV2Client sesV2;
+    private static String csName;
+
+    @BeforeAll
+    static void setup() {
+        sesV1 = TestFixtures.sesClient();
+        sesV2 = TestFixtures.sesV2Client();
+        csName = "sdk-v1-cs-delivery-" + TestFixtures.uniqueName();
+        sesV1.createConfigurationSet(CreateConfigurationSetRequest.builder()
+                .configurationSet(ConfigurationSet.builder().name(csName).build())
+                .build());
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (sesV1 != null) {
+            try {
+                sesV1.deleteConfigurationSet(DeleteConfigurationSetRequest.builder()
+                        .configurationSetName(csName).build());
+            } catch (Exception ignored) {}
+            sesV1.close();
+        }
+        if (sesV2 != null) {
+            sesV2.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void v1PutDeliveryOptions_pascalCaseTlsPolicy_readsBackAsCanonical() {
+        sesV1.putConfigurationSetDeliveryOptions(PutConfigurationSetDeliveryOptionsRequest.builder()
+                .configurationSetName(csName)
+                .deliveryOptions(DeliveryOptions.builder().tlsPolicy("Require").build())
+                .build());
+
+        GetConfigurationSetResponse response = sesV2.getConfigurationSet(
+                GetConfigurationSetRequest.builder().configurationSetName(csName).build());
+        assertThat(response.deliveryOptions()).isNotNull();
+        assertThat(response.deliveryOptions().tlsPolicyAsString()).isEqualTo("REQUIRE");
+    }
+
+    @Test
+    @Order(2)
+    void v1PutDeliveryOptions_emptyPayload_clearsTheBlock() {
+        sesV1.putConfigurationSetDeliveryOptions(PutConfigurationSetDeliveryOptionsRequest.builder()
+                .configurationSetName(csName)
+                .deliveryOptions(DeliveryOptions.builder().tlsPolicy("Require").build())
+                .build());
+
+        // A put with no DeliveryOptions fields clears the block rather than persisting an
+        // empty object, matching the V2 PutConfigurationSetDeliveryOptions behavior.
+        sesV1.putConfigurationSetDeliveryOptions(PutConfigurationSetDeliveryOptionsRequest.builder()
+                .configurationSetName(csName)
+                .build());
+
+        GetConfigurationSetResponse response = sesV2.getConfigurationSet(
+                GetConfigurationSetRequest.builder().configurationSetName(csName).build());
+        assertThat(response.deliveryOptions()).isNull();
+    }
+
+    @Test
+    @Order(3)
+    void v1PutDeliveryOptions_unknownConfigurationSet_raisesModeledException() {
+        assertThatThrownBy(() -> sesV1.putConfigurationSetDeliveryOptions(
+                PutConfigurationSetDeliveryOptionsRequest.builder()
+                        .configurationSetName("sdk-v1-cs-delivery-missing-" + System.currentTimeMillis())
+                        .deliveryOptions(DeliveryOptions.builder().tlsPolicy("Require").build())
+                        .build()))
+                .isInstanceOf(ConfigurationSetDoesNotExistException.class);
+    }
+}

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -50,6 +50,7 @@ Floci exposes the classic Amazon SES Query API used by `aws ses ...` commands an
 | `UpdateConfigurationSetTrackingOptions`  | Change the custom tracking redirect domain |
 | `DeleteConfigurationSetTrackingOptions`  | Remove the custom tracking redirect domain |
 | `UpdateConfigurationSetReputationMetricsEnabled` | Enable or disable reputation metrics for a configuration set |
+| `PutConfigurationSetDeliveryOptions` | Set the TLS policy (delivery options) for a configuration set |
 
 ## Configuration
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -385,7 +385,8 @@ public class AwsQueryController {
             "CreateConfigurationSetTrackingOptions",
             "UpdateConfigurationSetTrackingOptions",
             "DeleteConfigurationSetTrackingOptions",
-            "UpdateConfigurationSetReputationMetricsEnabled"
+            "UpdateConfigurationSetReputationMetricsEnabled",
+            "PutConfigurationSetDeliveryOptions"
     );
 
     private static final Set<String> COGNITO_ACTIONS = Set.of(

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
@@ -761,9 +761,18 @@ public class SesQueryHandler {
                                                               String region) {
         String configSet = requireParam(params, "ConfigurationSetName");
         String tlsPolicy = getParam(params, "DeliveryOptions.TlsPolicy");
+        // The V1 API accepts TlsPolicy Require/Optional (PascalCase, case-sensitive). Validate
+        // here so an invalid enum value yields the v1 ValidationError AWS returns rather than the
+        // shared service's v2-style BadRequestException. Message verified against real AWS.
+        if (tlsPolicy != null && !"Require".equals(tlsPolicy) && !"Optional".equals(tlsPolicy)) {
+            throw new AwsException("ValidationError",
+                    "1 validation error detected: Value at 'deliveryOptions.tlsPolicy' failed to "
+                            + "satisfy constraint: Member must satisfy enum value set: [Optional, Require]",
+                    400);
+        }
         // Mirror the V2 path: an all-null DeliveryOptions clears the block rather than
-        // persisting an empty object. The V1 API uses Require/Optional for TlsPolicy, so
-        // normalize to the V2 canonical REQUIRE/OPTIONAL that Floci stores internally.
+        // persisting an empty object. Normalize the value to the V2 canonical REQUIRE/OPTIONAL
+        // that Floci stores internally.
         DeliveryOptions options = null;
         if (tlsPolicy != null) {
             options = new DeliveryOptions();

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
 import io.github.hectorvent.floci.services.ses.model.CloudWatchDestination;
 import io.github.hectorvent.floci.services.ses.model.CloudWatchDimensionConfiguration;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.DeliveryOptions;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.EventDestination;
 import io.github.hectorvent.floci.services.ses.model.Identity;
@@ -25,6 +26,7 @@ import org.jboss.logging.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Query-protocol handler for SES actions.
@@ -98,6 +100,8 @@ public class SesQueryHandler {
                         handleDeleteConfigurationSetTrackingOptions(params, region);
                 case "UpdateConfigurationSetReputationMetricsEnabled" ->
                         handleUpdateConfigurationSetReputationMetricsEnabled(params, region);
+                case "PutConfigurationSetDeliveryOptions" ->
+                        handlePutConfigurationSetDeliveryOptions(params, region);
                 default -> AwsQueryResponse.error("UnsupportedOperation",
                         "Operation " + action + " is not supported by SES.", AwsNamespaces.SES, 400);
             };
@@ -751,6 +755,23 @@ public class SesQueryHandler {
         sesService.setConfigurationSetReputationOptions(configSet, enabled, region);
         return Response.ok(AwsQueryResponse.envelopeEmptyResult(
                 "UpdateConfigurationSetReputationMetricsEnabled", AwsNamespaces.SES)).build();
+    }
+
+    private Response handlePutConfigurationSetDeliveryOptions(MultivaluedMap<String, String> params,
+                                                              String region) {
+        String configSet = requireParam(params, "ConfigurationSetName");
+        String tlsPolicy = getParam(params, "DeliveryOptions.TlsPolicy");
+        // Mirror the V2 path: an all-null DeliveryOptions clears the block rather than
+        // persisting an empty object. The V1 API uses Require/Optional for TlsPolicy, so
+        // normalize to the V2 canonical REQUIRE/OPTIONAL that Floci stores internally.
+        DeliveryOptions options = null;
+        if (tlsPolicy != null) {
+            options = new DeliveryOptions();
+            options.setTlsPolicy(tlsPolicy.toUpperCase(Locale.ROOT));
+        }
+        sesService.setConfigurationSetDeliveryOptions(configSet, options, region);
+        return Response.ok(AwsQueryResponse.envelopeEmptyResult(
+                "PutConfigurationSetDeliveryOptions", AwsNamespaces.SES)).build();
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV1IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV1IntegrationTest.java
@@ -245,7 +245,10 @@ class SesConfigurationSetV1IntegrationTest {
             .post("/")
         .then()
             .statusCode(400)
-            .body(containsString("<Code>BadRequestException</Code>"))
-            .body(containsString("tlsPolicy"));
+            // Real AWS returns the Smithy enum ValidationError (not the v2 BadRequestException)
+            // for an invalid TlsPolicy value; the single quotes are XML-escaped on the wire.
+            .body(containsString("<Code>ValidationError</Code>"))
+            .body(containsString("deliveryOptions.tlsPolicy"))
+            .body(containsString("[Optional, Require]"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV1IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetV1IntegrationTest.java
@@ -189,4 +189,63 @@ class SesConfigurationSetV1IntegrationTest {
             .statusCode(400)
             .body(containsString("<Code>InvalidParameterValue</Code>"));
     }
+
+    @Test
+    @Order(11)
+    void putConfigurationSetDeliveryOptions() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateConfigurationSet")
+            .formParam("ConfigurationSet.Name", "v1-cs-delivery")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "PutConfigurationSetDeliveryOptions")
+            .formParam("ConfigurationSetName", "v1-cs-delivery")
+            .formParam("DeliveryOptions.TlsPolicy", "Require")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("PutConfigurationSetDeliveryOptionsResponse"));
+    }
+
+    @Test
+    @Order(12)
+    void putConfigurationSetDeliveryOptions_unknownSetReturns400() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "PutConfigurationSetDeliveryOptions")
+            .formParam("ConfigurationSetName", "v1-cs-ghost")
+            .formParam("DeliveryOptions.TlsPolicy", "Require")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>ConfigurationSetDoesNotExist</Code>"));
+    }
+
+    @Test
+    @Order(13)
+    void putConfigurationSetDeliveryOptions_invalidTlsPolicyReturns400() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "PutConfigurationSetDeliveryOptions")
+            .formParam("ConfigurationSetName", "v1-cs-delivery")
+            .formParam("DeliveryOptions.TlsPolicy", "Bogus")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>BadRequestException</Code>"))
+            .body(containsString("tlsPolicy"));
+    }
 }


### PR DESCRIPTION
## Summary

`PutConfigurationSetDeliveryOptions` was only reachable through the SES v2 REST path — the classic SES Query (v1) API returned `UnsupportedOperation`, even though the `setConfigurationSetDeliveryOptions` service logic and validation already existed. This wires the v1 action:

- `SesQueryHandler`: added `PutConfigurationSetDeliveryOptions`, parsing `ConfigurationSetName` and `DeliveryOptions.TlsPolicy` and delegating to the shared service.
- `AwsQueryController`: registered the action in the SES action set so it routes to the SES handler.
- `docs/services/ses.md`: listed the action.

The v1 `DeliveryOptions` structure carries only `TlsPolicy` (`Require`/`Optional`), whereas Floci stores the v2 canonical `REQUIRE`/`OPTIONAL`. The handler normalizes the value before delegating, so a v1 SDK client sending `Require` is accepted rather than rejected by the shared validator. An all-null payload passes `null` to clear the block, mirroring the v2 path rather than persisting an empty object.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Parameter and enum shapes were verified against the AWS API reference for [PutConfigurationSetDeliveryOptions](https://docs.aws.amazon.com/ses/latest/APIReference/API_PutConfigurationSetDeliveryOptions.html) and [DeliveryOptions](https://docs.aws.amazon.com/ses/latest/APIReference/API_DeliveryOptions.html): request params `ConfigurationSetName` and `DeliveryOptions.TlsPolicy` with valid values `Require | Optional` (the v1 structure has no `SendingPoolName`). Coverage: v1 Query integration tests (happy path, unknown configuration set, invalid TLS policy) and an AWS Java SDK v1 compatibility test that writes `Require` via the v1 `SesClient`, reads it back as the canonical `REQUIRE` via v2 `GetConfigurationSet`, asserts an empty put clears the block, and asserts the modeled `ConfigurationSetDoesNotExistException` for an unknown set.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
