### PR TITLE
docs: add supported action description columns

### DIFF
--- a/docs/services/cognito.md
+++ b/docs/services/cognito.md
@@ -19,17 +19,91 @@ Standalone `TagResource` rejects reserved `floci:*` keys. `ListTagsForResource` 
 
 ## Supported Actions
 
-| Category                  | Actions                                                                                                                                              |
-|---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **User Pools**            | CreateUserPool, DescribeUserPool, ListUserPools, UpdateUserPool, DeleteUserPool                                                                      |
-| **User Pool Tags**        | TagResource, UntagResource, ListTagsForResource                                                                                                      |
-| **User Pool Clients**     | CreateUserPoolClient, DescribeUserPoolClient, ListUserPoolClients, DeleteUserPoolClient                                                              |
-| **Resource Servers**      | CreateResourceServer, DescribeResourceServer, ListResourceServers, DeleteResourceServer                                                              |
-| **Admin User Management** | AdminCreateUser (including `MessageAction=RESEND`), AdminGetUser, AdminDeleteUser, AdminSetUserPassword, AdminUpdateUserAttributes                   |
-| **User Operations**       | SignUp, ConfirmSignUp, GetUser, UpdateUserAttributes, ChangePassword, ForgotPassword, ConfirmForgotPassword                                          |
-| **Authentication**        | InitiateAuth, AdminInitiateAuth, RespondToAuthChallenge (supports USER_PASSWORD_AUTH, USER_SRP_AUTH, ADMIN_USER_SRP_AUTH)                            |
-| **User Listing**          | ListUsers                                                                                                                                            |
-| **Groups**                | CreateGroup, GetGroup, UpdateGroup, ListGroups, ListUsersInGroup, DeleteGroup, AdminAddUserToGroup, AdminRemoveUserFromGroup, AdminListGroupsForUser |
+### User Pools
+
+| Action | Description |
+|--------|-------------|
+| CreateUserPool | - |
+| DescribeUserPool | - |
+| ListUserPools | - |
+| UpdateUserPool | - |
+| DeleteUserPool | - |
+
+### User Pool Tags
+
+| Action | Description |
+|--------|-------------|
+| TagResource | - |
+| UntagResource | - |
+| ListTagsForResource | - |
+
+### User Pool Clients
+
+| Action | Description |
+|--------|-------------|
+| CreateUserPoolClient | - |
+| DescribeUserPoolClient | - |
+| ListUserPoolClients | - |
+| DeleteUserPoolClient | - |
+
+### Resource Servers
+
+| Action | Description |
+|--------|-------------|
+| CreateResourceServer | - |
+| DescribeResourceServer | - |
+| ListResourceServers | - |
+| DeleteResourceServer | - |
+
+### Admin User Management
+
+| Action | Description |
+|--------|-------------|
+| AdminCreateUser | - |
+| AdminGetUser | - |
+| AdminDeleteUser | - |
+| AdminSetUserPassword | - |
+| AdminUpdateUserAttributes | - |
+
+### User Operations
+
+| Action | Description |
+|--------|-------------|
+| SignUp | - |
+| ConfirmSignUp | - |
+| GetUser | - |
+| UpdateUserAttributes | - |
+| ChangePassword | - |
+| ForgotPassword | - |
+| ConfirmForgotPassword | - |
+
+### Authentication
+
+| Action | Description |
+|--------|-------------|
+| InitiateAuth | - |
+| AdminInitiateAuth | - |
+| RespondToAuthChallenge | - |
+
+### User Listing
+
+| Action | Description |
+|--------|-------------|
+| ListUsers | - |
+
+### Groups
+
+| Action | Description |
+|--------|-------------|
+| CreateGroup | - |
+| GetGroup | - |
+| UpdateGroup | - |
+| ListGroups | - |
+| ListUsersInGroup | - |
+| DeleteGroup | - |
+| AdminAddUserToGroup | - |
+| AdminRemoveUserFromGroup | - |
+| AdminListGroupsForUser | - |
 
 ## Well-Known And OAuth Endpoints
 

