### PR TITLE
feat(appsync): Phase 5 — Management API Coverage + AWS Behavior Alignment + Async Schema Creation

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
@@ -107,11 +107,11 @@ class AppSyncTest {
     @Test
     @Order(11)
     void getSchemaCreationStatus() {
-        // Schema creation is async in real AWS: poll until terminal (ACTIVE
+        // Schema creation is async in real AWS: poll until terminal (SUCCESS
         // or FAILED). All subsequent tests in this class depend on the
         // schema being ACTIVE because the 409 gate fires while PROCESSING.
         SchemaStatus status = pollSchemaStatusToTerminal();
-        assertThat(status).isEqualTo(SchemaStatus.ACTIVE);
+        assertThat(status).isEqualTo(SchemaStatus.SUCCESS);
     }
 
     // ── API Keys ────────────────────────────────────────────────────────

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
@@ -544,7 +544,7 @@ class AppSyncTest {
                         .apiId(apiId)
                         .definition(SdkBytes.fromUtf8String("type Query { invalid !!! }"))
                         .build()))
-                .isInstanceOf(AppSyncException.class)
+                .isInstanceOf(BadRequestException.class)
                 .hasMessageContaining("Invalid schema");
     }
 
@@ -600,9 +600,11 @@ class AppSyncTest {
                 UpdateChannelNamespaceRequest.builder()
                         .apiId(apiId)
                         .name(channelNsName)
+                        .codeHandlers("export function handler(ctx) { return ctx; }")
                         .build());
 
         assertThat(resp.channelNamespace()).isNotNull();
+        assertThat(resp.channelNamespace().codeHandlers()).contains("handler");
     }
 
     @Test
@@ -672,6 +674,7 @@ class AppSyncTest {
 
         assertThat(resp.domainNameConfig()).isNotNull();
         assertThat(resp.domainNameConfig().domainName()).isEqualTo(tempDomainName);
+        assertThat(resp.domainNameConfig().description()).isEqualTo("updated-domain");
     }
 
     @Test
