### PR TITLE
fix(ses): treat missing SendingEnabled as false in v2 PutConfigurationSetSendingOptions

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -768,23 +768,15 @@ public class SesController {
                                                        String body) {
         String region = regionResolver.resolveRegion(headers);
         try {
-            JsonNode request = (body == null || body.isBlank())
-                    ? objectMapper.createObjectNode()
-                    : objectMapper.readTree(body);
-            requireJsonObject(request);
-            JsonNode enabledNode = request.path("SendingEnabled");
-            if (enabledNode.isMissingNode() || enabledNode.isNull() || !enabledNode.isBoolean()) {
-                throw new AwsException("BadRequestException",
-                        "SendingEnabled must be present and must be a boolean.", 400);
-            }
-            sesService.setConfigurationSetSendingEnabled(name, enabledNode.booleanValue(), region);
-            LOG.infov("SES V2 PutConfigurationSetSendingOptions: {0} on {1}",
-                    enabledNode.booleanValue(), name);
+            // Reuse the AWS-aligned SendingEnabled deserialization shared with CreateConfigurationSet:
+            // absent -> false, string -> true, null/number -> SerializationException. An empty body
+            // / {} therefore disables sending (200). Verified against real AWS.
+            boolean enabled = parseSendingEnabled(readOptionBody(body).path("SendingEnabled"));
+            sesService.setConfigurationSetSendingEnabled(name, enabled, region);
+            LOG.infov("SES V2 PutConfigurationSetSendingOptions: {0} on {1}", enabled, name);
             return Response.ok(objectMapper.createObjectNode()).build();
         } catch (AwsException e) {
             throw remapV1Exception(e);
-        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
-            throw new AwsException("BadRequestException", e.getMessage(), 400);
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetSendingOptionsV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetSendingOptionsV2IntegrationTest.java
@@ -170,21 +170,31 @@ class SesConfigurationSetSendingOptionsV2IntegrationTest {
 
     @Test
     @Order(12)
-    void putSendingOptions_missingSendingEnabled_returns400() {
+    void putSendingOptions_emptyBody_treatsSendingEnabledAsFalse() {
+        // AWS treats an absent SendingEnabled as false: a true empty body succeeds (200) and
+        // disables sending (verified against real AWS). Sending is enabled here from @Order(9).
         given()
                 .contentType("application/json")
                 .header("Authorization", SES_AUTH)
-                .body("{}")
         .when()
                 .put("/v2/email/configuration-sets/" + CS + "/sending")
         .then()
-                .statusCode(400)
-                .body("message", containsString("SendingEnabled"));
+                .statusCode(200);
+
+        given()
+                .header("Authorization", SES_AUTH)
+        .when()
+                .get("/v2/email/configuration-sets/" + CS)
+        .then()
+                .statusCode(200)
+                .body("SendingOptions.SendingEnabled", equalTo(false));
     }
 
     @Test
     @Order(13)
-    void putSendingOptions_nonBooleanSendingEnabled_returns400() {
+    void putSendingOptions_stringSendingEnabled_coercesToTrue() {
+        // Real AWS coerces any string to true (200), matching CreateConfigurationSet. Verify the
+        // persisted value, not just the status — CS was disabled by @Order(12).
         given()
                 .contentType("application/json")
                 .header("Authorization", SES_AUTH)
@@ -192,12 +202,35 @@ class SesConfigurationSetSendingOptionsV2IntegrationTest {
         .when()
                 .put("/v2/email/configuration-sets/" + CS + "/sending")
         .then()
-                .statusCode(400)
-                .body("message", containsString("SendingEnabled"));
+                .statusCode(200);
+
+        given()
+                .header("Authorization", SES_AUTH)
+        .when()
+                .get("/v2/email/configuration-sets/" + CS)
+        .then()
+                .statusCode(200)
+                .body("SendingOptions.SendingEnabled", equalTo(true));
     }
 
     @Test
     @Order(14)
+    void putSendingOptions_nullSendingEnabled_returnsSerializationException() {
+        // Real AWS rejects an explicit JSON null for the boolean field with SerializationException,
+        // matching CreateConfigurationSet's deserialization.
+        given()
+                .contentType("application/json")
+                .header("Authorization", SES_AUTH)
+                .body("{\"SendingEnabled\":null}")
+        .when()
+                .put("/v2/email/configuration-sets/" + CS + "/sending")
+        .then()
+                .statusCode(400)
+                .body("__type", equalTo("SerializationException"));
+    }
+
+    @Test
+    @Order(15)
     void putSendingOptions_unknownConfigSet_returns404_NotFoundException() {
         given()
                 .contentType("application/json")
@@ -212,7 +245,7 @@ class SesConfigurationSetSendingOptionsV2IntegrationTest {
     }
 
     @Test
-    @Order(15)
+    @Order(16)
     void v1_updateConfigurationSetSendingEnabled_nonBooleanEnabled_returnsInvalidParameterValue() {
         // parseRequiredBoolean enforces AWS-style "true"|"false". Anything else (e.g.
         // "yes") must surface as InvalidParameterValue instead of being silently


### PR DESCRIPTION
## Summary

The v2 `PutConfigurationSetSendingOptions` required `SendingEnabled` and returned `400` when it was absent, which is stricter than AWS. Real AWS accepts an empty body, treating an absent `SendingEnabled` as `false` and returning `200` — the same way the already-AWS-aligned `PutConfigurationSetReputationOptions` handles a missing `ReputationMetricsEnabled`.

- `SesController.putConfigurationSetSendingOptions`: parse the body via the shared `readOptionBody` helper and reuse the AWS-aligned `parseSendingEnabled` deserialization already used by `CreateConfigurationSet`, instead of requiring the field.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Each body shape was verified against real AWS (raw signed requests, us-east-1); the "after" column matches AWS exactly by reusing the same `parseSendingEnabled` deserialization as `CreateConfigurationSet`:

| Body | Before this PR | After this PR |
| --- | --- | --- |
| empty body | `400 BadRequestException` | `200` (SendingEnabled→false) |
| `{}` | `400 BadRequestException` | `200` (false) |
| `{"SendingEnabled": "yes"}` (string) | `400 BadRequestException` | `200`, stored as `true` |
| `{"SendingEnabled": null}` | `400 BadRequestException` | `400 SerializationException` |
| `{"SendingEnabled": true/false}` | `200` | `200` (unchanged) |

This is a v2-only change — the v1 Query `UpdateConfigurationSetSendingEnabled` keeps `Enabled` required, matching the v1 contract.

**Reproduce** with the AWS CLI against a running Floci (`./mvnw quarkus:dev`). Before this PR this failed with `400 SendingEnabled must be present and must be a boolean.`:

```bash
export AWS_ENDPOINT_URL=http://localhost:4566
export AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=us-east-1

aws sesv2 create-configuration-set --configuration-set-name cs

# Omit SendingEnabled -> 200 (empty body accepted)
aws sesv2 put-configuration-set-sending-options --configuration-set-name cs

# Reads back disabled
aws sesv2 get-configuration-set --configuration-set-name cs --query SendingOptions
# -> { "SendingEnabled": false }
```

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
