### PR TITLE
fix(ec2): added timeout in manager test

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
@@ -49,6 +49,7 @@ import static org.mockito.Answers.RETURNS_SELF;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
@@ -202,7 +203,7 @@ class Ec2ContainerManagerTest {
         harness.manager.launch(instance, "ubuntu:24.04", null, "us-west-2");
         awaitUntil(() -> "running".equals(instance.getState().getName()), Duration.ofSeconds(2));
 
-        verify(harness.logStreamer).streamToCloudWatchLogs(
+        verify(harness.logStreamer, timeout(2000)).streamToCloudWatchLogs(
             any(String.class), any(String.class), eq("us-west-2"), eq(TEST_USER_DATA_OUTPUT)
         );
     }


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->
Follow up on PR #1474 
Fixed a bug in the unit test  `Ec2ContainerManagerTest::launchInstanceUserDataStreamToCloudWatch` 

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

The unit test `Ec2ContainerManagerTest::launchInstanceUserDataStreamToCloudWatch` was found to not pass when run individually. The test was verifying the mock before before the invokation `logStreamer.streamToCloudWatchLogs` was recorded.  Added a Mockito timeout to wait for the invokation to complete.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Note: Has rerun the Ec2ContainerManagerTest only, since it is a small change in the unit test file.