--- a/docs/services/ec2.md
+++ b/docs/services/ec2.md
@@ -140,63 +140,190 @@ Floci seeds the following resources on first use in each region so Terraform, th
 ## Supported Actions
 
 ### Instances
-`RunInstances` · `DescribeInstances` · `TerminateInstances` · `StartInstances` · `StopInstances` · `RebootInstances` · `DescribeInstanceStatus` · `DescribeInstanceAttribute` · `ModifyInstanceAttribute`
+
+| Action | Description |
+|--------|-------------|
+| RunInstances | - |
+| DescribeInstances | - |
+| TerminateInstances | - |
+| StartInstances | - |
+| StopInstances | - |
+| RebootInstances | - |
+| DescribeInstanceStatus | - |
+| DescribeInstanceAttribute | - |
+| ModifyInstanceAttribute | - |
 
 ### VPCs
-`CreateVpc` · `DescribeVpcs` · `DeleteVpc` · `ModifyVpcAttribute` · `DescribeVpcAttribute` · `DescribeVpcEndpointServices` · `CreateVpcEndpoint` · `DescribeVpcEndpoints` · `DeleteVpcEndpoints` · `CreateDefaultVpc` · `AssociateVpcCidrBlock` · `DisassociateVpcCidrBlock`
+
+| Action | Description |
+|--------|-------------|
+| CreateVpc | - |
+| DescribeVpcs | - |
+| DeleteVpc | - |
+| ModifyVpcAttribute | - |
+| DescribeVpcAttribute | - |
+| DescribeVpcEndpointServices | - |
+| CreateVpcEndpoint | - |
+| DescribeVpcEndpoints | - |
+| DeleteVpcEndpoints | - |
+| CreateDefaultVpc | - |
+| AssociateVpcCidrBlock | - |
+| DisassociateVpcCidrBlock | - |
 
 ### Subnets
-`CreateSubnet` · `DescribeSubnets` · `DeleteSubnet` · `ModifySubnetAttribute`
+
+| Action | Description |
+|--------|-------------|
+| CreateSubnet | - |
+| DescribeSubnets | - |
+| DeleteSubnet | - |
+| ModifySubnetAttribute | - |
 
 ### Security Groups
-`CreateSecurityGroup` · `DescribeSecurityGroups` · `DeleteSecurityGroup` · `AuthorizeSecurityGroupIngress` · `AuthorizeSecurityGroupEgress` · `RevokeSecurityGroupIngress` · `RevokeSecurityGroupEgress` · `DescribeSecurityGroupRules` · `ModifySecurityGroupRules` · `UpdateSecurityGroupRuleDescriptionsIngress` · `UpdateSecurityGroupRuleDescriptionsEgress`
+
+| Action | Description |
+|--------|-------------|
+| CreateSecurityGroup | - |
+| DescribeSecurityGroups | - |
+| DeleteSecurityGroup | - |
+| AuthorizeSecurityGroupIngress | - |
+| AuthorizeSecurityGroupEgress | - |
+| RevokeSecurityGroupIngress | - |
+| RevokeSecurityGroupEgress | - |
+| DescribeSecurityGroupRules | - |
+| ModifySecurityGroupRules | - |
+| UpdateSecurityGroupRuleDescriptionsIngress | - |
+| UpdateSecurityGroupRuleDescriptionsEgress | - |
 
 ### Key Pairs
-`CreateKeyPair` · `DescribeKeyPairs` · `DeleteKeyPair` · `ImportKeyPair`
+
+| Action | Description |
+|--------|-------------|
+| CreateKeyPair | - |
+| DescribeKeyPairs | - |
+| DeleteKeyPair | - |
+| ImportKeyPair | - |
 
 ### AMIs