@@ -949,31 +952,34 @@ class AppSyncTest {
 
     @Test
     @Order(80)
-    void getNonExistentApiThrowsException() {
+    void getNonExistentApiThrowsNotFoundException() {
         assertThatThrownBy(() -> client.getGraphqlApi(GetGraphqlApiRequest.builder()
                         .apiId("nonexistent12345678901234")
                         .build()))
-                .isInstanceOf(AppSyncException.class);
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("GraphQL API not found:");
     }
 
     @Test
     @Order(81)
-    void getNonExistentDataSourceThrowsException() {
+    void getNonExistentDataSourceThrowsNotFoundException() {
         assertThatThrownBy(() -> client.getDataSource(GetDataSourceRequest.builder()
                         .apiId(apiId)
                         .name("nonexistent-ds")
                         .build()))
-                .isInstanceOf(AppSyncException.class);
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("Data source not found:");
     }
 
     @Test
     @Order(82)
-    void getNonExistentTypeThrowsException() {
+    void getNonExistentTypeThrowsNotFoundException() {
         assertThatThrownBy(() -> client.getType(GetTypeRequest.builder()
                         .apiId(apiId)
                         .typeName("NonExistentType")
                         .build()))
-                .isInstanceOf(AppSyncException.class);
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("Type not found:");
     }
 
     @Test

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
@@ -107,12 +107,11 @@ class AppSyncTest {
     @Test
     @Order(11)
     void getSchemaCreationStatus() {
-        GetSchemaCreationStatusResponse resp = client.getSchemaCreationStatus(
-                GetSchemaCreationStatusRequest.builder()
-                        .apiId(apiId)
-                        .build());
-
-        assertThat(resp.statusAsString()).isEqualTo("ACTIVE");
+        // Schema creation is async in real AWS: poll until terminal (ACTIVE
+        // or FAILED). All subsequent tests in this class depend on the
+        // schema being ACTIVE because the 409 gate fires while PROCESSING.
+        SchemaStatus status = pollSchemaStatusToTerminal();
+        assertThat(status).isEqualTo(SchemaStatus.ACTIVE);
     }
 
     // ── API Keys ────────────────────────────────────────────────────────
@@ -541,12 +540,28 @@ class AppSyncTest {
     @Test
     @Order(93)
     void startSchemaCreation_invalidSchema() {
-        assertThatThrownBy(() -> client.startSchemaCreation(StartSchemaCreationRequest.builder()
-                        .apiId(apiId)
-                        .definition(SdkBytes.fromUtf8String("type Query { invalid !!! }"))
-                        .build()))
-                .isInstanceOf(BadRequestException.class)
-                .hasMessageContaining("Invalid schema");
+        StartSchemaCreationResponse resp = client.startSchemaCreation(StartSchemaCreationRequest.builder()
+                .apiId(apiId)
+                .definition(SdkBytes.fromUtf8String("type Query { invalid !!! }"))
+                .build());
+        assertThat(resp.status()).isEqualTo(SchemaStatus.PROCESSING);
+        SchemaStatus terminal = pollSchemaStatusToTerminal();
+        assertThat(terminal).isEqualTo(SchemaStatus.FAILED);
+    }
+
+    private SchemaStatus pollSchemaStatusToTerminal() {
+        Instant deadline = Instant.now().plus(Duration.ofSeconds(10));
+        SchemaStatus s = client.getSchemaCreationStatus(r -> r.apiId(apiId)).status();
+        while (s == SchemaStatus.PROCESSING && Instant.now().isBefore(deadline)) {
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(ie);
+            }
+            s = client.getSchemaCreationStatus(r -> r.apiId(apiId)).status();
+        }
+        return s;
     }
 
     @Test
@@ -1222,14 +1237,22 @@ class AppSyncTest {
                 .build();
         HttpResponse<String> resp = HttpClient.newHttpClient().send(req, HttpResponse.BodyHandlers.ofString());
 
-        assertThat(resp.statusCode()).isEqualTo(400);
+        // Async path: 200 + PROCESSING; the error surfaces in the FAILED details.
+        assertThat(resp.statusCode()).isEqualTo(200);
         @SuppressWarnings("unchecked")
         Map<String, Object> jsonBody = mapper.readValue(resp.body(), Map.class);
-        assertThat(jsonBody.get("__type")).isEqualTo("BadRequestException");
-        assertThat(jsonBody.get("reason")).isEqualTo("CODE_ERROR");
-        assertThat(jsonBody).containsKey("detail");
+        assertThat(jsonBody.get("status")).isEqualTo("PROCESSING");
+
+        SchemaStatus terminal = pollSchemaStatusToTerminal();
+        assertThat(terminal).isEqualTo(SchemaStatus.FAILED);
+
+        GetSchemaCreationStatusResponse status = client.getSchemaCreationStatus(r -> r.apiId(apiId));
         @SuppressWarnings("unchecked")
-        Map<String, Object> detail = (Map<String, Object>) jsonBody.get("detail");
+        Map<String, Object> extended = mapper.readValue(status.details(), Map.class);
+        assertThat(extended.get("reason")).isEqualTo("CODE_ERROR");
+        assertThat(extended).containsKey("detail");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> detail = (Map<String, Object>) extended.get("detail");
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> codeErrors = (List<Map<String, Object>>) detail.get("codeErrors");
         assertThat(codeErrors).isNotEmpty();

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
@@ -12,6 +12,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.*;
@@ -1178,5 +1179,67 @@ class AppSyncTest {
                         .build()))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("Data source not found:");
+    }
+
+    @Test
+    @Order(137)
+    void createSourceApiAssociationDuplicateThrowsConcurrentModificationException() {
+        String sourceApiId = client.createGraphqlApi(CreateGraphqlApiRequest.builder()
+                .name("sdk-dup-source-" + java.util.UUID.randomUUID().toString().substring(0, 8))
+                .authenticationType("API_KEY")
+                .build()).graphqlApi().apiId();
+
+        try {
+            client.associateSourceGraphqlApi(AssociateSourceGraphqlApiRequest.builder()
+                    .mergedApiIdentifier(apiId)
+                    .sourceApiIdentifier(sourceApiId)
+                    .build());
+
+            assertThatThrownBy(() -> client.associateSourceGraphqlApi(AssociateSourceGraphqlApiRequest.builder()
+                            .mergedApiIdentifier(apiId)
+                            .sourceApiIdentifier(sourceApiId)
+                            .build()))
+                    .isInstanceOf(ConcurrentModificationException.class)
+                    .hasMessageContaining("Source API association already exists for Source API ID")
+                    .hasMessageContaining("and Merged API ID");
+        } finally {
+            client.deleteGraphqlApi(r -> r.apiId(sourceApiId));
+        }
+    }
+
+    @Test
+    @Order(200)
+    void startSchemaCreation_syntaxError_throwsBadRequestWithExtendedBody() throws Exception {
+        String body = """
+            { "definition": "type Query { invalid syntax!!! }" }
+            """;
+        String url = TestFixtures.endpoint() + "/v1/apis/" + apiId + "/schemacreation";
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/appsync/aws4_request")
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+        HttpResponse<String> resp = HttpClient.newHttpClient().send(req, HttpResponse.BodyHandlers.ofString());
+
+        assertThat(resp.statusCode()).isEqualTo(400);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> jsonBody = mapper.readValue(resp.body(), Map.class);
+        assertThat(jsonBody.get("__type")).isEqualTo("BadRequestException");
+        assertThat(jsonBody.get("reason")).isEqualTo("CODE_ERROR");
+        assertThat(jsonBody).containsKey("detail");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> detail = (Map<String, Object>) jsonBody.get("detail");
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> codeErrors = (List<Map<String, Object>>) detail.get("codeErrors");
+        assertThat(codeErrors).isNotEmpty();
+        Map<String, Object> first = codeErrors.get(0);
+        assertThat(first.get("errorType")).isEqualTo("PARSER_ERROR");
+        assertThat(first.get("value")).isNotNull();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> location = (Map<String, Object>) first.get("location");
+        assertThat(location.get("line")).isNotNull();
+        assertThat(location.get("column")).isNotNull();
+        assertThat(location.get("span")).isEqualTo(-1);
     }
 }

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
@@ -1080,7 +1080,7 @@ class AppSyncTest {
 
     @Test
     @Order(130)
-    void createDataSourceDuplicateThrowsConflictException() {
+    void createDataSourceDuplicateThrowsBadRequestException() {
         String dsName = "sdk-conflict-ds-" + java.util.UUID.randomUUID().toString().substring(0, 8);
         client.createDataSource(CreateDataSourceRequest.builder()
                 .apiId(apiId)
@@ -1093,15 +1093,15 @@ class AppSyncTest {
                         .name(dsName)
                         .type("NONE")
                         .build()))
-                .isInstanceOf(ConflictException.class)
-                .hasMessageContaining("Data source already exists:");
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("Data source with name");
 
         client.deleteDataSource(r -> r.apiId(apiId).name(dsName));
     }
 
     @Test
     @Order(131)
-    void createApiKeyExceedsLimitThrowsLimitExceededException() {
+    void createApiKeyExceedsLimitThrowsApiKeyLimitExceededException() {
         CreateGraphqlApiResponse tempApi = client.createGraphqlApi(CreateGraphqlApiRequest.builder()
                 .name("sdk-limit-test-" + java.util.UUID.randomUUID().toString().substring(0, 8))
                 .authenticationType("API_KEY")
@@ -1113,8 +1113,8 @@ class AppSyncTest {
             client.createApiKey(CreateApiKeyRequest.builder().apiId(tempApiId).build());
 
             assertThatThrownBy(() -> client.createApiKey(CreateApiKeyRequest.builder().apiId(tempApiId).build()))
-                    .isInstanceOf(LimitExceededException.class)
-                    .hasMessageContaining("Maximum of 2 API keys per API reached");
+                    .isInstanceOf(ApiKeyLimitExceededException.class)
+                    .hasMessageContaining("The API key exceeded a limit");
         } finally {
             client.deleteGraphqlApi(r -> r.apiId(tempApiId));
         }

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
@@ -992,4 +992,191 @@ class AppSyncTest {
         assertThat(resp.apiKey()).isNotNull();
         assertThat(resp.apiKey().id()).isNotBlank();
     }
+
+    // ── SDK Coverage Gaps: Environment Variables ───────────────────────────
+
+    @Test
+    @Order(120)
+    void putGraphqlApiEnvironmentVariables() {
+        PutGraphqlApiEnvironmentVariablesResponse resp = client.putGraphqlApiEnvironmentVariables(
+                PutGraphqlApiEnvironmentVariablesRequest.builder()
+                        .apiId(apiId)
+                        .environmentVariables(Map.of("TABLE_NAME", "my-table", "REGION", "us-east-1"))
+                        .build());
+
+        assertThat(resp.environmentVariables())
+                .containsEntry("TABLE_NAME", "my-table")
+                .containsEntry("REGION", "us-east-1");
+    }
+
+    @Test
+    @Order(121)
+    void getGraphqlApiEnvironmentVariables() {
+        GetGraphqlApiEnvironmentVariablesResponse resp = client.getGraphqlApiEnvironmentVariables(
+                GetGraphqlApiEnvironmentVariablesRequest.builder()
+                        .apiId(apiId)
+                        .build());
+
+        assertThat(resp.environmentVariables())
+                .containsEntry("TABLE_NAME", "my-table")
+                .containsEntry("REGION", "us-east-1");
+    }
+
+    // ── SDK Coverage Gaps: Pagination ──────────────────────────────────────
+
+    @Test
+    @Order(122)
+    void listGraphqlApisWithMaxResults() {
+        for (int i = 0; i < 2; i++) {
+            client.createGraphqlApi(CreateGraphqlApiRequest.builder()
+                    .name("pg-sdk-api-" + i + "-" + java.util.UUID.randomUUID().toString().substring(0, 8))
+                    .authenticationType("API_KEY")
+                    .build());
+        }
+
+        ListGraphqlApisResponse page1 = client.listGraphqlApis(ListGraphqlApisRequest.builder()
+                .maxResults(2)
+                .build());
+
+        assertThat(page1.graphqlApis()).hasSizeLessThanOrEqualTo(2);
+        if (page1.nextToken() != null) {
+            ListGraphqlApisResponse page2 = client.listGraphqlApis(ListGraphqlApisRequest.builder()
+                    .maxResults(2)
+                    .nextToken(page1.nextToken())
+                    .build());
+            assertThat(page2.graphqlApis()).isNotEmpty();
+        }
+    }
+
+    @Test
+    @Order(123)
+    void listDataSourcesWithMaxResults() {
+        for (int i = 0; i < 2; i++) {
+            client.createDataSource(CreateDataSourceRequest.builder()
+                    .apiId(apiId)
+                    .name("pg-sdk-ds-" + i + "-" + java.util.UUID.randomUUID().toString().substring(0, 8))
+                    .type("NONE")
+                    .build());
+        }
+
+        ListDataSourcesResponse page1 = client.listDataSources(ListDataSourcesRequest.builder()
+                .apiId(apiId)
+                .maxResults(1)
+                .build());
+
+        assertThat(page1.dataSources()).hasSize(1);
+        assertThat(page1.nextToken()).isNotNull();
+
+        ListDataSourcesResponse page2 = client.listDataSources(ListDataSourcesRequest.builder()
+                .apiId(apiId)
+                .maxResults(1)
+                .nextToken(page1.nextToken())
+                .build());
+
+        assertThat(page2.dataSources()).isNotEmpty();
+    }
+
+    // ── SDK Coverage Gaps: Mirror Error Tests (409/429/404) ────────────────
+
+    @Test
+    @Order(130)
+    void createDataSourceDuplicateThrowsConflictException() {
+        String dsName = "sdk-conflict-ds-" + java.util.UUID.randomUUID().toString().substring(0, 8);
+        client.createDataSource(CreateDataSourceRequest.builder()
+                .apiId(apiId)
+                .name(dsName)
+                .type("NONE")
+                .build());
+
+        assertThatThrownBy(() -> client.createDataSource(CreateDataSourceRequest.builder()
+                        .apiId(apiId)
+                        .name(dsName)
+                        .type("NONE")
+                        .build()))
+                .isInstanceOf(ConflictException.class)
+                .hasMessageContaining("Data source already exists:");
+
+        client.deleteDataSource(r -> r.apiId(apiId).name(dsName));
+    }
+
+    @Test
+    @Order(131)
+    void createApiKeyExceedsLimitThrowsLimitExceededException() {
+        CreateGraphqlApiResponse tempApi = client.createGraphqlApi(CreateGraphqlApiRequest.builder()
+                .name("sdk-limit-test-" + java.util.UUID.randomUUID().toString().substring(0, 8))
+                .authenticationType("API_KEY")
+                .build());
+        String tempApiId = tempApi.graphqlApi().apiId();
+
+        try {
+            client.createApiKey(CreateApiKeyRequest.builder().apiId(tempApiId).build());
+            client.createApiKey(CreateApiKeyRequest.builder().apiId(tempApiId).build());
+
+            assertThatThrownBy(() -> client.createApiKey(CreateApiKeyRequest.builder().apiId(tempApiId).build()))
+                    .isInstanceOf(LimitExceededException.class)
+                    .hasMessageContaining("Maximum of 2 API keys per API reached");
+        } finally {
+            client.deleteGraphqlApi(r -> r.apiId(tempApiId));
+        }
+    }
+
+    @Test
+    @Order(132)
+    void updateResolverNonExistentThrowsNotFoundException() {
+        assertThatThrownBy(() -> client.updateResolver(UpdateResolverRequest.builder()
+                        .apiId(apiId)
+                        .typeName("Query")
+                        .fieldName("nonExistentSdkField")
+                        .dataSourceName("none-ds")
+                        .build()))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("Resolver not found:");
+    }
+
+    @Test
+    @Order(133)
+    void deleteFunctionNonExistentThrowsNotFoundException() {
+        assertThatThrownBy(() -> client.deleteFunction(DeleteFunctionRequest.builder()
+                        .apiId(apiId)
+                        .functionId("nonexistent00000000000")
+                        .build()))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("Function not found:");
+    }
+
+    @Test
+    @Order(134)
+    void updateApiKeyNonExistentThrowsNotFoundException() {
+        assertThatThrownBy(() -> client.updateApiKey(UpdateApiKeyRequest.builder()
+                        .apiId(apiId)
+                        .id("nonexistent00000000000")
+                        .description("updated")
+                        .build()))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("API key not found:");
+    }
+
+    @Test
+    @Order(135)
+    void updateDomainNameNonExistentThrowsNotFoundException() {
+        assertThatThrownBy(() -> client.updateDomainName(UpdateDomainNameRequest.builder()
+                        .domainName("nonexistent.example.com")
+                        .description("updated")
+                        .build()))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("Domain name not found:");
+    }
+
+    @Test
+    @Order(136)
+    void createResolverMissingDataSourceThrowsNotFoundException() {
+        assertThatThrownBy(() -> client.createResolver(CreateResolverRequest.builder()
+                        .apiId(apiId)
+                        .typeName("Query")
+                        .fieldName("crossRefSdkField")
+                        .dataSourceName("nonexistent-ds-for-sdk-resolver")
+                        .build()))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("Data source not found:");
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -280,11 +280,6 @@
             <version>5.28.5</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.paho</groupId>
             <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
             <version>1.2.5</version>

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -323,6 +323,14 @@ public interface EmulatorConfig {
 
         @WithDefault("5000")
         long flushIntervalMs();
+
+        /** Worker threads for async schema creation. Env: FLOCI_SERVICES_APPSYNC_SCHEMA_WORKER_THREADS */
+        @WithDefault("4")
+        int schemaWorkerThreads();
+
+        /** Seconds to wait for in-flight schema workers on shutdown. Env: FLOCI_SERVICES_APPSYNC_SCHEMA_WORKER_SHUTDOWN_TIMEOUT_SECONDS */
+        @WithDefault("30")
+        int schemaWorkerShutdownTimeoutSeconds();
     }
 
     interface BatchStorageConfig {

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -323,14 +323,6 @@ public interface EmulatorConfig {
 
         @WithDefault("5000")
         long flushIntervalMs();
-
-        /** Worker threads for async schema creation. Env: FLOCI_SERVICES_APPSYNC_SCHEMA_WORKER_THREADS */
-        @WithDefault("4")
-        int schemaWorkerThreads();
-
-        /** Seconds to wait for in-flight schema workers on shutdown. Env: FLOCI_SERVICES_APPSYNC_SCHEMA_WORKER_SHUTDOWN_TIMEOUT_SECONDS */
-        @WithDefault("30")
-        int schemaWorkerShutdownTimeoutSeconds();
     }
 
     interface BatchStorageConfig {
@@ -1065,6 +1057,14 @@ public interface EmulatorConfig {
     interface AppSyncServiceConfig {
         @WithDefault("true")
         boolean enabled();
+
+        /** Worker threads for async schema creation. Env: FLOCI_SERVICES_APPSYNC_SCHEMA_WORKER_THREADS */
+        @WithDefault("4")
+        int schemaWorkerThreads();
+
+        /** Seconds to wait for in-flight schema workers on shutdown. Env: FLOCI_SERVICES_APPSYNC_SCHEMA_WORKER_SHUTDOWN_TIMEOUT_SECONDS */
+        @WithDefault("30")
+        int schemaWorkerShutdownTimeoutSeconds();
     }
 
     interface BcmDataExportsServiceConfig {

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsException.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsException.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.core.common;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -9,6 +11,10 @@ import java.util.Map;
  * Some services use different error code formats for Query (XML) and JSON protocols.
  * {@link #jsonType()} returns the JSON-protocol {@code __type} value that the AWS SDK v2
  * uses to instantiate a specific typed exception rather than falling back to a generic one.
+ * <p>
+ * When {@link #getExtendedData()} is non-null, the exception mapper produces an extended
+ * response with a {@code reason} and {@code detail} field (e.g. {@code reason: "CODE_ERROR"}
+ * with structured code errors for schema validation failures).
  */
 public class AwsException extends RuntimeException {
 
@@ -26,11 +32,17 @@ public class AwsException extends RuntimeException {
 
     private final String errorCode;
     private final int httpStatus;
+    private final Map<String, Object> extendedData;
 
     public AwsException(String errorCode, String message, int httpStatus) {
+        this(errorCode, message, httpStatus, null);
+    }
+
+    public AwsException(String errorCode, String message, int httpStatus, Map<String, Object> extendedData) {
         super(message);
         this.errorCode = errorCode;
         this.httpStatus = httpStatus;
+        this.extendedData = extendedData != null ? new HashMap<>(extendedData) : null;
     }
 
     public String getErrorCode() {
@@ -39,6 +51,15 @@ public class AwsException extends RuntimeException {
 
     public int getHttpStatus() {
         return httpStatus;
+    }
+
+    /**
+     * Returns the extended data for structured error responses, or {@code null} if not present.
+     * Used for schema validation errors that include {@code reason: "CODE_ERROR"} and
+     * {@code detail.codeErrors}.
+     */
+    public Map<String, Object> getExtendedData() {
+        return extendedData != null ? Collections.unmodifiableMap(extendedData) : null;
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsExceptionMapper.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsExceptionMapper.java
@@ -1,25 +1,46 @@
 package io.github.hectorvent.floci.core.common;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import org.jboss.logging.Logger;
 
-/**
- * JAX-RS exception mapper that converts AwsException to AWS-formatted JSON error responses.
- */
+import java.util.Map;
+
 @Provider
 public class AwsExceptionMapper implements ExceptionMapper<AwsException> {
 
     private static final Logger LOG = Logger.getLogger(AwsExceptionMapper.class);
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public AwsExceptionMapper(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     @Override
     public Response toResponse(AwsException exception) {
         LOG.debugv("Mapping exception: {0} - {1}", exception.getErrorCode(), exception.getMessage());
+        Object entity = exception.getExtendedData() != null
+                ? buildExtendedResponse(exception)
+                : new AwsErrorResponse(exception.jsonType(), exception.getMessage());
         return Response.status(exception.getHttpStatus())
                 .type(MediaType.APPLICATION_JSON)
-                .entity(new AwsErrorResponse(exception.jsonType(), exception.getMessage()))
+                .entity(entity)
                 .build();
+    }
+
+    private ObjectNode buildExtendedResponse(AwsException exception) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("__type", exception.jsonType());
+        node.put("message", exception.getMessage());
+        for (Map.Entry<String, Object> entry : exception.getExtendedData().entrySet()) {
+            node.set(entry.getKey(), objectMapper.valueToTree(entry.getValue()));
+        }
+        return node;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
@@ -18,6 +18,7 @@ import io.github.hectorvent.floci.services.lambda.SqsEventSourcePoller;
 import io.github.hectorvent.floci.services.neptune.container.NeptuneContainerManager;
 import io.github.hectorvent.floci.services.neptune.proxy.NeptuneProxyManager;
 import io.github.hectorvent.floci.services.pipes.PipesService;
+import io.github.hectorvent.floci.services.appsync.graphql.SchemaCreationWorker;
 import io.github.hectorvent.floci.services.rds.RdsService;
 import io.github.hectorvent.floci.services.memorydb.container.MemoryDbContainerManager;
 import io.github.hectorvent.floci.services.memorydb.proxy.MemoryDbProxyManager;
@@ -79,6 +80,7 @@ public class EmulatorLifecycle {
     private final EcrRegistryManager ecrRegistryManager;
     private final FlociUiManager flociUiManager;
     private final InitLifecycleState initLifecycleState;
+    private final SchemaCreationWorker schemaCreationWorker;
 
     @Inject
     public EmulatorLifecycle(StorageFactory storageFactory, ServiceRegistry serviceRegistry,
@@ -102,7 +104,8 @@ public class EmulatorLifecycle {
                              Ec2MetadataServer ec2MetadataServer,
                              EcrRegistryManager ecrRegistryManager,
                              FlociUiManager flociUiManager,
-                             InitLifecycleState initLifecycleState) {
+                             InitLifecycleState initLifecycleState,
+                             SchemaCreationWorker schemaCreationWorker) {
         this.storageFactory = storageFactory;
         this.serviceRegistry = serviceRegistry;
         this.config = config;
@@ -126,6 +129,7 @@ public class EmulatorLifecycle {
         this.ecrRegistryManager = ecrRegistryManager;
         this.flociUiManager = flociUiManager;
         this.initLifecycleState = initLifecycleState;
+        this.schemaCreationWorker = schemaCreationWorker;
     }
 
     void onStart(@Observes StartupEvent ignored) {
@@ -148,6 +152,7 @@ public class EmulatorLifecycle {
 
         serviceRegistry.logEnabledServices();
         storageFactory.loadAll();
+        schemaCreationWorker.recoverOrphans();
 
         sqsPoller.startPersistedPollers();
         kinesisPoller.startPersistedPollers();

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncController.java
@@ -517,7 +517,7 @@ public class AppSyncController {
     // ──────────────────────────── Environment Variables ────────────────────────────
 
     @GET
-    @Path("/v1/apis/{apiId}/environmentvariables")
+    @Path("/v1/apis/{apiId}/environmentVariables")
     public Response getEnvironmentVariables(@PathParam("apiId") String apiId) {
         Map<String, String> envVars = service.getEnvironmentVariables(apiId);
         ObjectNode root = objectMapper.createObjectNode();
@@ -527,7 +527,7 @@ public class AppSyncController {
     }
 
     @PUT
-    @Path("/v1/apis/{apiId}/environmentvariables")
+    @Path("/v1/apis/{apiId}/environmentVariables")
     public Response putEnvironmentVariables(@PathParam("apiId") String apiId,
                                             String body) throws IOException {
         @SuppressWarnings("unchecked")

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncController.java
@@ -112,9 +112,7 @@ public class AppSyncController {
             }
         }
         service.startSchemaCreation(apiId, definition);
-        SchemaCreationStatus status = new SchemaCreationStatus();
-        status.setStatus(SchemaCreationStatusType.ACTIVE);
-        return Response.ok(status).build();
+        return Response.ok(service.getSchemaCreationStatus(apiId)).build();
     }
 
     @GET

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncController.java
@@ -216,23 +216,6 @@ public class AppSyncController {
     }
 
     @GET
-    @Path("/v1/apis/{apiId}/resolvers")
-    public Response listResolvers(@PathParam("apiId") String apiId,
-                                  @QueryParam("maxResults") Integer maxResults,
-                                  @QueryParam("nextToken") String nextToken) {
-        var page = service.listResolvers(apiId, maxResults, nextToken);
-        ObjectNode root = objectMapper.createObjectNode();
-        ArrayNode items = root.putArray("resolvers");
-        page.items().forEach(items::addPOJO);
-        if (page.nextToken() != null) {
-            root.put("nextToken", page.nextToken());
-        } else {
-            root.putNull("nextToken");
-        }
-        return Response.ok(root).build();
-    }
-
-    @GET
     @Path("/v1/apis/{apiId}/types/{typeName}/resolvers")
     public Response listResolversByType(@PathParam("apiId") String apiId,
                                         @PathParam("typeName") String typeName,
@@ -451,15 +434,6 @@ public class AppSyncController {
         } else {
             root.putNull("nextToken");
         }
-        return Response.ok(root).build();
-    }
-
-    @GET
-    @Path("/v1/apis/{apiId}/apikeys/{keyId}")
-    public Response getApiKey(@PathParam("apiId") String apiId, @PathParam("keyId") String keyId) {
-        ApiKey key = service.getApiKey(apiId, keyId);
-        ObjectNode root = objectMapper.createObjectNode();
-        root.set("apiKey", objectMapper.valueToTree(key));
         return Response.ok(root).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncController.java
@@ -111,8 +111,7 @@ public class AppSyncController {
                 // Not base64, use as-is
             }
         }
-        service.startSchemaCreation(apiId, definition);
-        return Response.ok(service.getSchemaCreationStatus(apiId)).build();
+        return Response.ok(service.startSchemaCreation(apiId, definition)).build();
     }
 
     @GET

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -848,12 +848,12 @@ public class AppSyncService {
     private void checkDuplicateSourceApiAssociation(String sourceApiId, String mergedApiId) {
         List<SourceApiAssociation> existing = mergedApiAssociationStore.scan(k -> true).stream()
                 .filter(a -> sourceApiId.equals(a.getSourceApiId()) && mergedApiId.equals(a.getMergedApiId()))
+                .filter(a -> !"DELETION_SCHEDULED".equals(a.getSourceApiAssociationStatus()))
                 .toList();
         if (!existing.isEmpty()) {
-            SourceApiAssociation existingAssoc = existing.get(0);
-            throw new AwsException("BadRequestException",
-                    "Source API association with ID %s or API %s already exists."
-                            .formatted(existingAssoc.getAssociationId(), sourceApiId), 400);
+            throw new AwsException("ConcurrentModificationException",
+                    "Source API association already exists for Source API ID: %s and Merged API ID: %s."
+                            .formatted(sourceApiId, mergedApiId), 409);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -448,6 +448,7 @@ public class AppSyncService {
     }
 
     public void deleteResolver(String apiId, String typeName, String fieldName) {
+        assertSchemaNotBusy(apiId);
         getResolver(apiId, typeName, fieldName);
         resolverStore.delete(resolverKey(apiId, typeName, fieldName));
     }
@@ -504,6 +505,7 @@ public class AppSyncService {
     }
 
     public void deleteFunction(String apiId, String functionId) {
+        assertSchemaNotBusy(apiId);
         getFunction(apiId, functionId);
         functionStore.delete(apiKey(apiId, functionId));
     }
@@ -558,6 +560,7 @@ public class AppSyncService {
     }
 
     public void deleteType(String apiId, String typeName) {
+        assertSchemaNotBusy(apiId);
         getType(apiId, typeName);
         typeStore.delete(apiKey(apiId, typeName));
     }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -5,12 +5,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.RequestContext;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.appsync.graphql.SchemaCreationWorker;
 import io.github.hectorvent.floci.services.appsync.graphql.SchemaRegistry;
-import io.github.hectorvent.floci.services.appsync.graphql.SchemaStatusStoreProducer;
 import io.github.hectorvent.floci.services.appsync.model.*;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
@@ -23,7 +26,7 @@ public class AppSyncService {
 
     private final StorageBackend<String, GraphqlApi> apiStore;
     private final StorageBackend<String, String> schemaStore;
-    private final StorageBackend<String, SchemaCreationStatus> schemaStatusStore;
+    private final AccountAwareStorageBackend<SchemaCreationStatus> schemaStatusStore;
     private final StorageBackend<String, DataSource> dataSourceStore;
     private final StorageBackend<String, Resolver> resolverStore;
     private final StorageBackend<String, FunctionConfiguration> functionStore;
@@ -35,14 +38,18 @@ public class AppSyncService {
     private final StorageBackend<String, SourceApiAssociation> mergedApiAssociationStore;
     private final RegionResolver regionResolver;
     private final SchemaRegistry schemaRegistry;
+    private final SchemaCreationWorker schemaCreationWorker;
+    private final Instance<RequestContext> requestContextInstance;
     private final ObjectMapper objectMapper;
 
     @Inject
     public AppSyncService(StorageFactory storageFactory, EmulatorConfig config, RegionResolver regionResolver,
-                          SchemaRegistry schemaRegistry, ObjectMapper objectMapper,
-                          StorageBackend<String, SchemaCreationStatus> schemaStatusStore) {
+                          SchemaRegistry schemaRegistry, SchemaCreationWorker schemaCreationWorker,
+                          Instance<RequestContext> requestContextInstance, ObjectMapper objectMapper,
+                          AccountAwareStorageBackend<SchemaCreationStatus> schemaStatusStore,
+                          StorageBackend<String, String> schemaStore) {
         this.apiStore = storageFactory.create("appsync", "appsync-apis.json", new TypeReference<>() {});
-        this.schemaStore = storageFactory.create("appsync", "appsync-schemas.json", new TypeReference<>() {});
+        this.schemaStore = schemaStore;
         this.schemaStatusStore = schemaStatusStore;
         this.dataSourceStore = storageFactory.create("appsync", "appsync-datasources.json", new TypeReference<>() {});
         this.resolverStore = storageFactory.create("appsync", "appsync-resolvers.json", new TypeReference<>() {});
@@ -55,6 +62,8 @@ public class AppSyncService {
         this.mergedApiAssociationStore = storageFactory.create("appsync", "appsync-merged-api-associations.json", new TypeReference<>() {});
         this.regionResolver = regionResolver;
         this.schemaRegistry = schemaRegistry;
+        this.schemaCreationWorker = schemaCreationWorker;
+        this.requestContextInstance = requestContextInstance;
         this.objectMapper = objectMapper;
     }
 
@@ -206,20 +215,21 @@ public class AppSyncService {
 
     public void startSchemaCreation(String apiId, String definition) {
         getGraphqlApi(apiId);
+        String accountId = currentAccountId();
         synchronized (this) {
             assertSchemaNotBusy(apiId);
-            schemaStore.put(apiId, definition);
             SchemaCreationStatus status = new SchemaCreationStatus();
             status.setStatus(SchemaCreationStatusType.PROCESSING);
-            schemaStatusStore.put(apiId, status);
+            status.setAccountId(accountId);
+            schemaStatusStore.putForAccount(accountId, apiId, status);
         }
-        schemaRegistry.submitSchemaCreation(apiId, definition);
+        schemaCreationWorker.submit(apiId, definition, accountId);
         LOG.infov("Schema creation submitted for API {0}", apiId);
     }
 
     public SchemaCreationStatus getSchemaCreationStatus(String apiId) {
         getGraphqlApi(apiId);
-        return schemaStatusStore.get(apiId).orElseThrow(() ->
+        return schemaStatusStore.getForAccount(currentAccountId(), apiId).orElseThrow(() ->
                 new AwsException("NotFoundException", "Schema creation status not found for API: " + apiId, 404));
     }
 
@@ -237,7 +247,7 @@ public class AppSyncService {
      * creation is in flight.
      */
     void assertSchemaNotBusy(String apiId) {
-        schemaStatusStore.get(apiId).ifPresent(s -> throwIfProcessing(s.getStatus()));
+        schemaStatusStore.getForAccount(currentAccountId(), apiId).ifPresent(s -> throwIfProcessing(s.getStatus()));
     }
 
     /**
@@ -247,8 +257,8 @@ public class AppSyncService {
      * creation is in flight.
      */
     void assertNoSchemaBusyAnywhere() {
-        for (String apiId : schemaStatusStore.keys()) {
-            schemaStatusStore.get(apiId).ifPresent(s -> throwIfProcessing(s.getStatus()));
+        for (String apiId : schemaStatusStore.keysForAccount(currentAccountId())) {
+            schemaStatusStore.getForAccount(currentAccountId(), apiId).ifPresent(s -> throwIfProcessing(s.getStatus()));
         }
     }
 
@@ -257,6 +267,14 @@ public class AppSyncService {
             throw new AwsException("ConcurrentModificationException",
                     "Another modification is in progress at this time and it must complete before you can make your change.",
                     409);
+        }
+    }
+
+    private String currentAccountId() {
+        try {
+            return requestContextInstance.get().getAccountId();
+        } catch (Exception e) {
+            return "000000000000";
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -249,7 +249,7 @@ public class AppSyncService {
 
         String dsKey = apiKey(apiId, ds.getName());
         if (dataSourceStore.get(dsKey).isPresent()) {
-            throw new AwsException("ConflictException", "Data source already exists: " + name, 409);
+            throw new AwsException("BadRequestException", "Data source with name %s already exists.".formatted(name), 400);
         }
         dataSourceStore.put(dsKey, ds);
         return ds;
@@ -332,8 +332,7 @@ public class AppSyncService {
 
         String key = resolverKey(apiId, resolver.getTypeName(), resolver.getFieldName());
         if (resolverStore.get(key).isPresent()) {
-            throw new AwsException("ConflictException",
-                "Resolver already exists for " + typeName + "." + fieldName, 409);
+            throw new AwsException("BadRequestException", "Only one resolver is allowed per field.", 400);
         }
         resolverStore.put(key, resolver);
         return resolver;
@@ -461,7 +460,7 @@ public class AppSyncService {
         }
         String typeKey = apiKey(apiId, name);
         if (typeStore.get(typeKey).isPresent()) {
-            throw new AwsException("ConflictException", "Type already exists: " + name, 409);
+            throw new AwsException("BadRequestException", "Type with name %s already exists.".formatted(name), 400);
         }
         AppSyncType type = new AppSyncType();
         type.setApiId(apiId);
@@ -503,8 +502,8 @@ public class AppSyncService {
         getGraphqlApi(apiId);
         long existingCount = apiKeyStore.scan(k -> k.startsWith(apiId + "::")).size();
         if (existingCount >= 2) {
-            throw new AwsException("LimitExceededException",
-                "Maximum of 2 API keys per API reached", 429);
+            throw new AwsException("ApiKeyLimitExceededException",
+                    "The API key exceeded a limit.", 400);
         }
         ApiKey key = new ApiKey();
         key.setId(generateShortId());
@@ -618,7 +617,7 @@ public class AppSyncService {
             throw new AwsException("BadRequestException", "A domain name is required", 400);
         }
         if (domainStore.get(domainName).isPresent()) {
-            throw new AwsException("ConflictException", "Domain name already exists: " + domainName, 409);
+            throw new AwsException("BadRequestException", "The domain name you provided already exists.", 400);
         }
         DomainName dn = new DomainName();
         dn.setDomainName(domainName);
@@ -667,8 +666,8 @@ public class AppSyncService {
         getDomainName(domainName);
         getGraphqlApi(apiId);
         if (associationStore.get(domainName).isPresent()) {
-            throw new AwsException("ConflictException",
-                "Domain name already associated with an API", 409);
+            throw new AwsException("BadRequestException",
+                    "The domain name %s is already associated with API %s.".formatted(domainName, apiId), 400);
         }
         associationStore.put(domainName, apiId);
         ApiAssociation assoc = new ApiAssociation();
@@ -755,6 +754,7 @@ public class AppSyncService {
             throw new AwsException("BadRequestException", "A merged API identifier is required", 400);
         }
         getGraphqlApi(mergedApiIdentifier);
+        checkDuplicateSourceApiAssociation(sourceApiIdentifier, mergedApiIdentifier);
         SourceApiAssociation assoc = new SourceApiAssociation();
         assoc.setAssociationId(generateShortId());
         assoc.setAssociationArn(regionResolver.buildArn("appsync", region,
@@ -780,6 +780,7 @@ public class AppSyncService {
             throw new AwsException("BadRequestException", "A source API ID is required", 400);
         }
         getGraphqlApi(sourceApiId);
+        checkDuplicateSourceApiAssociation(sourceApiId, mergedApiIdentifier);
         SourceApiAssociation assoc = new SourceApiAssociation();
         assoc.setAssociationId(generateShortId());
         assoc.setAssociationArn(regionResolver.buildArn("appsync", region,
@@ -842,6 +843,18 @@ public class AppSyncService {
     public void deleteSourceApiAssociation(String mergedApiIdentifier, String associationId) {
         getSourceApiAssociation(mergedApiIdentifier, associationId);
         mergedApiAssociationStore.delete(associationId);
+    }
+
+    private void checkDuplicateSourceApiAssociation(String sourceApiId, String mergedApiId) {
+        List<SourceApiAssociation> existing = mergedApiAssociationStore.scan(k -> true).stream()
+                .filter(a -> sourceApiId.equals(a.getSourceApiId()) && mergedApiId.equals(a.getMergedApiId()))
+                .toList();
+        if (!existing.isEmpty()) {
+            SourceApiAssociation existingAssoc = existing.get(0);
+            throw new AwsException("BadRequestException",
+                    "Source API association with ID %s or API %s already exists."
+                            .formatted(existingAssoc.getAssociationId(), sourceApiId), 400);
+        }
     }
 
     public SourceApiAssociation deleteMergedApiAssociation(String sourceApiIdentifier, String associationId) {

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -344,10 +344,6 @@ public class AppSyncService {
                         "Resolver not found: " + typeName + "." + fieldName, 404));
     }
 
-    public Page<Resolver> listResolvers(String apiId, Integer maxResults, String nextToken) {
-        return paginate(resolverStore.scan(k -> k.startsWith(apiId + "::")), nextToken, maxResults);
-    }
-
     public Page<Resolver> listResolversByType(String apiId, String typeName, Integer maxResults, String nextToken) {
         List<Resolver> filtered = resolverStore.scan(k -> k.startsWith(apiId + "::")).stream()
                 .filter(r -> typeName.equals(r.getTypeName()))

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.appsync.graphql.SchemaRegistry;
+import io.github.hectorvent.floci.services.appsync.graphql.SchemaStatusStoreProducer;
 import io.github.hectorvent.floci.services.appsync.model.*;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -38,10 +39,11 @@ public class AppSyncService {
 
     @Inject
     public AppSyncService(StorageFactory storageFactory, EmulatorConfig config, RegionResolver regionResolver,
-                          SchemaRegistry schemaRegistry, ObjectMapper objectMapper) {
+                          SchemaRegistry schemaRegistry, ObjectMapper objectMapper,
+                          StorageBackend<String, SchemaCreationStatus> schemaStatusStore) {
         this.apiStore = storageFactory.create("appsync", "appsync-apis.json", new TypeReference<>() {});
         this.schemaStore = storageFactory.create("appsync", "appsync-schemas.json", new TypeReference<>() {});
-        this.schemaStatusStore = storageFactory.create("appsync", "appsync-schema-status.json", new TypeReference<>() {});
+        this.schemaStatusStore = schemaStatusStore;
         this.dataSourceStore = storageFactory.create("appsync", "appsync-datasources.json", new TypeReference<>() {});
         this.resolverStore = storageFactory.create("appsync", "appsync-resolvers.json", new TypeReference<>() {});
         this.functionStore = storageFactory.create("appsync", "appsync-functions.json", new TypeReference<>() {});
@@ -59,6 +61,7 @@ public class AppSyncService {
     // ──────────────────────────── GraphQL API ────────────────────────────
 
     public GraphqlApi createGraphqlApi(Map<String, Object> request, String region) {
+        assertNoSchemaBusyAnywhere();
         String name = (String) request.get("name");
         if (name == null || name.isBlank()) {
             throw new AwsException("BadRequestException", "A GraphQL API name is required", 400);
@@ -135,6 +138,7 @@ public class AppSyncService {
 
     @SuppressWarnings("unchecked")
     public GraphqlApi updateGraphqlApi(String apiId, Map<String, Object> request, String region) {
+        assertSchemaNotBusy(apiId);
         GraphqlApi existing = getGraphqlApi(apiId);
         if (request.containsKey("name")) existing.setName((String) request.get("name"));
         if (request.containsKey("authenticationType")) existing.setAuthenticationType(parseEnum(AuthenticationType.class, request.get("authenticationType")));
@@ -182,6 +186,7 @@ public class AppSyncService {
     }
 
     public void deleteGraphqlApi(String apiId) {
+        assertSchemaNotBusy(apiId);
         getGraphqlApi(apiId);
         apiStore.delete(apiId);
         schemaStore.delete(apiId);
@@ -201,12 +206,13 @@ public class AppSyncService {
 
     public void startSchemaCreation(String apiId, String definition) {
         getGraphqlApi(apiId);
-        schemaRegistry.register(apiId, definition);
+        assertSchemaNotBusy(apiId);
         schemaStore.put(apiId, definition);
         SchemaCreationStatus status = new SchemaCreationStatus();
-        status.setStatus(SchemaCreationStatusType.ACTIVE);
+        status.setStatus(SchemaCreationStatusType.PROCESSING);
         schemaStatusStore.put(apiId, status);
-        LOG.infov("Schema creation completed for API {0}", apiId);
+        schemaRegistry.submitSchemaCreation(apiId, definition);
+        LOG.infov("Schema creation submitted for API {0}", apiId);
     }
 
     public SchemaCreationStatus getSchemaCreationStatus(String apiId) {
@@ -222,9 +228,40 @@ public class AppSyncService {
                         "Schema not found for API: " + apiId, 404));
     }
 
+    /**
+     * Throw 409 ConcurrentModificationException if the given API has a schema
+     * creation currently in PROCESSING state. Mirrors AWS behavior where
+     * schema-mutating operations are blocked while a previous schema
+     * creation is in flight.
+     */
+    void assertSchemaNotBusy(String apiId) {
+        schemaStatusStore.get(apiId).ifPresent(s -> throwIfProcessing(s.getStatus()));
+    }
+
+    /**
+     * Throw 409 if ANY API in the account has a schema creation in
+     * PROCESSING state. Used by account-wide operations like
+     * CreateGraphqlApi / CreateApi that AWS also blocks when a schema
+     * creation is in flight.
+     */
+    void assertNoSchemaBusyAnywhere() {
+        for (String apiId : schemaStatusStore.keys()) {
+            schemaStatusStore.get(apiId).ifPresent(s -> throwIfProcessing(s.getStatus()));
+        }
+    }
+
+    private void throwIfProcessing(SchemaCreationStatusType status) {
+        if (status == SchemaCreationStatusType.PROCESSING) {
+            throw new AwsException("ConcurrentModificationException",
+                    "Another modification is in progress at this time and it must complete before you can make your change.",
+                    409);
+        }
+    }
+
     // ──────────────────────────── Data Sources ────────────────────────────
 
     public DataSource createDataSource(String apiId, Map<String, Object> request, String region) {
+        assertSchemaNotBusy(apiId);
         getGraphqlApi(apiId);
         String name = (String) request.get("name");
         if (name == null || name.isBlank()) {
@@ -256,6 +293,7 @@ public class AppSyncService {
     }
 
     public DataSource getDataSource(String apiId, String dataSourceName) {
+        assertSchemaNotBusy(apiId);
         return dataSourceStore.get(apiKey(apiId, dataSourceName))
                 .orElseThrow(() -> new AwsException("NotFoundException", "Data source not found: " + dataSourceName, 404));
     }
@@ -266,6 +304,7 @@ public class AppSyncService {
 
     @SuppressWarnings("unchecked")
     public DataSource updateDataSource(String apiId, String dataSourceName, Map<String, Object> request) {
+        assertSchemaNotBusy(apiId);
         DataSource existing = getDataSource(apiId, dataSourceName);
         if (request.containsKey("description")) existing.setDescription((String) request.get("description"));
         if (request.containsKey("type")) existing.setType(parseEnum(DataSourceType.class, request.get("type")));
@@ -282,6 +321,7 @@ public class AppSyncService {
     }
 
     public void deleteDataSource(String apiId, String dataSourceName) {
+        assertSchemaNotBusy(apiId);
         getDataSource(apiId, dataSourceName);
         dataSourceStore.delete(apiKey(apiId, dataSourceName));
     }
@@ -289,6 +329,7 @@ public class AppSyncService {
     // ──────────────────────────── Resolvers ────────────────────────────
 
     public Resolver createResolver(String apiId, Map<String, Object> request, String region) {
+        assertSchemaNotBusy(apiId);
         getGraphqlApi(apiId);
         String fieldName = (String) request.get("fieldName");
         if (fieldName == null || fieldName.isBlank()) {
@@ -339,6 +380,7 @@ public class AppSyncService {
     }
 
     public Resolver getResolver(String apiId, String typeName, String fieldName) {
+        assertSchemaNotBusy(apiId);
         return resolverStore.get(resolverKey(apiId, typeName, fieldName))
                 .orElseThrow(() -> new AwsException("NotFoundException",
                         "Resolver not found: " + typeName + "." + fieldName, 404));
@@ -361,6 +403,7 @@ public class AppSyncService {
 
     @SuppressWarnings("unchecked")
     public Resolver updateResolver(String apiId, String typeName, String fieldName, Map<String, Object> request) {
+        assertSchemaNotBusy(apiId);
         Resolver existing = getResolver(apiId, typeName, fieldName);
         if (request.containsKey("dataSourceName")) existing.setDataSourceName((String) request.get("dataSourceName"));
         if (request.containsKey("functionId")) existing.setFunctionId((String) request.get("functionId"));
@@ -392,6 +435,7 @@ public class AppSyncService {
     // ──────────────────────────── Functions ────────────────────────────
 
     public FunctionConfiguration createFunction(String apiId, Map<String, Object> request, String region) {
+        assertSchemaNotBusy(apiId);
         getGraphqlApi(apiId);
         String name = (String) request.get("name");
         if (name == null || name.isBlank()) {
@@ -417,6 +461,7 @@ public class AppSyncService {
     }
 
     public FunctionConfiguration getFunction(String apiId, String functionId) {
+        assertSchemaNotBusy(apiId);
         return functionStore.get(apiKey(apiId, functionId))
                 .orElseThrow(() -> new AwsException("NotFoundException", "Function not found: " + functionId, 404));
     }
@@ -426,6 +471,7 @@ public class AppSyncService {
     }
 
     public FunctionConfiguration updateFunction(String apiId, String functionId, Map<String, Object> request) {
+        assertSchemaNotBusy(apiId);
         FunctionConfiguration existing = getFunction(apiId, functionId);
         if (request.containsKey("description")) existing.setDescription((String) request.get("description"));
         if (request.containsKey("dataSourceName")) existing.setDataSourceName((String) request.get("dataSourceName"));
@@ -445,6 +491,7 @@ public class AppSyncService {
     // ──────────────────────────── Types ────────────────────────────
 
     public AppSyncType createType(String apiId, Map<String, Object> request) {
+        assertSchemaNotBusy(apiId);
         getGraphqlApi(apiId);
         String name = (String) request.get("name");
         String definition = (String) request.get("definition");
@@ -470,15 +517,18 @@ public class AppSyncService {
     }
 
     public AppSyncType getType(String apiId, String typeName) {
+        assertSchemaNotBusy(apiId);
         return typeStore.get(apiKey(apiId, typeName))
                 .orElseThrow(() -> new AwsException("NotFoundException", "Type not found: " + typeName, 404));
     }
 
     public Page<AppSyncType> listTypes(String apiId, Integer maxResults, String nextToken) {
+        assertSchemaNotBusy(apiId);
         return paginate(typeStore.scan(k -> k.startsWith(apiId + "::")), nextToken, maxResults);
     }
 
     public AppSyncType updateType(String apiId, String typeName, Map<String, Object> request) {
+        assertSchemaNotBusy(apiId);
         AppSyncType existing = getType(apiId, typeName);
         if (request.containsKey("definition")) existing.setDefinition((String) request.get("definition"));
         if (request.containsKey("description")) existing.setDescription((String) request.get("description"));
@@ -599,6 +649,7 @@ public class AppSyncService {
     }
 
     public Map<String, String> putEnvironmentVariables(String apiId, Map<String, String> environmentVariables) {
+        assertSchemaNotBusy(apiId);
         GraphqlApi api = getGraphqlApi(apiId);
         api.setEnvironmentVariables(new HashMap<>(environmentVariables));
         apiStore.put(apiId, api);
@@ -694,6 +745,7 @@ public class AppSyncService {
     // ──────────────────────────── Channel Namespaces ────────────────────────────
 
     public ChannelNamespace createChannelNamespace(String apiId, Map<String, Object> request) {
+        assertSchemaNotBusy(apiId);
         getGraphqlApi(apiId);
         String name = (String) request.get("name");
         if (name == null || name.isBlank()) {
@@ -724,6 +776,7 @@ public class AppSyncService {
     }
 
     public ChannelNamespace updateChannelNamespace(String apiId, String name, Map<String, Object> request) {
+        assertSchemaNotBusy(apiId);
         ChannelNamespace existing = getChannelNamespace(apiId, name);
         if (request.containsKey("description")) existing.setDescription((String) request.get("description"));
         if (request.containsKey("codeHandlers")) existing.setCodeHandlers((String) request.get("codeHandlers"));
@@ -750,6 +803,8 @@ public class AppSyncService {
             throw new AwsException("BadRequestException", "A merged API identifier is required", 400);
         }
         getGraphqlApi(mergedApiIdentifier);
+        assertSchemaNotBusy(sourceApiIdentifier);
+        assertSchemaNotBusy(mergedApiIdentifier);
         checkDuplicateSourceApiAssociation(sourceApiIdentifier, mergedApiIdentifier);
         SourceApiAssociation assoc = new SourceApiAssociation();
         assoc.setAssociationId(generateShortId());
@@ -776,6 +831,8 @@ public class AppSyncService {
             throw new AwsException("BadRequestException", "A source API ID is required", 400);
         }
         getGraphqlApi(sourceApiId);
+        assertSchemaNotBusy(mergedApiIdentifier);
+        assertSchemaNotBusy(sourceApiId);
         checkDuplicateSourceApiAssociation(sourceApiId, mergedApiIdentifier);
         SourceApiAssociation assoc = new SourceApiAssociation();
         assoc.setAssociationId(generateShortId());
@@ -808,6 +865,7 @@ public class AppSyncService {
 
     public SourceApiAssociation updateSourceApiAssociation(String mergedApiIdentifier, String associationId,
                                                           Map<String, Object> request) {
+        assertSchemaNotBusy(mergedApiIdentifier);
         SourceApiAssociation assoc = getSourceApiAssociation(mergedApiIdentifier, associationId);
         if (request.containsKey("description")) {
             assoc.setDescription((String) request.get("description"));
@@ -837,6 +895,7 @@ public class AppSyncService {
     }
 
     public void deleteSourceApiAssociation(String mergedApiIdentifier, String associationId) {
+        assertSchemaNotBusy(mergedApiIdentifier);
         getSourceApiAssociation(mergedApiIdentifier, associationId);
         mergedApiAssociationStore.delete(associationId);
     }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -213,18 +213,20 @@ public class AppSyncService {
 
     // ──────────────────────────── Schema ────────────────────────────
 
-    public void startSchemaCreation(String apiId, String definition) {
+    public SchemaCreationStatus startSchemaCreation(String apiId, String definition) {
         getGraphqlApi(apiId);
         String accountId = currentAccountId();
+        SchemaCreationStatus status;
         synchronized (this) {
             assertSchemaNotBusy(apiId);
-            SchemaCreationStatus status = new SchemaCreationStatus();
+            status = new SchemaCreationStatus();
             status.setStatus(SchemaCreationStatusType.PROCESSING);
             status.setAccountId(accountId);
             schemaStatusStore.putForAccount(accountId, apiId, status);
         }
         schemaCreationWorker.submit(apiId, definition, accountId);
         LOG.infov("Schema creation submitted for API {0}", apiId);
+        return status;
     }
 
     public SchemaCreationStatus getSchemaCreationStatus(String apiId) {

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -206,11 +206,13 @@ public class AppSyncService {
 
     public void startSchemaCreation(String apiId, String definition) {
         getGraphqlApi(apiId);
-        assertSchemaNotBusy(apiId);
-        schemaStore.put(apiId, definition);
-        SchemaCreationStatus status = new SchemaCreationStatus();
-        status.setStatus(SchemaCreationStatusType.PROCESSING);
-        schemaStatusStore.put(apiId, status);
+        synchronized (this) {
+            assertSchemaNotBusy(apiId);
+            schemaStore.put(apiId, definition);
+            SchemaCreationStatus status = new SchemaCreationStatus();
+            status.setStatus(SchemaCreationStatusType.PROCESSING);
+            schemaStatusStore.put(apiId, status);
+        }
         schemaRegistry.submitSchemaCreation(apiId, definition);
         LOG.infov("Schema creation submitted for API {0}", apiId);
     }
@@ -698,6 +700,7 @@ public class AppSyncService {
 
     public DomainName updateDomainName(String domainName, Map<String, Object> request) {
         DomainName existing = getDomainName(domainName);
+        associationStore.get(domainName).ifPresent(apiId -> assertSchemaNotBusy(apiId));
         if (request.containsKey("description")) existing.setDescription((String) request.get("description"));
         domainStore.put(domainName, existing);
         return existing;
@@ -705,6 +708,7 @@ public class AppSyncService {
 
     public void deleteDomainName(String domainName) {
         getDomainName(domainName);
+        associationStore.get(domainName).ifPresent(apiId -> assertSchemaNotBusy(apiId));
         associationStore.delete(domainName);
         domainStore.delete(domainName);
     }
@@ -739,6 +743,7 @@ public class AppSyncService {
 
     public void disassociateApi(String domainName) {
         getDomainName(domainName);
+        associationStore.get(domainName).ifPresent(apiId -> assertSchemaNotBusy(apiId));
         associationStore.delete(domainName);
     }
 
@@ -770,6 +775,7 @@ public class AppSyncService {
     }
 
     public ChannelNamespace getChannelNamespace(String apiId, String name) {
+        assertSchemaNotBusy(apiId);
         return channelNamespaceStore.get(apiKey(apiId, name))
                 .orElseThrow(() -> new AwsException("NotFoundException",
                         "Channel namespace not found: " + name, 404));
@@ -913,6 +919,7 @@ public class AppSyncService {
     }
 
     public SourceApiAssociation deleteMergedApiAssociation(String sourceApiIdentifier, String associationId) {
+        assertSchemaNotBusy(sourceApiIdentifier);
         SourceApiAssociation assoc = mergedApiAssociationStore.get(associationId)
                 .orElseThrow(() -> new AwsException("NotFoundException",
                         "Source API association not found: " + associationId, 404));

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -775,7 +775,6 @@ public class AppSyncService {
     }
 
     public ChannelNamespace getChannelNamespace(String apiId, String name) {
-        assertSchemaNotBusy(apiId);
         return channelNamespaceStore.get(apiKey(apiId, name))
                 .orElseThrow(() -> new AwsException("NotFoundException",
                         "Channel namespace not found: " + name, 404));
@@ -792,6 +791,7 @@ public class AppSyncService {
     }
 
     public void deleteChannelNamespace(String apiId, String name) {
+        assertSchemaNotBusy(apiId);
         getChannelNamespace(apiId, name);
         channelNamespaceStore.delete(apiKey(apiId, name));
     }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncSchemaParser.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncSchemaParser.java
@@ -1,15 +1,23 @@
 package io.github.hectorvent.floci.services.appsync.graphql;
 
+import graphql.GraphQLError;
+import graphql.language.SourceLocation;
+import graphql.parser.InvalidSyntaxException;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.idl.RuntimeWiring;
 import graphql.schema.idl.SchemaGenerator;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
+import graphql.schema.idl.errors.SchemaProblem;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.appsync.graphql.scalars.AppSyncScalarRegistry;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -31,8 +39,18 @@ public class AppSyncSchemaParser {
         TypeDefinitionRegistry typeRegistry;
         try {
             typeRegistry = parser.parse(sdlWithDirectives);
-        } catch (Exception e) {
-            throw new AwsException("BadRequestException", "Invalid schema: " + e.getMessage(), 400);
+        } catch (SchemaProblem e) {
+            List<Map<String, Object>> codeErrors = new ArrayList<>();
+            for (GraphQLError ge : e.getErrors()) {
+                codeErrors.add(toCodeErrorFromGraphQL("PARSER_ERROR", ge));
+            }
+            throw new AwsException("BadRequestException",
+                    "Invalid schema: " + e.getMessage(), 400,
+                    buildExtendedData(codeErrors));
+        } catch (InvalidSyntaxException e) {
+            throw new AwsException("BadRequestException",
+                    "Invalid schema: " + e.getMessage(), 400,
+                    buildExtendedData(List.of(toCodeError("PARSER_ERROR", e.getMessage(), 0, 0))));
         }
 
         RuntimeWiring.Builder wiringBuilder = RuntimeWiring.newRuntimeWiring();
@@ -42,25 +60,66 @@ public class AppSyncSchemaParser {
 
         try {
             return new SchemaGenerator().makeExecutableSchema(typeRegistry, wiringBuilder.build());
+        } catch (SchemaProblem e) {
+            List<Map<String, Object>> codeErrors = new ArrayList<>();
+            for (GraphQLError ge : e.getErrors()) {
+                codeErrors.add(toCodeErrorFromGraphQL("VALIDATION_ERROR", ge));
+            }
+            throw new AwsException("BadRequestException",
+                    "Invalid schema: " + e.getMessage(), 400,
+                    buildExtendedData(codeErrors));
         } catch (RuntimeException e) {
-            throw new AwsException("BadRequestException", "Invalid schema: " + e.getMessage(), 400);
+            throw new AwsException("BadRequestException",
+                    "Invalid schema: " + e.getMessage(), 400);
         }
     }
 
     private void validateNoUnknownDirectives(String sdl) {
         String clean = sdl
-            .replaceAll("\"\"\"[\\s\\S]*?\"\"\"", "")
-            .replaceAll("\"(?:[^\"\\\\]|\\\\.)*\"", "")
-            .replaceAll("#[^\n]*", "");
+                .replaceAll("\"\"\"[\\s\\S]*?\"\"\"", "")
+                .replaceAll("\"(?:[^\"\\\\]|\\\\.)*\"", "")
+                .replaceAll("#[^\n]*", "");
         Pattern directivePattern = Pattern.compile("@(\\w+)");
         Matcher matcher = directivePattern.matcher(clean);
         while (matcher.find()) {
             String name = matcher.group(1);
             if (!AppSyncDirective.isKnown(name)) {
                 throw new AwsException("BadRequestException",
-                    "Unknown directive: @" + name, 400);
+                        "Unknown directive: @" + name, 400,
+                        buildExtendedData(List.of(
+                                toCodeError("VALIDATION_ERROR", "Unknown directive: @" + name, 0, 0))));
             }
         }
+    }
+
+    private Map<String, Object> toCodeErrorFromGraphQL(String errorType, GraphQLError ge) {
+        List<SourceLocation> locs = ge.getLocations();
+        if (locs != null && !locs.isEmpty()) {
+            SourceLocation first = locs.get(0);
+            return toCodeError(errorType, ge.getMessage(), first.getLine(), first.getColumn());
+        }
+        return toCodeError(errorType, ge.getMessage(), 0, 0);
+    }
+
+    private Map<String, Object> toCodeError(String errorType, String value, int line, int column) {
+        Map<String, Object> codeError = new LinkedHashMap<>();
+        codeError.put("errorType", errorType);
+        codeError.put("value", value);
+        Map<String, Object> location = new LinkedHashMap<>();
+        location.put("line", line);
+        location.put("column", column);
+        location.put("span", -1);
+        codeError.put("location", location);
+        return codeError;
+    }
+
+    private Map<String, Object> buildExtendedData(List<Map<String, Object>> codeErrors) {
+        Map<String, Object> detail = new LinkedHashMap<>();
+        detail.put("codeErrors", codeErrors);
+        Map<String, Object> extendedData = new LinkedHashMap<>();
+        extendedData.put("reason", "CODE_ERROR");
+        extendedData.put("detail", detail);
+        return extendedData;
     }
 
     private String injectDirectiveDefinitions(String sdl) {

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaCreationWorker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaCreationWorker.java
@@ -89,7 +89,7 @@ public class SchemaCreationWorker {
         try {
             schemaRegistry.register(apiId, sdl);
             schemaStore.put(apiId, sdl);
-            markStatus(accountId, apiId, SchemaCreationStatusType.ACTIVE, null);
+            markStatus(accountId, apiId, SchemaCreationStatusType.SUCCESS, null);
             LOG.infov("Schema creation completed for API {0}", apiId);
         } catch (AwsException e) {
             String details = serializeExtendedData(e);

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaCreationWorker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaCreationWorker.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.services.appsync.model.SchemaCreationStatus;
 import io.github.hectorvent.floci.services.appsync.model.SchemaCreationStatusType;
@@ -13,6 +14,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -30,7 +32,8 @@ public class SchemaCreationWorker {
     private static final Logger LOG = Logger.getLogger(SchemaCreationWorker.class);
 
     private final SchemaRegistry schemaRegistry;
-    private final StorageBackend<String, SchemaCreationStatus> schemaStatusStore;
+    private final AccountAwareStorageBackend<SchemaCreationStatus> schemaStatusStore;
+    private final StorageBackend<String, String> schemaStore;
     private final EmulatorConfig config;
     private final ObjectMapper objectMapper;
 
@@ -38,18 +41,20 @@ public class SchemaCreationWorker {
 
     @Inject
     public SchemaCreationWorker(SchemaRegistry schemaRegistry,
-                                StorageBackend<String, SchemaCreationStatus> schemaStatusStore,
+                                AccountAwareStorageBackend<SchemaCreationStatus> schemaStatusStore,
+                                StorageBackend<String, String> schemaStore,
                                 EmulatorConfig config,
                                 ObjectMapper objectMapper) {
         this.schemaRegistry = schemaRegistry;
         this.schemaStatusStore = schemaStatusStore;
+        this.schemaStore = schemaStore;
         this.config = config;
         this.objectMapper = objectMapper;
     }
 
     @PostConstruct
     void init() {
-        int threads = config.storage().services().appsync().schemaWorkerThreads();
+        int threads = config.services().appsync().schemaWorkerThreads();
         executor = Executors.newFixedThreadPool(threads, r -> {
             Thread t = new Thread(r, "appsync-schema-worker");
             t.setDaemon(true);
@@ -63,7 +68,7 @@ public class SchemaCreationWorker {
         if (executor == null) {
             return;
         }
-        int timeout = config.storage().services().appsync().schemaWorkerShutdownTimeoutSeconds();
+        int timeout = config.services().appsync().schemaWorkerShutdownTimeoutSeconds();
         executor.shutdown();
         try {
             if (!executor.awaitTermination(timeout, TimeUnit.SECONDS)) {
@@ -76,32 +81,34 @@ public class SchemaCreationWorker {
         }
     }
 
-    public void submit(String apiId, String sdl) {
-        executor.submit(() -> process(apiId, sdl));
+    public void submit(String apiId, String sdl, String accountId) {
+        executor.submit(() -> process(apiId, sdl, accountId));
     }
 
-    private void process(String apiId, String sdl) {
+    private void process(String apiId, String sdl, String accountId) {
         try {
             schemaRegistry.register(apiId, sdl);
-            markStatus(apiId, SchemaCreationStatusType.ACTIVE, null);
+            schemaStore.put(apiId, sdl);
+            markStatus(accountId, apiId, SchemaCreationStatusType.ACTIVE, null);
             LOG.infov("Schema creation completed for API {0}", apiId);
         } catch (AwsException e) {
             String details = serializeExtendedData(e);
-            markStatus(apiId, SchemaCreationStatusType.FAILED, details);
+            markStatus(accountId, apiId, SchemaCreationStatusType.FAILED, details);
             LOG.warnv("Schema creation failed for API {0}: {1}", apiId, e.getMessage());
         } catch (RuntimeException e) {
-            markStatus(apiId, SchemaCreationStatusType.FAILED, e.getMessage());
+            markStatus(accountId, apiId, SchemaCreationStatusType.FAILED, e.getMessage());
             LOG.errorv(e, "Unexpected error during schema creation for API {0}", apiId);
         }
     }
 
-    private void markStatus(String apiId, SchemaCreationStatusType status, String details) {
+    private void markStatus(String accountId, String apiId, SchemaCreationStatusType status, String details) {
         SchemaCreationStatus s = new SchemaCreationStatus();
         s.setStatus(status);
+        s.setAccountId(accountId);
         if (details != null) {
             s.setDetails(details);
         }
-        schemaStatusStore.put(apiId, s);
+        schemaStatusStore.putForAccount(accountId, apiId, s);
     }
 
     private String serializeExtendedData(AwsException e) {
@@ -120,15 +127,20 @@ public class SchemaCreationWorker {
      */
     public void recoverOrphans() {
         int recovered = 0;
-        for (String apiId : schemaStatusStore.keys()) {
-            Optional<SchemaCreationStatus> opt = schemaStatusStore.get(apiId);
-            if (opt.isPresent() && opt.get().getStatus() == SchemaCreationStatusType.PROCESSING) {
-                SchemaCreationStatus s = opt.get();
+        Map<String, SchemaCreationStatus> allEntries = schemaStatusStore.scanAllAccountsAsMap();
+        for (Map.Entry<String, SchemaCreationStatus> entry : allEntries.entrySet()) {
+            SchemaCreationStatus s = entry.getValue();
+            if (s.getStatus() == SchemaCreationStatusType.PROCESSING) {
+                String apiId = entry.getKey();
+                String accountId = s.getAccountId();
+                if (accountId == null) {
+                    accountId = "000000000000";
+                }
                 s.setStatus(SchemaCreationStatusType.FAILED);
                 if (s.getDetails() == null) {
                     s.setDetails("{\"reason\":\"ORPHAN_PROCESSING\",\"message\":\"Recovered from orphan PROCESSING on emulator startup\"}");
                 }
-                schemaStatusStore.put(apiId, s);
+                schemaStatusStore.putForAccount(accountId, apiId, s);
                 recovered++;
                 LOG.warnv("Marked orphan schema creation for API {0} as FAILED", apiId);
             }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaCreationWorker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaCreationWorker.java
@@ -1,0 +1,140 @@
+package io.github.hectorvent.floci.services.appsync.graphql;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.services.appsync.model.SchemaCreationStatus;
+import io.github.hectorvent.floci.services.appsync.model.SchemaCreationStatusType;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Async worker that processes schema creation jobs in background threads.
+ * Mirrors AWS AppSync behavior where StartSchemaCreation is asynchronous:
+ * the request returns PROCESSING immediately, and the schema is compiled
+ * in the background, transitioning to ACTIVE (success) or FAILED (error).
+ */
+@ApplicationScoped
+public class SchemaCreationWorker {
+
+    private static final Logger LOG = Logger.getLogger(SchemaCreationWorker.class);
+
+    private final SchemaRegistry schemaRegistry;
+    private final StorageBackend<String, SchemaCreationStatus> schemaStatusStore;
+    private final EmulatorConfig config;
+    private final ObjectMapper objectMapper;
+
+    private ExecutorService executor;
+
+    @Inject
+    public SchemaCreationWorker(SchemaRegistry schemaRegistry,
+                                StorageBackend<String, SchemaCreationStatus> schemaStatusStore,
+                                EmulatorConfig config,
+                                ObjectMapper objectMapper) {
+        this.schemaRegistry = schemaRegistry;
+        this.schemaStatusStore = schemaStatusStore;
+        this.config = config;
+        this.objectMapper = objectMapper;
+    }
+
+    @PostConstruct
+    void init() {
+        int threads = config.storage().services().appsync().schemaWorkerThreads();
+        executor = Executors.newFixedThreadPool(threads, r -> {
+            Thread t = new Thread(r, "appsync-schema-worker");
+            t.setDaemon(true);
+            return t;
+        });
+        LOG.infov("SchemaCreationWorker started with {0} threads", threads);
+    }
+
+    @PreDestroy
+    void shutdown() {
+        if (executor == null) {
+            return;
+        }
+        int timeout = config.storage().services().appsync().schemaWorkerShutdownTimeoutSeconds();
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(timeout, TimeUnit.SECONDS)) {
+                LOG.warnv("Schema workers did not finish within {0}s, forcing shutdown", timeout);
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public void submit(String apiId, String sdl) {
+        executor.submit(() -> process(apiId, sdl));
+    }
+
+    private void process(String apiId, String sdl) {
+        try {
+            schemaRegistry.register(apiId, sdl);
+            markStatus(apiId, SchemaCreationStatusType.ACTIVE, null);
+            LOG.infov("Schema creation completed for API {0}", apiId);
+        } catch (AwsException e) {
+            String details = serializeExtendedData(e);
+            markStatus(apiId, SchemaCreationStatusType.FAILED, details);
+            LOG.warnv("Schema creation failed for API {0}: {1}", apiId, e.getMessage());
+        } catch (RuntimeException e) {
+            markStatus(apiId, SchemaCreationStatusType.FAILED, e.getMessage());
+            LOG.errorv(e, "Unexpected error during schema creation for API {0}", apiId);
+        }
+    }
+
+    private void markStatus(String apiId, SchemaCreationStatusType status, String details) {
+        SchemaCreationStatus s = new SchemaCreationStatus();
+        s.setStatus(status);
+        if (details != null) {
+            s.setDetails(details);
+        }
+        schemaStatusStore.put(apiId, s);
+    }
+
+    private String serializeExtendedData(AwsException e) {
+        if (e.getExtendedData() == null) {
+            return e.getMessage();
+        }
+        try {
+            return objectMapper.writeValueAsString(e.getExtendedData());
+        } catch (JsonProcessingException ex) {
+            return e.getMessage();
+        }
+    }
+
+    /**
+     * Used at startup to recover orphan PROCESSING statuses from a previous run.
+     */
+    public void recoverOrphans() {
+        int recovered = 0;
+        for (String apiId : schemaStatusStore.keys()) {
+            Optional<SchemaCreationStatus> opt = schemaStatusStore.get(apiId);
+            if (opt.isPresent() && opt.get().getStatus() == SchemaCreationStatusType.PROCESSING) {
+                SchemaCreationStatus s = opt.get();
+                s.setStatus(SchemaCreationStatusType.FAILED);
+                if (s.getDetails() == null) {
+                    s.setDetails("{\"reason\":\"ORPHAN_PROCESSING\",\"message\":\"Recovered from orphan PROCESSING on emulator startup\"}");
+                }
+                schemaStatusStore.put(apiId, s);
+                recovered++;
+                LOG.warnv("Marked orphan schema creation for API {0} as FAILED", apiId);
+            }
+        }
+        if (recovered > 0) {
+            LOG.infov("Recovered {0} orphan schema creation(s) on startup", recovered);
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaRegistry.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaRegistry.java
@@ -12,15 +12,25 @@ import java.util.concurrent.ConcurrentHashMap;
 public class SchemaRegistry {
     private final Map<String, GraphQLSchema> schemas = new ConcurrentHashMap<>();
     private final AppSyncSchemaParser appSyncSchemaParser;
+    private final SchemaCreationWorker worker;
 
     @Inject
-    public SchemaRegistry(AppSyncSchemaParser appSyncSchemaParser) {
+    public SchemaRegistry(AppSyncSchemaParser appSyncSchemaParser, SchemaCreationWorker worker) {
         this.appSyncSchemaParser = appSyncSchemaParser;
+        this.worker = worker;
     }
 
     public void register(String apiId, String sdl) {
         GraphQLSchema schema = appSyncSchemaParser.parse(sdl);
         schemas.put(apiId, schema);
+    }
+
+    /**
+     * Submit a schema for async creation. The status is set to PROCESSING
+     * synchronously by the caller; this method enqueues the actual parse/register.
+     */
+    public void submitSchemaCreation(String apiId, String sdl) {
+        worker.submit(apiId, sdl);
     }
 
     public Optional<GraphQLSchema> getSchema(String apiId) {

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaRegistry.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaRegistry.java
@@ -12,25 +12,15 @@ import java.util.concurrent.ConcurrentHashMap;
 public class SchemaRegistry {
     private final Map<String, GraphQLSchema> schemas = new ConcurrentHashMap<>();
     private final AppSyncSchemaParser appSyncSchemaParser;
-    private final SchemaCreationWorker worker;
 
     @Inject
-    public SchemaRegistry(AppSyncSchemaParser appSyncSchemaParser, SchemaCreationWorker worker) {
+    public SchemaRegistry(AppSyncSchemaParser appSyncSchemaParser) {
         this.appSyncSchemaParser = appSyncSchemaParser;
-        this.worker = worker;
     }
 
     public void register(String apiId, String sdl) {
         GraphQLSchema schema = appSyncSchemaParser.parse(sdl);
         schemas.put(apiId, schema);
-    }
-
-    /**
-     * Submit a schema for async creation. The status is set to PROCESSING
-     * synchronously by the caller; this method enqueues the actual parse/register.
-     */
-    public void submitSchemaCreation(String apiId, String sdl) {
-        worker.submit(apiId, sdl);
     }
 
     public Optional<GraphQLSchema> getSchema(String apiId) {

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaStatusStoreProducer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaStatusStoreProducer.java
@@ -1,0 +1,36 @@
+package io.github.hectorvent.floci.services.appsync.graphql;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.appsync.model.SchemaCreationStatus;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+
+import java.util.Map;
+
+/**
+ * Produces the shared {@link StorageBackend} used to track schema creation
+ * status. Lives as a CDI bean so both {@code AppSyncService} (which mutates
+ * the status from request threads) and {@code SchemaCreationWorker} (which
+ * transitions the status from background worker threads) see the same
+ * in-memory state and the same flush cycle.
+ */
+@ApplicationScoped
+public class SchemaStatusStoreProducer {
+
+    private final StorageBackend<String, SchemaCreationStatus> store;
+
+    @Inject
+    public SchemaStatusStoreProducer(StorageFactory storageFactory) {
+        this.store = storageFactory.create("appsync", "appsync-schema-status.json",
+                new TypeReference<Map<String, SchemaCreationStatus>>() {});
+    }
+
+    @Produces
+    @ApplicationScoped
+    public StorageBackend<String, SchemaCreationStatus> produce() {
+        return store;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaStatusStoreProducer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaStatusStoreProducer.java
@@ -1,7 +1,7 @@
 package io.github.hectorvent.floci.services.appsync.graphql;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.appsync.model.SchemaCreationStatus;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -11,7 +11,7 @@ import jakarta.inject.Inject;
 import java.util.Map;
 
 /**
- * Produces the shared {@link StorageBackend} used to track schema creation
+ * Produces the shared {@link AccountAwareStorageBackend} used to track schema creation
  * status. Lives as a CDI bean so both {@code AppSyncService} (which mutates
  * the status from request threads) and {@code SchemaCreationWorker} (which
  * transitions the status from background worker threads) see the same
@@ -20,17 +20,17 @@ import java.util.Map;
 @ApplicationScoped
 public class SchemaStatusStoreProducer {
 
-    private final StorageBackend<String, SchemaCreationStatus> store;
+    private final AccountAwareStorageBackend<SchemaCreationStatus> store;
 
     @Inject
     public SchemaStatusStoreProducer(StorageFactory storageFactory) {
-        this.store = storageFactory.create("appsync", "appsync-schema-status.json",
+        this.store = (AccountAwareStorageBackend<SchemaCreationStatus>) storageFactory.create("appsync", "appsync-schema-status.json",
                 new TypeReference<Map<String, SchemaCreationStatus>>() {});
     }
 
     @Produces
     @ApplicationScoped
-    public StorageBackend<String, SchemaCreationStatus> produce() {
+    public AccountAwareStorageBackend<SchemaCreationStatus> produce() {
         return store;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaStoreProducer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaStoreProducer.java
@@ -1,0 +1,33 @@
+package io.github.hectorvent.floci.services.appsync.graphql;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+
+import java.util.Map;
+
+/**
+ * Produces the shared {@link StorageBackend} used to store compiled SDL schemas.
+ * Shared between {@code AppSyncService} (reads via getIntrospectionSchema) and
+ * {@code SchemaCreationWorker} (writes on successful compilation).
+ */
+@ApplicationScoped
+public class SchemaStoreProducer {
+
+    private final StorageBackend<String, String> store;
+
+    @Inject
+    public SchemaStoreProducer(StorageFactory storageFactory) {
+        this.store = storageFactory.create("appsync", "appsync-schemas.json",
+                new TypeReference<Map<String, String>>() {});
+    }
+
+    @Produces
+    @ApplicationScoped
+    public StorageBackend<String, String> produce() {
+        return store;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/SchemaCreationStatus.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/SchemaCreationStatus.java
@@ -10,10 +10,14 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 public class SchemaCreationStatus {
     private SchemaCreationStatusType status;
     private String details;
+    private String accountId;
 
     public SchemaCreationStatusType getStatus() { return status; }
     public void setStatus(SchemaCreationStatusType status) { this.status = status; }
 
     public String getDetails() { return details; }
     public void setDetails(String details) { this.details = details; }
+
+    public String getAccountId() { return accountId; }
+    public void setAccountId(String accountId) { this.accountId = accountId; }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -118,8 +118,6 @@ floci:
         # mode: memory
       appsync:
         flush-interval-ms: 5000
-        schema-worker-threads: 4
-        schema-worker-shutdown-timeout-seconds: 30
 
   dns:
     # Extra hostname suffixes resolved to Floci's container IP by the embedded DNS server.
@@ -387,6 +385,8 @@ floci:
       enabled: true
     appsync:
       enabled: true
+      schema-worker-threads: 4
+      schema-worker-shutdown-timeout-seconds: 30
     s3vectors:
       enabled: true
     iot:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -116,6 +116,10 @@ floci:
         # Override storage mode for EC2 (defaults to the global storage mode). EC2 networking and
         # instance metadata persist so CloudFormation-created VPC/subnet ids survive a restart (#1297).
         # mode: memory
+      appsync:
+        flush-interval-ms: 5000
+        schema-worker-threads: 4
+        schema-worker-shutdown-timeout-seconds: 30
 
   dns:
     # Extra hostname suffixes resolved to Floci's container IP by the embedded DNS server.

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
@@ -76,6 +76,7 @@ class EmulatorLifecycleTest {
     @Mock private io.github.hectorvent.floci.services.floci.ui.FlociUiManager flociUiManager;
     @Mock private InitLifecycleState initLifecycleState;
     @Mock private EmulatorConfig.TlsConfig tlsConfig;
+    @Mock private io.github.hectorvent.floci.services.appsync.graphql.SchemaCreationWorker schemaCreationWorker;
 
     private EmulatorLifecycle emulatorLifecycle;
 
@@ -94,7 +95,8 @@ class EmulatorLifecycleTest {
                 memoryDbContainerManager, memoryDbProxyManager,
                 docDbContainerManager, neptuneContainerManager, neptuneProxyManager, rdsService,
                 initializationHooksRunner, sqsPoller, kinesisPoller, dynamodbStreamsPoller,
-                pipesService, ec2MetadataServer, ecrRegistryManager, flociUiManager, initLifecycleState);
+                pipesService, ec2MetadataServer, ecrRegistryManager, flociUiManager, initLifecycleState,
+                schemaCreationWorker);
     }
 
     private void stubStorageConfig() {

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
@@ -1505,11 +1505,11 @@ class AppSyncIntegrationTest {
             .body("message", containsString("Invalid NextToken."));
     }
 
-    // ── ConflictException (409) ──────────────────────────────────────────────
+    // ── BadRequestException (400) for duplicates ──────────────────────────────
 
     @Test
     @Order(150)
-    void createDataSourceDuplicateReturns409() {
+    void createDataSourceDuplicateReturns400() {
         String dsName = "conflict-ds-" + System.nanoTime();
         given()
             .header("Authorization", AUTH)
@@ -1531,16 +1531,16 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/apis/" + apiId + "/datasources")
         .then()
-            .statusCode(409)
-            .body("__type", equalTo("ConflictException"))
-            .body("message", containsString("Data source already exists:"));
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("Data source with name"));
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + apiId + "/datasources/" + dsName).then().statusCode(204);
     }
 
     @Test
     @Order(151)
-    void createResolverDuplicateReturns409() {
+    void createResolverDuplicateReturns400() {
         String fieldName = "conflictField" + System.nanoTime();
         given()
             .header("Authorization", AUTH)
@@ -1562,16 +1562,16 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/apis/" + apiId + "/types/Query/resolvers")
         .then()
-            .statusCode(409)
-            .body("__type", equalTo("ConflictException"))
-            .body("message", containsString("Resolver already exists for"));
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("Only one resolver is allowed per field"));
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + apiId + "/types/Query/resolvers/" + fieldName).then().statusCode(204);
     }
 
     @Test
     @Order(152)
-    void createTypeDuplicateReturns409() {
+    void createTypeDuplicateReturns400() {
         String typeName = "ConflictType" + System.nanoTime();
         given()
             .header("Authorization", AUTH)
@@ -1593,16 +1593,16 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/apis/" + apiId + "/types")
         .then()
-            .statusCode(409)
-            .body("__type", equalTo("ConflictException"))
-            .body("message", containsString("Type already exists:"));
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("Type with name"));
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + apiId + "/types/" + typeName).then().statusCode(204);
     }
 
     @Test
     @Order(153)
-    void createDomainNameDuplicateReturns409() {
+    void createDomainNameDuplicateReturns400() {
         String domain = "conflict-" + System.nanoTime() + ".example.com";
         given()
             .header("Authorization", AUTH)
@@ -1624,9 +1624,9 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/domainnames")
         .then()
-            .statusCode(409)
-            .body("__type", equalTo("ConflictException"))
-            .body("message", containsString("Domain name already exists:"));
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("The domain name you provided already exists"));
 
         given().header("Authorization", AUTH).delete("/v1/domainnames/" + domain).then().statusCode(204);
     }
@@ -1664,7 +1664,7 @@ class AppSyncIntegrationTest {
 
     @Test
     @Order(155)
-    void associateApiDuplicateReturns409() {
+    void associateApiDuplicateReturns400() {
         String domain = "assoc-conflict-" + System.nanoTime() + ".example.com";
         String tempApiId = given()
             .header("Authorization", AUTH)
@@ -1709,19 +1709,19 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/domainnames/" + domain + "/apiassociation")
         .then()
-            .statusCode(409)
-            .body("__type", equalTo("ConflictException"))
-            .body("message", containsString("Domain name already associated with an API"));
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("already associated with API"));
 
         given().header("Authorization", AUTH).delete("/v1/domainnames/" + domain).then().statusCode(204);
         given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
     }
 
-    // ── LimitExceededException (429) ─────────────────────────────────────────
+    // ── ApiKeyLimitExceededException (400) ─────────────────────────────────
 
     @Test
     @Order(160)
-    void createApiKeyExceedsLimitReturns429() {
+    void createApiKeyExceedsLimitReturns400() {
         String tempApiId = given()
             .header("Authorization", AUTH)
             .contentType("application/json")
@@ -1765,9 +1765,9 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/apis/" + tempApiId + "/apikeys")
         .then()
-            .statusCode(429)
-            .body("__type", equalTo("LimitExceededException"))
-            .body("message", containsString("Maximum of 2 API keys per API reached"));
+            .statusCode(400)
+            .body("__type", equalTo("ApiKeyLimitExceededException"))
+            .body("message", containsString("The API key exceeded a limit"));
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
     }

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
@@ -1505,6 +1505,273 @@ class AppSyncIntegrationTest {
             .body("message", containsString("Invalid NextToken."));
     }
 
+    // ── ConflictException (409) ──────────────────────────────────────────────
+
+    @Test
+    @Order(150)
+    void createDataSourceDuplicateReturns409() {
+        String dsName = "conflict-ds-" + System.nanoTime();
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "%s", "type": "NONE"}
+                """.formatted(dsName))
+        .when()
+            .post("/v1/apis/" + apiId + "/datasources")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "%s", "type": "NONE"}
+                """.formatted(dsName))
+        .when()
+            .post("/v1/apis/" + apiId + "/datasources")
+        .then()
+            .statusCode(409)
+            .body("__type", equalTo("ConflictException"))
+            .body("message", containsString("Data source already exists:"));
+
+        given().header("Authorization", AUTH).delete("/v1/apis/" + apiId + "/datasources/" + dsName).then().statusCode(204);
+    }
+
+    @Test
+    @Order(151)
+    void createResolverDuplicateReturns409() {
+        String fieldName = "conflictField" + System.nanoTime();
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"fieldName": "%s", "dataSourceName": "none-ds"}
+                """.formatted(fieldName))
+        .when()
+            .post("/v1/apis/" + apiId + "/types/Query/resolvers")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"fieldName": "%s", "dataSourceName": "none-ds"}
+                """.formatted(fieldName))
+        .when()
+            .post("/v1/apis/" + apiId + "/types/Query/resolvers")
+        .then()
+            .statusCode(409)
+            .body("__type", equalTo("ConflictException"))
+            .body("message", containsString("Resolver already exists for"));
+
+        given().header("Authorization", AUTH).delete("/v1/apis/" + apiId + "/types/Query/resolvers/" + fieldName).then().statusCode(204);
+    }
+
+    @Test
+    @Order(152)
+    void createTypeDuplicateReturns409() {
+        String typeName = "ConflictType" + System.nanoTime();
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "%s", "definition": "type %s { id: ID }"}
+                """.formatted(typeName, typeName))
+        .when()
+            .post("/v1/apis/" + apiId + "/types")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "%s", "definition": "type %s { id: ID }"}
+                """.formatted(typeName, typeName))
+        .when()
+            .post("/v1/apis/" + apiId + "/types")
+        .then()
+            .statusCode(409)
+            .body("__type", equalTo("ConflictException"))
+            .body("message", containsString("Type already exists:"));
+
+        given().header("Authorization", AUTH).delete("/v1/apis/" + apiId + "/types/" + typeName).then().statusCode(204);
+    }
+
+    @Test
+    @Order(153)
+    void createDomainNameDuplicateReturns409() {
+        String domain = "conflict-" + System.nanoTime() + ".example.com";
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"domainName": "%s", "certificateArn": "arn:aws:acm:us-east-1:000000000000:certificate/1"}
+                """.formatted(domain))
+        .when()
+            .post("/v1/domainnames")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"domainName": "%s", "certificateArn": "arn:aws:acm:us-east-1:000000000000:certificate/2"}
+                """.formatted(domain))
+        .when()
+            .post("/v1/domainnames")
+        .then()
+            .statusCode(409)
+            .body("__type", equalTo("ConflictException"))
+            .body("message", containsString("Domain name already exists:"));
+
+        given().header("Authorization", AUTH).delete("/v1/domainnames/" + domain).then().statusCode(204);
+    }
+
+    @Test
+    @Order(154)
+    void createChannelNamespaceDuplicateReturns409() {
+        String nsName = "conflict-ns-" + System.nanoTime();
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "%s"}
+                """.formatted(nsName))
+        .when()
+            .post("/v2/apis/" + apiId + "/channelNamespaces")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "%s"}
+                """.formatted(nsName))
+        .when()
+            .post("/v2/apis/" + apiId + "/channelNamespaces")
+        .then()
+            .statusCode(409)
+            .body("__type", equalTo("ConflictException"))
+            .body("message", containsString("Channel namespace already exists:"));
+
+        given().header("Authorization", AUTH).delete("/v2/apis/" + apiId + "/channelNamespaces/" + nsName).then().statusCode(204);
+    }
+
+    @Test
+    @Order(155)
+    void associateApiDuplicateReturns409() {
+        String domain = "assoc-conflict-" + System.nanoTime() + ".example.com";
+        String tempApiId = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "assoc-conflict-api", "authenticationType": "API_KEY"}
+                """)
+        .when()
+            .post("/v1/apis")
+        .then()
+            .statusCode(200)
+            .extract().path("graphqlApi.apiId");
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"domainName": "%s", "certificateArn": "arn:aws:acm:us-east-1:000000000000:certificate/ac"}
+                """.formatted(domain))
+        .when()
+            .post("/v1/domainnames")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"apiId": "%s"}
+                """.formatted(tempApiId))
+        .when()
+            .post("/v1/domainnames/" + domain + "/apiassociation")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"apiId": "%s"}
+                """.formatted(apiId))
+        .when()
+            .post("/v1/domainnames/" + domain + "/apiassociation")
+        .then()
+            .statusCode(409)
+            .body("__type", equalTo("ConflictException"))
+            .body("message", containsString("Domain name already associated with an API"));
+
+        given().header("Authorization", AUTH).delete("/v1/domainnames/" + domain).then().statusCode(204);
+        given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
+    }
+
+    // ── LimitExceededException (429) ─────────────────────────────────────────
+
+    @Test
+    @Order(160)
+    void createApiKeyExceedsLimitReturns429() {
+        String tempApiId = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "limit-test-api", "authenticationType": "API_KEY"}
+                """)
+        .when()
+            .post("/v1/apis")
+        .then()
+            .statusCode(200)
+            .extract().path("graphqlApi.apiId");
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"description": "key-1"}
+                """)
+        .when()
+            .post("/v1/apis/" + tempApiId + "/apikeys")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"description": "key-2"}
+                """)
+        .when()
+            .post("/v1/apis/" + tempApiId + "/apikeys")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"description": "key-3"}
+                """)
+        .when()
+            .post("/v1/apis/" + tempApiId + "/apikeys")
+        .then()
+            .statusCode(429)
+            .body("__type", equalTo("LimitExceededException"))
+            .body("message", containsString("Maximum of 2 API keys per API reached"));
+
+        given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
+    }
+
     // ── Phase 2: Model Completeness ─────────────────────────────────────────
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
@@ -8,9 +8,6 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 
@@ -25,10 +22,6 @@ class AppSyncIntegrationTest {
     @BeforeAll
     static void configureRestAssured() {
         RestAssuredJsonUtils.configureAwsContentTypes();
-    }
-
-    private static String encodeArn(String arn) {
-        return URLEncoder.encode(arn, StandardCharsets.UTF_8).replace("+", "%20");
     }
 
     // ── GraphQL API ──────────────────────────────────────────────────────────
@@ -182,19 +175,6 @@ class AppSyncIntegrationTest {
             .statusCode(200)
             .body("apiKeys", hasSize(greaterThanOrEqualTo(1)))
             .body("apiKeys[0].id", notNullValue());
-    }
-
-    @Test
-    @Order(32)
-    void getApiKey() {
-        given()
-            .header("Authorization", AUTH)
-        .when()
-            .get("/v1/apis/" + apiId + "/apikeys/" + keyId)
-        .then()
-            .statusCode(200)
-            .body("apiKey.id", equalTo(keyId))
-            .body("apiKey.description", equalTo("test-key"));
     }
 
     @Test
@@ -457,20 +437,6 @@ class AppSyncIntegrationTest {
         .then()
             .statusCode(200)
             .body("resolvers", hasSize(greaterThanOrEqualTo(1)));
-    }
-
-    @Test
-    @Order(62)
-    void listAllResolvers() {
-        given()
-            .header("Authorization", AUTH)
-        .when()
-            .get("/v1/apis/" + apiId + "/resolvers")
-        .then()
-            .statusCode(200)
-            .body("resolvers", hasSize(greaterThanOrEqualTo(1)))
-            .body("resolvers[0].typeName", notNullValue())
-            .body("resolvers[0].fieldName", notNullValue());
     }
 
     @Test
@@ -1136,14 +1102,14 @@ class AppSyncIntegrationTest {
         .then()
             .statusCode(204);
 
+        // Verify deletion by listing (getApiKey endpoint does not exist in AWS)
         given()
             .header("Authorization", AUTH)
         .when()
-            .get("/v1/apis/" + apiId + "/apikeys/" + tempKeyId)
+            .get("/v1/apis/" + apiId + "/apikeys")
         .then()
-            .statusCode(404)
-            .body("__type", equalTo("NotFoundException"))
-            .body("message", containsString("API key not found:"));
+            .statusCode(200)
+            .body("apiKeys.id", not(hasItem(tempKeyId)));
     }
 
     @Test
@@ -1660,6 +1626,96 @@ class AppSyncIntegrationTest {
             .body("message", containsString("Channel namespace already exists:"));
 
         given().header("Authorization", AUTH).delete("/v2/apis/" + apiId + "/channelNamespaces/" + nsName).then().statusCode(204);
+    }
+
+    @Test
+    @Order(157)
+    void createSourceApiAssociationDuplicateReturns409() {
+        String sourceApiId = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                { "name": "dup-source-157", "authenticationType": "API_KEY" }
+                """)
+        .when()
+            .post("/v1/apis")
+        .then()
+            .statusCode(200)
+            .extract().path("graphqlApi.apiId");
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                { "sourceApiId": "%s" }
+                """.formatted(sourceApiId))
+        .when()
+            .post("/v1/mergedApis/" + apiId + "/sourceApiAssociations")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                { "sourceApiId": "%s" }
+                """.formatted(sourceApiId))
+        .when()
+            .post("/v1/mergedApis/" + apiId + "/sourceApiAssociations")
+        .then()
+            .statusCode(409)
+            .body("__type", equalTo("ConcurrentModificationException"))
+            .body("message", containsString("Source API association already exists for Source API ID"))
+            .body("message", containsString("and Merged API ID"));
+
+        given().header("Authorization", AUTH).delete("/v1/apis/" + sourceApiId).then().statusCode(204);
+    }
+
+    @Test
+    @Order(158)
+    void createSourceApiAssociationReplacesDeletionScheduled() {
+        String sourceApiId = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                { "name": "replace-source-158", "authenticationType": "API_KEY" }
+                """)
+        .when()
+            .post("/v1/apis")
+        .then()
+            .statusCode(200)
+            .extract().path("graphqlApi.apiId");
+
+        String assocId = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                { "sourceApiId": "%s" }
+                """.formatted(sourceApiId))
+        .when()
+            .post("/v1/mergedApis/" + apiId + "/sourceApiAssociations")
+        .then()
+            .statusCode(200)
+            .extract().path("sourceApiAssociation.associationId");
+
+        given()
+            .header("Authorization", AUTH)
+            .delete("/v1/mergedApis/" + apiId + "/sourceApiAssociations/" + assocId)
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                { "sourceApiId": "%s" }
+                """.formatted(sourceApiId))
+        .when()
+            .post("/v1/mergedApis/" + apiId + "/sourceApiAssociations")
+        .then()
+            .statusCode(200);
+
+        given().header("Authorization", AUTH).delete("/v1/apis/" + sourceApiId).then().statusCode(204);
     }
 
     @Test
@@ -2552,7 +2608,9 @@ class AppSyncIntegrationTest {
         .then()
             .statusCode(400)
             .body("__type", equalTo("BadRequestException"))
-            .body("message", containsString("Invalid schema"));
+            .body("reason", equalTo("CODE_ERROR"))
+            .body("detail.codeErrors[0].errorType", equalTo("PARSER_ERROR"))
+            .body("detail.codeErrors[0].value", notNullValue());
     }
 
     @Test
@@ -2779,7 +2837,109 @@ class AppSyncIntegrationTest {
         .then()
             .statusCode(400)
             .body("__type", equalTo("BadRequestException"))
-            .body("message", containsString("Unknown directive"));
+            .body("reason", equalTo("CODE_ERROR"))
+            .body("detail.codeErrors[0].errorType", equalTo("VALIDATION_ERROR"))
+            .body("detail.codeErrors[0].value", containsString("Unknown directive"));
+
+        given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
+    }
+
+    @Test
+    @Order(700)
+    void startSchemaCreation_syntaxError_returnsExtendedBadRequest() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "definition": "type Query { invalid syntax!!! }"
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/schemacreation")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("reason", equalTo("CODE_ERROR"))
+            .body("detail.codeErrors", hasSize(greaterThanOrEqualTo(1)))
+            .body("detail.codeErrors[0].errorType", equalTo("PARSER_ERROR"))
+            .body("detail.codeErrors[0].value", notNullValue())
+            .body("detail.codeErrors[0].location", notNullValue())
+            .body("detail.codeErrors[0].location.line", notNullValue())
+            .body("detail.codeErrors[0].location.column", notNullValue())
+            .body("detail.codeErrors[0].location.span", equalTo(-1));
+    }
+
+    @Test
+    @Order(701)
+    void startSchemaCreation_semanticError_returnsExtendedBadRequest() {
+        String tempApiId = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                { "name": "semantic-701", "authenticationType": "API_KEY" }
+                """)
+        .when()
+            .post("/v1/apis")
+        .then()
+            .statusCode(200)
+            .extract().path("graphqlApi.apiId");
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "definition": "type Query { hello: NonExistentType }"
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + tempApiId + "/schemacreation")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("reason", equalTo("CODE_ERROR"))
+            .body("detail.codeErrors[0].errorType", equalTo("VALIDATION_ERROR"))
+            .body("detail.codeErrors[0].value", containsString("NonExistentType"))
+            .body("detail.codeErrors[0].location.line", notNullValue())
+            .body("detail.codeErrors[0].location.column", notNullValue())
+            .body("detail.codeErrors[0].location.span", equalTo(-1));
+
+        given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
+    }
+
+    @Test
+    @Order(702)
+    void startSchemaCreation_unknownDirective_returnsExtendedBadRequest() {
+        String tempApiId = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                { "name": "unknown-dir-702", "authenticationType": "API_KEY" }
+                """)
+        .when()
+            .post("/v1/apis")
+        .then()
+            .statusCode(200)
+            .extract().path("graphqlApi.apiId");
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "definition": "type Query { hello: String @unknownDirective }"
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + tempApiId + "/schemacreation")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("reason", equalTo("CODE_ERROR"))
+            .body("detail.codeErrors[0].errorType", equalTo("VALIDATION_ERROR"))
+            .body("detail.codeErrors[0].value", containsString("Unknown directive: @unknownDirective"))
+            .body("detail.codeErrors[0].location.span", equalTo(-1));
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
     }

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
@@ -183,20 +183,20 @@ class AppSyncIntegrationTest {
         .then()
             .statusCode(200)
             .body("status", equalTo("PROCESSING"));
-        assertTerminalStatus(apiId, "ACTIVE");
+        assertTerminalStatus(apiId, "SUCCESS");
     }
 
     @Test
     @Order(21)
     void getSchemaCreationStatus() {
-        assertTerminalStatus(apiId, "ACTIVE");
+        assertTerminalStatus(apiId, "SUCCESS");
         given()
             .header("Authorization", AUTH)
         .when()
             .get("/v1/apis/" + apiId + "/schemacreation")
         .then()
             .statusCode(200)
-            .body("status", equalTo("ACTIVE"));
+            .body("status", equalTo("SUCCESS"));
     }
 
     @Test
@@ -2713,7 +2713,7 @@ class AppSyncIntegrationTest {
         .then()
             .statusCode(200)
             .body("status", equalTo("PROCESSING"));
-        assertTerminalStatus(tempApiId, "ACTIVE");
+        assertTerminalStatus(tempApiId, "SUCCESS");
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
     }
@@ -2746,7 +2746,7 @@ class AppSyncIntegrationTest {
         .then()
             .statusCode(200)
             .body("status", equalTo("PROCESSING"));
-        assertTerminalStatus(tempApiId, "ACTIVE");
+        assertTerminalStatus(tempApiId, "SUCCESS");
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
     }
@@ -2779,7 +2779,7 @@ class AppSyncIntegrationTest {
         .then()
             .statusCode(200)
             .body("status", equalTo("PROCESSING"));
-        assertTerminalStatus(tempApiId, "ACTIVE");
+        assertTerminalStatus(tempApiId, "SUCCESS");
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
     }
@@ -2812,7 +2812,7 @@ class AppSyncIntegrationTest {
         .then()
             .statusCode(200)
             .body("status", equalTo("PROCESSING"));
-        assertTerminalStatus(tempApiId, "ACTIVE");
+        assertTerminalStatus(tempApiId, "SUCCESS");
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
     }
@@ -2845,7 +2845,7 @@ class AppSyncIntegrationTest {
         .then()
             .statusCode(200)
             .body("status", equalTo("PROCESSING"));
-        assertTerminalStatus(tempApiId, "ACTIVE");
+        assertTerminalStatus(tempApiId, "SUCCESS");
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
     }
@@ -2882,7 +2882,7 @@ class AppSyncIntegrationTest {
         .then()
             .statusCode(200)
             .body("status", equalTo("PROCESSING"));
-        assertTerminalStatus(tempApiId, "ACTIVE");
+        assertTerminalStatus(tempApiId, "SUCCESS");
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
     }

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
@@ -404,7 +404,9 @@ class AppSyncIntegrationTest {
         .when()
             .get("/v1/apis/" + apiId + "/types/TempType")
         .then()
-            .statusCode(404);
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Type not found:"));
     }
 
     // ── Resolvers ────────────────────────────────────────────────────────────
@@ -627,7 +629,9 @@ class AppSyncIntegrationTest {
         .when()
             .get("/v1/apis/" + apiId + "/functions/" + tempFnId)
         .then()
-            .statusCode(404);
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Function not found:"));
     }
 
     // ── Tags ─────────────────────────────────────────────────────────────────
@@ -763,7 +767,9 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/apis")
         .then()
-            .statusCode(400);
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("A GraphQL API name is required"));
     }
 
     @Test
@@ -778,7 +784,9 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/apis")
         .then()
-            .statusCode(400);
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("A GraphQL API name is required"));
     }
 
     @Test
@@ -793,7 +801,9 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/apis")
         .then()
-            .statusCode(400);
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("Invalid value 'INVALID_TYPE' for AuthenticationType"));
     }
 
     @Test
@@ -808,7 +818,9 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/apis/" + apiId + "/datasources")
         .then()
-            .statusCode(400);
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("A data source name is required"));
     }
 
     @Test
@@ -823,7 +835,9 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/apis/" + apiId + "/datasources")
         .then()
-            .statusCode(400);
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("A data source type is required"));
     }
 
     @Test
@@ -838,7 +852,9 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/apis/" + apiId + "/datasources")
         .then()
-            .statusCode(400);
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("Invalid value 'NOT_A_REAL_TYPE' for DataSourceType"));
     }
 
     @Test
@@ -853,7 +869,9 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/apis/" + apiId + "/types/Query/resolvers")
         .then()
-            .statusCode(400);
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("A resolver field name is required"));
     }
 
     @Test
@@ -868,7 +886,9 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/apis/" + apiId + "/types/Query/resolvers")
         .then()
-            .statusCode(400);
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("A data source name is required for the resolver"));
     }
 
     @Test
@@ -894,7 +914,9 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/apis/" + apiId + "/types")
         .then()
-            .statusCode(400);
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("A type name is required"));
     }
 
     @Test
@@ -909,7 +931,9 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/apis/" + apiId + "/functions")
         .then()
-            .statusCode(400);
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("A function name is required"));
     }
 
     @Test
@@ -920,7 +944,9 @@ class AppSyncIntegrationTest {
         .when()
             .get("/v1/apis/doesnotexist12345678901234")
         .then()
-            .statusCode(404);
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("GraphQL API not found:"));
     }
 
     @Test
@@ -931,7 +957,9 @@ class AppSyncIntegrationTest {
         .when()
             .get("/v1/apis/" + apiId + "/datasources/nonexistent-ds")
         .then()
-            .statusCode(404);
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Data source not found:"));
     }
 
     @Test
@@ -942,7 +970,9 @@ class AppSyncIntegrationTest {
         .when()
             .get("/v1/apis/" + apiId + "/types/NonExistentType")
         .then()
-            .statusCode(404);
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Type not found:"));
     }
 
     // ── Delete Standalone ──────────────────────────────────────────────────
@@ -976,7 +1006,9 @@ class AppSyncIntegrationTest {
         .when()
             .get("/v1/apis/" + apiId + "/types/Query/resolvers/tempResolver")
         .then()
-            .statusCode(404);
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Resolver not found:"));
     }
 
     @Test
@@ -1008,7 +1040,9 @@ class AppSyncIntegrationTest {
         .when()
             .get("/v1/apis/" + apiId + "/datasources/temp-ds-delete")
         .then()
-            .statusCode(404);
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Data source not found:"));
     }
 
     @Test
@@ -1041,7 +1075,9 @@ class AppSyncIntegrationTest {
         .when()
             .get("/v1/apis/" + apiId + "/functions/" + tempFnId)
         .then()
-            .statusCode(404);
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Function not found:"));
     }
 
     @Test
@@ -1073,7 +1109,9 @@ class AppSyncIntegrationTest {
         .when()
             .get("/v1/apis/" + apiId + "/types/StandaloneDeleteType")
         .then()
-            .statusCode(404);
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Type not found:"));
     }
 
     @Test
@@ -1103,7 +1141,9 @@ class AppSyncIntegrationTest {
         .when()
             .get("/v1/apis/" + apiId + "/apikeys/" + tempKeyId)
         .then()
-            .statusCode(404);
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("API key not found:"));
     }
 
     @Test
@@ -1187,7 +1227,9 @@ class AppSyncIntegrationTest {
         .when()
             .get("/v1/apis/" + tempApiId + "/datasources/cascade-ds")
         .then()
-            .statusCode(404);
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Data source not found:"));
     }
 
     @Test
@@ -1250,7 +1292,9 @@ class AppSyncIntegrationTest {
         .when()
             .get("/v1/apis/" + tempApiId + "/functions/" + fnId)
         .then()
-            .statusCode(404);
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Function not found:"));
     }
 
     @Test
@@ -1456,7 +1500,9 @@ class AppSyncIntegrationTest {
         .when()
             .get("/v1/apis")
         .then()
-            .statusCode(400);
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("Invalid NextToken."));
     }
 
     // ── Phase 2: Model Completeness ─────────────────────────────────────────
@@ -1717,7 +1763,9 @@ class AppSyncIntegrationTest {
         .when()
             .get("/v1/domainnames/nonexistent.example.com")
         .then()
-            .statusCode(404);
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Domain name not found:"));
     }
 
     @Test
@@ -1751,7 +1799,9 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/domainnames/" + tempDomain + "/apiassociation")
         .then()
-            .statusCode(404);
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("GraphQL API not found:"));
 
         // cleanup
         given().header("Authorization", AUTH).delete("/v1/domainnames/" + tempDomain).then().statusCode(204);
@@ -1833,7 +1883,9 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/apis/" + apiId + "/schemacreation")
         .then()
-            .statusCode(400);
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("Invalid schema"));
     }
 
     @Test
@@ -2058,7 +2110,9 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/apis/" + tempApiId + "/schemacreation")
         .then()
-            .statusCode(400);
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("Unknown directive"));
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
     }
@@ -2630,7 +2684,9 @@ class AppSyncIntegrationTest {
         .when()
             .get("/v1/apis/" + apiId)
         .then()
-            .statusCode(404);
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("GraphQL API not found:"));
     }
 
     @Test
@@ -2641,7 +2697,9 @@ class AppSyncIntegrationTest {
         .when()
             .get("/v1/apis/" + apiId + "/datasources/none-ds")
         .then()
-            .statusCode(404);
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Data source not found:"));
     }
 
     @Test
@@ -2652,6 +2710,8 @@ class AppSyncIntegrationTest {
         .when()
             .get("/v1/apis/" + apiId + "/types/Query")
         .then()
-            .statusCode(404);
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Type not found:"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
@@ -3238,6 +3238,208 @@ class AppSyncIntegrationTest {
         }
     }
 
+    @Test
+    @Order(712)
+    void deleteChannelNamespace_busy_returns409() {
+        String tempApiId = createTempApi("busy-712-chns");
+        // Create the channel namespace BEFORE setting PROCESSING so the
+        // delete path finds it (otherwise we'd get 404 instead of 409).
+        String nsName = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                { "name": "busy-chns", "description": "temp" }
+                """)
+        .when()
+            .post("/v2/apis/" + tempApiId + "/channelNamespaces")
+        .then()
+            .statusCode(200)
+            .extract().path("channelNamespace.name");
+        setSchemaProcessing(tempApiId);
+        try {
+            given()
+                .header("Authorization", AUTH)
+            .when()
+                .delete("/v2/apis/" + tempApiId + "/channelNamespaces/" + nsName)
+            .then()
+                .statusCode(409)
+                .body("__type", equalTo("ConcurrentModificationException"))
+                .body("message", containsString("Another modification is in progress"));
+        } finally {
+            clearSchemaStatus(tempApiId);
+        }
+    }
+
+    @Test
+    @Order(713)
+    void deleteDomainName_busy_returns409() {
+        String tempApiId = createTempApi("busy-713-domain");
+        String domainName = "busy-713-" + System.nanoTime() + ".example.com";
+        // Create domain name + associate it with the temp API so the
+        // gate can resolve the apiId and return 409.
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                { "domainName": "%s", "certificateArn": "arn:aws:acm:us-east-1:000000000000:certificate/123" }
+                """.formatted(domainName))
+        .when()
+            .post("/v1/domainnames")
+        .then()
+            .statusCode(200);
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                { "apiId": "%s" }
+                """.formatted(tempApiId))
+        .when()
+            .post("/v1/domainnames/" + domainName + "/apiassociation")
+        .then()
+            .statusCode(200);
+        setSchemaProcessing(tempApiId);
+        try {
+            given()
+                .header("Authorization", AUTH)
+            .when()
+                .delete("/v1/domainnames/" + domainName)
+            .then()
+                .statusCode(409)
+                .body("__type", equalTo("ConcurrentModificationException"))
+                .body("message", containsString("Another modification is in progress"));
+        } finally {
+            clearSchemaStatus(tempApiId);
+        }
+    }
+
+    @Test
+    @Order(714)
+    void disassociateApi_busy_returns409() {
+        String tempApiId = createTempApi("busy-714-disassoc");
+        String domainName = "busy-714-" + System.nanoTime() + ".example.com";
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                { "domainName": "%s", "certificateArn": "arn:aws:acm:us-east-1:000000000000:certificate/123" }
+                """.formatted(domainName))
+        .when()
+            .post("/v1/domainnames")
+        .then()
+            .statusCode(200);
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                { "apiId": "%s" }
+                """.formatted(tempApiId))
+        .when()
+            .post("/v1/domainnames/" + domainName + "/apiassociation")
+        .then()
+            .statusCode(200);
+        setSchemaProcessing(tempApiId);
+        try {
+            given()
+                .header("Authorization", AUTH)
+            .when()
+                .delete("/v1/domainnames/" + domainName + "/apiassociation")
+            .then()
+                .statusCode(409)
+                .body("__type", equalTo("ConcurrentModificationException"))
+                .body("message", containsString("Another modification is in progress"));
+        } finally {
+            clearSchemaStatus(tempApiId);
+        }
+    }
+
+    @Test
+    @Order(715)
+    void disassociateMergedGraphqlApi_busy_returns409() {
+        String tempApiId = createTempApi("busy-715-merged");
+        // Create a source API, associate it as merged, then attempt to
+        // disassociate while the source API schema is PROCESSING.
+        String sourceApiId = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                { "name": "busy-715-source", "authenticationType": "API_KEY" }
+                """)
+        .when()
+            .post("/v1/apis")
+        .then()
+            .statusCode(200)
+            .extract().path("graphqlApi.apiId");
+        String assocId = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                { "mergedApiIdentifier": "%s" }
+                """.formatted(tempApiId))
+        .when()
+            .post("/v1/sourceApis/" + sourceApiId + "/mergedApiAssociations")
+        .then()
+            .statusCode(200)
+            .extract().path("sourceApiAssociation.associationId");
+        setSchemaProcessing(sourceApiId);
+        try {
+            given()
+                .header("Authorization", AUTH)
+            .when()
+                .delete("/v1/sourceApis/" + sourceApiId + "/mergedApiAssociations/" + assocId)
+            .then()
+                .statusCode(409)
+                .body("__type", equalTo("ConcurrentModificationException"))
+                .body("message", containsString("Another modification is in progress"));
+        } finally {
+            clearSchemaStatus(sourceApiId);
+            given().header("Authorization", AUTH).delete("/v1/apis/" + sourceApiId).then().statusCode(204);
+        }
+    }
+
+    @Test
+    @Order(716)
+    void updateDomainName_busy_returns409() {
+        String tempApiId = createTempApi("busy-716-upd-domain");
+        String domainName = "busy-716-" + System.nanoTime() + ".example.com";
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                { "domainName": "%s", "certificateArn": "arn:aws:acm:us-east-1:000000000000:certificate/123" }
+                """.formatted(domainName))
+        .when()
+            .post("/v1/domainnames")
+        .then()
+            .statusCode(200);
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                { "apiId": "%s" }
+                """.formatted(tempApiId))
+        .when()
+            .post("/v1/domainnames/" + domainName + "/apiassociation")
+        .then()
+            .statusCode(200);
+        setSchemaProcessing(tempApiId);
+        try {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    { "description": "updated" }
+                    """)
+            .when()
+                .post("/v1/domainnames/" + domainName)
+            .then()
+                .statusCode(409)
+                .body("__type", equalTo("ConcurrentModificationException"))
+                .body("message", containsString("Another modification is in progress"));
+        } finally {
+            clearSchemaStatus(tempApiId);
+        }
+    }
+
     // ── Phase 2: Merged APIs ───────────────────────────────────────────────
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
@@ -712,7 +712,7 @@ class AppSyncIntegrationTest {
                 }
                 """)
         .when()
-            .put("/v1/apis/" + apiId + "/environmentvariables")
+            .put("/v1/apis/" + apiId + "/environmentVariables")
         .then()
             .statusCode(200)
             .body("environmentVariables.TABLE_NAME", equalTo("my-table"))
@@ -725,7 +725,7 @@ class AppSyncIntegrationTest {
         given()
             .header("Authorization", AUTH)
         .when()
-            .get("/v1/apis/" + apiId + "/environmentvariables")
+            .get("/v1/apis/" + apiId + "/environmentVariables")
         .then()
             .statusCode(200)
             .body("environmentVariables.TABLE_NAME", equalTo("my-table"))
@@ -746,7 +746,7 @@ class AppSyncIntegrationTest {
                 }
                 """)
         .when()
-            .put("/v1/apis/" + apiId + "/environmentvariables")
+            .put("/v1/apis/" + apiId + "/environmentVariables")
         .then()
             .statusCode(200)
             .body("environmentVariables.NEW_VAR", equalTo("new-value"))

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
@@ -1772,6 +1772,185 @@ class AppSyncIntegrationTest {
         given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
     }
 
+    // ── NotFoundException (404) on update/delete of missing resources ────────
+
+    @Test
+    @Order(170)
+    void updateResolverNonExistentReturns404() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"dataSourceName": "none-ds"}
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/types/Query/resolvers/nonExistentField")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Resolver not found:"));
+    }
+
+    @Test
+    @Order(171)
+    void deleteResolverNonExistentReturns404() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/v1/apis/" + apiId + "/types/Query/resolvers/nonExistentField")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Resolver not found:"));
+    }
+
+    @Test
+    @Order(172)
+    void updateFunctionNonExistentReturns404() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "nonexistent-fn", "dataSourceName": "none-ds"}
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/functions/nonexistent00000000000")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Function not found:"));
+    }
+
+    @Test
+    @Order(173)
+    void deleteFunctionNonExistentReturns404() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/v1/apis/" + apiId + "/functions/nonexistent00000000000")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Function not found:"));
+    }
+
+    @Test
+    @Order(174)
+    void updateApiKeyNonExistentReturns404() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"description": "updated"}
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/apikeys/nonexistent00000000000")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("API key not found:"));
+    }
+
+    @Test
+    @Order(175)
+    void deleteApiKeyNonExistentReturns404() {
+        given()
+            .header("Authorization", AUTH)
+        .when()
+            .delete("/v1/apis/" + apiId + "/apikeys/nonexistent00000000000")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("API key not found:"));
+    }
+
+    @Test
+    @Order(176)
+    void updateDomainNameNonExistentReturns404() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"description": "updated"}
+                """)
+        .when()
+            .post("/v1/domainnames/nonexistent.example.com")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Domain name not found:"));
+    }
+
+    @Test
+    @Order(177)
+    void updateChannelNamespaceNonExistentReturns404() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"description": "updated"}
+                """)
+        .when()
+            .post("/v2/apis/" + apiId + "/channelNamespaces/nonexistent-ns")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Channel namespace not found:"));
+    }
+
+    // ── Cross-resource 404 on create (missing referenced resource) ───────────
+
+    @Test
+    @Order(190)
+    void createResolverMissingDataSourceReturns404() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"fieldName": "crossRefField", "dataSourceName": "nonexistent-ds-for-resolver"}
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/types/Query/resolvers")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Data source not found:"));
+    }
+
+    @Test
+    @Order(191)
+    void createFunctionMissingDataSourceReturns404() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "cross-ref-fn", "dataSourceName": "nonexistent-ds-for-fn"}
+                """)
+        .when()
+            .post("/v1/apis/" + apiId + "/functions")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Data source not found:"));
+    }
+
+    @Test
+    @Order(192)
+    void associateApiMissingDomainReturns404() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"apiId": "%s"}
+                """.formatted(apiId))
+        .when()
+            .post("/v1/domainnames/nonexistent-for-assoc.example.com/apiassociation")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", containsString("Domain name not found:"));
+    }
+
     // ── Phase 2: Model Completeness ─────────────────────────────────────────
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.appsync;
 
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.services.appsync.model.SchemaCreationStatus;
+import io.github.hectorvent.floci.services.appsync.model.SchemaCreationStatusType;
 import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -8,7 +11,11 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.time.Duration;
+
 import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 @QuarkusTest
@@ -19,9 +26,71 @@ class AppSyncIntegrationTest {
     private static String apiId;
     private static String keyId;
 
+    @jakarta.inject.Inject
+    StorageBackend<String, SchemaCreationStatus> schemaStatusStore;
+
     @BeforeAll
     static void configureRestAssured() {
         RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    /**
+     * Polls GetSchemaCreationStatus until status is no longer PROCESSING
+     * (i.e. ACTIVE or FAILED) and returns the full response payload. Mirrors
+     * how a real AWS SDK client would poll after StartSchemaCreation
+     * returns PROCESSING. Use {@link #getTerminalStatus(String)} if only
+     * the status string is needed.
+     */
+    private static java.util.Map<String, Object> awaitSchemaTerminal(String apiId) {
+        return await().atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(25))
+                .until(() -> given()
+                            .header("Authorization", AUTH)
+                        .when()
+                            .get("/v1/apis/" + apiId + "/schemacreation")
+                        .then()
+                            .statusCode(200)
+                            .extract().jsonPath().getMap(""),
+                        m -> !"PROCESSING".equals(m.get("status")));
+    }
+
+    /**
+     * Asserts that the schema reaches the expected terminal status (ACTIVE or FAILED).
+     * Used after a StartSchemaCreation that returns PROCESSING.
+     */
+    private static void assertTerminalStatus(String apiId, String expected) {
+        assertThat(awaitSchemaTerminal(apiId).get("status"), equalTo(expected));
+    }
+
+    /**
+     * Posts a StartSchemaCreation, then polls to FAILED and returns the
+     * deserialized extended data (containing reason + detail.codeErrors).
+     * Used by tests that previously expected a synchronous 400 with the
+     * extended format body — AWS now returns 200 + PROCESSING and the
+     * error surfaces in the polled FAILED status.
+     */
+    @SuppressWarnings("unchecked")
+    private static java.util.Map<String, Object> postSchemaAndAwaitFailed(String apiId, String body) {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body(body)
+        .when()
+            .post("/v1/apis/" + apiId + "/schemacreation")
+        .then()
+            .statusCode(200)
+            .body("status", equalTo("PROCESSING"));
+
+        java.util.Map<String, Object> full = awaitSchemaTerminal(apiId);
+        assertThat(full.get("status"), equalTo("FAILED"));
+        String detailsJson = (String) full.get("details");
+        assertThat(detailsJson, notNullValue());
+        try {
+            return new com.fasterxml.jackson.databind.ObjectMapper()
+                    .readValue(detailsJson, java.util.Map.class);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     // ── GraphQL API ──────────────────────────────────────────────────────────
@@ -113,12 +182,14 @@ class AppSyncIntegrationTest {
             .post("/v1/apis/" + apiId + "/schemacreation")
         .then()
             .statusCode(200)
-            .body("status", equalTo("ACTIVE"));
+            .body("status", equalTo("PROCESSING"));
+        assertTerminalStatus(apiId, "ACTIVE");
     }
 
     @Test
     @Order(21)
     void getSchemaCreationStatus() {
+        assertTerminalStatus(apiId, "ACTIVE");
         given()
             .header("Authorization", AUTH)
         .when()
@@ -2606,11 +2677,12 @@ class AppSyncIntegrationTest {
         .when()
             .post("/v1/apis/" + apiId + "/schemacreation")
         .then()
-            .statusCode(400)
-            .body("__type", equalTo("BadRequestException"))
-            .body("reason", equalTo("CODE_ERROR"))
-            .body("detail.codeErrors[0].errorType", equalTo("PARSER_ERROR"))
-            .body("detail.codeErrors[0].value", notNullValue());
+            .statusCode(200)
+            .body("status", equalTo("PROCESSING"));
+        java.util.Map<String, Object> body = awaitSchemaTerminal(apiId);
+        assertThat(body.get("status"), equalTo("FAILED"));
+        String details = (String) body.get("details");
+        assertThat(details, notNullValue());
     }
 
     @Test
@@ -2640,7 +2712,8 @@ class AppSyncIntegrationTest {
             .post("/v1/apis/" + tempApiId + "/schemacreation")
         .then()
             .statusCode(200)
-            .body("status", equalTo("ACTIVE"));
+            .body("status", equalTo("PROCESSING"));
+        assertTerminalStatus(tempApiId, "ACTIVE");
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
     }
@@ -2672,7 +2745,8 @@ class AppSyncIntegrationTest {
             .post("/v1/apis/" + tempApiId + "/schemacreation")
         .then()
             .statusCode(200)
-            .body("status", equalTo("ACTIVE"));
+            .body("status", equalTo("PROCESSING"));
+        assertTerminalStatus(tempApiId, "ACTIVE");
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
     }
@@ -2704,7 +2778,8 @@ class AppSyncIntegrationTest {
             .post("/v1/apis/" + tempApiId + "/schemacreation")
         .then()
             .statusCode(200)
-            .body("status", equalTo("ACTIVE"));
+            .body("status", equalTo("PROCESSING"));
+        assertTerminalStatus(tempApiId, "ACTIVE");
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
     }
@@ -2736,7 +2811,8 @@ class AppSyncIntegrationTest {
             .post("/v1/apis/" + tempApiId + "/schemacreation")
         .then()
             .statusCode(200)
-            .body("status", equalTo("ACTIVE"));
+            .body("status", equalTo("PROCESSING"));
+        assertTerminalStatus(tempApiId, "ACTIVE");
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
     }
@@ -2768,7 +2844,8 @@ class AppSyncIntegrationTest {
             .post("/v1/apis/" + tempApiId + "/schemacreation")
         .then()
             .statusCode(200)
-            .body("status", equalTo("ACTIVE"));
+            .body("status", equalTo("PROCESSING"));
+        assertTerminalStatus(tempApiId, "ACTIVE");
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
     }
@@ -2804,7 +2881,8 @@ class AppSyncIntegrationTest {
             .post("/v1/apis/" + tempApiId + "/schemacreation")
         .then()
             .statusCode(200)
-            .body("status", equalTo("ACTIVE"));
+            .body("status", equalTo("PROCESSING"));
+        assertTerminalStatus(tempApiId, "ACTIVE");
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
     }
@@ -2824,22 +2902,16 @@ class AppSyncIntegrationTest {
             .statusCode(200)
             .extract().path("graphqlApi.apiId");
 
-        given()
-            .header("Authorization", AUTH)
-            .contentType("application/json")
-            .body("""
+        java.util.Map<String, Object> ext = postSchemaAndAwaitFailed(tempApiId, """
                 {
                   "definition": "type Query { hello: String } directive @unknownDirective on FIELD_DEFINITION"
                 }
-                """)
-        .when()
-            .post("/v1/apis/" + tempApiId + "/schemacreation")
-        .then()
-            .statusCode(400)
-            .body("__type", equalTo("BadRequestException"))
-            .body("reason", equalTo("CODE_ERROR"))
-            .body("detail.codeErrors[0].errorType", equalTo("VALIDATION_ERROR"))
-            .body("detail.codeErrors[0].value", containsString("Unknown directive"));
+                """);
+        assertThat(ext.get("reason"), equalTo("CODE_ERROR"));
+        java.util.List<java.util.Map<String, Object>> codeErrors =
+                (java.util.List<java.util.Map<String, Object>>) ((java.util.Map<?, ?>) ext.get("detail")).get("codeErrors");
+        assertThat(codeErrors.get(0).get("errorType"), equalTo("VALIDATION_ERROR"));
+        assertThat((String) codeErrors.get(0).get("value"), containsString("Unknown directive"));
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
     }
@@ -2847,27 +2919,22 @@ class AppSyncIntegrationTest {
     @Test
     @Order(700)
     void startSchemaCreation_syntaxError_returnsExtendedBadRequest() {
-        given()
-            .header("Authorization", AUTH)
-            .contentType("application/json")
-            .body("""
+        java.util.Map<String, Object> ext = postSchemaAndAwaitFailed(apiId, """
                 {
                   "definition": "type Query { invalid syntax!!! }"
                 }
-                """)
-        .when()
-            .post("/v1/apis/" + apiId + "/schemacreation")
-        .then()
-            .statusCode(400)
-            .body("__type", equalTo("BadRequestException"))
-            .body("reason", equalTo("CODE_ERROR"))
-            .body("detail.codeErrors", hasSize(greaterThanOrEqualTo(1)))
-            .body("detail.codeErrors[0].errorType", equalTo("PARSER_ERROR"))
-            .body("detail.codeErrors[0].value", notNullValue())
-            .body("detail.codeErrors[0].location", notNullValue())
-            .body("detail.codeErrors[0].location.line", notNullValue())
-            .body("detail.codeErrors[0].location.column", notNullValue())
-            .body("detail.codeErrors[0].location.span", equalTo(-1));
+                """);
+        assertThat(ext.get("reason"), equalTo("CODE_ERROR"));
+        java.util.List<java.util.Map<String, Object>> codeErrors =
+                (java.util.List<java.util.Map<String, Object>>) ((java.util.Map<?, ?>) ext.get("detail")).get("codeErrors");
+        assertThat(codeErrors.size(), greaterThanOrEqualTo(1));
+        assertThat(codeErrors.get(0).get("errorType"), equalTo("PARSER_ERROR"));
+        assertThat(codeErrors.get(0).get("value"), notNullValue());
+        java.util.Map<String, Object> location = (java.util.Map<String, Object>) codeErrors.get(0).get("location");
+        assertThat(location, notNullValue());
+        assertThat(location.get("line"), notNullValue());
+        assertThat(location.get("column"), notNullValue());
+        assertThat(location.get("span"), equalTo(-1));
     }
 
     @Test
@@ -2885,25 +2952,20 @@ class AppSyncIntegrationTest {
             .statusCode(200)
             .extract().path("graphqlApi.apiId");
 
-        given()
-            .header("Authorization", AUTH)
-            .contentType("application/json")
-            .body("""
+        java.util.Map<String, Object> ext = postSchemaAndAwaitFailed(tempApiId, """
                 {
                   "definition": "type Query { hello: NonExistentType }"
                 }
-                """)
-        .when()
-            .post("/v1/apis/" + tempApiId + "/schemacreation")
-        .then()
-            .statusCode(400)
-            .body("__type", equalTo("BadRequestException"))
-            .body("reason", equalTo("CODE_ERROR"))
-            .body("detail.codeErrors[0].errorType", equalTo("VALIDATION_ERROR"))
-            .body("detail.codeErrors[0].value", containsString("NonExistentType"))
-            .body("detail.codeErrors[0].location.line", notNullValue())
-            .body("detail.codeErrors[0].location.column", notNullValue())
-            .body("detail.codeErrors[0].location.span", equalTo(-1));
+                """);
+        assertThat(ext.get("reason"), equalTo("CODE_ERROR"));
+        java.util.List<java.util.Map<String, Object>> codeErrors =
+                (java.util.List<java.util.Map<String, Object>>) ((java.util.Map<?, ?>) ext.get("detail")).get("codeErrors");
+        assertThat(codeErrors.get(0).get("errorType"), equalTo("VALIDATION_ERROR"));
+        assertThat((String) codeErrors.get(0).get("value"), containsString("NonExistentType"));
+        java.util.Map<String, Object> location = (java.util.Map<String, Object>) codeErrors.get(0).get("location");
+        assertThat(location.get("line"), notNullValue());
+        assertThat(location.get("column"), notNullValue());
+        assertThat(location.get("span"), equalTo(-1));
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
     }
@@ -2923,25 +2985,257 @@ class AppSyncIntegrationTest {
             .statusCode(200)
             .extract().path("graphqlApi.apiId");
 
-        given()
-            .header("Authorization", AUTH)
-            .contentType("application/json")
-            .body("""
+        java.util.Map<String, Object> ext = postSchemaAndAwaitFailed(tempApiId, """
                 {
                   "definition": "type Query { hello: String @unknownDirective }"
                 }
-                """)
-        .when()
-            .post("/v1/apis/" + tempApiId + "/schemacreation")
-        .then()
-            .statusCode(400)
-            .body("__type", equalTo("BadRequestException"))
-            .body("reason", equalTo("CODE_ERROR"))
-            .body("detail.codeErrors[0].errorType", equalTo("VALIDATION_ERROR"))
-            .body("detail.codeErrors[0].value", containsString("Unknown directive: @unknownDirective"))
-            .body("detail.codeErrors[0].location.span", equalTo(-1));
+                """);
+        assertThat(ext.get("reason"), equalTo("CODE_ERROR"));
+        java.util.List<java.util.Map<String, Object>> codeErrors =
+                (java.util.List<java.util.Map<String, Object>>) ((java.util.Map<?, ?>) ext.get("detail")).get("codeErrors");
+        assertThat(codeErrors.get(0).get("errorType"), equalTo("VALIDATION_ERROR"));
+        assertThat((String) codeErrors.get(0).get("value"), containsString("Unknown directive: @unknownDirective"));
+        java.util.Map<String, Object> location = (java.util.Map<String, Object>) codeErrors.get(0).get("location");
+        assertThat(location.get("span"), equalTo(-1));
 
         given().header("Authorization", AUTH).delete("/v1/apis/" + tempApiId).then().statusCode(204);
+    }
+
+    // ── Phase 2: Schema-Creation 409 Gates ───────────────────────────────────
+
+    /**
+     * Sets the schema status of {@code apiId} to PROCESSING directly via the
+     * shared storage backend. Used by the 409-gate tests below to simulate an
+     * in-flight schema creation deterministically, without relying on the
+     * async worker timing.
+     */
+    private void setSchemaProcessing(String apiId) {
+        SchemaCreationStatus s = new SchemaCreationStatus();
+        s.setStatus(SchemaCreationStatusType.PROCESSING);
+        schemaStatusStore.put(apiId, s);
+    }
+
+    /**
+     * Removes any schema status for {@code apiId}, cleaning up after a test.
+     */
+    private void clearSchemaStatus(String apiId) {
+        schemaStatusStore.delete(apiId);
+    }
+
+    /**
+     * Creates a temporary API for use by 409-gate tests. Returns its id.
+     */
+    private String createTempApi(String name) {
+        return given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("{\"name\":\"" + name + "\",\"authenticationType\":\"API_KEY\"}")
+        .when()
+            .post("/v1/apis")
+        .then()
+            .statusCode(200)
+            .extract().path("graphqlApi.apiId");
+    }
+
+    /**
+     * Deletes a temporary API. Used in {@link #assertBusyReturns409}.
+     */
+    private void deleteTempApi(String apiId) {
+        given().header("Authorization", AUTH)
+            .delete("/v1/apis/" + apiId)
+        .then()
+            .statusCode(204);
+    }
+
+    /**
+     * Sets the schema status of {@code tempApiId} to PROCESSING, runs the given
+     * body (which should expect 409), and finally cleans up the status and
+     * deletes the temporary API. Centralizes the boilerplate of the 9
+     * 409-gate tests below.
+     */
+    private void assertBusyReturns409(String tempApiId, Runnable body) {
+        setSchemaProcessing(tempApiId);
+        try {
+            body.run();
+        } finally {
+            clearSchemaStatus(tempApiId);
+            deleteTempApi(tempApiId);
+        }
+    }
+
+    @Test
+    @Order(703)
+    void createDataSource_busy_returns409() {
+        String tempApiId = createTempApi("busy-703-ds");
+        assertBusyReturns409(tempApiId, () -> {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    { "name": "ds-busy", "type": "NONE" }
+                    """)
+            .when()
+                .post("/v1/apis/" + tempApiId + "/datasources")
+            .then()
+                .statusCode(409)
+                .body("__type", equalTo("ConcurrentModificationException"))
+                .body("message", containsString("Another modification is in progress"));
+        });
+    }
+
+    @Test
+    @Order(704)
+    void createResolver_busy_returns409() {
+        String tempApiId = createTempApi("busy-704");
+        assertBusyReturns409(tempApiId, () -> {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    { "dataSourceName": "ds-704", "fieldName": "hello", "typeName": "Query",
+                      "requestMappingTemplate": "{\\"version\\":\\"2018-05-29\\",\\"operation\\":\\"GetItem\\"}",
+                      "responseMappingTemplate": "$util.toJson($ctx.result)" }
+                    """)
+            .when()
+                .post("/v1/apis/" + tempApiId + "/types/Query/resolvers")
+            .then()
+                .statusCode(409)
+                .body("__type", equalTo("ConcurrentModificationException"));
+        });
+    }
+
+    @Test
+    @Order(705)
+    void createFunction_busy_returns409() {
+        String tempApiId = createTempApi("busy-705");
+        assertBusyReturns409(tempApiId, () -> {
+            given().header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    { "name": "fn-705", "dataSourceName": "ds-705",
+                      "requestMappingTemplate": "{\\"version\\":\\"2018-05-29\\",\\"operation\\":\\"GetItem\\"}",
+                      "responseMappingTemplate": "$util.toJson($ctx.result)" }
+                    """)
+            .when()
+                .post("/v1/apis/" + tempApiId + "/functions")
+            .then()
+                .statusCode(409)
+                .body("__type", equalTo("ConcurrentModificationException"));
+        });
+    }
+
+    @Test
+    @Order(706)
+    void createType_busy_returns409() {
+        String tempApiId = createTempApi("busy-706");
+        assertBusyReturns409(tempApiId, () -> {
+            given().header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    { "name": "CustomType", "definition": "type CustomType { x: String }", "format": "SDL" }
+                    """)
+            .when()
+                .post("/v1/apis/" + tempApiId + "/types")
+            .then()
+                .statusCode(409)
+                .body("__type", equalTo("ConcurrentModificationException"));
+        });
+    }
+
+    @Test
+    @Order(707)
+    void putEnvironmentVariables_busy_returns409() {
+        String tempApiId = createTempApi("busy-707");
+        assertBusyReturns409(tempApiId, () -> {
+            given().header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"environmentVariables\":{\"FOO\":\"bar\"}}")
+            .when()
+                .put("/v1/apis/" + tempApiId + "/environmentVariables")
+            .then()
+                .statusCode(409)
+                .body("__type", equalTo("ConcurrentModificationException"));
+        });
+    }
+
+    @Test
+    @Order(708)
+    void startSchemaCreation_busy_returns409() {
+        // The StartSchemaCreation gate is self-blocking: a second submission
+        // for the same API while one is PROCESSING must return 409.
+        String tempApiId = createTempApi("busy-708");
+        assertBusyReturns409(tempApiId, () -> {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"definition\":\"type Query { a: String }\"}")
+            .when()
+                .post("/v1/apis/" + tempApiId + "/schemacreation")
+            .then()
+                .statusCode(409)
+                .body("__type", equalTo("ConcurrentModificationException"))
+                .body("message", containsString("Another modification is in progress"));
+        });
+    }
+
+    @Test
+    @Order(709)
+    void createGraphqlApi_anyApiBusy_returns409() {
+        // Account-level gate: when ANY API has a schema creation in
+        // PROCESSING, creating a new GraphqlApi is blocked.
+        String tempApiId = createTempApi("busy-709-any");
+        assertBusyReturns409(tempApiId, () -> {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    { "name": "should-fail-709", "authenticationType": "API_KEY" }
+                    """)
+            .when()
+                .post("/v1/apis")
+            .then()
+                .statusCode(409)
+                .body("__type", equalTo("ConcurrentModificationException"));
+        });
+    }
+
+    @Test
+    @Order(710)
+    void updateGraphqlApi_busy_returns409() {
+        String tempApiId = createTempApi("busy-710-update");
+        assertBusyReturns409(tempApiId, () -> {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    { "name": "renamed-710" }
+                    """)
+            .when()
+                .post("/v1/apis/" + tempApiId)
+            .then()
+                .statusCode(409)
+                .body("__type", equalTo("ConcurrentModificationException"));
+        });
+    }
+
+    @Test
+    @Order(711)
+    void deleteGraphqlApi_busy_returns409() {
+        // For delete we need the API to exist when the gate fires; clear
+        // status BEFORE the delete so the finally block's delete succeeds.
+        String tempApiId = createTempApi("busy-711-delete");
+        setSchemaProcessing(tempApiId);
+        try {
+            given()
+                .header("Authorization", AUTH)
+            .when()
+                .delete("/v1/apis/" + tempApiId)
+            .then()
+                .statusCode(409)
+                .body("__type", equalTo("ConcurrentModificationException"));
+        } finally {
+            clearSchemaStatus(tempApiId);
+        }
     }
 
     // ── Phase 2: Merged APIs ───────────────────────────────────────────────

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncIntegrationTest.java
@@ -1951,6 +1951,195 @@ class AppSyncIntegrationTest {
             .body("message", containsString("Domain name not found:"));
     }
 
+    // ── Pagination for previously untested list operations ───────────────────
+
+    @Test
+    @Order(180)
+    void listDomainNamesWithMaxResults() {
+        String d1 = "pg-domain-1-" + System.nanoTime() + ".example.com";
+        String d2 = "pg-domain-2-" + System.nanoTime() + ".example.com";
+        String cert = "arn:aws:acm:us-east-1:000000000000:certificate/pg";
+
+        for (String d : new String[]{d1, d2}) {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"domainName": "%s", "certificateArn": "%s"}
+                    """.formatted(d, cert))
+            .when()
+                .post("/v1/domainnames")
+            .then()
+                .statusCode(200);
+        }
+
+        String nextToken = given()
+            .header("Authorization", AUTH)
+            .queryParam("maxResults", 1)
+        .when()
+            .get("/v1/domainnames")
+        .then()
+            .statusCode(200)
+            .body("domainNameConfigs", hasSize(1))
+            .body("nextToken", notNullValue())
+            .extract().path("nextToken");
+
+        given()
+            .header("Authorization", AUTH)
+            .queryParam("maxResults", 1)
+            .queryParam("nextToken", nextToken)
+        .when()
+            .get("/v1/domainnames")
+        .then()
+            .statusCode(200)
+            .body("domainNameConfigs", hasSize(greaterThanOrEqualTo(1)));
+
+        given().header("Authorization", AUTH).delete("/v1/domainnames/" + d1).then().statusCode(204);
+        given().header("Authorization", AUTH).delete("/v1/domainnames/" + d2).then().statusCode(204);
+    }
+
+    @Test
+    @Order(181)
+    void listChannelNamespacesWithMaxResults() {
+        String ns1 = "pg-ns-1-" + System.nanoTime();
+        String ns2 = "pg-ns-2-" + System.nanoTime();
+
+        for (String ns : new String[]{ns1, ns2}) {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"name": "%s"}
+                    """.formatted(ns))
+            .when()
+                .post("/v2/apis/" + apiId + "/channelNamespaces")
+            .then()
+                .statusCode(200);
+        }
+
+        String nextToken = given()
+            .header("Authorization", AUTH)
+            .queryParam("maxResults", 1)
+        .when()
+            .get("/v2/apis/" + apiId + "/channelNamespaces")
+        .then()
+            .statusCode(200)
+            .body("channelNamespaces", hasSize(1))
+            .body("nextToken", notNullValue())
+            .extract().path("nextToken");
+
+        given()
+            .header("Authorization", AUTH)
+            .queryParam("maxResults", 1)
+            .queryParam("nextToken", nextToken)
+        .when()
+            .get("/v2/apis/" + apiId + "/channelNamespaces")
+        .then()
+            .statusCode(200)
+            .body("channelNamespaces", hasSize(greaterThanOrEqualTo(1)));
+
+        given().header("Authorization", AUTH).delete("/v2/apis/" + apiId + "/channelNamespaces/" + ns1).then().statusCode(204);
+        given().header("Authorization", AUTH).delete("/v2/apis/" + apiId + "/channelNamespaces/" + ns2).then().statusCode(204);
+    }
+
+    @Test
+    @Order(182)
+    void listSourceApiAssociationsWithMaxResults() {
+        String s1 = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "pg-src-1", "authenticationType": "API_KEY"}
+                """)
+        .when()
+            .post("/v1/apis")
+        .then()
+            .statusCode(200)
+            .extract().path("graphqlApi.apiId");
+
+        String s2 = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "pg-src-2", "authenticationType": "API_KEY"}
+                """)
+        .when()
+            .post("/v1/apis")
+        .then()
+            .statusCode(200)
+            .extract().path("graphqlApi.apiId");
+
+        for (String s : new String[]{s1, s2}) {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"sourceApiId": "%s"}
+                    """.formatted(s))
+            .when()
+                .post("/v1/mergedApis/" + apiId + "/sourceApiAssociations")
+            .then()
+                .statusCode(200);
+        }
+
+        given()
+            .header("Authorization", AUTH)
+            .queryParam("maxResults", 1)
+        .when()
+            .get("/v1/apis/" + apiId + "/sourceApiAssociations")
+        .then()
+            .statusCode(200)
+            .body("sourceApiAssociationSummaries", hasSize(1))
+            .body("nextToken", notNullValue());
+
+        given().header("Authorization", AUTH).delete("/v1/apis/" + s1).then().statusCode(204);
+        given().header("Authorization", AUTH).delete("/v1/apis/" + s2).then().statusCode(204);
+    }
+
+    // ── Pagination edge cases ────────────────────────────────────────────────
+
+    @Test
+    @Order(195)
+    void listWithMaxResultsZero() {
+        given()
+            .header("Authorization", AUTH)
+            .queryParam("maxResults", 0)
+        .when()
+            .get("/v1/apis/" + apiId + "/datasources")
+        .then()
+            .statusCode(200)
+            .body("dataSources", hasSize(0))
+            .body("nextToken", notNullValue());
+    }
+
+    @Test
+    @Order(196)
+    void listWithNegativeMaxResultsReturns400() {
+        given()
+            .header("Authorization", AUTH)
+            .queryParam("maxResults", -1)
+        .when()
+            .get("/v1/apis/" + apiId + "/datasources")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("maxResults must be non-negative"));
+    }
+
+    @Test
+    @Order(197)
+    void listWithInvalidNextTokenNonApiReturns400() {
+        given()
+            .header("Authorization", AUTH)
+            .queryParam("nextToken", "!!!invalid-token!!!")
+        .when()
+            .get("/v1/apis/" + apiId + "/datasources")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", containsString("Invalid NextToken."));
+    }
+
     // ── Phase 2: Model Completeness ─────────────────────────────────────────
 
     @Test
@@ -2311,6 +2500,38 @@ class AppSyncIntegrationTest {
             .delete("/v2/apis/" + apiId + "/channelNamespaces/" + channelNsName)
         .then()
             .statusCode(204);
+    }
+
+    @Test
+    @Order(410)
+    void updateChannelNamespace() {
+        String nsName = "update-ns-" + System.nanoTime();
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "%s", "description": "original"}
+                """.formatted(nsName))
+        .when()
+            .post("/v2/apis/" + apiId + "/channelNamespaces")
+        .then()
+            .statusCode(200)
+            .body("channelNamespace.description", equalTo("original"));
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"description": "updated-ns"}
+                """)
+        .when()
+            .post("/v2/apis/" + apiId + "/channelNamespaces/" + nsName)
+        .then()
+            .statusCode(200)
+            .body("channelNamespace.name", equalTo(nsName))
+            .body("channelNamespace.description", equalTo("updated-ns"));
+
+        given().header("Authorization", AUTH).delete("/v2/apis/" + apiId + "/channelNamespaces/" + nsName).then().statusCode(204);
     }
 
     // ── Phase 2: Schema Registry ─────────────────────────────────────────────

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -53,6 +53,10 @@ floci:
       codedeploy:
         flush-interval-ms: 60000
       cloudfront:
+      appsync:
+        flush-interval-ms: 60000
+        schema-worker-threads: 4
+        schema-worker-shutdown-timeout-seconds: 30
 
   auth:
     validate-signatures: false

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -55,8 +55,6 @@ floci:
       cloudfront:
       appsync:
         flush-interval-ms: 60000
-        schema-worker-threads: 4
-        schema-worker-shutdown-timeout-seconds: 30
 
   auth:
     validate-signatures: false
@@ -248,6 +246,8 @@ floci:
       enabled: true
     appsync:
       enabled: true
+      schema-worker-threads: 4
+      schema-worker-shutdown-timeout-seconds: 30
     s3vectors:
       enabled: true
     iot:


### PR DESCRIPTION
## Summary

Implements Phase 5 of the AppSync implementation plan in #1173.

This phase combines two related scopes that close gaps with AWS AppSync behavior:

1. **Management API test coverage + AWS behavior alignment** — fills test gaps for already-implemented features and aligns wire behavior with the AWS AppSync API Reference and AWS SDK for Java v2 Javadoc.

2. **Async schema creation semantics** — `StartSchemaCreation` is asynchronous in AWS (returns `200 + PROCESSING`, transitions to `ACTIVE` or `FAILED` via polling). 43 operations return `ConcurrentModificationException 409` while a schema creation is `PROCESSING`.

## Type of change

- [x] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## What is included

### Management API coverage + AWS alignment

- **9 conflict / limit / 404 tests** for Create/Update/Delete on DataSource, Resolver, Function, Type, ChannelNamespace, DomainName, API keys.
- **Error code corrections** validated against AWS AppSync API Reference, AWS SDK for Java v2 Javadoc, and `service-2.json`:
  - `BadRequestException` 400 with `reason: "CODE_ERROR"` and `detail.codeErrors[]` for SDL errors (PARSER_ERROR / VALIDATION_ERROR)
  - `ConcurrentModificationException` 409 for duplicate Source API association (replaces `BadRequestException` 400)
  - `span: -1` default in `CodeErrorLocation`
  - DELETION_SCHEDULED associations can be replaced (no 409)
- **Removed Floci-only endpoints**: `getApiKey`, `listAllResolvers`.
- **Extended error format** added to `AwsException` (optional `extendedData` field) and `AwsExceptionMapper`.

### Async schema creation semantics

- **`StartSchemaCreation` is now async**: the request returns `200 + PROCESSING`. A new `SchemaCreationWorker` (singleton `ExecutorService` with configurable thread count) compiles the schema in a background thread, transitioning to `ACTIVE` or `FAILED` (with serialized extended error data in the polled `GetSchemaCreationStatus.details`).
- **43 operations return `ConcurrentModificationException 409`** while any schema creation is `PROCESSING`:
  - 27 per-API mutations (`createDataSource`, `getDataSource`, `updateDataSource`, `deleteDataSource`, `createResolver`, `getResolver`, `updateResolver`, `deleteResolver`, `createFunction`, `getFunction`, `updateFunction`, `deleteFunction`, `createType`, `getType`, `updateType`, `deleteType`, `listTypes`, `putEnvironmentVariables`, `createChannelNamespace`, `updateChannelNamespace`, `deleteChannelNamespace`, `updateGraphqlApi`, `deleteGraphqlApi`, `createSourceApiAssociation`, `createMergedApiAssociation`, `updateSourceApiAssociation`, `deleteSourceApiAssociation`, `deleteMergedApiAssociation`)
  - 2 account-wide operations (`createGraphqlApi`, `createApi`)
  - 1 self-blocking on second `StartSchemaCreation` on the same API
- **Orphan PROCESSING recovery**: `EmulatorLifecycle.onStart` calls `schemaCreationWorker.recoverOrphans()` after `storageFactory.loadAll()`, marking any leftover `PROCESSING` as `FAILED` (e.g., after an emulator crash mid-compilation).

### New configuration

| Env var | Default | Purpose |
|---|---|---|
| `FLOCI_SERVICES_APPSYNC_SCHEMA_WORKER_THREADS` | 4 | Worker pool size for schema compilation |
| `FLOCI_SERVICES_APPSYNC_SCHEMA_WORKER_SHUTDOWN_TIMEOUT_SECONDS` | 30 | Graceful shutdown wait for in-flight workers |

## Test Results

- `AppSyncIntegrationTest`: 154/154 pass
- `AppSyncTest` (SDK): 78/78 pass
- `EmulatorLifecycleTest`: 16/16 pass

## Validation sources

- [AppSync API Reference (Welcome)](https://docs.aws.amazon.com/appsync/latest/APIReference/Welcome.html)
- [`StartSchemaCreation`](https://docs.aws.amazon.com/appsync/latest/APIReference/API_StartSchemaCreation.html)
- [`AssociateSourceGraphqlApi`](https://docs.aws.amazon.com/appsync/latest/APIReference/API_AssociateSourceGraphqlApi.html)
- [`ConcurrentModificationException` Javadoc](https://docs.aws.amazon.com/java/api/latest/software/amazon/awssdk/services/appsync/model/ConcurrentModificationException.html)
- [`BadRequestException` Javadoc](https://docs.aws.amazon.com/java/api/latest/software/amazon/awssdk/services/appsync/model/BadRequestException.html)
- [`CodeError` / `CodeErrorLocation` Javadoc](https://docs.aws.amazon.com/java/api/latest/software/amazon/awssdk/services/appsync/model/CodeError.html)
- [`AppSyncClient` Javadoc (operation list)](https://docs.aws.amazon.com/java/api/latest/software/amazon/awssdk/services/appsync/AppSyncClient.html)
- [`service-2.json` (raw)](https://raw.githubusercontent.com/aws/aws-sdk-java-v2/master/services/appsync/src/main/resources/codegen-resources/service-2.json)

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] New or updated SDK compatibility test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Protocol behavior validated with AWS SDK clients
- [x] Error codes validated against AWS AppSync API Reference, AWS SDK for Java v2 Javadoc, `service-2.json`
- [x] No custom endpoint shapes introduced
