### PR TITLE
fix(s3): omit checksum headers from GetObject/HeadObject unless x-amz-checksum-mode: ENABLED

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -603,6 +603,7 @@ public class S3Controller {
                               @HeaderParam("If-Modified-Since") String ifModifiedSince,
                               @HeaderParam("If-Unmodified-Since") String ifUnmodifiedSince,
                               @HeaderParam("Range") String rangeHeader,
+                              @HeaderParam("x-amz-checksum-mode") String checksumMode,
                               @Context UriInfo uriInfo,
                               @Context HttpHeaders httpHeaders) {
         try {
@@ -656,7 +657,8 @@ public class S3Controller {
                 return handleRangeRequest(bucket, key, versionId, obj, rangeHeader, overrides);
             }
 
-            return fullObjectResponse(bucket, key, versionId, obj, overrides);
+            boolean includeChecksum = "ENABLED".equalsIgnoreCase(checksumMode);
+            return fullObjectResponse(bucket, key, versionId, obj, overrides, includeChecksum);
         } catch (AwsException e) {
             if ("NoSuchKey".equals(e.getErrorCode()) && isWebsiteRequest(httpHeaders)) {
                 try {
@@ -671,7 +673,8 @@ public class S3Controller {
     }
 
     private Response fullObjectResponse(String bucket, String key, String versionId,
-                                        S3Object obj, ResponseHeaderOverrides overrides) {
+                                        S3Object obj, ResponseHeaderOverrides overrides,
+                                        boolean includeChecksum) {
         StreamingOutput stream = output -> {
             try (InputStream input = s3Service.openObjectStream(bucket, key, versionId)) {
                 input.transferTo(output);
@@ -686,7 +689,7 @@ public class S3Controller {
         if (obj.getVersionId() != null) {
             resp.header("x-amz-version-id", obj.getVersionId());
         }
-        appendObjectHeaders(resp, obj, overrides);
+        appendObjectHeaders(resp, obj, overrides, includeChecksum);
         return resp.build();
     }
 
@@ -724,7 +727,7 @@ public class S3Controller {
 
         if (start < 0 || start >= totalSize || start > end) {
             if (totalSize == 0 && rangeSpec.startsWith("-")) {
-                return fullObjectResponse(bucket, key, versionId, obj, overrides);
+                return fullObjectResponse(bucket, key, versionId, obj, overrides, false);
             }
             return invalidRangeResponse(totalSize);
         }
@@ -797,6 +800,7 @@ public class S3Controller {
                                @HeaderParam("If-None-Match") String ifNoneMatch,
                                @HeaderParam("If-Modified-Since") String ifModifiedSince,
                                @HeaderParam("If-Unmodified-Since") String ifUnmodifiedSince,
+                               @HeaderParam("x-amz-checksum-mode") String checksumMode,
                                @Context UriInfo uriInfo,
                                @Context HttpHeaders httpHeaders) {
         try {
@@ -827,7 +831,8 @@ public class S3Controller {
             if (obj.getVersionId() != null) {
                 resp.header("x-amz-version-id", obj.getVersionId());
             }
-            appendObjectHeaders(resp, obj, overrides);
+            boolean includeChecksum = "ENABLED".equalsIgnoreCase(checksumMode);
+            appendObjectHeaders(resp, obj, overrides, includeChecksum);
             return resp.build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -1643,8 +1643,6 @@ public class S3Controller {
             String cacheControl,
             String contentDisposition,
             String contentEncoding) {
-        static final ResponseHeaderOverrides NONE = new ResponseHeaderOverrides(null, null, null, null, null, null);
-
         boolean hasAny() {
             return contentType != null || contentLanguage != null || expires != null
                     || cacheControl != null || contentDisposition != null || contentEncoding != null;
@@ -1665,10 +1663,6 @@ public class S3Controller {
         }
     }
 
-    private void appendObjectHeaders(Response.ResponseBuilder resp, S3Object obj) {
-        appendObjectHeaders(resp, obj, ResponseHeaderOverrides.NONE);
-    }
-
     // PutObject's response body is empty — body-describing headers and x-amz-meta-*
     // must not be emitted, or SDK clients will try to decompress and fail.
     private void appendPutObjectResponseHeaders(Response.ResponseBuilder resp, S3Object obj) {
@@ -1681,10 +1675,6 @@ public class S3Controller {
         appendSseCustomerHeaders(resp, obj);
         appendChecksumHeaders(resp, obj.getChecksum());
         appendLockHeaders(resp, obj);
-    }
-
-    private void appendObjectHeaders(Response.ResponseBuilder resp, S3Object obj, ResponseHeaderOverrides overrides) {
-        appendObjectHeaders(resp, obj, overrides, true);
     }
 
     // includeChecksum must be false for partial (206) responses: obj.getChecksum() is the

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -653,11 +653,11 @@ public class S3Controller {
                         "Request specific response headers cannot be used for anonymous GET requests.", 400));
             }
 
+            boolean includeChecksum = "ENABLED".equalsIgnoreCase(checksumMode);
             if (rangeHeader != null && rangeHeader.startsWith("bytes=")) {
-                return handleRangeRequest(bucket, key, versionId, obj, rangeHeader, overrides);
+                return handleRangeRequest(bucket, key, versionId, obj, rangeHeader, overrides, includeChecksum);
             }
 
-            boolean includeChecksum = "ENABLED".equalsIgnoreCase(checksumMode);
             return fullObjectResponse(bucket, key, versionId, obj, overrides, includeChecksum);
         } catch (AwsException e) {
             if ("NoSuchKey".equals(e.getErrorCode()) && isWebsiteRequest(httpHeaders)) {
@@ -695,7 +695,8 @@ public class S3Controller {
 
     private Response handleRangeRequest(String bucket, String key, String versionId,
                                         S3Object obj, String rangeHeader,
-                                        ResponseHeaderOverrides overrides) {
+                                        ResponseHeaderOverrides overrides,
+                                        boolean includeChecksum) {
         long totalSize = obj.getSize();
         String rangeSpec = rangeHeader.substring("bytes=".length()).trim();
 
@@ -727,7 +728,7 @@ public class S3Controller {
 
         if (start < 0 || start >= totalSize || start > end) {
             if (totalSize == 0 && rangeSpec.startsWith("-")) {
-                return fullObjectResponse(bucket, key, versionId, obj, overrides, false);
+                return fullObjectResponse(bucket, key, versionId, obj, overrides, includeChecksum);
             }
             return invalidRangeResponse(totalSize);
         }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -204,6 +204,7 @@ class S3IntegrationTest {
 
         // Verify the copy
         given()
+            .header("x-amz-checksum-mode", "ENABLED")
         .when()
             .get("/test-bucket/greeting-copy.txt")
         .then()
@@ -241,6 +242,7 @@ class S3IntegrationTest {
 
         // Verify the copy inherits the source checksum (CRC64NVME)
         given()
+            .header("x-amz-checksum-mode", "ENABLED")
         .when()
             .get("/test-bucket/greeting-copy-no-override.txt")
         .then()
@@ -274,6 +276,7 @@ class S3IntegrationTest {
 
         // Verify the source object has a SHA256 checksum
         given()
+            .header("x-amz-checksum-mode", "ENABLED")
         .when()
             .get("/test-bucket/sha256-source.txt")
         .then()
@@ -293,6 +296,7 @@ class S3IntegrationTest {
 
         // Verify the copy preserves the source's SHA256 checksum
         given()
+            .header("x-amz-checksum-mode", "ENABLED")
         .when()
             .get("/test-bucket/sha256-copy.txt")
         .then()
@@ -536,24 +540,56 @@ class S3IntegrationTest {
     @Order(118)
     void getObjectWithChecksumModeReturnsChecksum() {
         given()
+            .when()
+            .put("/checksum-mode-bucket")
+        .then()
+            .statusCode(200);
+
+        given()
+            .body("Hello World from S3!")
+        .when()
+            .put("/checksum-mode-bucket/greeting.txt")
+        .then()
+            .statusCode(200);
+
+        given()
             .header("x-amz-checksum-mode", "ENABLED")
         .when()
-            .get("/test-bucket/greeting.txt")
+            .get("/checksum-mode-bucket/greeting.txt")
         .then()
             .statusCode(200)
             .header("x-amz-checksum-crc64nvme", notNullValue());
+
+        given().delete("/checksum-mode-bucket/greeting.txt");
+        given().delete("/checksum-mode-bucket");
     }
 
     @Test
     @Order(119)
     void headObjectWithChecksumModeReturnsChecksum() {
         given()
+            .when()
+            .put("/checksum-mode-head-bucket")
+        .then()
+            .statusCode(200);
+
+        given()
+            .body("Hello World from S3!")
+        .when()
+            .put("/checksum-mode-head-bucket/greeting.txt")
+        .then()
+            .statusCode(200);
+
+        given()
             .header("x-amz-checksum-mode", "ENABLED")
         .when()
-            .head("/test-bucket/greeting.txt")
+            .head("/checksum-mode-head-bucket/greeting.txt")
         .then()
             .statusCode(200)
             .header("x-amz-checksum-crc64nvme", notNullValue());
+
+        given().delete("/checksum-mode-head-bucket/greeting.txt");
+        given().delete("/checksum-mode-head-bucket");
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -718,11 +718,42 @@ class S3IntegrationTest {
             .header("Content-Length", equalTo("0"))
             .header("Accept-Ranges", equalTo("bytes"))
             .header("x-amz-meta-kind", equalTo("empty"))
+            .header("x-amz-checksum-crc64nvme", nullValue())
             .body(equalTo(""));
 
         given()
         .when()
             .delete("/test-bucket/empty.txt")
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    @Order(207)
+    void getObjectWithSuffixRangeForEmptyObjectAndChecksumModeIncludesChecksum() {
+        // The empty-object suffix-range path returns via fullObjectResponse (a full 200, not
+        // a 206), so it must honor x-amz-checksum-mode like any other full-object response.
+        given()
+            .header("x-amz-meta-kind", "empty")
+            .body(new byte[0])
+        .when()
+            .put("/test-bucket/empty-checksum.txt")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Range", "bytes=-13")
+            .header("x-amz-checksum-mode", "ENABLED")
+        .when()
+            .get("/test-bucket/empty-checksum.txt")
+        .then()
+            .statusCode(200)
+            .header("Content-Length", equalTo("0"))
+            .header("x-amz-checksum-crc64nvme", notNullValue());
+
+        given()
+        .when()
+            .delete("/test-bucket/empty-checksum.txt")
         .then()
             .statusCode(204);
     }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -87,8 +87,20 @@ class S3IntegrationTest {
             .header("Content-Length", notNullValue())
             .header("x-amz-meta-owner", equalTo("team-a"))
             .header("x-amz-storage-class", equalTo("STANDARD_IA"))
-            .header("x-amz-checksum-crc64nvme", notNullValue())
+            .header("x-amz-checksum-crc64nvme", nullValue())
             .body(equalTo("Hello World from S3!"));
+    }
+
+    @Test
+    @Order(5)
+    void getObjectWithChecksumModeReturnsChecksum() {
+        given()
+            .header("x-amz-checksum-mode", "ENABLED")
+        .when()
+            .get("/test-bucket/greeting.txt")
+        .then()
+            .statusCode(200)
+            .header("x-amz-checksum-crc64nvme", notNullValue());
     }
 
     @Test
@@ -118,6 +130,18 @@ class S3IntegrationTest {
             .header("Content-Length", notNullValue())
             .header("x-amz-meta-owner", equalTo("team-a"))
             .header("x-amz-storage-class", equalTo("STANDARD_IA"))
+            .header("x-amz-checksum-crc64nvme", nullValue());
+    }
+
+    @Test
+    @Order(7)
+    void headObjectWithChecksumModeReturnsChecksum() {
+        given()
+            .header("x-amz-checksum-mode", "ENABLED")
+        .when()
+            .head("/test-bucket/greeting.txt")
+        .then()
+            .statusCode(200)
             .header("x-amz-checksum-crc64nvme", notNullValue());
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -92,18 +92,6 @@ class S3IntegrationTest {
     }
 
     @Test
-    @Order(5)
-    void getObjectWithChecksumModeReturnsChecksum() {
-        given()
-            .header("x-amz-checksum-mode", "ENABLED")
-        .when()
-            .get("/test-bucket/greeting.txt")
-        .then()
-            .statusCode(200)
-            .header("x-amz-checksum-crc64nvme", notNullValue());
-    }
-
-    @Test
     @Order(6)
     void getObjectAttributes() {
         given()
@@ -131,18 +119,6 @@ class S3IntegrationTest {
             .header("x-amz-meta-owner", equalTo("team-a"))
             .header("x-amz-storage-class", equalTo("STANDARD_IA"))
             .header("x-amz-checksum-crc64nvme", nullValue());
-    }
-
-    @Test
-    @Order(7)
-    void headObjectWithChecksumModeReturnsChecksum() {
-        given()
-            .header("x-amz-checksum-mode", "ENABLED")
-        .when()
-            .head("/test-bucket/greeting.txt")
-        .then()
-            .statusCode(200)
-            .header("x-amz-checksum-crc64nvme", notNullValue());
     }
 
     @Test
@@ -554,6 +530,30 @@ class S3IntegrationTest {
 
         given().delete("/large-object-bucket/large-file.bin");
         given().delete("/large-object-bucket");
+    }
+
+    @Test
+    @Order(118)
+    void getObjectWithChecksumModeReturnsChecksum() {
+        given()
+            .header("x-amz-checksum-mode", "ENABLED")
+        .when()
+            .get("/test-bucket/greeting.txt")
+        .then()
+            .statusCode(200)
+            .header("x-amz-checksum-crc64nvme", notNullValue());
+    }
+
+    @Test
+    @Order(119)
+    void headObjectWithChecksumModeReturnsChecksum() {
+        given()
+            .header("x-amz-checksum-mode", "ENABLED")
+        .when()
+            .head("/test-bucket/greeting.txt")
+        .then()
+            .statusCode(200)
+            .header("x-amz-checksum-crc64nvme", notNullValue());
     }
 
     @Test


### PR DESCRIPTION
## Problem

Closes #1632

`GetObject` and `HeadObject` responses unconditionally include `x-amz-checksum-*` headers regardless of whether the request contained `x-amz-checksum-mode: ENABLED`. On real AWS, these headers are only returned when the client explicitly opts in via that header.

This causes `fopen('s3://bucket/key', 'r')` in PHP's AWS SDK to fail with **"Stream is not seekable"**: the SDK's `ValidateResponseChecksumResultMutator` detects a checksum header in the response, reads the entire body to validate it, then calls `seek(0)` to rewind — which fails because the underlying stream is a non-seekable socket (the SDK uses `stream=true` internally to avoid buffering).

## Root cause

`appendObjectHeaders` / `appendChecksumHeaders` were called unconditionally in both `getObject` and `headObject`, without checking for the `x-amz-checksum-mode` request header.

## Fix

- Added `@HeaderParam("x-amz-checksum-mode")` to `getObject` and `headObject`
- Gate checksum header inclusion behind `"ENABLED".equalsIgnoreCase(checksumMode)`
- Added `includeChecksum` boolean parameter to `fullObjectResponse` to propagate the gate through range-request edge cases
- Updated integration tests: existing `getObject`/`headObject` tests now assert checksum headers are absent; new tests assert they are present when `x-amz-checksum-mode: ENABLED` is sent

## Testing

All 117 integration tests pass. Verified end-to-end with PHP 8.2 + `aws/aws-sdk-php`:
- Against unpatched 1.5.26: `fopen` fails with "Stream is not seekable"
- Against this fix: `fopen`, `fread`, and `fseek` all succeed