### PR TITLE
fix(ec2): align AMI guest and launch template parity

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -81,6 +81,7 @@ See [Storage Modes](./storage.md) for a full explanation of each mode.
 |---|---|---|
 | `FLOCI_DOCKER_DOCKER_HOST` | `unix:///var/run/docker.sock` | Docker daemon socket path or TCP address |
 | `FLOCI_DOCKER_DOCKER_CONFIG_PATH` | _(none)_ | Path to a directory containing Docker's `config.json` for registry auth |
+| `FLOCI_DOCKER_IMAGE_REGISTRY_BASE` | _(none)_ | Optional registry/repository base for every Docker image Floci launches. When set, `postgres:16-alpine` resolves as `<base>/postgres:16-alpine` and `public.ecr.aws/docker/library/ubuntu:24.04` resolves as `<base>/public.ecr.aws/docker/library/ubuntu:24.04` |
 | `FLOCI_DOCKER_LOG_MAX_SIZE` | `10m` | Log rotation max size for spawned containers (e.g. `10m`, `1g`) |
 | `FLOCI_DOCKER_LOG_MAX_FILE` | `3` | Number of rotated log files to keep for spawned containers |
 

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -1312,6 +1312,14 @@ public interface EmulatorConfig {
         String dockerHost();
 
         /**
+         * Optional registry/repository base for every Docker image Floci launches.
+         * When set, images such as {@code postgres:16-alpine} and
+         * {@code public.ecr.aws/docker/library/ubuntu:24.04} resolve under this
+         * base before the container is created.
+         */
+        Optional<String> imageRegistryBase();
+
+        /**
          * Path to a directory containing Docker's config.json (e.g. /root/.docker).
          * When set, overrides the system default. Useful when Floci runs inside Docker
          * and the host ~/.docker directory is mounted in.

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilder.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilder.java
@@ -83,7 +83,7 @@ public class ContainerBuilder {
         if (config == null || config.docker() == null) {
             return Optional.empty();
         }
-        return normalizeImageRegistryBase(config.docker().imageRegistryBase());
+        return config.docker().imageRegistryBase();
     }
 
     private static Optional<String> normalizeImageRegistryBase(Optional<String> imageRegistryBase) {

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilder.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilder.java
@@ -62,7 +62,40 @@ public class ContainerBuilder {
      * @return a new Builder instance
      */
     public Builder newContainer(String image) {
-        return new Builder(image, config, dockerHostResolver, embeddedDnsServer, currentContainerNetworkResolver);
+        return new Builder(resolveImage(image), config, dockerHostResolver, embeddedDnsServer, currentContainerNetworkResolver);
+    }
+
+    private String resolveImage(String image) {
+        return resolveImage(image, configuredImageRegistryBase(config));
+    }
+
+    static String resolveImage(String image, Optional<String> imageRegistryBase) {
+        if (image == null || image.isBlank()) {
+            return image;
+        }
+        return normalizeImageRegistryBase(imageRegistryBase)
+                .filter(base -> !image.startsWith(base + "/"))
+                .map(base -> base + "/" + image)
+                .orElse(image);
+    }
+
+    private static Optional<String> configuredImageRegistryBase(EmulatorConfig config) {
+        if (config == null || config.docker() == null || config.docker().imageRegistryBase() == null) {
+            return Optional.empty();
+        }
+        return normalizeImageRegistryBase(config.docker().imageRegistryBase());
+    }
+
+    private static Optional<String> normalizeImageRegistryBase(Optional<String> imageRegistryBase) {
+        return imageRegistryBase
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .map(value -> {
+                    while (value.endsWith("/")) {
+                        value = value.substring(0, value.length() - 1);
+                    }
+                    return value;
+                });
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilder.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilder.java
@@ -80,7 +80,7 @@ public class ContainerBuilder {
     }
 
     private static Optional<String> configuredImageRegistryBase(EmulatorConfig config) {
-        if (config == null || config.docker() == null || config.docker().imageRegistryBase() == null) {
+        if (config == null || config.docker() == null) {
             return Optional.empty();
         }
         return normalizeImageRegistryBase(config.docker().imageRegistryBase());

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
@@ -394,7 +394,7 @@ public class AutoScalingReconciler {
                     version.getSecurityGroupIds(),
                     version.getInstanceTags(),
                     version.getUserData(),
-                    null,
+                    version.getIamInstanceProfileArn(),
                     asg.getLaunchTemplateId(),
                     asg.getLaunchTemplateName(),
                     resolvedVersion);
@@ -423,7 +423,7 @@ public class AutoScalingReconciler {
                         version.getSecurityGroupIds(),
                         version.getInstanceTags(),
                         version.getUserData(),
-                        null,
+                        version.getIamInstanceProfileArn(),
                         specification.getLaunchTemplateId() == null
                                 ? mixedLaunchTemplate.getLaunchTemplateId()
                                 : specification.getLaunchTemplateId(),

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2MetadataServer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2MetadataServer.java
@@ -1,7 +1,9 @@
 package io.github.hectorvent.floci.services.ec2;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.ec2.model.Instance;
+import io.github.hectorvent.floci.services.iam.IamService;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
 import io.vertx.ext.web.Router;
@@ -40,6 +42,7 @@ public class Ec2MetadataServer {
 
     private final Vertx vertx;
     private final EmulatorConfig config;
+    private final IamService iamService;
 
     /** IMDSv2: token value → Instance */
     private final Map<String, Instance> tokenToInstance = new ConcurrentHashMap<>();
@@ -49,9 +52,10 @@ public class Ec2MetadataServer {
     private volatile HttpServer httpServer;
 
     @Inject
-    public Ec2MetadataServer(Vertx vertx, EmulatorConfig config) {
+    public Ec2MetadataServer(Vertx vertx, EmulatorConfig config, IamService iamService) {
         this.vertx = vertx;
         this.config = config;
+        this.iamService = iamService;
     }
 
     /** Called by Ec2ContainerManager after a container starts to register its IP. */
@@ -227,7 +231,7 @@ public class Ec2MetadataServer {
             ctx.response().setStatusCode(404).end();
             return;
         }
-        String roleName = extractRoleName(profileArn);
+        String roleName = resolveRoleName(profileArn);
         ctx.response().setStatusCode(200)
                 .putHeader("content-type", "text/plain")
                 .end(roleName);
@@ -350,7 +354,22 @@ public class Ec2MetadataServer {
 
     // ── Utilities ─────────────────────────────────────────────────────────────
 
-    private static String extractRoleName(String profileArn) {
+    String resolveRoleName(String profileArn) {
+        if (iamService != null) {
+            String profileName = extractProfileName(profileArn);
+            try {
+                var profile = iamService.getInstanceProfile(profileName);
+                if (profile.getRoleNames() != null && !profile.getRoleNames().isEmpty()) {
+                    return profile.getRoleNames().getFirst();
+                }
+            } catch (AwsException ignored) {
+                // Fall back to the profile name when only the EC2 profile ARN was modeled.
+            }
+        }
+        return extractProfileName(profileArn);
+    }
+
+    private static String extractProfileName(String profileArn) {
         // arn:aws:iam::000000000000:instance-profile/my-role
         int lastSlash = profileArn.lastIndexOf('/');
         if (lastSlash >= 0 && lastSlash < profileArn.length() - 1) {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2MetadataServer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2MetadataServer.java
@@ -362,7 +362,8 @@ public class Ec2MetadataServer {
                 if (profile.getRoleNames() != null && !profile.getRoleNames().isEmpty()) {
                     return profile.getRoleNames().getFirst();
                 }
-            } catch (AwsException ignored) {
+            } catch (AwsException e) {
+                LOG.debugf(e, "IMDS: instance profile %s unavailable; falling back to profile name", profileName);
                 // Fall back to the profile name when only the EC2 profile ARN was modeled.
             }
         }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -1505,6 +1505,7 @@ public class Ec2QueryHandler {
                 p.getFirst("LaunchTemplateData.KeyName"),
                 parseLaunchTemplateSecurityGroupIds(p),
                 decodeUserData(p.getFirst("LaunchTemplateData.UserData")),
+                resolveIamInstanceProfileArn(p, "LaunchTemplateData.IamInstanceProfile"),
                 parseTagsForResource(p, "launch-template"),
                 parseLaunchTemplateDataTagsForResource(p, "instance"));
         XmlBuilder xml = new XmlBuilder()
@@ -1526,6 +1527,7 @@ public class Ec2QueryHandler {
                 p.getFirst("LaunchTemplateData.KeyName"),
                 parseLaunchTemplateSecurityGroupIds(p),
                 decodeUserData(p.getFirst("LaunchTemplateData.UserData")),
+                resolveIamInstanceProfileArn(p, "LaunchTemplateData.IamInstanceProfile"),
                 parseLaunchTemplateDataTagsForResource(p, "instance"));
         XmlBuilder xml = new XmlBuilder()
                 .start("CreateLaunchTemplateVersionResponse", AwsNamespaces.EC2)
@@ -1823,11 +1825,15 @@ public class Ec2QueryHandler {
     }
 
     private String resolveIamInstanceProfileArn(MultivaluedMap<String, String> p) {
-        String arn = p.getFirst("IamInstanceProfile.Arn");
+        return resolveIamInstanceProfileArn(p, "IamInstanceProfile");
+    }
+
+    private String resolveIamInstanceProfileArn(MultivaluedMap<String, String> p, String prefix) {
+        String arn = p.getFirst(prefix + ".Arn");
         if (arn != null && !arn.isBlank()) {
             return arn;
         }
-        String name = p.getFirst("IamInstanceProfile.Name");
+        String name = p.getFirst(prefix + ".Name");
         if (name == null || name.isBlank()) {
             return null;
         }
@@ -2041,6 +2047,11 @@ public class Ec2QueryHandler {
         }
         if (launchTemplate.getUserData() != null) {
             xml.elem("userData", launchTemplate.getUserData());
+        }
+        if (launchTemplate.getIamInstanceProfileArn() != null) {
+            xml.start("iamInstanceProfile")
+                    .elem("arn", launchTemplate.getIamInstanceProfileArn())
+                    .end("iamInstanceProfile");
         }
         xml.start("securityGroupIdSet");
         for (String securityGroupId : launchTemplate.getSecurityGroupIds()) {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -327,6 +327,24 @@ public class Ec2QueryHandler {
             }
         }
 
+        LaunchTemplateData launchTemplateData = resolveRunInstancesLaunchTemplateData(p, region);
+        if (launchTemplateData != null) {
+            imageId = firstNonBlank(imageId, launchTemplateData.getImageId());
+            instanceType = firstNonBlank(instanceType, launchTemplateData.getInstanceType());
+            keyName = firstNonBlank(keyName, launchTemplateData.getKeyName());
+            userData = firstNonBlank(userData, launchTemplateData.getUserData());
+            iamInstanceProfileArn = firstNonBlank(iamInstanceProfileArn, launchTemplateData.getIamInstanceProfileArn());
+            if (sgIds.isEmpty()) {
+                sgIds = new ArrayList<>(launchTemplateData.getSecurityGroupIds());
+            }
+            if (!launchTemplateData.getInstanceTags().isEmpty()) {
+                Map<String, Tag> mergedTags = new LinkedHashMap<>();
+                launchTemplateData.getInstanceTags().forEach(tag -> mergedTags.put(tag.getKey(), tag));
+                instanceTags.forEach(tag -> mergedTags.put(tag.getKey(), tag));
+                instanceTags = new ArrayList<>(mergedTags.values());
+            }
+        }
+
         Reservation res = service.runInstances(region, imageId, instanceType, minCount, maxCount,
                 keyName, sgIds, subnetId, clientToken, instanceTags, userData, iamInstanceProfileArn);
 
@@ -343,6 +361,20 @@ public class Ec2QueryHandler {
         xml.end("instancesSet")
                 .end("RunInstancesResponse");
         return xmlResponse(xml.build());
+    }
+
+    private LaunchTemplateData resolveRunInstancesLaunchTemplateData(MultivaluedMap<String, String> p, String region) {
+        String id = p.getFirst("LaunchTemplate.LaunchTemplateId");
+        String name = p.getFirst("LaunchTemplate.LaunchTemplateName");
+        String version = p.getFirst("LaunchTemplate.Version");
+        if ((id == null || id.isBlank()) && (name == null || name.isBlank())) {
+            return null;
+        }
+        return service.resolveLaunchTemplateData(region, id, name, version);
+    }
+
+    private static String firstNonBlank(String first, String fallback) {
+        return first != null && !first.isBlank() ? first : fallback;
     }
 
     private Response handleDescribeIamInstanceProfileAssociations(MultivaluedMap<String, String> p, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1369,6 +1369,7 @@ public class Ec2Service {
     public LaunchTemplate createLaunchTemplate(String region, String name, String imageId,
                                                String instanceType, String keyName,
                                                List<String> securityGroupIds, String userData,
+                                               String iamInstanceProfileArn,
                                                List<Tag> launchTemplateTags, List<Tag> instanceTags) {
         ensureDefaultResources(region);
         if (name == null || name.isBlank()) {
@@ -1391,6 +1392,7 @@ public class Ec2Service {
         launchTemplate.setInstanceType(instanceType);
         launchTemplate.setKeyName(keyName);
         launchTemplate.setUserData(userData);
+        launchTemplate.setIamInstanceProfileArn(iamInstanceProfileArn);
         if (securityGroupIds != null) {
             launchTemplate.setSecurityGroupIds(new ArrayList<>(securityGroupIds));
         }
@@ -1410,6 +1412,7 @@ public class Ec2Service {
                                                       String sourceVersion,
                                                       String imageId, String instanceType, String keyName,
                                                       List<String> securityGroupIds, String userData,
+                                                      String iamInstanceProfileArn,
                                                       List<Tag> instanceTags) {
         ensureDefaultResources(region);
         LaunchTemplate launchTemplate = findLaunchTemplate(region, id, name);
@@ -1429,6 +1432,9 @@ public class Ec2Service {
         }
         if (userData != null && !userData.isBlank()) {
             data.setUserData(userData);
+        }
+        if (iamInstanceProfileArn != null && !iamInstanceProfileArn.isBlank()) {
+            data.setIamInstanceProfileArn(iamInstanceProfileArn);
         }
         if (securityGroupIds != null && !securityGroupIds.isEmpty()) {
             data.setSecurityGroupIds(securityGroupIds);
@@ -1567,6 +1573,7 @@ public class Ec2Service {
         data.setInstanceType(launchTemplate.getInstanceType());
         data.setKeyName(launchTemplate.getKeyName());
         data.setUserData(launchTemplate.getUserData());
+        data.setIamInstanceProfileArn(launchTemplate.getIamInstanceProfileArn());
         data.setSecurityGroupIds(launchTemplate.getSecurityGroupIds());
         data.setInstanceTags(launchTemplate.getInstanceTags());
         return data;
@@ -1577,6 +1584,7 @@ public class Ec2Service {
         launchTemplate.setInstanceType(data.getInstanceType());
         launchTemplate.setKeyName(data.getKeyName());
         launchTemplate.setUserData(data.getUserData());
+        launchTemplate.setIamInstanceProfileArn(data.getIamInstanceProfileArn());
         launchTemplate.setSecurityGroupIds(new ArrayList<>(data.getSecurityGroupIds()));
         launchTemplate.setInstanceTags(data.getInstanceTags());
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1503,6 +1503,16 @@ public class Ec2Service {
                 .collect(Collectors.toList());
     }
 
+    public LaunchTemplateData resolveLaunchTemplateData(String region, String id, String name, String version) {
+        ensureDefaultResources(region);
+        LaunchTemplate launchTemplate = findLaunchTemplate(region, id, name);
+        String resolvedVersion = resolveLaunchTemplateVersion(
+                launchTemplate,
+                version,
+                launchTemplate.getDefaultVersionNumber());
+        return new LaunchTemplateData(versionData(launchTemplate, resolvedVersion));
+    }
+
     public LaunchTemplate deleteLaunchTemplate(String region, String id, String name) {
         ensureDefaultResources(region);
         LaunchTemplate launchTemplate = findLaunchTemplate(region, id, name);

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/LaunchTemplate.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/LaunchTemplate.java
@@ -24,6 +24,7 @@ public class LaunchTemplate {
     private String instanceType;
     private String keyName;
     private String userData;
+    private String iamInstanceProfileArn;
     private List<String> securityGroupIds = new ArrayList<>();
     private List<Tag> tags = new ArrayList<>();
     private List<Tag> instanceTags = new ArrayList<>();
@@ -63,6 +64,9 @@ public class LaunchTemplate {
 
     public String getUserData() { return userData; }
     public void setUserData(String userData) { this.userData = userData; }
+
+    public String getIamInstanceProfileArn() { return iamInstanceProfileArn; }
+    public void setIamInstanceProfileArn(String iamInstanceProfileArn) { this.iamInstanceProfileArn = iamInstanceProfileArn; }
 
     public List<String> getSecurityGroupIds() { return securityGroupIds; }
     public void setSecurityGroupIds(List<String> securityGroupIds) { this.securityGroupIds = securityGroupIds; }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/LaunchTemplateData.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/LaunchTemplateData.java
@@ -14,6 +14,7 @@ public class LaunchTemplateData {
     private String instanceType;
     private String keyName;
     private String userData;
+    private String iamInstanceProfileArn;
     private List<String> securityGroupIds = new ArrayList<>();
     private List<Tag> instanceTags = new ArrayList<>();
 
@@ -24,6 +25,7 @@ public class LaunchTemplateData {
         this.instanceType = source.instanceType;
         this.keyName = source.keyName;
         this.userData = source.userData;
+        this.iamInstanceProfileArn = source.iamInstanceProfileArn;
         this.securityGroupIds = new ArrayList<>(source.securityGroupIds);
         this.instanceTags = new ArrayList<>(source.instanceTags);
     }
@@ -39,6 +41,9 @@ public class LaunchTemplateData {
 
     public String getUserData() { return userData; }
     public void setUserData(String userData) { this.userData = userData; }
+
+    public String getIamInstanceProfileArn() { return iamInstanceProfileArn; }
+    public void setIamInstanceProfileArn(String iamInstanceProfileArn) { this.iamInstanceProfileArn = iamInstanceProfileArn; }
 
     public List<String> getSecurityGroupIds() { return securityGroupIds; }
     public void setSecurityGroupIds(List<String> securityGroupIds) {

--- a/src/main/java/io/github/hectorvent/floci/tools/ami/AmiImageTool.java
+++ b/src/main/java/io/github/hectorvent/floci/tools/ami/AmiImageTool.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 public final class AmiImageTool {
     public static final Path DEFAULT_METADATA = Path.of("docker/ec2/ami-images/image-build-metadata.yaml");
     public static final Path DEFAULT_OUTPUT = Path.of("target/ami-images");
+    private static final String NETWORKD_WAIT_ONLINE_DROP_IN = "systemd-networkd-wait-online-floci.conf";
     private static final ObjectMapper YAML = new ObjectMapper(new YAMLFactory());
     private static final HttpClient HTTP = HttpClient.newHttpClient();
 
@@ -100,6 +101,7 @@ public final class AmiImageTool {
             }
             if (write) {
                 Files.writeString(context.resolve("Dockerfile"), dockerfile(image), StandardCharsets.UTF_8);
+                Files.writeString(context.resolve(NETWORKD_WAIT_ONLINE_DROP_IN), networkdWaitOnlineDropIn(), StandardCharsets.UTF_8);
                 Files.writeString(context.resolve("README.md"), readme(image), StandardCharsets.UTF_8);
                 YAML.writerWithDefaultPrettyPrinter().writeValue(context.resolve("provenance.yaml").toFile(), provenance);
             }
@@ -162,10 +164,20 @@ public final class AmiImageTool {
                 LABEL io.floci.ami.catalog-image-id="%s"
                 LABEL io.floci.ami.architecture="%s"
                 ADD %s /
+                COPY %s /etc/systemd/system/systemd-networkd-wait-online.service.d/floci.conf
                 ENV container=docker
                 STOPSIGNAL SIGRTMIN+3
                 CMD ["/sbin/init"]
-                """.formatted(image.canonical.rootfsUrl(), image.catalogImageId, image.architecture, image.canonical.rootfs);
+                """.formatted(image.canonical.rootfsUrl(), image.catalogImageId, image.architecture, image.canonical.rootfs,
+                NETWORKD_WAIT_ONLINE_DROP_IN);
+    }
+
+    static String networkdWaitOnlineDropIn() {
+        return """
+                [Service]
+                ExecStart=
+                ExecStart=/bin/true
+                """;
     }
 
     static String readme(ImageSpec image) {

--- a/src/main/java/io/github/hectorvent/floci/tools/ami/AmiImageTool.java
+++ b/src/main/java/io/github/hectorvent/floci/tools/ami/AmiImageTool.java
@@ -165,6 +165,10 @@ public final class AmiImageTool {
                 LABEL io.floci.ami.architecture="%s"
                 ADD %s /
                 COPY %s /etc/systemd/system/systemd-networkd-wait-online.service.d/floci.conf
+                RUN set -eux; \\
+                    getent group ubuntu >/dev/null || groupadd --gid 1000 ubuntu; \\
+                    id ubuntu >/dev/null 2>&1 || useradd --uid 1000 --gid ubuntu --groups sudo --create-home --shell /bin/bash ubuntu; \\
+                    install -d -o ubuntu -g ubuntu /home/ubuntu
                 ENV container=docker
                 STOPSIGNAL SIGRTMIN+3
                 CMD ["/sbin/init"]

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilderTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilderTest.java
@@ -98,6 +98,31 @@ class ContainerBuilderTest {
         assertEquals("host", spec.cgroupnsMode());
     }
 
+    @Test
+    void imageRegistryBasePrefixesEveryContainerImage() {
+        TestFixture fixture = new TestFixture();
+        when(fixture.docker.imageRegistryBase()).thenReturn(Optional.of("ghcr.io/floci-io/mirror/"));
+
+        assertEquals(
+                "ghcr.io/floci-io/mirror/postgres:16-alpine",
+                fixture.builder.newContainer("postgres:16-alpine").build().image());
+        assertEquals(
+                "ghcr.io/floci-io/mirror/public.ecr.aws/docker/library/ubuntu:24.04",
+                fixture.builder.newContainer("public.ecr.aws/docker/library/ubuntu:24.04").build().image());
+    }
+
+    @Test
+    void imageRegistryBaseDoesNotDoublePrefixImagesAlreadyUnderBase() {
+        TestFixture fixture = new TestFixture();
+        when(fixture.docker.imageRegistryBase()).thenReturn(Optional.of("ghcr.io/floci-io/mirror"));
+
+        ContainerSpec spec = fixture.builder
+                .newContainer("ghcr.io/floci-io/mirror/floci/ami-ubuntu:24.04-arm64")
+                .build();
+
+        assertEquals("ghcr.io/floci-io/mirror/floci/ami-ubuntu:24.04-arm64", spec.image());
+    }
+
     private static class TestFixture {
         final EmulatorConfig config = mock(EmulatorConfig.class);
         final EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
@@ -116,6 +141,7 @@ class ContainerBuilderTest {
             when(config.docker()).thenReturn(docker);
             when(docker.logMaxSize()).thenReturn("10m");
             when(docker.logMaxFile()).thenReturn("3");
+            when(docker.imageRegistryBase()).thenReturn(Optional.empty());
             when(config.dns()).thenReturn(dns);
             when(dns.containerFallbackEnabled()).thenReturn(true);
             when(dns.containerFallbackServers()).thenReturn(List.of("8.8.8.8", "8.8.4.4"));

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconcilerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconcilerTest.java
@@ -75,6 +75,7 @@ class AutoScalingReconcilerTest {
         version.setLatestVersionNumber("1");
         version.setImageId("ami-version-1");
         version.setInstanceType("t3.micro");
+        version.setIamInstanceProfileArn("arn:aws:iam::000000000000:instance-profile/app-profile");
         List<Tag> instanceTags = List.of(new Tag("app.ClusterId", "development"));
         version.setInstanceTags(instanceTags);
         when(ec2Service.describeLaunchTemplates("us-east-1", List.of("lt-123"), List.of(), Map.of()))
@@ -87,7 +88,7 @@ class AutoScalingReconcilerTest {
         reservation.setInstances(List.of(ec2Instance));
         when(ec2Service.runInstances(eq("us-east-1"), eq("ami-version-1"), eq("t3.micro"),
                 eq(1), eq(1), eq(null), eq(List.of()), eq(null), eq(null),
-                eq(instanceTags), eq(null), eq(null))).thenReturn(reservation);
+                eq(instanceTags), eq(null), eq("arn:aws:iam::000000000000:instance-profile/app-profile"))).thenReturn(reservation);
 
         reconciler.reconcile(asg);
 
@@ -97,7 +98,7 @@ class AutoScalingReconcilerTest {
         assertEquals("1", asg.getInstances().getFirst().getLaunchTemplateVersion());
         verify(ec2Service).runInstances(eq("us-east-1"), eq("ami-version-1"), eq("t3.micro"),
                 eq(1), eq(1), eq(null), eq(List.of()), eq(null), eq(null),
-                eq(instanceTags), eq(null), eq(null));
+                eq(instanceTags), eq(null), eq("arn:aws:iam::000000000000:instance-profile/app-profile"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -714,6 +714,7 @@ class Ec2IntegrationTest {
             .formParam("LaunchTemplateData.ImageId", "ami-0abcdef1234567890")
             .formParam("LaunchTemplateData.InstanceType", "t3.micro")
             .formParam("LaunchTemplateData.KeyName", "test-key")
+            .formParam("LaunchTemplateData.IamInstanceProfile.Name", "sample-profile")
             .formParam("LaunchTemplateData.SecurityGroupId.1", securityGroupId)
             .formParam("LaunchTemplateData.UserData", gzipBase64("#!/bin/sh\necho launch-template\n"))
             .formParam("LaunchTemplateData.TagSpecification.1.ResourceType", "instance")
@@ -772,6 +773,8 @@ class Ec2IntegrationTest {
                     equalTo("t3.micro"))
             .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.userData",
                     equalTo("#!/bin/sh\necho launch-template\n"))
+            .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.iamInstanceProfile.arn",
+                    equalTo("arn:aws:iam::000000000000:instance-profile/sample-profile"))
             .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.tagSpecificationSet.item.resourceType",
                     equalTo("instance"))
             .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.tagSpecificationSet.item.tagSet.item.find { it.key == 'example:ClusterId' }.value",
@@ -792,6 +795,7 @@ class Ec2IntegrationTest {
             .formParam("LaunchTemplateData.ImageId", "ami-0abcdef1234567890")
             .formParam("LaunchTemplateData.InstanceType", "t3.small")
             .formParam("LaunchTemplateData.KeyName", "test-key")
+            .formParam("LaunchTemplateData.IamInstanceProfile.Name", "sample-profile-v2")
             .formParam("LaunchTemplateData.SecurityGroupId.1", securityGroupId)
             .formParam("LaunchTemplateData.UserData", gzipBase64("#!/bin/sh\necho launch-template-version\n"))
             .formParam("LaunchTemplateData.TagSpecification.1.ResourceType", "instance")
@@ -812,6 +816,8 @@ class Ec2IntegrationTest {
                     equalTo("t3.small"))
             .body("CreateLaunchTemplateVersionResponse.launchTemplateVersion.launchTemplateData.userData",
                     equalTo("#!/bin/sh\necho launch-template-version\n"))
+            .body("CreateLaunchTemplateVersionResponse.launchTemplateVersion.launchTemplateData.iamInstanceProfile.arn",
+                    equalTo("arn:aws:iam::000000000000:instance-profile/sample-profile-v2"))
             .body("CreateLaunchTemplateVersionResponse.launchTemplateVersion.launchTemplateData.tagSpecificationSet.item.tagSet.item.find { it.key == 'example:NodeType' }.value",
                     equalTo("WORKER"));
 

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -721,7 +721,7 @@ class Ec2IntegrationTest {
             .formParam("LaunchTemplateData.TagSpecification.1.Tag.1.Key", "example:ClusterId")
             .formParam("LaunchTemplateData.TagSpecification.1.Tag.1.Value", "sample-template")
             .formParam("LaunchTemplateData.TagSpecification.1.Tag.2.Key", "example:NodeType")
-            .formParam("LaunchTemplateData.TagSpecification.1.Tag.2.Value", "COORDINATOR")
+            .formParam("LaunchTemplateData.TagSpecification.1.Tag.2.Value", "PRIMARY")
             .formParam("TagSpecification.1.ResourceType", "launch-template")
             .formParam("TagSpecification.1.Tag.1.Key", "Name")
             .formParam("TagSpecification.1.Tag.1.Value", "sample-template")
@@ -780,7 +780,7 @@ class Ec2IntegrationTest {
             .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.tagSpecificationSet.item.tagSet.item.find { it.key == 'example:ClusterId' }.value",
                     equalTo("sample-template"))
             .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.tagSpecificationSet.item.tagSet.item.find { it.key == 'example:NodeType' }.value",
-                    equalTo("COORDINATOR"));
+                    equalTo("PRIMARY"));
     }
 
     @Test
@@ -800,7 +800,7 @@ class Ec2IntegrationTest {
             .formParam("LaunchTemplateData.UserData", gzipBase64("#!/bin/sh\necho launch-template-version\n"))
             .formParam("LaunchTemplateData.TagSpecification.1.ResourceType", "instance")
             .formParam("LaunchTemplateData.TagSpecification.1.Tag.1.Key", "example:NodeType")
-            .formParam("LaunchTemplateData.TagSpecification.1.Tag.1.Value", "WORKER")
+            .formParam("LaunchTemplateData.TagSpecification.1.Tag.1.Value", "SECONDARY")
             .header("Authorization", AUTH_HEADER)
         .when()
             .post("/")
@@ -819,7 +819,7 @@ class Ec2IntegrationTest {
             .body("CreateLaunchTemplateVersionResponse.launchTemplateVersion.launchTemplateData.iamInstanceProfile.arn",
                     equalTo("arn:aws:iam::000000000000:instance-profile/sample-profile-v2"))
             .body("CreateLaunchTemplateVersionResponse.launchTemplateVersion.launchTemplateData.tagSpecificationSet.item.tagSet.item.find { it.key == 'example:NodeType' }.value",
-                    equalTo("WORKER"));
+                    equalTo("SECONDARY"));
 
         given()
             .formParam("Action", "DescribeLaunchTemplateVersions")
@@ -839,7 +839,7 @@ class Ec2IntegrationTest {
             .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.userData",
                     equalTo("#!/bin/sh\necho launch-template\n"))
             .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.tagSpecificationSet.item.tagSet.item.find { it.key == 'example:NodeType' }.value",
-                    equalTo("COORDINATOR"));
+                    equalTo("PRIMARY"));
     }
 
     @Test
@@ -884,6 +884,55 @@ class Ec2IntegrationTest {
 
     @Test
     @Order(49)
+    void runInstancesResolvesLaunchTemplateDefaultsWithRequestOverrides() {
+        String launchedInstanceId = given()
+            .formParam("Action", "RunInstances")
+            .formParam("LaunchTemplate.LaunchTemplateId", launchTemplateId)
+            .formParam("LaunchTemplate.Version", "$Default")
+            .formParam("ImageId", "ami-sample-override")
+            .formParam("InstanceType", "c7g.large")
+            .formParam("MinCount", "1")
+            .formParam("MaxCount", "1")
+            .formParam("TagSpecification.1.ResourceType", "instance")
+            .formParam("TagSpecification.1.Tag.1.Key", "example:NodeType")
+            .formParam("TagSpecification.1.Tag.1.Value", "REQUEST")
+            .formParam("TagSpecification.1.Tag.2.Key", "sample-name")
+            .formParam("TagSpecification.1.Tag.2.Value", "sample-local")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("RunInstancesResponse.instancesSet.item.imageId", equalTo("ami-sample-override"))
+            .body("RunInstancesResponse.instancesSet.item.instanceType", equalTo("c7g.large"))
+            .body("RunInstancesResponse.instancesSet.item.keyName", equalTo("test-key"))
+            .body("RunInstancesResponse.instancesSet.item.iamInstanceProfile.arn",
+                    equalTo("arn:aws:iam::000000000000:instance-profile/sample-profile-v2"))
+            .body("RunInstancesResponse.instancesSet.item.groupSet.item.groupId", equalTo(securityGroupId))
+            .body("RunInstancesResponse.instancesSet.item.tagSet.item.find { it.key == 'example:NodeType' }.value",
+                    equalTo("REQUEST"))
+            .body("RunInstancesResponse.instancesSet.item.tagSet.item.findAll { it.key == 'example:NodeType' }.size()",
+                    equalTo(1))
+            .body("RunInstancesResponse.instancesSet.item.tagSet.item.find { it.key == 'sample-name' }.value",
+                    equalTo("sample-local"))
+            .extract().path("RunInstancesResponse.instancesSet.item.instanceId");
+
+        given()
+            .formParam("Action", "DescribeInstances")
+            .formParam("InstanceId.1", launchedInstanceId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeInstancesResponse.reservationSet.item.instancesSet.item.instanceId",
+                    equalTo(launchedInstanceId))
+            .body("DescribeInstancesResponse.reservationSet.item.instancesSet.item.iamInstanceProfile.arn",
+                    equalTo("arn:aws:iam::000000000000:instance-profile/sample-profile-v2"));
+    }
+
+    @Test
+    @Order(50)
     void deleteLaunchTemplate() {
         given()
             .formParam("Action", "DeleteLaunchTemplate")
@@ -1526,8 +1575,7 @@ class Ec2IntegrationTest {
             .post("/")
         .then()
             .statusCode(200)
-            .body("DescribeTagsResponse.tagSet.item.key", equalTo("Name"))
-            .body("DescribeTagsResponse.tagSet.item.value", equalTo("test-instance"));
+            .body("DescribeTagsResponse.tagSet.item.find { it.key == 'Name' }.value", equalTo("test-instance"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2MetadataServerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2MetadataServerTest.java
@@ -2,12 +2,16 @@ package io.github.hectorvent.floci.services.ec2;
 
 import io.github.hectorvent.floci.services.ec2.model.Instance;
 import io.github.hectorvent.floci.services.ec2.model.Tag;
+import io.github.hectorvent.floci.services.iam.IamService;
+import io.github.hectorvent.floci.services.iam.model.InstanceProfile;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class Ec2MetadataServerTest {
 
@@ -50,7 +54,7 @@ class Ec2MetadataServerTest {
 
     @Test
     void staleContainerUnregisterDoesNotRemoveCurrentRegistration() {
-        Ec2MetadataServer server = new Ec2MetadataServer(null, null);
+        Ec2MetadataServer server = new Ec2MetadataServer(null, null, null);
         Instance oldInstance = new Instance();
         oldInstance.setInstanceId("i-old");
         Instance currentInstance = new Instance();
@@ -63,5 +67,19 @@ class Ec2MetadataServerTest {
         assertEquals(
                 currentInstance,
                 server.registeredContainer("192.168.215.7").orElseThrow());
+    }
+
+    @Test
+    void iamCredentialRoleNameComesFromInstanceProfileRole() {
+        IamService iamService = mock(IamService.class);
+        InstanceProfile profile = new InstanceProfile();
+        profile.setInstanceProfileName("iceguard-profile");
+        profile.setRoleNames(List.of("iceguard-role"));
+        when(iamService.getInstanceProfile("iceguard-profile")).thenReturn(profile);
+
+        Ec2MetadataServer server = new Ec2MetadataServer(null, null, iamService);
+
+        assertEquals("iceguard-role", server.resolveRoleName(
+                "arn:aws:iam::000000000000:instance-profile/iceguard-profile"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2MetadataServerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2MetadataServerTest.java
@@ -73,13 +73,13 @@ class Ec2MetadataServerTest {
     void iamCredentialRoleNameComesFromInstanceProfileRole() {
         IamService iamService = mock(IamService.class);
         InstanceProfile profile = new InstanceProfile();
-        profile.setInstanceProfileName("iceguard-profile");
-        profile.setRoleNames(List.of("iceguard-role"));
-        when(iamService.getInstanceProfile("iceguard-profile")).thenReturn(profile);
+        profile.setInstanceProfileName("sample-profile");
+        profile.setRoleNames(List.of("sample-role"));
+        when(iamService.getInstanceProfile("sample-profile")).thenReturn(profile);
 
         Ec2MetadataServer server = new Ec2MetadataServer(null, null, iamService);
 
-        assertEquals("iceguard-role", server.resolveRoleName(
-                "arn:aws:iam::000000000000:instance-profile/iceguard-profile"));
+        assertEquals("sample-role", server.resolveRoleName(
+                "arn:aws:iam::000000000000:instance-profile/sample-profile"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -59,10 +59,11 @@ class Ec2ServiceTest {
                 mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new InMemoryStorageFactory());
         LaunchTemplate template = service.createLaunchTemplate("us-east-1", "app-template",
                 "ami-source", "t3.micro", "app-key", List.of("sg-source"),
-                "source-user-data", List.of(), List.of(new Tag("Role", "source")));
+                "source-user-data", "arn:aws:iam::000000000000:instance-profile/app-profile",
+                List.of(), List.of(new Tag("Role", "source")));
 
         service.createLaunchTemplateVersion("us-east-1", template.getLaunchTemplateId(), null,
-                "1", null, "t3.small", null, List.of(), null, List.of());
+                "1", null, "t3.small", null, List.of(), null, null, List.of());
 
         LaunchTemplate version = service.describeLaunchTemplateVersions(
                 "us-east-1", template.getLaunchTemplateId(), null, List.of("2")).getFirst();
@@ -71,6 +72,7 @@ class Ec2ServiceTest {
         assertEquals("app-key", version.getKeyName());
         assertEquals(List.of("sg-source"), version.getSecurityGroupIds());
         assertEquals("source-user-data", version.getUserData());
+        assertEquals("arn:aws:iam::000000000000:instance-profile/app-profile", version.getIamInstanceProfileArn());
         assertEquals("2", version.getLatestVersionNumber());
         assertEquals(1, version.getInstanceTags().size());
         assertEquals("Role", version.getInstanceTags().getFirst().getKey());

--- a/src/test/java/io/github/hectorvent/floci/tools/ami/AmiImageToolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/tools/ami/AmiImageToolTest.java
@@ -62,6 +62,8 @@ class AmiImageToolTest {
         assertTrue(Files.readString(context.resolve("Dockerfile")).contains("FROM scratch"));
         assertTrue(Files.readString(context.resolve("Dockerfile")).contains("io.floci.ami.catalog-image-id"));
         assertTrue(Files.readString(context.resolve("Dockerfile")).contains("ADD ubuntu-root.tar.xz /"));
+        assertTrue(Files.readString(context.resolve("Dockerfile")).contains("systemd-networkd-wait-online.service.d/floci.conf"));
+        assertTrue(Files.readString(context.resolve("systemd-networkd-wait-online-floci.conf")).contains("ExecStart=/bin/true"));
         assertTrue(Files.readString(context.resolve("provenance.yaml")).contains("manifestSha256"));
 
         Path catalog = tempDir.resolve("image-catalog.yaml");

--- a/src/test/java/io/github/hectorvent/floci/tools/ami/AmiImageToolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/tools/ami/AmiImageToolTest.java
@@ -62,6 +62,7 @@ class AmiImageToolTest {
         assertTrue(Files.readString(context.resolve("Dockerfile")).contains("FROM scratch"));
         assertTrue(Files.readString(context.resolve("Dockerfile")).contains("io.floci.ami.catalog-image-id"));
         assertTrue(Files.readString(context.resolve("Dockerfile")).contains("ADD ubuntu-root.tar.xz /"));
+        assertTrue(Files.readString(context.resolve("Dockerfile")).contains("useradd --uid 1000 --gid ubuntu"));
         assertTrue(Files.readString(context.resolve("Dockerfile")).contains("systemd-networkd-wait-online.service.d/floci.conf"));
         assertTrue(Files.readString(context.resolve("systemd-networkd-wait-online-floci.conf")).contains("ExecStart=/bin/true"));
         assertTrue(Files.readString(context.resolve("provenance.yaml")).contains("manifestSha256"));


### PR DESCRIPTION
## Summary
- preserve launch template instance profile data used by ASG-launched instances
- support registry override for container-backed guest images
- align launch template AMI resolution and skip networkd wait-online in generated AMI guests

## Verification
- ./mvnw -q -Dtest='Ec2ServiceTest,Ec2IntegrationTest,AmiImageToolTest,ContainerBuilderTest' test