### PR TITLE
fix(kms): normalize alias targetKeyId to plain key ID on createAlias

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -576,12 +576,12 @@ public class KmsService {
         if (!aliasName.startsWith("alias/")) {
             throw new AwsException("InvalidAliasNameException", "Alias name must begin with 'alias/'", 400);
         }
-        resolveKey(targetKeyId, region); // Validate key exists
+        KmsKey key = resolveKey(targetKeyId, region); // Validate key exists and normalize to plain key ID
 
         String aliasArn = regionResolver.buildArn("kms", region, aliasName);
-        KmsAlias alias = new KmsAlias(aliasName, aliasArn, targetKeyId);
+        KmsAlias alias = new KmsAlias(aliasName, aliasArn, key.getKeyId());
         aliasStore.put(region + "::" + aliasName, alias);
-        LOG.infov("Created KMS alias: {0} -> {1}", aliasName, targetKeyId);
+        LOG.infov("Created KMS alias: {0} -> {1}", aliasName, key.getKeyId());
     }
 
     public void deleteAlias(String aliasName, String region) {

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -525,6 +525,15 @@ class KmsServiceTest {
     }
 
     @Test
+    void resolveKeyByAliasCreatedWithArn() {
+        KmsKey key = kmsService.createKey(null, REGION);
+        kmsService.createAlias("alias/by-arn", key.getArn(), REGION);
+
+        KmsKey resolved = kmsService.describeKey("alias/by-arn", REGION);
+        assertEquals(key.getKeyId(), resolved.getKeyId());
+    }
+
+    @Test
     void encryptAndDecryptWithId() {
         KmsKey key = kmsService.createKey(null, REGION);
         byte[] plaintext = "hello world".getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
## Summary

`createAlias` stored the `targetKeyId` parameter as-is in `KmsAlias`, without normalizing it to the plain key UUID. When a caller passed a full key ARN (e.g. `arn:aws:kms:us-east-1:000000000000:key/<uuid>`) as `targetKeyId`, the raw ARN was persisted. On any subsequent operation that resolved the key through that alias (e.g. `DescribeKey`, `Encrypt`, `Decrypt`), `resolveKey` retrieved the stored ARN and used it directly as the storage lookup key (`region + "::" + arn`), which never matched the entry stored as `region + "::" + uuid` — causing a `NotFoundException`.

The fix captures the result of `resolveKey` (which already handles ARN, alias ARN, and alias name normalization) in `createAlias` and stores `key.getKeyId()` — the plain UUID — in the alias instead of the raw input.

A regression test `resolveKeyByAliasCreatedWithArn` is added to `KmsServiceTest` to cover this path.

Closes #1647

## Type of change

* [x] Bug fix (`fix:`)
* [ ] New feature (`feat:`)
* [ ] Breaking change (`feat!:` or `fix!:`)
* [ ] Docs / chore

## AWS Compatibility

Incorrect behavior:

`CreateAlias` accepted a full key ARN as `TargetKeyId` but stored it verbatim, causing any subsequent resolution through that alias (e.g. `DescribeKey`, `Encrypt`, `Decrypt`) to fail with `NotFoundException`. The AWS SDK and CLI always pass the ARN form in some flows, so this broke real-world SDK usage.

Updated behavior:

`createAlias` now normalizes `TargetKeyId` to the plain key UUID regardless of whether a plain ID, full ARN, or alias ARN is supplied, matching the AWS KMS behavior where aliases always resolve correctly.

## Checklist

* [x] `./mvnw test` passes locally
* [x] New or updated unit test added (`resolveKeyByAliasCreatedWithArn` in `KmsServiceTest`)
* [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)