### PR TITLE
fix(ecs): honor task portMappings hostPort when launching containers

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManager.java
@@ -120,12 +120,18 @@ public class EcsContainerManager {
                 specBuilder.withMemoryMb(def.getMemory());
             }
 
-            // Add port mappings. Publish to host only in native mode; in Docker
-            // mode ECS consumers reach containers via the docker network IP.
+            // Add port mappings. An explicit hostPort is always published to the
+            // Docker host so the service is reachable at localhost:<hostPort>,
+            // matching AWS bridge mode (mirrors the ECR registry's fixed-port
+            // publishing). When no hostPort is requested, publish a dynamic host
+            // port in native mode; in Docker mode only expose the port, since ECS
+            // consumers reach containers via the docker network IP.
             if (def.getPortMappings() != null) {
                 boolean publishToHost = !containerDetector.isRunningInContainer();
                 for (PortMapping pm : def.getPortMappings()) {
-                    if (publishToHost) {
+                    if (pm.hostPort() > 0) {
+                        specBuilder.withPortBinding(pm.containerPort(), pm.hostPort());
+                    } else if (publishToHost) {
                         specBuilder.withDynamicPort(pm.containerPort());
                     } else {
                         specBuilder.withExposedPort(pm.containerPort());

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerPortMappingsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerPortMappingsTest.java
@@ -1,0 +1,131 @@
+package io.github.hectorvent.floci.services.ecs.container;
+
+import com.github.dockerjava.api.DockerClient;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
+import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
+import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
+import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
+import io.github.hectorvent.floci.services.ecs.model.EcsTask;
+import io.github.hectorvent.floci.services.ecs.model.PortMapping;
+import io.github.hectorvent.floci.services.ecs.model.TaskDefinition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for container {@code portMappings} handling in
+ * {@link EcsContainerManager#startTask} (regression coverage for issue #1270:
+ * ECS task portMappings were ignored when launching Docker containers).
+ *
+ * <p>An explicit {@code hostPort} is published as a fixed host port binding so
+ * the service is reachable at {@code localhost:<hostPort>}, in both native and
+ * in-container modes. When {@code hostPort} is 0/unset, the container gets a
+ * dynamic host port in native mode and is exposed-only when Floci runs inside
+ * Docker.
+ *
+ * <p>The container builder and lifecycle manager are mocked, so the test asserts
+ * the port arguments that <em>would</em> be handed to Docker without launching
+ * one — runnable under {@code mvn test} (CI) with no Docker daemon.
+ */
+class EcsContainerManagerPortMappingsTest {
+
+    private ContainerBuilder containerBuilder;
+    private ContainerBuilder.Builder builder;
+    private ContainerLifecycleManager lifecycleManager;
+    private ContainerDetector containerDetector;
+    private EcsContainerManager manager;
+
+    @BeforeEach
+    void setUp() {
+        builder = mock(ContainerBuilder.Builder.class, RETURNS_SELF);
+        containerBuilder = mock(ContainerBuilder.class);
+        when(containerBuilder.newContainer(anyString())).thenReturn(builder);
+
+        lifecycleManager = mock(ContainerLifecycleManager.class);
+        when(lifecycleManager.createAndStart(any()))
+                .thenReturn(new ContainerInfo("docker-id", Map.of()));
+        // resolveNetworkBindings() inspects the container after launch; deep stubs
+        // make the empty-binding readback (Map.get(...) -> null) NPE-free.
+        DockerClient dockerClient = mock(DockerClient.class, RETURNS_DEEP_STUBS);
+        when(lifecycleManager.getDockerClient()).thenReturn(dockerClient);
+
+        ContainerLogStreamer logStreamer = mock(ContainerLogStreamer.class);
+        containerDetector = mock(ContainerDetector.class);
+        EmulatorConfig config = mock(EmulatorConfig.class, RETURNS_DEEP_STUBS);
+        RegionResolver regionResolver = mock(RegionResolver.class);
+
+        manager = new EcsContainerManager(containerBuilder, lifecycleManager, logStreamer,
+                containerDetector, config, regionResolver);
+    }
+
+    private void startWith(List<PortMapping> portMappings) {
+        ContainerDefinition app = new ContainerDefinition();
+        app.setName("app");
+        app.setImage("app:latest");
+        app.setPortMappings(portMappings);
+
+        TaskDefinition taskDef = new TaskDefinition();
+        taskDef.setFamily("test-family");
+        taskDef.setContainerDefinitions(List.of(app));
+
+        EcsTask task = new EcsTask();
+        task.setTaskArn("arn:aws:ecs:us-east-1:000000000000:task/test-cluster/abc123");
+
+        manager.startTask(task, taskDef, List.of(), "us-east-1");
+    }
+
+    @Test
+    void explicitHostPortIsPublishedAsFixedBindingInNativeMode() {
+        when(containerDetector.isRunningInContainer()).thenReturn(false);
+
+        startWith(List.of(new PortMapping(5000, 5000, "tcp")));
+
+        // Regression guard for #1270: the requested hostPort must be honored,
+        // not replaced by a dynamic (random) host port.
+        verify(builder, times(1)).withPortBinding(5000, 5000);
+        verify(builder, never()).withDynamicPort(5000);
+        verify(builder, never()).withExposedPort(5000);
+    }
+
+    @Test
+    void zeroHostPortUsesDynamicPortInNativeMode() {
+        when(containerDetector.isRunningInContainer()).thenReturn(false);
+
+        startWith(List.of(new PortMapping(8080))); // hostPort defaults to 0
+
+        verify(builder, times(1)).withDynamicPort(8080);
+        verify(builder, never()).withPortBinding(eq(8080), anyInt());
+    }
+
+    @Test
+    void inContainerModePublishesExplicitHostPortAndExposesDynamic() {
+        when(containerDetector.isRunningInContainer()).thenReturn(true);
+
+        startWith(List.of(
+                new PortMapping(5000, 5000, "tcp"), // explicit -> published in both modes
+                new PortMapping(9090)));            // dynamic -> exposed only when in-container
+
+        verify(builder, times(1)).withPortBinding(5000, 5000);
+        verify(builder, times(1)).withExposedPort(9090);
+        verify(builder, never()).withDynamicPort(9090);
+        verify(builder, never()).withPortBinding(eq(9090), anyInt());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1270. ECS task definitions can declare `portMappings` with an explicit `hostPort` (e.g. `containerPort: 5000, hostPort: 5000`). AWS bridge mode publishes that port so the app is reachable on the host at `localhost:5000`. Floci parsed the value correctly but **discarded it at launch**, so containers ran but were unreachable from the host.

`EcsContainerManager.startTask` always called:
- `withDynamicPort()` in native mode → a random host port, never the requested one; and
- `withExposedPort()` when Floci runs inside Docker → no host binding at all (`docker inspect` shows `"5000/tcp": null`, the exact symptom in the issue).

## Fix

Honor an explicit `hostPort` by binding it as a fixed host port via `withPortBinding(containerPort, hostPort)`, publishing to the Docker host in **both** native and in-container modes. This mirrors the existing ECR registry fixed-port publishing pattern (`EcrRegistryManager`), and the shared `ContainerLifecycleManager` already handles publishing (including the macOS Docker Desktop network-mode workaround).

A `hostPort` of `0`/unset keeps the prior behavior: dynamic host port in native mode, exposed-only when running inside Docker (ECS consumers reach the container via the docker network IP).

```java
if (pm.hostPort() > 0) {
    specBuilder.withPortBinding(pm.containerPort(), pm.hostPort());
} else if (publishToHost) {
    specBuilder.withDynamicPort(pm.containerPort());
} else {
    specBuilder.withExposedPort(pm.containerPort());
}
```

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

Matches AWS ECS bridge-mode behavior: an explicit `hostPort` is published on the host; an omitted/`0` `hostPort` gets a dynamically assigned host port.

## Known limitation / follow-up

TCP only. The PortMapping `protocol` field (udp) is not yet honored — the shared container infra (`ContainerSpec.portBindings` is `Map<Integer,Integer>`; `buildHostConfig` hardcodes `ExposedPort.tcp`) cannot express udp without a broader change across the 7+ container-based services. udp mappings still bind as tcp, as before this change.

## Testing

- New `EcsContainerManagerPortMappingsTest` (mocked builder, **no Docker daemon required**) covers all three branches, including the regression guard that an explicit `hostPort` produces `withPortBinding(5000, 5000)` and not a dynamic port.
- `./mvnw test -Dtest='EcsContainerManager*Test'` → 6/6 green.
- `./mvnw test -Dtest='EcsIntegrationTest,EcsLoadBalancersIntegrationTest,EcsJsonHandlerVolumesTest,EcsServicePersistenceTest,EcsLoadBalancerRegistrarTest'` → 55/55 green, no regressions.

End-to-end Docker verification (register a task def with `hostPort: 5000`, run the task, expect `0.0.0.0:5000->5000/tcp` and `http://localhost:5000` reachable) was not run locally in this environment.