### PR TITLE
fix(lambda): resolve handler paths with a leading "./" against the package

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -1201,6 +1201,12 @@ public class LambdaService {
         if (fn.getRuntime().startsWith("python")) {
             return modulePath.replace('.', '/');
         }
+        // A file-based handler may be given with a leading "./" (e.g.
+        // "./v1/lambda-handlers/entry.handler"); deployment-package entries are stored without
+        // it, so normalize the prefix away before matching.
+        if (modulePath.startsWith("./")) {
+            modulePath = modulePath.substring(2);
+        }
         return modulePath;
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaIntegrationTest.java
@@ -279,6 +279,43 @@ class LambdaIntegrationTest {
         given().delete(BASE_PATH + "/functions/large-zip-fn");
     }
 
+    @Test
+    @Order(15)
+    void createFunctionWithDotSlashNestedHandler() throws Exception {
+        // A handler given with a leading "./" and a nested path (e.g.
+        // "./v1/lambda-handlers/entry.handler") must resolve against the zip entry
+        // "v1/lambda-handlers/entry.js" — the "./" prefix is normalized away.
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry("v1/lambda-handlers/entry.js"));
+            zos.write("exports.handler = async () => ({ ok: true });".getBytes());
+            zos.closeEntry();
+        }
+        String base64Zip = Base64.getEncoder().encodeToString(baos.toByteArray());
+
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "dotslash-fn",
+                    "Runtime": "nodejs20.x",
+                    "Role": "arn:aws:iam::000000000000:role/lambda-role",
+                    "Handler": "./v1/lambda-handlers/entry.handler",
+                    "Code": {
+                        "ZipFile": "%s"
+                    }
+                }
+                """.formatted(base64Zip))
+        .when()
+            .post(BASE_PATH + "/functions")
+        .then()
+            .statusCode(201)
+            .body("FunctionName", equalTo("dotslash-fn"));
+
+        // cleanup
+        given().delete(BASE_PATH + "/functions/dotslash-fn");
+    }
+
     // ── ImageConfig ───────────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
Closes #1574.

## Summary

A Node/file-based Lambda handler can be specified with a leading `./` — e.g. `./v1/lambda-handlers/entry.handler`, as the terraform-aws-modules/lambda module (and GE DPS) emit. `CreateFunction` validates the handler file exists in the deployment package; `resolveHandlerFilePath` stripped only the `.handler` export suffix, leaving `./v1/lambda-handlers/entry`, which never matched the package entry `v1/lambda-handlers/entry.js` (stored without the `./`). The function was rejected with `InvalidParameterValueException: Handler file ... not found in deployment package`.

Handlers without the prefix (`index.handler`, `bdd-lambda-handler.handler`) already worked; only the `./`-prefixed nested form failed.

## What changed

- `LambdaService.resolveHandlerFilePath` normalizes a leading `./` away from the resolved module path before the package-entry match (non-Python/.NET file-based runtimes).

## Testing

- `mvn test -Dtest=LambdaIntegrationTest` green (23 tests). New `createFunctionWithDotSlashNestedHandler`: a zip with `v1/lambda-handlers/entry.js` + `Handler="./v1/lambda-handlers/entry.handler"` now creates successfully (was 400 before).
- Found while applying GE DPS ship-builder-infra against Floci: 23 of 24 Lambdas used this handler form and failed CreateFunction; with the fix they resolve.