### PR TITLE
fix(ses): make FromEmailAddress optional for v2 SendEmail

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -270,11 +270,10 @@ public class SesController {
             JsonNode request = objectMapper.readTree(body);
             requireJsonObject(request);
 
+            // FromEmailAddress is optional per the AWS v2 contract. Each content type below
+            // enforces the sender requirement the way AWS does: Raw can take its From from the
+            // MIME message, while Simple and Templated require FromEmailAddress.
             String fromEmailAddress = request.path("FromEmailAddress").asText(null);
-            if (fromEmailAddress == null || fromEmailAddress.isBlank()) {
-                throw new AwsException("BadRequestException",
-                        "FromEmailAddress is required.", 400);
-            }
 
             JsonNode destination = requireObjectOrAbsent(request, "Destination");
             List<String> toAddresses = jsonArrayToList(destination.path("ToAddresses"));
@@ -301,6 +300,10 @@ public class SesController {
                 messageId = sesService.sendRawEmail(fromEmailAddress, allDestinations, rawData,
                         configurationSetName, emailTags, region);
             } else if (content.has("Simple")) {
+                if (fromEmailAddress == null || fromEmailAddress.isBlank()) {
+                    // AWS returns BadRequestException with a null message body here.
+                    throw new AwsException("BadRequestException", null, 400);
+                }
                 JsonNode simple = content.path("Simple");
                 String subject = simple.path("Subject").path("Data").asText("");
                 String bodyText = simple.path("Body").path("Text").path("Data").asText(null);
@@ -310,6 +313,9 @@ public class SesController {
                         bccAddresses, replyToAddresses, subject, bodyText, bodyHtml,
                         configurationSetName, emailTags, additionalHeaders, region);
             } else if (content.has("Template")) {
+                if (fromEmailAddress == null || fromEmailAddress.isBlank()) {
+                    throw new AwsException("BadRequestException", "Source cannot be empty", 400);
+                }
                 JsonNode template = content.path("Template");
                 String templateName = template.path("TemplateName").asText(null);
                 String templateArn = template.path("TemplateArn").asText(null);

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -254,6 +254,13 @@ public class SesService {
         String effectiveSource = sourceOmitted && headers != null && !headers.from().isBlank()
                 ? headers.from()
                 : source;
+        if (effectiveSource == null || effectiveSource.isBlank()) {
+            // Shared by the v1 Query and v2 REST surfaces. Throw the v1-native code; the v2
+            // controller's remapV1Exception translates InvalidParameterValue -> BadRequestException.
+            // Verified against real AWS: v1 returns InvalidParameterValue and v2 BadRequestException,
+            // both with this message.
+            throw new AwsException("InvalidParameterValue", "Missing required header 'From'.", 400);
+        }
         List<String> effectiveDestinations = hasExplicitDestinations
                 ? destinations
                 : allRecipients(headers.to(), headers.cc(), headers.bcc());

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesIntegrationTest.java
@@ -221,6 +221,27 @@ class SesIntegrationTest {
     }
 
     @Test
+    @Order(30)
+    void sendRawEmail_withoutSource_andNoMimeFrom_returnsInvalidParameterValue() {
+        // Complements sendRawEmail_withoutSource_acceptedWhenMimeFromPresent: with neither a
+        // Source parameter nor a MIME From header there is no sender, so the send is rejected.
+        // Verified against real AWS: v1 returns InvalidParameterValue "Missing required header 'From'." (400).
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/email/aws4_request")
+            .formParam("Action", "SendRawEmail")
+            .formParam("Destinations.member.1", "recipient@example.com")
+            .formParam("RawMessage.Data", "Subject: hello\r\n\r\nbody\r\n")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>InvalidParameterValue</Code>"))
+            // The apostrophes are XML-escaped on the Query (XML) wire, matching AWS.
+            .body(containsString("Missing required header &apos;From&apos;."));
+    }
+
+    @Test
     @Order(12)
     void getSendQuota() {
         given()

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
@@ -852,7 +852,73 @@ class SesV2IntegrationTest {
             .post("/v2/email/outbound-emails")
         .then()
             .statusCode(400)
-            .body("__type", equalTo("BadRequestException"));
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("Missing required header 'From'."));
+    }
+
+    // FromEmailAddress is optional in the AWS v2 contract; the per-content-type behavior
+    // below is verified against real AWS (Raw takes its From from the MIME message; Simple
+    // returns a null message; Templated returns "Source cannot be empty").
+
+    @Test
+    @Order(67)
+    void sendEmail_raw_noFromAddress_usesMimeFrom() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                    "Destination": {"ToAddresses": ["r@example.com"]},
+                    "Content": {"Raw": {"Data": "From: raw-from@floci.test\\r\\nTo: r@example.com\\r\\nSubject: s\\r\\n\\r\\nbody"}}
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-emails")
+        .then()
+            .statusCode(200)
+            .body("MessageId", notNullValue());
+    }
+
+    @Test
+    @Order(68)
+    void sendEmail_simple_missingFrom() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                    "Destination": {"ToAddresses": ["r@example.com"]},
+                    "Content": {"Simple": {"Subject": {"Data": "s"}, "Body": {"Text": {"Data": "hi"}}}}
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-emails")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            // AWS returns the message key present with a JSON null value.
+            .body("$", hasKey("message"))
+            .body("message", nullValue());
+    }
+
+    @Test
+    @Order(69)
+    void sendEmail_template_missingFrom() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                    "Destination": {"ToAddresses": ["r@example.com"]},
+                    "Content": {"Template": {"TemplateName": "any-tpl", "TemplateData": "{}"}}
+                }
+                """)
+        .when()
+            .post("/v2/email/outbound-emails")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("Source cannot be empty"));
     }
 
     // ──────────────── Inspection endpoint (/_aws/ses) ────────────────


### PR DESCRIPTION
## Summary

Floci's v2 `SendEmail` handler rejected any request without `FromEmailAddress`, diverging from AWS where the field is marked `Required: No`. This aligns the behavior per content type, matching what real AWS returns (confirmed via probes against a live account, including the raw HTTP error bodies):

- **Raw** content takes its sender from the MIME `From` header, so `FromEmailAddress` may be omitted. When neither is present, the send fails with `BadRequestException` `Missing required header 'From'.`. (This also corrects the v1 `SendRawEmail` path, which previously accepted a From-less raw message.)
- **Simple** content with no `FromEmailAddress` returns `BadRequestException` with a `null` message body (`{"message":null}`), exactly as AWS does.
- **Templated** content with no `FromEmailAddress` returns `BadRequestException` `Source cannot be empty`.

Related to #797 (the v2 sender-resolution counterpart to the v1 `SendRawEmail` MIME-`From` handling).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against the AWS API reference for [SendEmail](https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_SendEmail.html) (`FromEmailAddress` Required: No) and against real AWS via probes that captured the exact wire responses for each content type with the sender omitted: Raw-with-MIME-From succeeds (200), Raw-with-no-From → 400 `Missing required header 'From'.`, Simple → 400 `{"message":null}`, Templated → 400 `Source cannot be empty`. A new v2 integration test pins all four cases.

**Reproduce** the Raw behavior with the AWS CLI against a running Floci (`./mvnw quarkus:dev`). Before this PR both calls failed with `400 FromEmailAddress is required.`:

```bash
export AWS_ENDPOINT_URL=http://localhost:4566
export AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=us-east-1

# Raw, no FromEmailAddress but the MIME has a From header -> 200, returns a MessageId
aws sesv2 send-email --cli-input-json '{"Destination":{"ToAddresses":["r@example.com"]},
  "Content":{"Raw":{"Data":"'"$(printf 'From: s@floci.test\r\nSubject: x\r\n\r\nb' | base64 | tr -d '\n')"'"}}}'

# Raw, no From anywhere -> BadRequestException: Missing required header 'From'.
aws sesv2 send-email --cli-input-json '{"Destination":{"ToAddresses":["r@example.com"]},
  "Content":{"Raw":{"Data":"'"$(printf 'Subject: x\r\n\r\nb' | base64 | tr -d '\n')"'"}}}'
```

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
