### PR TITLE
fix(cognito): register VerificationCode for reflection so HybridStora…

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/verification/VerificationCode.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/verification/VerificationCode.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.cognito.verification;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
 
@@ -10,6 +11,7 @@ import java.time.Instant;
  * password reset, MFA SMS, attribute verification). The actual code is hashed
  * with a per-code salt so dumps and storage snapshots cannot reveal valid codes.
  */
+@RegisterForReflection
 public final class VerificationCode {
 
     public enum Purpose {


### PR DESCRIPTION
## Summary

In a native image, Jackson could not serialize VerificationCode because it lacked reflection metadata, so HybridStorage can wrote cognito-verification-codes.json.

Closes https://github.com/floci-io/floci/issues/1586

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: Cognito state failed to persist in the native image (No serializer found for class ... VerificationCode). This fix restores persistence.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
