### PR TITLE
fix(cloudwatch): return ResourceNotFound for SetAlarmState on missing alarm

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsService.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.cloudwatch.metrics;
 
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
@@ -266,7 +267,7 @@ public class CloudWatchMetricsService {
     public void setAlarmState(String alarmName, String stateValue, String stateReason, String stateReasonData, String region) {
         String key = region + "::" + alarmName;
         MetricAlarm alarm = alarmStore.get(key)
-                .orElseThrow(() -> new RuntimeException("Alarm not found: " + alarmName));
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException", "Alarm not found: " + alarmName, 400));
 
         alarm.setStateValue(stateValue);
         alarm.setStateReason(stateReason);

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsService.java
@@ -267,7 +267,7 @@ public class CloudWatchMetricsService {
     public void setAlarmState(String alarmName, String stateValue, String stateReason, String stateReasonData, String region) {
         String key = region + "::" + alarmName;
         MetricAlarm alarm = alarmStore.get(key)
-                .orElseThrow(() -> new AwsException("ResourceNotFound", "Alarm not found: " + alarmName, 400));
+                .orElseThrow(() -> new AwsException("ResourceNotFound", "Alarm not found: " + alarmName, 404));
 
         alarm.setStateValue(stateValue);
         alarm.setStateReason(stateReason);

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsService.java
@@ -267,7 +267,7 @@ public class CloudWatchMetricsService {
     public void setAlarmState(String alarmName, String stateValue, String stateReason, String stateReasonData, String region) {
         String key = region + "::" + alarmName;
         MetricAlarm alarm = alarmStore.get(key)
-                .orElseThrow(() -> new AwsException("ResourceNotFoundException", "Alarm not found: " + alarmName, 400));
+                .orElseThrow(() -> new AwsException("ResourceNotFound", "Alarm not found: " + alarmName, 400));
 
         alarm.setStateValue(stateValue);
         alarm.setStateReason(stateReason);

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsServiceTest.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.cloudwatch.metrics;
 
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.cloudwatch.metrics.model.Dimension;
@@ -227,6 +228,15 @@ class CloudWatchMetricsServiceTest {
         MetricAlarm updated = service.describeAlarms(List.of("my-alarm"), null, REGION).getFirst();
         assertEquals("ALARM", updated.getStateValue());
         assertEquals("Threshold breached", updated.getStateReason());
+    }
+
+    @Test
+    void setAlarmStateOnNonexistentAlarmThrowsResourceNotFound() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> service.setAlarmState("missing-alarm", "ALARM", "reason", null, REGION));
+
+        assertEquals(400, ex.getHttpStatus());
+        assertEquals("ResourceNotFoundException", ex.getErrorCode());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsServiceTest.java
@@ -235,7 +235,7 @@ class CloudWatchMetricsServiceTest {
         AwsException ex = assertThrows(AwsException.class,
                 () -> service.setAlarmState("missing-alarm", "ALARM", "reason", null, REGION));
 
-        assertEquals(400, ex.getHttpStatus());
+        assertEquals(404, ex.getHttpStatus());
         assertEquals("ResourceNotFound", ex.getErrorCode());
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsServiceTest.java
@@ -236,7 +236,7 @@ class CloudWatchMetricsServiceTest {
                 () -> service.setAlarmState("missing-alarm", "ALARM", "reason", null, REGION));
 
         assertEquals(400, ex.getHttpStatus());
-        assertEquals("ResourceNotFoundException", ex.getErrorCode());
+        assertEquals("ResourceNotFound", ex.getErrorCode());
     }
 
     @Test


### PR DESCRIPTION
## Summary

`SetAlarmState` on an alarm that does not exist now returns an AWS-shaped client error instead of an HTTP 500 with an empty body. Closes #1582.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Before this change, `CloudWatchMetricsService.setAlarmState` threw a generic `RuntimeException("Alarm not found: ...")` when the alarm key was absent. That exception propagated uncaught and the request returned HTTP 500 with no body, which no AWS SDK can interpret.

Real CloudWatch returns the `ResourceNotFound` error with HTTP 400 for this case (as reported and verified in #1582). The service now throws `AwsException("ResourceNotFound", "Alarm not found: <name>", 400)`, which the existing `AwsExceptionMapper` renders as the standard AWS error envelope across the JSON, CBOR, and Query paths. This mirrors how other services (Kinesis, CodeBuild, EventBridge) already signal not-found conditions. The success path is unchanged.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
