### PR TITLE
fix(storage): flush persisted state before container teardown on shutdown

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
@@ -233,6 +233,12 @@ public class EmulatorLifecycle {
     }
 
     void onStop(@Observes ShutdownEvent ignored) {
+        // Flush persisted state to disk FIRST, before the slow proxy/container teardown below.
+        // Stopping Docker sidecars (RDS/ElastiCache/etc.) can block long enough to exhaust the
+        // SIGTERM grace window and trigger SIGKILL; if the flush ran last it would be skipped and
+        // in-memory (hybrid) data would be lost on an otherwise-graceful shutdown. shutdownAll()
+        // still runs at the end to stop the flush schedulers and capture any shutdown-time writes.
+        storageFactory.flushAll();
         if (config.services().ec2().enabled() && !config.services().ec2().mock()) {
             ec2MetadataServer.stop();
         }

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
@@ -266,6 +266,22 @@ class EmulatorLifecycleTest {
     }
 
     @Test
+    @DisplayName("onStop flushes storage BEFORE the slow container teardown, and shuts it down last")
+    void shouldFlushStorageBeforeContainerTeardown() {
+        emulatorLifecycle.onStop(Mockito.mock(ShutdownEvent.class));
+
+        // The disk flush must run before the blocking Docker container teardown so a graceful
+        // shutdown can't be cut off by the SIGTERM grace window before data is persisted
+        // (regression guard for issue #1521). shutdownAll() still runs last to stop the flush
+        // schedulers and capture any shutdown-time writes.
+        var inOrder = Mockito.inOrder(storageFactory, rdsContainerManager, elastiCacheContainerManager);
+        inOrder.verify(storageFactory).flushAll();
+        inOrder.verify(elastiCacheContainerManager).stopAll();
+        inOrder.verify(rdsContainerManager).stopAll();
+        inOrder.verify(storageFactory).shutdownAll();
+    }
+
+    @Test
     @DisplayName("Should still run full resource cleanup when a pre-shutdown hook fails")
     void shouldRunFullCleanupAfterFailingPreShutdownHook() throws IOException, InterruptedException {
         doThrow(new IOException("hook blew up")).when(initializationHooksRunner).run(InitializationHook.STOP);


### PR DESCRIPTION
## Summary

`EmulatorLifecycle.onStop` flushed persisted storage **last**, after stopping all the Docker sidecar containers (RDS/ElastiCache/MemoryDB/DocDB/Neptune). That teardown is slow and blocking, so on a graceful `docker compose down` / `docker stop` it can exhaust the SIGTERM grace window and trigger SIGKILL before the flush runs — losing buffered `hybrid`-mode data (e.g. an ECS cluster created seconds earlier). This moves `storageFactory.flushAll()` to the **start** of `onStop`, before the teardown, and keeps `shutdownAll()` at the end (stop schedulers + final flush). Adds an `EmulatorLifecycle` ordering-guard test. 

Note: hard kills (`docker rm -f` = SIGKILL) bypass every shutdown hook and are unaffected by design; durability against a hard kill requires `FLOCI_STORAGE_MODE=persistent`. Setting a persistent storage mode as the docker-compose default is intentionally out of scope for this PR.

Closes #1521

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Not a wire-protocol change. Incorrect behavior: with persistent/`hybrid` storage, a graceful shutdown while Docker-backed sidecars were running could kill the process before the storage flush, so recently-created state (reproduced with an ECS cluster) was missing after restart.

## Checklist

- [x] `./mvnw test` passes locally — `EmulatorLifecycleTest` green (17/17, incl. the new `shouldFlushStorageBeforeContainerTeardown` ordering guard)
- [x] New or updated integration test added — `EmulatorLifecycleTest` ordering guard verifying `flushAll()` runs before container teardown and `shutdownAll()` runs last
- [x] Commit messages follow Conventional Commits