-`DescribeImages`
+
+| Action | Description |
+|--------|-------------|
+| DescribeImages | - |
 
 ### Tags
-`CreateTags` · `DeleteTags` · `DescribeTags`
+
+| Action | Description |
+|--------|-------------|
+| CreateTags | - |
+| DeleteTags | - |
+| DescribeTags | - |
 
 ### Internet Gateways
-`CreateInternetGateway` · `DescribeInternetGateways` · `DeleteInternetGateway` · `AttachInternetGateway` · `DetachInternetGateway`
+
+| Action | Description |
+|--------|-------------|
+| CreateInternetGateway | - |
+| DescribeInternetGateways | - |
+| DeleteInternetGateway | - |
+| AttachInternetGateway | - |
+| DetachInternetGateway | - |
 
 ### Route Tables
-`CreateRouteTable` · `DescribeRouteTables` · `DeleteRouteTable` · `AssociateRouteTable` · `DisassociateRouteTable` · `CreateRoute` · `DeleteRoute`
+
+| Action | Description |
+|--------|-------------|
+| CreateRouteTable | - |
+| DescribeRouteTables | - |
+| DeleteRouteTable | - |
+| AssociateRouteTable | - |
+| DisassociateRouteTable | - |
+| CreateRoute | - |
+| DeleteRoute | - |
 
 ### Network ACLs
-`CreateNetworkAcl` · `DescribeNetworkAcls` · `DeleteNetworkAcl` · `CreateNetworkAclEntry` · `ReplaceNetworkAclEntry` · `DeleteNetworkAclEntry` · `ReplaceNetworkAclAssociation`
+
+| Action | Description |
+|--------|-------------|
+| CreateNetworkAcl | - |
+| DescribeNetworkAcls | - |
+| DeleteNetworkAcl | - |
+| CreateNetworkAclEntry | - |
+| ReplaceNetworkAclEntry | - |
+| DeleteNetworkAclEntry | - |
+| ReplaceNetworkAclAssociation | - |
 
 ### Prefix Lists
-`DescribePrefixLists`
+
+| Action | Description |
+|--------|-------------|
+| DescribePrefixLists | - |
 
 ### NAT Gateways
-`CreateNatGateway` · `DescribeNatGateways` · `DeleteNatGateway`
+
+| Action | Description |
+|--------|-------------|
+| CreateNatGateway | - |
+| DescribeNatGateways | - |
+| DeleteNatGateway | - |
 
 ### Elastic IPs
-`AllocateAddress` · `DescribeAddresses` · `DescribeAddressesAttribute` · `AssociateAddress` · `DisassociateAddress` · `ReleaseAddress`
+
+| Action | Description |
+|--------|-------------|
+| AllocateAddress | - |
+| DescribeAddresses | - |
+| DescribeAddressesAttribute | - |
+| AssociateAddress | - |
+| DisassociateAddress | - |
+| ReleaseAddress | - |
 
 ### Availability Zones & Regions
-`DescribeAvailabilityZones` · `DescribeRegions` · `DescribeAccountAttributes`
+
+| Action | Description |
+|--------|-------------|
+| DescribeAvailabilityZones | - |
+| DescribeRegions | - |
+| DescribeAccountAttributes | - |
 
 ### Instance Types
-`DescribeInstanceTypes` · `DescribeInstanceTypeOfferings`
+
+| Action | Description |
+|--------|-------------|
+| DescribeInstanceTypes | - |
+| DescribeInstanceTypeOfferings | - |
 
 ### Launch Templates
-`CreateLaunchTemplate` · `CreateLaunchTemplateVersion` · `DescribeLaunchTemplates` · `DescribeLaunchTemplateVersions` · `ModifyLaunchTemplate` · `DeleteLaunchTemplate`
+
+| Action | Description |
+|--------|-------------|
+| CreateLaunchTemplate | - |
+| CreateLaunchTemplateVersion | - |
+| DescribeLaunchTemplates | - |
+| DescribeLaunchTemplateVersions | - |
+| ModifyLaunchTemplate | - |
+| DeleteLaunchTemplate | - |
 
 Launch templates store versioned launch data. New template versions can be created from an existing source version, and `ModifyLaunchTemplate` updates the default version used by later launches.
 
 ### IAM Instance Profiles
