### PR TITLE
fix(stepfunctions): repair main compilation after #1558/#1564 semantic conflict

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorPathIntrinsicsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorPathIntrinsicsTest.java
@@ -39,6 +39,8 @@ class AslExecutorPathIntrinsicsTest {
                 mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
                 mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
                 mock(io.github.hectorvent.floci.services.s3.S3Service.class),
+                mock(io.github.hectorvent.floci.services.ecs.EcsService.class),
+                mock(io.github.hectorvent.floci.services.ecs.EcsJsonHandler.class),
                 mapper,
                 new JsonataEvaluator(mapper),
                 mock(Instance.class));


### PR DESCRIPTION
## Summary
Main fails to compile since #1564 merged: #1558 added `AslExecutorPathIntrinsicsTest` against the old `AslExecutor` constructor, while #1564 added `EcsService` and `EcsJsonHandler` constructor parameters. Each PR passed CI on its own branch, but the combination broke the build.

This adds the two ECS mocks to the test's `setUp()`, in the same position and style as `AslExecutorCatchTest`.

Failing run: https://github.com/floci-io/floci/actions/runs/28565764019/job/84692642848

## Verification
- `./mvnw -Dtest='io.github.hectorvent.floci.services.stepfunctions.**' test` — full package passes, including all 13 tests in `AslExecutorPathIntrinsicsTest`