### PR TITLE
feat(rds): add mock mode to create clusters and instances without Docker

### DIFF
--- a/docs/configuration/advanced/application-yml.md
+++ b/docs/configuration/advanced/application-yml.md
@@ -151,6 +151,7 @@ floci:
 
     rds:
       enabled: true
+      mock: false                             # true = clusters/instances created without Docker (useful for CI)
       proxy-base-port: 7001
       proxy-max-port: 7099
       default-postgres-image: "postgres:16-alpine"

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -319,6 +319,7 @@ These services spawn Docker containers. They require access to the Docker socket
 | Variable | Default | Description |
 |---|---|---|
 | `FLOCI_SERVICES_RDS_ENABLED` | `true` | Enable the RDS service |
+| `FLOCI_SERVICES_RDS_MOCK` | `false` | When `true`, DB clusters and instances are created instantly without a real container or auth proxy (API only) |
 | `FLOCI_SERVICES_RDS_PROXY_BASE_PORT` | `7001` | First port in the RDS proxy range |
 | `FLOCI_SERVICES_RDS_PROXY_MAX_PORT` | `7099` | Last port in the RDS proxy range |
 | `FLOCI_SERVICES_RDS_DEFAULT_POSTGRES_IMAGE` | `postgres:16-alpine` | Default PostgreSQL Docker image |

--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -40,6 +40,7 @@ RDS Data API (`rds-data`) is documented separately because it uses REST JSON rou
 | Variable | Default | Description |
 |---|---|---|
 | `FLOCI_SERVICES_RDS_ENABLED` | `true` | Enable or disable the service |
+| `FLOCI_SERVICES_RDS_MOCK` | `false` | `true` = metadata only (no Docker container or auth proxy) |
 | `FLOCI_SERVICES_RDS_PROXY_BASE_PORT` | `7000` | First host port in the RDS proxy range |
 | `FLOCI_SERVICES_RDS_PROXY_MAX_PORT` | `7099` | Last host port in the RDS proxy range |
 | `FLOCI_SERVICES_RDS_DEFAULT_POSTGRES_IMAGE` | `postgres:16-alpine` | Docker image for PostgreSQL instances |
