### PR TITLE
fix(lambda): return event source mapping failure config

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -322,6 +322,17 @@ public class LambdaController {
         node.put("State", esm.getState());
         node.put("LastModified", (double) esm.getLastModified() / 1000.0);
         ArrayNode responseTypes = node.putArray("FunctionResponseTypes");
+
+        if (esm.getBisectBatchOnFunctionError() != null) {
+            node.put("BisectBatchOnFunctionError", esm.getBisectBatchOnFunctionError());
+        }
+
+        if (esm.getDestinationConfig() != null && esm.getDestinationConfig().getOnFailure() != null) {
+            ObjectNode destinationConfig = node.putObject("DestinationConfig");
+            ObjectNode onFailure = destinationConfig.putObject("OnFailure");
+            onFailure.put("Destination", esm.getDestinationConfig().getOnFailure().getDestination());
+        }
+
         if (esm.getFunctionResponseTypes() != null) {
             esm.getFunctionResponseTypes().forEach(responseTypes::add);
         }

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -660,6 +660,12 @@ public class LambdaService {
 
         ScalingConfig scalingConfig = parseScalingConfig(request, eventSourceArn);
 
+        Boolean bisectBatchOnFunctionError = request.get("BisectBatchOnFunctionError") instanceof Boolean b
+                ? b
+                : null;
+
+        EventSourceMapping.DestinationConfig destinationConfig = parseDestinationConfig(request);
+
         String queueUrl = eventSourceArn.contains(":sqs:") ? AwsArnUtils.arnToQueueUrl(eventSourceArn, config.effectiveBaseUrl()) : null;
 
         EventSourceMapping esm = new EventSourceMapping();
@@ -675,6 +681,8 @@ public class LambdaService {
         esm.setState(enabled ? "Enabled" : "Disabled");
         esm.setScalingConfig(scalingConfig);
         esm.setFunctionResponseTypes(functionResponseTypes);
+        esm.setBisectBatchOnFunctionError(bisectBatchOnFunctionError);
+        esm.setDestinationConfig(destinationConfig);
         esm.setLastModified(System.currentTimeMillis());
 
         esmStore.save(esm);
@@ -683,6 +691,38 @@ public class LambdaService {
         }
         LOG.infov("Created ESM {0}: {1} → {2}", esm.getUuid(), eventSourceArn, resolvedName);
         return esm;
+    }
+
+    private EventSourceMapping.DestinationConfig parseDestinationConfig(Map<String, Object> request) {
+        Object raw = request.get("DestinationConfig");
+        if (raw == null) {
+            return null;
+        }
+        if (!(raw instanceof Map<?, ?> destMap)) {
+            throw new AwsException("InvalidParameterValueException",
+                    "DestinationConfig must be a JSON object", 400);
+        }
+
+        Object rawOnFailure = destMap.get("OnFailure");
+        if (rawOnFailure == null) {
+            return null;
+        }
+        if (!(rawOnFailure instanceof Map<?, ?> onFailureMap)) {
+            throw new AwsException("InvalidParameterValueException",
+                    "DestinationConfig.OnFailure must be a JSON object", 400);
+        }
+
+        Object destination = onFailureMap.get("Destination");
+        if (destination == null) {
+            return null;
+        }
+
+        EventSourceMapping.OnFailure onFailure = new EventSourceMapping.OnFailure();
+        onFailure.setDestination(String.valueOf(destination));
+
+        EventSourceMapping.DestinationConfig destinationConfig = new EventSourceMapping.DestinationConfig();
+        destinationConfig.setOnFailure(onFailure);
+        return destinationConfig;
     }
 
     /**
@@ -785,6 +825,15 @@ public class LambdaService {
             // AWS: passing ScalingConfig resets it. An empty object or one
             // with MaximumConcurrency=null clears the cap.
             esm.setScalingConfig(parseScalingConfig(request, esm.getEventSourceArn()));
+        }
+
+        if (request.containsKey("BisectBatchOnFunctionError")) {
+            Object raw = request.get("BisectBatchOnFunctionError");
+            esm.setBisectBatchOnFunctionError(raw instanceof Boolean b ? b : null);
+        }
+
+        if (request.containsKey("DestinationConfig")) {
+            esm.setDestinationConfig(parseDestinationConfig(request));
         }
 
         esm.setLastModified(System.currentTimeMillis());

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/model/EventSourceMapping.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/model/EventSourceMapping.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.lambda.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.util.ArrayList;
@@ -26,6 +27,8 @@ public class EventSourceMapping {
     private List<String> functionResponseTypes = new ArrayList<>();
     private Map<String, String> shardSequenceNumbers = new HashMap<>();
     private ScalingConfig scalingConfig;
+    private Boolean bisectBatchOnFunctionError;
+    private DestinationConfig destinationConfig;
 
     public EventSourceMapping() {
     }
@@ -83,5 +86,51 @@ public class EventSourceMapping {
     /** Convenience accessor: returns {@code null} when no cap is configured. */
     public Integer getMaximumConcurrency() {
         return scalingConfig != null ? scalingConfig.getMaximumConcurrency() : null;
+    }
+
+    public Boolean getBisectBatchOnFunctionError() {
+        return bisectBatchOnFunctionError;
+    }
+
+    public void setBisectBatchOnFunctionError(Boolean bisectBatchOnFunctionError) {
+        this.bisectBatchOnFunctionError = bisectBatchOnFunctionError;
+    }
+
+    public DestinationConfig getDestinationConfig() {
+        return destinationConfig;
+    }
+
+    public void setDestinationConfig(DestinationConfig destinationConfig) {
+        this.destinationConfig = destinationConfig;
+    }
+
+    public static class DestinationConfig {
+        private OnFailure onFailure;
+
+        public DestinationConfig() {
+        }
+
+        public OnFailure getOnFailure() {
+            return onFailure;
+        }
+
+        public void setOnFailure(OnFailure onFailure) {
+            this.onFailure = onFailure;
+        }
+    }
+
+    public static class OnFailure {
+        private String destination;
+
+        public OnFailure() {
+        }
+
+        public String getDestination() {
+            return destination;
+        }
+
+        public void setDestination(String destination) {
+            this.destination = destination;
+        }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/EsmIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/EsmIntegrationTest.java
@@ -135,6 +135,86 @@ class EsmIntegrationTest {
     }
 
     @Test
+    void updateEventSourceMappingReturnsFailureConfig() {
+        String streamArn = "arn:aws:dynamodb:us-east-1:000000000000:table/esm-table/stream/2026-01-01T00:00:00.000";
+        String destinationArn = "arn:aws:sqs:us-east-1:000000000000:esm-updated-failure-config-dlq";
+
+        String uuid = given()
+                .contentType("application/json")
+                .body("""
+                        {
+                          "FunctionName": "%s",
+                          "EventSourceArn": "%s"
+                        }
+                        """.formatted(FUNCTION_NAME, streamArn))
+                .when()
+                .post(LAMBDA_BASE + "/event-source-mappings/")
+                .then()
+                .statusCode(202)
+                .body("$", not(hasKey("BisectBatchOnFunctionError")))
+                .body("$", not(hasKey("DestinationConfig")))
+                .extract()
+                .path("UUID");
+
+        given()
+                .contentType("application/json")
+                .body("""
+                        {
+                          "BisectBatchOnFunctionError": true,
+                          "DestinationConfig": {
+                            "OnFailure": {
+                              "Destination": "%s"
+                            }
+                          }
+                        }
+                        """.formatted(destinationArn))
+                .when()
+                .put(LAMBDA_BASE + "/event-source-mappings/" + uuid)
+                .then()
+                .statusCode(202)
+                .body("BisectBatchOnFunctionError", equalTo(true))
+                .body("DestinationConfig.OnFailure.Destination", equalTo(destinationArn));
+
+        given()
+                .when()
+                .get(LAMBDA_BASE + "/event-source-mappings/" + uuid)
+                .then()
+                .statusCode(200)
+                .body("BisectBatchOnFunctionError", equalTo(true))
+                .body("DestinationConfig.OnFailure.Destination", equalTo(destinationArn));
+
+        given()
+                .delete(LAMBDA_BASE + "/event-source-mappings/" + uuid)
+                .then()
+                .statusCode(202);
+    }
+
+    @Test
+    void responseOmitsFailureConfigWhenUnset() {
+        String uuid = given()
+                .contentType("application/json")
+                .body("""
+                        {
+                          "FunctionName": "%s",
+                          "EventSourceArn": "%s"
+                        }
+                        """.formatted(FUNCTION_NAME, QUEUE_ARN))
+                .when()
+                .post(LAMBDA_BASE + "/event-source-mappings/")
+                .then()
+                .statusCode(202)
+                .body("$", not(hasKey("BisectBatchOnFunctionError")))
+                .body("$", not(hasKey("DestinationConfig")))
+                .extract()
+                .path("UUID");
+
+        given()
+                .delete(LAMBDA_BASE + "/event-source-mappings/" + uuid)
+                .then()
+                .statusCode(202);
+    }
+
+    @Test
     @Order(5)
     void createEventSourceMappingForNonExistentFunction() {
         given()


### PR DESCRIPTION
## Summary

Preserves and returns Lambda Event Source Mapping failure configuration fields.

`CreateEventSourceMapping` accepted request payloads containing `BisectBatchOnFunctionError` and `DestinationConfig.OnFailure.Destination`, but those values were not included in the create/get responses.

This change stores those fields on the event source mapping model and includes them in both `CreateEventSourceMapping` and `GetEventSourceMapping` responses.

Closes #1537

## Type of change

* [x] Bug fix (`fix:`)
* [ ] New feature (`feat:`)
* [ ] Breaking change (`feat!:` or `fix!:`)
* [ ] Docs / chore

## AWS Compatibility

Incorrect behavior:

`CreateEventSourceMapping` accepted `BisectBatchOnFunctionError` and `DestinationConfig.OnFailure.Destination`, but omitted those fields from the create response and subsequent `GetEventSourceMapping` response.

Updated behavior:

Floci now preserves those values and returns them in both `CreateEventSourceMapping` and `GetEventSourceMapping` responses, matching the Lambda Event Source Mapping response shape.

## Checklist

* [ ] `./mvnw test` passes locally
* [x] New or updated integration test added
* [x] Commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/)