-`DescribeIamInstanceProfileAssociations`
+
+| Action | Description |
+|--------|-------------|
+| DescribeIamInstanceProfileAssociations | - |
 
 ### Network Interfaces
-`DescribeNetworkInterfaces`
+
+| Action | Description |
+|--------|-------------|
+| DescribeNetworkInterfaces | - |
 
 ### Volumes
-`CreateVolume` · `DescribeVolumes` · `DeleteVolume`
+
+| Action | Description |
+|--------|-------------|
+| CreateVolume | - |
+| DescribeVolumes | - |
+| DeleteVolume | - |
 
 ## Configuration
 

--- a/docs/services/elb.md
+++ b/docs/services/elb.md
@@ -7,25 +7,76 @@ Floci supports Application Load Balancers (ALB) and Network Load Balancers (NLB)
 ## Supported Actions
 
 ### Load Balancers
-`CreateLoadBalancer` · `DescribeLoadBalancers` · `DeleteLoadBalancer` · `ModifyLoadBalancerAttributes` · `DescribeLoadBalancerAttributes` · `DescribeCapacityReservation` · `SetSecurityGroups` · `SetSubnets` · `SetIpAddressType`
+
+| Action | Description |
+|--------|-------------|
+| CreateLoadBalancer | - |
+| DescribeLoadBalancers | - |
+| DeleteLoadBalancer | - |
+| ModifyLoadBalancerAttributes | - |
+| DescribeLoadBalancerAttributes | - |
+| DescribeCapacityReservation | - |
+| SetSecurityGroups | - |
+| SetSubnets | - |
+| SetIpAddressType | - |
 
 ### Target Groups
-`CreateTargetGroup` · `DescribeTargetGroups` · `ModifyTargetGroup` · `DeleteTargetGroup` · `ModifyTargetGroupAttributes` · `DescribeTargetGroupAttributes`
+
+| Action | Description |
+|--------|-------------|
+| CreateTargetGroup | - |
+| DescribeTargetGroups | - |
+| ModifyTargetGroup | - |
+| DeleteTargetGroup | - |
+| ModifyTargetGroupAttributes | - |
+| DescribeTargetGroupAttributes | - |
 
 ### Targets
-`RegisterTargets` · `DeregisterTargets` · `DescribeTargetHealth`
+
+| Action | Description |
+|--------|-------------|
+| RegisterTargets | - |
+| DeregisterTargets | - |
+| DescribeTargetHealth | - |
 
 ### Listeners
-`CreateListener` · `DescribeListeners` · `ModifyListener` · `ModifyListenerAttributes` · `DescribeListenerAttributes` · `DeleteListener` · `AddListenerCertificates` · `RemoveListenerCertificates` · `DescribeListenerCertificates`
+
+| Action | Description |
+|--------|-------------|
+| CreateListener | - |
+| DescribeListeners | - |
+| ModifyListener | - |
+| ModifyListenerAttributes | - |
+| DescribeListenerAttributes | - |
+| DeleteListener | - |
+| AddListenerCertificates | - |
+| RemoveListenerCertificates | - |
+| DescribeListenerCertificates | - |
 
 ### Rules
-`CreateRule` · `DescribeRules` · `ModifyRule` · `DeleteRule` · `SetRulePriorities`
+
+| Action | Description |
+|--------|-------------|
+| CreateRule | - |
+| DescribeRules | - |
+| ModifyRule | - |
+| DeleteRule | - |
+| SetRulePriorities | - |
 
 ### Tags
-`AddTags` · `RemoveTags` · `DescribeTags`
+
+| Action | Description |
+|--------|-------------|
+| AddTags | - |
+| RemoveTags | - |
+| DescribeTags | - |
 
 ### Metadata
