### PR TITLE
feat(cloudformation): apply S3 Bucket CorsConfiguration

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -1,6 +1,8 @@
 package io.github.hectorvent.floci.services.cloudformation;
 
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.AwsNamespaces;
+import io.github.hectorvent.floci.core.common.XmlBuilder;
 import io.github.hectorvent.floci.services.batch.BatchService;
 import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
 import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
@@ -462,6 +464,7 @@ public class CloudFormationResourceProvisioner {
             bucketName = generatePhysicalName(stackName, r.getLogicalId(), 63, true);
         }
         s3Service.createBucket(bucketName, region);
+        applyBucketCorsConfiguration(bucketName, props, engine);
         r.setPhysicalId(bucketName);
         r.getAttributes().put("Arn", AwsArnUtils.Arn.of("s3", "", "", bucketName).toString());
         r.getAttributes().put("DomainName", bucketName + ".s3.amazonaws.com");
@@ -470,7 +473,54 @@ public class CloudFormationResourceProvisioner {
         r.getAttributes().put("BucketName", bucketName);
     }
 
-    // ── SQS ───────────────────────────────────────────────────────────────────
+    /**
+     * Applies the optional {@code CorsConfiguration} property of {@code AWS::S3::Bucket} by translating
+     * the CloudFormation {@code CorsRules} list into the S3 CORS XML document the bucket stores and
+     * serves from its {@code ?cors} subresource.
+     *
+     * <p>This reconciles to the template on every provision (create and update): when the property is
+     * absent or has no rules, any existing CORS configuration is cleared so the bucket matches the
+     * template. Clearing is a harmless no-op on create since a freshly created bucket has none.
+     */
+    private void applyBucketCorsConfiguration(String bucketName, JsonNode props,
+                                              CloudFormationTemplateEngine engine) {
+        JsonNode corsRules = null;
+        if (props != null && props.has("CorsConfiguration") && !props.get("CorsConfiguration").isNull()) {
+            corsRules = props.get("CorsConfiguration").get("CorsRules");
+        }
+        if (corsRules == null || !corsRules.isArray() || corsRules.isEmpty()) {
+            s3Service.deleteBucketCors(bucketName);
+            return;
+        }
+        XmlBuilder xml = new XmlBuilder().start("CORSConfiguration", AwsNamespaces.S3);
+        for (JsonNode rule : corsRules) {
+            xml.start("CORSRule");
+            xml.elem("ID", resolveOptional(rule, "Id", engine));
+            appendCorsRuleElements(xml, rule.get("AllowedHeaders"), "AllowedHeader", engine);
+            appendCorsRuleElements(xml, rule.get("AllowedMethods"), "AllowedMethod", engine);
+            appendCorsRuleElements(xml, rule.get("AllowedOrigins"), "AllowedOrigin", engine);
+            appendCorsRuleElements(xml, rule.get("ExposedHeaders"), "ExposeHeader", engine);
+            String maxAge = resolveOptional(rule, "MaxAge", engine);
+            if (maxAge != null && !maxAge.isBlank()) {
+                xml.elem("MaxAgeSeconds", maxAge);
+            }
+            xml.end("CORSRule");
+        }
+        xml.end("CORSConfiguration");
+        s3Service.putBucketCors(bucketName, xml.build());
+    }
+
+    private void appendCorsRuleElements(XmlBuilder xml, JsonNode values, String elementName,
+                                        CloudFormationTemplateEngine engine) {
+        if (values == null || !values.isArray()) {
+            return;
+        }
+        for (JsonNode value : values) {
+            if (value != null && !value.isNull()) {
+                xml.elem(elementName, engine.resolve(value));
+            }
+        }
+    }
 
     private void provisionSqsQueue(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
                                    String region, String accountId, String stackName) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -517,7 +517,10 @@ public class CloudFormationResourceProvisioner {
         }
         for (JsonNode value : values) {
             if (value != null && !value.isNull()) {
-                xml.elem(elementName, engine.resolve(value));
+                String resolved = engine.resolve(value);
+                if (resolved != null && !resolved.isBlank()) {
+                    xml.elem(elementName, resolved);
+                }
             }
         }
     }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -225,6 +225,51 @@ class CloudFormationIntegrationTest {
     }
 
     @Test
