### PR TITLE
fix(autoscaling): align active instance refresh behavior

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AutoScalingTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AutoScalingTest.java
@@ -30,7 +30,7 @@ class AutoScalingTest {
             "Valid requests must contain either the InstanceID parameter "
                     + "or both the ImageId and InstanceType parameters.";
     private static final String ACTIVE_INSTANCE_REFRESH_DESIRED_CONFIGURATION_MESSAGE =
-            "You cannot update the launch template, launch configuration, or mixed instances policy while an instance refresh with a desired configuration is active.";
+            "An active instance refresh with a desired configuration exists. All configuration options derived from the desired configuration are not available for update while the instance refresh is active.";
 
     private static AutoScalingClient autoScaling;
     private static Ec2Client ec2;

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AutoScalingTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AutoScalingTest.java
@@ -5,12 +5,17 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.autoscaling.AutoScalingClient;
+import software.amazon.awssdk.services.autoscaling.model.AttachInstancesRequest;
 import software.amazon.awssdk.services.autoscaling.model.AutoScalingException;
 import software.amazon.awssdk.services.autoscaling.model.CreateAutoScalingGroupRequest;
 import software.amazon.awssdk.services.autoscaling.model.CreateLaunchConfigurationRequest;
+import software.amazon.awssdk.services.autoscaling.model.DesiredConfiguration;
 import software.amazon.awssdk.services.autoscaling.model.LaunchTemplateSpecification;
+import software.amazon.awssdk.services.autoscaling.model.StartInstanceRefreshRequest;
+import software.amazon.awssdk.services.autoscaling.model.UpdateAutoScalingGroupRequest;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.CreateLaunchTemplateRequest;
+import software.amazon.awssdk.services.ec2.model.CreateLaunchTemplateVersionRequest;
 import software.amazon.awssdk.services.ec2.model.RequestLaunchTemplateData;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,6 +29,8 @@ class AutoScalingTest {
     private static final String INVALID_LAUNCH_CONFIGURATION_PARAMETERS_MESSAGE =
             "Valid requests must contain either the InstanceID parameter "
                     + "or both the ImageId and InstanceType parameters.";
+    private static final String ACTIVE_INSTANCE_REFRESH_DESIRED_CONFIGURATION_MESSAGE =
+            "You cannot update the launch template, launch configuration, or mixed instances policy while an instance refresh with a desired configuration is active.";
 
     private static AutoScalingClient autoScaling;
     private static Ec2Client ec2;
@@ -118,6 +125,83 @@ class AutoScalingTest {
                     assertThat(error.awsErrorDetails().errorCode()).isEqualTo("ValidationError");
                     assertThat(error.awsErrorDetails().errorMessage())
                             .isEqualTo(INVALID_LAUNCH_CONFIGURATION_PARAMETERS_MESSAGE);
+                });
+    }
+
+    @Test
+    @DisplayName("UpdateAutoScalingGroup rejects desired configuration changes during active instance refresh")
+    void activeInstanceRefreshDesiredConfigurationConflictMapsToSdkAutoScalingException() {
+        String launchTemplateName = TestFixtures.uniqueName("sdk-active-refresh");
+        String autoScalingGroupName = TestFixtures.uniqueName("sdk-active-refresh-asg");
+
+        ec2.createLaunchTemplate(CreateLaunchTemplateRequest.builder()
+                .launchTemplateName(launchTemplateName)
+                .launchTemplateData(RequestLaunchTemplateData.builder()
+                        .imageId("ami-12345678")
+                        .instanceType("t3.micro")
+                        .build())
+                .build());
+        ec2.createLaunchTemplateVersion(CreateLaunchTemplateVersionRequest.builder()
+                .launchTemplateName(launchTemplateName)
+                .sourceVersion("1")
+                .launchTemplateData(RequestLaunchTemplateData.builder()
+                        .imageId("ami-12345678")
+                        .instanceType("t3.small")
+                        .build())
+                .build());
+        ec2.createLaunchTemplateVersion(CreateLaunchTemplateVersionRequest.builder()
+                .launchTemplateName(launchTemplateName)
+                .sourceVersion("1")
+                .launchTemplateData(RequestLaunchTemplateData.builder()
+                        .imageId("ami-12345678")
+                        .instanceType("t3.medium")
+                        .build())
+                .build());
+        autoScaling.createAutoScalingGroup(CreateAutoScalingGroupRequest.builder()
+                .autoScalingGroupName(autoScalingGroupName)
+                .launchTemplate(LaunchTemplateSpecification.builder()
+                        .launchTemplateName(launchTemplateName)
+                        .version("1")
+                        .build())
+                .minSize(0)
+                .maxSize(1)
+                .desiredCapacity(1)
+                .availabilityZones("us-east-1a")
+                .build());
+        autoScaling.attachInstances(AttachInstancesRequest.builder()
+                .autoScalingGroupName(autoScalingGroupName)
+                .instanceIds("i-sdk-active-refresh")
+                .build());
+        autoScaling.startInstanceRefresh(StartInstanceRefreshRequest.builder()
+                .autoScalingGroupName(autoScalingGroupName)
+                .desiredConfiguration(DesiredConfiguration.builder()
+                        .launchTemplate(LaunchTemplateSpecification.builder()
+                                .launchTemplateName(launchTemplateName)
+                                .version("2")
+                                .build())
+                        .build())
+                .build());
+
+        assertThatThrownBy(() -> autoScaling.updateAutoScalingGroup(UpdateAutoScalingGroupRequest.builder()
+                .autoScalingGroupName(autoScalingGroupName)
+                .launchTemplate(LaunchTemplateSpecification.builder()
+                        .launchTemplateName(launchTemplateName)
+                        .version("3")
+                        .build())
+                .build()))
+                .isInstanceOfSatisfying(AutoScalingException.class, error -> {
+                    assertThat(error.statusCode()).isEqualTo(400);
+                    assertThat(error.awsErrorDetails().serviceName()).isEqualTo("AutoScaling");
+                    assertThat(error.awsErrorDetails().errorCode()).isEqualTo("ValidationError");
+                    assertThat(error.awsErrorDetails().errorMessage())
+                            .isEqualTo(ACTIVE_INSTANCE_REFRESH_DESIRED_CONFIGURATION_MESSAGE);
+                    assertThat(error.requestId()).isNotBlank();
+                    assertThat(error.getMessage()).contains(
+                            ACTIVE_INSTANCE_REFRESH_DESIRED_CONFIGURATION_MESSAGE,
+                            "Service: AutoScaling",
+                            "Status Code: 400",
+                            "Request ID: ",
+                            "SDK Attempt Count: 1");
                 });
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
@@ -222,6 +222,10 @@ public class AutoScalingService {
                                         List<String> terminationPolicies) {
         AutoScalingGroup asg = requireGroup(region, name);
         validateLaunchSource(launchConfigName, launchTemplateId, launchTemplateName, mixedInstancesPolicy);
+        if (launchTemplateVersion != null && launchTemplateId == null && launchTemplateName == null) {
+            throw new AwsException("ValidationError",
+                    "LaunchTemplateVersion requires a LaunchTemplateId or LaunchTemplateName.", 400);
+        }
         rejectDesiredConfigurationUpdateDuringActiveRefresh(region, name,
                 launchConfigName, launchTemplateId, launchTemplateName, launchTemplateVersion, mixedInstancesPolicy);
         LaunchIdentity effectiveIdentity = effectiveLaunchIdentity(asg, launchConfigName,

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
@@ -30,7 +30,7 @@ public class AutoScalingService {
             "Valid requests must contain either the InstanceID parameter "
                     + "or both the ImageId and InstanceType parameters.";
     static final String ACTIVE_INSTANCE_REFRESH_DESIRED_CONFIGURATION_MESSAGE =
-            "You cannot update the launch template, launch configuration, or mixed instances policy while an instance refresh with a desired configuration is active.";
+            "An active instance refresh with a desired configuration exists. All configuration options derived from the desired configuration are not available for update while the instance refresh is active.";
 
     @Inject
     RegionResolver regionResolver;

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
@@ -29,6 +29,8 @@ public class AutoScalingService {
     static final String INVALID_LAUNCH_CONFIGURATION_PARAMETERS_MESSAGE =
             "Valid requests must contain either the InstanceID parameter "
                     + "or both the ImageId and InstanceType parameters.";
+    static final String ACTIVE_INSTANCE_REFRESH_DESIRED_CONFIGURATION_MESSAGE =
+            "Cannot update Auto Scaling group desired configuration while an instance refresh with desired configuration is active.";
 
     @Inject
     RegionResolver regionResolver;
@@ -220,6 +222,8 @@ public class AutoScalingService {
                                         List<String> terminationPolicies) {
         AutoScalingGroup asg = requireGroup(region, name);
         validateLaunchSource(launchConfigName, launchTemplateId, launchTemplateName, mixedInstancesPolicy);
+        rejectDesiredConfigurationUpdateDuringActiveRefresh(region, name,
+                launchConfigName, launchTemplateId, launchTemplateName, launchTemplateVersion, mixedInstancesPolicy);
         LaunchIdentity effectiveIdentity = effectiveLaunchIdentity(asg, launchConfigName,
                 launchTemplateId, launchTemplateName, launchTemplateVersion, mixedInstancesPolicy);
         validateEffectiveLaunchImage(region,
@@ -833,6 +837,37 @@ public class AutoScalingService {
                 || "Cancelling".equals(status)
                 || "RollbackInProgress".equals(status)
                 || "Baking".equals(status);
+    }
+
+    private void rejectDesiredConfigurationUpdateDuringActiveRefresh(String region, String asgName,
+                                                                     String launchConfigName,
+                                                                     String launchTemplateId,
+                                                                     String launchTemplateName,
+                                                                     String launchTemplateVersion,
+                                                                     MixedInstancesPolicy mixedInstancesPolicy) {
+        if (!updatesLaunchSource(launchConfigName, launchTemplateId, launchTemplateName, launchTemplateVersion, mixedInstancesPolicy)) {
+            return;
+        }
+        boolean activeDesiredConfigurationRefresh = instanceRefreshes.values().stream()
+                .filter(r -> region.equals(r.getRegion()))
+                .filter(r -> asgName.equals(r.getAutoScalingGroupName()))
+                .filter(r -> isActiveRefreshStatus(r.getStatus()))
+                .anyMatch(InstanceRefresh::hasDesiredConfiguration);
+        if (activeDesiredConfigurationRefresh) {
+            throw new AwsException("ValidationError", ACTIVE_INSTANCE_REFRESH_DESIRED_CONFIGURATION_MESSAGE, 400);
+        }
+    }
+
+    private static boolean updatesLaunchSource(String launchConfigName,
+                                               String launchTemplateId,
+                                               String launchTemplateName,
+                                               String launchTemplateVersion,
+                                               MixedInstancesPolicy mixedInstancesPolicy) {
+        return launchConfigName != null
+                || launchTemplateId != null
+                || launchTemplateName != null
+                || launchTemplateVersion != null
+                || mixedInstancesPolicy != null;
     }
 
     private static String normalizeRefreshStrategy(String strategy) {

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
@@ -30,7 +30,7 @@ public class AutoScalingService {
             "Valid requests must contain either the InstanceID parameter "
                     + "or both the ImageId and InstanceType parameters.";
     static final String ACTIVE_INSTANCE_REFRESH_DESIRED_CONFIGURATION_MESSAGE =
-            "Cannot update Auto Scaling group desired configuration while an instance refresh with desired configuration is active.";
+            "You cannot update the launch template, launch configuration, or mixed instances policy while an instance refresh with a desired configuration is active.";
 
     @Inject
     RegionResolver regionResolver;

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandlerTest.java
@@ -81,6 +81,61 @@ class AutoScalingQueryHandlerTest {
     }
 
     @Test
+    void updateAutoScalingGroupRejectsDesiredConfigurationChangeDuringActiveInstanceRefresh() {
+        AutoScalingService service = new AutoScalingService();
+        service.regionResolver = new RegionResolver(REGION, "000000000000");
+        service.createAutoScalingGroup(REGION,
+                "query-asg",
+                null,
+                "lt-original",
+                null,
+                "1",
+                null,
+                0,
+                3,
+                1,
+                300,
+                List.of("us-east-1a"),
+                List.of(),
+                List.of(),
+                List.of(),
+                "EC2",
+                0,
+                List.of("Default"),
+                java.util.Map.of());
+        AsgInstance instance = new AsgInstance();
+        instance.setInstanceId("i-original");
+        instance.setAvailabilityZone("us-east-1a");
+        instance.setLifecycleState("InService");
+        instance.setHealthStatus("Healthy");
+        instance.setLaunchTemplateId("lt-original");
+        instance.setLaunchTemplateVersion("1");
+        service.describeAutoScalingGroups(REGION, List.of("query-asg"))
+                .getFirst()
+                .getInstances()
+                .add(instance);
+
+        AutoScalingQueryHandler handler = new AutoScalingQueryHandler(service);
+        MultivaluedHashMap<String, String> startParams = new MultivaluedHashMap<>();
+        startParams.add("AutoScalingGroupName", "query-asg");
+        startParams.add("DesiredConfiguration.LaunchTemplate.LaunchTemplateId", "lt-refresh");
+        startParams.add("DesiredConfiguration.LaunchTemplate.Version", "2");
+        assertEquals(200, handler.handle("StartInstanceRefresh", startParams, REGION).getStatus());
+
+        MultivaluedHashMap<String, String> updateParams = new MultivaluedHashMap<>();
+        updateParams.add("AutoScalingGroupName", "query-asg");
+        updateParams.add("LaunchTemplate.LaunchTemplateId", "lt-next");
+        updateParams.add("LaunchTemplate.Version", "3");
+
+        Response response = handler.handle("UpdateAutoScalingGroup", updateParams, REGION);
+
+        assertEquals(400, response.getStatus());
+        String xml = (String) response.getEntity();
+        assertTrue(xml.contains("<Code>ValidationError</Code>"));
+        assertTrue(xml.contains(AutoScalingService.ACTIVE_INSTANCE_REFRESH_DESIRED_CONFIGURATION_MESSAGE));
+    }
+
+    @Test
     void describeAutoScalingGroupsIncludesInstanceLaunchTemplateMetadata() {
         AutoScalingService service = new AutoScalingService();
         service.regionResolver = new RegionResolver(REGION, "000000000000");

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingServiceTest.java
@@ -272,6 +272,41 @@ class AutoScalingServiceTest {
     }
 
     @Test
+    void updateAutoScalingGroupRejectsDesiredConfigurationChangeDuringActiveInstanceRefresh() {
+        AutoScalingGroupFixture.addInstance(service, REGION, "test-asg", "i-original", "InService", "lt-original", "1");
+        InstanceRefresh request = new InstanceRefresh();
+        request.setDesiredLaunchTemplateId("lt-refresh");
+        request.setDesiredLaunchTemplateVersion("2");
+        service.startInstanceRefresh(REGION, "test-asg", request);
+
+        AwsException error = assertThrows(AwsException.class, () -> service.updateAutoScalingGroup(
+                REGION,
+                "test-asg",
+                null,
+                "lt-next",
+                null,
+                "3",
+                null,
+                null,
+                5,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null));
+
+        assertEquals("ValidationError", error.getErrorCode());
+        assertEquals(AutoScalingService.ACTIVE_INSTANCE_REFRESH_DESIRED_CONFIGURATION_MESSAGE, error.getMessage());
+        assertEquals(400, error.getHttpStatus());
+        var group = service.describeAutoScalingGroups(REGION, List.of("test-asg")).getFirst();
+        assertEquals("lt-refresh", group.getLaunchTemplateId());
+        assertEquals("2", group.getLaunchTemplateVersion());
+        assertEquals(3, group.getMaxSize());
+    }
+
+    @Test
     void describeInstanceRefreshesPaginatesNewestFirst() {
         InstanceRefresh first = service.startInstanceRefresh(REGION, "test-asg", new InstanceRefresh());
         InstanceRefresh second = service.startInstanceRefresh(REGION, "test-asg", new InstanceRefresh());

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingServiceTest.java
@@ -272,6 +272,33 @@ class AutoScalingServiceTest {
     }
 
     @Test
+    void updateAutoScalingGroupRejectsVersionWithoutLaunchTemplateIdentifier() {
+        AwsException error = assertThrows(AwsException.class, () -> service.updateAutoScalingGroup(
+                REGION,
+                "test-asg",
+                null,
+                null,
+                null,
+                "2",
+                null,
+                null,
+                5,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null));
+
+        assertEquals("ValidationError", error.getErrorCode());
+        assertEquals("LaunchTemplateVersion requires a LaunchTemplateId or LaunchTemplateName.", error.getMessage());
+        var group = service.describeAutoScalingGroups(REGION, List.of("test-asg")).getFirst();
+        assertEquals("1", group.getLaunchTemplateVersion());
+        assertEquals(3, group.getMaxSize());
+    }
+
+    @Test
     void updateAutoScalingGroupRejectsDesiredConfigurationChangeDuringActiveInstanceRefresh() {
         AutoScalingGroupFixture.addInstance(service, REGION, "test-asg", "i-original", "InService", "lt-original", "1");
         InstanceRefresh request = new InstanceRefresh();


### PR DESCRIPTION
## Summary
- reject Auto Scaling group config updates while instance refresh is active
- align active refresh failure shape with AWS SDK expectations
- keep the change focused on active refresh control-plane parity

## Verification
- ./mvnw -q -Dtest='AutoScalingServiceTest,AutoScalingQueryHandlerTest' test