### PR TITLE
feat(ecs): mount efsVolumeConfiguration task volumes as shared local volumes

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilder.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilder.java
@@ -238,13 +238,21 @@ public class ContainerBuilder {
         }
 
         /**
-         * Adds a named volume mount.
+         * Adds a read-write named volume mount.
          */
         public Builder withNamedVolume(String volumeName, String containerPath) {
+            return withNamedVolume(volumeName, containerPath, false);
+        }
+
+        /**
+         * Adds a named volume mount, read-only when {@code readOnly} is true.
+         */
+        public Builder withNamedVolume(String volumeName, String containerPath, boolean readOnly) {
             this.mounts.add(new Mount()
                     .withType(MountType.VOLUME)
                     .withSource(volumeName)
-                    .withTarget(containerPath));
+                    .withTarget(containerPath)
+                    .withReadOnly(readOnly));
             return this;
         }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
@@ -25,6 +25,7 @@ import io.github.hectorvent.floci.services.ecs.model.ServiceDeployment;
 import io.github.hectorvent.floci.services.ecs.model.ServiceRevision;
 import io.github.hectorvent.floci.services.ecs.model.TaskDefinition;
 import io.github.hectorvent.floci.services.ecs.model.TaskSet;
+import io.github.hectorvent.floci.services.ecs.model.EfsVolumeConfiguration;
 import io.github.hectorvent.floci.services.ecs.model.Volume;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -951,6 +952,31 @@ public class EcsJsonHandler {
                     host.put("sourcePath", v.hostSourcePath());
                     vNode.set("host", host);
                 }
+                if (v.efs() != null) {
+                    EfsVolumeConfiguration e = v.efs();
+                    ObjectNode efs = objectMapper.createObjectNode();
+                    efs.put("fileSystemId", e.fileSystemId());
+                    if (e.rootDirectory() != null) {
+                        efs.put("rootDirectory", e.rootDirectory());
+                    }
+                    if (e.transitEncryption() != null) {
+                        efs.put("transitEncryption", e.transitEncryption());
+                    }
+                    if (e.transitEncryptionPort() != null) {
+                        efs.put("transitEncryptionPort", e.transitEncryptionPort());
+                    }
+                    if (e.accessPointId() != null || e.iam() != null) {
+                        ObjectNode auth = objectMapper.createObjectNode();
+                        if (e.accessPointId() != null) {
+                            auth.put("accessPointId", e.accessPointId());
+                        }
+                        if (e.iam() != null) {
+                            auth.put("iam", e.iam());
+                        }
+                        efs.set("authorizationConfig", auth);
+                    }
+                    vNode.set("efsVolumeConfiguration", efs);
+                }
                 vols.add(vNode);
             }
             n.set("volumes", vols);
@@ -1292,9 +1318,30 @@ public class EcsJsonHandler {
         }
         for (JsonNode item : node) {
             String hostSourcePath = item.path("host").path("sourcePath").asText(null);
-            result.add(new Volume(item.path("name").asText(), hostSourcePath));
+            EfsVolumeConfiguration efs = parseEfsVolumeConfiguration(item.path("efsVolumeConfiguration"));
+            result.add(new Volume(item.path("name").asText(), hostSourcePath, efs));
         }
         return result;
