### PR TITLE
feat(kms): add ListKeyPolicies Support for KMS

### DIFF
--- a/docs/services/kms.md
+++ b/docs/services/kms.md
@@ -33,6 +33,7 @@
 | `ListResourceTags` | List tags |
 | `GetKeyPolicy` | Get a key's resource policy |
 | `PutKeyPolicy` | Update a key's resource policy |
+| `ListKeyPolicies` | List a key's resource policies |
 | `UpdateKeyDescription` | Update a key's description |
 | `GetKeyRotationStatus` | Check if automatic key rotation is enabled |
 | `EnableKeyRotation` | Enable automatic key rotation (symmetric keys only) |

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
@@ -67,6 +67,7 @@ public class KmsJsonHandler {
             case "ListResourceTags" -> handleListResourceTags(request, region);
             case "GetKeyPolicy" -> handleGetKeyPolicy(request, region);
             case "PutKeyPolicy" -> handlePutKeyPolicy(request, region);
+            case "ListKeyPolicies" -> handleListKeyPolicies(request, region);
             case "UpdateKeyDescription" -> handleUpdateKeyDescription(request, region);
             case "GetKeyRotationStatus" -> handleGetKeyRotationStatus(request, region);
             case "EnableKeyRotation" -> handleEnableKeyRotation(request, region);
@@ -459,6 +460,15 @@ public class KmsJsonHandler {
                 request.path("Policy").asText(),
                 region);
         return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleListKeyPolicies(JsonNode request, String region) {
+        Map<String, Object> result = service.listKeyPolicies(
+                requiredText(request, "KeyId"),
+                request.path("Limit").asInt(100),
+                request.path("Marker").asText(null),
+                region);
+        return Response.ok(objectMapper.valueToTree(result)).build();
     }
 
     private Response handleUpdateKeyDescription(JsonNode request, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -489,6 +489,26 @@ public class KmsService {
         LOG.infov("Updated key policy for KMS key: {0} in {1}", key.getKeyId(), region);
     }
 
+    public Map<String, Object> listKeyPolicies(String keyId, int limit, String marker, String region) {
+        if (limit < 1 || limit > 1000) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '" + limit + "' at 'limit' failed to satisfy constraint: Member must have value greater than or equal to 1 and less than or equal to 1000", 400);
+        }
+        if (marker != null && !marker.isBlank()) {
+            throw new AwsException("InvalidMarkerException",
+                    "The request was rejected because the marker is not valid.", 400);
+        }
+
+        Map<String, Object> policyMap = getKeyPolicy(keyId, region);
+        String policyName = (String) policyMap.get("PolicyName");
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("PolicyNames", List.of(policyName));
+        result.put("Truncated", false);
+        result.put("NextMarker", null); // Ensure NextMarker is present as requested
+        return result;
+    }
+
     public void updateKeyDescription(String keyId, String description, String region) {
         KmsKey key = resolveKey(keyId, region);
         key.setDescription(description);

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
@@ -1106,4 +1106,45 @@ class KmsIntegrationTest {
                 .then()
                 .statusCode(expectedStatusCode);
     }
+
+    @Test
+    void listKeyPoliciesReturnsDefaultPolicyThroughJsonHandler() {
+        String keyId = given()
+                .header("X-Amz-Target", "TrentService.CreateKey")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"Description\":\"list-key-policies\"}")
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("KeyMetadata.KeyId");
+
+        given()
+                .header("X-Amz-Target", "TrentService.ListKeyPolicies")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("""
+                    {"KeyId":"%s"}
+                    """.formatted(keyId))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .body("PolicyNames.size()", equalTo(1))
+                .body("PolicyNames[0]", equalTo("default"))
+                .body("Truncated", equalTo(false));
+    }
+
+    @Test
+    void listKeyPoliciesReturnsNotFoundForUnknownKey() {
+        given()
+                .header("X-Amz-Target", "TrentService.ListKeyPolicies")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"KeyId\":\"non-existent-id\"}")
+                .when()
+                .post("/")
+                .then()
+                .statusCode(404)
+                .body("__type", equalTo("NotFoundException"));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -1001,6 +1001,48 @@ class KmsServiceTest {
                 kmsService.putKeyPolicy("non-existent", "{}", REGION));
     }
 
+    // ── Issue #1528 — ListKeyPolicies ────────────────────────────────────────
+
+    @Test
+    void listKeyPoliciesReturnsDefaultPolicy() {
+        KmsKey key = kmsService.createKey("list-policy-key", REGION);
+        Map<String, Object> result = kmsService.listKeyPolicies(key.getKeyId(), 100, null, REGION);
+        
+        @SuppressWarnings("unchecked")
+        List<String> policyNames = (List<String>) result.get("PolicyNames");
+        assertEquals(1, policyNames.size());
+        assertEquals("default", policyNames.getFirst());
+        assertFalse((Boolean) result.get("Truncated"));
+        assertNull(result.get("NextMarker"));
+    }
+
+    @Test
+    void listKeyPoliciesThrowsOnInvalidLimit() {
+        KmsKey key = kmsService.createKey("list-policy-key", REGION);
+        AwsException ex = assertThrows(AwsException.class, () ->
+                kmsService.listKeyPolicies(key.getKeyId(), 1001, null, REGION));
+        assertEquals("ValidationException", ex.getErrorCode());
+        
+        AwsException ex2 = assertThrows(AwsException.class, () ->
+                kmsService.listKeyPolicies(key.getKeyId(), 0, null, REGION));
+        assertEquals("ValidationException", ex2.getErrorCode());
+    }
+
+    @Test
+    void listKeyPoliciesThrowsOnInvalidMarker() {
+        KmsKey key = kmsService.createKey("list-policy-key", REGION);
+        AwsException ex = assertThrows(AwsException.class, () ->
+                kmsService.listKeyPolicies(key.getKeyId(), 100, "invalid", REGION));
+        assertEquals("InvalidMarkerException", ex.getErrorCode());
+    }
+
+    @Test
+    void listKeyPoliciesOnNonExistentKeyThrows() {
+        AwsException ex = assertThrows(AwsException.class, () ->
+                kmsService.listKeyPolicies("non-existent", 100, null, REGION));
+        assertEquals("NotFoundException", ex.getErrorCode());
+    }
+
     // ── Issue #290 — Key Rotation ───────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

This PR implements the KMS `ListKeyPolicies` action, resolving an `UnsupportedOperation` error when clients attempt to list key policies. It dynamically fetches the default policy using `getKeyPolicy`.

Closes #1528 

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

This implementation adheres to the AWS KMS expected response shape by:
- Enforcing limit boundaries (1-1000).
- Throwing `InvalidMarkerException` on invalid markers.
- Fetching the actual policy applied to the key rather than hardcoding.
- Always returning a valid JSON shape including `"NextMarker": null` when `Truncated` is `false`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)