### PR TITLE
fix(rds): improve postgres proxy startup parity

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandler.java
@@ -1,22 +1,44 @@
 package io.github.hectorvent.floci.services.rds.proxy;
 
 import org.jboss.logging.Logger;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 
 import javax.crypto.Mac;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
 import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.math.BigInteger;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +64,7 @@ public class PostgresProtocolHandler {
 
     private static final int SSL_REQUEST_CODE = 80877103;
     private static final int STARTUP_PROTOCOL_VERSION = 196608; // v3.0
+    private static volatile SSLContext serverSslContext;
 
     public static void handleAuth(Socket client, Socket backend,
                                   String masterUsername, String masterPassword, String dbName,
@@ -157,8 +180,9 @@ public class PostgresProtocolHandler {
             int proto = readInt32(in);
 
             if (proto == SSL_REQUEST_CODE) {
-                out.write('N');
+                out.write('S');
                 out.flush();
+                currentSocket = acceptSsl(currentSocket);
                 continue;
             }
 
@@ -174,6 +198,76 @@ public class PostgresProtocolHandler {
                     params.getOrDefault("user", "postgres"),
                     params.get("database"));
         }
+    }
+
+    static Socket acceptSsl(Socket socket) throws IOException {
+        try {
+            SSLSocket sslSocket = (SSLSocket) serverSslContext().getSocketFactory()
+                    .createSocket(socket, socket.getInetAddress().getHostAddress(), socket.getPort(), true);
+            sslSocket.setUseClientMode(false);
+            sslSocket.startHandshake();
+            return sslSocket;
+        } catch (Exception e) {
+            throw new IOException("Unable to negotiate PostgreSQL SSL", e);
+        }
+    }
+
+    private static SSLContext serverSslContext() throws Exception {
+        SSLContext context = serverSslContext;
+        if (context != null) {
+            return context;
+        }
+        synchronized (PostgresProtocolHandler.class) {
+            context = serverSslContext;
+            if (context == null) {
+                context = createServerSslContext();
+                serverSslContext = context;
+            }
+            return context;
+        }
+    }
+
+    private static SSLContext createServerSslContext() throws Exception {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048, new SecureRandom());
+        KeyPair keyPair = generator.generateKeyPair();
+        Instant now = Instant.now();
+
+        X500Name name = new X500Name("CN=localhost");
+        X509v3CertificateBuilder certificateBuilder = new JcaX509v3CertificateBuilder(
+                name,
+                new BigInteger(128, new SecureRandom()),
+                Date.from(now.minus(1, ChronoUnit.MINUTES)),
+                Date.from(now.plus(365, ChronoUnit.DAYS)),
+                name,
+                keyPair.getPublic());
+        certificateBuilder.addExtension(Extension.subjectAlternativeName, false, new GeneralNames(new GeneralName[] {
+                new GeneralName(GeneralName.dNSName, "localhost"),
+                new GeneralName(GeneralName.iPAddress, "127.0.0.1")
+        }));
+
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .build(keyPair.getPrivate());
+        X509Certificate certificate = new JcaX509CertificateConverter()
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .getCertificate(certificateBuilder.build(signer));
+
+        char[] password = new char[0];
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        keyStore.load(null, password);
+        keyStore.setKeyEntry("floci-rds-postgres", keyPair.getPrivate(), password, new java.security.cert.Certificate[] {certificate});
+
+        KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        keyManagerFactory.init(keyStore, password);
+
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(keyManagerFactory.getKeyManagers(), null, new SecureRandom());
+        return context;
     }
 
     private record StartupMessage(Socket socket, String username, String database) {}

--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandler.java
@@ -42,6 +42,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Handles the PostgreSQL wire protocol auth intercept.
@@ -628,10 +629,17 @@ public class PostgresProtocolHandler {
             closeQuietly(backend);
             return;
         }
+        AtomicBoolean closed = new AtomicBoolean();
+        Runnable closeBoth = () -> {
+            if (closed.compareAndSet(false, true)) {
+                closeQuietly(client);
+                closeQuietly(backend);
+            }
+        };
         Thread t1 = Thread.ofVirtual().name("rds-pg-c2b")
-                .start(() -> relay(clientIn, backendOut));
+                .start(() -> relay(clientIn, backendOut, closeBoth));
         Thread t2 = Thread.ofVirtual().name("rds-pg-b2c")
