### PR TITLE
fix(cloudformation): treat missing SecretsManager secret as already-deleted on stack delete

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -412,8 +412,7 @@ public class CloudFormationResourceProvisioner {
             case "AWS::KMS::Key" -> {
             } // KMS keys can't be immediately deleted; skip
             case "AWS::KMS::Alias" -> kmsService.deleteAlias(physicalId, region);
-            case "AWS::SecretsManager::Secret" ->
-                    secretsManagerService.deleteSecret(physicalId, null, true, region);
+            case "AWS::SecretsManager::Secret" -> deleteSecretSafe(physicalId, region);
             case "AWS::Events::Rule" -> deleteEventBridgeRuleSafe(physicalId, region);
             case "AWS::ApiGateway::RestApi" -> apiGatewayService.deleteRestApi(region, physicalId);
             case "AWS::ApiGatewayV2::Api" -> apiGatewayV2Service.deleteApi(region, physicalId);
@@ -3766,6 +3765,17 @@ public class CloudFormationResourceProvisioner {
             iamService.deletePolicy(policyArn);
         } catch (Exception e) {
             LOG.debugv("Could not delete policy {0}: {1}", policyArn, e.getMessage());
+        }
+    }
+
+    private void deleteSecretSafe(String secretId, String region) {
+        try {
+            secretsManagerService.deleteSecret(secretId, null, true, region);
+        } catch (AwsException e) {
+            if (!"ResourceNotFoundException".equals(e.getErrorCode())) {
+                throw e;
+            }
+            LOG.debugv("Secret already gone, treating as deleted: {0}", secretId);
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -1225,6 +1227,95 @@ class CloudFormationIntegrationTest {
             .get("/")
         .then()
             .statusCode(200);
+    }
+
+    // Regression: issue #1668. Deleting a stack that owns an AWS::SecretsManager::Secret which
+    // no longer exists (e.g. dropped by a persistent-state restore) must reach DELETE_COMPLETE,
+    // not DELETE_FAILED. A missing secret is already gone — AWS treats it as deleted.
+    @Test
+    void deleteStack_withAlreadyDeletedSecret_reachesDeleteComplete() throws Exception {
+        String secretName = "cfn-1668-already-deleted-secret";
+        String template = """
+            {
+              "Resources": {
+                "TestSecret": {
+                  "Type": "AWS::SecretsManager::Secret",
+                  "Properties": {
+                    "Name": "%s",
+                    "SecretString": "{\\"key\\":\\"value\\"}"
+                  }
+                }
+              }
+            }
+            """.formatted(secretName);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-1668-delete-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        // Wait for CREATE_COMPLETE before deleting the secret out of band.
+        long createDeadline = System.currentTimeMillis() + 10_000;
+        String createStatus = "";
+        while (System.currentTimeMillis() < createDeadline) {
+            String xml = given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "DescribeStacks")
+                .formParam("StackName", "cfn-1668-delete-stack")
+            .when().post("/").then().statusCode(200).extract().asString();
+            if (xml.contains("<StackStatus>CREATE_COMPLETE</StackStatus>")) {
+                createStatus = "CREATE_COMPLETE";
+                break;
+            }
+            Thread.sleep(200);
+        }
+        assertEquals("CREATE_COMPLETE", createStatus, "Stack did not reach CREATE_COMPLETE within timeout");
+
+        // Simulate a persistent-state restore dropping the secret while the stack still tracks it.
+        given()
+            .contentType(SM_CONTENT_TYPE)
+            .header("X-Amz-Target", "secretsmanager.DeleteSecret")
+            .body("{\"SecretId\":\"" + secretName + "\",\"ForceDeleteWithoutRecovery\":true}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DeleteStack")
+            .formParam("StackName", "cfn-1668-delete-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            String statusXml = given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "DescribeStacks")
+                .formParam("StackName", "cfn-1668-delete-stack")
+            .when()
+                .post("/")
+            .then()
+                .extract().body().asString();
+
+            assertThat(statusXml, not(containsString("<StackStatus>DELETE_FAILED</StackStatus>")));
+
+            if (statusXml.contains("<StackStatus>DELETE_COMPLETE</StackStatus>")
+                    || statusXml.contains("does not exist")) {
+                return;
+            }
+            Thread.sleep(200);
+        }
+        throw new AssertionError("Stack did not reach DELETE_COMPLETE within timeout");
     }
 
     @Test


### PR DESCRIPTION
Closes #1668

## Summary

#1554 removed the catch-all from `CloudFormationResourceProvisioner.delete()` so that real failures (like deleting a non-empty S3 bucket) correctly propagate as `DELETE_FAILED`. That was right, but `AWS::SecretsManager::Secret` was left as a bare call with no not-found handling. If the secret is missing at delete time (e.g. after a persistent-state restore), `deleteSecret` throws `ResourceNotFoundException`, which propagates up and puts the stack in `DELETE_FAILED`.

AWS CloudFormation treats a missing secret as already deleted and proceeds to `DELETE_COMPLETE`. The fix wraps the call in `deleteSecretSafe()`, which re-throws anything except `ResourceNotFoundException`, matching AWS behavior and the existing pattern used for IAM roles, policies, and EventBridge rules.

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

`delete-stack` on a stack with an `AWS::SecretsManager::Secret` whose physical resource no longer exists in Secrets Manager now reaches `DELETE_COMPLETE` instead of `DELETE_FAILED`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
