### PR TITLE
fix(codebuild): create build working directory before running phases

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildRunner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildRunner.java
@@ -190,12 +190,10 @@ public class CodeBuildRunner {
 
             List<String> envList = buildEnvList(region, build, project, buildspec, logStream);
 
-            // Create the working directory inside the container as part of startup,
-            // then keep the container alive. No bind mount needed — source and
-            // artifacts are transferred with docker cp.
+            // Keep the container alive so each phase can be run with docker exec.
+            // No bind mount needed — source and artifacts are transferred with docker cp.
             ContainerSpec spec = containerBuilder.newContainer(image)
-                    .withCmd(List.of("sh", "-c",
-                            "mkdir -p /codebuild/output/src/src && tail -f /dev/null"))
+                    .withCmd(List.of("sh", "-c", "tail -f /dev/null"))
                     .withEnv(envList)
                     .withDockerNetwork(config.services().codebuild().dockerNetwork())
                     .withEmbeddedDns()
@@ -210,12 +208,25 @@ public class CodeBuildRunner {
 
             logHandle = logStreamer.attach(containerId, logGroup, logStream, region, "codebuild:" + buildId);
 
-            // Copy downloaded source files into the container (no-op for NO_SOURCE builds)
-            copySourceToContainer(containerId, workspace, "/codebuild/output/src/src");
-
             String containerSrcDir = "/codebuild/output/src/src";
             int timeoutMinutes = build.getTimeoutInMinutes() != null ? build.getTimeoutInMinutes() : 60;
             boolean buildFailed = false;
+
+            // createAndStart returns as soon as the container's entrypoint process is
+            // running, which can be before any startup command would finish. Create the
+            // working directory with an explicit, awaited exec (run from "/", which always
+            // exists) so the source copy, the phase execs that chdir into it, and the final
+            // artifact copy can never race against container startup.
+            PhaseResult workDirResult = runPhase(containerId, "/", envList,
+                    List.of("mkdir -p " + containerSrcDir), timeoutMinutes, stopFlag);
+            if (workDirResult.stopped()) { finishStopped(build); return; }
+            if (workDirResult.failed()) {
+                throw new IllegalStateException("Could not create build working directory "
+                        + containerSrcDir + ": " + workDirResult.errorMessage());
+            }
+
+            // Copy downloaded source files into the container (no-op for NO_SOURCE builds)
+            copySourceToContainer(containerId, workspace, containerSrcDir);
 
             // INSTALL
             if (stopFlag.get()) { finishStopped(build); return; }


### PR DESCRIPTION
## Summary

`CodeBuildRunner` started the build container with a fire-and-forget entrypoint:

```
sh -c "mkdir -p /codebuild/output/src/src && tail -f /dev/null"
```

`createAndStart` returns as soon as the container is *running* — which can be before that `mkdir` finishes. The runner then immediately:

1. execs the build phases with `withWorkingDir("/codebuild/output/src/src")` (which `chdir`s into the directory), and
2. copies artifacts out of that path.

On a slow container start the directory does not exist yet, so the BUILD exec fails and the artifact copy 404s — and the build is reported as **FAILED** even though the buildspec is fine.

## What changed

- Drop the `mkdir` from the container entrypoint (now just `tail -f /dev/null`).
- Create the working directory with an explicit, **awaited** `mkdir -p` exec (run from `/`, which always exists) *before* the source copy and the build phases.

Because the runner now blocks until the `mkdir` exec completes, the source copy, the phase execs that `chdir` into the directory, and the final artifact copy can never race against container startup.

## Why

This surfaced as the intermittent failure of `CodeBuildTest.batchGetBuilds_eventuallySucceeds` in the `sdk-test-java` compatibility suite. CI logs show the container started and the artifact copy 404'd on the missing directory ~75 ms later:

```
22:15:00.628  Started container …
22:15:00.703  WARN CodeBuildRunner: Could not copy artifacts … Status 404:
              "Could not find the file /codebuild/output/src/src in container …"
```

The same single test was flaking across unrelated PRs, confirming it was an environmental race in shared code rather than a regression.

## Testing

The existing `CodeBuildTest.batchGetBuilds_eventuallySucceeds` is the regression test — it runs a real `alpine` build and asserts `SUCCEEDED`; with the directory guaranteed to exist before the BUILD phase, it no longer flakes on slow runners.