### PR TITLE
test(autoscaling): fix flaky mixed-policy override assertion

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingIntegrationTest.java
@@ -745,7 +745,7 @@ class AutoScalingIntegrationTest {
                 .statusCode(200)
                 .body(containsString("UpdateAutoScalingGroupResponse"));
 
-        given()
+        String describeBody = given()
                 .formParam("Action", "DescribeAutoScalingGroups")
                 .formParam("AutoScalingGroupNames.member.1", "my-mixed-asg")
                 .header("Authorization", AUTH)
@@ -755,10 +755,17 @@ class AutoScalingIntegrationTest {
                 .statusCode(200)
                 .body(containsString("<Version>5</Version>"))
                 .body(containsString("<InstanceType>r7g.large</InstanceType>"))
-                .body(not(containsString("<InstanceType>t4g.medium</InstanceType>")))
                 .body(containsString("<OnDemandBaseCapacity>2</OnDemandBaseCapacity>"))
                 .body(containsString("<OnDemandPercentageAboveBaseCapacity>50</OnDemandPercentageAboveBaseCapacity>"))
-                .body(containsString("<SpotAllocationStrategy>price-capacity-optimized</SpotAllocationStrategy>"));
+                .body(containsString("<SpotAllocationStrategy>price-capacity-optimized</SpotAllocationStrategy>"))
+                .extract().asString();
+
+        // Scope the negative check to the policy overrides: a previously launched
+        // instance keeps its original instance type after a policy update (matching
+        // AWS), so t4g.medium may still appear under <Instances>.
+        String overrides = describeBody.substring(
+                describeBody.indexOf("<Overrides>"), describeBody.indexOf("</Overrides>"));
+        assertThat(overrides, not(containsString("<InstanceType>t4g.medium</InstanceType>")));
     }
 
     @Test


### PR DESCRIPTION
## Summary

`AutoScalingIntegrationTest.updateMixedInstancesPolicyOverridesAndDistribution` is flaky. After switching the mixed instances policy override to `r7g.large`, it asserted the `DescribeAutoScalingGroups` response contained **no** `<InstanceType>t4g.medium</InstanceType>` *anywhere*.

The background `AutoScalingReconciler` (fixed-rate, every 10s) may have already launched an instance under the original `t4g.medium` override. A running instance keeps its original instance type after a policy update — matching AWS behavior — and is rendered under `<Instances>`. Whether that instance exists at assert time depends purely on reconciler timing, so the whole-response check fails intermittently (observed on an unrelated PR's CI run).

## Fix

Scope the negative assertion to the `<Overrides>` block, so it verifies the *policy* was updated away from `t4g.medium` without being tripped by a previously launched instance legitimately retaining that type.

## Type of change

- [x] Bug fix (`fix:`) — test-only

## Checklist

- [x] `./mvnw test -Dtest=AutoScalingIntegrationTest` passes locally (35/35)
- [x] No production code changed