### PR TITLE
feat(iam): add AmazonRDSEnhancedMonitoringRole managed policy

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
@@ -89,6 +89,10 @@ final class AwsManagedPolicies {
         new ManagedPolicyDef("AmazonEKS_CNI_Policy", "/",
                 "Provides the Amazon VPC CNI Plugin the permissions it requires to modify the IP address configuration on your EKS worker nodes."),
 
+        // RDS execution role policy
+        new ManagedPolicyDef("AmazonRDSEnhancedMonitoringRole", "/service-role/",
+                "Provides permissions required for Amazon RDS Enhanced Monitoring."),
+
         // S3 Object Lambda execution role policy
         new ManagedPolicyDef("AmazonS3ObjectLambdaExecutionRolePolicy", "/service-role/",
                 "Provides write permissions to CloudWatch Logs for S3 Object Lambda access points."),

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
@@ -236,6 +236,25 @@ class IamIntegrationTest {
     }
 
     @Test
+    @Order(17)
+    void getRdsEnhancedMonitoringPolicy() {
+        given()
+            .formParam("Action", "GetPolicy")
+            .formParam("PolicyArn",
+                    "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole")
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=test/20260227/us-east-1/iam/aws4_request")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("GetPolicyResponse.GetPolicyResult.Policy.PolicyName",
+                    equalTo("AmazonRDSEnhancedMonitoringRole"))
+            .body("GetPolicyResponse.GetPolicyResult.Policy.Arn",
+                    equalTo("arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"));
+    }
+
+    @Test
     @Order(9)
     void stsGetCallerIdentityFallsBackForUnseededFlociAccessKey() {
         given()

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
@@ -502,6 +502,11 @@ class IamServiceTest {
         IamPolicy ecrReadOnly = iamService.getPolicy("arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly");
         assertEquals("AmazonEC2ContainerRegistryReadOnly", ecrReadOnly.getPolicyName());
         assertEquals("/", ecrReadOnly.getPath());
+
+        IamPolicy rdsMonitoring = iamService.getPolicy(
+                "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole");
+        assertEquals("AmazonRDSEnhancedMonitoringRole", rdsMonitoring.getPolicyName());
+        assertEquals("/service-role/", rdsMonitoring.getPath());
     }
 
     @Test
@@ -610,6 +615,19 @@ class IamServiceTest {
         iamService.attachRolePolicy("Ec2Exec", policyArn);
 
         List<IamPolicy> attached = iamService.listAttachedRolePolicies("Ec2Exec", null);
+        assertEquals(1, attached.size());
+        assertEquals(policyArn, attached.getFirst().getArn());
+    }
+
+    @Test
+    void attachRdsEnhancedMonitoringRolePolicyToRole() {
+        iamService.seedAwsManagedPolicies();
+        iamService.createRole("RdsMonitor", "/", "{}", null, 0, null);
+
+        String policyArn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole";
+        iamService.attachRolePolicy("RdsMonitor", policyArn);
+
+        List<IamPolicy> attached = iamService.listAttachedRolePolicies("RdsMonitor", null);
         assertEquals(1, attached.size());
         assertEquals(policyArn, attached.getFirst().getArn());
     }


### PR DESCRIPTION
## Summary

Seeds `AmazonRDSEnhancedMonitoringRole` into the catalog of AWS-managed policies that floci creates at startup.

- Adds the policy definition to `AwsManagedPolicies` under `/service-role/`, matching the real AWS ARN `arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole`
- Without this entry callers that attach this policy to an RDS monitoring role (e.g. via Terraform's `aws_iam_role_policy_attachment`) get a `NoSuchEntityException` on startup

## Tests

- Extended `seedAwsManagedPolicies()` in `IamServiceTest` to assert the new policy is reachable by ARN with the correct name and path
- Added `attachRdsEnhancedMonitoringRolePolicyToRole()` unit test that attaches the policy to a role and verifies the attachment
- Added `getRdsEnhancedMonitoringPolicy()` integration test (`@Order(17)`) that retrieves the policy via the `GetPolicy` wire action and checks both `PolicyName` and `Arn`