### PR TITLE
feat(stepfunctions): implement States.JsonMerge intrinsic

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -1350,6 +1350,30 @@ public class AslExecutor {
             case "States.UUID" -> {
                 yield objectMapper.getNodeFactory().textNode(java.util.UUID.randomUUID().toString());
             }
+            case "States.JsonMerge" -> {
+                List<String> parts = splitIntrinsicArgs(argsStr);
+                if (parts.size() != 3) {
+                    throw new FailStateException("States.Runtime",
+                            "States.JsonMerge requires exactly 3 arguments");
+                }
+                JsonNode a = resolveIntrinsicArg(parts.get(0).trim(), root);
+                JsonNode b = resolveIntrinsicArg(parts.get(1).trim(), root);
+                boolean deep = resolveIntrinsicArg(parts.get(2).trim(), root).asBoolean();
+                if (deep) {
+                    // AWS Step Functions only supports the shallow merge (third argument false).
+                    throw new FailStateException("States.Runtime",
+                            "States.JsonMerge supports only shallow merge (third argument must be false)");
+                }
+                if (!a.isObject() || !b.isObject()) {
+                    throw new FailStateException("States.Runtime",
+                            "States.JsonMerge requires two JSON objects");
+                }
+                // Shallow merge: second object's top-level fields override the first's.
+                var merged = objectMapper.createObjectNode();
+                a.fields().forEachRemaining(e -> merged.set(e.getKey(), e.getValue()));
+                b.fields().forEachRemaining(e -> merged.set(e.getKey(), e.getValue()));
+                yield merged;
+            }
             default -> throw new FailStateException("States.Runtime",
                     "Unsupported intrinsic function: " + fnName);
         };
@@ -1369,6 +1393,12 @@ public class AslExecutor {
         }
         if (arg.startsWith("\"") && arg.endsWith("\"")) {
             return objectMapper.getNodeFactory().textNode(arg.substring(1, arg.length() - 1));
+        }
+        if ("true".equals(arg) || "false".equals(arg)) {
+            return objectMapper.getNodeFactory().booleanNode(Boolean.parseBoolean(arg));
+        }
+        if ("null".equals(arg)) {
+            return objectMapper.getNodeFactory().nullNode();
         }
         try {
             return objectMapper.getNodeFactory().numberNode(Long.parseLong(arg));

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorJsonMergeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorJsonMergeTest.java
@@ -1,0 +1,81 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbJsonHandler;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
+import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
+import jakarta.enterprise.inject.Instance;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Regression + functionality coverage for the {@code States.JsonMerge} intrinsic. AWS Step Functions
+ * supports only the shallow merge form {@code States.JsonMerge($.a, $.b, false)} where the second
+ * object's top-level fields win on a key conflict; deep-merge ({@code true}) and non-object arguments
+ * are rejected. DPS's provisioning state machine relies on this intrinsic, which the executor
+ * previously failed with "Unsupported intrinsic function: States.JsonMerge".
+ */
+class AslExecutorJsonMergeTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private AslExecutor executor;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        executor = new AslExecutor(
+                mock(LambdaExecutorService.class),
+                mock(LambdaFunctionStore.class),
+                mock(DynamoDbService.class),
+                mock(DynamoDbJsonHandler.class),
+                mock(SqsJsonHandler.class),
+                mock(CloudFormationQueryHandler.class),
+                mock(Ec2Service.class),
+                mock(S3Service.class),
+                mapper,
+                new JsonataEvaluator(mapper),
+                mock(Instance.class));
+    }
+
+    @Test
+    void shallowMergeSecondObjectWins() throws Exception {
+        JsonNode root = mapper.readTree("{\"a\":{\"x\":1,\"y\":2},\"b\":{\"y\":9,\"z\":3}}");
+        JsonNode out = executor.resolvePath("States.JsonMerge($.a, $.b, false)", root);
+        assertTrue(out.isObject());
+        assertEquals(1, out.path("x").asInt());
+        assertEquals(9, out.path("y").asInt(), "second object's value should win on key conflict");
+        assertEquals(3, out.path("z").asInt());
+    }
+
+    @Test
+    void deepMergeTrueIsRejected() throws Exception {
+        JsonNode root = mapper.readTree("{\"a\":{\"x\":1},\"b\":{\"y\":2}}");
+        assertThrows(RuntimeException.class,
+                () -> executor.resolvePath("States.JsonMerge($.a, $.b, true)", root));
+    }
+
+    @Test
+    void nonObjectArgumentsRejected() throws Exception {
+        JsonNode root = mapper.readTree("{\"a\":[1,2],\"b\":{\"y\":2}}");
+        assertThrows(RuntimeException.class,
+                () -> executor.resolvePath("States.JsonMerge($.a, $.b, false)", root));
+    }
+
+    @Test
+    void wrongArgumentCountRejected() throws Exception {
+        JsonNode root = mapper.readTree("{\"a\":{\"x\":1},\"b\":{\"y\":2}}");
+        assertThrows(RuntimeException.class,
+                () -> executor.resolvePath("States.JsonMerge($.a, $.b)", root));
+    }
+}


### PR DESCRIPTION
## Summary

`AslExecutor` did not implement the `States.JsonMerge` intrinsic, so a state machine using it failed
with `Unsupported intrinsic function: States.JsonMerge`. This implements the shallow merge: the
second object's top-level fields override the first's on a key conflict. Deep-merge (third argument
`true`) and non-object arguments are rejected, matching AWS. The intrinsic-arg resolver also learns
`true`/`false`/`null` literals so the third argument parses.

## Type of change

- [x] New feature (`feat:`)

## AWS Compatibility

AWS Step Functions' `States.JsonMerge(obj1, obj2, false)` performs a shallow merge and **only**
supports the shallow form — passing `true` (deep merge) is a documented error. Behavior verified
against the [intrinsic functions reference](https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-intrinsic-functions.html):
second object wins on conflict, deep-merge rejected, non-object args rejected.

## Checklist

- [x] `./mvnw test` passes locally — `AslExecutorJsonMergeTest` (run in `eclipse-temurin:25-jdk`)
- [x] New test added — `AslExecutorJsonMergeTest` (shallow merge, deep-merge rejection, non-object rejection, arg-count)
- [x] Commit messages follow Conventional Commits
