### PR TITLE
fix(docker): isolate managed resource containers

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -92,6 +92,7 @@ See [Storage Modes](./storage.md) for a full explanation of each mode.
 | `FLOCI_DOCKER_IMAGE_REGISTRY_BASE` | _(none)_ | Optional registry/repository base for every Docker image Floci launches. When set, `postgres:16-alpine` resolves as `<base>/postgres:16-alpine` and `public.ecr.aws/docker/library/ubuntu:24.04` resolves as `<base>/public.ecr.aws/docker/library/ubuntu:24.04` |
 | `FLOCI_DOCKER_LOG_MAX_SIZE` | `10m` | Log rotation max size for spawned containers (e.g. `10m`, `1g`) |
 | `FLOCI_DOCKER_LOG_MAX_FILE` | `3` | Number of rotated log files to keep for spawned containers |
+| `FLOCI_DOCKER_RESOURCE_NAMESPACE` | _(none)_ | Optional namespace prefix for managed child Docker container and volume names |
 
 ### Registry credentials
 

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -1448,6 +1448,12 @@ public interface EmulatorConfig {
         String dockerHost();
 
         /**
+         * Optional namespace inserted into Floci-managed child container and volume names.
+         * Useful when multiple Floci processes share one Docker daemon.
+         */
+        Optional<String> resourceNamespace();
+
+        /**
          * Optional registry/repository base for every Docker image Floci launches.
          * When set, images such as {@code postgres:16-alpine} and
          * {@code public.ecr.aws/docker/library/ubuntu:24.04} resolve under this

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerStorageHelper.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerStorageHelper.java
@@ -30,7 +30,49 @@ public final class ContainerStorageHelper {
      * this change.
      */
     public static String resourceName(String service, String volumeId, String fallbackId) {
-        return "floci-" + service + "-" + (volumeId != null ? volumeId : fallbackId);
+        return resourceName(null, service, volumeId, fallbackId);
+    }
+
+    public static String resourceName(EmulatorConfig config, String service, String volumeId, String fallbackId) {
+        return dockerName(config, "floci-" + service + "-" + (volumeId != null ? volumeId : fallbackId));
+    }
+
+    public static String dockerName(EmulatorConfig config, String baseName) {
+        String namespace = resourceNamespace(config);
+        if (namespace.isBlank()) {
+            return baseName;
+        }
+        if (baseName.startsWith("floci-")) {
+            return "floci-" + namespace + "-" + baseName.substring("floci-".length());
+        }
+        return "floci-" + namespace + "-" + baseName;
+    }
+
+    public static Path hostResourcePath(EmulatorConfig config, String service, String resourceId) {
+        String namespace = resourceNamespace(config);
+        Path base = Path.of(config.storage().hostPersistentPath());
+        if (namespace.isBlank()) {
+            return base.resolve(service).resolve(resourceId);
+        }
+        return base.resolve(namespace).resolve(service).resolve(resourceId);
+    }
+
+    private static String resourceNamespace(EmulatorConfig config) {
+        if (config == null || config.docker() == null || config.docker().resourceNamespace() == null) {
+            return "";
+        }
+        return sanitizeNamePart(config.docker().resourceNamespace().orElse(""));
+    }
+
+    private static String sanitizeNamePart(String value) {
+        String cleaned = value.trim().replaceAll("[^A-Za-z0-9_.-]+", "-");
+        while (cleaned.startsWith("-")) {
+            cleaned = cleaned.substring(1);
+        }
+        while (cleaned.endsWith("-")) {
+            cleaned = cleaned.substring(0, cleaned.length() - 1);
+        }
+        return cleaned;
     }
 
     /**
@@ -51,11 +93,12 @@ public final class ContainerStorageHelper {
     public static void applyStorage(
             ContainerBuilder.Builder builder,
             ContainerLifecycleManager lifecycleManager,
+            EmulatorConfig config,
             String service,
             String volumeId,
             String fallbackId,
             String internalMount) {
-        String volumeName = resourceName(service, volumeId, fallbackId);
+        String volumeName = resourceName(config, service, volumeId, fallbackId);
         lifecycleManager.ensureVolume(volumeName);
         builder.withNamedVolume(volumeName, internalMount);
     }
@@ -74,7 +117,7 @@ public final class ContainerStorageHelper {
             String service,
             String volumeId,
             String fallbackId) {
-        String volumeName = resourceName(service, volumeId, fallbackId);
+        String volumeName = resourceName(config, service, volumeId, fallbackId);
         boolean isMemory = "memory".equals(config.storage().mode());
         if (isMemory || config.storage().pruneVolumesOnDelete()) {
             lifecycleManager.removeVolume(volumeName);

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerStorageHelper.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerStorageHelper.java
@@ -72,6 +72,9 @@ public final class ContainerStorageHelper {
         while (cleaned.endsWith("-")) {
             cleaned = cleaned.substring(0, cleaned.length() - 1);
         }
+        if (cleaned.equals(".") || cleaned.equals("..")) {
+            return "";
+        }
         return cleaned;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/amazonmq/container/RabbitMqManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/amazonmq/container/RabbitMqManager.java
@@ -20,7 +20,6 @@ import org.jboss.logging.Logger;
 import java.io.Closeable;
 import java.net.HttpURLConnection;
 import java.net.URI;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -111,13 +110,15 @@ public class RabbitMqManager {
         }
 
         if (ContainerStorageHelper.isNamedVolumeMode(config)) {
-            ContainerStorageHelper.applyStorage(specBuilder, lifecycleManager,
+            ContainerStorageHelper.applyStorage(specBuilder, lifecycleManager, config,
                     "amazonmq", broker.getVolumeId(), broker.getBrokerId(),
                     "/var/lib/rabbitmq");
         } else {
-            String hostDataPath = Path.of(config.storage().hostPersistentPath(), "amazonmq", broker.getBrokerId())
+            String hostDataPath = ContainerStorageHelper.hostResourcePath(config, "amazonmq", broker.getBrokerId())
                     .toAbsolutePath().toString();
-            ContainerStorageHelper.ensureHostDir(hostDataPath);
+            if (!containerDetector.isRunningInContainer()) {
+                ContainerStorageHelper.ensureHostDir(hostDataPath);
+            }
             specBuilder.withBind(hostDataPath, "/var/lib/rabbitmq");
         }
 

--- a/src/main/java/io/github/hectorvent/floci/services/batch/BatchDockerRunner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/batch/BatchDockerRunner.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
+import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
 import io.github.hectorvent.floci.services.batch.model.BatchJob;
 import io.github.hectorvent.floci.services.batch.model.BatchKeyValue;
 import io.github.hectorvent.floci.services.batch.model.BatchResourceRequirement;
@@ -51,7 +52,7 @@ public class BatchDockerRunner {
         long startedAt = System.currentTimeMillis();
         String logStreamName = logStreamer.generateLogStreamName(
                 job.getJobDefinitionName() + "/default/" + job.getJobId());
-        String containerName = "floci-batch-" + job.getJobId() + "-" + attemptNumber;
+        String containerName = ContainerStorageHelper.dockerName(config, "floci-batch-" + job.getJobId() + "-" + attemptNumber);
         Closeable logHandle = null;
         String containerId = null;
 

--- a/src/main/java/io/github/hectorvent/floci/services/docdb/container/DocDbContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/docdb/container/DocDbContainerManager.java
@@ -10,6 +10,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.C
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.EndpointInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
+import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -58,7 +59,7 @@ public class DocDbContainerManager {
     public DocDbContainerHandle start(String clusterId, String image, String masterUsername, String masterPassword) {
         LOG.infov("Starting DocumentDB container for cluster: {0}", clusterId);
 
-        String containerName = "floci-docdb-" + clusterId;
+        String containerName = ContainerStorageHelper.resourceName(config, "docdb", null, clusterId);
         lifecycleManager.removeIfExists(containerName);
 
         List<String> envVars = List.of(

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
+import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
 import io.github.hectorvent.floci.core.common.docker.DockerHostResolver;
 import io.github.hectorvent.floci.core.common.docker.PortAllocator;
 import io.github.hectorvent.floci.services.ec2.model.Instance;
@@ -123,7 +124,7 @@ public class Ec2ContainerManager {
         executor.submit(() -> {
             try {
                 String instanceId = instance.getInstanceId();
-                String containerName = "floci-ec2-" + instanceId;
+                String containerName = ContainerStorageHelper.resourceName(config, "ec2", null, instanceId);
 
                 // Allocate SSH host port
                 int sshHostPort = portAllocator.allocate(

--- a/src/main/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManager.java
@@ -135,7 +135,7 @@ public class EcrRegistryManager {
         if (started) {
             return;
         }
-        String name = config.services().ecr().registryContainerName();
+        String name = ContainerStorageHelper.dockerName(config, config.services().ecr().registryContainerName());
 
         // Check for existing container to adopt
         var existing = lifecycleManager.findByName(name);
@@ -194,8 +194,9 @@ public class EcrRegistryManager {
 
     private void addPersistenceMounts(ContainerBuilder.Builder specBuilder, List<String> env) {
         if (ContainerStorageHelper.isNamedVolumeMode(config)) {
-            lifecycleManager.ensureVolume(NAMED_VOLUME);
-            specBuilder.withNamedVolume(NAMED_VOLUME, "/var/lib/registry");
+            String volumeName = ContainerStorageHelper.dockerName(config, NAMED_VOLUME);
+            lifecycleManager.ensureVolume(volumeName);
+            specBuilder.withNamedVolume(volumeName, "/var/lib/registry");
             return;
         }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManager.java
@@ -112,8 +112,7 @@ public class EcrRegistryManager {
     /** Returns a {@link RegistryHttpClient} bound to the current registry endpoint. */
     public RegistryHttpClient httpClient() {
         if (containerDetector.isRunningInContainer()) {
-            return new RegistryHttpClient("http://" + config.services().ecr().registryContainerName()
-                    + ":" + CONTAINER_INTERNAL_PORT);
+            return new RegistryHttpClient("http://" + registryContainerName() + ":" + CONTAINER_INTERNAL_PORT);
         }
         return new RegistryHttpClient("http://localhost:" + effectivePort());
     }
@@ -135,7 +134,7 @@ public class EcrRegistryManager {
         if (started) {
             return;
         }
-        String name = ContainerStorageHelper.dockerName(config, config.services().ecr().registryContainerName());
+        String name = registryContainerName();
 
         // Check for existing container to adopt
         var existing = lifecycleManager.findByName(name);
@@ -190,6 +189,10 @@ public class EcrRegistryManager {
             throw new RuntimeException("Failed to start ECR backing registry container: " + e.getMessage(), e);
         }
         runReconcileOnce();
+    }
+
+    private String registryContainerName() {
+        return ContainerStorageHelper.dockerName(config, config.services().ecr().registryContainerName());
     }
 
     private void addPersistenceMounts(ContainerBuilder.Builder specBuilder, List<String> env) {

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManager.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
+import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
 import io.github.hectorvent.floci.services.ecs.model.Container;
 import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
 import io.github.hectorvent.floci.services.ecs.model.ContainerOverride;
@@ -94,7 +95,7 @@ public class EcsContainerManager {
         }
 
         for (ContainerDefinition def : taskDef.getContainerDefinitions()) {
-            String containerName = "floci-ecs-" + taskId + "-" + def.getName();
+            String containerName = ContainerStorageHelper.dockerName(config, "floci-ecs-" + taskId + "-" + def.getName());
 
             // RunTask containerOverrides matched by container name: command replaces
             // the task-def command; environment is merged over the task-def environment.

--- a/src/main/java/io/github/hectorvent/floci/services/eks/EksClusterManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eks/EksClusterManager.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
+import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
 import io.github.hectorvent.floci.core.common.docker.DockerHostResolver;
 import io.github.hectorvent.floci.core.common.docker.PortAllocator;
 import io.github.hectorvent.floci.services.eks.model.CertificateAuthority;
@@ -72,7 +73,7 @@ public class EksClusterManager {
      */
     public void startCluster(Cluster cluster) {
         String image = config.services().eks().defaultImage();
-        String containerName = "floci-eks-" + cluster.getName();
+        String containerName = ContainerStorageHelper.resourceName(config, "eks", null, cluster.getName());
 
         LOG.infov("Starting k3s container for EKS cluster: {0} using image {1}",
                 cluster.getName(), image);
@@ -96,7 +97,7 @@ public class EksClusterManager {
         // socket (kine.sock) on macOS APFS, which returns EINVAL on chmod — crashing
         // k3s before it can start. Named volumes live in the Docker VM's Linux
         // filesystem, so chmod works correctly and data persists across container restarts.
-        String volumeName = "floci-eks-" + cluster.getName();
+        String volumeName = ContainerStorageHelper.resourceName(config, "eks", null, cluster.getName());
 
         List<String> serverArgs = new ArrayList<>(List.of("server",
                 "--disable=traefik",
@@ -230,7 +231,7 @@ public class EksClusterManager {
             return;
         }
         lifecycleManager.stopAndRemove(cluster.getContainerId(), null);
-        lifecycleManager.removeVolume("floci-eks-" + cluster.getName());
+        lifecycleManager.removeVolume(ContainerStorageHelper.resourceName(config, "eks", null, cluster.getName()));
         LOG.infov("Stopped k3s container for cluster {0}", cluster.getName());
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/container/ElastiCacheContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/container/ElastiCacheContainerManager.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.C
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.EndpointInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
+import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -71,7 +72,7 @@ public class ElastiCacheContainerManager {
     public ElastiCacheContainerHandle start(String groupId, String image) {
         LOG.infov("Starting ElastiCache backend container for group: {0}", groupId);
 
-        String containerName = "floci-valkey-" + groupId;
+        String containerName = ContainerStorageHelper.resourceName(config, "valkey", null, groupId);
 
         // Remove any stale container with the same name
         lifecycleManager.removeIfExists(containerName);

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/container/ElastiCacheMemcachedContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/container/ElastiCacheMemcachedContainerManager.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.C
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.EndpointInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
+import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -67,7 +68,7 @@ public class ElastiCacheMemcachedContainerManager {
     public ElastiCacheContainerHandle start(String clusterId, String image) {
         LOG.infov("Starting Memcached container for cluster: {0}", clusterId);
 
-        String containerName = "floci-memcached-" + clusterId;
+        String containerName = ContainerStorageHelper.resourceName(config, "memcached", null, clusterId);
         lifecycleManager.removeIfExists(containerName);
 
         ContainerBuilder.Builder specBuilder = containerBuilder.newContainer(image)

--- a/src/main/java/io/github/hectorvent/floci/services/floci/duck/FlociDuckManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/floci/duck/FlociDuckManager.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.EndpointInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
+import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
 import io.quarkus.runtime.ShutdownEvent;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
@@ -110,14 +111,15 @@ public class FlociDuckManager {
         String image = config.services().duck().defaultImage();
         LOG.infov("Starting floci-duck container using image {0}", image);
 
-        lifecycleManager.removeIfExists(CONTAINER_NAME);
+        String containerName = ContainerStorageHelper.dockerName(config, CONTAINER_NAME);
+        lifecycleManager.removeIfExists(containerName);
 
         ContainerSpec spec = containerBuilder.newContainer(image)
-                .withName(CONTAINER_NAME)
+                .withName(containerName)
                 .withEnv("FLOCI_DUCK_S3_ACCESS_KEY", "test")
                 .withEnv("FLOCI_DUCK_S3_SECRET_KEY", "test")
                 .withEnv("FLOCI_DUCK_S3_REGION", config.defaultRegion())
-                .withPortBinding(DUCK_PORT, DUCK_PORT)
+                .withDynamicPort(DUCK_PORT)
                 .withDockerNetwork(config.services().dockerNetwork())
                 .withEmbeddedDns()
                 .withLogRotation()

--- a/src/main/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManager.java
@@ -19,6 +19,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.C
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.EndpointInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
+import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
 import io.github.hectorvent.floci.core.common.docker.CurrentContainerNetworkResolver;
 import io.github.hectorvent.floci.core.common.docker.DockerHostResolver;
 import com.github.dockerjava.api.exception.DockerClientException;
@@ -111,7 +112,7 @@ public class FlociUiManager {
         // Clear any error from a prior failed attempt so status() reports this retry
         // as in-progress rather than surfacing the stale failure.
         this.lastError = null;
-        String name = config.services().ui().containerName();
+        String name = ContainerStorageHelper.dockerName(config, config.services().ui().containerName());
 
         Optional<Container> existing = lifecycleManager.findByName(name);
         if (existing.isPresent()) {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerReachableEndpoint;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
+import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
 import io.github.hectorvent.floci.core.common.docker.DockerHostResolver;
 import io.github.hectorvent.floci.services.ecr.registry.EcrRegistryManager;
 import io.github.hectorvent.floci.services.lambda.LambdaLayerService;
@@ -160,7 +161,7 @@ public class ContainerLauncher {
 
         // Give the container a human-readable name (needed for log stream name below)
         String shortId = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 8);
-        String containerName = "floci-" + fn.getFunctionName() + "-" + shortId;
+        String containerName = ContainerStorageHelper.dockerName(config, "floci-" + fn.getFunctionName() + "-" + shortId);
 
         // CloudWatch log coordinates — computed here so they can be injected as env vars
         String cwLogGroup  = "/aws/lambda/" + fn.getFunctionName();

--- a/src/main/java/io/github/hectorvent/floci/services/memorydb/container/MemoryDbContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/memorydb/container/MemoryDbContainerManager.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.C
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.EndpointInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
+import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -67,7 +68,7 @@ public class MemoryDbContainerManager {
     public MemoryDbContainerHandle start(String clusterName, String image) {
         LOG.infov("Starting MemoryDB backend container for cluster: {0}", clusterName);
 
-        String containerName = "floci-memorydb-" + clusterName;
+        String containerName = ContainerStorageHelper.resourceName(config, "memorydb", null, clusterName);
 
         lifecycleManager.removeIfExists(containerName);
 

--- a/src/main/java/io/github/hectorvent/floci/services/msk/RedpandaManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/RedpandaManager.java
@@ -120,7 +120,9 @@ public class RedpandaManager {
             // Legacy host-path mode: host-persistent-path is an absolute path
             String hostDataPath = ContainerStorageHelper.hostResourcePath(config, "msk", cluster.getClusterName())
                     .toAbsolutePath().toString();
-            ContainerStorageHelper.ensureHostDir(hostDataPath);
+            if (!containerDetector.isRunningInContainer()) {
+                ContainerStorageHelper.ensureHostDir(hostDataPath);
+            }
             specBuilder.withBind(hostDataPath, "/var/lib/redpanda/data");
         }
 

--- a/src/main/java/io/github/hectorvent/floci/services/msk/RedpandaManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/RedpandaManager.java
@@ -65,7 +65,7 @@ public class RedpandaManager {
         String image = config.services().msk().defaultImage();
         LOG.infov("Starting Redpanda container for MSK cluster: {0} using image {1}", cluster.getClusterName(), image);
 
-        String containerName = "floci-msk-" + cluster.getClusterName();
+        String containerName = ContainerStorageHelper.resourceName(config, "msk", cluster.getVolumeId(), cluster.getClusterName());
 
         // Cleanup stale container
         lifecycleManager.removeIfExists(containerName);
@@ -113,12 +113,12 @@ public class RedpandaManager {
 
         // Handle persistence mounting
         if (ContainerStorageHelper.isNamedVolumeMode(config)) {
-            ContainerStorageHelper.applyStorage(specBuilder, lifecycleManager,
+            ContainerStorageHelper.applyStorage(specBuilder, lifecycleManager, config,
                     "msk", cluster.getVolumeId(), cluster.getClusterName(),
                     "/var/lib/redpanda/data");
         } else {
             // Legacy host-path mode: host-persistent-path is an absolute path
-            String hostDataPath = Path.of(config.storage().hostPersistentPath(), "msk", cluster.getClusterName())
+            String hostDataPath = ContainerStorageHelper.hostResourcePath(config, "msk", cluster.getClusterName())
                     .toAbsolutePath().toString();
             ContainerStorageHelper.ensureHostDir(hostDataPath);
             specBuilder.withBind(hostDataPath, "/var/lib/redpanda/data");

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/container/NeptuneContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/container/NeptuneContainerManager.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.C
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.EndpointInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
+import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
 import io.github.hectorvent.floci.services.neptune.model.NeptuneDbType;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -65,7 +66,7 @@ public class NeptuneContainerManager {
         LOG.infov("Starting Neptune backend container ({0}) for cluster: {1}", dbType, clusterId);
 
         int backendPort = dbType.backendPort();
-        String containerName = "floci-neptune-" + clusterId;
+        String containerName = ContainerStorageHelper.resourceName(config, "neptune", null, clusterId);
         lifecycleManager.removeIfExists(containerName);
 
         ContainerBuilder.Builder specBuilder = containerBuilder.newContainer(image)

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainManager.java
@@ -75,7 +75,9 @@ public class OpenSearchDomainManager {
         } else {
             // Legacy host-path mode: host-persistent-path is an absolute path
             Path dataPath = ContainerStorageHelper.hostResourcePath(config, "opensearch", domain.getDomainName());
-            ContainerStorageHelper.ensureHostDir(dataPath.toString());
+            if (!containerDetector.isRunningInContainer()) {
+                ContainerStorageHelper.ensureHostDir(dataPath.toString());
+            }
             String dataPathStr = dataPath.toAbsolutePath().normalize().toString();
             String persistentPathStr = Path.of(config.storage().persistentPath()).toAbsolutePath().normalize().toString();
             String hostDataPath = dataPathStr.replace(persistentPathStr, config.storage().hostPersistentPath());

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainManager.java
@@ -48,7 +48,7 @@ public class OpenSearchDomainManager {
 
     public void startDomain(Domain domain) {
         String image = resolveImage(domain.getEngineVersion());
-        String containerName = "floci-opensearch-" + domain.getDomainName();
+        String containerName = ContainerStorageHelper.resourceName(config, "opensearch", domain.getVolumeId(), domain.getDomainName());
 
         LOG.infov("Starting OpenSearch container for domain: {0} (version={1}, image={2})",
                 domain.getDomainName(), domain.getEngineVersion(), image);
@@ -69,12 +69,12 @@ public class OpenSearchDomainManager {
         applyEngineEnv(specBuilder, domain.getEngineVersion());
 
         if (ContainerStorageHelper.isNamedVolumeMode(config)) {
-            ContainerStorageHelper.applyStorage(specBuilder, lifecycleManager,
+            ContainerStorageHelper.applyStorage(specBuilder, lifecycleManager, config,
                     "opensearch", domain.getVolumeId(), domain.getDomainName(),
                     "/usr/share/opensearch/data");
         } else {
             // Legacy host-path mode: host-persistent-path is an absolute path
-            Path dataPath = Path.of(config.services().opensearch().dataPath(), domain.getDomainName());
+            Path dataPath = ContainerStorageHelper.hostResourcePath(config, "opensearch", domain.getDomainName());
             ContainerStorageHelper.ensureHostDir(dataPath.toString());
             String dataPathStr = dataPath.toAbsolutePath().normalize().toString();
             String persistentPathStr = Path.of(config.storage().persistentPath()).toAbsolutePath().normalize().toString();
@@ -98,7 +98,7 @@ public class OpenSearchDomainManager {
     }
 
     public boolean isReady(Domain domain) {
-        String containerName = "floci-opensearch-" + domain.getDomainName();
+        String containerName = ContainerStorageHelper.resourceName(config, "opensearch", domain.getVolumeId(), domain.getDomainName());
         String url = "http://" + containerName + ":" + OPENSEARCH_PORT + "/_cluster/health";
         try {
             HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection();

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainManager.java
@@ -48,7 +48,7 @@ public class OpenSearchDomainManager {
 
     public void startDomain(Domain domain) {
         String image = resolveImage(domain.getEngineVersion());
-        String containerName = ContainerStorageHelper.resourceName(config, "opensearch", domain.getVolumeId(), domain.getDomainName());
+        String containerName = containerName(domain);
 
         LOG.infov("Starting OpenSearch container for domain: {0} (version={1}, image={2})",
                 domain.getDomainName(), domain.getEngineVersion(), image);
@@ -100,7 +100,7 @@ public class OpenSearchDomainManager {
     }
 
     public boolean isReady(Domain domain) {
-        String containerName = ContainerStorageHelper.resourceName(config, "opensearch", domain.getVolumeId(), domain.getDomainName());
+        String containerName = containerName(domain);
         String url = "http://" + containerName + ":" + OPENSEARCH_PORT + "/_cluster/health";
         try {
             HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
@@ -142,6 +142,10 @@ public class OpenSearchDomainManager {
     private String resolveImage(String engineVersion) {
         return OpenSearchVersions.resolveImage(
                 config.services().opensearch().defaultImage(), engineVersion);
+    }
+
+    private String containerName(Domain domain) {
+        return ContainerStorageHelper.resourceName(config, "opensearch", null, domain.getDomainName());
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -1133,7 +1133,7 @@ public class RdsService implements Resettable {
     }
 
     private String volumeName(String volumeId, String fallbackId) {
-        return ContainerStorageHelper.resourceName("rds", volumeId, fallbackId);
+        return ContainerStorageHelper.resourceName(config, "rds", volumeId, fallbackId);
     }
 
     private RdsContainerHandle buildHandle(DbInstance instance) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
@@ -160,7 +160,9 @@ public class RdsContainerManager {
 
         // Legacy host-path mode: host-persistent-path is an absolute path
         String hostDataPath = ContainerStorageHelper.hostResourcePath(config, "rds", instanceId).toString();
-        ContainerStorageHelper.ensureHostDir(hostDataPath);
+        if (!containerDetector.isRunningInContainer()) {
+            ContainerStorageHelper.ensureHostDir(hostDataPath);
+        }
         specBuilder.withBind(hostDataPath, engineDefaultDataPath(engine, image));
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
@@ -71,7 +71,7 @@ public class RdsContainerManager {
         LOG.infov("Starting RDS backend container for instance: {0} engine={1}", instanceId, engine);
 
         int enginePort = engine.defaultPort();
-        String containerName = ContainerStorageHelper.resourceName(config, "rds", null, instanceId);
+        String containerName = ContainerStorageHelper.resourceName(config, "rds", volumeId, instanceId);
 
         // Remove any stale container with the same name
         lifecycleManager.removeIfExists(containerName);

--- a/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
@@ -71,7 +71,7 @@ public class RdsContainerManager {
         LOG.infov("Starting RDS backend container for instance: {0} engine={1}", instanceId, engine);
 
         int enginePort = engine.defaultPort();
-        String containerName = "floci-rds-" + instanceId;
+        String containerName = ContainerStorageHelper.resourceName(config, "rds", null, instanceId);
 
         // Remove any stale container with the same name
         lifecycleManager.removeIfExists(containerName);
@@ -153,13 +153,13 @@ public class RdsContainerManager {
                                       String volumeId, DatabaseEngine engine, String image) {
         if (ContainerStorageHelper.isNamedVolumeMode(config)) {
             ContainerStorageHelper.applyStorage(
-                    specBuilder, lifecycleManager, "rds", volumeId, instanceId,
+                    specBuilder, lifecycleManager, config, "rds", volumeId, instanceId,
                     engineDefaultDataPath(engine, image));
             return;
         }
 
         // Legacy host-path mode: host-persistent-path is an absolute path
-        String hostDataPath = Path.of(config.storage().hostPersistentPath(), "rds", instanceId).toString();
+        String hostDataPath = ContainerStorageHelper.hostResourcePath(config, "rds", instanceId).toString();
         ContainerStorageHelper.ensureHostDir(hostDataPath);
         specBuilder.withBind(hostDataPath, engineDefaultDataPath(engine, image));
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -166,6 +166,7 @@ floci:
     log-max-size: "10m"
     log-max-file: "3"
     docker-host: unix:///var/run/docker.sock
+    resource-namespace: ""          # FLOCI_DOCKER_RESOURCE_NAMESPACE; scopes child container/volume names
     docker-config-path: ""
 
   services:

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerStorageHelperTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerStorageHelperTest.java
@@ -36,6 +36,14 @@ class ContainerStorageHelperTest {
         assertEquals(Path.of("/tmp/floci/run-one/rds/db1"), ContainerStorageHelper.hostResourcePath(config, "rds", "db1"));
     }
 
+    @Test
+    void unsafeNamespaceSegmentsAreIgnored() {
+        EmulatorConfig config = config("..");
+
+        assertEquals(Path.of("/tmp/floci/rds/db1"), ContainerStorageHelper.hostResourcePath(config, "rds", "db1"));
+        assertEquals("floci-rds-db1", ContainerStorageHelper.resourceName(config, "rds", null, "db1"));
+    }
+
     private static EmulatorConfig config(String namespace) {
         EmulatorConfig config = mock(EmulatorConfig.class);
         EmulatorConfig.DockerConfig docker = mock(EmulatorConfig.DockerConfig.class);

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerStorageHelperTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerStorageHelperTest.java
@@ -1,0 +1,49 @@
+package io.github.hectorvent.floci.core.common.docker;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ContainerStorageHelperTest {
+
+    @Test
+    void resourceNamesStayUnchangedWithoutNamespace() {
+        assertEquals("floci-rds-db1", ContainerStorageHelper.resourceName("rds", null, "db1"));
+        assertEquals("floci-rds-vol1", ContainerStorageHelper.resourceName(config(""), "rds", "vol1", "db1"));
+        assertEquals("floci-ec2-i-123", ContainerStorageHelper.dockerName(config(""), "floci-ec2-i-123"));
+    }
+
+    @Test
+    void resourceNamesIncludeSanitizedNamespaceWhenConfigured() {
+        EmulatorConfig config = config(" run/one ");
+
+        assertEquals("floci-run-one-rds-db1", ContainerStorageHelper.resourceName(config, "rds", null, "db1"));
+        assertEquals("floci-run-one-rds-vol1", ContainerStorageHelper.resourceName(config, "rds", "vol1", "db1"));
+        assertEquals("floci-run-one-ec2-i-123", ContainerStorageHelper.dockerName(config, "floci-ec2-i-123"));
+        assertEquals("floci-run-one-ui", ContainerStorageHelper.dockerName(config, "floci-ui"));
+    }
+
+    @Test
+    void hostResourcePathsIncludeNamespaceWhenConfigured() {
+        EmulatorConfig config = config("run-one");
+
+        assertEquals(Path.of("/tmp/floci/run-one/rds/db1"), ContainerStorageHelper.hostResourcePath(config, "rds", "db1"));
+    }
+
+    private static EmulatorConfig config(String namespace) {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.DockerConfig docker = mock(EmulatorConfig.DockerConfig.class);
+        EmulatorConfig.StorageConfig storage = mock(EmulatorConfig.StorageConfig.class);
+        when(config.docker()).thenReturn(docker);
+        when(config.storage()).thenReturn(storage);
+        when(docker.resourceNamespace()).thenReturn(namespace.isBlank() ? Optional.empty() : Optional.of(namespace));
+        when(storage.hostPersistentPath()).thenReturn("/tmp/floci");
+        return config;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerStorageHelperTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerStorageHelperTest.java
@@ -16,6 +16,7 @@ class ContainerStorageHelperTest {
     void resourceNamesStayUnchangedWithoutNamespace() {
         assertEquals("floci-rds-db1", ContainerStorageHelper.resourceName("rds", null, "db1"));
         assertEquals("floci-rds-vol1", ContainerStorageHelper.resourceName(config(""), "rds", "vol1", "db1"));
+        assertEquals("floci-opensearch-domain1", ContainerStorageHelper.resourceName(config(""), "opensearch", null, "domain1"));
         assertEquals("floci-ec2-i-123", ContainerStorageHelper.dockerName(config(""), "floci-ec2-i-123"));
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManagerTest.java
@@ -41,6 +41,7 @@ class EcrRegistryManagerTest {
     private ContainerLifecycleManager lifecycleManager;
     private ContainerDetector containerDetector;
     private CurrentContainerNetworkResolver currentContainerNetworkResolver;
+    private EmulatorConfig.DockerConfig docker;
     private EcrRegistryManager manager;
 
     @BeforeEach
@@ -63,10 +64,13 @@ class EcrRegistryManagerTest {
 
         EmulatorConfig config = Mockito.mock(EmulatorConfig.class);
         EmulatorConfig.EcrServiceConfig ecr = Mockito.mock(EmulatorConfig.EcrServiceConfig.class);
+        docker = Mockito.mock(EmulatorConfig.DockerConfig.class);
         EmulatorConfig.StorageConfig storage = Mockito.mock(EmulatorConfig.StorageConfig.class);
         when(config.services()).thenReturn(Mockito.mock(EmulatorConfig.ServicesConfig.class));
         when(config.services().ecr()).thenReturn(ecr);
+        when(config.docker()).thenReturn(docker);
         when(config.storage()).thenReturn(storage);
+        when(docker.resourceNamespace()).thenReturn(Optional.empty());
         // Empty host-persistent-path selects named-volume mode (no host bind-mount logic).
         when(storage.hostPersistentPath()).thenReturn("");
         when(ecr.registryContainerName()).thenReturn(REGISTRY_NAME);
@@ -135,5 +139,13 @@ class EcrRegistryManagerTest {
         manager.ensureStarted();
 
         assertEquals(BASE_PORT, manager.effectivePort());
+    }
+
+    @Test
+    void httpClient_usesNamespacedRegistryContainerDnsWhenConfigured() {
+        when(containerDetector.isRunningInContainer()).thenReturn(true);
+        when(docker.resourceNamespace()).thenReturn(Optional.of("run/one"));
+
+        assertEquals("http://floci-run-one-test-ecr-registry:5000", manager.httpClient().baseUrl());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/msk/RedpandaManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/msk/RedpandaManagerTest.java
@@ -29,6 +29,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.net.InetSocketAddress;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
@@ -195,11 +196,13 @@ class RedpandaManagerTest {
 
         int flagIndex = spec.cmd().indexOf("--advertise-kafka-addr");
         assertTrue(flagIndex >= 0, "cmd should contain --advertise-kafka-addr");
-        assertEquals("floci-msk-test-cluster:9092", spec.cmd().get(flagIndex + 1));
+        assertEquals("floci-msk-abc123:9092", spec.cmd().get(flagIndex + 1));
 
         assertFalse(spec.portBindings().containsKey(KAFKA_PORT), "container mode should not publish ports to host");
         assertTrue(spec.exposedPorts().contains(KAFKA_PORT));
         assertTrue(spec.exposedPorts().contains(RedpandaManager.ADMIN_PORT));
+        assertFalse(Files.exists(tempDir.resolve("msk").resolve("test-cluster")),
+                "container mode must not create host directories from inside the emulator container");
 
         verifyNoInteractions(portAllocator);
     }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManagerTest.java
@@ -102,6 +102,60 @@ class RdsContainerManagerTest {
         assertEquals("/var/lib/mysql", bind.getVolume().getPath());
     }
 
+    @Test
+    void childContainerNameUsesVolumeIdWhenAvailable() {
+        EmulatorConfig config = config(tempDir.resolve("host-root"));
+        ContainerDetector containerDetector = mock(ContainerDetector.class);
+        ContainerLifecycleManager lifecycleManager = mock(ContainerLifecycleManager.class);
+        when(lifecycleManager.createAndStart(any())).thenReturn(new ContainerLifecycleManager.ContainerInfo(
+                "container-id", Map.of(3306, new ContainerLifecycleManager.EndpointInfo("db1", 3306))));
+        ContainerLogStreamer logStreamer = mock(ContainerLogStreamer.class);
+        lenient().when(logStreamer.generateLogStreamName(any())).thenReturn("log-stream");
+
+        RdsContainerManager manager = new RdsContainerManager(
+                new ContainerBuilder(config, mock(DockerHostResolver.class), mock(EmbeddedDnsServer.class)),
+                lifecycleManager,
+                logStreamer,
+                containerDetector,
+                config,
+                new RegionResolver("us-east-1", "000000000000"),
+                mock(ServiceConfigAccess.class));
+
+        manager.start("db1", "volume-a", DatabaseEngine.MYSQL, "mysql:8.0", "root", "password", "db");
+
+        var spec = org.mockito.ArgumentCaptor.forClass(ContainerSpec.class);
+        verify(lifecycleManager).removeIfExists("floci-rds-volume-a");
+        verify(lifecycleManager).createAndStart(spec.capture());
+        assertEquals("floci-rds-volume-a", spec.getValue().name());
+    }
+
+    @Test
+    void childContainerNameFallsBackToInstanceIdWithoutVolumeId() {
+        EmulatorConfig config = config(tempDir.resolve("host-root"));
+        ContainerDetector containerDetector = mock(ContainerDetector.class);
+        ContainerLifecycleManager lifecycleManager = mock(ContainerLifecycleManager.class);
+        when(lifecycleManager.createAndStart(any())).thenReturn(new ContainerLifecycleManager.ContainerInfo(
+                "container-id", Map.of(3306, new ContainerLifecycleManager.EndpointInfo("db1", 3306))));
+        ContainerLogStreamer logStreamer = mock(ContainerLogStreamer.class);
+        lenient().when(logStreamer.generateLogStreamName(any())).thenReturn("log-stream");
+
+        RdsContainerManager manager = new RdsContainerManager(
+                new ContainerBuilder(config, mock(DockerHostResolver.class), mock(EmbeddedDnsServer.class)),
+                lifecycleManager,
+                logStreamer,
+                containerDetector,
+                config,
+                new RegionResolver("us-east-1", "000000000000"),
+                mock(ServiceConfigAccess.class));
+
+        manager.start("db1", null, DatabaseEngine.MYSQL, "mysql:8.0", "root", "password", "db");
+
+        var spec = org.mockito.ArgumentCaptor.forClass(ContainerSpec.class);
+        verify(lifecycleManager).removeIfExists("floci-rds-db1");
+        verify(lifecycleManager).createAndStart(spec.capture());
+        assertEquals("floci-rds-db1", spec.getValue().name());
+    }
+
     private static EmulatorConfig config(Path hostRoot) {
         EmulatorConfig config = mock(EmulatorConfig.class);
         EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);

--- a/src/test/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManagerTest.java
@@ -1,13 +1,39 @@
 package io.github.hectorvent.floci.services.rds.container;
 
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.ServiceConfigAccess;
+import io.github.hectorvent.floci.core.common.dns.EmbeddedDnsServer;
+import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
+import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
+import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
+import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
+import io.github.hectorvent.floci.core.common.docker.DockerHostResolver;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+import com.github.dockerjava.api.model.Bind;
 import io.github.hectorvent.floci.services.rds.model.DatabaseEngine;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class RdsContainerManagerTest {
+
+    @TempDir
+    Path tempDir;
 
     @Test
     void postgresInitSqlCreatesRdsIamRoleWhenMissing() {
@@ -42,5 +68,56 @@ class RdsContainerManagerTest {
                 RdsContainerManager.engineDefaultDataPath(DatabaseEngine.POSTGRES, "postgres:latest"));
         assertEquals("/var/lib/postgresql/data",
                 RdsContainerManager.engineDefaultDataPath(DatabaseEngine.POSTGRES, "localhost:5000/postgres"));
+    }
+
+    @Test
+    void containerizedHostPathModeDoesNotCreateHostDataDirectory() {
+        Path hostRoot = tempDir.resolve("host-root");
+        Path dbPath = hostRoot.resolve("rds").resolve("db1");
+        EmulatorConfig config = config(hostRoot);
+        ContainerDetector containerDetector = mock(ContainerDetector.class);
+        when(containerDetector.isRunningInContainer()).thenReturn(true);
+        ContainerLifecycleManager lifecycleManager = mock(ContainerLifecycleManager.class);
+        when(lifecycleManager.createAndStart(any())).thenReturn(new ContainerLifecycleManager.ContainerInfo(
+                "container-id", Map.of(3306, new ContainerLifecycleManager.EndpointInfo("db1", 3306))));
+        ContainerLogStreamer logStreamer = mock(ContainerLogStreamer.class);
+        lenient().when(logStreamer.generateLogStreamName(any())).thenReturn("log-stream");
+
+        RdsContainerManager manager = new RdsContainerManager(
+                new ContainerBuilder(config, mock(DockerHostResolver.class), mock(EmbeddedDnsServer.class)),
+                lifecycleManager,
+                logStreamer,
+                containerDetector,
+                config,
+                new RegionResolver("us-east-1", "000000000000"),
+                mock(ServiceConfigAccess.class));
+
+        manager.start("db1", "vol1", DatabaseEngine.MYSQL, "mysql:8.0", "root", "password", "db");
+
+        assertFalse(Files.exists(dbPath));
+        var spec = org.mockito.ArgumentCaptor.forClass(ContainerSpec.class);
+        verify(lifecycleManager).createAndStart(spec.capture());
+        Bind bind = spec.getValue().binds().getFirst();
+        assertEquals(dbPath.toString(), bind.getPath());
+        assertEquals("/var/lib/mysql", bind.getVolume().getPath());
+    }
+
+    private static EmulatorConfig config(Path hostRoot) {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.RdsServiceConfig rds = mock(EmulatorConfig.RdsServiceConfig.class);
+        EmulatorConfig.DockerConfig docker = mock(EmulatorConfig.DockerConfig.class);
+        EmulatorConfig.StorageConfig storage = mock(EmulatorConfig.StorageConfig.class);
+        when(config.services()).thenReturn(services);
+        when(services.rds()).thenReturn(rds);
+        when(services.dockerNetwork()).thenReturn(Optional.empty());
+        when(rds.dockerNetwork()).thenReturn(Optional.empty());
+        when(config.docker()).thenReturn(docker);
+        when(docker.resourceNamespace()).thenReturn(Optional.empty());
+        when(docker.logMaxSize()).thenReturn("10m");
+        when(docker.logMaxFile()).thenReturn("3");
+        when(config.storage()).thenReturn(storage);
+        when(storage.hostPersistentPath()).thenReturn(hostRoot.toString());
+        return config;
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -78,6 +78,7 @@ floci:
   docker:
     log-max-size: "10m"
     log-max-file: "3"
+    resource-namespace: ""
 
   services:
     ssm:


### PR DESCRIPTION
## Summary
- add a per-run discriminator to managed container and volume names
- avoid creating host filesystem paths from inside containerized runs
- keep RDS child containers isolated when separate emulator instances create the same logical DB identifier

## Verification
- ./mvnw -q -Dtest=ContainerStorageHelperTest,RdsContainerManagerTest test
- git diff --check origin/main..HEAD
- product-name diff scan: clean