### PR TITLE
test(ssm): keep diagnostics fixture generic

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/ssm/SsmDirectCommandExecutorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssm/SsmDirectCommandExecutorTest.java
@@ -106,10 +106,7 @@ class SsmDirectCommandExecutorTest {
         assertTrue(command.contains("processes"));
         assertTrue(command.contains("/var/log/*.log"));
         assertTrue(command.contains("REDACTED"));
-        assertFalse(command.contains("airship"));
-        assertFalse(command.contains("iceguard"));
-        assertFalse(command.contains("trino"));
-        assertFalse(command.contains("coordinator"));
+        assertFalse(command.contains("grep"));
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #1529.\n\nThis removes consumer-specific names from the SSM direct diagnostics test fixture and keeps the assertion focused on generic behavior: diagnostics should not use fixed process-name grep patterns.\n\nVerification:\n- `./mvnw -q -Dtest=SsmDirectCommandExecutorTest test`\n- forbidden product-name scan over SSM production and test sources returned no remaining matches