### PR TITLE
fix(dynamodb): throw ValidationException when list_append operand is not a list type

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -1586,16 +1586,22 @@ public class DynamoDbService {
                         String arg2 = inner.substring(commaPos + 1).trim();
                         JsonNode list1 = evaluateSetExpr(snapshot, arg1, exprAttrNames, exprAttrValues);
                         JsonNode list2 = evaluateSetExpr(snapshot, arg2, exprAttrNames, exprAttrValues);
-                        if (list1 != null && list2 != null && list1.has("L") && list2.has("L")) {
-                            com.fasterxml.jackson.databind.node.ArrayNode merged =
-                                    com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.arrayNode();
-                            list1.get("L").forEach(merged::add);
-                            list2.get("L").forEach(merged::add);
-                            com.fasterxml.jackson.databind.node.ObjectNode result =
-                                    com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
-                            result.set("L", merged);
-                            item.set(attrName, result);
+                        if (list1 == null || list2 == null) {
+                            throw new AwsException("ValidationException",
+                                    "The provided expression refers to an attribute that does not exist in the item", 400);
                         }
+                        if (!list1.has("L") || !list2.has("L")) {
+                            throw new AwsException("ValidationException",
+                                    "An operand in the update expression has an incorrect data type", 400);
+                        }
+                        com.fasterxml.jackson.databind.node.ArrayNode merged =
+                                com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.arrayNode();
+                        list1.get("L").forEach(merged::add);
+                        list2.get("L").forEach(merged::add);
+                        com.fasterxml.jackson.databind.node.ObjectNode result =
+                                com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+                        result.set("L", merged);
+                        item.set(attrName, result);
                     }
                 }
             } else if (valuePart.startsWith(":") && exprAttrValues != null) {

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -1299,6 +1299,68 @@ class DynamoDbIntegrationTest {
     }
 
     @Test
+    void updateItemListAppendAgainstMissingAttributeReturnsValidationException() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "MissingListAppendTable",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "MissingListAppendTable",
+                    "Item": {"pk": {"S": "row-1"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "MissingListAppendTable",
+                    "Key": {"pk": {"S": "row-1"}},
+                    "UpdateExpression": "SET #t = list_append(#t, :new)",
+                    "ExpressionAttributeNames": {"#t": "Tags"},
+                    "ExpressionAttributeValues": {":new": {"L": [{"S": "tag-a"}]}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "MissingListAppendTable"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
     @Order(29)
     void deleteElementsFromStringSet() {
         // Create table

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -1237,6 +1237,68 @@ class DynamoDbIntegrationTest {
     }
 
     @Test
+    void updateItemListAppendAgainstNullAttributeReturnsValidationException() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "NullListAppendTable",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "NullListAppendTable",
+                    "Item": {"pk": {"S": "row-1"}, "Tags": {"NULL": true}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "NullListAppendTable",
+                    "Key": {"pk": {"S": "row-1"}},
+                    "UpdateExpression": "SET #t = list_append(#t, :new)",
+                    "ExpressionAttributeNames": {"#t": "Tags"},
+                    "ExpressionAttributeValues": {":new": {"L": [{"S": "tag-a"}]}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "NullListAppendTable"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
     @Order(29)
     void deleteElementsFromStringSet() {
         // Create table

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -1077,6 +1077,55 @@ class DynamoDbServiceTest {
     }
 
     @Test
+    void listAppendAgainstNullAttributeThrowsValidationException() {
+        String region = "eu-west-1";
+        createUsersTable(region);
+
+        ObjectNode existing = mapper.createObjectNode();
+        existing.set("userId", attributeValue("S", "u-null-list"));
+        ObjectNode nullAttr = mapper.createObjectNode();
+        nullAttr.put("NULL", true);
+        existing.set("tags", nullAttr);
+        service.putItem("Users", existing, region);
+
+        ObjectNode key = item("userId", "u-null-list");
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":new", listAttributeValue("tag-a"));
+
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#t", "tags");
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                service.updateItem("Users", key, null,
+                        "SET #t = list_append(#t, :new)",
+                        exprNames, exprValues, null, region));
+        assertEquals("ValidationException", ex.getErrorCode());
+        assertTrue(ex.getMessage().contains("An operand in the update expression has an incorrect data type"));
+    }
+
+    @Test
+    void listAppendAgainstMissingAttributeThrowsValidationException() {
+        String region = "eu-west-1";
+        createUsersTable(region);
+
+        service.putItem("Users", item("userId", "u-no-tags"), region);
+
+        ObjectNode key = item("userId", "u-no-tags");
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":new", listAttributeValue("tag-a"));
+
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#t", "tags");
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                service.updateItem("Users", key, null,
+                        "SET #t = list_append(#t, :new)",
+                        exprNames, exprValues, null, region));
+        assertEquals("ValidationException", ex.getErrorCode());
+        assertTrue(ex.getMessage().contains("The provided expression refers to an attribute that does not exist in the item"));
+    }
+
+    @Test
     void scanContainsOnListWithNumericElements() {
         String region = "eu-west-1";
         createUsersTable(region);


### PR DESCRIPTION
## Summary

`list_append` silently no-oped when either operand resolved to a non-list attribute, returning HTTP 200 with the item unchanged. AWS returns a 400 `ValidationException` in both cases with distinct messages depending on whether the operand is the wrong type or simply absent.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Two cases verified against real AWS:

| Scenario | Real AWS | Floci (before) | Floci (after) |
|---|---|---|---|
| Operand is `NULL` type | 400 `ValidationException`: _An operand in the update expression has an incorrect data type_ | HTTP 200, silent no-op | 400 `ValidationException`  |
| Operand attribute does not exist | 400 `ValidationException`: _The provided expression refers to an attribute that does not exist in the item_ | HTTP 200, silent no-op | 400 `ValidationException`  |

floci docker digest: 794407b5deee

<details>
<summary>Reproduction</summary>

```bash
# 1. Create table
aws dynamodb create-table --endpoint-url http://localhost:4566 \
  --table-name FlociNullTest \
  --attribute-definitions AttributeName=pk,AttributeType=S \
  --key-schema AttributeName=pk,KeyType=HASH \
  --billing-mode PAY_PER_REQUEST

# Baseline: list_append works normally on a real list

# 2. Seed an item with a proper list attribute
aws dynamodb put-item --endpoint-url http://localhost:4566 \
  --table-name FlociNullTest \
  --item '{"pk":{"S":"row-ok"},"Tags":{"L":[{"S":"existing"}]}}'

# 3. list_append against the list -- should succeed on both Floci and real AWS
aws dynamodb update-item --endpoint-url http://localhost:4566 \
  --table-name FlociNullTest \
  --key '{"pk":{"S":"row-ok"}}' \
  --update-expression "SET #t = list_append(#t, :new)" \
  --expression-attribute-names '{"#t":"Tags"}' \
  --expression-attribute-values '{":new":{"L":[{"S":"tag-a"}]}}'
# Expected: "Tags": {"L": [{"S": "existing"}, {"S": "tag-a"}]}  -- works as expected

# Bug case 1: list_append against a NULL attribute

# 4. Seed an item with a NULL list attribute
aws dynamodb put-item --endpoint-url http://localhost:4566 \
  --table-name FlociNullTest \
  --item '{"pk":{"S":"row-null"},"Tags":{"NULL":true}}'

# 5. list_append directly against the NULL attribute
#    Real AWS: ValidationException -- An operand in the update expression has an incorrect data type
#    Floci:    HTTP 200, no error
aws dynamodb update-item --endpoint-url http://localhost:4566 \
  --table-name FlociNullTest \
  --key '{"pk":{"S":"row-null"}}' \
  --update-expression "SET #t = list_append(#t, :new)" \
  --expression-attribute-names '{"#t":"Tags"}' \
  --expression-attribute-values '{":new":{"L":[{"S":"tag-a"}]}}'
# Floci returns: HTTP 200, "Tags": {"NULL": true} unchanged
# Real AWS:      ValidationException at step 5, item never modified

# Bug case 2: list_append against a missing attribute

# 6. Seed an item with no Tags attribute
aws dynamodb put-item --endpoint-url http://localhost:4566 \
  --table-name FlociNullTest \
  --item '{"pk":{"S":"row-missing"}}'

# 7. list_append against the missing attribute
#    Real AWS: ValidationException -- The provided expression refers to an attribute that does not exist in the item
#    Floci:    HTTP 200, no error
aws dynamodb update-item --endpoint-url http://localhost:4566 \
  --table-name FlociNullTest \
  --key '{"pk":{"S":"row-missing"}}' \
  --update-expression "SET #t = list_append(#t, :new)" \
  --expression-attribute-names '{"#t":"Tags"}' \
  --expression-attribute-values '{":new":{"L":[{"S":"tag-a"}]}}'
# Floci returns: HTTP 200, Tags attribute never created
# Real AWS:      ValidationException at step 7, item never modified
```

</details>

## Checklist

- [x] Focused tests pass locally: `./mvnw test -Dtest="DynamoDbServiceTest#listAppendAgainstNullAttributeThrowsValidationException+listAppendAgainstMissingAttributeThrowsValidationException+listAppendIfNotExistsCreatesListWhenAttributeMissing+listAppendIfNotExistsAppendsWhenAttributePresent,DynamoDbIntegrationTest#updateItemListAppendAgainstNullAttributeReturnsValidationException+updateItemListAppend" -B`
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
