### PR TITLE
fix(iam): enforce STS session policies

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/IamEnforcementTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/IamEnforcementTest.java
@@ -66,6 +66,7 @@ class IamEnforcementTest {
 
     private static final String DENY_S3_LIST_SESSION_POLICY = """
             {"Version":"2012-10-17","Statement":[
+              {"Effect":"Allow","Action":"s3:ListAllMyBuckets","Resource":"*"},
               {"Effect":"Deny","Action":"s3:ListAllMyBuckets","Resource":"*"}
             ]}""";
 

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/IamEnforcementTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/IamEnforcementTest.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.*;
  *   <li>Wildcard action policy grants access → ALLOW</li>
  *   <li>Assumed role with no policies → DENY</li>
  *   <li>Assumed role with attached allow policy → ALLOW</li>
+ *   <li>Assumed role session policy deny overrides role allow → DENY</li>
  * </ul>
  */
 @DisplayName("IAM Enforcement Mode")
@@ -61,6 +62,11 @@ class IamEnforcementTest {
     private static final String ALLOW_S3_WILDCARD_POLICY = """
             {"Version":"2012-10-17","Statement":[
               {"Effect":"Allow","Action":"s3:*","Resource":"*"}
+            ]}""";
+
+    private static final String DENY_S3_LIST_SESSION_POLICY = """
+            {"Version":"2012-10-17","Statement":[
+              {"Effect":"Deny","Action":"s3:ListAllMyBuckets","Resource":"*"}
             ]}""";
 
     // ── Shared state ───────────────────────────────────────────────────────────
@@ -291,6 +297,32 @@ class IamEnforcementTest {
                 assumed.credentials().secretAccessKey(),
                 assumed.credentials().sessionToken())) {
             assertThatCode(s3::listBuckets).doesNotThrowAnyException();
+        }
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("assumed role session policy deny overrides role allow")
+    void assumedRoleSessionPolicyDenyOverridesRoleAllow() {
+        assumeEnforcementEnabled();
+
+        iam.attachRolePolicy(AttachRolePolicyRequest.builder()
+                .roleName(ROLE).policyArn(allowPolicyArn).build());
+
+        AssumeRoleResponse assumed = sts.assumeRole(AssumeRoleRequest.builder()
+                .roleArn(roleArn)
+                .roleSessionName("enf-test-session-deny")
+                .policy(DENY_S3_LIST_SESSION_POLICY)
+                .build());
+
+        try (S3Client s3 = s3WithSessionCredentials(
+                assumed.credentials().accessKeyId(),
+                assumed.credentials().secretAccessKey(),
+                assumed.credentials().sessionToken())) {
+            assertThatThrownBy(s3::listBuckets)
+                    .isInstanceOf(S3Exception.class)
+                    .extracting(e -> ((S3Exception) e).statusCode())
+                    .isEqualTo(403);
         }
     }
 }