@@ -63,6 +64,27 @@ services:
       FLOCI_SERVICES_DOCKER_NETWORK: my-project_default
       FLOCI_SERVICES_RDS_PROXY_BASE_PORT: "7001"
 ```
+
+### Mock mode (CI / tests)
+
+Set `FLOCI_SERVICES_RDS_MOCK=true` when you only need the management API shape: clusters and
+instances are registered as `available` immediately, with no Docker container or auth proxy behind
+them. Each resource still gets a unique endpoint port, but nothing listens on it.
+
+```yaml
+# docker-compose.yml — CI / test environment
+services:
+  floci:
+    image: floci/floci:latest
+    environment:
+      FLOCI_SERVICES_RDS_MOCK: "true"
+```
+
+!!! note "Switching modes over persisted state"
+    With a persistent storage mode, changing `FLOCI_SERVICES_RDS_MOCK` between restarts is
+    best-effort, as with the other mock-capable services: resources created in real mode and
+    deleted under mock leave their containers and volumes behind, and resources created in mock
+    mode are restored with fresh, empty containers when loaded in real mode.
 
 ## Examples
 

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -695,6 +695,12 @@ public interface EmulatorConfig {
         @WithDefault("true")
         boolean enabled();
 
+        /** When true, DB clusters and instances are created instantly without a real Docker
+         *  container or auth proxy (API/metadata only). Useful for CI and environments without
+         *  access to the Docker socket. */
+        @WithDefault("false")
+        boolean mock();
+
         @WithDefault("7000")
         int proxyBasePort();
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -448,34 +448,39 @@ public class RdsService implements Resettable {
         instance.setStatus(DbInstanceStatus.REBOOTING);
         instances.put(id, instance);
 
-        // Stop proxy during reboot
-        proxyManager.stopProxy(id);
+        boolean mock = config.services().rds().mock();
+        if (!mock) {
+            // Stop proxy during reboot
+            proxyManager.stopProxy(id);
 
-        // Restart container if it's a standalone instance
-        if (instance.getDbClusterIdentifier() == null && instance.getContainerId() != null) {
-            try {
-                containerManager.stop(buildHandle(instance));
-            } catch (Exception e) {
-                LOG.warnv("Error stopping container during reboot of {0}: {1}", id, e.getMessage());
+            // Restart container if it's a standalone instance
+            if (instance.getDbClusterIdentifier() == null && instance.getContainerId() != null) {
+                try {
+                    containerManager.stop(buildHandle(instance));
+                } catch (Exception e) {
+                    LOG.warnv("Error stopping container during reboot of {0}: {1}", id, e.getMessage());
+                }
+                String image = imageForEngine(instance.getEngine(), instance.getEngineVersion());
+                RdsContainerHandle handle = containerManager.start(id, instance.getVolumeId(), instance.getEngine(), image,
+                        instance.getMasterUsername(), instance.getMasterPassword(), instance.getDbName());
+                instance.setContainerId(handle.getContainerId());
+                instance.setContainerHost(handle.getHost());
+                instance.setContainerPort(handle.getPort());
             }
-            String image = imageForEngine(instance.getEngine(), instance.getEngineVersion());
-            RdsContainerHandle handle = containerManager.start(id, instance.getVolumeId(), instance.getEngine(), image,
-                    instance.getMasterUsername(), instance.getMasterPassword(), instance.getDbName());
-            instance.setContainerId(handle.getContainerId());
-            instance.setContainerHost(handle.getHost());
-            instance.setContainerPort(handle.getPort());
         }
 
         instance.setStatus(DbInstanceStatus.AVAILABLE);
         instances.put(id, instance);
 
-        String effectiveMasterUser = instance.getMasterUsername() != null
-                ? instance.getMasterUsername() : "root";
-        proxyManager.startProxy(id, instance.getEngine(),
-                instance.isIamDatabaseAuthenticationEnabled(),
-                instance.getProxyPort(), instance.getContainerHost(), instance.getContainerPort(),
-                effectiveMasterUser, instance.getMasterPassword(), instance.getDbName(),
-                (user, pw) -> validateDbPassword(id, user, pw));
+        if (!mock) {
+            String effectiveMasterUser = instance.getMasterUsername() != null
+                    ? instance.getMasterUsername() : "root";
+            proxyManager.startProxy(id, instance.getEngine(),
+                    instance.isIamDatabaseAuthenticationEnabled(),
+                    instance.getProxyPort(), instance.getContainerHost(), instance.getContainerPort(),
+                    effectiveMasterUser, instance.getMasterPassword(), instance.getDbName(),
+                    (user, pw) -> validateDbPassword(id, user, pw));
+        }
 
         LOG.infov("DB instance {0} rebooted", id);
         return instance;

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -222,7 +222,8 @@ public class RdsService implements Resettable {
             getDbSubnetGroup(dbSubnetGroupName);
         }
         validateInstanceParameterGroup(paramGroupName, engineParam, engineVersion);
-        int proxyPort = allocateProxyPort();
+        boolean mock = config.services().rds().mock();
+        int proxyPort = mock ? config.services().rds().proxyBasePort() : allocateProxyPort();
         if (masterUsername == null || masterUsername.isBlank()) {
             masterUsername = "root";
         }
@@ -230,8 +231,8 @@ public class RdsService implements Resettable {
             masterPassword = generatedMasterPassword();
         }
 
-        String backendHost;
-        int backendPort;
+        String backendHost = null;
+        int backendPort = 0;
         String containerId = null;
         String containerHost = null;
         int containerPort = 0;
@@ -240,7 +241,7 @@ public class RdsService implements Resettable {
         PlacementResolution placement;
 
         if (dbClusterIdentifier != null && !dbClusterIdentifier.isBlank()) {
-            // Cluster member — share the cluster's container
+            // Cluster member — share the cluster's container (none exists in mock mode)
             DbCluster cluster = clusters.get(dbClusterIdentifier).orElseThrow(() ->
                     new AwsException("DBClusterNotFoundFault",
                             "DB cluster " + dbClusterIdentifier + " not found.", 404));
@@ -255,19 +256,21 @@ public class RdsService implements Resettable {
             placement = PlacementResolution.fromCluster(cluster);
         } else {
             placement = resolvePlacement(dbSubnetGroupName, availabilityZone, multiAz);
-            // Standalone instance — start its own container
-            String image = imageForEngine(engine, engineVersion);
-            instanceVolumeId = String.format("%06x", new SecureRandom().nextInt(0xFFFFFF));
-            RdsContainerHandle handle = containerManager.start(id, instanceVolumeId, engine, image, masterUsername, masterPassword, dbName);
-            backendHost = handle.getHost();
-            backendPort = handle.getPort();
-            containerId = handle.getContainerId();
-            containerHost = handle.getHost();
-            containerPort = handle.getPort();
-            instanceDockerVolumeName = volumeName(instanceVolumeId, id);
+            if (!mock) {
+                // Standalone instance — start its own container
+                String image = imageForEngine(engine, engineVersion);
+                instanceVolumeId = String.format("%06x", new SecureRandom().nextInt(0xFFFFFF));
+                RdsContainerHandle handle = containerManager.start(id, instanceVolumeId, engine, image, masterUsername, masterPassword, dbName);
+                backendHost = handle.getHost();
+                backendPort = handle.getPort();
+                containerId = handle.getContainerId();
+                containerHost = handle.getHost();
+                containerPort = handle.getPort();
+                instanceDockerVolumeName = volumeName(instanceVolumeId, id);
+            }
         }
 
-        DbEndpoint endpoint = new DbEndpoint(proxyEndpointHost(), proxyPort);
+        DbEndpoint endpoint = new DbEndpoint(mock ? "localhost" : proxyEndpointHost(), proxyPort);
         DbInstance instance = new DbInstance(id, engine, engineVersion, masterUsername, masterPassword,
                 dbName, dbInstanceClass, allocatedStorage, DbInstanceStatus.AVAILABLE,
                 endpoint, iamEnabled, paramGroupName, dbClusterIdentifier, Instant.now(), proxyPort);
@@ -291,9 +294,11 @@ public class RdsService implements Resettable {
             attachManagedMasterUserSecret(instance, region, masterUserSecretKmsKeyId);
         }
 
-        proxyManager.startProxy(id, engine, iamEnabled, proxyPort, backendHost, backendPort,
-                masterUsername, masterPassword, dbName,
-                (user, pw) -> validateDbPassword(id, user, pw));
+        if (!mock) {
+            proxyManager.startProxy(id, engine, iamEnabled, proxyPort, backendHost, backendPort,
+                    masterUsername, masterPassword, dbName,
+                    (user, pw) -> validateDbPassword(id, user, pw));
+        }
 
         if (dbClusterIdentifier != null && !dbClusterIdentifier.isBlank()) {
             DbCluster cluster = clusters.get(dbClusterIdentifier).orElse(null);
@@ -492,11 +497,13 @@ public class RdsService implements Resettable {
 
         String clusterId = instance.getDbClusterIdentifier();
         if (clusterId == null || clusterId.isBlank()) {
-            // Standalone — stop its container and clean up its Docker volume
-            if (instance.getContainerId() != null) {
-                containerManager.stop(buildHandle(instance));
+            // Standalone — stop its container and clean up its Docker volume (neither exists in mock mode)
+            if (!config.services().rds().mock()) {
+                if (instance.getContainerId() != null) {
+                    containerManager.stop(buildHandle(instance));
+                }
+                containerManager.removeVolume(instance.getDbInstanceIdentifier(), instance.getVolumeId());
             }
-            containerManager.removeVolume(instance.getDbInstanceIdentifier(), instance.getVolumeId());
         } else {
             // Cluster member — remove from cluster's member list
             DbCluster cluster = clusters.get(clusterId).orElse(null);
@@ -534,21 +541,23 @@ public class RdsService implements Resettable {
         DatabaseEngine engine = resolveEngine(engineParam);
         validateClusterParameterGroup(paramGroupName, engineParam, engineVersion);
         PlacementResolution placement = resolvePlacement(dbSubnetGroupName, availabilityZone, multiAz);
-        int proxyPort = allocateProxyPort();
-        String image = imageForEngine(engine, engineVersion);
-        String clusterVolumeId = String.format("%06x", new SecureRandom().nextInt(0xFFFFFF));
 
-        RdsContainerHandle handle = containerManager.start(id, clusterVolumeId, engine, image, masterUsername, masterPassword, databaseName);
-
-        DbEndpoint endpoint = new DbEndpoint(proxyEndpointHost(), proxyPort);
+        boolean mock = config.services().rds().mock();
+        int proxyPort = mock ? config.services().rds().proxyBasePort() : allocateProxyPort();
+        DbEndpoint endpoint = new DbEndpoint(mock ? "localhost" : proxyEndpointHost(), proxyPort);
         DbCluster cluster = new DbCluster(id, engine, engineVersion, masterUsername, masterPassword,
                 databaseName, DbInstanceStatus.AVAILABLE, endpoint, endpoint,
                 iamEnabled, new ArrayList<>(), paramGroupName, Instant.now(), proxyPort);
-        cluster.setContainerId(handle.getContainerId());
-        cluster.setContainerHost(handle.getHost());
-        cluster.setContainerPort(handle.getPort());
-        cluster.setVolumeId(clusterVolumeId);
-        cluster.setDockerVolumeName(volumeName(clusterVolumeId, id));
+        if (!mock) {
+            String image = imageForEngine(engine, engineVersion);
+            String clusterVolumeId = String.format("%06x", new SecureRandom().nextInt(0xFFFFFF));
+            RdsContainerHandle handle = containerManager.start(id, clusterVolumeId, engine, image, masterUsername, masterPassword, databaseName);
+            cluster.setContainerId(handle.getContainerId());
+            cluster.setContainerHost(handle.getHost());
+            cluster.setContainerPort(handle.getPort());
+            cluster.setVolumeId(clusterVolumeId);
+            cluster.setDockerVolumeName(volumeName(clusterVolumeId, id));
+        }
         cluster.setDbSubnetGroupName(placement.dbSubnetGroupName());
         cluster.setVpcId(placement.vpcId());
         cluster.setAvailabilityZone(placement.availabilityZone());
@@ -559,13 +568,16 @@ public class RdsService implements Resettable {
         cluster.setDbClusterResourceId("cluster-" + java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 24).toUpperCase());
         cluster.setDbClusterArn(regionResolver.buildArn("rds", region, "cluster:" + id));
 
-        String effectiveMasterUser = masterUsername != null ? masterUsername : "root";
-        proxyManager.startProxy(id, engine, iamEnabled, proxyPort, handle.getHost(), handle.getPort(),
-                effectiveMasterUser, masterPassword, databaseName,
-                (user, pw) -> validateDbClusterPassword(id, user, pw));
+        if (!mock) {
+            String effectiveMasterUser = masterUsername != null ? masterUsername : "root";
+            proxyManager.startProxy(id, engine, iamEnabled, proxyPort, cluster.getContainerHost(), cluster.getContainerPort(),
+                    effectiveMasterUser, masterPassword, databaseName,
+                    (user, pw) -> validateDbClusterPassword(id, user, pw));
+        }
 
         clusters.put(id, cluster);
-        LOG.infov("DB cluster {0} created, engine={1}, endpoint=localhost:{2}", id, engine, String.valueOf(proxyPort));
+        LOG.infov("DB cluster {0} created (mock={1}), engine={2}, endpoint=localhost:{3}",
+                id, String.valueOf(mock), engine, String.valueOf(proxyPort));
         return cluster;
     }
 
@@ -610,10 +622,12 @@ public class RdsService implements Resettable {
 
         proxyManager.stopProxy(id);
 
-        if (cluster.getContainerId() != null) {
-            containerManager.stop(buildClusterHandle(cluster));
+        if (!config.services().rds().mock()) {
+            if (cluster.getContainerId() != null) {
+                containerManager.stop(buildClusterHandle(cluster));
+            }
+            containerManager.removeVolume(id, cluster.getVolumeId());
         }
-        containerManager.removeVolume(id, cluster.getVolumeId());
 
         releaseProxyPort(cluster.getProxyPort());
         clusters.delete(id);
@@ -927,6 +941,14 @@ public class RdsService implements Resettable {
             if (cluster.getStatus() == DbInstanceStatus.DELETING) {
                 continue;
             }
+            if (config.services().rds().mock()) {
+                int mockPort = config.services().rds().proxyBasePort();
+                cluster.setProxyPort(mockPort);
+                cluster.setEndpoint(new DbEndpoint("localhost", mockPort));
+                cluster.setReaderEndpoint(new DbEndpoint("localhost", mockPort));
+                cluster.setStatus(DbInstanceStatus.AVAILABLE);
+                continue;
+            }
             int proxyPort = reserveOrAllocateProxyPort(cluster.getProxyPort());
             cluster.setProxyPort(proxyPort);
             cluster.setEndpoint(new DbEndpoint(proxyEndpointHost(), proxyPort));
@@ -961,6 +983,13 @@ public class RdsService implements Resettable {
     private void restoreInstances() {
         for (DbInstance instance : allInstances()) {
             if (instance.getStatus() == DbInstanceStatus.DELETING) {
+                continue;
+            }
+            if (config.services().rds().mock()) {
+                int mockPort = config.services().rds().proxyBasePort();
+                instance.setProxyPort(mockPort);
+                instance.setEndpoint(new DbEndpoint("localhost", mockPort));
+                instance.setStatus(DbInstanceStatus.AVAILABLE);
                 continue;
             }
             int proxyPort = reserveOrAllocateProxyPort(instance.getProxyPort());

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -223,7 +223,9 @@ public class RdsService implements Resettable {
         }
         validateInstanceParameterGroup(paramGroupName, engineParam, engineVersion);
         boolean mock = config.services().rds().mock();
-        int proxyPort = mock ? config.services().rds().proxyBasePort() : allocateProxyPort();
+        // Always reserve a unique port (even in mock) so endpoints stay distinct and usedPorts
+        // is consistent; mock mode only skips starting the container and auth proxy.
+        int proxyPort = allocateProxyPort();
         if (masterUsername == null || masterUsername.isBlank()) {
             masterUsername = "root";
         }
@@ -498,12 +500,15 @@ public class RdsService implements Resettable {
         instance.setStatus(DbInstanceStatus.DELETING);
         instances.put(id, instance);
 
-        proxyManager.stopProxy(id);
+        boolean mock = config.services().rds().mock();
+        if (!mock) {
+            proxyManager.stopProxy(id);
+        }
 
         String clusterId = instance.getDbClusterIdentifier();
         if (clusterId == null || clusterId.isBlank()) {
             // Standalone — stop its container and clean up its Docker volume (neither exists in mock mode)
-            if (!config.services().rds().mock()) {
+            if (!mock) {
                 if (instance.getContainerId() != null) {
                     containerManager.stop(buildHandle(instance));
                 }
@@ -548,7 +553,9 @@ public class RdsService implements Resettable {
         PlacementResolution placement = resolvePlacement(dbSubnetGroupName, availabilityZone, multiAz);
 
         boolean mock = config.services().rds().mock();
-        int proxyPort = mock ? config.services().rds().proxyBasePort() : allocateProxyPort();
+        // Always reserve a unique port (even in mock) so endpoints stay distinct and usedPorts
+        // is consistent; mock mode only skips starting the container and auth proxy.
+        int proxyPort = allocateProxyPort();
         DbEndpoint endpoint = new DbEndpoint(mock ? "localhost" : proxyEndpointHost(), proxyPort);
         DbCluster cluster = new DbCluster(id, engine, engineVersion, masterUsername, masterPassword,
                 databaseName, DbInstanceStatus.AVAILABLE, endpoint, endpoint,
@@ -625,9 +632,8 @@ public class RdsService implements Resettable {
         cluster.setStatus(DbInstanceStatus.DELETING);
         clusters.put(id, cluster);
 
-        proxyManager.stopProxy(id);
-
         if (!config.services().rds().mock()) {
+            proxyManager.stopProxy(id);
             if (cluster.getContainerId() != null) {
                 containerManager.stop(buildClusterHandle(cluster));
             }
@@ -947,7 +953,7 @@ public class RdsService implements Resettable {
                 continue;
             }
             if (config.services().rds().mock()) {
-                int mockPort = config.services().rds().proxyBasePort();
+                int mockPort = reserveOrAllocateProxyPort(cluster.getProxyPort());
                 cluster.setProxyPort(mockPort);
                 cluster.setEndpoint(new DbEndpoint("localhost", mockPort));
                 cluster.setReaderEndpoint(new DbEndpoint("localhost", mockPort));
@@ -991,7 +997,7 @@ public class RdsService implements Resettable {
                 continue;
             }
             if (config.services().rds().mock()) {
-                int mockPort = config.services().rds().proxyBasePort();
+                int mockPort = reserveOrAllocateProxyPort(instance.getProxyPort());
                 instance.setProxyPort(mockPort);
                 instance.setEndpoint(new DbEndpoint("localhost", mockPort));
                 instance.setStatus(DbInstanceStatus.AVAILABLE);

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -252,9 +252,13 @@ public class RdsService implements Resettable {
             containerId = cluster.getContainerId();
             containerHost = cluster.getContainerHost();
             containerPort = cluster.getContainerPort();
-            instanceDockerVolumeName = cluster.getDockerVolumeName() != null
-                    ? cluster.getDockerVolumeName()
-                    : volumeName(cluster.getVolumeId(), cluster.getDbClusterIdentifier());
+            if (!mock) {
+                // In mock mode the cluster has no volume id, so the fallback would persist a
+                // bogus volume name that a later non-mock restore could try to reference.
+                instanceDockerVolumeName = cluster.getDockerVolumeName() != null
+                        ? cluster.getDockerVolumeName()
+                        : volumeName(cluster.getVolumeId(), cluster.getDbClusterIdentifier());
+            }
             placement = PlacementResolution.fromCluster(cluster);
         } else {
             placement = resolvePlacement(dbSubnetGroupName, availabilityZone, multiAz);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -221,6 +221,7 @@ floci:
       default-image: "valkey/valkey:8"
     rds:
       enabled: true
+      mock: false                                 # FLOCI_SERVICES_RDS_MOCK — true = metadata only, no Docker (useful for CI)
       proxy-base-port: 7001
       proxy-max-port: 7099
       default-postgres-image: "postgres:16-alpine"

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -14,6 +14,7 @@ import io.github.hectorvent.floci.services.rds.model.DbClusterParameterGroup;
 import io.github.hectorvent.floci.services.rds.container.RdsContainerHandle;
 import io.github.hectorvent.floci.services.rds.container.RdsContainerManager;
 import io.github.hectorvent.floci.services.rds.model.DbInstance;
+import io.github.hectorvent.floci.services.rds.model.DbInstanceStatus;
 import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
 import io.github.hectorvent.floci.services.rds.model.DbSubnetGroup;
 import io.github.hectorvent.floci.services.rds.proxy.RdsProxyManager;
@@ -339,6 +340,64 @@ class RdsServiceTest {
 
         assertEquals("InvalidDBClusterStateFault", exception.getErrorCode());
         assertTrue(exception.getMessage().contains("still has DB instances"));
+    }
+
+    @Test
+    void mockModeCreatesClusterAvailableWithoutContainerOrProxy() {
+        when(config.services().rds().mock()).thenReturn(true);
+
+        DbCluster cluster = rdsService.createDbCluster("cluster1", "aurora-postgresql", "16.3",
+                "admin", "password", "dbname", false, null);
+
+        assertEquals(DbInstanceStatus.AVAILABLE, cluster.getStatus());
+        assertEquals("localhost", cluster.getEndpoint().address());
+        assertTrue(cluster.getEndpoint().port() > 0);
+        assertNull(cluster.getContainerId());
+        verify(containerManager, never()).start(any(), any(), any(), any(), any(), any(), any());
+        verify(proxyManager, never()).startProxy(any(), any(), anyBoolean(), anyInt(), any(), anyInt(),
+                any(), any(), any(), any());
+    }
+
+    @Test
+    void mockModeCreatesClusterInstanceAvailableWithoutContainer() {
+        when(config.services().rds().mock()).thenReturn(true);
+        rdsService.createDbCluster("cluster1", "aurora-postgresql", "16.3",
+                "admin", "password", "dbname", false, null);
+
+        DbInstance instance = rdsService.createDbInstance("inst1", "aurora-postgresql", "16.3",
+                "admin", "password", "dbname", "db.serverless",
+                0, false, null, null, "cluster1");
+
+        assertEquals(DbInstanceStatus.AVAILABLE, instance.getStatus());
+        assertEquals("localhost", instance.getEndpoint().address());
+        verify(containerManager, never()).start(any(), any(), any(), any(), any(), any(), any());
+        verify(proxyManager, never()).startProxy(any(), any(), anyBoolean(), anyInt(), any(), anyInt(),
+                any(), any(), any(), any());
+    }
+
+    @Test
+    void mockModeCreatesStandaloneInstanceAvailableWithoutContainer() {
+        when(config.services().rds().mock()).thenReturn(true);
+
+        DbInstance instance = rdsService.createDbInstance("standalone", "postgres", "16",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null);
+
+        assertEquals(DbInstanceStatus.AVAILABLE, instance.getStatus());
+        assertNull(instance.getContainerId());
+        verify(containerManager, never()).start(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void mockModeDeleteClusterSkipsDockerCleanup() {
+        when(config.services().rds().mock()).thenReturn(true);
+        rdsService.createDbCluster("cluster1", "aurora-postgresql", "16.3",
+                "admin", "password", "dbname", false, null);
+
+        rdsService.deleteDbCluster("cluster1");
+
+        verify(containerManager, never()).stop(any());
+        verify(containerManager, never()).removeVolume(any(), any());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -401,6 +401,31 @@ class RdsServiceTest {
     }
 
     @Test
+    void mockModeDeleteStandaloneInstanceSkipsDockerCleanup() {
+        when(config.services().rds().mock()).thenReturn(true);
+        rdsService.createDbInstance("standalone", "postgres", "16",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null);
+
+        rdsService.deleteDbInstance("standalone");
+
+        verify(containerManager, never()).stop(any());
+        verify(containerManager, never()).removeVolume(any(), any());
+    }
+
+    @Test
+    void mockModeAssignsDistinctEndpointPorts() {
+        when(config.services().rds().mock()).thenReturn(true);
+
+        DbCluster a = rdsService.createDbCluster("cluster-a", "aurora-postgresql", "16.3",
+                "admin", "password", "dbname", false, null);
+        DbCluster b = rdsService.createDbCluster("cluster-b", "aurora-postgresql", "16.3",
+                "admin", "password", "dbname", false, null);
+
+        assertNotEquals(a.getEndpoint().port(), b.getEndpoint().port());
+    }
+
+    @Test
     void mockModeRebootSkipsContainerAndProxy() {
         when(config.services().rds().mock()).thenReturn(true);
         rdsService.createDbInstance("standalone", "postgres", "16",

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -401,6 +401,22 @@ class RdsServiceTest {
     }
 
     @Test
+    void mockModeRebootSkipsContainerAndProxy() {
+        when(config.services().rds().mock()).thenReturn(true);
+        rdsService.createDbInstance("standalone", "postgres", "16",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null);
+
+        DbInstance rebooted = rdsService.rebootDbInstance("standalone");
+
+        assertEquals(DbInstanceStatus.AVAILABLE, rebooted.getStatus());
+        verify(containerManager, never()).start(any(), any(), any(), any(), any(), any(), any());
+        verify(containerManager, never()).stop(any());
+        verify(proxyManager, never()).startProxy(any(), any(), anyBoolean(), anyInt(), any(), anyInt(),
+                any(), any(), any(), any());
+    }
+
+    @Test
     void createDbClusterRejectsUnknownClusterParameterGroup() {
         AwsException exception = assertThrows(AwsException.class, () -> rdsService.createDbCluster("cluster1", "aurora-postgresql", "16.3",
                 "admin", "password", "dbname", false, "does-not-exist"));

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -370,6 +370,9 @@ class RdsServiceTest {
 
         assertEquals(DbInstanceStatus.AVAILABLE, instance.getStatus());
         assertEquals("localhost", instance.getEndpoint().address());
+        // No Docker volume name may be persisted: the mock cluster has a null volume id, so the
+        // fallback would fabricate a name that a later non-mock restore could try to reference.
+        assertNull(instance.getDockerVolumeName());
         verify(containerManager, never()).start(any(), any(), any(), any(), any(), any(), any());
         verify(proxyManager, never()).startProxy(any(), any(), anyBoolean(), anyInt(), any(), anyInt(),
                 any(), any(), any(), any());

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -120,6 +120,7 @@ floci:
       default-image: "valkey/valkey:8"
     rds:
       enabled: true
+      mock: false
       proxy-base-port: 7001
       proxy-max-port: 7099
       default-postgres-image: "postgres:16-alpine"


### PR DESCRIPTION
## Summary

Floci backs RDS clusters and instances with real Docker containers and an auth proxy. In CI or environments without access to the Docker socket, `CreateDBCluster`/`CreateDBInstance` fail, so the resources never reach an available state.

This adds `FLOCI_SERVICES_RDS_MOCK` (default `false`), mirroring the existing mock mode of EC2/EKS/ECS/OpenSearch/MSK. When enabled:

- cluster and instance creation skip the container and auth proxy and are registered as `AVAILABLE` immediately, with a `localhost` endpoint;
- subnet/AZ/VPC placement metadata is still resolved (it needs no Docker), so `Describe*` responses stay realistic;
- delete, reboot, and runtime restoration likewise skip all Docker/proxy calls.

Non-mock behavior is unchanged.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No wire-protocol change — this adds a runtime mode toggle, not a new action, following the established `FLOCI_SERVICES_<svc>_MOCK` convention ("metadata only, no Docker"). Mocked clusters/instances report `available` so standard clients and IaC tools observe them as ready without a backing container.

Verified with the AWS Crossplane / Upbound AWS provider (`aws-sdk-go-v2`) provisioning an Aurora PostgreSQL cluster + serverless instance on a Docker-less k3d cluster: the managed resources reach `Ready` and the connection ConfigMap is populated. Also covered by unit tests.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added <!-- unit-level coverage in RdsServiceTest: cluster/instance/standalone create register AVAILABLE with no container or proxy, delete and reboot skip Docker -->
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
