### PR TITLE
fix: S3 PutObjectRetention returns 400 instead of 500 on malformed RetainUntilDate

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -40,6 +40,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -1563,7 +1564,13 @@ public class S3Controller {
         String xml = new String(body, StandardCharsets.UTF_8);
         String mode = XmlParser.extractFirst(xml, "Mode", null);
         String dateStr = XmlParser.extractFirst(xml, "RetainUntilDate", null);
-        Instant retainUntil = dateStr != null ? Instant.parse(dateStr) : null;
+        Instant retainUntil;
+        try {
+            retainUntil = dateStr != null ? Instant.parse(dateStr) : null;
+        } catch (DateTimeParseException | IllegalArgumentException e) {
+            throw new AwsException("MalformedXML",
+                    "The XML you provided was not well-formed.", 400);
+        }
         boolean bypass = "true".equalsIgnoreCase(
                 httpHeaders.getHeaderString("x-amz-bypass-governance-retention"));
         s3Service.putObjectRetention(bucket, key, versionId, mode, retainUntil, bypass);

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ObjectLockIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ObjectLockIntegrationTest.java
@@ -122,10 +122,83 @@ class S3ObjectLockIntegrationTest {
             .body(containsString("<Days>30</Days>"));
     }
 
+    // --- PutObjectRetention RetainUntilDate parsing ---
+
+    private static final String RETENTION_KEY = "retained-object.txt";
+
+    @Test
+    @Order(10)
+    void putObjectForRetention() {
+        given()
+            .body("hello")
+        .when()
+            .put("/" + LOCK_BUCKET + "/" + RETENTION_KEY)
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(11)
+    void putObjectRetentionWithValidIsoDateReturns200() {
+        String body = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <Retention xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                  <Mode>GOVERNANCE</Mode>
+                  <RetainUntilDate>2030-01-01T00:00:00Z</RetainUntilDate>
+                </Retention>
+                """;
+        given()
+            .body(body)
+        .when()
+            .put("/" + LOCK_BUCKET + "/" + RETENTION_KEY + "?retention")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(12)
+    void putObjectRetentionWithEpochSecondsReturns400MalformedXml() {
+        String body = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <Retention xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                  <Mode>GOVERNANCE</Mode>
+                  <RetainUntilDate>1577836800</RetainUntilDate>
+                </Retention>
+                """;
+        given()
+            .body(body)
+        .when()
+            .put("/" + LOCK_BUCKET + "/" + RETENTION_KEY + "?retention")
+        .then()
+            .statusCode(400)
+            .body(containsString("MalformedXML"))
+            .body(not(containsString("Internal Server Error")));
+    }
+
+    @Test
+    @Order(13)
+    void putObjectRetentionWithGarbageDateReturns400MalformedXml() {
+        String body = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <Retention xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                  <Mode>GOVERNANCE</Mode>
+                  <RetainUntilDate>notadate</RetainUntilDate>
+                </Retention>
+                """;
+        given()
+            .body(body)
+        .when()
+            .put("/" + LOCK_BUCKET + "/" + RETENTION_KEY + "?retention")
+        .then()
+            .statusCode(400)
+            .body(containsString("MalformedXML"))
+            .body(not(containsString("Internal Server Error")));
+    }
+
     // --- non-existent bucket ---
 
     @Test
-    @Order(9)
+    @Order(14)
     void nonExistentBucketReturnsNoSuchBucket() {
         given()
         .when()


### PR DESCRIPTION
## Summary

`PutObjectRetention` returned an HTTP 500 HTML "Internal Server Error" page when the `RetainUntilDate` could not be parsed, because `S3Controller.handlePutObjectRetention` called `Instant.parse` without catching the parse failure. Real AWS S3 returns HTTP 400 `MalformedXML` for the same request. This wraps the parse in a try/catch and throws an `AwsException` mapped to 400 `MalformedXML`, matching the existing S3 controller error pattern.

Closes #1614

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Before this change, a `RetainUntilDate` value that is not a valid ISO-8601 instant (for example epoch seconds `1577836800` or arbitrary text `notadate`) leaked an uncaught `DateTimeParseException` as a 500 HTML page. Real S3 returns 400 `MalformedXML`. The handler at `S3Controller.java:1565` now throws `AwsException("MalformedXML", ..., 400)`, which the existing `AwsExceptionMapper` renders as an AWS-shaped XML error. Valid ISO-8601 values keep returning 200.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
