### PR TITLE
chore(ci): skip nightly workflow on forks

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,6 +28,7 @@ jobs:
   prepare:
     name: Prepare nightly version
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' || !github.event.repository.fork
     outputs:
       version: ${{ steps.date.outputs.version }}
 


### PR DESCRIPTION
## Summary

Do not run the nightly workflow on a schedule from forks as its a waste of resources and they fail due to a lack of Docker credentials.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

N/A

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
