### PR TITLE
fix(dynamodb): return a null Message for non-failed item cancellation reason

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbConformanceChangesTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbConformanceChangesTest.java
@@ -7,14 +7,13 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValueUpdate;
 import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
-import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.BillingMode;
 import software.amazon.awssdk.services.dynamodb.model.ComparisonOperator;
 import software.amazon.awssdk.services.dynamodb.model.Condition;
+import software.amazon.awssdk.services.dynamodb.model.ConditionCheck;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
-import software.amazon.awssdk.services.dynamodb.model.ExpectedAttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
-import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.ExpectedAttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
 import software.amazon.awssdk.services.dynamodb.model.KeyType;
@@ -37,6 +36,8 @@ import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
 import software.amazon.awssdk.services.dynamodb.model.Select;
 import software.amazon.awssdk.services.dynamodb.model.Tag;
 import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem;
+import software.amazon.awssdk.services.dynamodb.model.TransactWriteItemsRequest;
+import software.amazon.awssdk.services.dynamodb.model.TransactionCanceledException;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
 
@@ -703,6 +704,35 @@ class DynamoDbConformanceChangesTest {
                 .conditionExpression("attribute_not_exists(pk)")
                 .expressionAttributeNames(Map.of("#st", "status"))))
                 .doesNotThrowAnyException();
