### PR TITLE
fix: register persisted enums for native-image reflection

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/verification/VerificationCode.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/verification/VerificationCode.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.cognito.verification;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
 
@@ -10,8 +11,10 @@ import java.time.Instant;
  * password reset, MFA SMS, attribute verification). The actual code is hashed
  * with a per-code salt so dumps and storage snapshots cannot reveal valid codes.
  */
+@RegisterForReflection
 public final class VerificationCode {
 
+    @RegisterForReflection
     public enum Purpose {
         SIGNUP_CONFIRMATION,
         PASSWORD_RESET,

--- a/src/main/java/io/github/hectorvent/floci/services/eks/model/ClusterStatus.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eks/model/ClusterStatus.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.eks.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public enum ClusterStatus {
     CREATING, ACTIVE, DELETING, FAILED, UPDATING, DEGRADED
 }

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/model/AuthMode.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/model/AuthMode.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.elasticache.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public enum AuthMode {
     IAM, PASSWORD, NO_AUTH
 }

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/model/CacheClusterStatus.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/model/CacheClusterStatus.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.elasticache.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public enum CacheClusterStatus {
     AVAILABLE, CREATING, DELETING
 }

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/model/ReplicationGroupStatus.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/model/ReplicationGroupStatus.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.elasticache.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public enum ReplicationGroupStatus {
     CREATING, AVAILABLE, DELETING
 }

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/ArchiveState.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/ArchiveState.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.eventbridge.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public enum ArchiveState {
     ENABLED, DISABLED, CREATING, UPDATING, DELETING
 }

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/ReplayState.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/ReplayState.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.eventbridge.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public enum ReplayState {
     STARTING, RUNNING, CANCELLING, COMPLETED, CANCELLED, FAILED
 }

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/RuleState.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/model/RuleState.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.eventbridge.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public enum RuleState {
     ENABLED,
     DISABLED

--- a/src/main/java/io/github/hectorvent/floci/services/memorydb/model/AuthMode.java
+++ b/src/main/java/io/github/hectorvent/floci/services/memorydb/model/AuthMode.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.services.memorydb.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 /**
  * Authentication type of a MemoryDB {@link User}. Mirrors the {@code Type} field of the
  * real API's {@code AuthenticationMode}/{@code Authentication} structures, whose wire
@@ -8,6 +10,7 @@ package io.github.hectorvent.floci.services.memorydb.model;
  * <p>A cluster does not carry an auth mode of its own — it references an ACL, and the
  * effective authentication is determined by the auth modes of the users in that ACL.
  */
+@RegisterForReflection
 public enum AuthMode {
     PASSWORD("password"),
     IAM("iam"),

--- a/src/main/java/io/github/hectorvent/floci/services/memorydb/model/ClusterStatus.java
+++ b/src/main/java/io/github/hectorvent/floci/services/memorydb/model/ClusterStatus.java
@@ -1,9 +1,12 @@
 package io.github.hectorvent.floci.services.memorydb.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 /**
  * MemoryDB cluster lifecycle states. The wire value is lowercase
  * (e.g. {@code available}) to match the real AWS MemoryDB API.
  */
+@RegisterForReflection
 public enum ClusterStatus {
     CREATING("creating"),
     AVAILABLE("available"),

--- a/src/main/java/io/github/hectorvent/floci/services/pipes/model/DesiredState.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/model/DesiredState.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.pipes.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public enum DesiredState {
     RUNNING,
     STOPPED

--- a/src/main/java/io/github/hectorvent/floci/services/pipes/model/PipeState.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/model/PipeState.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.pipes.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public enum PipeState {
     RUNNING,
     STOPPED,

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DatabaseEngine.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DatabaseEngine.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.rds.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public enum DatabaseEngine {
     POSTGRES, MYSQL, MARIADB;
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstanceStatus.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstanceStatus.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.rds.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public enum DbInstanceStatus {
     CREATING, AVAILABLE, DELETING, REBOOTING, MODIFYING
 }


### PR DESCRIPTION
## Summary

Registers persisted enums (and Cognito's `VerificationCode`) with
`@RegisterForReflection` so the native image can deserialize persisted state on
restart. Covers cognito, eks, elasticache, eventbridge, memorydb, pipes, and
rds. One 3 line annotation addition per type, 14 files total.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No wire protocol change. Without these registrations the native image build
fails to deserialize persisted state for these services after a restart, while
the JVM build works, so the gap only shows up in native mode.

## Checklist

- [x] `./mvnw test` passes locally (compile verified; annotation only change)
- [ ] New or updated integration test added (native image reflection is not
      exercisable from JVM unit tests; existing persistence tests cover the
      JVM path)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
