### PR TITLE
perf(lambda): drop the base64 encode-decode round-trip on the S3 code path

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -1135,7 +1135,10 @@ public class LambdaService {
     }
 
     private void extractZipCode(LambdaFunction fn, String zipFileBase64) {
-        byte[] zipBytes = Base64.getDecoder().decode(zipFileBase64);
+        extractZipCodeBytes(fn, Base64.getDecoder().decode(zipFileBase64));
+    }
+
+    private void extractZipCodeBytes(LambdaFunction fn, byte[] zipBytes) {
         Path codePath = codeStore.getCodePath(fn.getFunctionName());
         try {
             zipExtractor.extractTo(zipBytes, codePath);
@@ -1191,7 +1194,7 @@ public class LambdaService {
             throw new AwsException("InvalidParameterValueException",
                     "Unable to fetch code from s3://" + s3Bucket + "/" + s3Key + ": " + e.getMessage(), 400);
         }
-        extractZipCode(fn, Base64.getEncoder().encodeToString(obj.getData()));
+        extractZipCodeBytes(fn, obj.getData());
     }
 
     private String resolveHandlerFilePath(LambdaFunction fn) {
@@ -1482,7 +1485,7 @@ public class LambdaService {
                         fn.getFunctionName(), event.bucketName(), event.key());
                 try {
                     S3Object obj = s3Service.getObject(event.bucketName(), event.key());
-                    extractZipCode(fn, Base64.getEncoder().encodeToString(obj.getData()));
+                    extractZipCodeBytes(fn, obj.getData());
                     fn.setLastModified(Instant.now().toEpochMilli());
                     fn.setRevisionId(UUID.randomUUID().toString());
                     functionStore.save(region, fn);


### PR DESCRIPTION
## Summary

For S3-sourced function code, `extractZipCodeFromS3` (and the S3 code-update path) called
`extractZipCode(fn, Base64.getEncoder().encodeToString(obj.getData()))` — base64-encoding the fetched
bytes purely so `extractZipCode` could immediately base64-**decode** them again. That is a wasted
CPU + allocation of a String ~1.33x the (often tens-of-MB) zip on every create/update. This splits
the extraction into a `extractZipCodeBytes(LambdaFunction, byte[])` core, with `extractZipCode(fn, base64)`
becoming a thin decode-and-delegate shim; the S3 paths now pass the bytes straight through.

## Type of change

- [x] Performance (`perf:`)

## AWS Compatibility

Behavior-identical — `decode(encode(x)) == x`, so the extracted code, size, and SHA-256 are unchanged;
only the redundant round-trip is removed. The direct (request-supplied base64) upload path is unchanged.

## Checklist

- [x] `./mvnw test` compiles + Lambda code tests pass locally (eclipse-temurin:25-jdk)
- [x] No new test (behavior-neutral refactor; existing Lambda code tests cover extraction)
- [x] Commit messages follow Conventional Commits