-`DescribeSSLPolicies` · `DescribeAccountLimits`
+
+| Action | Description |
+|--------|-------------|
+| DescribeSSLPolicies | - |
+| DescribeAccountLimits | - |
 
 ## Behavior Notes
 

--- a/docs/services/glue.md
+++ b/docs/services/glue.md
@@ -9,21 +9,85 @@ Floci emulates the AWS Glue Data Catalog and Glue Schema Registry, allowing you 
 
 ### Data Catalog
 
-| Area | Actions |
-|---|---|
-| Databases | `CreateDatabase` · `GetDatabase` · `GetDatabases` · `DeleteDatabase` |
-| Tables | `CreateTable` · `GetTable` · `GetTables` · `DeleteTable` |
-| Partitions | `CreatePartition` · `GetPartitions` |
-| User-defined functions | `CreateUserDefinedFunction` · `GetUserDefinedFunction` · `GetUserDefinedFunctions` · `UpdateUserDefinedFunction` · `DeleteUserDefinedFunction` |
+#### Databases
+
+| Action | Description |
+|--------|-------------|
+| CreateDatabase | - |
+| GetDatabase | - |
+| GetDatabases | - |
+| DeleteDatabase | - |
+
+#### Tables
+
+| Action | Description |
+|--------|-------------|
+| CreateTable | - |
+| GetTable | - |
+| GetTables | - |
+| DeleteTable | - |
+
+#### Partitions
+
+| Action | Description |
+|--------|-------------|
+| CreatePartition | - |
+| GetPartitions | - |
+
+#### User-defined Functions
+
+| Action | Description |
+|--------|-------------|
+| CreateUserDefinedFunction | - |
+| GetUserDefinedFunction | - |
+| GetUserDefinedFunctions | - |
+| UpdateUserDefinedFunction | - |
+| DeleteUserDefinedFunction | - |
 
 ### Schema Registry
 
-| Area | Actions |
-|---|---|
-| Registries | `CreateRegistry` · `GetRegistry` · `ListRegistries` · `UpdateRegistry` · `DeleteRegistry` |
-| Schemas | `CreateSchema` · `GetSchema` · `ListSchemas` · `UpdateSchema` · `DeleteSchema` |
-| Versions | `RegisterSchemaVersion` · `GetSchemaByDefinition` · `GetSchemaVersion` · `ListSchemaVersions` · `DeleteSchemaVersions` · `GetSchemaVersionsDiff` · `CheckSchemaVersionValidity` |
-| Metadata and tags | `PutSchemaVersionMetadata` · `RemoveSchemaVersionMetadata` · `QuerySchemaVersionMetadata` · `TagResource` · `UntagResource` · `GetTags` |
+#### Registries
+
+| Action | Description |
+|--------|-------------|
+| CreateRegistry | - |
+| GetRegistry | - |
+| ListRegistries | - |
+| UpdateRegistry | - |
+| DeleteRegistry | - |
+
+#### Schemas
+
+| Action | Description |
+|--------|-------------|
+| CreateSchema | - |
+| GetSchema | - |
+| ListSchemas | - |
+| UpdateSchema | - |
+| DeleteSchema | - |
+
+#### Versions
+
+| Action | Description |
+|--------|-------------|
+| RegisterSchemaVersion | - |
+| GetSchemaByDefinition | - |
+| GetSchemaVersion | - |
+| ListSchemaVersions | - |
+| DeleteSchemaVersions | - |
+| GetSchemaVersionsDiff | - |
+| CheckSchemaVersionValidity | - |
+
+#### Metadata and Tags
+
+| Action | Description |
+|--------|-------------|
+| PutSchemaVersionMetadata | - |
+| RemoveSchemaVersionMetadata | - |
+| QuerySchemaVersionMetadata | - |
+| TagResource | - |
+| UntagResource | - |
+| GetTags | - |
 
 Supported schema formats are `AVRO`, `JSON`, and `PROTOBUF`. Compatibility modes are `NONE`, `DISABLED`, `BACKWARD`, `BACKWARD_ALL`, `FORWARD`, `FORWARD_ALL`, `FULL`, and `FULL_ALL`.
 