-                .start(() -> relay(backendIn, clientOut));
+                .start(() -> relay(backendIn, clientOut, closeBoth));
         try {
             t1.join();
             t2.join();
@@ -643,7 +651,7 @@ public class PostgresProtocolHandler {
         }
     }
 
-    private static void relay(InputStream from, OutputStream to) {
+    private static void relay(InputStream from, OutputStream to, Runnable onDone) {
         try {
             byte[] buf = new byte[8192];
             int n;
@@ -651,7 +659,10 @@ public class PostgresProtocolHandler {
                 to.write(buf, 0, n);
                 to.flush();
             }
-        } catch (IOException ignored) {}
+        } catch (IOException ignored) {
+        } finally {
+            onDone.run();
+        }
     }
 
     // ── Error response ────────────────────────────────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandler.java
@@ -1,44 +1,22 @@
 package io.github.hectorvent.floci.services.rds.proxy;
 
 import org.jboss.logging.Logger;
-import org.bouncycastle.asn1.x500.X500Name;
-import org.bouncycastle.asn1.x509.Extension;
-import org.bouncycastle.asn1.x509.GeneralName;
-import org.bouncycastle.asn1.x509.GeneralNames;
-import org.bouncycastle.cert.X509v3CertificateBuilder;
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.operator.ContentSigner;
-import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 
 import javax.crypto.Mac;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocket;
 import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.math.BigInteger;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.KeyStore;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
-import java.security.Security;
-import java.security.cert.X509Certificate;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -64,7 +42,6 @@ public class PostgresProtocolHandler {
 
     private static final int SSL_REQUEST_CODE = 80877103;
     private static final int STARTUP_PROTOCOL_VERSION = 196608; // v3.0
-    private static volatile SSLContext serverSslContext;
 
     public static void handleAuth(Socket client, Socket backend,
                                   String masterUsername, String masterPassword, String dbName,
@@ -180,9 +157,8 @@ public class PostgresProtocolHandler {
             int proto = readInt32(in);
 
             if (proto == SSL_REQUEST_CODE) {
-                out.write('S');
+                out.write('N');
                 out.flush();
-                currentSocket = acceptSsl(currentSocket);
                 continue;
             }
 
@@ -198,76 +174,6 @@ public class PostgresProtocolHandler {
                     params.getOrDefault("user", "postgres"),
                     params.get("database"));
         }
-    }
-
-    static Socket acceptSsl(Socket socket) throws IOException {
-        try {
-            SSLSocket sslSocket = (SSLSocket) serverSslContext().getSocketFactory()
-                    .createSocket(socket, socket.getInetAddress().getHostAddress(), socket.getPort(), true);
-            sslSocket.setUseClientMode(false);
-            sslSocket.startHandshake();
-            return sslSocket;
-        } catch (Exception e) {
-            throw new IOException("Unable to negotiate PostgreSQL SSL", e);
-        }
-    }
-
-    private static SSLContext serverSslContext() throws Exception {
-        SSLContext context = serverSslContext;
-        if (context != null) {
-            return context;
-        }
-        synchronized (PostgresProtocolHandler.class) {
-            context = serverSslContext;
-            if (context == null) {
-                context = createServerSslContext();
-                serverSslContext = context;
-            }
-            return context;
-        }
-    }
-
-    private static SSLContext createServerSslContext() throws Exception {
-        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
-            Security.addProvider(new BouncyCastleProvider());
-        }
-
-        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
-        generator.initialize(2048, new SecureRandom());
-        KeyPair keyPair = generator.generateKeyPair();
-        Instant now = Instant.now();
-
-        X500Name name = new X500Name("CN=localhost");
-        X509v3CertificateBuilder certificateBuilder = new JcaX509v3CertificateBuilder(
-                name,
-                new BigInteger(128, new SecureRandom()),
-                Date.from(now.minus(1, ChronoUnit.MINUTES)),
-                Date.from(now.plus(365, ChronoUnit.DAYS)),
-                name,
-                keyPair.getPublic());
-        certificateBuilder.addExtension(Extension.subjectAlternativeName, false, new GeneralNames(new GeneralName[] {
-                new GeneralName(GeneralName.dNSName, "localhost"),
-                new GeneralName(GeneralName.iPAddress, "127.0.0.1")
-        }));
-
-        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
-                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
-                .build(keyPair.getPrivate());
-        X509Certificate certificate = new JcaX509CertificateConverter()
-                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
-                .getCertificate(certificateBuilder.build(signer));
-
-        char[] password = new char[0];
-        KeyStore keyStore = KeyStore.getInstance("PKCS12");
-        keyStore.load(null, password);
-        keyStore.setKeyEntry("floci-rds-postgres", keyPair.getPrivate(), password, new java.security.cert.Certificate[] {certificate});
-
-        KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-        keyManagerFactory.init(keyStore, password);
-
-        SSLContext context = SSLContext.getInstance("TLS");
-        context.init(keyManagerFactory.getKeyManagers(), null, new SecureRandom());
-        return context;
     }
 
     private record StartupMessage(Socket socket, String username, String database) {}

