### PR TITLE
feat(apigateway): support floci:override-id for api gateways

### DIFF
--- a/docs/services/api-gateway.md
+++ b/docs/services/api-gateway.md
@@ -2,6 +2,13 @@
 
 Floci supports both API Gateway v1 (REST APIs) and API Gateway v2 (HTTP APIs).
 
+## Custom Resource IDs
+
+When creating APIs in Floci, you can optionally pin the generated `ApiId` (or `id`) by passing a reserved tag `floci:override-id`. This is particularly useful in testing environments where you want predictable endpoint URLs. Floci uses the tag value as the created API ID and automatically strips it from the stored and returned resource tags so it is never persisted as user-visible metadata.
+
+> [!WARNING]
+> The older `_custom_id_` tag is also supported for backwards compatibility, but is considered deprecated. Unlike `floci:override-id`, the `_custom_id_` tag is not stripped and will remain attached to the API resource.
+
 ## API Gateway v1 (REST APIs) {#v1}
 
 **Protocol:** REST JSON

--- a/src/main/java/io/github/hectorvent/floci/core/common/ReservedTags.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ReservedTags.java
@@ -10,6 +10,7 @@ public final class ReservedTags {
 
     public static final String RESERVED_PREFIX = "floci:";
     public static final String OVERRIDE_ID_KEY = RESERVED_PREFIX + "override-id";
+    public static final String DEPRECATED_CUSTOM_ID_KEY = "_custom_id_";
 
     private ReservedTags() {
     }
@@ -18,7 +19,13 @@ public final class ReservedTags {
         if (tags == null) {
             return null;
         }
-        return tags.get(OVERRIDE_ID_KEY);
+        if (tags.containsKey(OVERRIDE_ID_KEY)) {
+            return tags.get(OVERRIDE_ID_KEY);
+        }
+        if (tags.containsKey(DEPRECATED_CUSTOM_ID_KEY)) {
+            return tags.get(DEPRECATED_CUSTOM_ID_KEY);
+        }
+        return null;
     }
 
     public static Map<String, String> stripReservedTags(Map<String, String> tags) {
@@ -50,6 +57,6 @@ public final class ReservedTags {
     }
 
     private static boolean isReserved(String key) {
-        return key != null && key.startsWith(RESERVED_PREFIX);
+        return key != null && (key.startsWith(RESERVED_PREFIX) || key.equals(DEPRECATED_CUSTOM_ID_KEY));
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.ReservedTags;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.apigateway.model.Account;
@@ -172,7 +173,7 @@ public class ApiGatewayService {
         Map<String, String> tags = request.get("tags") instanceof Map<?, ?> m
                 ? (Map<String, String>) m : new HashMap<>();
 
-        String customId = tags.get("_custom_id_");
+        String customId = ReservedTags.extractOverrideId(tags);
         String apiId = (customId != null && !customId.isBlank()) ? customId : shortId(10);
 
         RestApi api = new RestApi();
@@ -180,7 +181,7 @@ public class ApiGatewayService {
         api.setName(name);
         api.setDescription(description);
         api.setCreatedDate(System.currentTimeMillis() / 1000L);
-        api.setTags(tags);
+        api.setTags(ReservedTags.stripReservedTags(tags));
 
         EndpointConfiguration endpointConfiguration = new EndpointConfiguration();
         if (request.get(EPC_KEY) instanceof Map<?, ?> epMap) {

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.apigatewayv2;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.ReservedTags;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -80,8 +81,14 @@ public class ApiGatewayV2Service {
             routeSelectionExpression = "${request.method} ${request.path}";
         }
 
+        @SuppressWarnings("unchecked")
+        Map<String, String> tags = (Map<String, String>) request.get("tags");
+
+        String customId = ReservedTags.extractOverrideId(tags);
+        String apiId = (customId != null && !customId.isBlank()) ? customId : shortId(10);
+
         Api api = new Api();
-        api.setApiId(shortId(10));
+        api.setApiId(apiId);
         api.setName(name);
         api.setProtocolType(protocolType);
         api.setCreatedDate(System.currentTimeMillis());
@@ -95,10 +102,8 @@ public class ApiGatewayV2Service {
             api.setApiEndpoint(String.format("https://%s.execute-api.%s.amazonaws.com", api.getApiId(), region));
         }
 
-        @SuppressWarnings("unchecked")
-        Map<String, String> tags = (Map<String, String>) request.get("tags");
         if (tags != null) {
-            api.setTags(tags);
+            api.setTags(ReservedTags.stripReservedTags(tags));
         }
 
         @SuppressWarnings("unchecked")
@@ -111,6 +116,7 @@ public class ApiGatewayV2Service {
         LOG.infov("Created {0} API: {1} ({2}) in {3}", protocolType, api.getName(), api.getApiId(), region);
         return api;
     }
+
 
     public Api getApi(String region, String apiId) {
         return apiStore.get(apiKey(region, apiId))

--- a/src/test/java/io/github/hectorvent/floci/core/common/ReservedTagsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/ReservedTagsTest.java
@@ -35,6 +35,7 @@ class ReservedTagsTest {
         Map<String, String> tags = new LinkedHashMap<>();
         tags.put("env", "test");
         tags.put(ReservedTags.OVERRIDE_ID_KEY, "my-id");
+        tags.put(ReservedTags.DEPRECATED_CUSTOM_ID_KEY, "custom-id");
         tags.put("floci:internal", "hidden");
         tags.put("team", "platform");
 
@@ -47,6 +48,7 @@ class ReservedTagsTest {
     void stripReservedTagsRemovesAllReservedTags() {
         Map<String, String> tags = Map.of(
                 ReservedTags.OVERRIDE_ID_KEY, "my-id",
+                ReservedTags.DEPRECATED_CUSTOM_ID_KEY, "custom-id",
                 "floci:internal", "hidden"
         );
 
@@ -65,7 +67,24 @@ class ReservedTagsTest {
                 "floci:internal", "hidden",
                 "env", "test"
         );
+        assertEquals("my-id", ReservedTags.extractOverrideId(tags));
+    }
 
+    @Test
+    void extractOverrideIdReturnsDeprecatedCustomId() {
+        Map<String, String> tags = Map.of(
+                ReservedTags.DEPRECATED_CUSTOM_ID_KEY, "custom-id",
+                "env", "test"
+        );
+        assertEquals("custom-id", ReservedTags.extractOverrideId(tags));
+    }
+
+    @Test
+    void extractOverrideIdFavorsReservedOverrideOverDeprecatedCustomId() {
+        Map<String, String> tags = Map.of(
+                ReservedTags.OVERRIDE_ID_KEY, "my-id",
+                ReservedTags.DEPRECATED_CUSTOM_ID_KEY, "custom-id"
+        );
         assertEquals("my-id", ReservedTags.extractOverrideId(tags));
     }
 
@@ -79,6 +98,16 @@ class ReservedTagsTest {
         AwsException exception = assertThrows(
                 AwsException.class,
                 () -> ReservedTags.rejectReservedTagsOnUpdate(Map.of(ReservedTags.OVERRIDE_ID_KEY, "my-id"))
+        );
+
+        assertEquals("ValidationException", exception.getErrorCode());
+    }
+
+    @Test
+    void rejectReservedTagsOnUpdateRejectsDeprecatedCustomId() {
+        AwsException exception = assertThrows(
+                AwsException.class,
+                () -> ReservedTags.rejectReservedTagsOnUpdate(Map.of(ReservedTags.DEPRECATED_CUSTOM_ID_KEY, "custom-id"))
         );
 
         assertEquals("ValidationException", exception.getErrorCode());

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayIntegrationTest.java
@@ -387,7 +387,7 @@ class ApiGatewayIntegrationTest {
                 .then()
                 .statusCode(201)
                 .body("id", equalTo("MYCUSTOMNAME"))
-                .body("tags._custom_id_", equalTo("MYCUSTOMNAME"));
+                .body("tags", nullValue()); // Should be stripped and thus omitted
     }
 
     @Test @Order(51)
@@ -400,10 +400,45 @@ class ApiGatewayIntegrationTest {
                 .body("name", equalTo("custom-id-api"));
     }
 
+    // ──────────────────────────── floci:override-id tag ────────────────────────────
+
     @Test @Order(52)
+    void createRestApi_flociOverrideIdTag_usesTagValueAsApiId() {
+        String body = """
+                {"name":"override-id-api","tags":{"floci:override-id":"MYOVERRIDEID"}}
+                """;
+        given()
+                .contentType(ContentType.JSON)
+                .body(body)
+                .when().post("/restapis")
+                .then()
+                .statusCode(201)
+                .body("id", equalTo("MYOVERRIDEID"))
+                .body("tags", nullValue()); // Should be stripped and thus omitted
+    }
+
+    @Test @Order(53)
+    void getRestApi_flociOverrideId_resolvesById() {
+        given()
+                .when().get("/restapis/MYOVERRIDEID")
+                .then()
+                .statusCode(200)
+                .body("id", equalTo("MYOVERRIDEID"))
+                .body("name", equalTo("override-id-api"));
+    }
+
+    @Test @Order(54)
     void deleteRestApi_customId() {
         given()
                 .when().delete("/restapis/MYCUSTOMNAME")
+                .then()
+                .statusCode(202);
+    }
+
+    @Test @Order(55)
+    void deleteRestApi_flociOverrideId() {
+        given()
+                .when().delete("/restapis/MYOVERRIDEID")
                 .then()
                 .statusCode(202);
     }

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2IntegrationTest.java
@@ -330,4 +330,51 @@ class ApiGatewayV2IntegrationTest {
                 .then()
                 .statusCode(404);
     }
+
+    // ──────────────────────────── Override IDs ────────────────────────────
+
+    @Test @Order(100)
+    void createApi_customIdTag_usesTagValueAsApiId() {
+        String body = """
+                {"name":"custom-id-api","protocolType":"HTTP","tags":{"_custom_id_":"MYV2CUSTOM"}}
+                """;
+        given()
+                .contentType(ContentType.JSON)
+                .body(body)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .body("apiId", equalTo("MYV2CUSTOM"))
+                .body("tags", nullValue()); // Should be stripped and thus omitted
+    }
+
+    @Test @Order(101)
+    void createApi_flociOverrideIdTag_usesTagValueAsApiId() {
+        String body = """
+                {"name":"override-id-api","protocolType":"HTTP","tags":{"floci:override-id":"MYV2OVERRIDE"}}
+                """;
+        given()
+                .contentType(ContentType.JSON)
+                .body(body)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .body("apiId", equalTo("MYV2OVERRIDE"))
+                .body("tags", nullValue()); // V2 omits empty maps if all tags stripped
+    }
+
+    @Test @Order(102)
+    void getApi_customId_resolvesById() {
+        given()
+                .when().get("/v2/apis/MYV2CUSTOM")
+                .then()
+                .statusCode(200)
+                .body("apiId", equalTo("MYV2CUSTOM"));
+    }
+
+    @Test @Order(103)
+    void deleteApi_customAndOverrideId() {
+        given().when().delete("/v2/apis/MYV2CUSTOM").then().statusCode(204);
+        given().when().delete("/v2/apis/MYV2OVERRIDE").then().statusCode(204);
+    }
 }


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

This PR adds support for specifying a custom resource ID for API Gateway V1 (REST API) and API Gateway V2 (HTTP/WebSocket API) using the standard `floci:override-id` tag. 
This unifies the custom ID configuration behavior across services like KMS and Cognito, enabling consistent API Gateway endpoints/URLs across different local environments and machines. 
Additionally, the old/undocumented `_custom_id_` tag key has been marked as deprecated for API Gateway and is now treated as a reserved tag (meaning it is stripped on creation and rejected on update), though it remains supported for backwards-compatible ID overrides on resource creation.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->


- **Previous behavior:** API Gateway V1 used a non-standard `_custom_id_` tag (which remained in the response payload tags), and API Gateway V2 did not support custom IDs. Other services (Cognito, KMS) used `floci:override-id`.
- **New behavior:** 
  - API Gateway V1 and V2 both accept `floci:override-id` during creation to override the auto-generated API ID.
  - The standard `floci:override-id` tag is correctly stripped from the returned resource tags.
  - The deprecated `_custom_id_` tag key remains supported for backwards compatibility, but is now treated as a reserved tag (meaning it is stripped from returned resource tags and rejected on resource updates).
     
## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
