### PR TITLE
fix(stepfunctions): resolve qualified Lambda function ARNs in lambda:invoke

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -302,19 +302,43 @@ public class AslExecutor {
         }
     }
 
+    /**
+     * Extracts the Lambda function name from a reference that may be a bare name, a name with a
+     * version/alias qualifier (e.g. "name:$LATEST"), or a full/partial function ARN
+     * (e.g. "arn:aws:lambda:region:acct:function:name[:qualifier]"). The qualifier is dropped
+     * because the function store is keyed by name. Taking the last ':'-segment is wrong for a
+     * qualified ARN — it yields the qualifier (e.g. "$LATEST") instead of the function name.
+     */
+    static String extractLambdaFunctionName(String ref) {
+        if (ref == null) {
+            return null;
+        }
+        String fn = ref;
+        int fi = ref.indexOf(":function:");
+        if (fi >= 0) {
+            fn = ref.substring(fi + ":function:".length());
+        }
+        // Drop an optional trailing version/alias qualifier (e.g. ":$LATEST", ":1", ":prod").
+        int colon = fn.indexOf(':');
+        if (colon >= 0) {
+            fn = fn.substring(0, colon);
+        }
+        return fn;
+    }
+
     private JsonNode invokeResource(String resource, JsonNode input, StateMachine sm, String taskToken) throws Exception {
         // Support Lambda resources: direct ARN or optimized integration
         String functionName = null;
         JsonNode lambdaPayload = input;
 
         if (resource.contains(":lambda:") && resource.contains(":function:")) {
-            // Direct Lambda ARN: arn:aws:lambda:region:account:function:name
-            functionName = resource.substring(resource.lastIndexOf(':') + 1);
+            // Direct Lambda ARN: arn:aws:lambda:region:account:function:name[:qualifier]
+            functionName = extractLambdaFunctionName(resource);
         } else if (resource.equals("arn:aws:states:::lambda:invoke")) {
             // Optimized Lambda integration — function name and payload come from resolved input
             String fnRef = input.path("FunctionName").asText(null);
             if (fnRef != null) {
-                functionName = fnRef.contains(":") ? fnRef.substring(fnRef.lastIndexOf(':') + 1) : fnRef;
+                functionName = extractLambdaFunctionName(fnRef);
             }
             JsonNode payload = input.path("Payload");
             if (!payload.isMissingNode()) {

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorLambdaArnTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorLambdaArnTest.java
@@ -1,0 +1,73 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Regression tests for {@link AslExecutor#extractLambdaFunctionName(String)}.
+ *
+ * Real-world trigger: CDK/Step Functions emit the optimized lambda:invoke integration with a
+ * FunctionName of the form "arn:aws:lambda:region:acct:function:NAME:$LATEST". The previous
+ * implementation took the last ':'-segment, which yields the version qualifier ("$LATEST")
+ * instead of the function name, causing "Lambda function not found: $LATEST".
+ */
+class AslExecutorLambdaArnTest {
+
+    @Test
+    void qualifiedFunctionArnDropsLatestQualifier() {
+        assertEquals("my-fn",
+                AslExecutor.extractLambdaFunctionName(
+                        "arn:aws:lambda:us-east-1:000000000000:function:my-fn:$LATEST"));
+    }
+
+    @Test
+    void qualifiedFunctionArnDropsNumericVersion() {
+        assertEquals("my-fn",
+                AslExecutor.extractLambdaFunctionName(
+                        "arn:aws:lambda:us-east-1:000000000000:function:my-fn:7"));
+    }
+
+    @Test
+    void qualifiedFunctionArnDropsAlias() {
+        assertEquals("my-fn",
+                AslExecutor.extractLambdaFunctionName(
+                        "arn:aws:lambda:us-east-1:000000000000:function:my-fn:prod"));
+    }
+
+    @Test
+    void unqualifiedFunctionArnReturnsName() {
+        assertEquals("my-fn",
+                AslExecutor.extractLambdaFunctionName(
+                        "arn:aws:lambda:us-east-1:000000000000:function:my-fn"));
+    }
+
+    @Test
+    void partialFunctionArnReturnsName() {
+        assertEquals("my-fn",
+                AslExecutor.extractLambdaFunctionName("000000000000:function:my-fn"));
+    }
+
+    @Test
+    void bareNameReturnsName() {
+        assertEquals("my-fn", AslExecutor.extractLambdaFunctionName("my-fn"));
+    }
+
+    @Test
+    void bareNameWithQualifierDropsQualifier() {
+        assertEquals("my-fn", AslExecutor.extractLambdaFunctionName("my-fn:$LATEST"));
+    }
+
+    @Test
+    void hyphenAndUnderscoreNamesPreserved() {
+        assertEquals("local-solutions-prepare-handler",
+                AslExecutor.extractLambdaFunctionName(
+                        "arn:aws:lambda:us-east-1:000000000000:function:local-solutions-prepare-handler:$LATEST"));
+    }
+
+    @Test
+    void nullReturnsNull() {
+        assertNull(AslExecutor.extractLambdaFunctionName(null));
+    }
+}


### PR DESCRIPTION
## Summary

The `lambda:invoke` integration resolved a function name by taking the **last `:`-segment** of the reference. For a qualified function ARN like `arn:aws:lambda:region:acct:function:NAME:$LATEST` (which CDK / Step Functions commonly emit), that yields the version/alias qualifier (`$LATEST`) instead of `NAME`, so the executor fails with **`Lambda function not found: $LATEST`**.

This adds `AslExecutor.extractLambdaFunctionName(ref)` which:
- strips the `:function:` prefix from a full/partial ARN, then
- drops an optional trailing version/alias qualifier (`:$LATEST`, `:1`, `:prod`),

and routes both `lambda:invoke` call sites (direct ARN resource and the optimized `arn:aws:states:::lambda:invoke` `FunctionName`) through it. Bare names and unqualified ARNs are unaffected.

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

For bug fixes: the incorrect behavior was that a Step Functions task using `lambda:invoke` with a **qualified** function ARN failed to locate the function (the qualifier was treated as the name). AWS resolves the function by name and applies the qualifier separately. The function store is keyed by name, so the qualifier is dropped.

## Checklist

- [x] `./mvnw test` passes locally (`AslExecutorLambdaArnTest`: 9 tests; sibling `AslExecutorCatchTest` regression green — run in an `eclipse-temurin:25-jdk` container)
- [x] New or updated integration test added (`AslExecutorLambdaArnTest`)
- [x] Commit messages follow Conventional Commits