+    }
+
+    private EfsVolumeConfiguration parseEfsVolumeConfiguration(JsonNode node) {
+        if (node == null || !node.isObject()) {
+            return null;
+        }
+        String fileSystemId = node.path("fileSystemId").asText(null);
+        if (fileSystemId == null) {
+            return null;
+        }
+        Integer transitEncryptionPort = node.path("transitEncryptionPort").isNumber()
+                ? node.path("transitEncryptionPort").asInt() : null;
+        JsonNode auth = node.path("authorizationConfig");
+        return new EfsVolumeConfiguration(
+                fileSystemId,
+                node.path("rootDirectory").asText(null),
+                node.path("transitEncryption").asText(null),
+                transitEncryptionPort,
+                auth.path("accessPointId").asText(null),
+                auth.path("iam").asText(null));
     }
 
     private List<MountPoint> parseMountPoints(JsonNode node) {

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManager.java
@@ -12,6 +12,7 @@ import io.github.hectorvent.floci.services.ecs.model.Container;
 import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
 import io.github.hectorvent.floci.services.ecs.model.ContainerOverride;
 import io.github.hectorvent.floci.services.ecs.model.EcsTask;
+import io.github.hectorvent.floci.services.ecs.model.EfsVolumeConfiguration;
 import io.github.hectorvent.floci.services.ecs.model.MountPoint;
 import io.github.hectorvent.floci.services.ecs.model.NetworkBinding;
 import io.github.hectorvent.floci.services.ecs.model.PortMapping;
@@ -74,12 +75,20 @@ public class EcsContainerManager {
         List<Closeable> logStreams = new ArrayList<>();
         List<Container> runtimeContainers = new ArrayList<>();
 
-        // Task-level volumes: map volume name -> host source path, consumed by per-container mountPoints.
+        // Task-level volumes consumed by per-container mountPoints: host volumes map their
+        // name -> absolute host source path; efsVolumeConfiguration volumes map their
+        // name -> EFS configuration (materialised below as a shared local Docker volume).
         Map<String, String> volumeSourcePaths = new LinkedHashMap<>();
+        Map<String, EfsVolumeConfiguration> efsVolumes = new LinkedHashMap<>();
         if (taskDef.getVolumes() != null) {
             for (Volume v : taskDef.getVolumes()) {
-                if (v.name() != null && v.hostSourcePath() != null) {
+                if (v.name() == null) {
+                    continue;
+                }
+                if (v.hostSourcePath() != null) {
                     volumeSourcePaths.put(v.name(), v.hostSourcePath());
+                } else if (v.efs() != null) {
+                    efsVolumes.put(v.name(), v.efs());
                 }
             }
         }
@@ -142,16 +151,28 @@ public class EcsContainerManager {
             // so it must be an absolute host path. Unresolved volume references are skipped.
             if (def.getMountPoints() != null) {
                 for (MountPoint mp : def.getMountPoints()) {
-                    String sourcePath = volumeSourcePaths.get(mp.sourceVolume());
-                    if (sourcePath == null || mp.containerPath() == null) {
-                        LOG.warnv("Skipping mountPoint with unresolved volume {0} on container {1}",
-                                mp.sourceVolume(), def.getName());
+                    if (mp.containerPath() == null) {
                         continue;
                     }
-                    if (mp.readOnly()) {
-                        specBuilder.withReadOnlyBind(sourcePath, mp.containerPath());
+                    String sourcePath = volumeSourcePaths.get(mp.sourceVolume());
+                    EfsVolumeConfiguration efs = efsVolumes.get(mp.sourceVolume());
+                    if (sourcePath != null) {
+                        // Host volume: bind-mount an absolute path on the Docker host.
+                        if (mp.readOnly()) {
+                            specBuilder.withReadOnlyBind(sourcePath, mp.containerPath());
+                        } else {
+                            specBuilder.withBind(sourcePath, mp.containerPath());
+                        }
+                    } else if (efs != null) {
+                        // EFS volume: a shared local Docker named volume, so every task
+                        // container that mounts the same EFS file system shares persistent
+                        // storage — the local stand-in for an EFS mount (Docker cannot mount
+                        // a real EFS file system).
+                        specBuilder.withNamedVolume(efsVolumeName(efs.fileSystemId()),
+                                mp.containerPath(), mp.readOnly());
                     } else {
-                        specBuilder.withBind(sourcePath, mp.containerPath());
+                        LOG.warnv("Skipping mountPoint with unresolved volume {0} on container {1}",
+                                mp.sourceVolume(), def.getName());
                     }
                 }
             }
@@ -405,6 +426,11 @@ public class EcsContainerManager {
     private static String extractTaskId(String taskArn) {
         int slash = taskArn.lastIndexOf('/');
         return slash >= 0 ? taskArn.substring(slash + 1) : taskArn;
+    }
+
+    /** Name of the local Docker named volume backing an EFS file system. */
+    private static String efsVolumeName(String fileSystemId) {
+        return "floci-efs-" + fileSystemId;
     }
 
     // Inner enum to avoid import cycle — mirrors model.TaskStatus for readability

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/EfsVolumeConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/EfsVolumeConfiguration.java
@@ -1,0 +1,25 @@
+package io.github.hectorvent.floci.services.ecs.model;
+
+/**
+ * The {@code efsVolumeConfiguration} of an ECS task-definition volume:
+ * {@code {"fileSystemId": ..., "rootDirectory": ..., "transitEncryption": ...,
+ * "transitEncryptionPort": ..., "authorizationConfig": {"accessPointId": ..., "iam": ...}}}.
+ *
+ * <p>A container references the owning {@link Volume} by name via a {@link MountPoint}.
+ * Docker cannot mount a real Amazon EFS file system, so Floci materialises an EFS-backed
+ * volume as a shared local Docker <em>named volume</em> ({@code floci-efs-<fileSystemId>}):
+ * every container that mounts the same file system shares persistent storage that survives
+ * task restarts — the local equivalent of an EFS mount.
+ *
+ * <p>{@code rootDirectory}, {@code transitEncryption}, {@code transitEncryptionPort} and
+ * {@code authorizationConfig} are modelled for RegisterTaskDefinition/DescribeTaskDefinition
+ * round-trip fidelity (so Terraform sees no drift) but have no effect on the local mount.
+ */
+public record EfsVolumeConfiguration(
+        String fileSystemId,
+        String rootDirectory,
+        String transitEncryption,
+        Integer transitEncryptionPort,
+        String accessPointId,
+        String iam) {
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/Volume.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/Volume.java
@@ -1,10 +1,20 @@
 package io.github.hectorvent.floci.services.ecs.model;
 
 /**
- * A task-level volume in an ECS task definition. Only the EC2-launch-type
- * {@code host} volume shape is modelled: {@code {"name": ..., "host": {"sourcePath": ...}}}.
- * {@code hostSourcePath} is the absolute path on the Docker host that the volume
- * binds to; a container references this volume by {@code name} via a {@link MountPoint}.
+ * A task-level volume in an ECS task definition. Two shapes are modelled:
+ * <ul>
+ *   <li>EC2-launch-type {@code host} volume — {@code {"name": ..., "host": {"sourcePath": ...}}};
+ *       {@code hostSourcePath} is the absolute path on the Docker host that the volume binds to.</li>
+ *   <li>{@code efsVolumeConfiguration} volume — {@code {"name": ..., "efsVolumeConfiguration": {...}}};
+ *       see {@link EfsVolumeConfiguration}.</li>
+ * </ul>
+ * The two are mutually exclusive. A container references the volume by {@code name} via a
+ * {@link MountPoint}.
  */
-public record Volume(String name, String hostSourcePath) {
+public record Volume(String name, String hostSourcePath, EfsVolumeConfiguration efs) {
+
+    /** Convenience constructor for a {@code host} volume (no EFS configuration). */
+    public Volume(String name, String hostSourcePath) {
+        this(name, hostSourcePath, null);
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandlerVolumesTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandlerVolumesTest.java
@@ -96,4 +96,50 @@ class EcsJsonHandlerVolumesTest {
         assertEquals("/root/.aws", mps.get(1).path("containerPath").asText());
         assertFalse(mps.get(1).path("readOnly").asBoolean(), "aws mount is read-write");
     }
+
+    @Test
+    void registerTaskDefinitionRoundTripsEfsVolumeConfiguration() throws Exception {
+        String requestJson = """
+                {
+                  "family": "efs-family",
+                  "containerDefinitions": [
+                    {
+                      "name": "app",
+                      "image": "alpine:latest",
+                      "mountPoints": [
+                        {"sourceVolume": "customer-data", "containerPath": "/mnt/efs", "readOnly": false}
+                      ]
+                    }
+                  ],
+                  "volumes": [
+                    {
+                      "name": "customer-data",
+                      "efsVolumeConfiguration": {
+                        "fileSystemId": "fs-0123456789abcdef0",
+                        "rootDirectory": "/dps",
+                        "transitEncryption": "ENABLED",
+                        "transitEncryptionPort": 2999,
+                        "authorizationConfig": {"accessPointId": "fsap-0abc", "iam": "ENABLED"}
+                      }
+                    }
+                  ]
+                }
+                """;
+        JsonNode request = objectMapper.readTree(requestJson);
+
+        Response response = handler.handle("RegisterTaskDefinition", request, "us-east-1");
+        JsonNode td = objectMapper.valueToTree(response.getEntity()).path("taskDefinition");
+
+        // The efsVolumeConfiguration round-trips faithfully (no drift on Terraform reads).
+        JsonNode vol = td.path("volumes").get(0);
+        assertEquals("customer-data", vol.path("name").asText());
+        assertTrue(vol.path("host").isMissingNode(), "EFS volume must not carry a host shape");
+        JsonNode efs = vol.path("efsVolumeConfiguration");
+        assertEquals("fs-0123456789abcdef0", efs.path("fileSystemId").asText());
+        assertEquals("/dps", efs.path("rootDirectory").asText());
+        assertEquals("ENABLED", efs.path("transitEncryption").asText());
+        assertEquals(2999, efs.path("transitEncryptionPort").asInt());
+        assertEquals("fsap-0abc", efs.path("authorizationConfig").path("accessPointId").asText());
+        assertEquals("ENABLED", efs.path("authorizationConfig").path("iam").asText());
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerVolumesTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerVolumesTest.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.C
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
 import io.github.hectorvent.floci.services.ecs.model.EcsTask;
+import io.github.hectorvent.floci.services.ecs.model.EfsVolumeConfiguration;
 import io.github.hectorvent.floci.services.ecs.model.MountPoint;
 import io.github.hectorvent.floci.services.ecs.model.TaskDefinition;
 import io.github.hectorvent.floci.services.ecs.model.Volume;
@@ -105,5 +106,38 @@ class EcsContainerManagerVolumesTest {
 
         // The unresolved "missing-vol" mountPoint contributes no bind beyond the two above.
         verify(builder, never()).withBind("/app/nope", "/app/nope");
+    }
+
+    @Test
+    void efsVolumeMountPointsResolveToSharedNamedVolumesByAccessMode() {
+        ContainerDefinition app = new ContainerDefinition();
+        app.setName("app");
+        app.setImage("app:latest");
+        app.setMountPoints(List.of(
+                new MountPoint("customer-data", "/mnt/efs", false),    // read-write
+                new MountPoint("shared-ro", "/mnt/shared", true)));    // read-only
+
+        TaskDefinition taskDef = new TaskDefinition();
+        taskDef.setFamily("efs-family");
+        taskDef.setContainerDefinitions(List.of(app));
+        taskDef.setVolumes(List.of(
+                new Volume("customer-data", null,
+                        new EfsVolumeConfiguration("fs-0123456789abcdef0", "/dps", "ENABLED", null, null, null)),
+                new Volume("shared-ro", null,
+                        new EfsVolumeConfiguration("fs-00000000000000001", null, null, null, null, null))));
+
+        EcsTask task = new EcsTask();
+        task.setTaskArn("arn:aws:ecs:us-east-1:000000000000:task/test-cluster/efs1");
+
+        manager.startTask(task, taskDef, List.of(), "us-east-1");
+
+        // Each EFS volume -> a shared local Docker named volume keyed by file system id,
+        // read-write or read-only per the mountPoint.
+        verify(builder, times(1)).withNamedVolume("floci-efs-fs-0123456789abcdef0", "/mnt/efs", false);
+        verify(builder, times(1)).withNamedVolume("floci-efs-fs-00000000000000001", "/mnt/shared", true);
+
+        // EFS volumes are never bind-mounted as host paths.
+        verify(builder, never()).withBind(any(), any());
+        verify(builder, never()).withReadOnlyBind(any(), any());
     }
 }


### PR DESCRIPTION
Closes #1568.

## Summary

ECS task definitions can declare EFS-backed task volumes via `efsVolumeConfiguration`, but Floci modelled only the EC2 `host` volume shape. An EFS volume’s `mountPoint` resolved to no source path and was skipped, so the container launched with **no filesystem at the mount path** — and the `efsVolumeConfiguration` block was dropped from `RegisterTaskDefinition`/`DescribeTaskDefinition`, causing Terraform drift.

This teaches the ECS layer to honor EFS volumes. Since Docker cannot mount a real Amazon EFS file system, an EFS-backed volume is materialised as a shared local Docker **named volume** `floci-efs-<fileSystemId>`, mounted at the container path (read-only/read-write per the `mountPoint`). Containers that mount the same file system share persistent storage that survives task restarts — the local stand-in for an EFS mount, mirroring the documented LocalStack EFS-simulation pattern but applied automatically at the ECS layer.

## What changed

- **`Volume` model** — carries an optional `EfsVolumeConfiguration` alongside the existing host source path (back-compatible 2-arg constructor retained).
- **New `EfsVolumeConfiguration`** — `fileSystemId`, `rootDirectory`, `transitEncryption`, `transitEncryptionPort`, `authorizationConfig` (`accessPointId`, `iam`).
- **`EcsJsonHandler`** — parses `efsVolumeConfiguration` in `RegisterTaskDefinition` and serializes it back in `DescribeTaskDefinition` (full round-trip, no drift).
- **`EcsContainerManager`** — resolves an EFS volume’s `mountPoint` to a named volume `floci-efs-<fileSystemId>` via `withNamedVolume(...)`; host volumes keep their existing bind-mount behavior; truly-unresolved mountPoints still warn and skip.
- **`ContainerBuilder`** — adds a read-only overload `withNamedVolume(name, path, readOnly)`.

`rootDirectory`/`transitEncryption`/`transitEncryptionPort`/`authorizationConfig` are modelled for API round-trip but have no local effect.

## Testing

- `mvn test -Dtest="Ecs*,ContainerBuilder*"` green (65 tests).
- New unit tests: EFS volume → shared named volume by access mode (`EcsContainerManagerVolumesTest`); `efsVolumeConfiguration` JSON round-trip (`EcsJsonHandlerVolumesTest`).
- **Verified live** against a running Floci: `register-task-definition` round-trips the EFS volume; `run-task` launches a container whose mounts include `volume floci-efs-fs-verify123 -> /mnt/efs (rw)`; the docker named volume is created; the container wrote and read back `/mnt/efs/probe.txt`.