### PR TITLE
perf(lambda): widen the code-tar pipe buffer to speed Lambda cold start

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -51,6 +51,11 @@ public class ContainerLauncher {
     private static final String TASK_DIR = "/var/task";
     private static final String RUNTIME_DIR = "/var/runtime";
 
+    // Pipe buffer for streaming the code tar into the container. The JDK default is 1 KB, which
+    // forces a producer/consumer monitor handoff roughly every kilobyte; for a tens-of-MB
+    // node_modules tar that is the dominant cold-start cost. 256 KB cuts the handoffs ~250x.
+    private static final int TAR_PIPE_BUFFER_BYTES = 256 * 1024;
+
     private static final DateTimeFormatter LOG_STREAM_DATE_FMT = DateTimeFormatter.ofPattern("yyyy/MM/dd");
 
     private final ContainerBuilder containerBuilder;
@@ -322,7 +327,7 @@ public class ContainerLauncher {
     private void copyDirToContainer(DockerClient dockerClient, String containerId,
                                     Path sourceDir, String remotePath, String functionName) {
         try (java.io.PipedOutputStream pos = new java.io.PipedOutputStream();
-             java.io.PipedInputStream pis = new java.io.PipedInputStream(pos)) {
+             java.io.PipedInputStream pis = new java.io.PipedInputStream(pos, TAR_PIPE_BUFFER_BYTES)) {
 
             new Thread(() -> {
                 try (pos) {
@@ -345,7 +350,7 @@ public class ContainerLauncher {
     private void copyFileToContainer(DockerClient dockerClient, String containerId,
                                      Path sourceFile, String remotePath, String entryName, String functionName) {
         try (java.io.PipedOutputStream pos = new java.io.PipedOutputStream();
-             java.io.PipedInputStream pis = new java.io.PipedInputStream(pos)) {
+             java.io.PipedInputStream pis = new java.io.PipedInputStream(pos, TAR_PIPE_BUFFER_BYTES)) {
 
             new Thread(() -> {
                 try (TarArchiveOutputStream tar = newTarStream(pos)) {


### PR DESCRIPTION
## Summary

Lambda cold start streams the function's code (frequently a tens-of-MB `node_modules` tar) into the
container through a `PipedOutputStream`/`PipedInputStream` pair. The `PipedInputStream` used the JDK
default 1 KB buffer, which forces a producer/consumer monitor handoff roughly every kilobyte — for a
~90 MB payload that is ~90k+ synchronization points and the dominant cold-start cost. This widens the
pipe buffer to 256 KB at both tar-copy sites (`copyDirToContainer`, `copyFileToContainer`), ~250x
fewer handoffs.

## Type of change

- [x] Performance (`perf:`)

## AWS Compatibility

No behavior change — the same tar stream is copied via the Docker `copyArchiveToContainer` endpoint;
only the in-process pipe buffer size changes. Correctness of the code-injection path is covered by the
existing Lambda container integration tests.

## Checklist

- [x] `./mvnw test` compiles + `ContainerLauncher*Test` pass locally (eclipse-temurin:25-jdk)
- [x] No new test (behavior-neutral perf change; existing integration tests cover the tar-copy)
- [x] Commit messages follow Conventional Commits
