### PR TITLE
fix(rds): resolve tags by ARN resource type, not only DB instances

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
@@ -309,37 +310,79 @@ public class RdsService implements Resettable {
     }
 
     public Map<String, String> listTagsForResource(String resourceName) {
-        DbInstance instance = getDbInstance(dbInstanceIdentifierFromResourceName(resourceName));
-        return Map.copyOf(instance.getTags());
+        return Map.copyOf(resolveTagHandle(resourceName).tags());
     }
 
     public void addTagsToResource(String resourceName, Map<String, String> tags) {
-        String id = dbInstanceIdentifierFromResourceName(resourceName);
-        DbInstance instance = getDbInstance(id);
-        Map<String, String> updated = new java.util.LinkedHashMap<>(instance.getTags());
+        TagHandle handle = resolveTagHandle(resourceName);
+        Map<String, String> updated = new java.util.LinkedHashMap<>(handle.tags());
         updated.putAll(tags);
-        instance.setTags(updated);
-        instances.put(id, instance);
+        handle.save().accept(updated);
     }
 
     public void removeTagsFromResource(String resourceName, Collection<String> tagKeys) {
-        String id = dbInstanceIdentifierFromResourceName(resourceName);
-        DbInstance instance = getDbInstance(id);
-        Map<String, String> updated = new java.util.LinkedHashMap<>(instance.getTags());
+        TagHandle handle = resolveTagHandle(resourceName);
+        Map<String, String> updated = new java.util.LinkedHashMap<>(handle.tags());
         tagKeys.forEach(updated::remove);
-        instance.setTags(updated);
-        instances.put(id, instance);
+        handle.save().accept(updated);
     }
 
