### PR TITLE
fix(ecs): register persisted model records for native-image reflection

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/EfsVolumeConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/EfsVolumeConfiguration.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.services.ecs.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 /**
  * The {@code efsVolumeConfiguration} of an ECS task-definition volume:
  * {@code {"fileSystemId": ..., "rootDirectory": ..., "transitEncryption": ...,
@@ -15,6 +17,7 @@ package io.github.hectorvent.floci.services.ecs.model;
  * {@code authorizationConfig} are modelled for RegisterTaskDefinition/DescribeTaskDefinition
  * round-trip fidelity (so Terraform sees no drift) but have no effect on the local mount.
  */
+@RegisterForReflection
 public record EfsVolumeConfiguration(
         String fileSystemId,
         String rootDirectory,

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/KeyValuePair.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/KeyValuePair.java
@@ -1,4 +1,7 @@
 package io.github.hectorvent.floci.services.ecs.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public record KeyValuePair(String name, String value) {
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/MountPoint.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/MountPoint.java
@@ -1,10 +1,13 @@
 package io.github.hectorvent.floci.services.ecs.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 /**
  * A container mount point in an ECS container definition:
  * {@code {"sourceVolume": ..., "containerPath": ..., "readOnly": ...}}.
  * {@code sourceVolume} references a task-level {@link Volume} by name; the volume's
  * host source path is bind-mounted into the container at {@code containerPath}.
  */
+@RegisterForReflection
 public record MountPoint(String sourceVolume, String containerPath, boolean readOnly) {
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/NetworkBinding.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/NetworkBinding.java
@@ -1,4 +1,7 @@
 package io.github.hectorvent.floci.services.ecs.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public record NetworkBinding(String bindIP, int containerPort, int hostPort, String protocol) {
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/PortMapping.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/PortMapping.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.ecs.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public record PortMapping(int containerPort, int hostPort, String protocol) {
 
     public PortMapping(int containerPort) {

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/Volume.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/Volume.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.services.ecs.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 /**
  * A task-level volume in an ECS task definition. Two shapes are modelled:
  * <ul>
@@ -11,6 +13,7 @@ package io.github.hectorvent.floci.services.ecs.model;
  * The two are mutually exclusive. A container references the volume by {@code name} via a
  * {@link MountPoint}.
  */
+@RegisterForReflection
 public record Volume(String name, String hostSourcePath, EfsVolumeConfiguration efs) {
 
     /** Convenience constructor for a {@code host} volume (no EFS configuration). */


### PR DESCRIPTION
## Summary

ECS task-definition state is persisted to disk via `StorageBackedMap` / `HybridStorage` (since #1514). Several nested ECS model **records** lacked `@RegisterForReflection`, so in the GraalVM **native image** Jackson couldn't introspect them ("No serializer found for class ...PortMapping ... no properties discovered to create BeanSerializer") and the flush of `ecs-task-definitions.json` failed. This adds `@RegisterForReflection` to the six unregistered records (`PortMapping`, `KeyValuePair`, `MountPoint`, `Volume`, `EfsVolumeConfiguration`, `NetworkBinding`), matching the already-registered ECS classes and the repo-wide per-class convention.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Not a wire-protocol change. Incorrect behavior: running the **native** image with hybrid/persistent storage, registering a task definition with `portMappings` (or `environment`/`mountPoints`/EFS volumes) caused `HybridStorage` to fail writing `ecs-task-definitions.json` with a Jackson "no serializer found / no properties discovered" error, so ECS task definitions were lost across a restart. Works under the JVM (reflection always available); fails only in native.

## Checklist

- [ ] `./mvnw test` passes locally — `./mvnw compile` is clean; the change only adds native-image reflection metadata and is JVM-behavior-invariant. Real verification is a native build.
- [ ] New or updated integration test added — a JVM test cannot reproduce this (HotSpot always has reflection), which is exactly why it slipped past `EcsServicePersistenceTest` (InMemoryStorage). Guard is the native compat job; an optional JVM meta-test (assert every `ecs.model` record carries `@RegisterForReflection`) was noted but not added.
- [x] Commit messages follow Conventional Commits