### PR TITLE
feat(kms): support KeyId filter on ListAliases

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
@@ -384,7 +384,8 @@ public class KmsJsonHandler {
     }
 
     private Response handleListAliases(JsonNode request, String region) {
-        String keyId = request.path("KeyId").isMissingNode() ? null : request.path("KeyId").asText(null);
+        JsonNode keyIdNode = request.path("KeyId");
+        String keyId = (keyIdNode.isMissingNode() || keyIdNode.isNull()) ? null : keyIdNode.asText();
         List<KmsAlias> aliases = service.listAliases(keyId, region);
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode array = response.putArray("Aliases");

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
@@ -384,7 +384,8 @@ public class KmsJsonHandler {
     }
 
     private Response handleListAliases(JsonNode request, String region) {
-        List<KmsAlias> aliases = service.listAliases(region);
+        String keyId = request.path("KeyId").isMissingNode() ? null : request.path("KeyId").asText(null);
+        List<KmsAlias> aliases = service.listAliases(keyId, region);
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode array = response.putArray("Aliases");
         for (KmsAlias a : aliases) {

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -593,8 +593,19 @@ public class KmsService {
     }
 
     public List<KmsAlias> listAliases(String region) {
+        return listAliases(null, region);
+    }
+
+    public List<KmsAlias> listAliases(String keyId, String region) {
         String prefix = region + "::";
-        return aliasStore.scan(k -> k.startsWith(prefix));
+        List<KmsAlias> all = aliasStore.scan(k -> k.startsWith(prefix));
+        if (keyId == null || keyId.isBlank()) {
+            return all;
+        }
+        KmsKey key = resolveKey(keyId, region);
+        return all.stream()
+                .filter(a -> key.getKeyId().equals(a.getTargetKeyId()))
+                .toList();
     }
 
     // ──────────────────────────── Crypto Ops (Mocks) ────────────────────────────

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -534,6 +534,50 @@ class KmsServiceTest {
     }
 
     @Test
+    void listAliasesFilteredByKeyId() {
+        KmsKey key1 = kmsService.createKey(null, REGION);
+        KmsKey key2 = kmsService.createKey(null, REGION);
+        kmsService.createAlias("alias/key1-a", key1.getKeyId(), REGION);
+        kmsService.createAlias("alias/key1-b", key1.getKeyId(), REGION);
+        kmsService.createAlias("alias/key2-a", key2.getKeyId(), REGION);
+
+        List<KmsAlias> filtered = kmsService.listAliases(key1.getKeyId(), REGION);
+        assertEquals(2, filtered.size());
+        assertTrue(filtered.stream().allMatch(a -> key1.getKeyId().equals(a.getTargetKeyId())));
+    }
+
+    @Test
+    void listAliasesFilteredByKeyIdWithArn() {
+        KmsKey key1 = kmsService.createKey(null, REGION);
+        KmsKey key2 = kmsService.createKey(null, REGION);
+        kmsService.createAlias("alias/key1-a", key1.getKeyId(), REGION);
+        kmsService.createAlias("alias/key2-a", key2.getKeyId(), REGION);
+
+        List<KmsAlias> filtered = kmsService.listAliases(key1.getArn(), REGION);
+        assertEquals(1, filtered.size());
+        assertEquals("alias/key1-a", filtered.getFirst().getAliasName());
+    }
+
+    @Test
+    void listAliasesFilteredByKeyIdReturnsEmptyWhenNoAliases() {
+        KmsKey key1 = kmsService.createKey(null, REGION);
+        KmsKey key2 = kmsService.createKey(null, REGION);
+        kmsService.createAlias("alias/key2-a", key2.getKeyId(), REGION);
+
+        List<KmsAlias> filtered = kmsService.listAliases(key1.getKeyId(), REGION);
+        assertTrue(filtered.isEmpty());
+    }
+
+    @Test
+    void listAliasesFilteredByKeyIdWithAliasCreatedByArn() {
+        KmsKey key = kmsService.createKey(null, REGION);
+        kmsService.createAlias("alias/by-arn", key.getArn(), REGION);
+
+        List<KmsAlias> filtered = kmsService.listAliases(key.getKeyId(), REGION);
+        assertEquals(1, filtered.size());
+    }
+
+    @Test
     void encryptAndDecryptWithId() {
         KmsKey key = kmsService.createKey(null, REGION);
         byte[] plaintext = "hello world".getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
## Summary

The AWS KMS `ListAliases` API accepts an optional `KeyId` parameter to return only the aliases associated with a specific key — used by `aws kms list-aliases --key-id <key-id>`. Floci was ignoring the parameter and always returning all aliases for the region.

This change wires `KeyId` through the handler into a new `listAliases(String keyId, String region)` overload on `KmsService`. The parameter accepts a plain key UUID or a full key ARN, matching AWS behavior. Alias name and alias ARN forms are also accepted as intentional leniency beyond what AWS supports, consistent with how Floci resolves KeyId in other KMS operations. When `KeyId` is provided the service filters the result to only aliases whose `TargetKeyId` matches the resolved key. When `KeyId` is omitted the existing behavior is preserved.

Three new unit tests cover: filtering by plain key UUID, filtering by full key ARN, and returning an empty list for a key with no aliases.

Closes #1650

## Type of change

* [ ] Bug fix (`fix:`)
* [x] New feature (`feat:`)
* [ ] Breaking change (`feat!:` or `fix!:`)
* [ ] Docs / chore

## AWS Compatibility

Previous behavior:

`ListAliases` silently ignored the `KeyId` parameter and returned all aliases in the region, regardless of which key they were associated with.

Updated behavior:

When `KeyId` is provided, `ListAliases` returns only aliases whose `TargetKeyId` matches the resolved key. The parameter accepts a plain key UUID, a full key ARN, or an alias ARN — consistent with how other KMS operations resolve `KeyId`. When `KeyId` is omitted, all aliases for the region are returned as before.

## Checklist

* [x] `./mvnw test` passes locally
* [x] New unit tests added (`listAliasesFilteredByKeyId`, `listAliasesFilteredByKeyIdWithArn`, `listAliasesFilteredByKeyIdReturnsEmptyWhenNoAliases` in `KmsServiceTest`)
* [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)