### PR TITLE
feat(ecs): resolve containerDefinitions[].secrets from SSM / Secrets Manager

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/EcsTests.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/EcsTests.java
@@ -17,6 +17,7 @@ class EcsTests {
     private static String clusterName;
     private static String family;
     private static String serviceName;
+    private static String secretArn;
     private static Cluster cluster;
     private static TaskDefinition taskDef;
     private static TaskDefinition taskDefRev2;
@@ -30,6 +31,7 @@ class EcsTests {
         clusterName = "sdk-test-cluster-" + suffix;
         family = "sdk-test-task-" + suffix;
         serviceName = "sdk-test-svc-" + suffix;
+        secretArn = "arn:aws:secretsmanager:us-east-1:000000000000:secret:sdk-db-password-AbCdEf";
     }
 
     @AfterAll
@@ -1022,5 +1024,36 @@ class EcsTests {
     void listClustersAfterDelete() {
         List<String> arns = ecs.listClusters(ListClustersRequest.builder().build()).clusterArns();
         assertThat(arns).doesNotContain(cluster.clusterArn());
+    }
+
+    @Test
+    @Order(57)
+    @DisplayName("RegisterTaskDefinition - container secrets round trip")
+    void registerTaskDefinitionWithSecrets() {
+        String secretFamily = family + "-secrets";
+        TaskDefinition secretTaskDef = ecs.registerTaskDefinition(RegisterTaskDefinitionRequest.builder()
+                .family(secretFamily)
+                .containerDefinitions(ContainerDefinition.builder()
+                        .name("app")
+                        .image("alpine:latest")
+                        .essential(true)
+                        .secrets(Secret.builder()
+                                .name("DB_PASSWORD")
+                                .valueFrom(secretArn)
+                                .build())
+                        .build())
+                .build()).taskDefinition();
+
+        assertThat(secretTaskDef.containerDefinitions().get(0).secrets()).hasSize(1);
+        assertThat(secretTaskDef.containerDefinitions().get(0).secrets().get(0).name()).isEqualTo("DB_PASSWORD");
+        assertThat(secretTaskDef.containerDefinitions().get(0).secrets().get(0).valueFrom()).isEqualTo(secretArn);
+
+        TaskDefinition described = ecs.describeTaskDefinition(DescribeTaskDefinitionRequest.builder()
+                .taskDefinition(secretTaskDef.taskDefinitionArn())
+                .build()).taskDefinition();
+
+        assertThat(described.containerDefinitions().get(0).secrets()).hasSize(1);
+        assertThat(described.containerDefinitions().get(0).secrets().get(0).name()).isEqualTo("DB_PASSWORD");
+        assertThat(described.containerDefinitions().get(0).secrets().get(0).valueFrom()).isEqualTo(secretArn);
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
@@ -23,6 +23,7 @@ import io.github.hectorvent.floci.services.ecs.model.PortMapping;
 import io.github.hectorvent.floci.services.ecs.model.ProtectedTask;
 import io.github.hectorvent.floci.services.ecs.model.ServiceDeployment;
 import io.github.hectorvent.floci.services.ecs.model.ServiceRevision;
+import io.github.hectorvent.floci.services.ecs.model.Secret;
 import io.github.hectorvent.floci.services.ecs.model.TaskDefinition;
 import io.github.hectorvent.floci.services.ecs.model.TaskSet;
 import io.github.hectorvent.floci.services.ecs.model.EfsVolumeConfiguration;
@@ -1023,6 +1024,17 @@ public class EcsJsonHandler {
             n.set("environment", envArr);
         }
 
+        if (def.getSecrets() != null && !def.getSecrets().isEmpty()) {
+            ArrayNode secretsArr = objectMapper.createArrayNode();
+            for (Secret secret : def.getSecrets()) {
+                ObjectNode secretNode = objectMapper.createObjectNode();
+                secretNode.put("name", secret.name());
+                secretNode.put("valueFrom", secret.valueFrom());
+                secretsArr.add(secretNode);
+            }
+            n.set("secrets", secretsArr);
+        }
+
         if (def.getMountPoints() != null && !def.getMountPoints().isEmpty()) {
             ArrayNode mps = objectMapper.createArrayNode();
             for (MountPoint mp : def.getMountPoints()) {
@@ -1275,6 +1287,9 @@ public class EcsJsonHandler {
 
             def.setPortMappings(parsePortMappings(item.path("portMappings")));
             def.setEnvironment(parseKeyValuePairs(item.path("environment")));
+            if (item.has("secrets")) {
+                def.setSecrets(parseSecrets(item.path("secrets")));
+            }
             def.setMountPoints(parseMountPoints(item.path("mountPoints")));
 
             if (item.has("command") && item.path("command").isArray()) {
@@ -1314,6 +1329,17 @@ public class EcsJsonHandler {
         }
         for (JsonNode item : node) {
             result.add(new KeyValuePair(item.path("name").asText(), item.path("value").asText()));
+        }
+        return result;
+    }
+
+    private List<Secret> parseSecrets(JsonNode node) {
+        List<Secret> result = new ArrayList<>();
+        if (!node.isArray()) {
+            return result;
+        }
+        for (JsonNode item : node) {
+            result.add(new Secret(item.path("name").asText(), item.path("valueFrom").asText()));
         }
         return result;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
@@ -481,7 +481,14 @@ public class EcsService {
                     LOG.errorv("Failed to start ECS task {0}: {1}", taskArn, e.getMessage());
                     task.setLastStatus(TaskStatus.STOPPED.name());
                     task.setDesiredStatus(TaskStatus.STOPPED.name());
-                    task.setStoppedReason("Failed to start: " + e.getMessage());
+                    // A ResourceInitializationError is already AWS's exact stopped-reason wording
+                    // (e.g. a secret that could not be resolved), so pass it through verbatim.
+                    // Other start failures keep the generic prefix.
+                    boolean resourceInitError = e instanceof AwsException ae
+                            && "ResourceInitializationError".equals(ae.getErrorCode());
+                    task.setStoppedReason(resourceInitError
+                            ? e.getMessage()
+                            : "Failed to start: " + e.getMessage());
                     task.setStoppedAt(Instant.now());
                 }
             } else {

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManager.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.ecs.container;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
 import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
@@ -19,8 +20,11 @@ import io.github.hectorvent.floci.services.ecs.model.MountPoint;
 import io.github.hectorvent.floci.services.ecs.model.NetworkBinding;
 import io.github.hectorvent.floci.services.ecs.model.NetworkMode;
 import io.github.hectorvent.floci.services.ecs.model.PortMapping;
+import io.github.hectorvent.floci.services.ecs.model.Secret;
 import io.github.hectorvent.floci.services.ecs.model.TaskDefinition;
 import io.github.hectorvent.floci.services.ecs.model.Volume;
+import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerService;
+import io.github.hectorvent.floci.services.ssm.SsmService;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.ExposedPort;
@@ -52,6 +56,8 @@ public class EcsContainerManager {
     private final EmulatorConfig config;
     private final RegionResolver regionResolver;
     private final LaunchedContainerAwsEnv awsEnv;
+    private final SsmService ssmService;
+    private final SecretsManagerService secretsManagerService;
 
     @Inject
     public EcsContainerManager(ContainerBuilder containerBuilder,
@@ -60,7 +66,9 @@ public class EcsContainerManager {
                                ContainerDetector containerDetector,
                                EmulatorConfig config,
                                RegionResolver regionResolver,
-                               LaunchedContainerAwsEnv awsEnv) {
+                               LaunchedContainerAwsEnv awsEnv,
+                               SsmService ssmService,
+                               SecretsManagerService secretsManagerService) {
         this.containerBuilder = containerBuilder;
         this.lifecycleManager = lifecycleManager;
         this.logStreamer = logStreamer;
@@ -68,6 +76,8 @@ public class EcsContainerManager {
         this.config = config;
         this.regionResolver = regionResolver;
         this.awsEnv = awsEnv;
+        this.ssmService = ssmService;
+        this.secretsManagerService = secretsManagerService;
     }
 
     /**
@@ -100,25 +110,23 @@ public class EcsContainerManager {
             }
         }
 
+        Map<String, ContainerOverride> overridesByName = overridesByName(containerOverrides);
+        Map<ContainerDefinition, List<String>> envVarsByContainer = new LinkedHashMap<>();
+        for (ContainerDefinition def : taskDef.getContainerDefinitions()) {
+            envVarsByContainer.put(def, buildEnvVars(def, overridesByName.get(def.getName()), region));
+        }
+
         for (ContainerDefinition def : taskDef.getContainerDefinitions()) {
             String containerName = ContainerStorageHelper.dockerName(config, "floci-ecs-" + taskId + "-" + def.getName());
 
             // RunTask containerOverrides matched by container name: command replaces
             // the task-def command; environment is merged over the task-def environment.
-            ContainerOverride override = null;
-            if (containerOverrides != null) {
-                for (ContainerOverride co : containerOverrides) {
-                    if (def.getName() != null && def.getName().equals(co.getName())) {
-                        override = co;
-                        break;
-                    }
-                }
-            }
+            ContainerOverride override = overridesByName.get(def.getName());
 
             // Build container spec
             ContainerBuilder.Builder specBuilder = containerBuilder.newContainer(def.getImage())
                     .withName(containerName)
-                    .withEnv(buildEnvVars(def, override, region))
+                    .withEnv(envVarsByContainer.get(def))
                     .withDockerNetwork(config.services().ecs().dockerNetwork())
                     // Resolve Floci's endpoint from inside the task container the same way Lambda
                     // containers do: host.docker.internal on Linux, plus Floci's embedded DNS so the
@@ -344,9 +352,10 @@ public class EcsContainerManager {
     }
 
     private List<String> buildEnvVars(ContainerDefinition def, ContainerOverride override, String region) {
-        // AWS SDK baseline (endpoint + region + credentials) so the task can reach the emulator,
-        // then the task-def environment, then the override environment — the task def and override
-        // win on key conflict, so an explicit task-def value is never clobbered.
+        // AWS SDK baseline (endpoint + region + credentials) first so the task can reach the
+        // emulator, then the task-def environment, then task-def secrets, then the override
+        // environment. Later entries win on key conflict, so an explicit task-def value or
+        // secret is never clobbered by the baseline.
         Map<String, String> envMap = new LinkedHashMap<>();
         for (String kv : awsEnv.sdkBaselineEnv(region, Optional.empty())) {
             int eq = kv.indexOf('=');
@@ -359,6 +368,11 @@ public class EcsContainerManager {
                 envMap.put(kv.name(), kv.value());
             }
         }
+        if (def.getSecrets() != null) {
+            for (Secret secret : def.getSecrets()) {
+                envMap.put(secret.name(), resolveSecretValue(secret.valueFrom(), region));
+            }
+        }
         if (override != null && override.getEnvironment() != null) {
             for (var kv : override.getEnvironment()) {
                 envMap.put(kv.name(), kv.value());
@@ -369,6 +383,84 @@ public class EcsContainerManager {
             envVars.add(entry.getKey() + "=" + entry.getValue());
         }
         return envVars;
+    }
+
+    private Map<String, ContainerOverride> overridesByName(List<ContainerOverride> containerOverrides) {
+        Map<String, ContainerOverride> overrides = new LinkedHashMap<>();
+        if (containerOverrides == null) {
+            return overrides;
+        }
+        for (ContainerOverride override : containerOverrides) {
+            if (override.getName() != null) {
+                overrides.put(override.getName(), override);
+            }
+        }
+        return overrides;
+    }
+
+    private String resolveSecretValue(String valueFrom, String region) {
+        // A full ARN carries its own region; use it so cross-region references resolve
+        // against the right store instead of the task's region. Bare SSM names fall back
+        // to the task region.
+        String secretRegion = arnRegion(valueFrom, region);
+        String value;
+        try {
+            if (valueFrom != null && valueFrom.startsWith("arn:aws:secretsmanager:")) {
+                // A plain secret ARN (or partial ARN) resolves to its full SecretString.
+                // The ECS `:json-key:version-stage:version-id` selector suffix is not yet
+                // supported: it is passed through unparsed, so a valueFrom carrying one fails
+                // to resolve and stops the task with ResourceInitializationError rather than
+                // silently returning the whole secret. See floci-io/floci#1624.
+                var secret = secretsManagerService.getSecretValue(valueFrom, null, null, secretRegion);
+                value = secret == null ? null : secret.getSecretString();
+            } else {
+                String parameterName = ssmParameterName(valueFrom);
+                var parameter = ssmService.getParameter(parameterName, secretRegion);
+                value = parameter == null ? null : parameter.getValue();
+            }
+        } catch (AwsException e) {
+            throw resourceInitializationError(valueFrom, e.getMessage(), e.getHttpStatus());
+        }
+        if (value == null) {
+            // A Secrets Manager secret stored as SecretBinary (no SecretString) has no string
+            // value to inject as an env var. Real AWS fails the task launch rather than starting
+            // the container with a missing value, so surface the same ResourceInitializationError
+            // instead of emitting a literal "NAME=null".
+            throw resourceInitializationError(valueFrom, "secret value is not a string", 400);
+        }
+        return value;
+    }
+
+    // The error code is ResourceInitializationError, not the underlying store's code: this
+    // exception never reaches a client (it is caught in EcsService and rendered as the task's
+    // stoppedReason), and EcsService keys off this code to pass the reason through as AWS's
+    // exact wording rather than wrapping it in the generic "Failed to start:" prefix.
+    private AwsException resourceInitializationError(String valueFrom, String detail, int httpStatus) {
+        return new AwsException("ResourceInitializationError",
+                "ResourceInitializationError: unable to pull secrets or registry auth: "
+                        + valueFrom + ": " + detail,
+                httpStatus);
+    }
+
+    /** The region embedded in an ARN {@code valueFrom} (4th segment), or {@code taskRegion} for a bare name. */
+    private String arnRegion(String valueFrom, String taskRegion) {
+        if (valueFrom != null && valueFrom.startsWith("arn:")) {
+            String[] parts = valueFrom.split(":", 5);
+            if (parts.length >= 4 && !parts[3].isBlank()) {
+                return parts[3];
+            }
+        }
+        return taskRegion;
+    }
+
+    private String ssmParameterName(String valueFrom) {
+        if (valueFrom != null && valueFrom.startsWith("arn:aws:ssm:")) {
+            int parameterMarker = valueFrom.indexOf(":parameter");
+            if (parameterMarker >= 0) {
+                return valueFrom.substring(parameterMarker + ":parameter".length());
+            }
+        }
+        return valueFrom;
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/ContainerDefinition.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/ContainerDefinition.java
@@ -15,6 +15,7 @@ public class ContainerDefinition {
     private boolean essential = true;
     private List<PortMapping> portMappings;
     private List<KeyValuePair> environment;
+    private List<Secret> secrets;
     private List<String> command;
     private List<String> entryPoint;
     private List<MountPoint> mountPoints;
@@ -42,6 +43,9 @@ public class ContainerDefinition {
 
     public List<KeyValuePair> getEnvironment() { return environment; }
     public void setEnvironment(List<KeyValuePair> environment) { this.environment = environment; }
+
+    public List<Secret> getSecrets() { return secrets; }
+    public void setSecrets(List<Secret> secrets) { this.secrets = secrets; }
 
     public List<String> getCommand() { return command; }
     public void setCommand(List<String> command) { this.command = command; }

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/Secret.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/Secret.java
@@ -1,0 +1,7 @@
+package io.github.hectorvent.floci.services.ecs.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public record Secret(String name, String valueFrom) {
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/EcsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/EcsIntegrationTest.java
@@ -348,6 +348,56 @@ class EcsIntegrationTest {
 
     @Test
     @Order(16)
+    void registerTaskDefinitionWithSecretsRoundTripsReferences() {
+        String secretArn = "arn:aws:secretsmanager:%s:%s:secret:db-password-AbCdEf"
+                .formatted(REGION, ACCOUNT);
+
+        String secretsTaskDefArn = ecs("RegisterTaskDefinition")
+            .body("""
+                {
+                    "family": "task-with-secrets",
+                    "containerDefinitions": [
+                        {
+                            "name": "app",
+                            "image": "nginx:latest",
+                            "essential": true,
+                            "secrets": [
+                                {"name": "DB_PASSWORD", "valueFrom": "%s"},
+                                {"name": "CONFIG_VALUE", "valueFrom": "/app/config"}
+                            ]
+                        }
+                    ]
+                }
+                """.formatted(secretArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("taskDefinition.containerDefinitions[0].secrets", hasSize(2))
+            .body("taskDefinition.containerDefinitions[0].secrets[0].name", equalTo("DB_PASSWORD"))
+            .body("taskDefinition.containerDefinitions[0].secrets[0].valueFrom", equalTo(secretArn))
+            .body("taskDefinition.containerDefinitions[0].secrets[1].name", equalTo("CONFIG_VALUE"))
+            .body("taskDefinition.containerDefinitions[0].secrets[1].valueFrom", equalTo("/app/config"))
+        .extract()
+            .path("taskDefinition.taskDefinitionArn");
+
+        ecs("DescribeTaskDefinition")
+            .body("""
+                {"taskDefinition": "%s"}
+                """.formatted(secretsTaskDefArn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("taskDefinition.containerDefinitions[0].secrets", hasSize(2))
+            .body("taskDefinition.containerDefinitions[0].secrets[0].name", equalTo("DB_PASSWORD"))
+            .body("taskDefinition.containerDefinitions[0].secrets[0].valueFrom", equalTo(secretArn))
+            .body("taskDefinition.containerDefinitions[0].secrets[1].name", equalTo("CONFIG_VALUE"))
+            .body("taskDefinition.containerDefinitions[0].secrets[1].valueFrom", equalTo("/app/config"));
+    }
+
+    @Test
+    @Order(17)
     void describeTaskDefinition() {
         ecs("DescribeTaskDefinition")
             .body("""
@@ -363,7 +413,7 @@ class EcsIntegrationTest {
     }
 
     @Test
-    @Order(17)
+    @Order(18)
     void listTaskDefinitions() {
         ecs("ListTaskDefinitions")
             .body("{}")
@@ -375,7 +425,7 @@ class EcsIntegrationTest {
     }
 
     @Test
-    @Order(18)
+    @Order(19)
     void listTaskDefinitionFamilies() {
         ecs("ListTaskDefinitionFamilies")
             .body("{}")

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/EcsServiceContainerSecretsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/EcsServiceContainerSecretsTest.java
@@ -1,0 +1,64 @@
+package io.github.hectorvent.floci.services.ecs;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.ecs.container.EcsContainerManager;
+import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
+import io.github.hectorvent.floci.services.ecs.model.EcsTask;
+import io.github.hectorvent.floci.services.ecs.model.LaunchType;
+import io.github.hectorvent.floci.services.ecs.model.NetworkMode;
+import io.github.hectorvent.floci.services.ecs.model.Secret;
+import io.github.hectorvent.floci.services.ecs.model.TaskStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class EcsServiceContainerSecretsTest {
+
+    @Test
+    void runTaskReturnsStoppedTaskWhenSecretResolutionFailsDuringDockerLaunch() {
+        EcsContainerManager containerManager = mock(EcsContainerManager.class);
+        // resolveSecretValue wraps any resolution failure as a ResourceInitializationError-coded
+        // AwsException; EcsService keys off that code to pass the reason through verbatim.
+        when(containerManager.startTask(any(), any(), any(), eq("us-east-1")))
+                .thenThrow(new AwsException("ResourceInitializationError",
+                        "ResourceInitializationError: unable to pull secrets or registry auth: /missing: not found",
+                        400));
+
+        EmulatorConfig config = mock(EmulatorConfig.class, RETURNS_DEEP_STUBS);
+        when(config.services().ecs().mock()).thenReturn(false);
+        when(config.effectiveBaseUrl()).thenReturn("http://localhost:4566");
+
+        EcsService service = new EcsService(new RegionResolver("us-east-1", "000000000000"),
+                containerManager, config, mock(EcsLoadBalancerRegistrar.class), null);
+        service.createCluster("test-cluster", "us-east-1");
+
+        ContainerDefinition app = new ContainerDefinition();
+        app.setName("app");
+        app.setImage("app:latest");
+        app.setSecrets(List.of(new Secret("MISSING", "/missing")));
+        service.registerTaskDefinition("secret-task", List.of(app), NetworkMode.bridge, null, null,
+                null, null, null, "us-east-1");
+
+        List<EcsTask> tasks = service.runTask("test-cluster", "secret-task", 1,
+                LaunchType.EC2, null, null, List.of(), null, "us-east-1");
+
+        assertEquals(1, tasks.size());
+        EcsTask task = tasks.getFirst();
+        assertEquals(TaskStatus.STOPPED.name(), task.getLastStatus());
+        assertEquals(TaskStatus.STOPPED.name(), task.getDesiredStatus());
+        // A ResourceInitializationError is AWS's exact stopped-reason wording, so it must be
+        // passed through verbatim rather than wrapped in the generic "Failed to start:" prefix.
+        assertTrue(task.getStoppedReason().startsWith("ResourceInitializationError"));
+        assertTrue(task.getStoppedReason().contains("/missing"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerAwsBaselineTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerAwsBaselineTest.java
@@ -13,6 +13,8 @@ import io.github.hectorvent.floci.services.ecs.model.ContainerOverride;
 import io.github.hectorvent.floci.services.ecs.model.EcsTask;
 import io.github.hectorvent.floci.services.ecs.model.KeyValuePair;
 import io.github.hectorvent.floci.services.ecs.model.TaskDefinition;
+import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerService;
+import io.github.hectorvent.floci.services.ssm.SsmService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -72,7 +74,8 @@ class EcsContainerManagerAwsBaselineTest {
                 "AWS_ENDPOINT_URL=http://localhost:4566"));
 
         manager = new EcsContainerManager(containerBuilder, lifecycleManager, logStreamer,
-                containerDetector, config, regionResolver, awsEnv);
+                containerDetector, config, regionResolver, awsEnv, mock(SsmService.class),
+                mock(SecretsManagerService.class));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerOverridesTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerOverridesTest.java
@@ -13,6 +13,8 @@ import io.github.hectorvent.floci.services.ecs.model.ContainerOverride;
 import io.github.hectorvent.floci.services.ecs.model.EcsTask;
 import io.github.hectorvent.floci.services.ecs.model.KeyValuePair;
 import io.github.hectorvent.floci.services.ecs.model.TaskDefinition;
+import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerService;
+import io.github.hectorvent.floci.services.ssm.SsmService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -66,9 +68,11 @@ class EcsContainerManagerOverridesTest {
         RegionResolver regionResolver = mock(RegionResolver.class);
         LaunchedContainerAwsEnv awsEnv = mock(LaunchedContainerAwsEnv.class);
         when(awsEnv.sdkBaselineEnv(any(), any())).thenReturn(List.of());
+        SsmService ssmService = mock(SsmService.class);
+        SecretsManagerService secretsManagerService = mock(SecretsManagerService.class);
 
         manager = new EcsContainerManager(containerBuilder, lifecycleManager, logStreamer,
-                containerDetector, config, regionResolver, awsEnv);
+                containerDetector, config, regionResolver, awsEnv, ssmService, secretsManagerService);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerPortMappingsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerPortMappingsTest.java
@@ -14,6 +14,8 @@ import io.github.hectorvent.floci.services.ecs.model.EcsTask;
 import io.github.hectorvent.floci.services.ecs.model.NetworkMode;
 import io.github.hectorvent.floci.services.ecs.model.PortMapping;
 import io.github.hectorvent.floci.services.ecs.model.TaskDefinition;
+import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerService;
+import io.github.hectorvent.floci.services.ssm.SsmService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -80,9 +82,11 @@ class EcsContainerManagerPortMappingsTest {
         RegionResolver regionResolver = mock(RegionResolver.class);
         LaunchedContainerAwsEnv awsEnv = mock(LaunchedContainerAwsEnv.class);
         when(awsEnv.sdkBaselineEnv(any(), any())).thenReturn(List.of());
+        SsmService ssmService = mock(SsmService.class);
+        SecretsManagerService secretsManagerService = mock(SecretsManagerService.class);
 
         manager = new EcsContainerManager(containerBuilder, lifecycleManager, logStreamer,
-                containerDetector, config, regionResolver, awsEnv);
+                containerDetector, config, regionResolver, awsEnv, ssmService, secretsManagerService);
     }
 
     private void startWith(List<PortMapping> portMappings) {

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerSecretsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerSecretsTest.java
@@ -1,0 +1,195 @@
+package io.github.hectorvent.floci.services.ecs.container;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
+import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
+import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
+import io.github.hectorvent.floci.core.common.docker.LaunchedContainerAwsEnv;
+import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
+import io.github.hectorvent.floci.services.ecs.model.ContainerOverride;
+import io.github.hectorvent.floci.services.ecs.model.EcsTask;
+import io.github.hectorvent.floci.services.ecs.model.KeyValuePair;
+import io.github.hectorvent.floci.services.ecs.model.Secret;
+import io.github.hectorvent.floci.services.ecs.model.TaskDefinition;
+import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerService;
+import io.github.hectorvent.floci.services.secretsmanager.model.SecretVersion;
+import io.github.hectorvent.floci.services.ssm.SsmService;
+import io.github.hectorvent.floci.services.ssm.model.Parameter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class EcsContainerManagerSecretsTest {
+
+    private ContainerBuilder containerBuilder;
+    private ContainerBuilder.Builder builder;
+    private ContainerLifecycleManager lifecycleManager;
+    private SsmService ssmService;
+    private SecretsManagerService secretsManagerService;
+    private EcsContainerManager manager;
+
+    @BeforeEach
+    void setUp() {
+        builder = mock(ContainerBuilder.Builder.class, RETURNS_SELF);
+        containerBuilder = mock(ContainerBuilder.class);
+        when(containerBuilder.newContainer(anyString())).thenReturn(builder);
+
+        lifecycleManager = mock(ContainerLifecycleManager.class);
+        when(lifecycleManager.createAndStart(any()))
+                .thenReturn(new ContainerInfo("docker-id", Map.of()));
+
+        ContainerLogStreamer logStreamer = mock(ContainerLogStreamer.class);
+        ContainerDetector containerDetector = mock(ContainerDetector.class);
+        EmulatorConfig config = mock(EmulatorConfig.class, RETURNS_DEEP_STUBS);
+        RegionResolver regionResolver = mock(RegionResolver.class);
+        LaunchedContainerAwsEnv awsEnv = mock(LaunchedContainerAwsEnv.class);
+        when(awsEnv.sdkBaselineEnv(any(), any())).thenReturn(List.of());
+        ssmService = mock(SsmService.class);
+        secretsManagerService = mock(SecretsManagerService.class);
+
+        manager = new EcsContainerManager(containerBuilder, lifecycleManager, logStreamer,
+                containerDetector, config, regionResolver, awsEnv, ssmService, secretsManagerService);
+    }
+
+    @Test
+    void resolvesSsmAndSecretsManagerSecretsAndKeepsOverridesLast() {
+        String secretArn = "arn:aws:secretsmanager:us-east-1:000000000000:secret:db-password-AbCdEf";
+        when(ssmService.getParameter("/app/config", "us-east-1"))
+                .thenReturn(new Parameter("/app/config", "from-ssm", "String"));
+        when(secretsManagerService.getSecretValue(secretArn, null, null, "us-east-1"))
+                .thenReturn(secretVersion("from-secrets-manager"));
+
+        ContainerDefinition app = containerDef("app", List.of(
+                new Secret("CONFIG", "/app/config"),
+                new Secret("PASSWORD", secretArn)));
+        app.setEnvironment(List.of(new KeyValuePair("PASSWORD", "plain-env")));
+
+        ContainerOverride override = new ContainerOverride();
+        override.setName("app");
+        override.setEnvironment(List.of(new KeyValuePair("PASSWORD", "override")));
+
+        manager.startTask(task(), taskDef(app), List.of(override), "us-east-1");
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<String>> envCaptor = ArgumentCaptor.forClass(List.class);
+        verify(builder).withEnv(envCaptor.capture());
+
+        List<String> env = envCaptor.getValue();
+        assertTrue(env.contains("CONFIG=from-ssm"));
+        assertTrue(env.contains("PASSWORD=override"));
+    }
+
+    @Test
+    void ssmArnKeepsLeadingSlashInParameterName() {
+        String ssmArn = "arn:aws:ssm:us-east-1:000000000000:parameter/foo/bar";
+        when(ssmService.getParameter("/foo/bar", "us-east-1"))
+                .thenReturn(new Parameter("/foo/bar", "path-value", "String"));
+
+        manager.startTask(task(), taskDef(containerDef("app", List.of(new Secret("PATH_VALUE", ssmArn)))),
+                List.of(), "us-east-1");
+
+        verify(ssmService).getParameter("/foo/bar", "us-east-1");
+    }
+
+    @Test
+    void crossRegionArnResolvesAgainstArnRegionNotTaskRegion() {
+        String ssmArn = "arn:aws:ssm:eu-west-1:000000000000:parameter/app/token";
+        String secretArn = "arn:aws:secretsmanager:eu-west-1:000000000000:secret:db-AbCdEf";
+        when(ssmService.getParameter("/app/token", "eu-west-1"))
+                .thenReturn(new Parameter("/app/token", "ssm-eu", "String"));
+        when(secretsManagerService.getSecretValue(secretArn, null, null, "eu-west-1"))
+                .thenReturn(secretVersion("sm-eu"));
+
+        // Task runs in us-east-1, but both references are eu-west-1 ARNs.
+        manager.startTask(task(), taskDef(containerDef("app", List.of(
+                new Secret("TOKEN", ssmArn),
+                new Secret("PASSWORD", secretArn)))),
+                List.of(), "us-east-1");
+
+        verify(ssmService).getParameter("/app/token", "eu-west-1");
+        verify(secretsManagerService).getSecretValue(secretArn, null, null, "eu-west-1");
+    }
+
+    @Test
+    void unresolvedSecretPropagatesAndNoContainerIsCreated() {
+        ContainerDefinition first = containerDef("first", List.of(new Secret("OK", "/ok")));
+        ContainerDefinition second = containerDef("second", List.of(new Secret("MISSING", "/missing")));
+        when(ssmService.getParameter("/ok", "us-east-1"))
+                .thenReturn(new Parameter("/ok", "ok", "String"));
+        when(ssmService.getParameter("/missing", "us-east-1"))
+                .thenThrow(new AwsException("ParameterNotFound", "Parameter /missing not found.", 400));
+
+        AwsException thrown = assertThrows(AwsException.class,
+                () -> manager.startTask(task(), taskDef(first, second), List.of(), "us-east-1"));
+
+        assertTrue(thrown.getMessage().contains("ResourceInitializationError"));
+        assertTrue(thrown.getMessage().contains("/missing"));
+        verify(containerBuilder, never()).newContainer(anyString());
+        verify(lifecycleManager, never()).createAndStart(any());
+    }
+
+    @Test
+    void binarySecretWithNoStringValueFailsLaunch() {
+        String secretArn = "arn:aws:secretsmanager:us-east-1:000000000000:secret:bin-AbCdEf";
+        // A SecretBinary-only secret round-trips with a null SecretString. Injecting
+        // "BIN=null" would be wrong, so the launch must fail like real AWS rather than
+        // start the container with a missing value.
+        when(secretsManagerService.getSecretValue(secretArn, null, null, "us-east-1"))
+                .thenReturn(new SecretVersion());
+
+        AwsException thrown = assertThrows(AwsException.class,
+                () -> manager.startTask(task(),
+                        taskDef(containerDef("app", List.of(new Secret("BIN", secretArn)))),
+                        List.of(), "us-east-1"));
+
+        assertTrue(thrown.getMessage().contains("ResourceInitializationError"));
+        assertTrue(thrown.getMessage().contains(secretArn));
+        verify(containerBuilder, never()).newContainer(anyString());
+        verify(lifecycleManager, never()).createAndStart(any());
+    }
+
+    private static ContainerDefinition containerDef(String name, List<Secret> secrets) {
+        ContainerDefinition def = new ContainerDefinition();
+        def.setName(name);
+        def.setImage(name + ":latest");
+        def.setSecrets(secrets);
+        return def;
+    }
+
+    private static TaskDefinition taskDef(ContainerDefinition... containers) {
+        TaskDefinition taskDef = new TaskDefinition();
+        taskDef.setFamily("test-family");
+        taskDef.setContainerDefinitions(List.of(containers));
+        return taskDef;
+    }
+
+    private static EcsTask task() {
+        EcsTask task = new EcsTask();
+        task.setTaskArn("arn:aws:ecs:us-east-1:000000000000:task/test-cluster/abc123");
+        return task;
+    }
+
+    private static SecretVersion secretVersion(String value) {
+        SecretVersion version = new SecretVersion();
+        version.setSecretString(value);
+        return version;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerVolumesTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerVolumesTest.java
@@ -14,6 +14,8 @@ import io.github.hectorvent.floci.services.ecs.model.EfsVolumeConfiguration;
 import io.github.hectorvent.floci.services.ecs.model.MountPoint;
 import io.github.hectorvent.floci.services.ecs.model.TaskDefinition;
 import io.github.hectorvent.floci.services.ecs.model.Volume;
+import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerService;
+import io.github.hectorvent.floci.services.ssm.SsmService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -69,9 +71,11 @@ class EcsContainerManagerVolumesTest {
         RegionResolver regionResolver = mock(RegionResolver.class);
         awsEnv = mock(LaunchedContainerAwsEnv.class);
         when(awsEnv.sdkBaselineEnv(any(), any())).thenReturn(List.of());
+        SsmService ssmService = mock(SsmService.class);
+        SecretsManagerService secretsManagerService = mock(SecretsManagerService.class);
 
         manager = new EcsContainerManager(containerBuilder, lifecycleManager, logStreamer,
-                containerDetector, config, regionResolver, awsEnv);
+                containerDetector, config, regionResolver, awsEnv, ssmService, secretsManagerService);
     }
 
     @Test
@@ -160,7 +164,8 @@ class EcsContainerManagerVolumesTest {
         when(cfg.storage().efs().initImage()).thenReturn("busybox:stable");
         EcsContainerManager configured = new EcsContainerManager(containerBuilder, lifecycleManager,
                 mock(ContainerLogStreamer.class), mock(ContainerDetector.class), cfg,
-                mock(RegionResolver.class), awsEnv);
+                mock(RegionResolver.class), awsEnv, mock(SsmService.class),
+                mock(SecretsManagerService.class));
 
         ContainerDefinition app = new ContainerDefinition();
         app.setName("app");
@@ -193,7 +198,8 @@ class EcsContainerManagerVolumesTest {
         when(cfg.storage().efs().mountGroupAdd()).thenReturn(OptionalInt.of(2000));
         EcsContainerManager configured = new EcsContainerManager(containerBuilder, lifecycleManager,
                 mock(ContainerLogStreamer.class), mock(ContainerDetector.class), cfg,
-                mock(RegionResolver.class), awsEnv);
+                mock(RegionResolver.class), awsEnv, mock(SsmService.class),
+                mock(SecretsManagerService.class));
 
         ContainerDefinition app = new ContainerDefinition();
         app.setName("app");


### PR DESCRIPTION
Closes #1624.

## What

Support `containerDefinitions[].secrets` end to end: parse and round-trip the `Secret` references on register/describe, and inject the resolved values as environment variables when a task launches. Previously `secrets` was dropped on register and never resolved, so containers came up without the env vars their task definition declares via `secrets`.

## How

- **Register / describe**: `EcsJsonHandler` parses `secrets[]` (`name` + `valueFrom`) into the container definition and emits them back on `RegisterTaskDefinition` / `DescribeTaskDefinition` as references. Resolved values are never returned, matching AWS.
- **Launch**: `EcsContainerManager` resolves each secret through the in-process `SsmService` / `SecretsManagerService`, the same local resolution `CodeBuildRunner` already uses (no extra HTTP hops):
  - SSM parameter by name or full ARN → `Parameter.value`
  - Secrets Manager full ARN → `SecretString`
  - a full ARN's own region is used, so cross-region references resolve against the right store instead of the task's region
- **Precedence**: task-def `environment` < resolved `secrets` < RunTask container-override `environment`. Overrides still win on a name collision.

## Failure behavior

Per the design question in #1624, this matches AWS rather than CodeBuild's lenient skip: if a referenced secret/parameter can't be resolved, no container is started and the task goes `STOPPED` with a `ResourceInitializationError` stopped reason (naming the offending `valueFrom`), instead of silently starting without the variable.

## Deferred

The Secrets Manager `valueFrom` selector suffix (`:json-key:version-stage:version-id`) is not yet parsed; such a `valueFrom` is resolved as the plain secret. Called out as deferrable in #1624; happy to follow up.

## Test plan

- [x] `EcsIntegrationTest` (register/describe round-trip of `secrets`)
- [x] `EcsContainerManagerSecretsTest` (SSM name + SM ARN resolution, override-wins, SSM-ARN name parsing, cross-region ARN region, unresolved → propagates with no container created)
- [x] `EcsServiceContainerSecretsTest` (unresolved secret → task STOPPED with `ResourceInitializationError` reason)
- [x] `EcsTests` Java SDK compatibility: register + describe round-trips the `Secret`
- [x] Full ECS suite green locally (`./mvnw test -Dtest='Ecs*'`)