--- a/docs/configuration/multi-account.md
+++ b/docs/configuration/multi-account.md
@@ -33,7 +33,7 @@ Account 111111111111 ──AssumeRole arn:aws:iam::222222222222:role/Deployer─
 ASIA… temp key ──CreateTable orders──▶ stored as 222222222222/...::orders  ◀──┘
 ```
 
-This makes the cross-account `AssumeRole`-then-provision pattern (e.g. CloudFormation deploying into a target account) work locally exactly as it does in AWS. Resolution precedence is: **12-digit AKID → temporary-session lookup → `FLOCI_DEFAULT_ACCOUNT_ID`.**
+This makes the cross-account `AssumeRole`-then-provision pattern (e.g. CloudFormation deploying into a target account) work locally exactly as it does in AWS. Resolution precedence is: **12-digit AKID → account ID; otherwise temporary-session lookup → `FLOCI_DEFAULT_ACCOUNT_ID`.**
 
 ## Default Behavior (Single Account)
 

--- a/docs/services/iam.md
+++ b/docs/services/iam.md
@@ -99,8 +99,8 @@ environment:
 
 Policy evaluation follows the standard AWS precedence:
 
-1. An explicit **Deny** in any identity, resource, session, or boundary policy → request is denied (HTTP 403 `AccessDeniedException`)
-2. An explicit **Allow** in an identity or resource policy creates the base grant
+1. An explicit **Deny** in any identity, session, or boundary policy → request is denied (HTTP 403 `AccessDeniedException`)
+2. An explicit **Allow** in an identity policy creates the base grant
 3. If a session policy is present, it must also explicitly allow the request
 4. If a permission boundary is present, it must also explicitly allow the request
 5. No matching effective allow → implicit deny (HTTP 403)

--- a/docs/services/iam.md
+++ b/docs/services/iam.md
@@ -99,9 +99,11 @@ environment:
 
 Policy evaluation follows the standard AWS precedence:
 
-1. An explicit **Deny** in any policy → request is denied (HTTP 403 `AccessDeniedException`)
-2. An explicit **Allow** in any policy → request is allowed
-3. No matching statement → implicit deny (HTTP 403)
+1. An explicit **Deny** in any identity, resource, session, or boundary policy → request is denied (HTTP 403 `AccessDeniedException`)
+2. An explicit **Allow** in an identity or resource policy creates the base grant
+3. If a session policy is present, it must also explicitly allow the request
+4. If a permission boundary is present, it must also explicitly allow the request
+5. No matching effective allow → implicit deny (HTTP 403)
 
 ### Bypass rules
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/IamEnforcementFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/IamEnforcementFilter.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.services.iam.IamPolicyEvaluator;
 import io.github.hectorvent.floci.services.iam.IamPolicyEvaluator.Decision;
 import io.github.hectorvent.floci.services.iam.IamService;
 import io.github.hectorvent.floci.services.iam.ResourceArnBuilder;
+import io.github.hectorvent.floci.services.iam.model.CallerContext;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
@@ -15,7 +16,6 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
 import org.jboss.logging.Logger;
 
-import java.util.List;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -32,8 +32,9 @@ import java.util.regex.Pattern;
  *   <li>The action cannot be resolved (unknown mapping → permissive)</li>
  * </ul>
  *
- * <p>Phase 1 evaluates identity-based policies only.
- * Resource-based policies (S3 bucket policy, Lambda resource policy, etc.) are Phase 2.
+ * <p>Evaluates the caller's identity policies, optional session policy, and optional
+ * permissions boundary. Resource-based policies (S3 bucket policy, Lambda resource
+ * policy, etc.) are not yet supplied to this filter.
  */
 @Provider
 @ApplicationScoped
@@ -51,6 +52,7 @@ public class IamEnforcementFilter implements ContainerRequestFilter {
     private final IamPolicyEvaluator evaluator;
     private final IamActionRegistry actionRegistry;
     private final ResourceArnBuilder arnBuilder;
+    private final RequestContext requestContext;
 
     @Inject
     public IamEnforcementFilter(EmulatorConfig config,
@@ -58,13 +60,15 @@ public class IamEnforcementFilter implements ContainerRequestFilter {
                                 IamService iamService,
                                 IamPolicyEvaluator evaluator,
                                 IamActionRegistry actionRegistry,
-                                ResourceArnBuilder arnBuilder) {
+                                ResourceArnBuilder arnBuilder,
+                                RequestContext requestContext) {
         this.config = config;
         this.accountResolver = accountResolver;
         this.iamService = iamService;
         this.evaluator = evaluator;
         this.actionRegistry = actionRegistry;
         this.arnBuilder = arnBuilder;
+        this.requestContext = requestContext;
     }
 
     @Override
@@ -93,16 +97,18 @@ public class IamEnforcementFilter implements ContainerRequestFilter {
             return; // unknown action → ALLOW (permissive)
         }
 
-        List<String> policies = iamService.resolveCallerPolicies(akid);
-        if (policies == null) {
+        CallerContext caller = iamService.resolveCallerContext(akid);
+        if (caller == null) {
             return; // unknown access key → bypass (backward-compat)
         }
 
-        String region = config.defaultRegion();
-        String accountId = accountResolver.resolve(auth);
+        String region = requestContext.getRegion() == null ? config.defaultRegion() : requestContext.getRegion();
+        String accountId = requestContext.getAccountId() == null
+                ? accountResolver.resolve(auth)
+                : requestContext.getAccountId();
         String resource = arnBuilder.build(credentialScope, ctx, region, accountId);
 
-        Decision decision = evaluator.evaluate(policies, action, resource);
+        Decision decision = evaluator.evaluate(caller, null, action, resource, null);
         if (decision == Decision.DENY) {
             LOG.infov("IAM enforcement DENY: akid={0} action={1} resource={2}", akid, action, resource);
             ctx.abortWith(accessDeniedResponse(action, credentialScope, ctx.getMediaType()));

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
@@ -922,7 +922,7 @@ public class IamService implements SessionAccountLookup {
         if (fromAccessKey.isPresent()) {
             return fromAccessKey;
         }
-        return sessions.get(accessKeyId).map(SessionCredential::getSecretAccessKey);
+        return findSessionAnyAccount(accessKeyId).map(SessionCredential::getSecretAccessKey);
     }
 
     // =========================================================================
@@ -976,9 +976,7 @@ public class IamService implements SessionAccountLookup {
      */
     @Override
     public Optional<String> resolveAccountId(String accessKeyId) {
-        // STS issues only ASIA-prefixed temporary keys, so anything else cannot be a session.
-        // Short-circuit here to keep the per-request hot path off the session-store scan below.
-        if (accessKeyId == null || !accessKeyId.startsWith("ASIA")) {
+        if (accessKeyId == null || accessKeyId.isBlank()) {
             return Optional.empty();
         }
         Optional<SessionCredential> sessionOpt = findSessionAnyAccount(accessKeyId);
@@ -1024,8 +1022,9 @@ public class IamService implements SessionAccountLookup {
             return new CallerContext(identityPolicies, null, boundaryDoc);
         }
 
-        // Check assumed-role sessions
-        Optional<SessionCredential> sessionOpt = sessions.get(accessKeyId);
+        // Check assumed-role sessions. These can be stored under the account that minted the
+        // session, while request routing for temporary credentials uses the role's account.
+        Optional<SessionCredential> sessionOpt = findSessionForCallerContext(accessKeyId);
         if (sessionOpt.isPresent()) {
             SessionCredential session = sessionOpt.get();
             if (session.getExpiration() != null && session.getExpiration().isBefore(java.time.Instant.now())) {
@@ -1043,6 +1042,17 @@ public class IamService implements SessionAccountLookup {
 
         // Unknown key — bypass
         return null;
+    }
+
+    private Optional<SessionCredential> findSessionForCallerContext(String accessKeyId) {
+        if (accessKeyId == null || accessKeyId.isBlank()) {
+            return Optional.empty();
+        }
+        Optional<SessionCredential> session = sessions.get(accessKeyId);
+        if (session.isPresent()) {
+            return session;
+        }
+        return findSessionAnyAccount(accessKeyId);
     }
 
     /**
@@ -1070,7 +1080,7 @@ public class IamService implements SessionAccountLookup {
             return users.get(userName).map(IamUser::getArn);
         }
 
-        Optional<SessionCredential> sessionOpt = sessions.get(accessKeyId);
+        Optional<SessionCredential> sessionOpt = findSessionForCallerContext(accessKeyId);
         if (sessionOpt.isPresent()) {
             SessionCredential session = sessionOpt.get();
             if (session.getExpiration() != null && session.getExpiration().isBefore(java.time.Instant.now())) {

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
@@ -48,6 +48,7 @@ public class IamService implements SessionAccountLookup {
 
     private static final Logger LOG = Logger.getLogger(IamService.class);
     private static final String CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    private static final String TEMPORARY_ACCESS_KEY_PREFIX = "ASIA";
     private static final String DEFAULT_DEPLOYER_USER = "floci-deployer";
     private static final String DEFAULT_DEPLOYER_ACCESS_KEY_ID = "floci";
     private static final String DEFAULT_DEPLOYER_SECRET_ACCESS_KEY = "floci";
@@ -976,7 +977,7 @@ public class IamService implements SessionAccountLookup {
      */
     @Override
     public Optional<String> resolveAccountId(String accessKeyId) {
-        if (accessKeyId == null || accessKeyId.isBlank()) {
+        if (!isTemporaryAccessKey(accessKeyId)) {
             return Optional.empty();
         }
         Optional<SessionCredential> sessionOpt = findSessionAnyAccount(accessKeyId);
@@ -1000,6 +1001,9 @@ public class IamService implements SessionAccountLookup {
      * across all accounts; the access key's global uniqueness keeps the result unambiguous.
      */
     private Optional<SessionCredential> findSessionAnyAccount(String accessKeyId) {
+        if (!isTemporaryAccessKey(accessKeyId)) {
+            return Optional.empty();
+        }
         if (sessions instanceof AccountAwareStorageBackend<SessionCredential> aware) {
             return Optional.ofNullable(aware.scanAllAccountsAsMap().get(accessKeyId));
         }
@@ -1028,7 +1032,7 @@ public class IamService implements SessionAccountLookup {
         if (sessionOpt.isPresent()) {
             SessionCredential session = sessionOpt.get();
             if (session.getExpiration() != null && session.getExpiration().isBefore(java.time.Instant.now())) {
-                sessions.delete(accessKeyId);
+                deleteSession(accessKeyId, session);
                 return null; // expired — unknown key → bypass
             }
 
@@ -1051,6 +1055,9 @@ public class IamService implements SessionAccountLookup {
         Optional<SessionCredential> session = sessions.get(accessKeyId);
         if (session.isPresent()) {
             return session;
+        }
+        if (!isTemporaryAccessKey(accessKeyId)) {
+            return Optional.empty();
         }
         return findSessionAnyAccount(accessKeyId);
     }
@@ -1084,7 +1091,7 @@ public class IamService implements SessionAccountLookup {
         if (sessionOpt.isPresent()) {
             SessionCredential session = sessionOpt.get();
             if (session.getExpiration() != null && session.getExpiration().isBefore(java.time.Instant.now())) {
-                sessions.delete(accessKeyId);
+                deleteSession(accessKeyId, session);
                 return Optional.empty();
             }
             String roleArn = session.getRoleArn();
@@ -1094,6 +1101,20 @@ public class IamService implements SessionAccountLookup {
         }
 
         return Optional.empty();
+    }
+
+    private static boolean isTemporaryAccessKey(String accessKeyId) {
+        return accessKeyId != null && accessKeyId.startsWith(TEMPORARY_ACCESS_KEY_PREFIX);
+    }
+
+    private void deleteSession(String accessKeyId, SessionCredential session) {
+        String originAccountId = session.getOriginAccountId();
+        if (originAccountId != null && !originAccountId.isBlank()
+                && sessions instanceof AccountAwareStorageBackend<SessionCredential> aware) {
+            aware.deleteForAccount(originAccountId, accessKeyId);
+            return;
+        }
+        sessions.delete(accessKeyId);
     }
 
     public CallerContext resolvePrincipalContext(String principalArn) {

--- a/src/test/java/io/github/hectorvent/floci/core/common/IamEnforcementFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/IamEnforcementFilterTest.java
@@ -1,14 +1,28 @@
 package io.github.hectorvent.floci.core.common;
 
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.iam.IamActionRegistry;
+import io.github.hectorvent.floci.services.iam.IamPolicyEvaluator;
+import io.github.hectorvent.floci.services.iam.IamService;
+import io.github.hectorvent.floci.services.iam.ResourceArnBuilder;
+import io.github.hectorvent.floci.services.iam.model.CallerContext;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.container.ContainerRequestContext;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link IamEnforcementFilter#accessDeniedResponse}, focused on
@@ -18,6 +32,56 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * envelope.
  */
 class IamEnforcementFilterTest {
+
+    @Test
+    void filterBuildsResourceArnWithRequestContextAccount() {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.IamServiceConfig iamConfig = mock(EmulatorConfig.IamServiceConfig.class);
+        AccountResolver accountResolver = mock(AccountResolver.class);
+        IamService iamService = mock(IamService.class);
+        IamPolicyEvaluator evaluator = mock(IamPolicyEvaluator.class);
+        IamActionRegistry actionRegistry = mock(IamActionRegistry.class);
+        ResourceArnBuilder arnBuilder = mock(ResourceArnBuilder.class);
+        RequestContext requestContext = new RequestContext();
+        ContainerRequestContext containerRequest = mock(ContainerRequestContext.class);
+
+        String auth = "AWS4-HMAC-SHA256 Credential=ASIASESSION/20260629/us-east-1/lambda/aws4_request, "
+                + "SignedHeaders=host, Signature=abc";
+        requestContext.setAccountId("222233334444");
+        requestContext.setRegion("us-east-1");
+
+        when(config.services()).thenReturn(services);
+        when(services.iam()).thenReturn(iamConfig);
+        when(iamConfig.enforcementEnabled()).thenReturn(true);
+        when(config.defaultRegion()).thenReturn("us-east-1");
+        when(accountResolver.extractAccessKeyId(auth)).thenReturn("ASIASESSION");
+        when(accountResolver.resolve(auth)).thenReturn("000000000000");
+        when(containerRequest.getHeaderString("Authorization")).thenReturn(auth);
+        when(actionRegistry.resolve("lambda", containerRequest)).thenReturn("lambda:InvokeFunction");
+        when(iamService.resolveCallerContext("ASIASESSION"))
+                .thenReturn(CallerContext.of(List.of("""
+                        {"Version":"2012-10-17","Statement":[
+                          {"Effect":"Allow","Action":"lambda:InvokeFunction",
+                           "Resource":"arn:aws:lambda:us-east-1:222233334444:function:fn"}
+                        ]}""")));
+        when(arnBuilder.build("lambda", containerRequest, "us-east-1", "222233334444"))
+                .thenReturn("arn:aws:lambda:us-east-1:222233334444:function:fn");
+        when(evaluator.evaluate(
+                any(),
+                isNull(),
+                eq("lambda:InvokeFunction"),
+                eq("arn:aws:lambda:us-east-1:222233334444:function:fn"),
+                isNull()))
+                .thenReturn(IamPolicyEvaluator.Decision.ALLOW);
+
+        IamEnforcementFilter filter = new IamEnforcementFilter(
+                config, accountResolver, iamService, evaluator, actionRegistry, arnBuilder, requestContext);
+
+        filter.filter(containerRequest);
+
+        verify(arnBuilder).build("lambda", containerRequest, "us-east-1", "222233334444");
+    }
 
     @Test
     void queryProtocolGetsXmlErrorResponse() {

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
@@ -2,7 +2,9 @@ package io.github.hectorvent.floci.services.iam;
 
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.services.iam.model.AccessKey;
 import io.github.hectorvent.floci.services.iam.model.IamGroup;
 import io.github.hectorvent.floci.services.iam.model.IamPolicy;
@@ -10,6 +12,7 @@ import io.github.hectorvent.floci.services.iam.model.IamRole;
 import io.github.hectorvent.floci.services.iam.model.IamUser;
 import io.github.hectorvent.floci.services.iam.model.InstanceProfile;
 import io.github.hectorvent.floci.services.iam.model.PolicyVersion;
+import io.github.hectorvent.floci.services.iam.model.SessionCredential;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,6 +36,11 @@ class IamServiceTest {
     }
 
     private static IamService iamService(boolean seedDeployerPrincipal, InMemoryStorage<String, AccessKey> accessKeys) {
+        return iamService(seedDeployerPrincipal, accessKeys, new InMemoryStorage<>());
+    }
+
+    private static IamService iamService(boolean seedDeployerPrincipal, InMemoryStorage<String, AccessKey> accessKeys,
+                                         StorageBackend<String, SessionCredential> sessions) {
         return new IamService(
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
@@ -40,7 +48,7 @@ class IamServiceTest {
                 new InMemoryStorage<>(),
                 accessKeys,
                 new InMemoryStorage<>(),
-                new InMemoryStorage<>(),
+                sessions,
                 new RegionResolver("us-east-1", "000000000000"),
                 seedDeployerPrincipal
         );
@@ -454,6 +462,31 @@ class IamServiceTest {
     }
 
     @Test
+    void resolveAccountIdDoesNotScanSessionsForLongTermAccessKey() {
+        CountingAccountAwareSessionStorage sessions = new CountingAccountAwareSessionStorage();
+        IamService service = iamService(false, new InMemoryStorage<>(), sessions);
+
+        assertTrue(service.resolveAccountId("AKIAIOSFODNN7EXAMPLE").isEmpty());
+        assertEquals(0, sessions.scanAllAccountsAsMapCalls);
+    }
+
+    private static final class CountingAccountAwareSessionStorage
+            extends AccountAwareStorageBackend<SessionCredential> {
+
+        private int scanAllAccountsAsMapCalls;
+
+        private CountingAccountAwareSessionStorage() {
+            super(new InMemoryStorage<>(), null, "000000000000");
+        }
+
+        @Override
+        public Map<String, SessionCredential> scanAllAccountsAsMap() {
+            scanAllAccountsAsMapCalls++;
+            return super.scanAllAccountsAsMap();
+        }
+    }
+
+    @Test
     void resolveAccountIdEmptyForExpiredSession() {
         iamService.registerSession(
                 "ASIAEXPIRED",
@@ -465,6 +498,25 @@ class IamServiceTest {
         );
 
         assertTrue(iamService.resolveAccountId("ASIAEXPIRED").isEmpty());
+    }
+
+    @Test
+    void resolveCallerContextDeletesExpiredCrossAccountSessionFromOriginAccount() {
+        String accessKeyId = "ASIAEXPIREDCROSSACCOUNT";
+        AccountAwareStorageBackend<SessionCredential> sessions = new AccountAwareStorageBackend<>(
+                new InMemoryStorage<>(), null, "222233334444");
+        sessions.putForAccount("111122223333", accessKeyId, new SessionCredential(
+                accessKeyId,
+                "temp-secret",
+                "arn:aws:iam::222233334444:role/CrossAccountAccess",
+                Instant.now().minusSeconds(60),
+                null,
+                "111122223333"));
+        IamService service = iamService(false, new InMemoryStorage<>(), sessions);
+
+        assertNull(service.resolveCallerContext(accessKeyId));
+
+        assertTrue(sessions.getForAccount("111122223333", accessKeyId).isEmpty());
     }
 
     // =========================================================================

--- a/src/test/java/io/github/hectorvent/floci/services/iam/StsSessionPolicyS3EnforcementIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/StsSessionPolicyS3EnforcementIntegrationTest.java
@@ -16,7 +16,8 @@ import static org.hamcrest.Matchers.startsWith;
 @TestProfile(StsSessionPolicyS3EnforcementIntegrationTest.IamEnforcementProfile.class)
 class StsSessionPolicyS3EnforcementIntegrationTest {
 
-    private static final String ACCOUNT_ID = "000000000000";
+    private static final String CALLER_ACCOUNT_ID = "111122223333";
+    private static final String ROLE_ACCOUNT_ID = "222233334444";
     private static final String REGION = "us-east-1";
 
     @Test
@@ -53,7 +54,7 @@ class StsSessionPolicyS3EnforcementIntegrationTest {
 
     private static void createBucket(String bucket) {
         given()
-                .header("Authorization", auth("test", "s3"))
+                .header("Authorization", auth(ROLE_ACCOUNT_ID, "s3"))
         .when()
                 .put("/" + bucket)
         .then()
@@ -77,7 +78,7 @@ class StsSessionPolicyS3EnforcementIntegrationTest {
                       ]
                     }
                     """)
-                .header("Authorization", auth("test", "iam"))
+                .header("Authorization", auth(ROLE_ACCOUNT_ID, "iam"))
         .when()
                 .post("/")
         .then()
@@ -104,7 +105,7 @@ class StsSessionPolicyS3EnforcementIntegrationTest {
                       ]
                     }
                     """.formatted(bucket))
-                .header("Authorization", auth("test", "iam"))
+                .header("Authorization", auth(ROLE_ACCOUNT_ID, "iam"))
         .when()
                 .post("/")
         .then()
@@ -114,7 +115,7 @@ class StsSessionPolicyS3EnforcementIntegrationTest {
     private static String assumeRoleWithS3SessionPolicy(String roleName, String bucket) {
         return given()
                 .formParam("Action", "AssumeRole")
-                .formParam("RoleArn", "arn:aws:iam::" + ACCOUNT_ID + ":role/" + roleName)
+                .formParam("RoleArn", "arn:aws:iam::" + ROLE_ACCOUNT_ID + ":role/" + roleName)
                 .formParam("RoleSessionName", "session-policy-test")
                 .formParam("Policy", """
                     {
@@ -136,7 +137,7 @@ class StsSessionPolicyS3EnforcementIntegrationTest {
                       ]
                     }
                     """.formatted(bucket))
-                .header("Authorization", auth("test", "sts"))
+                .header("Authorization", auth(CALLER_ACCOUNT_ID, "sts"))
         .when()
                 .post("/")
         .then()

--- a/src/test/java/io/github/hectorvent/floci/services/iam/StsSessionPolicyS3EnforcementIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/StsSessionPolicyS3EnforcementIntegrationTest.java
@@ -1,0 +1,160 @@
+package io.github.hectorvent.floci.services.iam;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.startsWith;
+
+@QuarkusTest
+@TestProfile(StsSessionPolicyS3EnforcementIntegrationTest.IamEnforcementProfile.class)
+class StsSessionPolicyS3EnforcementIntegrationTest {
+
+    private static final String ACCOUNT_ID = "000000000000";
+    private static final String REGION = "us-east-1";
+
+    @Test
+    void assumeRoleSessionPolicyDenyRestrictsS3PutObject() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String bucket = "session-policy-" + suffix;
+        String roleName = "SessionPolicyRole" + suffix;
+
+        createBucket(bucket);
+        createRole(roleName);
+        putBroadS3RolePolicy(roleName, bucket);
+
+        String accessKeyId = assumeRoleWithS3SessionPolicy(roleName, bucket);
+
+        given()
+                .header("Authorization", auth(accessKeyId, "s3"))
+                .contentType("text/plain")
+                .body("allowed")
+        .when()
+                .put("/" + bucket + "/allowed/file.txt")
+        .then()
+                .statusCode(200);
+
+        given()
+                .header("Authorization", auth(accessKeyId, "s3"))
+                .contentType("text/plain")
+                .body("denied")
+        .when()
+                .put("/" + bucket + "/blocked/file.txt")
+        .then()
+                .statusCode(403)
+                .body(containsString("<Code>AccessDenied</Code>"));
+    }
+
+    private static void createBucket(String bucket) {
+        given()
+                .header("Authorization", auth("test", "s3"))
+        .when()
+                .put("/" + bucket)
+        .then()
+                .statusCode(200);
+    }
+
+    private static void createRole(String roleName) {
+        given()
+                .formParam("Action", "CreateRole")
+                .formParam("RoleName", roleName)
+                .formParam("Path", "/")
+                .formParam("AssumeRolePolicyDocument", """
+                    {
+                      "Version": "2012-10-17",
+                      "Statement": [
+                        {
+                          "Effect": "Allow",
+                          "Principal": { "AWS": "*" },
+                          "Action": "sts:AssumeRole"
+                        }
+                      ]
+                    }
+                    """)
+                .header("Authorization", auth("test", "iam"))
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200);
+    }
+
+    private static void putBroadS3RolePolicy(String roleName, String bucket) {
+        given()
+                .formParam("Action", "PutRolePolicy")
+                .formParam("RoleName", roleName)
+                .formParam("PolicyName", "AllowS3")
+                .formParam("PolicyDocument", """
+                    {
+                      "Version": "2012-10-17",
+                      "Statement": [
+                        {
+                          "Effect": "Allow",
+                          "Action": "s3:*",
+                          "Resource": [
+                            "arn:aws:s3:::%1$s",
+                            "arn:aws:s3:::%1$s/*"
+                          ]
+                        }
+                      ]
+                    }
+                    """.formatted(bucket))
+                .header("Authorization", auth("test", "iam"))
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200);
+    }
+
+    private static String assumeRoleWithS3SessionPolicy(String roleName, String bucket) {
+        return given()
+                .formParam("Action", "AssumeRole")
+                .formParam("RoleArn", "arn:aws:iam::" + ACCOUNT_ID + ":role/" + roleName)
+                .formParam("RoleSessionName", "session-policy-test")
+                .formParam("Policy", """
+                    {
+                      "Version": "2012-10-17",
+                      "Statement": [
+                        {
+                          "Effect": "Allow",
+                          "Action": "s3:*",
+                          "Resource": [
+                            "arn:aws:s3:::%1$s",
+                            "arn:aws:s3:::%1$s/*"
+                          ]
+                        },
+                        {
+                          "Effect": "Deny",
+                          "Action": "s3:*",
+                          "Resource": "arn:aws:s3:::%1$s/blocked/*"
+                        }
+                      ]
+                    }
+                    """.formatted(bucket))
+                .header("Authorization", auth("test", "sts"))
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200)
+                .body("AssumeRoleResponse.AssumeRoleResult.Credentials.AccessKeyId", startsWith("ASIA"))
+                .extract()
+                .path("AssumeRoleResponse.AssumeRoleResult.Credentials.AccessKeyId");
+    }
+
+    private static String auth(String accessKeyId, String service) {
+        return "AWS4-HMAC-SHA256 Credential=" + accessKeyId + "/20260629/" + REGION + "/" + service
+                + "/aws4_request, SignedHeaders=host, Signature=abc";
+    }
+
+    public static final class IamEnforcementProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci.services.iam.enforcement-enabled", "true");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

STS session policies were recorded on temporary credentials but IAM enforcement evaluated only the caller's identity policies. As a result, an assumed role with broad role permissions could still perform an action even when the inline `AssumeRole` session policy should have denied or narrowed it.

This changes enforcement to evaluate the full caller context, including identity policies, session policies, and permission boundaries. It also keeps temporary-credential lookup account-independent so assumed-role sessions can be resolved after account routing moves the request into the role account, and it uses the resolved request account when building resource ARNs for policy evaluation.

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

Incorrect behavior: STS `AssumeRole` accepted the standard inline `Policy` parameter, but later requests signed with those temporary credentials did not have that session policy applied by IAM enforcement.

The fix matches AWS policy evaluation semantics: explicit denies in session policies participate in the deny pass, and a present session policy must also explicitly allow the request for the role's permissions to be effective. This preserves the existing Floci bypass behavior for unknown local credentials and the `test` root credential.

## What changed

- `IamEnforcementFilter` resolves a `CallerContext` and evaluates the complete IAM context instead of identity-policy documents only.
- `IamService` resolves STS sessions across account namespaces for caller context, caller ARN, account routing, and temporary secret lookup.
- Enforcement resource ARN construction uses the request account already resolved by `AccountContextFilter`, so assumed-role credentials evaluate account-scoped resources against the role account.
- IAM and multi-account docs now describe session-policy intersection and temporary-credential resolution accurately.
- Java SDK compatibility coverage now checks that an assumed-role session policy deny overrides a role allow.

## Checklist

- [x] `./mvnw test` passes locally - attempted; only failures were unrelated LambdaReactiveSyncIntegrationTest container startup Broken pipe errors
- [x] Selected Java SDK compatibility tests pass locally - in `compatibility-tests/sdk-test-java`: `mvn -q -Dtest=IamEnforcementTest,IamTest,StsTest,S3Test test`
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits