### PR TITLE
fix(stepfunctions): add ListStateMachineVersions stub endpoint

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonHandler.java
@@ -18,7 +18,6 @@ import jakarta.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 @ApplicationScoped
 public class StepFunctionsJsonHandler {
@@ -66,7 +65,12 @@ public class StepFunctionsJsonHandler {
     private Response handleListStateMachineVersions(JsonNode request) {
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode array = response.putArray("stateMachineVersions");
-        StateMachine sm = service.describeStateMachine(request.path("stateMachineArn").asText());
+        StateMachine sm;
+        try{
+            sm = service.describeStateMachine(request.path("stateMachineArn").asText());
+        }catch (AwsException e){
+            return Response.ok(response).build();
+        }
         if (sm != null) {
             ObjectNode item = array.addObject();
             item.put("creationDate", sm.getCreationDate());

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonHandler.java
@@ -37,7 +37,7 @@ public class StepFunctionsJsonHandler {
             case "CreateStateMachine" -> handleCreateStateMachine(request, region);
             case "DescribeStateMachine" -> handleDescribeStateMachine(request);
             case "ListStateMachines" -> handleListStateMachines(request, region);
-            case "ListStateMachineVersions" -> handleListStateMachineVersions(request, region);
+            case "ListStateMachineVersions" -> handleListStateMachineVersions(request);
             case "DeleteStateMachine" -> handleDeleteStateMachine(request);
             case "ValidateStateMachineDefinition" -> handleValidateStateMachineDefinition(request);
             case "StartExecution" -> handleStartExecution(request, region);
@@ -63,16 +63,14 @@ public class StepFunctionsJsonHandler {
         };
     }
 
-    private Response handleListStateMachineVersions(JsonNode request, String region) {
+    private Response handleListStateMachineVersions(JsonNode request) {
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode array = response.putArray("stateMachineVersions");
-        List<StateMachine> stateMachines = service.listStateMachines(region);
-        for (StateMachine sm : stateMachines) {
-            if (Objects.equals(sm.getStateMachineArn(), request.path("stateMachineArn").asText())) {
-                ObjectNode item = array.addObject();
-                item.put("creationDate", sm.getCreationDate());
-                item.put("stateMachineVersionArn", sm.getStateMachineArn());
-            }
+        StateMachine sm = service.describeStateMachine(request.path("stateMachineArn").asText());
+        if (sm != null) {
+            ObjectNode item = array.addObject();
+            item.put("creationDate", sm.getCreationDate());
+            item.put("stateMachineVersionArn", String.format("%s:1", sm.getStateMachineArn()));
         }
         return Response.ok(response).build();
     }

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonHandler.java
@@ -18,6 +18,7 @@ import jakarta.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @ApplicationScoped
 public class StepFunctionsJsonHandler {
@@ -36,6 +37,7 @@ public class StepFunctionsJsonHandler {
             case "CreateStateMachine" -> handleCreateStateMachine(request, region);
             case "DescribeStateMachine" -> handleDescribeStateMachine(request);
             case "ListStateMachines" -> handleListStateMachines(request, region);
+            case "ListStateMachineVersions" -> handleListStateMachineVersions(request, region);
             case "DeleteStateMachine" -> handleDeleteStateMachine(request);
             case "ValidateStateMachineDefinition" -> handleValidateStateMachineDefinition(request);
             case "StartExecution" -> handleStartExecution(request, region);
@@ -59,6 +61,20 @@ public class StepFunctionsJsonHandler {
                     .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                     .build();
         };
+    }
+
+    private Response handleListStateMachineVersions(JsonNode request, String region) {
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode array = response.putArray("stateMachineVersions");
+        List<StateMachine> stateMachines = service.listStateMachines(region);
+        for (StateMachine sm : stateMachines) {
+            if (Objects.equals(sm.getStateMachineArn(), request.path("stateMachineArn").asText())) {
+                ObjectNode item = array.addObject();
+                item.put("creationDate", sm.getCreationDate());
+                item.put("stateMachineVersionArn", sm.getStateMachineArn());
+            }
+        }
+        return Response.ok(response).build();
     }
 
     private Response handleCreateStateMachine(JsonNode request, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonHandler.java
@@ -63,19 +63,14 @@ public class StepFunctionsJsonHandler {
     }
 
     private Response handleListStateMachineVersions(JsonNode request) {
+        String arn = request.path("stateMachineArn").asText("");
+        if (arn.isEmpty()) {
+            return Response.status(400)
+                    .entity(new AwsErrorResponse("ValidationException", "stateMachineArn is required."))
+                    .build();
+        }
         ObjectNode response = objectMapper.createObjectNode();
-        ArrayNode array = response.putArray("stateMachineVersions");
-        StateMachine sm;
-        try{
-            sm = service.describeStateMachine(request.path("stateMachineArn").asText());
-        }catch (AwsException e){
-            return Response.ok(response).build();
-        }
-        if (sm != null) {
-            ObjectNode item = array.addObject();
-            item.put("creationDate", sm.getCreationDate());
-            item.put("stateMachineVersionArn", String.format("%s:1", sm.getStateMachineArn()));
-        }
+        response.putArray("stateMachineVersions");
         return Response.ok(response).build();
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsListStateMachineVersionsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsListStateMachineVersionsIntegrationTest.java
@@ -58,28 +58,28 @@ class StepFunctionsListStateMachineVersionsIntegrationTest {
 
     @Test
     @Order(3)
-    void listVersions_nonExistentArn_returnsStateMachineDoesNotExist() {
+    void listVersions_nonExistentArn_returns200WithEmptyArray() {
         given()
                 .header("X-Amz-Target", TARGET)
                 .contentType(CT)
                 .body("{\"stateMachineArn\":\"arn:aws:states:us-east-1:000000000000:stateMachine:does-not-exist\"}")
                 .when().post("/")
                 .then()
-                .statusCode(400)
-                .body("__type", containsString("StateMachineDoesNotExist"));
+                .statusCode(200)
+                .body("stateMachineVersions", hasSize(0));
     }
 
     @Test
     @Order(4)
-    void listVersions_missingArn_returnsStateMachineDoesNotExist() {
+    void listVersions_missingArn_returns200WithEmptyArray() {
         given()
                 .header("X-Amz-Target", TARGET)
                 .contentType(CT)
                 .body("{}")
                 .when().post("/")
                 .then()
-                .statusCode(400)
-                .body("__type", containsString("StateMachineDoesNotExist"));
+                .statusCode(200)
+                .body("stateMachineVersions", hasSize(0));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsListStateMachineVersionsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsListStateMachineVersionsIntegrationTest.java
@@ -52,34 +52,34 @@ class StepFunctionsListStateMachineVersionsIntegrationTest {
                 .then()
                 .statusCode(200)
                 .body("stateMachineVersions", notNullValue())
-                .body("stateMachineVersions[0].stateMachineVersionArn", equalTo(stateMachineArn))
+                .body("stateMachineVersions[0].stateMachineVersionArn", equalTo(stateMachineArn + ":1"))
                 .body("stateMachineVersions[0].creationDate", notNullValue());
     }
 
     @Test
     @Order(3)
-    void listVersions_nonExistentArn_returns200WithEmptyArray() {
+    void listVersions_nonExistentArn_returnsStateMachineDoesNotExist() {
         given()
                 .header("X-Amz-Target", TARGET)
                 .contentType(CT)
                 .body("{\"stateMachineArn\":\"arn:aws:states:us-east-1:000000000000:stateMachine:does-not-exist\"}")
                 .when().post("/")
                 .then()
-                .statusCode(200)
-                .body("stateMachineVersions", hasSize(0));
+                .statusCode(400)
+                .body("__type", containsString("StateMachineDoesNotExist"));
     }
 
     @Test
     @Order(4)
-    void listVersions_missingArn_returns200WithEmptyArray() {
+    void listVersions_missingArn_returnsStateMachineDoesNotExist() {
         given()
                 .header("X-Amz-Target", TARGET)
                 .contentType(CT)
                 .body("{}")
                 .when().post("/")
                 .then()
-                .statusCode(200)
-                .body("stateMachineVersions", hasSize(0));
+                .statusCode(400)
+                .body("__type", containsString("StateMachineDoesNotExist"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsListStateMachineVersionsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsListStateMachineVersionsIntegrationTest.java
@@ -1,0 +1,95 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.*;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class StepFunctionsListStateMachineVersionsIntegrationTest {
+
+    private static final String CT = "application/x-amz-json-1.0";
+    private static final String TARGET = "AWSStepFunctions.ListStateMachineVersions";
+    private static final String CREATE_TARGET = "AWSStepFunctions.CreateStateMachine";
+    private static final String DELETE_TARGET = "AWSStepFunctions.DeleteStateMachine";
+    private static final String ROLE_ARN = "arn:aws:iam::000000000000:role/test-role";
+    private static final String SIMPLE_DEFINITION =
+            "{\"StartAt\":\"Done\",\"States\":{\"Done\":{\"Type\":\"Pass\",\"End\":true}}}";
+
+    private static String stateMachineArn;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    @Order(1)
+    void createStateMachine() {
+        Response resp = given()
+                .header("X-Amz-Target", CREATE_TARGET)
+                .contentType(CT)
+                .body("{\"name\":\"versions-test-sm\",\"definition\":\"" + SIMPLE_DEFINITION.replace("\"", "\\\"") + "\",\"roleArn\":\"" + ROLE_ARN + "\"}")
+                .when().post("/");
+        resp.then().statusCode(200);
+        stateMachineArn = resp.jsonPath().getString("stateMachineArn");
+        assertNotNull(stateMachineArn);
+    }
+
+    @Test
+    @Order(2)
+    void listVersions_existingMachine_returns200() {
+        given()
+                .header("X-Amz-Target", TARGET)
+                .contentType(CT)
+                .body("{\"stateMachineArn\":\"" + stateMachineArn + "\"}")
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("stateMachineVersions", notNullValue())
+                .body("stateMachineVersions[0].stateMachineVersionArn", equalTo(stateMachineArn))
+                .body("stateMachineVersions[0].creationDate", notNullValue());
+    }
+
+    @Test
+    @Order(3)
+    void listVersions_nonExistentArn_returns200WithEmptyArray() {
+        given()
+                .header("X-Amz-Target", TARGET)
+                .contentType(CT)
+                .body("{\"stateMachineArn\":\"arn:aws:states:us-east-1:000000000000:stateMachine:does-not-exist\"}")
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("stateMachineVersions", hasSize(0));
+    }
+
+    @Test
+    @Order(4)
+    void listVersions_missingArn_returns200WithEmptyArray() {
+        given()
+                .header("X-Amz-Target", TARGET)
+                .contentType(CT)
+                .body("{}")
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("stateMachineVersions", hasSize(0));
+    }
+
+    @Test
+    @Order(5)
+    void cleanup() {
+        given()
+                .header("X-Amz-Target", DELETE_TARGET)
+                .contentType(CT)
+                .body("{\"stateMachineArn\":\"" + stateMachineArn + "\"}")
+                .when().post("/")
+                .then().statusCode(200);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsListStateMachineVersionsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsListStateMachineVersionsIntegrationTest.java
@@ -43,7 +43,7 @@ class StepFunctionsListStateMachineVersionsIntegrationTest {
 
     @Test
     @Order(2)
-    void listVersions_existingMachine_returns200() {
+    void listVersions_existingMachine_returns200WithEmptyList() {
         given()
                 .header("X-Amz-Target", TARGET)
                 .contentType(CT)
@@ -52,8 +52,7 @@ class StepFunctionsListStateMachineVersionsIntegrationTest {
                 .then()
                 .statusCode(200)
                 .body("stateMachineVersions", notNullValue())
-                .body("stateMachineVersions[0].stateMachineVersionArn", equalTo(stateMachineArn + ":1"))
-                .body("stateMachineVersions[0].creationDate", notNullValue());
+                .body("stateMachineVersions", hasSize(0));
     }
 
     @Test
@@ -71,15 +70,15 @@ class StepFunctionsListStateMachineVersionsIntegrationTest {
 
     @Test
     @Order(4)
-    void listVersions_missingArn_returns200WithEmptyArray() {
+    void listVersions_missingArn_returns400ValidationException() {
         given()
                 .header("X-Amz-Target", TARGET)
                 .contentType(CT)
                 .body("{}")
                 .when().post("/")
                 .then()
-                .statusCode(200)
-                .body("stateMachineVersions", hasSize(0));
+                .statusCode(400)
+                .body("__type", containsString("ValidationException"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
Adds a handler for `ListStateMachineVersions`, when creating sfn with Terraform, this handler not being implemented causes issues.

<!-- What does this PR do? Link any related issues with "Closes #N" -->
Fixes: #1520

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Referenced AWS Docs for response: 

https://docs.aws.amazon.com/step-functions/latest/apireference/API_ListStateMachineVersions.html#API_ListStateMachineVersions_ResponseSyntax 

AWS CLI Version: `aws-cli/2.34.9 Python/3.13.11 Linux/6.18.36-1-lts exe/x86_64.arch

## Testing
```
./mvnw test -Dtest=StepFunctionsListStateMachineVersionsIntegrationTest
```

Results:
```
[INFO] Results:
[INFO]
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.930 s
[INFO] Finished at: 2026-06-26T18:46:06+05:45
[INFO] ------------------------------------------------------------------------
```

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
