### PR TITLE
feat: emit jti/origin_jti and support RevokeToken

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -91,6 +91,7 @@ public class CognitoJsonHandler {
             case "AdminRemoveUserFromGroup" -> handleAdminRemoveUserFromGroup(request);
             case "AdminListGroupsForUser" -> handleAdminListGroupsForUser(request);
             case "GetTokensFromRefreshToken" -> handleGetTokensFromRefreshToken(request);
+            case "RevokeToken" -> handleRevokeToken(request);
             case "ListUserPoolClientSecrets" -> handleListUserPoolClientSecrets(request);
             case "AddUserPoolClientSecret" -> handleAddUserPoolClientSecret(request);
             case "DeleteUserPoolClientSecret" -> handleDeleteUserPoolClientSecret(request);
@@ -448,6 +449,15 @@ public class CognitoJsonHandler {
                 request.path("RefreshToken").asText()
         );
         return Response.ok(objectMapper.valueToTree(result)).build();
+    }
+
+    private Response handleRevokeToken(JsonNode request) {
+        service.revokeToken(
+                request.path("ClientId").asText(null),
+                request.path("Token").asText(null),
+                request.path("ClientSecret").asText(null)
+        );
+        return Response.ok(objectMapper.createObjectNode()).build();
     }
 
     private Response handleInitiateAuth(JsonNode request) {

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -1476,14 +1476,17 @@ public class CognitoService {
         }
 
         UserPoolClient client = findClientById(clientId);
-        if (!isTokenRevocationEnabled(client)) {
-            throw new AwsException("UnsupportedOperationException",
-                    "Please enable token revocation before revoking tokens for this client", 400);
-        }
 
+        // Authenticate the caller before disclosing configuration state: a confidential client must
+        // present a valid secret first, matching AWS which validates identity ahead of feature checks.
         String secret = client.getClientSecret();
         if (secret != null && !secret.isBlank() && !secret.equals(clientSecret)) {
             throw new AwsException("NotAuthorizedException", "Invalid client secret", 400);
+        }
+
+        if (!isTokenRevocationEnabled(client)) {
+            throw new AwsException("UnsupportedOperationException",
+                    "Please enable token revocation before revoking tokens for this client", 400);
         }
 
         String[] parts = parseRefreshToken(token);

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -1260,13 +1260,13 @@ public class CognitoService {
         String username = extractUsernameFromToken(accessToken);
         String poolId = extractPoolIdFromToken(accessToken);
         String jti = extractJtiFromToken(accessToken);
-        
+
         if (username == null || poolId == null) {
             throw new AwsException("NotAuthorizedException", "Invalid access token", 400);
         }
-        
-        // Check if access token has been revoked
+
         validateTokenNotRevoked(jti, poolId, "access");
+        validateOriginJtiNotRevoked(accessToken, poolId);
         Long iat = extractIatFromToken(accessToken);
         validateUserNotGloballySignedOut(username, poolId, "access", iat != null ? iat : 0L);
 
@@ -1324,13 +1324,13 @@ public class CognitoService {
         String username = extractUsernameFromToken(accessToken);
         String poolId = extractPoolIdFromToken(accessToken);
         String jti = extractJtiFromToken(accessToken);
-        
+
         if (username == null || poolId == null || jti == null) {
             throw new AwsException("NotAuthorizedException", "Invalid access token", 400);
         }
-        
-        // Check if access token has been revoked
+
         validateTokenNotRevoked(jti, poolId, "access");
+        validateOriginJtiNotRevoked(accessToken, poolId);
         Long iat = extractIatFromToken(accessToken);
         validateUserNotGloballySignedOut(username, poolId, "access", iat != null ? iat : 0L);
         
@@ -1347,13 +1347,13 @@ public class CognitoService {
         String username = extractUsernameFromToken(accessToken);
         String poolId = extractPoolIdFromToken(accessToken);
         String jti = extractJtiFromToken(accessToken);
-        
+
         if (username == null || poolId == null) {
             throw new AwsException("NotAuthorizedException", "Invalid access token", 400);
         }
-        
-        // Check if access token has been revoked
+
         validateTokenNotRevoked(jti, poolId, "access");
+        validateOriginJtiNotRevoked(accessToken, poolId);
         Long iat = extractIatFromToken(accessToken);
         validateUserNotGloballySignedOut(username, poolId, "access", iat != null ? iat : 0L);
         
@@ -1364,13 +1364,13 @@ public class CognitoService {
         String username = extractUsernameFromToken(accessToken);
         String poolId = extractPoolIdFromToken(accessToken);
         String jti = extractJtiFromToken(accessToken);
-        
+
         if (username == null || poolId == null) {
             throw new AwsException("NotAuthorizedException", "Invalid access token", 400);
         }
-        
-        // Check if access token has been revoked
+
         validateTokenNotRevoked(jti, poolId, "access");
+        validateOriginJtiNotRevoked(accessToken, poolId);
         Long iat = extractIatFromToken(accessToken);
         validateUserNotGloballySignedOut(username, poolId, "access", iat != null ? iat : 0L);
         
@@ -1481,7 +1481,7 @@ public class CognitoService {
         // present a valid secret first, matching AWS which validates identity ahead of feature checks.
         String secret = client.getClientSecret();
         if (secret != null && !secret.isBlank() && !secret.equals(clientSecret)) {
-            throw new AwsException("NotAuthorizedException", "Invalid client secret", 400);
+            throw new AwsException("UnauthorizedException", "Invalid client secret", 403);
         }
 
         if (!isTokenRevocationEnabled(client)) {
@@ -1501,7 +1501,7 @@ public class CognitoService {
         String familyId = parts.length > 4 && !parts[4].isEmpty() ? parts[4] : null;
 
         if (!clientId.equals(tokenClientId)) {
-            throw new AwsException("NotAuthorizedException", "Refresh token was not issued to this client", 400);
+            throw new AwsException("UnauthorizedException", "Refresh token was not issued to this client", 403);
         }
         if (familyId == null) {
             return; // Nothing keyed to revoke (legacy token); revocation is idempotent.
@@ -2113,10 +2113,6 @@ public class CognitoService {
         }
     }
 
-    String buildRefreshToken(String poolId, String username, String clientId) {
-        return buildRefreshToken(poolId, username, clientId, null);
-    }
-
     String buildRefreshToken(String poolId, String username, String clientId, String originJti) {
         long issuedAt = System.currentTimeMillis();
         String familyId = originJti != null ? originJti : UUID.randomUUID().toString();
@@ -2236,6 +2232,17 @@ public class CognitoService {
         }
     }
 
+    private String extractOriginJtiFromToken(String token) {
+        try {
+            String[] parts = token.split("\\.");
+            if (parts.length < 2) return null;
+            String payloadJson = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
+            return extractJsonField(payloadJson, "origin_jti");
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
     private Long extractIatFromToken(String token) {
         try {
             String[] parts = token.split("\\.");
@@ -2303,6 +2310,13 @@ public class CognitoService {
         }
     }
     
+    private void validateOriginJtiNotRevoked(String accessToken, String poolId) {
+        String originJti = extractOriginJtiFromToken(accessToken);
+        if (originJti != null) {
+            validateTokenNotRevoked(originJti, poolId, "access");
+        }
+    }
+
     /**
      * Check if a user has been globally signed out (affects all their tokens).
      * This method should be called in addition to validateTokenNotRevoked.

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -1467,15 +1467,60 @@ public class CognitoService {
         return result;
     }
 
+    public void revokeToken(String clientId, String token, String clientSecret) {
+        if (token == null || token.isBlank()) {
+            throw new AwsException("InvalidParameterException", "Token is required", 400);
+        }
+        if (clientId == null || clientId.isBlank()) {
+            throw new AwsException("InvalidParameterException", "ClientId is required", 400);
+        }
+
+        UserPoolClient client = findClientById(clientId);
+        if (!isTokenRevocationEnabled(client)) {
+            throw new AwsException("UnsupportedOperationException",
+                    "Please enable token revocation before revoking tokens for this client", 400);
+        }
+
+        String secret = client.getClientSecret();
+        if (secret != null && !secret.isBlank() && !secret.equals(clientSecret)) {
+            throw new AwsException("NotAuthorizedException", "Invalid client secret", 400);
+        }
+
+        String[] parts = parseRefreshToken(token);
+        if (parts == null) {
+            throw new AwsException("UnsupportedTokenTypeException",
+                    "Only refresh tokens can be revoked", 400);
+        }
+
+        String poolId = parts[0];
+        String username = parts[1];
+        String tokenClientId = parts[2];
+        String familyId = parts.length > 4 && !parts[4].isEmpty() ? parts[4] : null;
+
+        if (!clientId.equals(tokenClientId)) {
+            throw new AwsException("NotAuthorizedException", "Refresh token was not issued to this client", 400);
+        }
+        if (familyId == null) {
+            return; // Nothing keyed to revoke (legacy token); revocation is idempotent.
+        }
+
+        long nowMs = System.currentTimeMillis();
+        long expiresAtSeconds = nowMs / 1000L + (365L * 24L * 60L * 60L);
+        RevokedTokenInfo info = new RevokedTokenInfo(familyId, "refresh", username, poolId, nowMs, expiresAtSeconds);
+        revokedTokenStore.put(revokedTokenKey(poolId, familyId), info);
+        LOG.infov("RevokeToken: revoked refresh token family {0} for user {1} in pool {2}", familyId, username, poolId);
+    }
+
     Map<String, Object> generateAuthResult(CognitoUser user, UserPool pool, UserPoolClient client, ClaimsOverride override) {
-        return generateAuthResult(user, pool, client, override, null);
+        String originJti = UUID.randomUUID().toString();
+        return generateAuthResult(user, pool, client, override, originJti);
     }
     
     Map<String, Object> generateAuthResult(CognitoUser user, UserPool pool, UserPoolClient client, ClaimsOverride override, String originJti) {
         Map<String, Object> auth = new HashMap<>();
         auth.put("AccessToken", generateSignedJwt(user, pool, "access", client, override, originJti));
         auth.put("IdToken", generateSignedJwt(user, pool, "id", client, override, originJti));
-        auth.put("RefreshToken", buildRefreshToken(pool.getId(), user.getUsername(), client.getClientId()));
+        auth.put("RefreshToken", buildRefreshToken(pool.getId(), user.getUsername(), client.getClientId(), originJti));
         auth.put("ExpiresIn", resolveAccessTokenLifetimeSeconds(client));
         auth.put("TokenType", "Bearer");
         return auth;
@@ -1508,8 +1553,7 @@ public class CognitoService {
         String jti = UUID.randomUUID().toString();
         claims.put("jti", jti);
         
-        // Add origin_jti for access and ID tokens derived from refresh tokens
-        if (("access".equals(type) || "id".equals(type)) && originJti != null) {
+        if (("access".equals(type) || "id".equals(type)) && originJti != null && isTokenRevocationEnabled(client)) {
             claims.put("origin_jti", originJti);
         }
         
@@ -2067,9 +2111,19 @@ public class CognitoService {
     }
 
     String buildRefreshToken(String poolId, String username, String clientId) {
+        return buildRefreshToken(poolId, username, clientId, null);
+    }
+
+    String buildRefreshToken(String poolId, String username, String clientId, String originJti) {
         long issuedAt = System.currentTimeMillis();
-        String raw = poolId + "|" + username + "|" + clientId + "|" + issuedAt + "|" + UUID.randomUUID();
+        String familyId = originJti != null ? originJti : UUID.randomUUID().toString();
+        String raw = poolId + "|" + username + "|" + clientId + "|" + issuedAt + "|" + familyId;
         return Base64.getEncoder().withoutPadding().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private boolean isTokenRevocationEnabled(UserPoolClient client) {
+        return client == null || client.getEnableTokenRevocation() == null
+                || Boolean.TRUE.equals(client.getEnableTokenRevocation());
     }
 
     String[] parseRefreshToken(String refreshToken) {

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/OriginJtiIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/OriginJtiIntegrationTest.java
@@ -333,7 +333,33 @@ class OriginJtiIntegrationTest {
         JsonNode body = cognitoJsonAny("RevokeToken", """
                 {"ClientId":"%s","Token":"any-token","ClientSecret":"wrong-secret"}
                 """.formatted(confidentialClientId));
-        assertEquals("NotAuthorizedException", body.path("__type").asText(),
+        assertEquals("UnauthorizedException", body.path("__type").asText(),
                 "Caller identity must be validated before the revocation-enabled check, body was: " + body);
+    }
+
+    @Test
+    @Order(12)
+    void revokeTokenInvalidatesAccessTokens() throws Exception {
+        requireSetup();
+        JsonNode auth = passwordLogin();
+        String freshAccess = auth.path("AuthenticationResult").path("AccessToken").asText();
+        String freshRefresh = auth.path("AuthenticationResult").path("RefreshToken").asText();
+
+        // GetUser must succeed before revocation.
+        JsonNode ok = cognitoJsonAny("GetUser", """
+                {"AccessToken":"%s"}
+                """.formatted(freshAccess));
+        assertFalse(ok.has("__type"), "GetUser must succeed before RevokeToken, body was: " + ok);
+
+        cognitoAction("RevokeToken", """
+                {"ClientId":"%s","Token":"%s"}
+                """.formatted(clientId, freshRefresh)).then().statusCode(200);
+
+        // Access token issued alongside the revoked refresh token must now be rejected.
+        JsonNode rejected = cognitoJsonAny("GetUser", """
+                {"AccessToken":"%s"}
+                """.formatted(freshAccess));
+        assertEquals("NotAuthorizedException", rejected.path("__type").asText(),
+                "GetUser must fail after RevokeToken invalidates the origin_jti family, body was: " + rejected);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/OriginJtiIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/OriginJtiIntegrationTest.java
@@ -24,6 +24,12 @@ import static org.junit.jupiter.api.Assertions.*;
  * client (the default). Downstream stateless authorizers key their deny-list on
  * {@code origin_jti}, so it must stay identical across a refresh of the same session and
  * differ between independent logins.
+ * <p>
+ * Provisioning runs in an {@code @Order(1)} test rather than {@code @BeforeAll} because a
+ * {@code @QuarkusTest} HTTP endpoint is only guaranteed reachable inside test methods. The
+ * remaining ordered tests form a session lifecycle (login → refresh → revoke); each guards
+ * the shared state it depends on via {@link #requireSetup()} / {@link #requireInitialAuthState()}
+ * so a failure in an earlier step reports a clear cause instead of a misleading assertion.
  */
 @QuarkusTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -71,6 +77,19 @@ class OriginJtiIntegrationTest {
                 """.formatted(clientId, USERNAME, PASSWORD));
     }
 
+    /** Guards the pool/client provisioned by setupPoolAndUser so a setup failure reads clearly. */
+    private static void requireSetup() {
+        assertNotNull(poolId, "setupPoolAndUser (Order 1) must run first to create the user pool");
+        assertNotNull(clientId, "setupPoolAndUser (Order 1) must run first to create the app client");
+    }
+
+    /** Guards the state handed forward by the initial-auth test so an earlier failure reads clearly. */
+    private static void requireInitialAuthState() {
+        assertNotNull(refreshToken, "initialAuthEmitsJtiAndOriginJti (Order 2) must run first to set refreshToken");
+        assertFalse(refreshToken.isBlank(), "refreshToken from the initial authentication must not be blank");
+        assertNotNull(originJti1, "initialAuthEmitsJtiAndOriginJti (Order 2) must run first to set origin_jti");
+    }
+
     // ─── setup ──────────────────────────────────────────────────────────────
 
     @Test
@@ -104,6 +123,7 @@ class OriginJtiIntegrationTest {
     @Test
     @Order(2)
     void initialAuthEmitsJtiAndOriginJti() throws Exception {
+        requireSetup();
         JsonNode auth = passwordLogin();
         JsonNode result = auth.path("AuthenticationResult");
 
@@ -130,6 +150,7 @@ class OriginJtiIntegrationTest {
     @Test
     @Order(3)
     void describeClientReportsEnableTokenRevocation() throws Exception {
+        requireSetup();
         JsonNode described = cognitoJson("DescribeUserPoolClient", """
                 {"UserPoolId":"%s","ClientId":"%s"}
                 """.formatted(poolId, clientId));
@@ -141,6 +162,8 @@ class OriginJtiIntegrationTest {
     @Test
     @Order(4)
     void refreshKeepsOriginJtiStableAndRotatesJti() throws Exception {
+        requireSetup();
+        requireInitialAuthState();
         JsonNode refreshed = cognitoJson("InitiateAuth", """
                 {
                   "ClientId": "%s",
@@ -160,6 +183,8 @@ class OriginJtiIntegrationTest {
     @Test
     @Order(5)
     void getTokensFromRefreshTokenKeepsOriginJti() throws Exception {
+        requireSetup();
+        requireInitialAuthState();
         JsonNode refreshed = cognitoJson("GetTokensFromRefreshToken", """
                 {"ClientId":"%s","RefreshToken":"%s"}
                 """.formatted(clientId, refreshToken));
@@ -172,6 +197,8 @@ class OriginJtiIntegrationTest {
     @Test
     @Order(6)
     void secondLoginUsesDifferentOriginJti() throws Exception {
+        requireSetup();
+        requireInitialAuthState();
         JsonNode auth = passwordLogin();
         JsonNode access = decodeJwtPayload(auth.path("AuthenticationResult").path("AccessToken").asText());
 
@@ -183,6 +210,7 @@ class OriginJtiIntegrationTest {
     @Test
     @Order(7)
     void clientWithRevocationDisabledOmitsOriginJti() throws Exception {
+        requireSetup();
         JsonNode client = cognitoJson("CreateUserPoolClient", """
                 {
                   "UserPoolId": "%s",
@@ -213,6 +241,7 @@ class OriginJtiIntegrationTest {
     @Test
     @Order(8)
     void revokeTokenInvalidatesRefreshFamily() throws Exception {
+        requireSetup();
         JsonNode auth = passwordLogin();
         String freshRefresh = auth.path("AuthenticationResult").path("RefreshToken").asText();
 
@@ -243,6 +272,7 @@ class OriginJtiIntegrationTest {
     @Test
     @Order(9)
     void revokeTokenRejectsNonRefreshToken() throws Exception {
+        requireSetup();
         JsonNode body = cognitoJsonAny("RevokeToken", """
                 {"ClientId":"%s","Token":"not-a-refresh-token"}
                 """.formatted(clientId));
@@ -253,6 +283,7 @@ class OriginJtiIntegrationTest {
     @Test
     @Order(10)
     void revokeTokenUnsupportedWhenRevocationDisabled() throws Exception {
+        requireSetup();
         JsonNode client = cognitoJson("CreateUserPoolClient", """
                 {
                   "UserPoolId": "%s",
@@ -277,5 +308,32 @@ class OriginJtiIntegrationTest {
                 """.formatted(disabledClientId, disabledRefresh));
         assertEquals("UnsupportedOperationException", body.path("__type").asText(),
                 "RevokeToken must be rejected when the client disables token revocation, body was: " + body);
+    }
+
+    @Test
+    @Order(11)
+    void revokeTokenChecksClientSecretBeforeRevocationConfig() throws Exception {
+        requireSetup();
+        // Confidential client with revocation disabled: an invalid secret must be rejected with
+        // NotAuthorizedException *before* the UnsupportedOperationException config check, so that
+        // revocation state is never disclosed to an unauthenticated caller (matches AWS ordering).
+        JsonNode client = cognitoJson("CreateUserPoolClient", """
+                {
+                  "UserPoolId": "%s",
+                  "ClientName": "confidential-disabled-client",
+                  "GenerateSecret": true,
+                  "ExplicitAuthFlows": ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"],
+                  "EnableTokenRevocation": false
+                }
+                """.formatted(poolId));
+        String confidentialClientId = client.path("UserPoolClient").path("ClientId").asText();
+        assertFalse(client.path("UserPoolClient").path("ClientSecret").asText().isBlank(),
+                "Confidential client must be issued a secret");
+
+        JsonNode body = cognitoJsonAny("RevokeToken", """
+                {"ClientId":"%s","Token":"any-token","ClientSecret":"wrong-secret"}
+                """.formatted(confidentialClientId));
+        assertEquals("NotAuthorizedException", body.path("__type").asText(),
+                "Caller identity must be validated before the revocation-enabled check, body was: " + body);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/OriginJtiIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/OriginJtiIntegrationTest.java
@@ -1,0 +1,281 @@
+package io.github.hectorvent.floci.services.cognito;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Base64;
+
+import static io.github.hectorvent.floci.services.cognito.CognitoRestAssuredUtils.cognitoAction;
+import static io.github.hectorvent.floci.services.cognito.CognitoRestAssuredUtils.cognitoJson;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for the Cognito-native {@code jti} and {@code origin_jti} token claims.
+ * <p>
+ * Real AWS Cognito stamps every access and ID token with a unique {@code jti} and a per
+ * refresh-token-family {@code origin_jti} whenever token revocation is enabled on the app
+ * client (the default). Downstream stateless authorizers key their deny-list on
+ * {@code origin_jti}, so it must stay identical across a refresh of the same session and
+ * differ between independent logins.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class OriginJtiIntegrationTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static String poolId;
+    private static String clientId;
+    private static String refreshToken;
+
+    private static String originJti1;
+    private static String accessJti1;
+
+    private static final String USERNAME = "bob";
+    private static final String PASSWORD = "Password123!";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    // ─── helpers ────────────────────────────────────────────────────────────
+
+    /** Decodes the JWT payload (second segment) into a JSON tree. */
+    private static JsonNode decodeJwtPayload(String jwt) throws Exception {
+        String[] segments = jwt.split("\\.");
+        assertEquals(3, segments.length, "JWT must have three dot-separated segments");
+        byte[] payload = Base64.getUrlDecoder().decode(segments[1]);
+        return MAPPER.readTree(payload);
+    }
+
+    /** POSTs without asserting 200 so error responses can be inspected. */
+    private static JsonNode cognitoJsonAny(String action, String body) throws Exception {
+        return MAPPER.readTree(cognitoAction(action, body).then().extract().asString());
+    }
+
+    private static JsonNode passwordLogin() throws Exception {
+        return cognitoJson("InitiateAuth", """
+                {
+                  "ClientId": "%s",
+                  "AuthFlow": "USER_PASSWORD_AUTH",
+                  "AuthParameters": {"USERNAME": "%s", "PASSWORD": "%s"}
+                }
+                """.formatted(clientId, USERNAME, PASSWORD));
+    }
+
+    // ─── setup ──────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(1)
+    void setupPoolAndUser() throws Exception {
+        JsonNode pool = cognitoJson("CreateUserPool", """
+                {"PoolName":"OriginJtiTestPool"}
+                """);
+        poolId = pool.path("UserPool").path("Id").asText();
+        assertFalse(poolId.isBlank(), "Pool ID must not be blank");
+
+        JsonNode client = cognitoJson("CreateUserPoolClient", """
+                {
+                  "UserPoolId": "%s",
+                  "ClientName": "origin-jti-client",
+                  "ExplicitAuthFlows": ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"]
+                }
+                """.formatted(poolId));
+        clientId = client.path("UserPoolClient").path("ClientId").asText();
+        assertFalse(clientId.isBlank(), "Client ID must not be blank");
+
+        cognitoAction("AdminCreateUser", """
+                {"UserPoolId":"%s","Username":"%s"}
+                """.formatted(poolId, USERNAME)).then().statusCode(200);
+
+        cognitoAction("AdminSetUserPassword", """
+                {"UserPoolId":"%s","Username":"%s","Password":"%s","Permanent":true}
+                """.formatted(poolId, USERNAME, PASSWORD)).then().statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void initialAuthEmitsJtiAndOriginJti() throws Exception {
+        JsonNode auth = passwordLogin();
+        JsonNode result = auth.path("AuthenticationResult");
+
+        refreshToken = result.path("RefreshToken").asText();
+        assertFalse(refreshToken.isBlank(), "RefreshToken must be present after sign-in");
+
+        JsonNode access = decodeJwtPayload(result.path("AccessToken").asText());
+        JsonNode id = decodeJwtPayload(result.path("IdToken").asText());
+
+        assertFalse(access.path("jti").asText().isBlank(), "Access token must contain jti");
+        assertFalse(access.path("origin_jti").asText().isBlank(), "Access token must contain origin_jti");
+        assertFalse(id.path("jti").asText().isBlank(), "ID token must contain jti");
+        assertFalse(id.path("origin_jti").asText().isBlank(), "ID token must contain origin_jti");
+
+        assertEquals(access.path("origin_jti").asText(), id.path("origin_jti").asText(),
+                "Access and ID tokens from the same authentication must share origin_jti");
+        assertNotEquals(access.path("jti").asText(), id.path("jti").asText(),
+                "Access and ID tokens must each carry their own unique jti");
+
+        originJti1 = access.path("origin_jti").asText();
+        accessJti1 = access.path("jti").asText();
+    }
+
+    @Test
+    @Order(3)
+    void describeClientReportsEnableTokenRevocation() throws Exception {
+        JsonNode described = cognitoJson("DescribeUserPoolClient", """
+                {"UserPoolId":"%s","ClientId":"%s"}
+                """.formatted(poolId, clientId));
+
+        assertTrue(described.path("UserPoolClient").path("EnableTokenRevocation").asBoolean(),
+                "EnableTokenRevocation should default to true and be reported by DescribeUserPoolClient");
+    }
+
+    @Test
+    @Order(4)
+    void refreshKeepsOriginJtiStableAndRotatesJti() throws Exception {
+        JsonNode refreshed = cognitoJson("InitiateAuth", """
+                {
+                  "ClientId": "%s",
+                  "AuthFlow": "REFRESH_TOKEN_AUTH",
+                  "AuthParameters": {"REFRESH_TOKEN": "%s"}
+                }
+                """.formatted(clientId, refreshToken));
+
+        JsonNode access = decodeJwtPayload(refreshed.path("AuthenticationResult").path("AccessToken").asText());
+
+        assertEquals(originJti1, access.path("origin_jti").asText(),
+                "origin_jti must stay identical across a refresh of the same session");
+        assertNotEquals(accessJti1, access.path("jti").asText(),
+                "jti must be freshly generated on every token issuance");
+    }
+
+    @Test
+    @Order(5)
+    void getTokensFromRefreshTokenKeepsOriginJti() throws Exception {
+        JsonNode refreshed = cognitoJson("GetTokensFromRefreshToken", """
+                {"ClientId":"%s","RefreshToken":"%s"}
+                """.formatted(clientId, refreshToken));
+
+        JsonNode access = decodeJwtPayload(refreshed.path("AuthenticationResult").path("AccessToken").asText());
+        assertEquals(originJti1, access.path("origin_jti").asText(),
+                "origin_jti must also stay stable through the GetTokensFromRefreshToken path");
+    }
+
+    @Test
+    @Order(6)
+    void secondLoginUsesDifferentOriginJti() throws Exception {
+        JsonNode auth = passwordLogin();
+        JsonNode access = decodeJwtPayload(auth.path("AuthenticationResult").path("AccessToken").asText());
+
+        assertFalse(access.path("origin_jti").asText().isBlank(), "Second login must also carry origin_jti");
+        assertNotEquals(originJti1, access.path("origin_jti").asText(),
+                "Each independent login must start a new revocation family with a distinct origin_jti");
+    }
+
+    @Test
+    @Order(7)
+    void clientWithRevocationDisabledOmitsOriginJti() throws Exception {
+        JsonNode client = cognitoJson("CreateUserPoolClient", """
+                {
+                  "UserPoolId": "%s",
+                  "ClientName": "no-revocation-client",
+                  "ExplicitAuthFlows": ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"],
+                  "EnableTokenRevocation": false
+                }
+                """.formatted(poolId));
+        String disabledClientId = client.path("UserPoolClient").path("ClientId").asText();
+
+        assertFalse(client.path("UserPoolClient").path("EnableTokenRevocation").asBoolean(),
+                "EnableTokenRevocation=false must round-trip through CreateUserPoolClient");
+
+        JsonNode auth = cognitoJson("InitiateAuth", """
+                {
+                  "ClientId": "%s",
+                  "AuthFlow": "USER_PASSWORD_AUTH",
+                  "AuthParameters": {"USERNAME": "%s", "PASSWORD": "%s"}
+                }
+                """.formatted(disabledClientId, USERNAME, PASSWORD));
+
+        JsonNode access = decodeJwtPayload(auth.path("AuthenticationResult").path("AccessToken").asText());
+        assertFalse(access.path("jti").asText().isBlank(), "jti is always emitted");
+        assertTrue(access.path("origin_jti").isMissingNode(),
+                "origin_jti must be omitted when token revocation is disabled on the client");
+    }
+
+    @Test
+    @Order(8)
+    void revokeTokenInvalidatesRefreshFamily() throws Exception {
+        JsonNode auth = passwordLogin();
+        String freshRefresh = auth.path("AuthenticationResult").path("RefreshToken").asText();
+
+        // Sanity: the fresh refresh token works before revocation.
+        JsonNode ok = cognitoJson("InitiateAuth", """
+                {"ClientId":"%s","AuthFlow":"REFRESH_TOKEN_AUTH","AuthParameters":{"REFRESH_TOKEN":"%s"}}
+                """.formatted(clientId, freshRefresh));
+        assertFalse(ok.path("AuthenticationResult").path("AccessToken").asText().isBlank(),
+                "Refresh must work before RevokeToken");
+
+        cognitoAction("RevokeToken", """
+                {"ClientId":"%s","Token":"%s"}
+                """.formatted(clientId, freshRefresh)).then().statusCode(200);
+
+        JsonNode rejected = cognitoJsonAny("InitiateAuth", """
+                {"ClientId":"%s","AuthFlow":"REFRESH_TOKEN_AUTH","AuthParameters":{"REFRESH_TOKEN":"%s"}}
+                """.formatted(clientId, freshRefresh));
+        assertEquals("NotAuthorizedException", rejected.path("__type").asText(),
+                "REFRESH_TOKEN_AUTH must fail after RevokeToken, body was: " + rejected);
+
+        JsonNode rejected2 = cognitoJsonAny("GetTokensFromRefreshToken", """
+                {"ClientId":"%s","RefreshToken":"%s"}
+                """.formatted(clientId, freshRefresh));
+        assertEquals("NotAuthorizedException", rejected2.path("__type").asText(),
+                "GetTokensFromRefreshToken must also fail after RevokeToken");
+    }
+
+    @Test
+    @Order(9)
+    void revokeTokenRejectsNonRefreshToken() throws Exception {
+        JsonNode body = cognitoJsonAny("RevokeToken", """
+                {"ClientId":"%s","Token":"not-a-refresh-token"}
+                """.formatted(clientId));
+        assertEquals("UnsupportedTokenTypeException", body.path("__type").asText(),
+                "Only refresh tokens may be revoked, body was: " + body);
+    }
+
+    @Test
+    @Order(10)
+    void revokeTokenUnsupportedWhenRevocationDisabled() throws Exception {
+        JsonNode client = cognitoJson("CreateUserPoolClient", """
+                {
+                  "UserPoolId": "%s",
+                  "ClientName": "revoke-disabled-client",
+                  "ExplicitAuthFlows": ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"],
+                  "EnableTokenRevocation": false
+                }
+                """.formatted(poolId));
+        String disabledClientId = client.path("UserPoolClient").path("ClientId").asText();
+
+        JsonNode auth = cognitoJson("InitiateAuth", """
+                {
+                  "ClientId": "%s",
+                  "AuthFlow": "USER_PASSWORD_AUTH",
+                  "AuthParameters": {"USERNAME": "%s", "PASSWORD": "%s"}
+                }
+                """.formatted(disabledClientId, USERNAME, PASSWORD));
+        String disabledRefresh = auth.path("AuthenticationResult").path("RefreshToken").asText();
+
+        JsonNode body = cognitoJsonAny("RevokeToken", """
+                {"ClientId":"%s","Token":"%s"}
+                """.formatted(disabledClientId, disabledRefresh));
+        assertEquals("UnsupportedOperationException", body.path("__type").asText(),
+                "RevokeToken must be rejected when the client disables token revocation, body was: " + body);
+    }
+}


### PR DESCRIPTION
## Summary

Brings Floci's Cognito token generation to parity with real AWS Cognito by emitting the two native token-revocation claims and honoring the RevokeToken API. Implements the Sapphire Terminal team's patch request (floci-patch-origin-jti-request.md) that unblocks end-to-end dev testing of "remote device logout" (instant session revocation).

- jti — a unique UUID stamped on every access and ID token, regenerated on each issuance/refresh.
- origin_jti — a per-refresh-token-family UUID: minted at initial authentication, embedded in the refresh token, and kept identical for every access/ID token later minted from that refresh token (stable across REFRESH_TOKEN_AUTH / GetTokensFromRefreshToken), while differing between independent logins.
- `jti` is always emitted (unconditional). `origin_jti` is gated on the app client's `EnableTokenRevocation` flag (default true) and omitted when revocation is disabled, matching AWS behavior.
- RevokeToken API wired: revoking a refresh token invalidates its whole `origin_jti` family, so subsequent refreshes **and access-token-gated operations** (GetUser, ChangePassword, UpdateUserAttributes, DeleteUserAttributes) fail with NotAuthorizedException. Error codes on RevokeToken itself use `UnauthorizedException` per the declared API model.

## Type of change

- [ ] Bug fix (fix:)
- [x] New feature (feat:)
- [ ] Breaking change (feat!: or fix!:)
- [ ] Docs / chore

## AWS Compatibility

- Protocol: Cognito AWS JSON 1.1 (X-Amz-Target: AWSCognitoIdentityProviderService.*). No wire-format or endpoint-shape changes.
- Claims: jti / origin_jti match AWS's documented token revocation semantics — origin_jti is the stable revocation identifier for the refresh-token family; jti is unique per JWT.
- RevokeToken errors modeled after AWS: UnsupportedOperationException when the client has EnableTokenRevocation=false, UnsupportedTokenTypeException for a non-refresh token, UnauthorizedException (403) for a client mismatch / bad client secret, InvalidParameterException for missing Token/ClientId; empty 200 on success.
- DescribeUserPoolClient already reports EnableTokenRevocation (defaults to true on client creation) — verified by the new test.
- Verification: RestAssured integration tests exercise the real JSON 1.1 wire path (InitiateAuth USER_PASSWORD_AUTH / REFRESH_TOKEN_AUTH, GetTokensFromRefreshToken, RevokeToken, DescribeUserPoolClient) and decode the issued JWTs to assert claim presence, family stability, per-token jti uniqueness, and revocation behavior.

## Checklist

- [x] ./mvnw test passes locally — full Cognito suite 234 + 10 new = green (run under JDK 26 with -Denforcer.skip=true, as no JDK 25 is installed locally; CI on JDK 25 is authoritative)
- [x] New or updated integration test added — OriginJtiIntegrationTest (12 tests)
- [x] Commit messages follow Conventional Commits — feat: emit jti/origin_jti and support RevokeToken
