### PR TITLE
Honor queue-level DelaySeconds for standard SQS queues

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
@@ -195,7 +195,8 @@ public class SqsJsonHandler {
     private Response handleSendMessage(JsonNode request, String region) {
         String queueUrl = request.path("QueueUrl").asText(null);
         String messageBody = request.path("MessageBody").asText(null);
-        int delaySeconds = request.path("DelaySeconds").asInt(0);
+        JsonNode delayNode = request.path("DelaySeconds");
+        Integer delaySeconds = parseOptionalInteger(delayNode, "DelaySeconds");
         String messageGroupId = request.path("MessageGroupId").asText(null);
         String messageDeduplicationId = request.path("MessageDeduplicationId").asText(null);
 
@@ -347,7 +348,7 @@ public class SqsJsonHandler {
         ArrayNode successful = objectMapper.createArrayNode();
         ArrayNode failed = objectMapper.createArrayNode();
 
-        record ParsedEntry(String id, String body, int delay, String groupId, String dedupId,
+        record ParsedEntry(String id, String body, Integer delay, String groupId, String dedupId,
                            Map<String, MessageAttributeValue> attributes, String awsTraceHeader) {}
 
         List<ParsedEntry> parsedEntries = new ArrayList<>();
@@ -356,7 +357,8 @@ public class SqsJsonHandler {
             for (JsonNode entry : entries) {
                 String id = entry.path("Id").asText();
                 String messageBody = entry.path("MessageBody").asText(null);
-                int delaySeconds = entry.path("DelaySeconds").asInt(0);
+                JsonNode entryDelayNode = entry.path("DelaySeconds");
+                Integer delaySeconds = parseOptionalInteger(entryDelayNode, "DelaySeconds");
                 String messageGroupId = entry.path("MessageGroupId").asText(null);
                 String messageDeduplicationId = entry.path("MessageDeduplicationId").asText(null);
 
@@ -582,5 +584,16 @@ public class SqsJsonHandler {
             });
         }
         return map;
+    }
+
+    private Integer parseOptionalInteger(JsonNode node, String paramName) {
+        if (node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        if (!node.isIntegralNumber()) {
+            throw new AwsException("InvalidParameterValue",
+                    "Value for parameter " + paramName + " is invalid. Reason: Must be an integer.", 400);
+        }
+        return node.asInt();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
@@ -196,7 +196,7 @@ public class SqsQueryHandler {
     private Response handleSendMessage(MultivaluedMap<String, String> params, String region) {
         String queueUrl = getParam(params, "QueueUrl");
         String body = getParam(params, "MessageBody");
-        int delaySeconds = getIntParam(params, "DelaySeconds", 0);
+        Integer delaySeconds = getIntegerParam(params, "DelaySeconds");
         String messageGroupId = getParam(params, "MessageGroupId");
         String messageDeduplicationId = getParam(params, "MessageDeduplicationId");
 
@@ -331,7 +331,7 @@ public class SqsQueryHandler {
         String queueUrl = getParam(params, "QueueUrl");
         var xml = new XmlBuilder();
 
-        record ParsedEntry(String id, String body, int delay, String groupId, String dedupId,
+        record ParsedEntry(String id, String body, Integer delay, String groupId, String dedupId,
                            Map<String, MessageAttributeValue> attributes, String awsTraceHeader) {}
 
         List<ParsedEntry> parsedEntries = new ArrayList<>();
@@ -340,7 +340,7 @@ public class SqsQueryHandler {
             String id = getParam(params, "SendMessageBatchRequestEntry." + i + ".Id");
             if (id == null) break;
             String body = getParam(params, "SendMessageBatchRequestEntry." + i + ".MessageBody");
-            int delaySeconds = getIntParam(params, "SendMessageBatchRequestEntry." + i + ".DelaySeconds", 0);
+            Integer delaySeconds = getIntegerParam(params, "SendMessageBatchRequestEntry." + i + ".DelaySeconds");
             String messageGroupId = getParam(params, "SendMessageBatchRequestEntry." + i + ".MessageGroupId");
             String messageDeduplicationId = getParam(params, "SendMessageBatchRequestEntry." + i + ".MessageDeduplicationId");
 
@@ -557,6 +557,17 @@ public class SqsQueryHandler {
             return Integer.parseInt(value);
         } catch (NumberFormatException e) {
             return defaultValue;
+        }
+    }
+
+    private Integer getIntegerParam(MultivaluedMap<String, String> params, String name) {
+        String value = params.getFirst(name);
+        if (value == null) return null;
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw new AwsException("InvalidParameterValue",
+                    "Value for parameter " + name + " is invalid. Reason: Must be an integer.", 400);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -340,17 +340,17 @@ public class SqsService {
         return filtered;
     }
 
-    public Message sendMessage(String queueUrl, String body, int delaySeconds, String region) {
+    public Message sendMessage(String queueUrl, String body, Integer delaySeconds, String region) {
         return sendMessage(queueUrl, body, delaySeconds, null, null, region);
     }
 
-    public Message sendMessage(String queueUrl, String body, int delaySeconds,
+    public Message sendMessage(String queueUrl, String body, Integer delaySeconds,
                                String messageGroupId, String messageDeduplicationId,
                                String region) {
         return sendMessage(queueUrl, body, delaySeconds, messageGroupId, messageDeduplicationId, null, region);
     }
 
-    public Message sendMessage(String queueUrl, String body, int delaySeconds,
+    public Message sendMessage(String queueUrl, String body, Integer delaySeconds,
                                String messageGroupId, String messageDeduplicationId,
                                Map<String, MessageAttributeValue> messageAttributes,
                                String region) {
@@ -358,7 +358,7 @@ public class SqsService {
                 messageAttributes, null, region);
     }
 
-    public Message sendMessage(String queueUrl, String body, int delaySeconds,
+    public Message sendMessage(String queueUrl, String body, Integer delaySeconds,
                                String messageGroupId, String messageDeduplicationId,
                                Map<String, MessageAttributeValue> messageAttributes,
                                String awsTraceHeader,
@@ -381,15 +381,16 @@ public class SqsService {
         // Resolve the effective delay:
         //   - FIFO queues only support queue-level DelaySeconds per AWS SQS,
         //     so any per-message value is ignored and we always use the
-        //     queue attribute. Without this, FIFO silently dropped the
-        //     queue-level default (issue #475).
-        //   - Standard queues honor per-message DelaySeconds when provided
-        //     (> 0). Applying the queue-level default on the standard path
-        //     requires distinguishing "omitted" from "explicit 0" in the
-        //     handlers, which the current int-parameter API cannot express;
-        //     that's left as follow-up work -- this patch only addresses
-        //     the FIFO regression called out in the issue.
-        int effectiveDelaySeconds = queue.isFifo() ? queueDelaySeconds : delaySeconds;
+        //     queue attribute.
+        //   - Standard queues honor per-message DelaySeconds when explicitly
+        //     provided (non-null). When omitted (null), the queue-level
+        //     default applies.
+        int effectiveDelaySeconds;
+        if (queue.isFifo()) {
+            effectiveDelaySeconds = queueDelaySeconds;
+        } else {
+            effectiveDelaySeconds = (delaySeconds != null) ? delaySeconds : queueDelaySeconds;
+        }
 
         // FIFO queue validation
         if (queue.isFifo()) {

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -461,6 +461,38 @@ class SqsServiceTest {
                 "FIFO queues must ignore per-message DelaySeconds");
     }
 
+    // --- Queue-level DelaySeconds for standard queues ---
+
+    @Test
+    void queueLevelDelaySecondsAppliesToStandardQueue() {
+        String region = "eu-west-1";
+        Queue queue = sqsService.createQueue("delay-standard",
+                Map.of("DelaySeconds", "1"), region);
+        sqsService.sendMessage(queue.getQueueUrl(), "msg", null, region);
+
+        List<Message> immediate = sqsService.receiveMessage(queue.getQueueUrl(), 1, 0, 0, region);
+        assertTrue(immediate.isEmpty(),
+                "Standard queue should honor queue-level DelaySeconds");
+
+        try { Thread.sleep(1100); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+
+        List<Message> later = sqsService.receiveMessage(queue.getQueueUrl(), 1, 0, 0, region);
+        assertEquals(1, later.size(),
+                "Message should become visible once DelaySeconds elapses");
+    }
+
+    @Test
+    void explicitZeroDelayOverridesQueueDefault() {
+        String region = "eu-west-1";
+        Queue queue = sqsService.createQueue("delay-override",
+                Map.of("DelaySeconds", "10"), region);
+        sqsService.sendMessage(queue.getQueueUrl(), "msg", 0, region);
+
+        List<Message> immediate = sqsService.receiveMessage(queue.getQueueUrl(), 1, 0, 0, region);
+        assertEquals(1, immediate.size(),
+                "Explicit DelaySeconds=0 must override queue-level default");
+    }
+
     // --- clearFifoDeduplicationCacheOnPurge tests ---
 
     @Test


### PR DESCRIPTION
## Summary
- Standard SQS queues with a `DelaySeconds` attribute were not applying the delay to messages sent without an explicit per-message `DelaySeconds`
- Root cause: the handler→service API used primitive `int` (default 0), making it impossible to distinguish "omitted" from "explicit 0"
- Changed `int delaySeconds` to `Integer delaySeconds` across the handler/service chain so `null` falls back to the queue attribute while `Integer(0)` overrides it
- Added tests for both queue-level delay application and explicit zero override

## Test plan
- [x] `mvn verify` passes all tests including new standard queue delay tests
- [x] Existing FIFO delay tests still pass
- [x] Camel Spring Boot `SqsDelayedQueueTest` passes with the fixed floci image