+    }
+
+    // Reproduces #1604
+    @Test
+    @Order(102)
+    void transactWriteCancellationReasonNullMessageForNonFailedItems() {
+        ddb.putItem(r -> r.tableName(TABLE).item(Map.of("pk", av("cancel-A"), "sk", av("s"))));
+
+        TransactionCanceledException ex = (TransactionCanceledException) catchThrowable(() ->
+                ddb.transactWriteItems(TransactWriteItemsRequest.builder()
+                        .transactItems(
+                                TransactWriteItem.builder().conditionCheck(ConditionCheck.builder()
+                                        .tableName(TABLE)
+                                        .key(Map.of("pk", av("cancel-A"), "sk", av("s")))
+                                        .conditionExpression("attribute_exists(pk)")
+                                        .build()).build(),
+                                TransactWriteItem.builder().conditionCheck(ConditionCheck.builder()
+                                        .tableName(TABLE)
+                                        .key(Map.of("pk", av("cancel-B"), "sk", av("s")))
+                                        .conditionExpression("attribute_exists(pk)")
+                                        .build()).build())
+                        .build()));
+
+        assertThat(ex.cancellationReasons()).hasSize(2);
+
+        assertThat(ex.cancellationReasons().get(0).code()).isEqualTo("None");
+        assertThat(ex.cancellationReasons().get(0).message()).isNull();
+
+        assertThat(ex.cancellationReasons().get(1).code()).isEqualTo("ConditionalCheckFailed");
     }
 
     // -----------------------------------------------------------------------

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -1338,7 +1338,9 @@ public class DynamoDbJsonHandler {
             for (TransactionCanceledException.CancellationReason reason : e.getCancellationReasons()) {
                 ObjectNode r = objectMapper.createObjectNode();
                 r.put("Code", reason.code().isEmpty() ? "None" : reason.code());
-                r.put("Message", reason.code().isEmpty() ? null : "The conditional request failed");
+                if (!reason.code().isEmpty()) {
+                    r.put("Message", "The conditional request failed");
+                }
                 if (reason.item() != null) {
                     r.set("Item", reason.item());
                 }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -1,16 +1,15 @@
 package io.github.hectorvent.floci.services.dynamodb;
 
-import io.github.hectorvent.floci.core.common.AwsArnUtils;
-import io.github.hectorvent.floci.core.common.AwsErrorResponse;
-import io.github.hectorvent.floci.core.common.AwsException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.AwsErrorResponse;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.AwsJsonController;
 import io.github.hectorvent.floci.services.dynamodb.model.*;
 import io.github.hectorvent.floci.services.kinesis.KinesisService;
-import io.github.hectorvent.floci.services.dynamodb.TransactionCanceledException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -1339,7 +1338,7 @@ public class DynamoDbJsonHandler {
             for (TransactionCanceledException.CancellationReason reason : e.getCancellationReasons()) {
                 ObjectNode r = objectMapper.createObjectNode();
                 r.put("Code", reason.code().isEmpty() ? "None" : reason.code());
-                r.put("Message", reason.code().isEmpty() ? "" : "The conditional request failed");
+                r.put("Message", reason.code().isEmpty() ? null : "The conditional request failed");
                 if (reason.item() != null) {
                     r.set("Item", reason.item());
                 }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -2459,6 +2459,82 @@ given()
                 "Second page should return the remaining 1 item");
 
         // Cleanup
+        deleteTable(tableName);
+    }
+
+    // Reproduces #1604
+    @Test
+    void transactWriteCancellationReasonMessageIsNullForNonFailedItems() {
+        String tableName = "TxCancelMsgTest";
+
+        given()
+                .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+                .contentType(DYNAMODB_CONTENT_TYPE)
+                .body("""
+                        {
+                            "TableName": "%s",
+                            "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                            "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                            "BillingMode": "PAY_PER_REQUEST"
+                        }
+                        """.formatted(tableName))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+
+        given()
+                .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+                .contentType(DYNAMODB_CONTENT_TYPE)
+                .body("""
+                        {
+                            "TableName": "%s",
+                            "Item": {"pk": {"S": "A"}}
+                        }
+                        """.formatted(tableName))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+
+        // item 0 passes (A exists), item 1 fails (B absent)
+        given()
+                .header("X-Amz-Target", "DynamoDB_20120810.TransactWriteItems")
+                .contentType(DYNAMODB_CONTENT_TYPE)
+                .body("""
+                        {
+                            "TransactItems": [
+                                {
+                                    "ConditionCheck": {
+                                        "TableName": "%s",
+                                        "Key": {"pk": {"S": "A"}},
+                                        "ConditionExpression": "attribute_exists(pk)"
+                                    }
+                                },
+                                {
+                                    "ConditionCheck": {
+                                        "TableName": "%s",
+                                        "Key": {"pk": {"S": "B"}},
+                                        "ConditionExpression": "attribute_exists(pk)"
+                                    }
+                                }
+                            ]
+                        }
+                        """.formatted(tableName, tableName))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("TransactionCanceledException"))
+                .body("CancellationReasons[0].Code", equalTo("None"))
+                .body("CancellationReasons[0].Message", nullValue())
+                .body("CancellationReasons[1].Code", equalTo("ConditionalCheckFailed"));
+
+        // Cleanup
+        deleteTable(tableName);
+    }
+
+    private void deleteTable(String tableName) {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
             .contentType(DYNAMODB_CONTENT_TYPE)

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandlerTest.java
@@ -331,6 +331,6 @@ class DynamoDbJsonHandlerTest {
         assertEquals(2, reasons.size());
 
         assertEquals("None", reasons.get(0).get("Code").asText());
-        assertTrue(reasons.get(0).get("Message").isNull(), "non failed item must not have a non-null Message field");
+        assertNull(reasons.get(0).get("Message"), "non failed item must not have a Message field");
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandlerTest.java
@@ -1,17 +1,16 @@
 package io.github.hectorvent.floci.services.dynamodb;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.dynamodb.model.AttributeDefinition;
 import io.github.hectorvent.floci.services.dynamodb.model.KeySchemaElement;
 import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-
-import jakarta.ws.rs.core.Response;
 
 import java.util.List;
 
@@ -293,5 +292,45 @@ class DynamoDbJsonHandlerTest {
 
         assertNotNull(responseData);
         assertFalse(responseData.has("Attributes"), "Attributes property must not be present");
+    }
+
+    // Reproduces #1604
+    @Test
+    void transactWriteItemsCancellationReasonMessageIsNullForNonFailedItems() throws Exception {
+        createUsersTable("us-east-1");
+        service.putItem("Users", item("userId", "A"), "us-east-1");
+
+        ObjectNode condCheckA = mapper.createObjectNode();
+        condCheckA.put("TableName", "Users");
+        condCheckA.set("Key", item("userId", "A"));
+        condCheckA.put("ConditionExpression", "attribute_exists(userId)");
+
+        ObjectNode condCheckB = mapper.createObjectNode();
+        condCheckB.put("TableName", "Users");
+        condCheckB.set("Key", item("userId", "B"));
+        condCheckB.put("ConditionExpression", "attribute_exists(userId)");
+
+        ObjectNode txItemA = mapper.createObjectNode();
+        txItemA.set("ConditionCheck", condCheckA);
+        ObjectNode txItemB = mapper.createObjectNode();
+        txItemB.set("ConditionCheck", condCheckB);
+
+        ObjectNode request = mapper.createObjectNode();
+        ArrayNode txItems = request.putArray("TransactItems");
+        txItems.add(txItemA);
+        txItems.add(txItemB);
+
+        Response response = handler.handle("TransactWriteItems", request, "us-east-1");
+
+        assertEquals(400, response.getStatus());
+
+        JsonNode body = mapper.convertValue(response.getEntity(), JsonNode.class);
+        assertEquals("TransactionCanceledException", body.get("__type").asText());
+
+        ArrayNode reasons = (ArrayNode) body.get("CancellationReasons");
+        assertEquals(2, reasons.size());
+
+        assertEquals("None", reasons.get(0).get("Code").asText());
+        assertTrue(reasons.get(0).get("Message").isNull(), "non failed item must not have a non-null Message field");
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
@@ -46,7 +46,13 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Answers.RETURNS_SELF;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 class Ec2ContainerManagerTest {
 

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
@@ -46,12 +46,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Answers.RETURNS_SELF;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
+import static org.mockito.Mockito.*;
 
 class Ec2ContainerManagerTest {
 
@@ -202,7 +197,7 @@ class Ec2ContainerManagerTest {
         harness.manager.launch(instance, "ubuntu:24.04", null, "us-west-2");
         awaitUntil(() -> "running".equals(instance.getState().getName()), Duration.ofSeconds(2));
 
-        verify(harness.logStreamer).streamToCloudWatchLogs(
+        verify(harness.logStreamer, timeout(2000)).streamToCloudWatchLogs(
             any(String.class), any(String.class), eq("us-west-2"), eq(TEST_USER_DATA_OUTPUT)
         );
     }


### PR DESCRIPTION
## Summary

Closes #1604 

Summary:
- Add regression coverage for DynamoDB TransactWriteItems cancellation reasons
- Return a null Message field for non-failed items

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behaviour**: when a DynamoDB transaction is cancelled, non-failed transaction items should have CancellationReason code None and message == null. Instead floci returned an empty string `""` in the message field.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