--- a/docs/services/iam.md
+++ b/docs/services/iam.md
@@ -5,41 +5,136 @@
 ## Supported Actions
 
 ### Users
-`CreateUser` · `GetUser` · `DeleteUser` · `ListUsers` · `UpdateUser` · `TagUser` · `UntagUser` · `ListUserTags`
+
+| Action | Description |
+|--------|-------------|
+| CreateUser | - |
+| GetUser | - |
+| DeleteUser | - |
+| ListUsers | - |
+| UpdateUser | - |
+| TagUser | - |
+| UntagUser | - |
+| ListUserTags | - |
 
 ### Groups
-`CreateGroup` · `GetGroup` · `DeleteGroup` · `ListGroups` · `AddUserToGroup` · `RemoveUserFromGroup` · `ListGroupsForUser`
+
+| Action | Description |
+|--------|-------------|
+| CreateGroup | - |
+| GetGroup | - |
+| DeleteGroup | - |
+| ListGroups | - |
+| AddUserToGroup | - |
+| RemoveUserFromGroup | - |
+| ListGroupsForUser | - |
 
 ### Roles
-`CreateRole` · `GetRole` · `DeleteRole` · `ListRoles` · `UpdateRole` · `UpdateAssumeRolePolicy` · `TagRole` · `UntagRole` · `ListRoleTags`
+
+| Action | Description |
+|--------|-------------|
+| CreateRole | - |
+| GetRole | - |
+| DeleteRole | - |
+| ListRoles | - |
+| UpdateRole | - |
+| UpdateAssumeRolePolicy | - |
+| TagRole | - |
+| UntagRole | - |
+| ListRoleTags | - |
 
 ### Policies
-`CreatePolicy` · `GetPolicy` · `DeletePolicy` · `ListPolicies` · `CreatePolicyVersion` · `GetPolicyVersion` · `DeletePolicyVersion` · `ListPolicyVersions` · `SetDefaultPolicyVersion` · `TagPolicy` · `UntagPolicy` · `ListPolicyTags`
+
+| Action | Description |
+|--------|-------------|
+| CreatePolicy | - |
+| GetPolicy | - |
+| DeletePolicy | - |
+| ListPolicies | - |
+| CreatePolicyVersion | - |
+| GetPolicyVersion | - |
+| DeletePolicyVersion | - |
+| ListPolicyVersions | - |
+| SetDefaultPolicyVersion | - |
+| TagPolicy | - |
+| UntagPolicy | - |
+| ListPolicyTags | - |
 
 ### Permission Boundaries
-`PutUserPermissionsBoundary` · `DeleteUserPermissionsBoundary` · `PutRolePermissionsBoundary` · `DeleteRolePermissionsBoundary`
+
+| Action | Description |
+|--------|-------------|
+| PutUserPermissionsBoundary | - |
+| DeleteUserPermissionsBoundary | - |
+| PutRolePermissionsBoundary | - |
+| DeleteRolePermissionsBoundary | - |
 
 ### Policy Attachments
-`AttachUserPolicy` · `DetachUserPolicy` · `ListAttachedUserPolicies`
-`AttachGroupPolicy` · `DetachGroupPolicy` · `ListAttachedGroupPolicies`
-`AttachRolePolicy` · `DetachRolePolicy` · `ListAttachedRolePolicies`
+
+| Action | Description |
+|--------|-------------|
+| AttachUserPolicy | - |
+| DetachUserPolicy | - |
+| ListAttachedUserPolicies | - |
+| AttachGroupPolicy | - |
+| DetachGroupPolicy | - |
+| ListAttachedGroupPolicies | - |
+| AttachRolePolicy | - |
+| DetachRolePolicy | - |
+| ListAttachedRolePolicies | - |
 
 ### Inline Policies
