### PR TITLE
fix(codebuild): stabilize compatibility tests

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CodeBuildTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CodeBuildTest.java
@@ -45,6 +45,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class CodeBuildTest {
 
+    private static final String CODEBUILD_TEST_IMAGE =
+            "public.ecr.aws/docker/library/busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d";
+
     static CodeBuildClient codebuild;
     static String reportGroupArn;
     static String sourceCredentialsArn;
@@ -210,7 +213,7 @@ class CodeBuildTest {
                         .build())
                 .environment(ProjectEnvironment.builder()
                         .type(EnvironmentType.LINUX_CONTAINER)
-                        .image("public.ecr.aws/docker/library/alpine:latest")
+                        .image(CODEBUILD_TEST_IMAGE)
                         .computeType(ComputeType.BUILD_GENERAL1_SMALL)
                         .build())
                 .serviceRole("arn:aws:iam::000000000000:role/codebuild-role"));
@@ -343,7 +346,7 @@ class CodeBuildTest {
                         .build())
                 .environment(ProjectEnvironment.builder()
                         .type(EnvironmentType.LINUX_CONTAINER)
-                        .image("public.ecr.aws/docker/library/alpine:latest")
+                        .image(CODEBUILD_TEST_IMAGE)
                         .computeType(ComputeType.BUILD_GENERAL1_SMALL)
                         .build())
                 .serviceRole("arn:aws:iam::000000000000:role/codebuild-role"));
@@ -358,7 +361,7 @@ class CodeBuildTest {
                 "  build:",
                 "    commands:",
                 "      - echo '=== OS Family ===' > command-output.txt",
-                "      - cat /etc/os-release >> command-output.txt",
+                "      - uname -a >> command-output.txt",
                 "      - echo '' >> command-output.txt",
                 "      - echo '=== Directory Tree (depth 3) ===' >> command-output.txt",
                 "      - find / -maxdepth 3 -type d 2>/dev/null >> command-output.txt",
@@ -409,7 +412,7 @@ class CodeBuildTest {
         System.out.println("=== command-output.txt from os-bucket ===");
         System.out.println(content);
 
-        assertThat(content).contains("NAME=");
+        assertThat(content).contains("Linux");
         assertThat(content).contains("/usr");
 
         s3.close();


### PR DESCRIPTION
## Summary

Stabilize CodeBuild compatibility tests by replacing unstable image/command assumptions in test fixtures.

- replace `public.ecr.aws/docker/library/alpine:latest` with a digest-pinned BusyBox image shared by both CodeBuild compatibility test scenarios
- switch the OS demo buildspec from `/etc/os-release` parsing to `uname -a` so the test no longer assumes distro-specific files
- keep the directory traversal bounded with `find / -maxdepth 3 -type d` to avoid the heavier full-tree listing approach

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The previous compatibility tests depended on `public.ecr.aws/docker/library/alpine:latest`, which is a mutable external image tag and can fail independently of Floci changes due to image drift or registry pull limits. They also assumed distro-specific OS metadata files. This change pins the image by digest and narrows the command assumptions to utilities available in the selected image, while keeping the test focus on CodeBuild execution and artifact upload behavior.

On PR #1295, CI failed for commit `cd5d289` but passed on the empty follow-up commit `04349b3`. That suggests the failure was not deterministically tied to the source diff and is consistent with test or external dependency instability rather than a stable product behavior regression.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
