### PR TITLE
fix(s3,sns): preserve root service-host routing

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.core.common.AwsNamespaces;
 import io.github.hectorvent.floci.core.common.XmlBuilder;
 import io.github.hectorvent.floci.core.common.XmlParser;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.sns.SnsQueryHandler;
 import io.github.hectorvent.floci.services.s3.model.Bucket;
 import io.github.hectorvent.floci.services.s3.model.GetObjectAttributesParts;
 import io.github.hectorvent.floci.services.s3.model.GetObjectAttributesResult;
@@ -29,6 +30,7 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 import jakarta.ws.rs.core.UriInfo;
@@ -86,17 +88,20 @@ public class S3Controller {
     private final S3Service s3Service;
     private final S3SelectService s3SelectService;
     private final RegionResolver regionResolver;
+    private final SnsQueryHandler snsQueryHandler;
     private final io.quarkus.vertx.http.runtime.CurrentVertxRequest currentVertxRequest;
     private final io.github.hectorvent.floci.services.floci.ui.UiPages uiPages;
 
     @Inject
     public S3Controller(S3Service s3Service, S3SelectService s3SelectService,
                         RegionResolver regionResolver,
+                        SnsQueryHandler snsQueryHandler,
                         io.quarkus.vertx.http.runtime.CurrentVertxRequest currentVertxRequest,
                         io.github.hectorvent.floci.services.floci.ui.UiPages uiPages) {
         this.s3Service = s3Service;
         this.s3SelectService = s3SelectService;
         this.regionResolver = regionResolver;
+        this.snsQueryHandler = snsQueryHandler;
         this.currentVertxRequest = currentVertxRequest;
         this.uiPages = uiPages;
     }
@@ -106,9 +111,17 @@ public class S3Controller {
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.TEXT_HTML})
     public Response listBuckets(@HeaderParam("X-Amz-Target") String target,
-                                @HeaderParam("Accept") String accept) {
+                                @HeaderParam("Accept") String accept,
+                                @Context HttpHeaders httpHeaders,
+                                @Context UriInfo uriInfo) {
         if (target != null) {
             return null;
+        }
+        MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
+        String action = queryParams.getFirst("Action");
+        if ("ConfirmSubscription".equals(action)) {
+            String region = regionResolver.resolveRegion(httpHeaders);
+            return snsQueryHandler.handle(action, queryParams, region);
         }
         // A browser hitting the root endpoint (Accept: text/html) gets the Floci
         // landing page; SDK/CLI callers (no Accept, */*, or an XML/JSON Accept) fall

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.s3;
 
 import static io.github.hectorvent.floci.services.s3.S3RequestParser.hasQueryParam;
 
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.AwsNamespaces;
 import io.github.hectorvent.floci.core.common.XmlBuilder;
@@ -119,8 +120,16 @@ public class S3Controller {
         }
         MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
         String action = queryParams.getFirst("Action");
-        if ("ConfirmSubscription".equals(action)) {
-            String region = regionResolver.resolveRegion(httpHeaders);
+        // SNS emits SubscribeURL/UnsubscribeURL as plain GET links against the
+        // service root, which collides with the S3 ListBuckets endpoint. Delegate
+        // those confirmation/unsubscribe GETs to SNS before falling through to S3.
+        // The links are unsigned (no Authorization header), so the region must come
+        // from the region-bearing ARN they carry, not the request headers.
+        if ("ConfirmSubscription".equals(action) || "Unsubscribe".equals(action)) {
+            String snsArn = "Unsubscribe".equals(action)
+                    ? queryParams.getFirst("SubscriptionArn")
+                    : queryParams.getFirst("TopicArn");
+            String region = AwsArnUtils.regionOrDefault(snsArn, regionResolver.resolveRegion(httpHeaders));
             return snsQueryHandler.handle(action, queryParams, region);
         }
         // A browser hitting the root endpoint (Accept: text/html) gets the Floci

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
@@ -115,6 +115,10 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
         String firstLabel = hostname.substring(0, firstDot);
         String remainder  = hostname.substring(firstDot + 1);
 
+        if (isS3ServiceEndpointHost(firstLabel, remainder, baseHostname)) {
+            return null;
+        }
+
         // Primary: remainder must match the configured base hostname,
         // either directly or in the AWS region-qualified s3.<region>.<host> form.
         if (baseHostname != null && matchesEndpointHost(remainder, baseHostname)) {
@@ -127,6 +131,19 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
         }
 
         return null;
+    }
+
+    private static boolean isS3ServiceEndpointHost(String firstLabel, String remainder, String baseHostname) {
+        if (!"s3".equalsIgnoreCase(firstLabel)) {
+            return false;
+        }
+        if (baseHostname != null && matchesEndpointHost(remainder, baseHostname)) {
+            return true;
+        }
+        String lowerRemainder = remainder.toLowerCase();
+        return "localhost".equals(lowerRemainder)
+                || "localhost.localstack.cloud".equals(lowerRemainder)
+                || "localhost.floci.io".equals(lowerRemainder);
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
@@ -65,6 +65,13 @@ class S3VirtualHostFilterTest {
             "localhost:4566, localhost",
             "localhost,      localhost",
             "plain-host,     plain-host",
+            // Bare S3 service hosts must NOT be treated as a bucket named s3
+            "s3.localhost:4566,                 localhost",
+            "s3.localhost,                      localhost",
+            "s3.localhost.localstack.cloud,     localhost",
+            "s3.localhost.localstack.cloud:4566, localhost",
+            "s3.localhost.floci.io,             localhost",
+            "s3.localhost.floci.io:4566,        localhost",
             // K8s service hostname used as endpoint (path-style) — must NOT be rewritten
             "floci.default.svc.cluster.local,           localhost",
             "floci-service.namespace.svc.cluster.local, localhost",

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostIntegrationTest.java
@@ -248,6 +248,32 @@ class S3VirtualHostIntegrationTest {
     }
 
     @Test
+    @Order(17)
+    void listBucketsViaLocalStackS3ServiceHost() {
+        given()
+            .header("Host", "s3.localhost.localstack.cloud")
+        .when()
+            .get("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("ListAllMyBucketsResult"))
+            .body(containsString(BUCKET));
+    }
+
+    @Test
+    @Order(18)
+    void listBucketsViaFlociS3ServiceHost() {
+        given()
+            .header("Host", "s3.localhost.floci.io")
+        .when()
+            .get("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("ListAllMyBucketsResult"))
+            .body(containsString(BUCKET));
+    }
+
+    @Test
     @Order(20)
     void cleanupAndDeleteBucket() {
         given().header("Host", HOST).delete("/hello.txt");

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsHttpDeliveryIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsHttpDeliveryIntegrationTest.java
@@ -45,6 +45,22 @@ class SnsHttpDeliveryIntegrationTest {
             exchange.sendResponseHeaders(200, 0);
             exchange.close();
         });
+        httpServer.createContext("/confirming-webhook", exchange -> {
+            byte[] bodyBytes = exchange.getRequestBody().readAllBytes();
+            String body = new String(bodyBytes, StandardCharsets.UTF_8);
+            Map<String, List<String>> headers = exchange.getRequestHeaders();
+            receivedRequests.add(new ReceivedRequest(body, headers));
+            try {
+                if ("SubscriptionConfirmation".equals(firstHeader(headers, "X-amz-sns-message-type"))) {
+                    confirmSubscription(new ReceivedRequest(body, headers));
+                }
+                exchange.sendResponseHeaders(200, 0);
+            } catch (Exception e) {
+                exchange.sendResponseHeaders(500, 0);
+            } finally {
+                exchange.close();
+            }
+        });
         httpServer.start();
     }
 
@@ -63,6 +79,11 @@ class SnsHttpDeliveryIntegrationTest {
         while (receivedRequests.size() < expectedCount && System.nanoTime() < deadline) {
             Thread.sleep(50);
         }
+    }
+
+    private static String firstHeader(Map<String, List<String>> headers, String name) {
+        List<String> values = headers.get(name);
+        return values == null || values.isEmpty() ? null : values.get(0);
     }
 
     /**
@@ -176,6 +197,117 @@ class SnsHttpDeliveryIntegrationTest {
         assertTrue(msgAttrs.has("env"));
         assertEquals("String", msgAttrs.get("env").get("Type").asText());
         assertEquals("production", msgAttrs.get("env").get("Value").asText());
+    }
+
+    @Test
+    void publish_toHttpSubscriber_confirmedDuringSuccessfulHandshake_deliversNotification() throws Exception {
+        receivedRequests.clear();
+        String endpoint = "http://localhost:" + httpPort + "/confirming-webhook";
+
+        String topicArn = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateTopic")
+            .formParam("Name", "http-inline-confirm-test")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath().getString("CreateTopicResponse.CreateTopicResult.TopicArn");
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "Subscribe")
+            .formParam("TopicArn", topicArn)
+            .formParam("Protocol", "http")
+            .formParam("Endpoint", endpoint)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<SubscriptionArn>"));
+
+        awaitRequests(1);
+        assertEquals(1, receivedRequests.size());
+        assertEquals("SubscriptionConfirmation", firstHeader(receivedRequests.get(0).headers(), "X-amz-sns-message-type"));
+        receivedRequests.clear();
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "Publish")
+            .formParam("TopicArn", topicArn)
+            .formParam("Message", "delivered after inline confirm")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<MessageId>"));
+
+        awaitRequests(1);
+        assertEquals(1, receivedRequests.size());
+        ReceivedRequest req = receivedRequests.get(0);
+        assertEquals("Notification", firstHeader(req.headers(), "X-amz-sns-message-type"));
+        JsonNode envelope = objectMapper.readTree(req.body());
+        assertEquals("Notification", envelope.get("Type").asText());
+        assertEquals("delivered after inline confirm", envelope.get("Message").asText());
+    }
+
+    @Test
+    void subscribeUrl_getConfirmsSubscriptionAndAllowsDelivery() throws Exception {
+        receivedRequests.clear();
+        String endpoint = "http://localhost:" + httpPort + "/webhook";
+
+        String topicArn = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateTopic")
+            .formParam("Name", "http-subscribe-url-get-test")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath().getString("CreateTopicResponse.CreateTopicResult.TopicArn");
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "Subscribe")
+            .formParam("TopicArn", topicArn)
+            .formParam("Protocol", "http")
+            .formParam("Endpoint", endpoint)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<SubscriptionArn>"));
+
+        awaitRequests(1);
+        assertEquals(1, receivedRequests.size());
+        JsonNode confirmation = objectMapper.readTree(receivedRequests.get(0).body());
+
+        given()
+            .queryParam("Action", "ConfirmSubscription")
+            .queryParam("TopicArn", confirmation.get("TopicArn").asText())
+            .queryParam("Token", confirmation.get("Token").asText())
+        .when()
+            .get("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<SubscriptionArn>"));
+
+        receivedRequests.clear();
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "Publish")
+            .formParam("TopicArn", topicArn)
+            .formParam("Message", "delivered after SubscribeURL GET")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<MessageId>"));
+
+        awaitRequests(1);
+        assertEquals(1, receivedRequests.size());
+        assertEquals("Notification", firstHeader(receivedRequests.get(0).headers(), "X-amz-sns-message-type"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsHttpDeliveryIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsHttpDeliveryIntegrationTest.java
@@ -31,6 +31,8 @@ class SnsHttpDeliveryIntegrationTest {
     private static int httpPort;
     private static final List<ReceivedRequest> receivedRequests = new CopyOnWriteArrayList<>();
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final java.util.logging.Logger LOG =
+            java.util.logging.Logger.getLogger(SnsHttpDeliveryIntegrationTest.class.getName());
     record ReceivedRequest(String body, Map<String, List<String>> headers) {}
 
     @BeforeAll
@@ -49,13 +51,23 @@ class SnsHttpDeliveryIntegrationTest {
             byte[] bodyBytes = exchange.getRequestBody().readAllBytes();
             String body = new String(bodyBytes, StandardCharsets.UTF_8);
             Map<String, List<String>> headers = exchange.getRequestHeaders();
-            receivedRequests.add(new ReceivedRequest(body, headers));
+            ReceivedRequest received = new ReceivedRequest(body, headers);
             try {
+                // Confirm the subscription BEFORE recording the request, so a test that
+                // awaits this request observes it only once the subscription is actually
+                // confirmed. Recording first would let a subsequent publish race ahead of
+                // the confirmation and see a still-pending subscription (flaky delivery).
                 if ("SubscriptionConfirmation".equals(firstHeader(headers, "X-amz-sns-message-type"))) {
-                    confirmSubscription(new ReceivedRequest(body, headers));
+                    confirmSubscription(received);
                 }
+                receivedRequests.add(received);
                 exchange.sendResponseHeaders(200, 0);
             } catch (Exception e) {
+                // Record even on failure so awaitRequests unblocks and the assertion
+                // reports the real state instead of timing out opaquely.
+                receivedRequests.add(received);
+                LOG.log(java.util.logging.Level.SEVERE,
+                        "confirming-webhook: subscription confirmation failed", e);
                 exchange.sendResponseHeaders(500, 0);
             } finally {
                 exchange.close();

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsHttpDeliveryIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsHttpDeliveryIntegrationTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -320,6 +321,83 @@ class SnsHttpDeliveryIntegrationTest {
         awaitRequests(1);
         assertEquals(1, receivedRequests.size());
         assertEquals("Notification", firstHeader(receivedRequests.get(0).headers(), "X-amz-sns-message-type"));
+    }
+
+    @Test
+    void unsubscribeUrl_getRoutesToSnsAndRemovesSubscription() throws Exception {
+        receivedRequests.clear();
+        String endpoint = "http://localhost:" + httpPort + "/webhook";
+        // Pin the subscription to a non-default region. The SubscribeURL/UnsubscribeURL
+        // links SNS emits are unsigned, so the delegation must recover this region from
+        // the ARN in the link, not from the (absent) request auth.
+        String snsAuth = "AWS4-HMAC-SHA256 Credential=000000000000/20260101/us-west-2/sns/aws4_request";
+
+        String topicArn = given()
+            .header("Authorization", snsAuth)
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateTopic")
+            .formParam("Name", "http-unsubscribe-url-get-test")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath().getString("CreateTopicResponse.CreateTopicResult.TopicArn");
+        assertTrue(topicArn.contains(":us-west-2:"), "topic should live in us-west-2");
+
+        given()
+            .header("Authorization", snsAuth)
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "Subscribe")
+            .formParam("TopicArn", topicArn)
+            .formParam("Protocol", "http")
+            .formParam("Endpoint", endpoint)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<SubscriptionArn>"));
+
+        awaitRequests(1);
+        assertEquals(1, receivedRequests.size());
+        JsonNode confirmation = objectMapper.readTree(receivedRequests.get(0).body());
+
+        // Confirm via the SubscribeURL GET (unsigned) to obtain a real SubscriptionArn.
+        // Region is recovered from the TopicArn, so the pending sub in us-west-2 is found.
+        String subscriptionArn = given()
+            .queryParam("Action", "ConfirmSubscription")
+            .queryParam("TopicArn", confirmation.get("TopicArn").asText())
+            .queryParam("Token", confirmation.get("Token").asText())
+        .when()
+            .get("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<SubscriptionArn>"))
+            .extract().xmlPath().getString("ConfirmSubscriptionResponse.ConfirmSubscriptionResult.SubscriptionArn");
+
+        // Following the UnsubscribeURL is a plain GET on the service root. It must
+        // reach SNS (UnsubscribeResponse), not fall through to S3 ListBuckets, and
+        // its region must come from the SubscriptionArn (us-west-2), not the default.
+        given()
+            .queryParam("Action", "Unsubscribe")
+            .queryParam("SubscriptionArn", subscriptionArn)
+        .when()
+            .get("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("UnsubscribeResponse"))
+            .body(not(containsString("ListAllMyBucketsResult")));
+
+        // The unsubscribe took effect: the subscription is no longer listed.
+        given()
+            .header("Authorization", snsAuth)
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ListSubscriptionsByTopic")
+            .formParam("TopicArn", topicArn)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(not(containsString(subscriptionArn)));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #1494.
Refs #1081.

- Treat bare `s3.*` service endpoint hosts as bucketless S3 requests.
- Route SNS `ConfirmSubscription` GET requests on `/` through SNS before normal S3 bucket listing.
- Add parser and integration coverage for S3 service-host routing plus SNS HTTP confirmation delivery flows.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Floci incorrectly parsed bare S3 service endpoint hosts such as `s3.localhost.localstack.cloud` and `s3.localhost.floci.io` as virtual-hosted bucket requests for a bucket named `s3`. Bucketless `GET /` now remains a service-level ListBuckets request, while bucket virtual-host forms still rewrite to bucket paths.

SNS `SubscribeURL` confirmation uses a GET request like `/?Action=ConfirmSubscription&TopicArn=...&Token=...`. That root-path GET now reaches the SNS query handler before the S3 ListBuckets fallback, matching the AWS confirmation flow without changing normal S3 root behavior.

## Changes

- `S3VirtualHostFilter`: skip virtual-host rewriting for bare S3 service endpoint hosts.
- `S3Controller`: route root `ConfirmSubscription` query-string requests to SNS before ListBuckets.
- `S3VirtualHostFilterTest` and `S3VirtualHostIntegrationTest`: add service-host parser and ListBuckets regression coverage.
- `SnsHttpDeliveryIntegrationTest`: add confirmation regressions for inline 200 confirmation and SubscribeURL GET confirmation.

## Test plan

- [x] `./mvnw test -Dtest=S3VirtualHostFilterTest,S3VirtualHostIntegrationTest,SnsHttpDeliveryIntegrationTest,AwsQueryControllerIntegrationTest`

## Review

- Internal fallback review: clean, no regressions detected.
- Claude bridge review: unavailable locally because the bridge is not logged in.
- Gemini bridge review: unavailable locally because the Gemini CLI is not installed.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
