### PR TITLE
feat(ses): implement ContactList CRUD for SES v2

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesContactListTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesContactListTest.java
@@ -1,0 +1,223 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.BadRequestException;
+import software.amazon.awssdk.services.sesv2.model.CreateContactListRequest;
+import software.amazon.awssdk.services.sesv2.model.DeleteContactListRequest;
+import software.amazon.awssdk.services.sesv2.model.GetContactListRequest;
+import software.amazon.awssdk.services.sesv2.model.GetContactListResponse;
+import software.amazon.awssdk.services.sesv2.model.NotFoundException;
+import software.amazon.awssdk.services.sesv2.model.SubscriptionStatus;
+import software.amazon.awssdk.services.sesv2.model.Topic;
+import software.amazon.awssdk.services.sesv2.model.UpdateContactListRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * SDK compatibility test for the SES v2 ContactList APIs. Verifies the AWS Java
+ * SDK v2 marshalling of CreateContactList / GetContactList / ListContactLists /
+ * UpdateContactList / DeleteContactList, the AWS-confirmed one-list-per-account
+ * limit and input constraints (BadRequestException), and NotFoundException for
+ * unknown lists, against a live Floci instance.
+ */
+@DisplayName("SES v2 Contact Lists")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesContactListTest {
+
+    private static final String LIST = "compat-contact-list";
+
+    private static SesV2Client sesV2;
+
+    @BeforeAll
+    static void setup() {
+        sesV2 = TestFixtures.sesV2Client();
+        deleteAllContactLists();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (sesV2 != null) {
+            deleteAllContactLists();
+            sesV2.close();
+        }
+    }
+
+    private static void deleteAllContactLists() {
+        // Only one contact list may exist per account, so clear whatever is present. Let failures
+        // surface — a stuck list here would otherwise make later tests fail with a confusing
+        // one-list-per-account error.
+        sesV2.listContactLists(r -> {}).contactLists().forEach(cl ->
+                sesV2.deleteContactList(DeleteContactListRequest.builder()
+                        .contactListName(cl.contactListName()).build()));
+    }
+
+    @Test
+    @Order(1)
+    void createContactList_thenGetReturnsTopicsAndDescription() {
+        sesV2.createContactList(CreateContactListRequest.builder()
+                .contactListName(LIST)
+                .description("newsletter")
+                .topics(Topic.builder()
+                        .topicName("weekly")
+                        .displayName("Weekly")
+                        .defaultSubscriptionStatus(SubscriptionStatus.OPT_IN)
+                        .description("weekly digest")
+                        .build())
+                .build());
+
+        GetContactListResponse response = sesV2.getContactList(
+                GetContactListRequest.builder().contactListName(LIST).build());
+        assertThat(response.contactListName()).isEqualTo(LIST);
+        assertThat(response.description()).isEqualTo("newsletter");
+        assertThat(response.topics()).hasSize(1);
+        assertThat(response.topics().get(0).topicName()).isEqualTo("weekly");
+        assertThat(response.topics().get(0).defaultSubscriptionStatus())
+                .isEqualTo(SubscriptionStatus.OPT_IN);
+        assertThat(response.createdTimestamp()).isNotNull();
+        assertThat(response.lastUpdatedTimestamp()).isNotNull();
+    }
+
+    @Test
+    @Order(2)
+    void createSecondContactList_throwsBadRequestPerAccountLimit() {
+        assertThatThrownBy(() -> sesV2.createContactList(CreateContactListRequest.builder()
+                .contactListName("compat-contact-list-2").build()))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("A maximum of 1 Lists allowed per account");
+    }
+
+    @Test
+    @Order(3)
+    void createDuplicateName_throwsPerAccountLimit() {
+        // A duplicate name hits the one-list-per-account limit before any "already exists" check,
+        // so AWS returns BadRequestException here, not AlreadyExistsException.
+        assertThatThrownBy(() -> sesV2.createContactList(CreateContactListRequest.builder()
+                .contactListName(LIST).build()))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("A maximum of 1 Lists allowed per account");
+    }
+
+    @Test
+    @Order(4)
+    void getContactList_unknown_throwsNotFound() {
+        assertThatThrownBy(() -> sesV2.getContactList(
+                GetContactListRequest.builder().contactListName("compat-contact-ghost").build()))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("List with name: compat-contact-ghost doesn't exist.");
+    }
+
+    @Test
+    @Order(5)
+    void listContactLists_includesCreatedList() {
+        assertThat(sesV2.listContactLists(r -> {}).contactLists())
+                .anyMatch(cl -> LIST.equals(cl.contactListName()));
+    }
+
+    @Test
+    @Order(6)
+    void updateContactList_replacesTopicsAndDescription() {
+        sesV2.updateContactList(UpdateContactListRequest.builder()
+                .contactListName(LIST)
+                .description("updated")
+                .topics(Topic.builder()
+                        .topicName("monthly")
+                        .displayName("Monthly")
+                        .defaultSubscriptionStatus(SubscriptionStatus.OPT_OUT)
+                        .build())
+                .build());
+
+        GetContactListResponse response = sesV2.getContactList(
+                GetContactListRequest.builder().contactListName(LIST).build());
+        assertThat(response.description()).isEqualTo("updated");
+        assertThat(response.topics()).hasSize(1);
+        assertThat(response.topics().get(0).topicName()).isEqualTo("monthly");
+        assertThat(response.topics().get(0).defaultSubscriptionStatus())
+                .isEqualTo(SubscriptionStatus.OPT_OUT);
+    }
+
+    @Test
+    @Order(7)
+    void deleteContactList_removesIt() {
+        sesV2.deleteContactList(DeleteContactListRequest.builder().contactListName(LIST).build());
+
+        assertThatThrownBy(() -> sesV2.getContactList(
+                GetContactListRequest.builder().contactListName(LIST).build()))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @Order(8)
+    void deleteContactList_unknown_throwsNotFound() {
+        assertThatThrownBy(() -> sesV2.deleteContactList(
+                DeleteContactListRequest.builder().contactListName("compat-contact-ghost").build()))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @Order(9)
+    void createContactList_tooManyTopics_throwsBadRequest() {
+        List<Topic> manyTopics = new ArrayList<>();
+        for (int i = 0; i < 21; i++) {
+            manyTopics.add(Topic.builder().topicName("t" + i).displayName("D" + i)
+                    .defaultSubscriptionStatus(SubscriptionStatus.OPT_IN).build());
+        }
+        assertThatThrownBy(() -> sesV2.createContactList(CreateContactListRequest.builder()
+                .contactListName("compat-many").topics(manyTopics).build()))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("Maximum of <20> topics allowed per ContactList");
+    }
+
+    @Test
+    @Order(10)
+    void createContactList_duplicateTopicNames_throwsBadRequest() {
+        assertThatThrownBy(() -> sesV2.createContactList(CreateContactListRequest.builder()
+                .contactListName("compat-dup")
+                .topics(Topic.builder().topicName("x").displayName("A")
+                                .defaultSubscriptionStatus(SubscriptionStatus.OPT_IN).build(),
+                        Topic.builder().topicName("x").displayName("B")
+                                .defaultSubscriptionStatus(SubscriptionStatus.OPT_IN).build())
+                .build()))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("Duplicate topic names are not allowed within a List.");
+    }
+
+    @Test
+    @Order(11)
+    void createContactList_invalidNameChars_throwsBadRequest() {
+        assertThatThrownBy(() -> sesV2.createContactList(CreateContactListRequest.builder()
+                .contactListName("bad name!").build()))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("ContactListName can contain up to 64 characters");
+    }
+
+    @Test
+    @Order(12)
+    void createContactList_descriptionTooLong_throwsBadRequest() {
+        assertThatThrownBy(() -> sesV2.createContactList(CreateContactListRequest.builder()
+                .contactListName("compat-desc").description("a".repeat(501)).build()))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("List description can contain up to 500 characters.");
+    }
+
+    @Test
+    @Order(13)
+    void getContactList_invalidName_throwsBadRequestNotNotFound() {
+        // Real AWS validates the name on read/delete too, returning 400 (not 404).
+        assertThatThrownBy(() -> sesV2.getContactList(
+                GetContactListRequest.builder().contactListName("a".repeat(65)).build()))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("ContactListName can contain up to 64 characters");
+    }
+}

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -206,6 +206,11 @@ Alongside the classic Query API, Floci implements a subset of the SES v2 REST JS
 | `GET` | `/v2/email/dedicated-ip-pools` | `ListDedicatedIpPools` |
 | `GET` | `/v2/email/dedicated-ip-pools/{PoolName}` | `GetDedicatedIpPool` |
 | `DELETE` | `/v2/email/dedicated-ip-pools/{PoolName}` | `DeleteDedicatedIpPool` |
+| `POST` | `/v2/email/contact-lists` | `CreateContactList` |
+| `GET` | `/v2/email/contact-lists` | `ListContactLists` |
+| `GET` | `/v2/email/contact-lists/{ContactListName}` | `GetContactList` |
+| `PUT` | `/v2/email/contact-lists/{ContactListName}` | `UpdateContactList` |
+| `DELETE` | `/v2/email/contact-lists/{ContactListName}` | `DeleteContactList` |
 | `PUT` | `/v2/email/suppression/addresses` | `PutSuppressedDestination` |
 | `GET` | `/v2/email/suppression/addresses/{EmailAddress}` | `GetSuppressedDestination` |
 | `DELETE` | `/v2/email/suppression/addresses/{EmailAddress}` | `DeleteSuppressedDestination` |

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -9,7 +9,9 @@ import io.github.hectorvent.floci.services.ses.model.GuardianOptions;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntry;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.ContactList;
 import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
+import io.github.hectorvent.floci.services.ses.model.Topic;
 import io.github.hectorvent.floci.services.ses.model.DeliveryOptions;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.EventDestination;
@@ -1150,6 +1152,146 @@ public class SesController {
         sesService.deleteDedicatedIpPool(poolName, region);
         LOG.infov("SES V2 DeleteDedicatedIpPool: {0}", poolName);
         return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    // ─────────────────────────── Contact lists ───────────────────────────
+
+    @POST
+    @Path("/contact-lists")
+    public Response createContactList(@Context HttpHeaders headers, String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            if (body == null || body.isBlank()) {
+                throw new AwsException("BadRequestException", "Request body is required.", 400);
+            }
+            JsonNode request = objectMapper.readTree(body);
+            requireJsonObject(request);
+            // Read leniently; the service surfaces a missing ContactListName as the AWS Smithy
+            // validation error rather than a custom "required" message.
+            String name = request.path("ContactListName").asText(null);
+            List<Topic> topics = parseTopicsArray(request.path("Topics"));
+            List<Tag> tags = parseTagsArray(request.path("Tags"));
+            String description = request.path("Description").asText(null);
+            sesService.createContactList(name, description, topics, tags, region);
+            LOG.infov("SES V2 CreateContactList: {0}", name);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @GET
+    @Path("/contact-lists")
+    public Response listContactLists(@Context HttpHeaders headers) {
+        String region = regionResolver.resolveRegion(headers);
+        ObjectNode result = objectMapper.createObjectNode();
+        ArrayNode lists = result.putArray("ContactLists");
+        for (ContactList cl : sesService.listContactLists(region)) {
+            ObjectNode item = lists.addObject();
+            item.put("ContactListName", cl.getContactListName());
+            if (cl.getLastUpdatedTimestamp() != null) {
+                item.put("LastUpdatedTimestamp", cl.getLastUpdatedTimestamp().getEpochSecond());
+            }
+        }
+        return Response.ok(result).build();
+    }
+
+    @GET
+    @Path("/contact-lists/{contactListName}")
+    public Response getContactList(@Context HttpHeaders headers,
+                                   @PathParam("contactListName") String contactListName) {
+        String region = regionResolver.resolveRegion(headers);
+        return Response.ok(contactListJson(sesService.getContactList(contactListName, region))).build();
+    }
+
+    @PUT
+    @Path("/contact-lists/{contactListName}")
+    public Response updateContactList(@Context HttpHeaders headers,
+                                      @PathParam("contactListName") String contactListName,
+                                      String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode request = (body == null || body.isBlank())
+                    ? objectMapper.createObjectNode()
+                    : objectMapper.readTree(body);
+            requireJsonObject(request);
+            JsonNode topicsNode = request.path("Topics");
+            // Treat absent or explicit-null Topics as "not provided" (keep existing), consistent
+            // with Description; clearing is done via an explicit empty array [].
+            List<Topic> topics = (topicsNode.isMissingNode() || topicsNode.isNull())
+                    ? null : parseTopicsArray(topicsNode);
+            JsonNode descNode = request.path("Description");
+            boolean descriptionPresent = !descNode.isMissingNode() && !descNode.isNull();
+            String description = descNode.asText(null);
+            sesService.updateContactList(contactListName, description, descriptionPresent, topics, region);
+            LOG.infov("SES V2 UpdateContactList: {0}", contactListName);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new AwsException("BadRequestException", e.getMessage(), 400);
+        }
+    }
+
+    @DELETE
+    @Path("/contact-lists/{contactListName}")
+    public Response deleteContactList(@Context HttpHeaders headers,
+                                      @PathParam("contactListName") String contactListName) {
+        String region = regionResolver.resolveRegion(headers);
+        sesService.deleteContactList(contactListName, region);
+        LOG.infov("SES V2 DeleteContactList: {0}", contactListName);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private List<Topic> parseTopicsArray(JsonNode topicsNode) {
+        List<Topic> out = new ArrayList<>();
+        if (topicsNode == null || topicsNode.isMissingNode() || topicsNode.isNull()) {
+            return out;
+        }
+        if (!topicsNode.isArray()) {
+            throw new AwsException("BadRequestException", "Topics must be an array.", 400);
+        }
+        for (JsonNode t : topicsNode) {
+            out.add(new Topic(
+                    t.path("TopicName").asText(null),
+                    t.path("DisplayName").asText(null),
+                    t.path("DefaultSubscriptionStatus").asText(null),
+                    t.path("Description").asText(null)));
+        }
+        return out;
+    }
+
+    private ObjectNode contactListJson(ContactList cl) {
+        ObjectNode result = objectMapper.createObjectNode();
+        result.put("ContactListName", cl.getContactListName());
+        if (cl.getDescription() != null) {
+            result.put("Description", cl.getDescription());
+        }
+        ArrayNode topics = result.putArray("Topics");
+        for (Topic t : cl.getTopics()) {
+            ObjectNode to = topics.addObject();
+            to.put("TopicName", t.getTopicName());
+            to.put("DisplayName", t.getDisplayName());
+            to.put("DefaultSubscriptionStatus", t.getDefaultSubscriptionStatus());
+            if (t.getDescription() != null) {
+                to.put("Description", t.getDescription());
+            }
+        }
+        if (cl.getCreatedTimestamp() != null) {
+            result.put("CreatedTimestamp", cl.getCreatedTimestamp().getEpochSecond());
+        }
+        if (cl.getLastUpdatedTimestamp() != null) {
+            result.put("LastUpdatedTimestamp", cl.getLastUpdatedTimestamp().getEpochSecond());
+        }
+        ArrayNode tags = result.putArray("Tags");
+        for (Tag tag : cl.getTags()) {
+            ObjectNode tn = tags.addObject();
+            tn.put("Key", tag.key());
+            tn.put("Value", tag.value());
+        }
+        return result;
     }
 
     // ──────────────────────────── Account ────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -15,6 +15,7 @@ import io.github.hectorvent.floci.services.ses.model.BulkEmailEntry;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntryResult;
 import io.github.hectorvent.floci.services.ses.model.CloudWatchDimensionConfiguration;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.ContactList;
 import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
 import io.github.hectorvent.floci.services.ses.model.DeliveryOptions;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
@@ -22,6 +23,7 @@ import io.github.hectorvent.floci.services.ses.model.EventDestination;
 import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.MessageHeader;
 import io.github.hectorvent.floci.services.ses.model.MessageTag;
+import io.github.hectorvent.floci.services.ses.model.Topic;
 import io.github.hectorvent.floci.services.ses.model.TrackingOptions;
 import io.github.hectorvent.floci.services.ses.model.VdmOptions;
 import io.github.hectorvent.floci.services.ses.model.SentEmail;
@@ -81,6 +83,9 @@ public class SesService {
     private final StorageBackend<String, SuppressedDestination> suppressionStore;
     private final StorageBackend<String, AccountSuppressionAttributes> accountSuppressionStore;
     private final StorageBackend<String, DedicatedIpPool> dedicatedIpPoolStore;
+    private final StorageBackend<String, ContactList> contactListStore;
+    // Guards the one-list-per-account check-then-create so concurrent creates can't both pass.
+    private final Object contactListCreateLock = new Object();
     private final SmtpRelay smtpRelay;
     private final ObjectMapper objectMapper;
     private final SesEventPublisher eventPublisher;
@@ -109,6 +114,8 @@ public class SesService {
                 new TypeReference<Map<String, AccountSuppressionAttributes>>() {});
         this.dedicatedIpPoolStore = storageFactory.create("ses", "ses-dedicated-ip-pools.json",
                 new TypeReference<Map<String, DedicatedIpPool>>() {});
+        this.contactListStore = storageFactory.create("ses", "ses-contact-lists.json",
+                new TypeReference<Map<String, ContactList>>() {});
         this.smtpRelay = smtpRelay;
         this.objectMapper = objectMapper;
         this.eventPublisher = eventPublisher;
@@ -125,11 +132,12 @@ public class SesService {
                StorageBackend<String, SuppressedDestination> suppressionStore,
                StorageBackend<String, AccountSuppressionAttributes> accountSuppressionStore,
                StorageBackend<String, DedicatedIpPool> dedicatedIpPoolStore,
+               StorageBackend<String, ContactList> contactListStore,
                SmtpRelay smtpRelay,
                ObjectMapper objectMapper,
                Clock clock) {
         this(identityStore, emailStore, accountSettingsStore, templateStore, configSetStore, suppressionStore,
-                accountSuppressionStore, dedicatedIpPoolStore, smtpRelay, objectMapper, null, clock);
+                accountSuppressionStore, dedicatedIpPoolStore, contactListStore, smtpRelay, objectMapper, null, clock);
     }
 
     SesService(StorageBackend<String, Identity> identityStore,
@@ -140,6 +148,7 @@ public class SesService {
                StorageBackend<String, SuppressedDestination> suppressionStore,
                StorageBackend<String, AccountSuppressionAttributes> accountSuppressionStore,
                StorageBackend<String, DedicatedIpPool> dedicatedIpPoolStore,
+               StorageBackend<String, ContactList> contactListStore,
                SmtpRelay smtpRelay,
                ObjectMapper objectMapper,
                Route53Service route53Service,
@@ -152,6 +161,7 @@ public class SesService {
         this.suppressionStore = suppressionStore;
         this.accountSuppressionStore = accountSuppressionStore;
         this.dedicatedIpPoolStore = dedicatedIpPoolStore;
+        this.contactListStore = contactListStore;
         this.smtpRelay = smtpRelay;
         this.objectMapper = objectMapper;
         this.eventPublisher = null;
@@ -1215,6 +1225,183 @@ public class SesService {
 
     private static String dedicatedIpPoolKey(String region, String name) {
         return "dedicatedIpPool::" + region + "::" + name;
+    }
+
+    private static final Set<String> SUBSCRIPTION_STATUSES = Set.of("OPT_IN", "OPT_OUT");
+    private static final Pattern CONTACT_LIST_NAME_CHARS = Pattern.compile("^[A-Za-z0-9_-]{1,64}$");
+    private static final int MAX_TOPICS_PER_LIST = 20;
+    private static final int MAX_DISPLAY_NAME_LENGTH = 128;
+    private static final int MAX_LIST_DESCRIPTION_LENGTH = 500;
+
+    public ContactList createContactList(String name, String description, List<Topic> topics,
+                                         List<Tag> tags, String region) {
+        validateContactListInput(name, description, topics);
+        ContactList list = new ContactList(name);
+        list.setDescription(description);
+        list.setTopics(topics);
+        list.setTags(tags);
+        Instant now = Instant.now();
+        list.setCreatedTimestamp(now);
+        list.setLastUpdatedTimestamp(now);
+        // AWS allows at most one contact list per account per region (verified against real AWS).
+        // A duplicate name hits this same limit before any "already exists" check, so
+        // AlreadyExistsException is never reachable for contact lists. Lock only the check-then-put
+        // so concurrent calls can't both observe an empty region; building and logging stay outside.
+        synchronized (contactListCreateLock) {
+            if (!listContactLists(region).isEmpty()) {
+                throw new AwsException("BadRequestException",
+                        "A maximum of 1 Lists allowed per account.", 400);
+            }
+            contactListStore.put(contactListKey(region, name), list);
+        }
+        LOG.infov("Created SES contact list: {0} in region {1}", name, region);
+        return list;
+    }
+
+    public ContactList getContactList(String name, String region) {
+        return contactListStore.get(contactListKey(region, name))
+                .orElseThrow(() -> contactListNotFound(name));
+    }
+
+    public List<ContactList> listContactLists(String region) {
+        String prefix = "contactList::" + region + "::";
+        return contactListStore.scan(k -> k.startsWith(prefix)).stream()
+                .sorted(Comparator.comparing(ContactList::getContactListName))
+                .toList();
+    }
+
+    public ContactList updateContactList(String name, String description, boolean descriptionPresent,
+                                         List<Topic> topics, String region) {
+        validateContactListInput(name, description, topics);
+        String key = contactListKey(region, name);
+        ContactList existing = contactListStore.get(key).orElseThrow(() -> contactListNotFound(name));
+        if (topics != null) {
+            existing.setTopics(topics);
+        }
+        if (descriptionPresent) {
+            existing.setDescription(description);
+        }
+        existing.setLastUpdatedTimestamp(Instant.now());
+        contactListStore.put(key, existing);
+        LOG.infov("Updated SES contact list: {0} in region {1}", name, region);
+        return existing;
+    }
+
+    public void deleteContactList(String name, String region) {
+        String key = contactListKey(region, name);
+        if (contactListStore.get(key).isEmpty()) {
+            throw contactListNotFound(name);
+        }
+        contactListStore.delete(key);
+        LOG.infov("Deleted SES contact list: {0} in region {1}", name, region);
+    }
+
+    private static AwsException contactListNotFound(String name) {
+        return new AwsException("NotFoundException",
+                "List with name: " + name + " doesn't exist.", 404);
+    }
+
+    // SES V2 surfaces missing/invalid input as Smithy validation errors. Field paths and the
+    // enum value order are taken verbatim from real AWS.
+    private static AwsException validationError(String fieldPath, String constraint) {
+        return new AwsException("BadRequestException",
+                "1 validation error detected: Value at '" + fieldPath
+                        + "' failed to satisfy constraint: " + constraint, 400);
+    }
+
+    private static void validateContactListName(String name) {
+        if (name == null) {
+            throw validationError("contactListName", "Member must not be null");
+        }
+        if (name.isBlank()) {
+            throw new AwsException("BadRequestException", "ContactListName can't be blank.", 400);
+        }
+        if (!CONTACT_LIST_NAME_CHARS.matcher(name).matches()) {
+            throw new AwsException("BadRequestException",
+                    "ContactListName can contain up to 64 characters. Only alphanumeric characters, "
+                            + "underscores(_) and hyphens(-) are allowed.", 400);
+        }
+    }
+
+    private static void validateDescription(String description) {
+        if (description != null && description.length() > MAX_LIST_DESCRIPTION_LENGTH) {
+            throw new AwsException("BadRequestException",
+                    "List description can contain up to 500 characters.", 400);
+        }
+    }
+
+    // Validates Create/Update input in the same two-phase order as real AWS (verified by probe):
+    // protocol-layer (Smithy) checks across all fields first, then service-level constraints with
+    // ContactListName ahead of topic/description constraints.
+    private static void validateContactListInput(String name, String description, List<Topic> topics) {
+        // Phase 1 — protocol-layer (Smithy) validation: null members and the subscription-status
+        // enum. AWS reports these before any service-level constraint.
+        if (name == null) {
+            throw validationError("contactListName", "Member must not be null");
+        }
+        if (topics != null) {
+            for (int i = 0; i < topics.size(); i++) {
+                Topic t = topics.get(i);
+                String member = "topics." + (i + 1) + ".member.";
+                if (t.getTopicName() == null) {
+                    throw validationError(member + "topicName", "Member must not be null");
+                }
+                if (t.getDisplayName() == null) {
+                    throw validationError(member + "displayName", "Member must not be null");
+                }
+                if (t.getDefaultSubscriptionStatus() == null) {
+                    throw validationError(member + "defaultSubscriptionStatus", "Member must not be null");
+                }
+                if (!SUBSCRIPTION_STATUSES.contains(t.getDefaultSubscriptionStatus())) {
+                    throw validationError(member + "defaultSubscriptionStatus",
+                            "Member must satisfy enum value set: [OPT_OUT, OPT_IN]");
+                }
+            }
+        }
+        // Phase 2 — service-level constraints: ContactListName first, then topics, then description.
+        if (name.isBlank()) {
+            throw new AwsException("BadRequestException", "ContactListName can't be blank.", 400);
+        }
+        if (!CONTACT_LIST_NAME_CHARS.matcher(name).matches()) {
+            throw new AwsException("BadRequestException",
+                    "ContactListName can contain up to 64 characters. Only alphanumeric characters, "
+                            + "underscores(_) and hyphens(-) are allowed.", 400);
+        }
+        if (topics != null) {
+            if (topics.size() > MAX_TOPICS_PER_LIST) {
+                throw new AwsException("BadRequestException",
+                        "Maximum of <" + MAX_TOPICS_PER_LIST + "> topics allowed per ContactList", 400);
+            }
+            Set<String> seenNames = new HashSet<>();
+            for (Topic t : topics) {
+                if (t.getTopicName().isBlank()) {
+                    throw new AwsException("BadRequestException", "TopicName can't be blank.", 400);
+                }
+                if (!CONTACT_LIST_NAME_CHARS.matcher(t.getTopicName()).matches()) {
+                    throw new AwsException("BadRequestException",
+                            "TopicName can contain up to 64 characters. Only alphanumeric characters, "
+                                    + "underscores(_) and hyphens(-) are allowed.", 400);
+                }
+                if (t.getDisplayName().length() > MAX_DISPLAY_NAME_LENGTH) {
+                    throw new AwsException("BadRequestException",
+                            "Topic DisplayName can contain up to <" + MAX_DISPLAY_NAME_LENGTH
+                                    + "> characters.", 400);
+                }
+                if (!seenNames.add(t.getTopicName())) {
+                    throw new AwsException("BadRequestException",
+                            "Duplicate topic names are not allowed within a List.", 400);
+                }
+            }
+        }
+        validateDescription(description);
+    }
+
+    private static String contactListKey(String region, String name) {
+        // Validate in the key builder so Get/Update/Delete reject an invalid ContactListName with
+        // the AWS validation error (400) rather than a 404, matching configSetKey. Verified
+        // against real AWS: read/delete with an invalid name returns the same constraint message.
+        validateContactListName(name);
+        return "contactList::" + region + "::" + name;
     }
 
     static void validateConfigurationSetName(String name) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/ContactList.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/ContactList.java
@@ -1,0 +1,68 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A SES V2 contact list: a named container of subscription topics. AWS allows at
+ * most one contact list per account per region.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ContactList {
+
+    @JsonProperty("ContactListName")
+    private String contactListName;
+
+    @JsonProperty("Description")
+    private String description;
+
+    @JsonProperty("Topics")
+    private List<Topic> topics = new ArrayList<>();
+
+    @JsonProperty("Tags")
+    private List<Tag> tags = new ArrayList<>();
+
+    @JsonProperty("CreatedTimestamp")
+    private Instant createdTimestamp;
+
+    @JsonProperty("LastUpdatedTimestamp")
+    private Instant lastUpdatedTimestamp;
+
+    public ContactList() {}
+
+    public ContactList(String contactListName) {
+        this.contactListName = contactListName;
+    }
+
+    public String getContactListName() { return contactListName; }
+    public void setContactListName(String contactListName) { this.contactListName = contactListName; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public List<Topic> getTopics() { return topics; }
+    public void setTopics(List<Topic> topics) {
+        this.topics = topics == null ? new ArrayList<>() : topics;
+    }
+
+    public List<Tag> getTags() { return tags; }
+    public void setTags(List<Tag> tags) {
+        this.tags = tags == null ? new ArrayList<>() : tags;
+    }
+
+    public Instant getCreatedTimestamp() { return createdTimestamp; }
+    public void setCreatedTimestamp(Instant createdTimestamp) { this.createdTimestamp = createdTimestamp; }
+
+    public Instant getLastUpdatedTimestamp() { return lastUpdatedTimestamp; }
+    public void setLastUpdatedTimestamp(Instant lastUpdatedTimestamp) {
+        this.lastUpdatedTimestamp = lastUpdatedTimestamp;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/Topic.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/Topic.java
@@ -1,0 +1,53 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * A subscription topic within a SES V2 contact list. Mirrors the AWS {@code Topic}
+ * shape: a topic name, its display name, the default subscription status
+ * ({@code OPT_IN} or {@code OPT_OUT}), and an optional description.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Topic {
+
+    @JsonProperty("TopicName")
+    private String topicName;
+
+    @JsonProperty("DisplayName")
+    private String displayName;
+
+    @JsonProperty("DefaultSubscriptionStatus")
+    private String defaultSubscriptionStatus;
+
+    @JsonProperty("Description")
+    private String description;
+
+    public Topic() {}
+
+    public Topic(String topicName, String displayName, String defaultSubscriptionStatus,
+                 String description) {
+        this.topicName = topicName;
+        this.displayName = displayName;
+        this.defaultSubscriptionStatus = defaultSubscriptionStatus;
+        this.description = description;
+    }
+
+    public String getTopicName() { return topicName; }
+    public void setTopicName(String topicName) { this.topicName = topicName; }
+
+    public String getDisplayName() { return displayName; }
+    public void setDisplayName(String displayName) { this.displayName = displayName; }
+
+    public String getDefaultSubscriptionStatus() { return defaultSubscriptionStatus; }
+    public void setDefaultSubscriptionStatus(String defaultSubscriptionStatus) {
+        this.defaultSubscriptionStatus = defaultSubscriptionStatus;
+    }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesContactListV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesContactListV2IntegrationTest.java
@@ -1,0 +1,457 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Integration test for SES V2 ContactList CRUD:
+ *   POST/GET/PUT/DELETE /v2/email/contact-lists[/{name}].
+ * Verifies the AWS-confirmed "at most one contact list per account per region"
+ * limit, topic validation, and the GetContactList response shape.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesContactListV2IntegrationTest {
+
+    private static final String SES_AUTH =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/ses/aws4_request";
+    private static final String LIST = "my-newsletter";
+
+    private static final String CREATE_BODY = "{"
+            + "\"ContactListName\":\"" + LIST + "\","
+            + "\"Description\":\"newsletter\","
+            + "\"Topics\":["
+            + "{\"TopicName\":\"weekly\",\"DisplayName\":\"Weekly\","
+            + "\"DefaultSubscriptionStatus\":\"OPT_IN\",\"Description\":\"weekly digest\"},"
+            + "{\"TopicName\":\"promos\",\"DisplayName\":\"Promotions\","
+            + "\"DefaultSubscriptionStatus\":\"OPT_OUT\"}"
+            + "]}";
+
+    @Test
+    @Order(1)
+    void createContactList() {
+        given()
+                .contentType("application/json")
+                .header("Authorization", SES_AUTH)
+                .body(CREATE_BODY)
+        .when()
+                .post("/v2/email/contact-lists")
+        .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void getContactList_returnsShape() {
+        given()
+                .header("Authorization", SES_AUTH)
+        .when()
+                .get("/v2/email/contact-lists/" + LIST)
+        .then()
+                .statusCode(200)
+                .body("ContactListName", equalTo(LIST))
+                .body("Description", equalTo("newsletter"))
+                .body("Topics", hasSize(2))
+                .body("Topics[0].TopicName", equalTo("weekly"))
+                .body("Topics[0].DefaultSubscriptionStatus", equalTo("OPT_IN"))
+                .body("Topics[1].TopicName", equalTo("promos"))
+                .body("CreatedTimestamp", notNullValue())
+                .body("LastUpdatedTimestamp", notNullValue());
+    }
+
+    @Test
+    @Order(3)
+    void listContactLists_containsList() {
+        given()
+                .header("Authorization", SES_AUTH)
+        .when()
+                .get("/v2/email/contact-lists")
+        .then()
+                .statusCode(200)
+                .body("ContactLists.ContactListName", hasItem(LIST));
+    }
+
+    @Test
+    @Order(4)
+    void createSecondContactList_rejectedByPerAccountLimit() {
+        given()
+                .contentType("application/json")
+                .header("Authorization", SES_AUTH)
+                .body("{\"ContactListName\":\"second-list\"}")
+        .when()
+                .post("/v2/email/contact-lists")
+        .then()
+                .statusCode(400)
+                .body("__type", equalTo("BadRequestException"))
+                .body("message", equalTo("A maximum of 1 Lists allowed per account."));
+    }
+
+    @Test
+    @Order(5)
+    void createDuplicateName_alsoHitsPerAccountLimit() {
+        // A duplicate name hits the one-list-per-account limit before any "already exists" check,
+        // so AWS never returns AlreadyExistsException here.
+        given()
+                .contentType("application/json")
+                .header("Authorization", SES_AUTH)
+                .body("{\"ContactListName\":\"" + LIST + "\"}")
+        .when()
+                .post("/v2/email/contact-lists")
+        .then()
+                .statusCode(400)
+                .body("__type", equalTo("BadRequestException"))
+                .body("message", equalTo("A maximum of 1 Lists allowed per account."));
+    }
+
+    @Test
+    @Order(6)
+    void createContactList_invalidTopicStatus_returns400() {
+        given()
+                .contentType("application/json")
+                .header("Authorization", SES_AUTH)
+                .body("{\"ContactListName\":\"bad-list\",\"Topics\":["
+                        + "{\"TopicName\":\"t\",\"DisplayName\":\"T\","
+                        + "\"DefaultSubscriptionStatus\":\"MAYBE\"}]}")
+        .when()
+                .post("/v2/email/contact-lists")
+        .then()
+                .statusCode(400)
+                .body("__type", equalTo("BadRequestException"))
+                .body("message", equalTo("1 validation error detected: Value at "
+                        + "'topics.1.member.defaultSubscriptionStatus' failed to satisfy constraint: "
+                        + "Member must satisfy enum value set: [OPT_OUT, OPT_IN]"));
+    }
+
+    @Test
+    @Order(7)
+    void updateContactList_replacesTopicsAndDescription() {
+        given()
+                .contentType("application/json")
+                .header("Authorization", SES_AUTH)
+                .body("{\"Description\":\"updated\",\"Topics\":["
+                        + "{\"TopicName\":\"monthly\",\"DisplayName\":\"Monthly\","
+                        + "\"DefaultSubscriptionStatus\":\"OPT_IN\"}]}")
+        .when()
+                .put("/v2/email/contact-lists/" + LIST)
+        .then()
+                .statusCode(200);
+
+        given()
+                .header("Authorization", SES_AUTH)
+        .when()
+                .get("/v2/email/contact-lists/" + LIST)
+        .then()
+                .statusCode(200)
+                .body("Description", equalTo("updated"))
+                .body("Topics", hasSize(1))
+                .body("Topics[0].TopicName", equalTo("monthly"));
+
+        // An explicit-null Topics is treated as "not provided" and preserves existing topics.
+        given()
+                .contentType("application/json")
+                .header("Authorization", SES_AUTH)
+                .body("{\"Topics\":null,\"Description\":\"kept-topics\"}")
+        .when()
+                .put("/v2/email/contact-lists/" + LIST)
+        .then()
+                .statusCode(200);
+
+        given()
+                .header("Authorization", SES_AUTH)
+        .when()
+                .get("/v2/email/contact-lists/" + LIST)
+        .then()
+                .statusCode(200)
+                .body("Description", equalTo("kept-topics"))
+                .body("Topics", hasSize(1))
+                .body("Topics[0].TopicName", equalTo("monthly"));
+
+        // An empty body is accepted as a no-op update (200), matching real AWS.
+        given()
+                .contentType("application/json")
+                .header("Authorization", SES_AUTH)
+        .when()
+                .put("/v2/email/contact-lists/" + LIST)
+        .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @Order(8)
+    void getContactList_unknown_returns404() {
+        given()
+                .header("Authorization", SES_AUTH)
+        .when()
+                .get("/v2/email/contact-lists/does-not-exist")
+        .then()
+                .statusCode(404)
+                .body("__type", equalTo("NotFoundException"))
+                .body("message", equalTo("List with name: does-not-exist doesn't exist."));
+    }
+
+    @Test
+    @Order(9)
+    void updateContactList_unknown_returns404() {
+        given()
+                .contentType("application/json")
+                .header("Authorization", SES_AUTH)
+                .body("{\"Description\":\"x\"}")
+        .when()
+                .put("/v2/email/contact-lists/does-not-exist")
+        .then()
+                .statusCode(404)
+                .body("__type", equalTo("NotFoundException"));
+    }
+
+    @Test
+    @Order(10)
+    void deleteContactList_thenGoneAndSlotFreed() {
+        given()
+                .header("Authorization", SES_AUTH)
+        .when()
+                .delete("/v2/email/contact-lists/" + LIST)
+        .then()
+                .statusCode(200);
+
+        given()
+                .header("Authorization", SES_AUTH)
+        .when()
+                .get("/v2/email/contact-lists/" + LIST)
+        .then()
+                .statusCode(404);
+
+        given()
+                .header("Authorization", SES_AUTH)
+        .when()
+                .get("/v2/email/contact-lists")
+        .then()
+                .statusCode(200)
+                .body("ContactLists", hasSize(0));
+
+        // The single-list slot is freed, so a new list can be created.
+        given()
+                .contentType("application/json")
+                .header("Authorization", SES_AUTH)
+                .body("{\"ContactListName\":\"fresh-list\"}")
+        .when()
+                .post("/v2/email/contact-lists")
+        .then()
+                .statusCode(200);
+
+        given()
+                .header("Authorization", SES_AUTH)
+        .when()
+                .delete("/v2/email/contact-lists/fresh-list")
+        .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @Order(11)
+    void createContactList_missingName_returnsSmithyValidationError() {
+        given()
+                .contentType("application/json")
+                .header("Authorization", SES_AUTH)
+                .body("{}")
+        .when()
+                .post("/v2/email/contact-lists")
+        .then()
+                .statusCode(400)
+                .body("__type", equalTo("BadRequestException"))
+                .body("message", equalTo("1 validation error detected: Value at 'contactListName' "
+                        + "failed to satisfy constraint: Member must not be null"));
+    }
+
+    @Test
+    @Order(12)
+    void createContactList_topicMissingTopicName_returnsSmithyValidationError() {
+        given()
+                .contentType("application/json")
+                .header("Authorization", SES_AUTH)
+                .body("{\"ContactListName\":\"x\",\"Topics\":["
+                        + "{\"DisplayName\":\"T\",\"DefaultSubscriptionStatus\":\"OPT_IN\"}]}")
+        .when()
+                .post("/v2/email/contact-lists")
+        .then()
+                .statusCode(400)
+                .body("__type", equalTo("BadRequestException"))
+                .body("message", equalTo("1 validation error detected: Value at "
+                        + "'topics.1.member.topicName' failed to satisfy constraint: "
+                        + "Member must not be null"));
+    }
+
+    @Test
+    @Order(13)
+    void createContactList_tooManyTopics_returns400() {
+        post(create("many-topics", topics(21)))
+        .then()
+                .statusCode(400)
+                .body("__type", equalTo("BadRequestException"))
+                .body("message", equalTo("Maximum of <20> topics allowed per ContactList"));
+    }
+
+    @Test
+    @Order(14)
+    void createContactList_duplicateTopicNames_returns400() {
+        post("{\"ContactListName\":\"dup\",\"Topics\":["
+                + "{\"TopicName\":\"x\",\"DisplayName\":\"A\",\"DefaultSubscriptionStatus\":\"OPT_IN\"},"
+                + "{\"TopicName\":\"x\",\"DisplayName\":\"B\",\"DefaultSubscriptionStatus\":\"OPT_IN\"}]}")
+        .then()
+                .statusCode(400)
+                .body("message", equalTo("Duplicate topic names are not allowed within a List."));
+    }
+
+    @Test
+    @Order(15)
+    void createContactList_invalidNameChars_returns400() {
+        post("{\"ContactListName\":\"bad name!\"}")
+        .then()
+                .statusCode(400)
+                .body("message", equalTo("ContactListName can contain up to 64 characters. "
+                        + "Only alphanumeric characters, underscores(_) and hyphens(-) are allowed."));
+    }
+
+    @Test
+    @Order(16)
+    void createContactList_blankName_returns400() {
+        post("{\"ContactListName\":\"\"}")
+        .then()
+                .statusCode(400)
+                .body("message", equalTo("ContactListName can't be blank."));
+    }
+
+    @Test
+    @Order(17)
+    void createContactList_blankTopicName_returns400() {
+        post("{\"ContactListName\":\"ok\",\"Topics\":["
+                + "{\"TopicName\":\"\",\"DisplayName\":\"A\",\"DefaultSubscriptionStatus\":\"OPT_IN\"}]}")
+        .then()
+                .statusCode(400)
+                .body("message", equalTo("TopicName can't be blank."));
+    }
+
+    @Test
+    @Order(18)
+    void createContactList_displayNameTooLong_returns400() {
+        post("{\"ContactListName\":\"ok\",\"Topics\":["
+                + "{\"TopicName\":\"t\",\"DisplayName\":\"" + "a".repeat(129)
+                + "\",\"DefaultSubscriptionStatus\":\"OPT_IN\"}]}")
+        .then()
+                .statusCode(400)
+                .body("message", equalTo("Topic DisplayName can contain up to <128> characters."));
+    }
+
+    @Test
+    @Order(19)
+    void createContactList_descriptionTooLong_returns400() {
+        post("{\"ContactListName\":\"ok\",\"Description\":\"" + "a".repeat(501) + "\"}")
+        .then()
+                .statusCode(400)
+                .body("message", equalTo("List description can contain up to 500 characters."));
+    }
+
+    @Test
+    @Order(20)
+    void getContactList_invalidName_returns400NotNotFound() {
+        given()
+                .header("Authorization", SES_AUTH)
+        .when()
+                .get("/v2/email/contact-lists/" + "a".repeat(65))
+        .then()
+                .statusCode(400)
+                .body("__type", equalTo("BadRequestException"))
+                .body("message", equalTo("ContactListName can contain up to 64 characters. "
+                        + "Only alphanumeric characters, underscores(_) and hyphens(-) are allowed."));
+    }
+
+    @Test
+    @Order(21)
+    void deleteContactList_invalidName_returns400NotNotFound() {
+        given()
+                .header("Authorization", SES_AUTH)
+        .when()
+                .delete("/v2/email/contact-lists/" + "a".repeat(65))
+        .then()
+                .statusCode(400)
+                .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    @Order(22)
+    void createContactList_invalidNameAndInvalidTopicEnum_reportsSmithyEnumFirst() {
+        // Probe-verified two-phase order: protocol-layer (Smithy) enum validation precedes the
+        // ContactListName constraint, so the enum error wins even though the name is also invalid.
+        post("{\"ContactListName\":\"bad name!\",\"Topics\":["
+                + "{\"TopicName\":\"t\",\"DisplayName\":\"T\",\"DefaultSubscriptionStatus\":\"MAYBE\"}]}")
+        .then()
+                .statusCode(400)
+                .body("message", equalTo("1 validation error detected: Value at "
+                        + "'topics.1.member.defaultSubscriptionStatus' failed to satisfy constraint: "
+                        + "Member must satisfy enum value set: [OPT_OUT, OPT_IN]"));
+    }
+
+    @Test
+    @Order(23)
+    void createContactList_invalidNameAndTooManyTopics_reportsNameFirst() {
+        // Probe-verified: among service-level constraints, ContactListName is validated before the
+        // topic-count limit.
+        post(create("bad name!", topics(21)))
+        .then()
+                .statusCode(400)
+                .body("message", equalTo("ContactListName can contain up to 64 characters. "
+                        + "Only alphanumeric characters, underscores(_) and hyphens(-) are allowed."));
+    }
+
+    @Test
+    @Order(24)
+    void updateContactList_invalidNameAndInvalidTopicEnum_reportsSmithyEnumFirst() {
+        // Same two-phase order on update: the Smithy enum error wins over the invalid path name.
+        given()
+                .contentType("application/json")
+                .header("Authorization", SES_AUTH)
+                .body("{\"Topics\":[{\"TopicName\":\"t\",\"DisplayName\":\"T\","
+                        + "\"DefaultSubscriptionStatus\":\"MAYBE\"}]}")
+        .when()
+                .put("/v2/email/contact-lists/" + "a".repeat(65))
+        .then()
+                .statusCode(400)
+                .body("message", equalTo("1 validation error detected: Value at "
+                        + "'topics.1.member.defaultSubscriptionStatus' failed to satisfy constraint: "
+                        + "Member must satisfy enum value set: [OPT_OUT, OPT_IN]"));
+    }
+
+    private static io.restassured.response.Response post(String body) {
+        return given()
+                .contentType("application/json")
+                .header("Authorization", SES_AUTH)
+                .body(body)
+        .when()
+                .post("/v2/email/contact-lists");
+    }
+
+    private static String create(String name, String topicsJson) {
+        return "{\"ContactListName\":\"" + name + "\",\"Topics\":" + topicsJson + "}";
+    }
+
+    private static String topics(int n) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < n; i++) {
+            if (i > 0) {
+                sb.append(",");
+            }
+            sb.append("{\"TopicName\":\"t").append(i)
+              .append("\",\"DisplayName\":\"D").append(i)
+              .append("\",\"DefaultSubscriptionStatus\":\"OPT_IN\"}");
+        }
+        return sb.append("]").toString();
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceDkimLookupCacheTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceDkimLookupCacheTest.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.services.route53.model.ResourceRecord;
 import io.github.hectorvent.floci.services.route53.model.ResourceRecordSet;
 import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.ContactList;
 import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
@@ -53,6 +54,7 @@ class SesServiceDkimLookupCacheTest {
                 new InMemoryStorage<String, SuppressedDestination>(),
                 new InMemoryStorage<String, AccountSuppressionAttributes>(),
                 new InMemoryStorage<String, DedicatedIpPool>(),
+                new InMemoryStorage<String, ContactList>(),
                 mock(SmtpRelay.class),
                 new ObjectMapper(),
                 route53Service,

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceLegacyDkimTokensTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceLegacyDkimTokensTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.ContactList;
 import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
@@ -42,6 +43,7 @@ class SesServiceLegacyDkimTokensTest {
                 new InMemoryStorage<String, SuppressedDestination>(),
                 new InMemoryStorage<String, AccountSuppressionAttributes>(),
                 new InMemoryStorage<String, DedicatedIpPool>(),
+                new InMemoryStorage<String, ContactList>(),
                 mock(SmtpRelay.class),
                 new ObjectMapper(),
                 Clock.systemUTC());

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSmtpTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSmtpTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.ContactList;
 import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
@@ -41,6 +42,7 @@ class SesServiceSmtpTest {
                 new InMemoryStorage<String, SuppressedDestination>(),
                 new InMemoryStorage<String, AccountSuppressionAttributes>(),
                 new InMemoryStorage<String, DedicatedIpPool>(),
+                new InMemoryStorage<String, ContactList>(),
                 smtpRelay,
                 new ObjectMapper(),
                 Clock.systemUTC());

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSuppressionLegacyKeyTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSuppressionLegacyKeyTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.ContactList;
 import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
@@ -49,6 +50,7 @@ class SesServiceSuppressionLegacyKeyTest {
                 suppressionStore,
                 new InMemoryStorage<String, AccountSuppressionAttributes>(),
                 new InMemoryStorage<String, DedicatedIpPool>(),
+                new InMemoryStorage<String, ContactList>(),
                 mock(SmtpRelay.class),
                 new ObjectMapper(),
                 Clock.systemUTC());

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSuppressionReasonTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSuppressionReasonTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.ContactList;
 import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
@@ -49,6 +50,7 @@ class SesServiceSuppressionReasonTest {
                 suppressionStore,
                 accountSuppressionStore,
                 new InMemoryStorage<String, DedicatedIpPool>(),
+                new InMemoryStorage<String, ContactList>(),
                 mock(SmtpRelay.class),
                 new ObjectMapper(),
                 Clock.systemUTC());


### PR DESCRIPTION
## Summary

Stage 1 of #1637.

Implements the SES v2 ContactList management APIs (the container half of contact-list/subscription management), under `/v2/email/contact-lists`:

| Method | Path | Operation |
| --- | --- | --- |
| `POST` | `/v2/email/contact-lists` | `CreateContactList` |
| `GET` | `/v2/email/contact-lists` | `ListContactLists` |
| `GET` | `/v2/email/contact-lists/{name}` | `GetContactList` |
| `PUT` | `/v2/email/contact-lists/{name}` | `UpdateContactList` |
| `DELETE` | `/v2/email/contact-lists/{name}` | `DeleteContactList` |

- New `ContactList` / `Topic` models; a `ses-contact-lists.json` store wired through `StorageFactory` (region-scoped key).
- A contact list holds subscription topics with `OPT_IN`/`OPT_OUT` defaults.
- `Contact` CRUD (the per-subscriber half) is the next stage and is intentionally out of scope here.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Behaviour and every error string were verified against real AWS (SES v2, boto3 / raw signed requests, us-east-1).

**One list per region.** AWS allows at most one contact list per account, enforced per region (lists in `us-east-1` and `us-west-2` coexist). A second `CreateContactList` is rejected with `BadRequestException` / `A maximum of 1 Lists allowed per account.`; Floci's region-scoped storage reproduces the per-region independence. A duplicate name hits this same limit before any "already exists" check, so `AlreadyExistsException` is never returned. Unknown lists return `NotFoundException` / `List with name: <name> doesn't exist.` — including on `Get`/`Update`/`Delete` with an invalid name (validated, returning 400, not 404).

**Input constraints** (all `BadRequestException`, and — confirmed by probe — evaluated *before* the per-account limit):

| Constraint | AWS message |
| --- | --- |
| Topics per list ≤ 20 | `Maximum of <20> topics allowed per ContactList` |
| Unique topic names | `Duplicate topic names are not allowed within a List.` |
| `ContactListName` ≤ 64, `[A-Za-z0-9_-]` | `ContactListName can contain up to 64 characters. Only alphanumeric characters, underscores(_) and hyphens(-) are allowed.` |
| `ContactListName` not blank | `ContactListName can't be blank.` |
| `TopicName` ≤ 64 / pattern / not blank | `TopicName can contain up to 64 characters. ...` / `TopicName can't be blank.` |
| `DisplayName` ≤ 128 | `Topic DisplayName can contain up to <128> characters.` |
| `Description` ≤ 500 | `List description can contain up to 500 characters.` |

A missing required field surfaces the Smithy validation error (`... 'topics.1.member.topicName' ... Member must not be null`); an invalid `DefaultSubscriptionStatus` surfaces the Smithy enum error (`... enum value set: [OPT_OUT, OPT_IN]`). `UpdateContactList` treats absent or explicit-null `Topics` as "not provided" (preserves existing); clearing is done with an explicit `[]`. An empty `UpdateContactList` body is accepted as a no-op (200), matching AWS. Timestamps are emitted as epoch seconds. This is a v2-only change.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