+    void createStack_s3BucketCorsConfigurationSkipsBlankListValues() {
+        String template = """
+            {
+              "Resources": {
+                "MyBucket": {
+                  "Type": "AWS::S3::Bucket",
+                  "Properties": {
+                    "BucketName": "cfn-cors-blank-bucket",
+                    "CorsConfiguration": {
+                      "CorsRules": [
+                        {
+                          "AllowedHeaders": ["x-real-header", ""],
+                          "AllowedMethods": ["GET"],
+                          "AllowedOrigins": ["https://app.example.com"]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-cors-blank-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        // A blank list entry must be skipped rather than emitted as an empty (invalid) element.
+        given()
+        .when()
+            .get("/cfn-cors-blank-bucket?cors")
+        .then()
+            .statusCode(200)
+            .body(containsString("<AllowedHeader>x-real-header</AllowedHeader>"))
+            .body(not(containsString("<AllowedHeader></AllowedHeader>")));
+    }
+
+    @Test
     void updateStack_s3BucketCorsConfigurationIsReconciled() {
         String stackName = "cfn-cors-update-stack";
         String bucketName = "cfn-cors-update-bucket";

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -171,6 +171,172 @@ class CloudFormationIntegrationTest {
     }
 
     @Test
+    void createStack_s3BucketWithCorsConfiguration() {
+        String template = """
+            {
+              "Resources": {
+                "MyBucket": {
+                  "Type": "AWS::S3::Bucket",
+                  "Properties": {
+                    "BucketName": "cfn-cors-test-bucket",
+                    "CorsConfiguration": {
+                      "CorsRules": [
+                        {
+                          "Id": "allow-app",
+                          "AllowedHeaders": ["*"],
+                          "AllowedMethods": ["GET", "PUT"],
+                          "AllowedOrigins": ["https://app.example.com"],
+                          "ExposedHeaders": ["x-amz-request-id"],
+                          "MaxAge": 3000
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-cors-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        // The bucket's ?cors subresource should reflect the CloudFormation CorsConfiguration.
+        given()
+        .when()
+            .get("/cfn-cors-test-bucket?cors")
+        .then()
+            .statusCode(200)
+            .body(containsString("<CORSRule>"))
+            .body(containsString("<ID>allow-app</ID>"))
+            .body(containsString("<AllowedMethod>GET</AllowedMethod>"))
+            .body(containsString("<AllowedMethod>PUT</AllowedMethod>"))
+            .body(containsString("<AllowedOrigin>https://app.example.com</AllowedOrigin>"))
+            .body(containsString("<AllowedHeader>*</AllowedHeader>"))
+            .body(containsString("<ExposeHeader>x-amz-request-id</ExposeHeader>"))
+            .body(containsString("<MaxAgeSeconds>3000</MaxAgeSeconds>"));
+    }
+
+    @Test
+    void updateStack_s3BucketCorsConfigurationIsReconciled() {
+        String stackName = "cfn-cors-update-stack";
+        String bucketName = "cfn-cors-update-bucket";
+        String withCors = """
+            {
+              "Resources": {
+                "MyBucket": {
+                  "Type": "AWS::S3::Bucket",
+                  "Properties": {
+                    "BucketName": "%s",
+                    "CorsConfiguration": {
+                      "CorsRules": [
+                        {
+                          "AllowedMethods": ["GET"],
+                          "AllowedOrigins": ["https://old.example.com"]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+            """.formatted(bucketName);
+        String changedCors = """
+            {
+              "Resources": {
+                "MyBucket": {
+                  "Type": "AWS::S3::Bucket",
+                  "Properties": {
+                    "BucketName": "%s",
+                    "CorsConfiguration": {
+                      "CorsRules": [
+                        {
+                          "AllowedMethods": ["POST"],
+                          "AllowedOrigins": ["https://new.example.com"]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+            """.formatted(bucketName);
+        String withoutCors = """
+            {
+              "Resources": {
+                "MyBucket": {
+                  "Type": "AWS::S3::Bucket",
+                  "Properties": {
+                    "BucketName": "%s"
+                  }
+                }
+              }
+            }
+            """.formatted(bucketName);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", withCors)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + bucketName + "?cors")
+        .then()
+            .statusCode(200)
+            .body(containsString("<AllowedOrigin>https://old.example.com</AllowedOrigin>"));
+
+        // Update: rules change → CORS document is replaced, no stale rule left behind.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "UpdateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", changedCors)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + bucketName + "?cors")
+        .then()
+            .statusCode(200)
+            .body(containsString("<AllowedOrigin>https://new.example.com</AllowedOrigin>"))
+            .body(not(containsString("https://old.example.com")));
+
+        // Update: property dropped → CORS is cleared, ?cors returns NoSuchCORSConfiguration.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "UpdateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", withoutCors)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + bucketName + "?cors")
+        .then()
+            .statusCode(404)
+            .body(containsString("NoSuchCORSConfiguration"));
+    }
+
+    @Test
     void createStack_lambdaWithS3Code() {
         byte[] zipBytes = buildHandlerZip();
 


### PR DESCRIPTION
## Summary

The CloudFormation provisioner created `AWS::S3::Bucket` resources but silently ignored the `CorsConfiguration` property, so a stack defining bucket CORS came up with no rules (`GET /<bucket>?cors` returned `NoSuchCORSConfiguration` and browser preflights were rejected).

This change translates `CorsConfiguration.CorsRules` into the S3 CORS document and applies it via the existing `S3Service` CORS API during provisioning. It reconciles to the template on both create and update:

- Property present with rules → writes the CORS document (replacing any prior one, so changed rules leave nothing stale).
- Property absent or emptied → clears CORS so the bucket matches the template (a harmless no-op on create).

No new resource type or endpoint is introduced. 
Note: CORS is a property of `AWS::S3::Bucket`. The work reuses the real S3 CORS contract (`PutBucketCors`/`GetBucketCors`/`DeleteBucketCors`).

## Related issue

Closes #1616

## Type of change

- [ ] Bug fix (`fix:` commit)
- [x] New feature (`feat:` commit)
- [ ] Breaking change (`feat!:` commit or `BREAKING CHANGE:` footer)
- [ ] Documentation or chore

## Checklist

- [x] `mvn verify` passes locally (requires Docker)
- [x] New or changed behaviour is covered by tests — added `createStack_s3BucketWithCorsConfiguration` (create) and `updateStack_s3BucketCorsConfigurationIsReconciled` (rule change + property removal)
- [x] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)