-    private static String dbInstanceIdentifierFromResourceName(String resourceName) {
+    /** A resolved tag target: its current tags plus a sink that persists an updated map. */
+    private record TagHandle(Map<String, String> tags, java.util.function.Consumer<Map<String, String>> save) {}
+
+    /**
+     * Resolves a tagging ResourceName to its backing resource.
+     *
+     * RDS tags can be attached to many resource types (DB instances, clusters, subnet groups, ...),
+     * each identified by an ARN of the form {@code arn:aws:rds:<region>:<account>:<type>:<id>}.
+     * A bare resource name (no ARN) is treated as a DB instance identifier for backwards compatibility.
+     */
+    private TagHandle resolveTagHandle(String resourceName) {
         if (resourceName == null || resourceName.isBlank()) {
             throw new AwsException("InvalidParameterValue", "ResourceName is required.", 400);
         }
-        int marker = resourceName.lastIndexOf(":db:");
-        if (marker >= 0) {
-            return resourceName.substring(marker + 4);
+
+        String type = "db";
+        String id = resourceName;
+        try {
+            String resource = AwsArnUtils.parse(resourceName).resource();
+            int sep = resource.indexOf(':');
+            if (sep >= 0) {
+                type = resource.substring(0, sep);
+                id = resource.substring(sep + 1);
+            } else {
+                id = resource;
+            }
+        } catch (IllegalArgumentException notAnArn) {
+            // Not an ARN — fall back to treating the value as a DB instance identifier.
         }
-        return resourceName;
+
+        String resourceId = id;
+        return switch (type) {
+            case "db" -> {
+                DbInstance instance = getDbInstance(resourceId);
+                yield new TagHandle(instance.getTags(), updated -> {
+                    instance.setTags(updated);
+                    instances.put(resourceId, instance);
+                });
+            }
+            case "cluster" -> {
+                DbCluster cluster = getDbCluster(resourceId);
+                yield new TagHandle(cluster.getTags(), updated -> {
+                    cluster.setTags(updated);
+                    clusters.put(resourceId, cluster);
+                });
+            }
+            case "subgrp" -> {
+                DbSubnetGroup group = getDbSubnetGroup(resourceId);
+                yield new TagHandle(group.getTags(), updated -> {
+                    group.setTags(updated);
+                    subnetGroups.put(resourceId, group);
+                });
+            }
+            default -> throw new AwsException("InvalidParameterValue",
+                    "Tagging is not supported for resource: " + resourceName, 400);
+        };
     }
 
     private void attachManagedMasterUserSecret(DbInstance instance, String region, String kmsKeyId) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -772,6 +772,7 @@ public class RdsService implements Resettable {
                     "SubnetIds must contain at least one subnet.", 400);
         }
         DbSubnetGroup group = buildSubnetGroup(name, existing.getDescription(), subnetIds);
+        group.setTags(existing.getTags());
         subnetGroups.put(name, group);
         return group;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -344,8 +344,17 @@ public class RdsService implements Resettable {
 
         String type = "db";
         String id = resourceName;
-        try {
-            String resource = AwsArnUtils.parse(resourceName).resource();
+        if (resourceName.startsWith("arn:")) {
+            AwsArnUtils.Arn arn;
+            try {
+                arn = AwsArnUtils.parse(resourceName);
+            } catch (IllegalArgumentException malformed) {
+                throw new AwsException("InvalidParameterValue", "Invalid resource name: " + resourceName, 400);
+            }
+            if (!"rds".equals(arn.service())) {
+                throw new AwsException("InvalidParameterValue", "Invalid resource name: " + resourceName, 400);
+            }
+            String resource = arn.resource();
             int sep = resource.indexOf(':');
             if (sep >= 0) {
                 type = resource.substring(0, sep);
@@ -353,9 +362,8 @@ public class RdsService implements Resettable {
             } else {
                 id = resource;
             }
-        } catch (IllegalArgumentException notAnArn) {
-            // Not an ARN — fall back to treating the value as a DB instance identifier.
         }
+        // A bare (non-ARN) resource name is treated as a DB instance identifier for backwards compatibility.
 
         String resourceId = id;
         return switch (type) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -356,12 +356,12 @@ public class RdsService implements Resettable {
             }
             String resource = arn.resource();
             int sep = resource.indexOf(':');
-            if (sep >= 0) {
-                type = resource.substring(0, sep);
-                id = resource.substring(sep + 1);
-            } else {
-                id = resource;
+            if (sep < 0) {
+                // Real AWS requires the resource part of an RDS ARN to be <type>:<id>.
+                throw new AwsException("InvalidParameterValue", "Invalid resource name: " + resourceName, 400);
             }
+            type = resource.substring(0, sep);
+            id = resource.substring(sep + 1);
         }
         // A bare (non-ARN) resource name is treated as a DB instance identifier for backwards compatibility.
 
@@ -388,8 +388,10 @@ public class RdsService implements Resettable {
                     subnetGroups.put(resourceId, group);
                 });
             }
+            // Valid RDS resource types Floci does not model yet (og, pg, snapshot, ...) — taggable
+            // on real AWS, so the message states the Floci limitation rather than AWS semantics.
             default -> throw new AwsException("InvalidParameterValue",
-                    "Tagging is not supported for resource: " + resourceName, 400);
+                    "Tagging for resource type '" + type + "' is not yet implemented by Floci: " + resourceName, 400);
         };
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbCluster.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbCluster.java
@@ -32,6 +32,7 @@ public class DbCluster {
     private String dbClusterArn;
     private Instant createdAt;
     private int proxyPort;
+    private Map<String, String> tags = new LinkedHashMap<>();
 
     private String dockerVolumeName;
     private String volumeId;
@@ -132,6 +133,9 @@ public class DbCluster {
 
     public int getProxyPort() { return proxyPort; }
     public void setProxyPort(int proxyPort) { this.proxyPort = proxyPort; }
+
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) { this.tags = tags != null ? new LinkedHashMap<>(tags) : new LinkedHashMap<>(); }
 
     public String getDockerVolumeName() { return dockerVolumeName; }
     public void setDockerVolumeName(String dockerVolumeName) { this.dockerVolumeName = dockerVolumeName; }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbSubnetGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbSubnetGroup.java
@@ -17,6 +17,7 @@ public class DbSubnetGroup {
     private String subnetGroupStatus = "Complete";
     private List<String> subnetIds = new ArrayList<>();
     private Map<String, String> subnetAvailabilityZones = new LinkedHashMap<>();
+    private Map<String, String> tags = new LinkedHashMap<>();
 
     public DbSubnetGroup() {}
 
@@ -61,4 +62,7 @@ public class DbSubnetGroup {
                 ? new LinkedHashMap<>(subnetAvailabilityZones)
                 : new LinkedHashMap<>();
     }
+
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) { this.tags = tags != null ? new LinkedHashMap<>(tags) : new LinkedHashMap<>(); }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -298,6 +298,19 @@ class RdsServiceTest {
     }
 
     @Test
+    void dbSubnetGroupTagsSurviveModify() {
+        rdsService.createDbSubnetGroup(
+                "sample-db-subnets", "test", java.util.List.of("subnet-default-a", "subnet-default-b"));
+        String arn = "arn:aws:rds:us-east-1:123456789012:subgrp:sample-db-subnets";
+        rdsService.addTagsToResource(arn, java.util.Map.of("Name", "sample-db-subnets"));
+
+        rdsService.modifyDbSubnetGroup("sample-db-subnets", java.util.List.of("subnet-default-a"));
+
+        assertEquals(java.util.Map.of("Name", "sample-db-subnets"),
+                rdsService.listTagsForResource(arn));
+    }
+
+    @Test
     void listTagsForMissingSubnetGroupReturnsSubnetGroupNotFound() {
         AwsException exception = assertThrows(AwsException.class, () ->
                 rdsService.listTagsForResource("arn:aws:rds:us-east-1:123456789012:subgrp:missing"));

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -280,6 +280,52 @@ class RdsServiceTest {
     }
 
     @Test
+    void dbSubnetGroupTagsRoundTripAndMutateByArn() {
+        rdsService.createDbSubnetGroup(
+                "sample-db-subnets", "test", java.util.List.of("subnet-default-a", "subnet-default-b"));
+        String arn = "arn:aws:rds:us-east-1:123456789012:subgrp:sample-db-subnets";
+
+        // A subnet group with no tags must list cleanly — previously this threw DBInstanceNotFound (404)
+        // because every ResourceName was resolved as a DB instance.
+        assertEquals(java.util.Map.of(), rdsService.listTagsForResource(arn));
+
+        rdsService.addTagsToResource(arn, java.util.Map.of("Name", "sample-db-subnets"));
+        assertEquals(java.util.Map.of("Name", "sample-db-subnets"),
+                rdsService.listTagsForResource(arn));
+
+        rdsService.removeTagsFromResource(arn, java.util.List.of("Name"));
+        assertEquals(java.util.Map.of(), rdsService.listTagsForResource(arn));
+    }
+
+    @Test
+    void listTagsForMissingSubnetGroupReturnsSubnetGroupNotFound() {
+        AwsException exception = assertThrows(AwsException.class, () ->
+                rdsService.listTagsForResource("arn:aws:rds:us-east-1:123456789012:subgrp:missing"));
+
+        assertEquals("DBSubnetGroupNotFoundFault", exception.getErrorCode());
+    }
+
+    @Test
+    void dbClusterTagsRoundTripByArn() {
+        DbCluster cluster = rdsService.createDbCluster("cluster1", "postgres", "13",
+                "admin", "password", "dbname", false, null);
+
+        assertEquals(java.util.Map.of(), rdsService.listTagsForResource(cluster.getDbClusterArn()));
+
+        rdsService.addTagsToResource(cluster.getDbClusterArn(), java.util.Map.of("env", "test"));
+        assertEquals(java.util.Map.of("env", "test"),
+                rdsService.listTagsForResource(cluster.getDbClusterArn()));
+    }
+
+    @Test
+    void tagOperationsRejectUnsupportedResourceArn() {
+        AwsException exception = assertThrows(AwsException.class, () ->
+                rdsService.listTagsForResource("arn:aws:rds:us-east-1:123456789012:og:some-option-group"));
+
+        assertEquals("InvalidParameterValue", exception.getErrorCode());
+    }
+
+    @Test
     void createDbInstanceRejectsMissingDbSubnetGroupBeforeStartingRuntime() {
         AwsException exception = assertThrows(AwsException.class, () ->
                 rdsService.createDbInstance("mydb", "postgres", "13",

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -326,6 +326,22 @@ class RdsServiceTest {
     }
 
     @Test
+    void tagOperationsRejectNonRdsArn() {
+        AwsException exception = assertThrows(AwsException.class, () ->
+                rdsService.listTagsForResource("arn:aws:s3:::some-bucket"));
+
+        assertEquals("InvalidParameterValue", exception.getErrorCode());
+    }
+
+    @Test
+    void tagOperationsRejectMalformedArn() {
+        AwsException exception = assertThrows(AwsException.class, () ->
+                rdsService.listTagsForResource("arn:aws:rds:incomplete"));
+
+        assertEquals("InvalidParameterValue", exception.getErrorCode());
+    }
+
+    @Test
     void createDbInstanceRejectsMissingDbSubnetGroupBeforeStartingRuntime() {
         AwsException exception = assertThrows(AwsException.class, () ->
                 rdsService.createDbInstance("mydb", "postgres", "13",

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -336,6 +336,18 @@ class RdsServiceTest {
                 rdsService.listTagsForResource("arn:aws:rds:us-east-1:123456789012:og:some-option-group"));
 
         assertEquals("InvalidParameterValue", exception.getErrorCode());
+        // The type is valid on real AWS; the message must present this as a Floci limitation.
+        assertTrue(exception.getMessage().contains("not yet implemented by Floci"));
+    }
+
+    @Test
+    void tagOperationsRejectTypelessRdsArn() {
+        // Real AWS rejects an RDS ARN whose resource part is not <type>:<id> with InvalidParameterValue;
+        // previously this fell back to a DB-instance lookup and returned DBInstanceNotFound.
+        AwsException exception = assertThrows(AwsException.class, () ->
+                rdsService.listTagsForResource("arn:aws:rds:us-east-1:123456789012:mydb"));
+
+        assertEquals("InvalidParameterValue", exception.getErrorCode());
     }
 
     @Test


### PR DESCRIPTION
## Summary

RDS tag operations (`ListTagsForResource`, `AddTagsToResource`, `RemoveTagsFromResource`) resolved **every** `ResourceName` to a DB instance, so any non-instance ARN (DB subnet group, cluster, …) failed with `404 DBInstanceNotFound` even when the resource existed.

This PR resolves the tagging `ResourceName` by its ARN resource-type segment (`db`, `cluster`, `subgrp`) and dispatches to the matching store. Tag storage is added to `DbCluster` and `DbSubnetGroup`, mirroring `DbInstance`.

- ARNs are parsed strictly: malformed ARNs and non-RDS ARNs return `400 InvalidParameterValue`; a bare (non-ARN) name still resolves to a DB instance for backwards compatibility.
- Missing resources return the resource-specific fault (e.g. `DBSubnetGroupNotFoundFault`); unsupported RDS resource types return `InvalidParameterValue`.
- `modifyDbSubnetGroup` preserves existing tags when subnets are updated.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

This is a bug fix to management-API behavior.

**Incorrect behavior:** the AWS Crossplane / Upbound provider calls `ListTagsForResource` on every observe of a DB subnet group. Floci returned:

```
ListTagsForResource → 404 DBInstanceNotFound:
DB instance arn:aws:rds:us-east-1:000000000000:subgrp:<name> not found.
```

so the managed resource never reconciled. Reproducible with the AWS CLI (AWS CLI v2):

```bash
aws rds create-db-subnet-group --db-subnet-group-name pg --db-subnet-group-description t --subnet-ids subnet-a subnet-b
aws rds list-tags-for-resource --resource-name arn:aws:rds:us-east-1:000000000000:subgrp:pg
# before: An error occurred (DBInstanceNotFound) ...
# after:  returns the tag list
```

Behavior now matches AWS: tags resolve per resource type, and modifying a subnet group preserves its tags.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added <!-- unit-level coverage in RdsServiceTest: subnet-group/cluster tag round-trips by ARN, missing-resource faults, non-RDS/malformed ARN rejection, and tag preservation across modifyDbSubnetGroup -->
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
