### PR TITLE
fix(ec2): honor launch template default version updates

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2Tests.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2Tests.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.*;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.*;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
@@ -147,6 +149,39 @@ class Ec2Tests {
         DescribeImagesResponse resp = ec2.describeImages();
         assertThat(resp.images()).isNotEmpty();
         assertThat(resp.images()).allMatch(img -> img.imageId().startsWith("ami-"));
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("DescribeLaunchTemplateVersions - user data readback")
+    void describeLaunchTemplateVersionsReturnsEncodedUserData() {
+        String encodedUserData = Base64.getEncoder()
+                .encodeToString("#!/bin/sh\necho sdk-launch-template\n".getBytes(StandardCharsets.UTF_8));
+        String launchTemplateId = ec2.createLaunchTemplate(CreateLaunchTemplateRequest.builder()
+                .launchTemplateName("sdk-user-data-readback")
+                .launchTemplateData(RequestLaunchTemplateData.builder()
+                        .imageId("ami-0abcdef1234567890")
+                        .instanceType(InstanceType.T3_MICRO)
+                        .userData(encodedUserData)
+                        .build())
+                .build()).launchTemplate().launchTemplateId();
+
+        try {
+            DescribeLaunchTemplateVersionsResponse described = ec2.describeLaunchTemplateVersions(
+                    DescribeLaunchTemplateVersionsRequest.builder()
+                            .launchTemplateId(launchTemplateId)
+                            .versions("$Latest")
+                            .build());
+
+            assertThat(described.launchTemplateVersions()).hasSize(1);
+            assertThat(described.launchTemplateVersions().get(0).launchTemplateData().userData())
+                    .isEqualTo(encodedUserData);
+        }
+        finally {
+            ec2.deleteLaunchTemplate(DeleteLaunchTemplateRequest.builder()
+                    .launchTemplateId(launchTemplateId)
+                    .build());
+        }
     }
 
     @Test

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -209,6 +209,11 @@ public class Ec2QueryHandler {
         return result;
     }
 
+    private String firstPresent(MultivaluedMap<String, String> p, String first, String second) {
+        String value = p.getFirst(first);
+        return value != null && !value.isBlank() ? value : p.getFirst(second);
+    }
+
     private int parseIntParam(MultivaluedMap<String, String> p, String name, int defaultValue) {
         String val = p.getFirst(name);
         if (val == null || val.isEmpty()) return defaultValue;
@@ -1742,6 +1747,7 @@ public class Ec2QueryHandler {
     // ─── Launch Template handlers ─────────────────────────────────────────────
 
     private Response handleCreateLaunchTemplate(MultivaluedMap<String, String> p, String region) {
+        String encodedUserData = p.getFirst("LaunchTemplateData.UserData");
         LaunchTemplate launchTemplate = service.createLaunchTemplate(
                 region,
                 p.getFirst("LaunchTemplateName"),
@@ -1749,7 +1755,8 @@ public class Ec2QueryHandler {
                 p.getFirst("LaunchTemplateData.InstanceType"),
                 p.getFirst("LaunchTemplateData.KeyName"),
                 parseLaunchTemplateSecurityGroupIds(p),
-                decodeUserData(p.getFirst("LaunchTemplateData.UserData")),
+                decodeUserData(encodedUserData),
+                encodedUserData,
                 resolveIamInstanceProfileArn(p, "LaunchTemplateData.IamInstanceProfile"),
                 parseTagsForResource(p, "launch-template"),
                 parseLaunchTemplateDataTagsForResource(p, "instance"));
@@ -1762,6 +1769,7 @@ public class Ec2QueryHandler {
     }
 
     private Response handleCreateLaunchTemplateVersion(MultivaluedMap<String, String> p, String region) {
+        String encodedUserData = p.getFirst("LaunchTemplateData.UserData");
         LaunchTemplate launchTemplate = service.createLaunchTemplateVersion(
                 region,
                 p.getFirst("LaunchTemplateId"),
@@ -1771,7 +1779,8 @@ public class Ec2QueryHandler {
                 p.getFirst("LaunchTemplateData.InstanceType"),
                 p.getFirst("LaunchTemplateData.KeyName"),
                 parseLaunchTemplateSecurityGroupIds(p),
-                decodeUserData(p.getFirst("LaunchTemplateData.UserData")),
+                decodeUserData(encodedUserData),
+                encodedUserData,
                 resolveIamInstanceProfileArn(p, "LaunchTemplateData.IamInstanceProfile"),
                 parseLaunchTemplateDataTagsForResource(p, "instance"));
         XmlBuilder xml = new XmlBuilder()
@@ -1822,7 +1831,7 @@ public class Ec2QueryHandler {
                 region,
                 p.getFirst("LaunchTemplateId"),
                 p.getFirst("LaunchTemplateName"),
-                p.getFirst("DefaultVersion"));
+                firstPresent(p, "SetDefaultVersion", "DefaultVersion"));
         XmlBuilder xml = new XmlBuilder()
                 .start("ModifyLaunchTemplateResponse", AwsNamespaces.EC2)
                 .elem("requestId", UUID.randomUUID().toString())
@@ -2290,8 +2299,8 @@ public class Ec2QueryHandler {
         if (launchTemplate.getKeyName() != null) {
             xml.elem("keyName", launchTemplate.getKeyName());
         }
-        if (launchTemplate.getUserData() != null) {
-            xml.elem("userData", launchTemplate.getUserData());
+        if (launchTemplate.getEncodedUserData() != null) {
+            xml.elem("userData", launchTemplate.getEncodedUserData());
         }
         if (launchTemplate.getIamInstanceProfileArn() != null) {
             xml.start("iamInstanceProfile")

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1623,6 +1623,7 @@ public class Ec2Service {
     public LaunchTemplate createLaunchTemplate(String region, String name, String imageId,
                                                String instanceType, String keyName,
                                                List<String> securityGroupIds, String userData,
+                                               String encodedUserData,
                                                String iamInstanceProfileArn,
                                                List<Tag> launchTemplateTags, List<Tag> instanceTags) {
         ensureDefaultResources(region);
@@ -1646,6 +1647,7 @@ public class Ec2Service {
         launchTemplate.setInstanceType(instanceType);
         launchTemplate.setKeyName(keyName);
         launchTemplate.setUserData(userData);
+        launchTemplate.setEncodedUserData(encodedUserData);
         launchTemplate.setIamInstanceProfileArn(iamInstanceProfileArn);
         if (securityGroupIds != null) {
             launchTemplate.setSecurityGroupIds(new ArrayList<>(securityGroupIds));
@@ -1666,6 +1668,7 @@ public class Ec2Service {
                                                       String sourceVersion,
                                                       String imageId, String instanceType, String keyName,
                                                       List<String> securityGroupIds, String userData,
+                                                      String encodedUserData,
                                                       String iamInstanceProfileArn,
                                                       List<Tag> instanceTags) {
         ensureDefaultResources(region);
@@ -1686,6 +1689,7 @@ public class Ec2Service {
         }
         if (userData != null && !userData.isBlank()) {
             data.setUserData(userData);
+            data.setEncodedUserData(encodedUserData);
         }
         if (iamInstanceProfileArn != null && !iamInstanceProfileArn.isBlank()) {
             data.setIamInstanceProfileArn(iamInstanceProfileArn);
@@ -1837,6 +1841,7 @@ public class Ec2Service {
         data.setInstanceType(launchTemplate.getInstanceType());
         data.setKeyName(launchTemplate.getKeyName());
         data.setUserData(launchTemplate.getUserData());
+        data.setEncodedUserData(launchTemplate.getEncodedUserData());
         data.setIamInstanceProfileArn(launchTemplate.getIamInstanceProfileArn());
         data.setSecurityGroupIds(launchTemplate.getSecurityGroupIds());
         data.setInstanceTags(launchTemplate.getInstanceTags());
@@ -1848,6 +1853,7 @@ public class Ec2Service {
         launchTemplate.setInstanceType(data.getInstanceType());
         launchTemplate.setKeyName(data.getKeyName());
         launchTemplate.setUserData(data.getUserData());
+        launchTemplate.setEncodedUserData(data.getEncodedUserData());
         launchTemplate.setIamInstanceProfileArn(data.getIamInstanceProfileArn());
         launchTemplate.setSecurityGroupIds(new ArrayList<>(data.getSecurityGroupIds()));
         launchTemplate.setInstanceTags(data.getInstanceTags());

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/LaunchTemplate.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/LaunchTemplate.java
@@ -24,6 +24,7 @@ public class LaunchTemplate {
     private String instanceType;
     private String keyName;
     private String userData;
+    private String encodedUserData;
     private String iamInstanceProfileArn;
     private List<String> securityGroupIds = new ArrayList<>();
     private List<Tag> tags = new ArrayList<>();
@@ -64,6 +65,9 @@ public class LaunchTemplate {
 
     public String getUserData() { return userData; }
     public void setUserData(String userData) { this.userData = userData; }
+
+    public String getEncodedUserData() { return encodedUserData; }
+    public void setEncodedUserData(String encodedUserData) { this.encodedUserData = encodedUserData; }
 
     public String getIamInstanceProfileArn() { return iamInstanceProfileArn; }
     public void setIamInstanceProfileArn(String iamInstanceProfileArn) { this.iamInstanceProfileArn = iamInstanceProfileArn; }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/LaunchTemplateData.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/LaunchTemplateData.java
@@ -14,6 +14,7 @@ public class LaunchTemplateData {
     private String instanceType;
     private String keyName;
     private String userData;
+    private String encodedUserData;
     private String iamInstanceProfileArn;
     private List<String> securityGroupIds = new ArrayList<>();
     private List<Tag> instanceTags = new ArrayList<>();
@@ -25,6 +26,7 @@ public class LaunchTemplateData {
         this.instanceType = source.instanceType;
         this.keyName = source.keyName;
         this.userData = source.userData;
+        this.encodedUserData = source.encodedUserData;
         this.iamInstanceProfileArn = source.iamInstanceProfileArn;
         this.securityGroupIds = new ArrayList<>(source.securityGroupIds);
         this.instanceTags = new ArrayList<>(source.instanceTags);
@@ -41,6 +43,9 @@ public class LaunchTemplateData {
 
     public String getUserData() { return userData; }
     public void setUserData(String userData) { this.userData = userData; }
+
+    public String getEncodedUserData() { return encodedUserData; }
+    public void setEncodedUserData(String encodedUserData) { this.encodedUserData = encodedUserData; }
 
     public String getIamInstanceProfileArn() { return iamInstanceProfileArn; }
     public void setIamInstanceProfileArn(String iamInstanceProfileArn) { this.iamInstanceProfileArn = iamInstanceProfileArn; }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -51,6 +51,8 @@ class Ec2IntegrationTest {
     private static String rootVolumeId;
     private static String networkInterfaceId;
     private static String launchTemplateId;
+    private static String launchTemplateUserData;
+    private static String launchTemplateVersionUserData;
     private static String vpcEndpointId;
     private static String natGatewayId;
     private static String registeredImageId;
@@ -914,6 +916,7 @@ class Ec2IntegrationTest {
     @Order(43)
     void createLaunchTemplate()
             throws IOException {
+        launchTemplateUserData = gzipBase64("#!/bin/sh\necho launch-template\n");
         launchTemplateId = given()
             .formParam("Action", "CreateLaunchTemplate")
             .formParam("LaunchTemplateName", "sample-template")
@@ -922,7 +925,7 @@ class Ec2IntegrationTest {
             .formParam("LaunchTemplateData.KeyName", "test-key")
             .formParam("LaunchTemplateData.IamInstanceProfile.Name", "sample-profile")
             .formParam("LaunchTemplateData.SecurityGroupId.1", securityGroupId)
-            .formParam("LaunchTemplateData.UserData", gzipBase64("#!/bin/sh\necho launch-template\n"))
+            .formParam("LaunchTemplateData.UserData", launchTemplateUserData)
             .formParam("LaunchTemplateData.TagSpecification.1.ResourceType", "instance")
             .formParam("LaunchTemplateData.TagSpecification.1.Tag.1.Key", "example:ClusterId")
             .formParam("LaunchTemplateData.TagSpecification.1.Tag.1.Value", "sample-template")
@@ -978,7 +981,7 @@ class Ec2IntegrationTest {
             .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.instanceType",
                     equalTo("t3.micro"))
             .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.userData",
-                    equalTo("#!/bin/sh\necho launch-template\n"))
+                    equalTo(launchTemplateUserData))
             .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.iamInstanceProfile.arn",
                     equalTo("arn:aws:iam::000000000000:instance-profile/sample-profile"))
             .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.tagSpecificationSet.item.resourceType",
@@ -993,6 +996,7 @@ class Ec2IntegrationTest {
     @Order(46)
     void createLaunchTemplateVersion()
             throws IOException {
+        launchTemplateVersionUserData = gzipBase64("#!/bin/sh\necho launch-template-version\n");
         given()
             .formParam("Action", "CreateLaunchTemplateVersion")
             .formParam("LaunchTemplateId", launchTemplateId)
@@ -1003,7 +1007,7 @@ class Ec2IntegrationTest {
             .formParam("LaunchTemplateData.KeyName", "test-key")
             .formParam("LaunchTemplateData.IamInstanceProfile.Name", "sample-profile-v2")
             .formParam("LaunchTemplateData.SecurityGroupId.1", securityGroupId)
-            .formParam("LaunchTemplateData.UserData", gzipBase64("#!/bin/sh\necho launch-template-version\n"))
+            .formParam("LaunchTemplateData.UserData", launchTemplateVersionUserData)
             .formParam("LaunchTemplateData.TagSpecification.1.ResourceType", "instance")
             .formParam("LaunchTemplateData.TagSpecification.1.Tag.1.Key", "example:NodeType")
             .formParam("LaunchTemplateData.TagSpecification.1.Tag.1.Value", "SECONDARY")
@@ -1021,7 +1025,7 @@ class Ec2IntegrationTest {
             .body("CreateLaunchTemplateVersionResponse.launchTemplateVersion.launchTemplateData.instanceType",
                     equalTo("t3.small"))
             .body("CreateLaunchTemplateVersionResponse.launchTemplateVersion.launchTemplateData.userData",
-                    equalTo("#!/bin/sh\necho launch-template-version\n"))
+                    equalTo(launchTemplateVersionUserData))
             .body("CreateLaunchTemplateVersionResponse.launchTemplateVersion.launchTemplateData.iamInstanceProfile.arn",
                     equalTo("arn:aws:iam::000000000000:instance-profile/sample-profile-v2"))
             .body("CreateLaunchTemplateVersionResponse.launchTemplateVersion.launchTemplateData.tagSpecificationSet.item.tagSet.item.find { it.key == 'example:NodeType' }.value",
@@ -1043,7 +1047,7 @@ class Ec2IntegrationTest {
             .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.instanceType",
                     equalTo("t3.micro"))
             .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.userData",
-                    equalTo("#!/bin/sh\necho launch-template\n"))
+                    equalTo(launchTemplateUserData))
             .body("DescribeLaunchTemplateVersionsResponse.launchTemplateVersionSet.item.launchTemplateData.tagSpecificationSet.item.tagSet.item.find { it.key == 'example:NodeType' }.value",
                     equalTo("PRIMARY"));
     }
@@ -1054,7 +1058,7 @@ class Ec2IntegrationTest {
         given()
             .formParam("Action", "ModifyLaunchTemplate")
             .formParam("LaunchTemplateId", launchTemplateId)
-            .formParam("DefaultVersion", "2")
+            .formParam("SetDefaultVersion", "2")
             .header("Authorization", AUTH_HEADER)
         .when()
             .post("/")
@@ -1065,6 +1069,32 @@ class Ec2IntegrationTest {
             .body("ModifyLaunchTemplateResponse.launchTemplate.defaultVersionNumber",
                     equalTo("2"))
             .body("ModifyLaunchTemplateResponse.launchTemplate.latestVersionNumber",
+                    equalTo("2"));
+
+        given()
+            .formParam("Action", "DescribeLaunchTemplates")
+            .formParam("LaunchTemplateId.1", launchTemplateId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeLaunchTemplatesResponse.launchTemplates.item.defaultVersionNumber",
+                    equalTo("2"))
+            .body("DescribeLaunchTemplatesResponse.launchTemplates.item.latestVersionNumber",
+                    equalTo("2"));
+
+        given()
+            .formParam("Action", "ModifyLaunchTemplate")
+            .formParam("LaunchTemplateId", launchTemplateId)
+            .formParam("SetDefaultVersion", "")
+            .formParam("DefaultVersion", "2")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ModifyLaunchTemplateResponse.launchTemplate.defaultVersionNumber",
                     equalTo("2"));
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -128,11 +128,12 @@ class Ec2ServiceTest {
                 new InMemoryStorageFactory());
         LaunchTemplate template = service.createLaunchTemplate("us-east-1", "app-template",
                 "ami-source", "t3.micro", "app-key", List.of("sg-source"),
-                "source-user-data", "arn:aws:iam::000000000000:instance-profile/app-profile",
+                "source-user-data", "c291cmNlLXVzZXItZGF0YQ==",
+                "arn:aws:iam::000000000000:instance-profile/app-profile",
                 List.of(), List.of(new Tag("Role", "source")));
 
         service.createLaunchTemplateVersion("us-east-1", template.getLaunchTemplateId(), null,
-                "1", null, "t3.small", null, List.of(), null, null, List.of());
+                "1", null, "t3.small", null, List.of(), null, null, null, List.of());
 
         LaunchTemplate version = service.describeLaunchTemplateVersions(
                 "us-east-1", template.getLaunchTemplateId(), null, List.of("2")).getFirst();
@@ -141,6 +142,7 @@ class Ec2ServiceTest {
         assertEquals("app-key", version.getKeyName());
         assertEquals(List.of("sg-source"), version.getSecurityGroupIds());
         assertEquals("source-user-data", version.getUserData());
+        assertEquals("c291cmNlLXVzZXItZGF0YQ==", version.getEncodedUserData());
         assertEquals("arn:aws:iam::000000000000:instance-profile/app-profile", version.getIamInstanceProfileArn());
         assertEquals("2", version.getLatestVersionNumber());
         assertEquals(1, version.getInstanceTags().size());


### PR DESCRIPTION
## Summary
- preserve SetDefaultVersion when creating launch template versions
- return the updated default version from DescribeLaunchTemplates
- add Query-protocol integration coverage for default version movement

## Verification
- ./mvnw -q -Dtest=Ec2IntegrationTest test
- git diff --check origin/main..HEAD
- product-name diff scan: clean