### PR TITLE
fix(cognito): align AdminGetUser lookup with pool sign-in settings

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -158,13 +158,14 @@ public class CognitoService {
     public UserPool updateUserPool(Map<String, Object> request, String region) {
         String id = (String) request.get("UserPoolId");
         UserPool pool = describeUserPool(id);
+        UserPool updatedPool = MAPPER.convertValue(pool, UserPool.class);
 
-        populateUserPool(pool, request);
+        populateUserPool(updatedPool, request);
 
-        pool.setLastModifiedDate(System.currentTimeMillis() / 1000L);
-        poolStore.put(id, pool);
+        updatedPool.setLastModifiedDate(System.currentTimeMillis() / 1000L);
+        poolStore.put(id, updatedPool);
         LOG.infov("Updated User Pool: {0}", id);
-        return pool;
+        return updatedPool;
     }
 
     public void addCustomAttributes(String userPoolId, List<Map<String, Object>> customAttributes) {
@@ -818,17 +819,21 @@ public class CognitoService {
     }
 
     public CognitoUser adminGetUser(String userPoolId, String username) {
-        Optional<CognitoUser> byKey = userStore.get(userKey(userPoolId, username));
-        if (byKey.isPresent()) {
-            return byKey.get();
-        }
-        // Fallback: resolve by sub UUID or email alias
+        UserPool pool = poolStore.get(userPoolId).orElseThrow(
+                () -> new AwsException("ResourceNotFoundException", "User pool not found", 400));
+        LinkedHashSet<CognitoUser> matches = new LinkedHashSet<>();
+        userStore.get(userKey(userPoolId, username)).ifPresent(matches::add);
         String prefix = userPoolId + "::";
-        return userStore.scan(k -> k.startsWith(prefix)).stream()
-                .filter(u -> username.equals(u.getAttributes().get("sub"))
-                          || username.equals(u.getAttributes().get("email")))
-                .findFirst()
-                .orElseThrow(() -> new AwsException("UserNotFoundException", "User not found", 404));
+        matches.addAll(userStore.scan(k -> k.startsWith(prefix)).stream()
+                .filter(u -> matchesAliasOrUsernameAttribute(pool, u, username)).toList());
+        if (matches.isEmpty()) {
+            throw new AwsException("UserNotFoundException", "User not found", 400);
+        }
+        if (matches.size() > 1) {
+            throw new AwsException("InvalidParameterException",
+                    "Multiple users found for the supplied username", 400);
+        }
+        return matches.getFirst();
     }
 
     public void adminDeleteUser(String userPoolId, String username) {
@@ -2386,6 +2391,38 @@ public class CognitoService {
                     "Invalid code provided, please request a code again.", 400);
             case RATE_LIMIT -> new AwsException("LimitExceededException",
                     "Attempt limit exceeded, please try again later", 400);
+        };
+    }
+
+    private boolean matchesAliasOrUsernameAttribute(UserPool pool, CognitoUser user,
+            String username) {
+        if (username.equals(user.getAttributes().get("sub"))) {
+            return true;
+        }
+
+        for (String attribute : pool.getAliasAttributes()) {
+            if (username.equals(user.getAttributes().get(attribute))
+                    && isActiveAliasAttribute(user, attribute)) {
+                return true;
+            }
+        }
+
+        for (String attribute : pool.getUsernameAttributes()) {
+            if (username.equals(user.getAttributes().get(attribute))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean isActiveAliasAttribute(CognitoUser user, String attribute) {
+        return switch (attribute) {
+            case "email" -> Boolean
+                    .parseBoolean(user.getAttributes().getOrDefault("email_verified", "false"));
+            case "phone_number" -> Boolean.parseBoolean(
+                    user.getAttributes().getOrDefault("phone_number_verified", "false"));
+            default -> true;
         };
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
@@ -33,18 +33,20 @@ import static org.mockito.Mockito.when;
 class CognitoServiceTest {
 
     private CognitoService service;
+    private InMemoryStorage<String, CognitoUser> userStore;
     private InMemoryStorage<String, CognitoGroup> groupStore;
     private RegionResolver regionResolver;
 
     @BeforeEach
     void setUp() {
+        userStore = new InMemoryStorage<>();
         groupStore = new InMemoryStorage<>();
         regionResolver = new RegionResolver("us-east-1", "000000000000");
         service = new CognitoService(
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
-                new InMemoryStorage<>(),
+                userStore,
                 groupStore,
                 new InMemoryStorage<>(), // revokedTokenStore
                 "http://localhost:4566",
@@ -1353,7 +1355,7 @@ class CognitoServiceTest {
     }
 
     // =========================================================================
-    // Issue #220 — adminGetUser resolves sub UUID and email aliases
+    // AdminGetUser resolves configured identifiers
     // =========================================================================
 
     @Test
@@ -1370,11 +1372,130 @@ class CognitoServiceTest {
 
     @Test
     void adminGetUserByEmailAlias() {
-        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
+        UserPool pool = service.createUserPool(
+                Map.of("PoolName", "TestPool", "AliasAttributes", List.of("email")),
+                "us-east-1"
+        );
+        service.adminCreateUser(pool.getId(), "bob",
+                Map.of("email", "bob@example.com", "email_verified", "true"), null);
+
+        CognitoUser found = service.adminGetUser(pool.getId(), "bob@example.com");
+        assertEquals("bob", found.getUsername());
+    }
+
+    @Test
+    void adminGetUserByPhoneNumberAlias() {
+        UserPool pool = service.createUserPool(
+                Map.of("PoolName", "TestPool", "AliasAttributes", List.of("phone_number")),
+                "us-east-1"
+        );
+        service.adminCreateUser(pool.getId(), "bob",
+                Map.of("phone_number", "+15551234567", "phone_number_verified", "true"), null);
+
+        CognitoUser found = service.adminGetUser(pool.getId(), "+15551234567");
+        assertEquals("bob", found.getUsername());
+    }
+
+    @Test
+    void adminGetUserByPreferredUsernameAlias() {
+        UserPool pool = service.createUserPool(
+                Map.of("PoolName", "TestPool", "AliasAttributes", List.of("preferred_username")),
+                "us-east-1"
+        );
+        service.adminCreateUser(pool.getId(), "bob", Map.of("preferred_username", "bobby"), null);
+
+        CognitoUser found = service.adminGetUser(pool.getId(), "bobby");
+        assertEquals("bob", found.getUsername());
+    }
+
+    @Test
+    void adminGetUserByEmailUsernameAttribute() {
+        UserPool pool = service.createUserPool(
+                Map.of("PoolName", "TestPool", "UsernameAttributes", List.of("email")),
+                "us-east-1"
+        );
         service.adminCreateUser(pool.getId(), "bob", Map.of("email", "bob@example.com"), null);
 
         CognitoUser found = service.adminGetUser(pool.getId(), "bob@example.com");
         assertEquals("bob", found.getUsername());
+    }
+
+    @Test
+    void adminGetUserByPhoneNumberUsernameAttribute() {
+        UserPool pool = service.createUserPool(
+                Map.of("PoolName", "TestPool", "UsernameAttributes", List.of("phone_number")),
+                "us-east-1"
+        );
+        service.adminCreateUser(pool.getId(), "bob", Map.of("phone_number", "+15551234567"), null);
+
+        CognitoUser found = service.adminGetUser(pool.getId(), "+15551234567");
+        assertEquals("bob", found.getUsername());
+    }
+
+    @Test
+    void adminGetUserRejectsEmailWithoutConfiguredAlias() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
+        service.adminCreateUser(pool.getId(), "bob", Map.of("email", "bob@example.com"), null);
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> service.adminGetUser(pool.getId(), "bob@example.com"));
+        assertEquals("UserNotFoundException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+    }
+
+    @Test
+    void adminGetUserRejectsUnverifiedEmailAlias() {
+        UserPool pool = service.createUserPool(
+                Map.of("PoolName", "TestPool", "AliasAttributes", List.of("email")),
+                "us-east-1"
+        );
+        service.adminCreateUser(pool.getId(), "bob", Map.of("email", "bob@example.com"), null);
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> service.adminGetUser(pool.getId(), "bob@example.com"));
+        assertEquals("UserNotFoundException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+    }
+
+    @Test
+    void adminGetUserRejectsUnknownPoolWithResourceNotFound() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> service.adminGetUser("us-east-1_missing", "bob"));
+        assertEquals("ResourceNotFoundException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+    }
+
+    @Test
+    void adminGetUserRejectsAmbiguousLookupValueCreatedViaAdminCreateUser() {
+        UserPool pool = service.createUserPool(
+                Map.of("PoolName", "TestPool", "AliasAttributes", List.of("email")),
+                "us-east-1"
+        );
+        service.adminCreateUser(pool.getId(), "shared-lookup", Map.of("email", "owner@example.com"), null);
+        service.adminCreateUser(pool.getId(), "alice",
+                Map.of("email", "shared-lookup", "email_verified", "true"), null);
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> service.adminGetUser(pool.getId(), "shared-lookup"));
+        assertEquals("InvalidParameterException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+    }
+
+    @Test
+    void adminGetUserRejectsAmbiguousLookupValueCreatedViaAdminUpdateUserAttributes() {
+        UserPool pool = service.createUserPool(
+                Map.of("PoolName", "TestPool", "AliasAttributes", List.of("email")),
+                "us-east-1"
+        );
+        service.adminCreateUser(pool.getId(), "shared-lookup", Map.of("email", "owner@example.com"), null);
+        service.adminCreateUser(pool.getId(), "alice", Map.of("email", "alice@example.com"), null);
+        service.adminUpdateUserAttributes(pool.getId(), "alice",
+                Map.of("email", "shared-lookup", "email_verified", "true"));
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> service.adminGetUser(pool.getId(), "shared-lookup"));
+        assertEquals("InvalidParameterException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

Align Cognito `AdminGetUser` username resolution with AWS-style pool sign-in settings.

- resolve `AdminGetUser.Username` by actual username and `sub`
- resolve configured alias attributes instead of accepting `email` unconditionally
- allow configured `phone_number` / `preferred_username` alias lookup
- require `email_verified` / `phone_number_verified` for active email/phone alias lookup
- reject ambiguous matches instead of returning an arbitrary user
- remove the accidental write-side uniqueness validation that expanded this issue beyond `AdminGetUser`
- add regression tests for verified alias lookup, unverified alias rejection, unconfigured email rejection, and ambiguous lookup rejection through public service APIs
- remove the now-unused `lookupAttributesForPool` helper

Closes #1570 
## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Before this change, Floci did not resolve `AdminGetUser.Username` according to the user pool sign-in configuration. It could accept `email` even when the pool had not configured it as a sign-in identifier, and it did not align alias resolution with configured pool settings.

This change aligns `AdminGetUser` more closely with AWS Cognito by resolving lookups through the actual username, `sub`, and configured sign-in identifiers only. It also requires verified state for `email` / `phone_number` aliases and avoids returning an arbitrary user when the lookup value is ambiguous.

Remaining follow-up points:

- AWS docs do not clearly settle whether `UsernameAttributes` lookup in `AdminGetUser` is always valid, so this area should be called out explicitly in review
- AWS docs also do not clearly document the exact error code/message for ambiguous multi-match lookup
- reviewer follow-up suggested adding broader regression coverage for `phone_number`, `UsernameAttributes`, and `preferred_username` ambiguity paths

## Validation

- `./mvnw -Dtest=CognitoServiceTest test`

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)