### PR TITLE
fix(cloudformation): register !Cidr and !GetAZs shorthand YAML tags

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationYamlParser.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationYamlParser.java
@@ -56,6 +56,8 @@ public class CloudFormationYamlParser {
             register("!Base64",     n -> fnMap("Fn::Base64", n));
             register("!FindInMap",  n -> fnMap("Fn::FindInMap", n));
             register("!Split",      n -> fnMap("Fn::Split", n));
+            register("!Cidr",       n -> fnMap("Fn::Cidr", n));
+            register("!GetAZs",     n -> fnMap("Fn::GetAZs", n));
             register("!ImportValue",n -> fnMap("Fn::ImportValue", n));
             register("!Condition",  n -> scalarMap("Condition", scalar(n)));
             register("!And",        n -> fnMap("Fn::And", n));

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationYamlParserTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationYamlParserTest.java
@@ -1,0 +1,46 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CloudFormationYamlParserTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private JsonNode parse(String yaml) throws Exception {
+        return new CloudFormationYamlParser(mapper).parse(yaml);
+    }
+
+    @Test
+    void cidrShorthandExpandsToFnCidr() throws Exception {
+        JsonNode cidr = parse("Value: !Cidr [\"10.0.0.0/16\", 4, 8]").get("Value").get("Fn::Cidr");
+        assertTrue(cidr.isArray());
+        assertEquals("10.0.0.0/16", cidr.get(0).asText());
+        assertEquals(4, cidr.get(1).asInt());
+        assertEquals(8, cidr.get(2).asInt());
+    }
+
+    @Test
+    void getAzsShorthandExpandsToFnGetAZs() throws Exception {
+        assertEquals("", parse("Value: !GetAZs \"\"").get("Value").get("Fn::GetAZs").asText());
+    }
+
+    @Test
+    void cidrShorthandMatchesLongFormInNestedSelect() throws Exception {
+        JsonNode shorthand = parse("CidrBlock: !Select [1, !Cidr [!GetAtt Vpc.CidrBlock, 4, 8]]");
+        JsonNode longForm = parse("""
+            CidrBlock:
+              Fn::Select:
+                - 1
+                - Fn::Cidr:
+                    - Fn::GetAtt: [Vpc, CidrBlock]
+                    - 4
+                    - 8
+            """);
+        assertEquals(longForm, shorthand);
+    }
+}


### PR DESCRIPTION
## Summary

`Fn::Cidr` and `Fn::GetAZs` were added in #1365, but only in their long form. The matching YAML shorthand tags `!Cidr` and `!GetAZs` were never registered in `CloudFormationYamlParser`, so any template using the shorthand fails to parse:

```
could not determine a constructor for the tag !Cidr
```

The long form (`Fn::Cidr` / `Fn::GetAZs`) works fine — only the shorthand is affected. This registers the two missing tags alongside the other intrinsic shorthands (`!Ref`, `!Select`, `!Split`, …), so both forms behave identically.

```yaml
# Failed before this change, works after:
CidrBlock: !Select [0, !Cidr [!GetAtt Vpc.CidrBlock, 4, 8]]
```

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Both shorthand and long form are valid CloudFormation; the AWS CLI/SDK accept either. Added `CloudFormationYamlParserTest` verifying that `!Cidr` / `!GetAZs` expand to the same long-form map the engine already resolves (including the nested `!Select` / `!GetAtt` case above).

## Checklist

- [x] `./mvnw test` passes locally (`-Dtest=CloudFormationYamlParserTest`)
- [x] New or updated test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