-`PutUserPolicy` · `GetUserPolicy` · `DeleteUserPolicy` · `ListUserPolicies`
-`PutGroupPolicy` · `GetGroupPolicy` · `DeleteGroupPolicy` · `ListGroupPolicies`
-`PutRolePolicy` · `GetRolePolicy` · `DeleteRolePolicy` · `ListRolePolicies`
+
+| Action | Description |
+|--------|-------------|
+| PutUserPolicy | - |
+| GetUserPolicy | - |
+| DeleteUserPolicy | - |
+| ListUserPolicies | - |
+| PutGroupPolicy | - |
+| GetGroupPolicy | - |
+| DeleteGroupPolicy | - |
+| ListGroupPolicies | - |
+| PutRolePolicy | - |
+| GetRolePolicy | - |
+| DeleteRolePolicy | - |
+| ListRolePolicies | - |
 
 ### Instance Profiles
-`CreateInstanceProfile` · `GetInstanceProfile` · `DeleteInstanceProfile` · `ListInstanceProfiles` · `AddRoleToInstanceProfile` · `RemoveRoleFromInstanceProfile` · `ListInstanceProfilesForRole`
+
+| Action | Description |
+|--------|-------------|
+| CreateInstanceProfile | - |
+| GetInstanceProfile | - |
+| DeleteInstanceProfile | - |
+| ListInstanceProfiles | - |
+| AddRoleToInstanceProfile | - |
+| RemoveRoleFromInstanceProfile | - |
+| ListInstanceProfilesForRole | - |
 
 ### Access Keys
-`CreateAccessKey` · `GetAccessKeyLastUsed` · `ListAccessKeys` · `UpdateAccessKey` · `DeleteAccessKey`
+
+| Action | Description |
+|--------|-------------|
+| CreateAccessKey | - |
+| GetAccessKeyLastUsed | - |
+| ListAccessKeys | - |
+| UpdateAccessKey | - |
+| DeleteAccessKey | - |
 
 ### Login Profiles
-`CreateLoginProfile` · `DeleteLoginProfile` · `UpdateLoginProfile`
+
+| Action | Description |
+|--------|-------------|
+| CreateLoginProfile | - |
+| DeleteLoginProfile | - |
+| UpdateLoginProfile | - |
 
 ### Policy Simulation
-`SimulatePrincipalPolicy`
+
+| Action | Description |
+|--------|-------------|
+| SimulatePrincipalPolicy | - |
 
 ## AWS Managed Policies
 


### PR DESCRIPTION
## Summary
- Normalize Supported Actions sections so the affected service docs can carry action descriptions.
- Convert grouped action lists in Cognito, EC2, ELBv2, Glue, and IAM into `Action` / `Description` tables.
- Preserve the existing action names and order, using `-` placeholders for the new description cells.
- Leave existing description-capable tables and non-action tables unchanged.

## Review
- Deterministic checks: `git diff --check` passed; Supported Actions sections now have description-capable tables.
- Markdown lint: attempted, but repo docs currently report broad pre-existing markdownlint style violations outside this scoped change.

## Changes
- `docs/services/cognito.md`: expands grouped Cognito action categories into per-action tables.
- `docs/services/ec2.md`: expands grouped EC2 action categories into per-action tables.
- `docs/services/elb.md`: expands grouped ELBv2 action categories into per-action tables.
- `docs/services/glue.md`: expands Glue Data Catalog and Schema Registry grouped rows into per-action tables.
- `docs/services/iam.md`: expands grouped IAM action categories into per-action tables.

## Test plan
- [x] `git diff --check`
- [x] Verified no Supported Actions service docs with missing description-capable table headers.
- [x] Reviewed diff for table-shape-only changes.
