### PR TITLE
fix(storage): make computeIfAbsent atomic

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/storage/StorageBackedMap.java
+++ b/src/main/java/io/github/hectorvent/floci/core/storage/StorageBackedMap.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * A mutable {@link Map} facade over {@link StorageBackend}.
@@ -53,6 +54,24 @@ public class StorageBackedMap<V>
             return false;
         }
         return storage.get(stringKey).isPresent();
+    }
+
+    @Override
+    public synchronized V computeIfAbsent(String key, Function<? super String, ? extends V> mappingFunction)
+    {
+        Objects.requireNonNull(key, "key is null");
+        Objects.requireNonNull(mappingFunction, "mappingFunction is null");
+
+        V value = get(key);
+        if (value != null) {
+            return value;
+        }
+
+        V newValue = mappingFunction.apply(key);
+        if (newValue != null) {
+            storage.put(key, newValue);
+        }
+        return newValue;
     }
 
     @Override

--- a/src/test/java/io/github/hectorvent/floci/core/storage/StorageBackedMapTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/storage/StorageBackedMapTest.java
@@ -3,6 +3,13 @@ package io.github.hectorvent.floci.core.storage;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -60,6 +67,46 @@ class StorageBackedMapTest
     }
 
     @Test
+    void computeIfAbsentCreatesOneValueUnderConcurrentAccess()
+            throws Exception
+    {
+        InMemoryStorage<String, Map<String, String>> storage = new InMemoryStorage<>();
+        StorageBackedMap<Map<String, String>> map = new StorageBackedMap<>(storage);
+        AtomicInteger calls = new AtomicInteger();
+        CountDownLatch firstMappingEntered = new CountDownLatch(1);
+        CountDownLatch releaseFirstMapping = new CountDownLatch(1);
+        CountDownLatch secondCallStarted = new CountDownLatch(1);
+
+        try (var executor = Executors.newFixedThreadPool(2)) {
+            var first = executor.submit(() -> map.computeIfAbsent("us-west-2", key -> {
+                calls.incrementAndGet();
+                firstMappingEntered.countDown();
+                await(releaseFirstMapping);
+                return Map.of("first", "one");
+            }));
+            await(firstMappingEntered);
+
+            var second = executor.submit(() -> {
+                secondCallStarted.countDown();
+                return map.computeIfAbsent("us-west-2", key -> {
+                    calls.incrementAndGet();
+                    return Map.of("second", "two");
+                });
+            });
+            await(secondCallStarted);
+            assertTimesOut(second);
+            releaseFirstMapping.countDown();
+
+            Map<String, String> firstValue = first.get(5, TimeUnit.SECONDS);
+            Map<String, String> secondValue = second.get(5, TimeUnit.SECONDS);
+
+            assertEquals(1, calls.get());
+            assertEquals(firstValue, secondValue);
+            assertEquals(firstValue, storage.get("us-west-2").orElseThrow());
+        }
+    }
+
+    @Test
     void conditionalReplaceOnlyUpdatesMatchingValues()
     {
         InMemoryStorage<String, String> storage = new InMemoryStorage<>();
@@ -101,5 +148,28 @@ class StorageBackedMapTest
 
         assertFalse(storage.get("alpha").isPresent());
         assertTrue(map.isEmpty());
+    }
+
+    private static void await(CountDownLatch latch)
+    {
+        try {
+            assertTrue(latch.await(5, TimeUnit.SECONDS));
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void assertTimesOut(Future<?> future)
+            throws InterruptedException, ExecutionException
+    {
+        try {
+            future.get(250, TimeUnit.MILLISECONDS);
+        }
+        catch (TimeoutException expected) {
+            return;
+        }
+        throw new AssertionError("future completed before the first mapping function was released");
     }
 }


### PR DESCRIPTION
## Summary
- serialize StorageBackedMap computeIfAbsent through the existing lock
- add concurrent coverage proving the mapping function runs once

## Verification
- ./mvnw -q -Dtest=StorageBackedMapTest test
- product-name diff scan: clean