--- a/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java
@@ -15,6 +15,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.security.cert.X509Certificate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -146,7 +151,7 @@ class PostgresProtocolHandlerTest {
     }
 
     @Test
-    void declinesPostgresSslRequestAndContinuesStartup() throws Exception {
+    void acceptsPostgresSslRequestAndContinuesStartup() throws Exception {
         AtomicReference<String> backendDatabase = new AtomicReference<>();
 
         try (ServerSocket backendServer = new ServerSocket(0);
@@ -182,7 +187,13 @@ class PostgresProtocolHandlerTest {
                 DataInputStream clientIn = new DataInputStream(ourClient.getInputStream());
 
                 writeSslRequest(clientOut);
-                assertEquals('N', clientIn.readUnsignedByte());
+                assertEquals('S', clientIn.readUnsignedByte());
+
+                SSLSocket sslClient = trustedClientSocket(ourClient);
+                sslClient.startHandshake();
+                clientOut = new DataOutputStream(sslClient.getOutputStream());
+                clientIn = new DataInputStream(sslClient.getInputStream());
+
                 writeStartup(clientOut, "dbadmin", "auth_db");
                 readCleartextPasswordChallenge(clientIn);
                 writePassword(clientOut, "adminpass");
@@ -354,6 +365,26 @@ class PostgresProtocolHandlerTest {
         out.writeInt(8);
         out.writeInt(SSL_REQUEST_CODE);
         out.flush();
+    }
+
+    private static SSLSocket trustedClientSocket(Socket socket) throws Exception {
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(null, new TrustManager[] {new X509TrustManager() {
+            @Override
+            public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+
+            @Override
+            public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+            }
+        }}, null);
+        SSLSocket sslSocket = (SSLSocket) context.getSocketFactory()
+                .createSocket(socket, socket.getInetAddress().getHostAddress(), socket.getPort(), true);
+        sslSocket.setUseClientMode(true);
+        return sslSocket;
     }
 
     private static void writePassword(DataOutputStream out, String password) throws IOException {

--- a/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java
@@ -5,10 +5,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocket;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -16,12 +12,8 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
-import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -154,49 +146,59 @@ class PostgresProtocolHandlerTest {
     }
 
     @Test
-    void acceptsPostgresSslRequestAndUpgradesSocket() throws Exception {
-        ArrayBlockingQueue<Integer> serverRead = new ArrayBlockingQueue<>(1);
+    void declinesPostgresSslRequestAndContinuesStartup() throws Exception {
+        AtomicReference<String> backendDatabase = new AtomicReference<>();
 
-        try (ServerSocket server = new ServerSocket(0)) {
-            Thread.ofVirtual().start(() -> {
-                try (Socket accepted = server.accept()) {
-                    DataInputStream in = new DataInputStream(accepted.getInputStream());
-                    DataOutputStream out = new DataOutputStream(accepted.getOutputStream());
-                    assertEquals(8, in.readInt());
-                    assertEquals(SSL_REQUEST_CODE, in.readInt());
+        try (ServerSocket backendServer = new ServerSocket(0);
+             ServerSocket clientServer = new ServerSocket(0)) {
 
-                    out.writeByte('S');
-                    out.flush();
-                    Socket sslSocket = PostgresProtocolHandler.acceptSsl(accepted);
-                    serverRead.add(sslSocket.getInputStream().read());
-                    sslSocket.getOutputStream().write(99);
-                    sslSocket.getOutputStream().flush();
-                    sslSocket.close();
-                } catch (Exception e) {
-                    serverRead.add(-1);
+            int backendPort = backendServer.getLocalPort();
+            Thread backendThread = Thread.ofVirtual().start(() -> {
+                try {
+                    mockBackendStartup(backendServer, backendDatabase, false);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
                 }
             });
 
-            try (Socket rawClient = new Socket("localhost", server.getLocalPort())) {
-                DataOutputStream out = new DataOutputStream(rawClient.getOutputStream());
-                DataInputStream in = new DataInputStream(rawClient.getInputStream());
-                out.writeInt(8);
-                out.writeInt(SSL_REQUEST_CODE);
-                out.flush();
-                assertEquals('S', in.readUnsignedByte());
+            Socket proxyClient;
+            try (Socket ourClient = new Socket("localhost", clientServer.getLocalPort())) {
+                proxyClient = clientServer.accept();
+                Socket backend = new Socket("localhost", backendPort);
 
-                SSLSocket sslClient = (SSLSocket) trustAllContext().getSocketFactory()
-                        .createSocket(rawClient, "localhost", server.getLocalPort(), true);
-                sslClient.setUseClientMode(true);
-                sslClient.startHandshake();
-                sslClient.getOutputStream().write(42);
-                sslClient.getOutputStream().flush();
-                assertEquals(99, sslClient.getInputStream().read());
-                sslClient.close();
+                Thread authThread = Thread.ofVirtual().start(() -> {
+                    try {
+                        PostgresProtocolHandler.handleAuth(
+                                proxyClient, backend,
+                                "dbadmin", "adminpass", "postgres",
+                                false, testSigV4Validator(),
+                                (user, pass) -> true);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+
+                DataOutputStream clientOut = new DataOutputStream(ourClient.getOutputStream());
+                DataInputStream clientIn = new DataInputStream(ourClient.getInputStream());
+
+                writeSslRequest(clientOut);
+                assertEquals('N', clientIn.readUnsignedByte());
+                writeStartup(clientOut, "dbadmin", "auth_db");
+                readCleartextPasswordChallenge(clientIn);
+                writePassword(clientOut, "adminpass");
+                readAuthenticationOk(clientIn);
+                readReadyForQuery(clientIn);
+
+                ourClient.close();
+                proxyClient.close();
+                authThread.join(5_000);
+                backendThread.join(5_000);
+                assertEquals(false, authThread.isAlive(), "authThread did not terminate");
+                assertEquals(false, backendThread.isAlive(), "backendThread did not terminate");
             }
-        }
 
-        assertEquals(42, serverRead.poll(5, TimeUnit.SECONDS));
+            assertEquals("auth_db", backendDatabase.get());
+        }
     }
 
     @Test
@@ -348,6 +350,12 @@ class PostgresProtocolHandlerTest {
         out.flush();
     }
 
+    private static void writeSslRequest(DataOutputStream out) throws IOException {
+        out.writeInt(8);
+        out.writeInt(SSL_REQUEST_CODE);
+        out.flush();
+    }
+
     private static void writePassword(DataOutputStream out, String password) throws IOException {
         byte[] pw = password.getBytes(StandardCharsets.UTF_8);
         out.writeByte('p');
@@ -432,20 +440,4 @@ class PostgresProtocolHandlerTest {
         return params;
     }
 
-    private static SSLContext trustAllContext() throws Exception {
-        SSLContext context = SSLContext.getInstance("TLS");
-        context.init(null, new TrustManager[] {new X509TrustManager() {
-            @Override
-            public void checkClientTrusted(X509Certificate[] chain, String authType) {}
-
-            @Override
-            public void checkServerTrusted(X509Certificate[] chain, String authType) {}
-
-            @Override
-            public X509Certificate[] getAcceptedIssuers() {
-                return new X509Certificate[0];
-            }
-        }}, new SecureRandom());
-        return context;
-    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java
@@ -199,6 +199,56 @@ class PostgresProtocolHandlerTest {
         assertEquals(42, serverRead.poll(5, TimeUnit.SECONDS));
     }
 
+    @Test
+    void closesClientWhenBackendClosesDuringBridge() throws Exception {
+        try (ServerSocket backendServer = new ServerSocket(0);
+             ServerSocket clientServer = new ServerSocket(0)) {
+
+            Thread backendThread = Thread.ofVirtual().start(() -> {
+                try {
+                    mockBackendClosesDuringBridge(backendServer);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            try (Socket ourClient = new Socket("localhost", clientServer.getLocalPort())) {
+                ourClient.setSoTimeout(5_000);
+                Socket proxyClient = clientServer.accept();
+                Socket backend = new Socket("localhost", backendServer.getLocalPort());
+
+                Thread authThread = Thread.ofVirtual().start(() -> {
+                    try {
+                        PostgresProtocolHandler.handleAuth(
+                                proxyClient, backend,
+                                "dbadmin", "adminpass", "postgres",
+                                false, testSigV4Validator(),
+                                (user, pass) -> true);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+
+                DataOutputStream clientOut = new DataOutputStream(ourClient.getOutputStream());
+                DataInputStream clientIn = new DataInputStream(ourClient.getInputStream());
+
+                writeStartup(clientOut, "dbadmin", "auth_db");
+                readCleartextPasswordChallenge(clientIn);
+                writePassword(clientOut, "adminpass");
+                readAuthenticationOk(clientIn);
+                readReadyForQuery(clientIn);
+
+                writeSimpleQuery(clientOut, "select 1");
+
+                assertEquals(-1, clientIn.read(), "backend close must be visible to the client");
+                authThread.join(5_000);
+                backendThread.join(5_000);
+                assertEquals(false, authThread.isAlive(), "authThread did not terminate");
+                assertEquals(false, backendThread.isAlive(), "backendThread did not terminate");
+            }
+        }
+    }
+
     private static RdsSigV4Validator testSigV4Validator() {
         return new RdsSigV4Validator(IamServiceTestHelper.iamServiceWithAccessKey("AKIATEST", "secret"));
     }
@@ -240,6 +290,39 @@ class PostgresProtocolHandlerTest {
         }
     }
 
+    private static void mockBackendClosesDuringBridge(ServerSocket server) throws IOException {
+        try (Socket socket = server.accept()) {
+            DataInputStream in = new DataInputStream(socket.getInputStream());
+            DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+
+            int length = in.readInt();
+            int proto = in.readInt();
+            assertEquals(STARTUP_PROTOCOL_VERSION, proto);
+            in.readNBytes(length - 8);
+
+            out.writeByte('R');
+            out.writeInt(8);
+            out.writeInt(3);
+            out.flush();
+
+            assertEquals('p', in.readByte());
+            int pwLength = in.readInt();
+            in.readNBytes(pwLength - 4);
+
+            out.writeByte('R');
+            out.writeInt(8);
+            out.writeInt(0);
+            out.writeByte('Z');
+            out.writeInt(5);
+            out.writeByte('I');
+            out.flush();
+
+            assertEquals('Q', in.readByte());
+            int queryLength = in.readInt();
+            in.readNBytes(queryLength - 4);
+        }
+    }
+
     private static void writeStartup(DataOutputStream out, String user, String database) throws IOException {
         byte[] userKey = "user".getBytes(StandardCharsets.UTF_8);
         byte[] userVal = user.getBytes(StandardCharsets.UTF_8);
@@ -270,6 +353,15 @@ class PostgresProtocolHandlerTest {
         out.writeByte('p');
         out.writeInt(4 + pw.length + 1);
         out.write(pw);
+        out.writeByte(0);
+        out.flush();
+    }
+
+    private static void writeSimpleQuery(DataOutputStream out, String query) throws IOException {
+        byte[] queryBytes = query.getBytes(StandardCharsets.UTF_8);
+        out.writeByte('Q');
+        out.writeInt(4 + queryBytes.length + 1);
+        out.write(queryBytes);
         out.writeByte(0);
         out.flush();
     }


### PR DESCRIPTION
## Summary
- close postgres proxy bridge relays cleanly on exit
- decline standalone Postgres SSL negotiation with the expected protocol response
- support Postgres SSL startup before forwarding startup/auth messages to the backend

## Verification
- ./mvnw -Dtest=PostgresProtocolHandlerTest,RdsQueryHandlerTest,RdsServiceTest test
