### PR TITLE
feat(apigateway): persist API key tags and add GetApiKey route

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
@@ -613,12 +613,19 @@ public class ApiGatewayController {
 
     @GET
     @Path("/apikeys")
-    public Response getApiKeys(@Context HttpHeaders headers) {
+    public Response getApiKeys(@Context HttpHeaders headers,
+                               @QueryParam("includeValues") boolean includeValues) {
         String region = regionResolver.resolveRegion(headers);
         List<ApiKey> keys = service.getApiKeys(region);
         ObjectNode root = objectMapper.createObjectNode();
         ArrayNode items = root.putArray("item");
-        keys.forEach(k -> items.add(toApiKeyNode(k)));
+        keys.forEach(k -> {
+            ObjectNode node = toApiKeyNode(k);
+            if (!includeValues) {
+                node.remove("value");
+            }
+            items.add(node);
+        });
         return Response.ok(root.toString()).type(MediaType.APPLICATION_JSON).build();
     }
 
@@ -1655,8 +1662,8 @@ public class ApiGatewayController {
         node.put("name", k.getName());
         node.put("value", k.getValue());
         node.put("enabled", k.isEnabled());
-        ObjectNode tags = node.putObject("tags");
-        if (k.getTags() != null) {
+        if (k.getTags() != null && !k.getTags().isEmpty()) {
+            ObjectNode tags = node.putObject("tags");
             k.getTags().forEach(tags::put);
         }
         return node;

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
@@ -1655,8 +1655,8 @@ public class ApiGatewayController {
         node.put("name", k.getName());
         node.put("value", k.getValue());
         node.put("enabled", k.isEnabled());
-        if (k.getTags() != null && !k.getTags().isEmpty()) {
-            ObjectNode tags = node.putObject("tags");
+        ObjectNode tags = node.putObject("tags");
+        if (k.getTags() != null) {
             k.getTags().forEach(tags::put);
         }
         return node;

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
@@ -622,6 +622,19 @@ public class ApiGatewayController {
         return Response.ok(root.toString()).type(MediaType.APPLICATION_JSON).build();
     }
 
+    @GET
+    @Path("/apikeys/{apiKeyId}")
+    public Response getApiKey(@Context HttpHeaders headers,
+                              @PathParam("apiKeyId") String apiKeyId,
+                              @QueryParam("includeValue") boolean includeValue) {
+        String region = regionResolver.resolveRegion(headers);
+        ObjectNode node = toApiKeyNode(service.getApiKey(region, apiKeyId));
+        if (!includeValue) {
+            node.remove("value");
+        }
+        return Response.ok(node.toString()).type(MediaType.APPLICATION_JSON).build();
+    }
+
     @POST
     @Path("/usageplans")
     public Response createUsagePlan(@Context HttpHeaders headers, String body) {
@@ -1642,6 +1655,10 @@ public class ApiGatewayController {
         node.put("name", k.getName());
         node.put("value", k.getValue());
         node.put("enabled", k.isEnabled());
+        if (k.getTags() != null && !k.getTags().isEmpty()) {
+            ObjectNode tags = node.putObject("tags");
+            k.getTags().forEach(tags::put);
+        }
         return node;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
@@ -661,6 +661,11 @@ public class ApiGatewayService {
         apiKey.setCreatedDate(System.currentTimeMillis() / 1000L);
         apiKey.setLastUpdatedDate(apiKey.getCreatedDate());
 
+        @SuppressWarnings("unchecked")
+        Map<String, String> tags = request.get("tags") instanceof Map<?, ?> m
+                ? (Map<String, String>) m : new HashMap<>();
+        apiKey.setTags(tags);
+
         apiKeyStore.put(apiKeyGlobalKey(region, apiKey.getId()), apiKey);
         LOG.infov("Created API Key {0}", apiKey.getId());
         return apiKey;

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
@@ -661,9 +661,10 @@ public class ApiGatewayService {
         apiKey.setCreatedDate(System.currentTimeMillis() / 1000L);
         apiKey.setLastUpdatedDate(apiKey.getCreatedDate());
 
-        @SuppressWarnings("unchecked")
-        Map<String, String> tags = request.get("tags") instanceof Map<?, ?> m
-                ? (Map<String, String>) m : new HashMap<>();
+        Map<String, String> tags = new HashMap<>();
+        if (request.get("tags") instanceof Map<?, ?> rawTags) {
+            rawTags.forEach((key, value) -> tags.put(String.valueOf(key), String.valueOf(value)));
+        }
         apiKey.setTags(tags);
 
         apiKeyStore.put(apiKeyGlobalKey(region, apiKey.getId()), apiKey);

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
@@ -674,7 +674,7 @@ public class ApiGatewayService {
 
     public ApiKey getApiKey(String region, String apiKeyId) {
         return apiKeyStore.get(apiKeyGlobalKey(region, apiKeyId))
-                .orElseThrow(() -> new AwsException("NotFoundException", "API Key not found", 404));
+                .orElseThrow(() -> new AwsException("NotFoundException", "Invalid API Key identifier specified", 404));
     }
 
     public List<ApiKey> getApiKeys(String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/model/ApiKey.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/model/ApiKey.java
@@ -3,6 +3,9 @@ package io.github.hectorvent.floci.services.apigateway.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ApiKey {
@@ -12,6 +15,7 @@ public class ApiKey {
     private boolean enabled;
     private long createdDate;
     private long lastUpdatedDate;
+    private Map<String, String> tags = new HashMap<>();
 
     public ApiKey() {}
 
@@ -32,4 +36,7 @@ public class ApiKey {
 
     public long getLastUpdatedDate() { return lastUpdatedDate; }
     public void setLastUpdatedDate(long lastUpdatedDate) { this.lastUpdatedDate = lastUpdatedDate; }
+
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) { this.tags = tags != null ? tags : new HashMap<>(); }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayApiKeyIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayApiKeyIntegrationTest.java
@@ -1,0 +1,83 @@
+package io.github.hectorvent.floci.services.apigateway;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Integration tests for API Gateway API key tags and the GetApiKey route.
+ *
+ * <p>Validates that {@code CreateApiKey} persists {@code tags} and returns them
+ * from {@code CreateApiKey}, {@code GetApiKey} and {@code GetApiKeys}, and that
+ * {@code GET /apikeys/{apiKeyId}} is served (returning the key, omitting the
+ * value unless {@code includeValue=true}, and 404 when the key is unknown).
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayApiKeyIntegrationTest {
+
+    private static String apiKeyId;
+
+    @Test @Order(1)
+    void createApiKeyPersistsTags() {
+        String body = """
+                {"name":"k","enabled":true,"tags":{"Team":"platform","Project":"demo"}}
+                """;
+        apiKeyId = given()
+                .contentType(ContentType.JSON)
+                .body(body)
+                .when().post("/apikeys")
+                .then()
+                .statusCode(201)
+                .body("id", notNullValue())
+                .body("name", equalTo("k"))
+                .body("enabled", equalTo(true))
+                .body("tags.Team", equalTo("platform"))
+                .body("tags.Project", equalTo("demo"))
+                .extract().path("id");
+    }
+
+    @Test @Order(2)
+    void getApiKeyReturnsTagsAndOmitsValueByDefault() {
+        given()
+                .when().get("/apikeys/" + apiKeyId)
+                .then()
+                .statusCode(200)
+                .body("id", equalTo(apiKeyId))
+                .body("tags.Team", equalTo("platform"))
+                .body("tags.Project", equalTo("demo"))
+                .body("value", nullValue());
+    }
+
+    @Test @Order(3)
+    void getApiKeyIncludesValueWhenRequested() {
+        given()
+                .when().get("/apikeys/" + apiKeyId + "?includeValue=true")
+                .then()
+                .statusCode(200)
+                .body("value", notNullValue());
+    }
+
+    @Test @Order(4)
+    void listApiKeysIncludesTags() {
+        given()
+                .when().get("/apikeys")
+                .then()
+                .statusCode(200)
+                .body("item.find { it.id == '" + apiKeyId + "' }.tags.Team", equalTo("platform"));
+    }
+
+    @Test @Order(5)
+    void getApiKeyNotFound() {
+        given()
+                .when().get("/apikeys/doesnotexist")
+                .then()
+                .statusCode(404);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayApiKeyIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayApiKeyIntegrationTest.java
@@ -65,12 +65,19 @@ class ApiGatewayApiKeyIntegrationTest {
     }
 
     @Test @Order(4)
-    void listApiKeysIncludesTags() {
+    void listApiKeysIncludesTagsAndOmitsValueByDefault() {
         given()
                 .when().get("/apikeys")
                 .then()
                 .statusCode(200)
-                .body("item.find { it.id == '" + apiKeyId + "' }.tags.Team", equalTo("platform"));
+                .body("item.find { it.id == '" + apiKeyId + "' }.tags.Team", equalTo("platform"))
+                .body("item.find { it.id == '" + apiKeyId + "' }.value", nullValue());
+
+        given()
+                .when().get("/apikeys?includeValues=true")
+                .then()
+                .statusCode(200)
+                .body("item.find { it.id == '" + apiKeyId + "' }.value", notNullValue());
     }
 
     @Test @Order(5)
@@ -81,6 +88,6 @@ class ApiGatewayApiKeyIntegrationTest {
                 .statusCode(404)
                 .contentType(ContentType.JSON)
                 .body("__type", equalTo("NotFoundException"))
-                .body("message", equalTo("API Key not found"));
+                .body("message", equalTo("Invalid API Key identifier specified"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayApiKeyIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayApiKeyIntegrationTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.*;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ApiGatewayApiKeyIntegrationTest {
 
-    private static String apiKeyId;
+    private static String apiKeyId = "uninitialized";
 
     @Test @Order(1)
     void createApiKeyPersistsTags() {
@@ -78,6 +78,9 @@ class ApiGatewayApiKeyIntegrationTest {
         given()
                 .when().get("/apikeys/doesnotexist")
                 .then()
-                .statusCode(404);
+                .statusCode(404)
+                .contentType(ContentType.JSON)
+                .body("__type", equalTo("NotFoundException"))
+                .body("message", equalTo("API Key not found"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes the two API Gateway API-key gaps reported in #1676:

- `CreateApiKey` now persists the request `tags` and returns them from `CreateApiKey`, `GetApiKey` and `GetApiKeys`.
- Adds the missing `GetApiKey` route (`GET /apikeys/{apiKeyId}`), delegating to the existing `service.getApiKey(...)`. It omits `value` unless `includeValue=true`, and returns a JSON `NotFoundException` (404) for unknown keys.

## Changes

- `model/ApiKey.java` — add a `tags` map (mirrors `RestApi`).
- `ApiGatewayService#createApiKey` — read `tags` from the request (same pattern as `createRestApi`).
- `ApiGatewayController` — serialize `tags` in `toApiKeyNode`; add the `GET /apikeys/{apiKeyId}` route.
- `ApiGatewayApiKeyIntegrationTest` — covers tag persistence, GetApiKey (with/without `value`), listing, and 404.

## Notes

Backward-compatible: keys persisted before this change deserialize with an empty `tags` map (`@JsonIgnoreProperties(ignoreUnknown = true)` + default field value).

Closes #1676
