### PR TITLE
feat(cloudtrail): support empty lookup events

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailJsonHandler.java
@@ -35,7 +35,7 @@ public class CloudTrailJsonHandler {
             case "DeleteTrail" -> deleteTrail(request, region);
             case "GetTrailStatus" -> getTrailStatus(request, region);
             case "PutEventSelectors" -> putEventSelectors(request, region);
-            case "LookupEvents" -> lookupEvents();
+            case "LookupEvents" -> lookupEvents(request, region);
             default -> throw new AwsException("UnsupportedOperation",
                     "Operation " + action + " is not supported.", 400);
         };
@@ -103,7 +103,7 @@ public class CloudTrailJsonHandler {
         return Response.ok(mapper.createObjectNode()).build();
     }
 
-    private Response lookupEvents() {
+    private Response lookupEvents(JsonNode request, String region) {
         ObjectNode response = mapper.createObjectNode();
         response.putArray("Events");
         return Response.ok(response).build();

--- a/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailJsonHandler.java
@@ -35,6 +35,7 @@ public class CloudTrailJsonHandler {
             case "DeleteTrail" -> deleteTrail(request, region);
             case "GetTrailStatus" -> getTrailStatus(request, region);
             case "PutEventSelectors" -> putEventSelectors(request, region);
+            case "LookupEvents" -> lookupEvents();
             default -> throw new AwsException("UnsupportedOperation",
                     "Operation " + action + " is not supported.", 400);
         };
@@ -100,6 +101,12 @@ public class CloudTrailJsonHandler {
     private Response putEventSelectors(JsonNode request, String region) {
         service.putEventSelectors(region, request.path("TrailName").asText(null));
         return Response.ok(mapper.createObjectNode()).build();
+    }
+
+    private Response lookupEvents() {
+        ObjectNode response = mapper.createObjectNode();
+        response.putArray("Events");
+        return Response.ok(response).build();
     }
 
     private ObjectNode trailNode(CloudTrailTrail trail) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailIntegrationTest.java
@@ -166,6 +166,26 @@ class CloudTrailIntegrationTest {
     }
 
     @Test
+    void lookupEventsReturnsEmptyEventPage() {
+        given()
+                .header("X-Amz-Target", TARGET_PREFIX + "LookupEvents")
+                .contentType(CONTENT_TYPE)
+                .body("""
+                        {
+                            "LookupAttributes": [
+                                {"AttributeKey": "EventName", "AttributeValue": "CreateBucket"}
+                            ],
+                            "MaxResults": 10
+                        }
+                        """)
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200)
+                .body("Events", hasSize(0));
+    }
+
+    @Test
     void trailProvisioningLifecycleWorksWithBucketNotificationsAndQueuePolicy() {
         String bucket = "cloudtrail-audit-feed-bucket";
         String bucket2 = "cloudtrail-audit-feed-bucket-2";


### PR DESCRIPTION
## Summary
- add CloudTrail LookupEvents handling for SDK-compatible local calls
- return an empty Events page when Floci has no synthetic CloudTrail event history
- keep existing trail lifecycle behavior unchanged

## Verification
- ./mvnw -q -Dtest=CloudTrailIntegrationTest test