### PR TITLE
fix(scheduler): forward MessageAttributes in universal sns:publish target

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvoker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvoker.java
@@ -14,6 +14,7 @@ import io.github.hectorvent.floci.services.scheduler.model.EcsParameters;
 import io.github.hectorvent.floci.services.scheduler.model.Target;
 import io.github.hectorvent.floci.services.sns.SnsService;
 import io.github.hectorvent.floci.services.sqs.SqsService;
+import io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -168,8 +169,9 @@ public class ScheduleInvoker {
                 String subject = text(params, "Subject");
                 String messageGroupId = text(params, "MessageGroupId");
                 String messageDeduplicationId = text(params, "MessageDeduplicationId");
+                Map<String, MessageAttributeValue> messageAttributes = parseMessageAttributes(params);
                 String snsRegion = extractRegion(topicArn != null ? topicArn : targetArn, region);
-                snsService.publish(topicArn, targetArn, null, message, subject, null,
+                snsService.publish(topicArn, targetArn, null, message, subject, messageAttributes,
                         messageGroupId, messageDeduplicationId, snsRegion);
                 LOG.debugv("Scheduler delivered to SNS (universal target): {0}", topicArn);
             }
@@ -183,6 +185,20 @@ public class ScheduleInvoker {
             }
             default -> LOG.warnv("Scheduler: unsupported universal target action: {0}", serviceAction);
         }
+    }
+
+    private Map<String, MessageAttributeValue> parseMessageAttributes(JsonNode params) {
+        JsonNode attrsNode = params.path("MessageAttributes");
+        if (!attrsNode.isObject()) {
+            return null;
+        }
+        Map<String, MessageAttributeValue> attributes = new HashMap<>();
+        attrsNode.fields().forEachRemaining(entry -> {
+            String dataType = entry.getValue().path("DataType").asText("String");
+            String stringValue = entry.getValue().path("StringValue").asText(null);
+            attributes.put(entry.getKey(), new MessageAttributeValue(stringValue, dataType));
+        });
+        return attributes.isEmpty() ? null : attributes;
     }
 
     private static String text(JsonNode node, String field) {

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvoker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvoker.java
@@ -12,6 +12,7 @@ import io.github.hectorvent.floci.services.lambda.model.InvocationType;
 import io.github.hectorvent.floci.services.scheduler.model.EventBridgeParameters;
 import io.github.hectorvent.floci.services.scheduler.model.EcsParameters;
 import io.github.hectorvent.floci.services.scheduler.model.Target;
+import io.github.hectorvent.floci.services.sns.SnsMessageAttributes;
 import io.github.hectorvent.floci.services.sns.SnsService;
 import io.github.hectorvent.floci.services.sqs.SqsService;
 import io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue;
@@ -169,7 +170,7 @@ public class ScheduleInvoker {
                 String subject = text(params, "Subject");
                 String messageGroupId = text(params, "MessageGroupId");
                 String messageDeduplicationId = text(params, "MessageDeduplicationId");
-                Map<String, MessageAttributeValue> messageAttributes = parseMessageAttributes(params);
+                Map<String, MessageAttributeValue> messageAttributes = SnsMessageAttributes.parse(params.path("MessageAttributes"));
                 String snsRegion = extractRegion(topicArn != null ? topicArn : targetArn, region);
                 snsService.publish(topicArn, targetArn, null, message, subject, messageAttributes,
                         messageGroupId, messageDeduplicationId, snsRegion);
@@ -185,20 +186,6 @@ public class ScheduleInvoker {
             }
             default -> LOG.warnv("Scheduler: unsupported universal target action: {0}", serviceAction);
         }
-    }
-
-    private Map<String, MessageAttributeValue> parseMessageAttributes(JsonNode params) {
-        JsonNode attrsNode = params.path("MessageAttributes");
-        if (!attrsNode.isObject()) {
-            return null;
-        }
-        Map<String, MessageAttributeValue> attributes = new HashMap<>();
-        attrsNode.fields().forEachRemaining(entry -> {
-            String dataType = entry.getValue().path("DataType").asText("String");
-            String stringValue = entry.getValue().path("StringValue").asText(null);
-            attributes.put(entry.getKey(), new MessageAttributeValue(stringValue, dataType));
-        });
-        return attributes.isEmpty() ? null : attributes;
     }
 
     private static String text(JsonNode node, String field) {

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsJsonHandler.java
@@ -171,7 +171,7 @@ public class SnsJsonHandler {
         String subject = request.path("Subject").asText(null);
         String messageStructure = request.path("MessageStructure").asText(null);
 
-        Map<String, MessageAttributeValue> attributes = parseMessageAttributes(request.path("MessageAttributes"));
+        Map<String, MessageAttributeValue> attributes = SnsMessageAttributes.parse(request.path("MessageAttributes"));
 
         String messageId = snsService.publish(topicArn, targetArn, phoneNumber, message, subject,
                 messageStructure, attributes, null, null, region);
@@ -239,7 +239,7 @@ public class SnsJsonHandler {
                 JsonNode attrsNode = entryNode.path("MessageAttributes");
                 if (attrsNode.isObject()) {
                     try {
-                        entry.put("MessageAttributes", parseMessageAttributes(attrsNode));
+                        entry.put("MessageAttributes", SnsMessageAttributes.parse(attrsNode));
                     } catch (AwsException e) {
                         // Real AWS SNS surfaces per-entry attribute errors as Failed entries
                         // and keeps processing the rest of the batch, instead of aborting.
@@ -315,32 +315,6 @@ public class SnsJsonHandler {
         return node;
     }
 
-    private Map<String, MessageAttributeValue> parseMessageAttributes(JsonNode attrsNode) {
-        Map<String, MessageAttributeValue> attributes = new HashMap<>();
-        if (!attrsNode.isObject()) {
-            return attributes;
-        }
-        attrsNode.fields().forEachRemaining(entry -> {
-            JsonNode valueNode = entry.getValue();
-            String binaryValueBase64 = valueNode.path("BinaryValue").asText(null);
-            String defaultDataType = binaryValueBase64 != null ? "Binary" : "String";
-            String dataType = valueNode.path("DataType").asText(defaultDataType);
-            if (binaryValueBase64 != null) {
-                byte[] binaryValue;
-                try {
-                    binaryValue = Base64.getDecoder().decode(binaryValueBase64);
-                } catch (IllegalArgumentException e) {
-                    throw new AwsException("InvalidParameterValue",
-                            "Invalid binary value for message attribute '" + entry.getKey() + "': not valid base64.", 400);
-                }
-                attributes.put(entry.getKey(), new MessageAttributeValue(binaryValue, dataType));
-            } else {
-                String stringValue = valueNode.path("StringValue").asText();
-                attributes.put(entry.getKey(), new MessageAttributeValue(stringValue, dataType));
-            }
-        });
-        return attributes;
-    }
 
     private Response handleCreatePlatformApplication(JsonNode request, String region) {
         String name = request.path("Name").asText(null);

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsMessageAttributes.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsMessageAttributes.java
@@ -1,0 +1,41 @@
+package io.github.hectorvent.floci.services.sns;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class SnsMessageAttributes {
+
+    private SnsMessageAttributes() {}
+
+    public static Map<String, MessageAttributeValue> parse(JsonNode attrsNode) {
+        Map<String, MessageAttributeValue> attributes = new HashMap<>();
+        if (!attrsNode.isObject()) {
+            return attributes;
+        }
+        attrsNode.fields().forEachRemaining(entry -> {
+            JsonNode valueNode = entry.getValue();
+            String binaryValueBase64 = valueNode.path("BinaryValue").asText(null);
+            String defaultDataType = binaryValueBase64 != null ? "Binary" : "String";
+            String dataType = valueNode.path("DataType").asText(defaultDataType);
+            if (binaryValueBase64 != null) {
+                byte[] binaryValue;
+                try {
+                    binaryValue = Base64.getDecoder().decode(binaryValueBase64);
+                } catch (IllegalArgumentException e) {
+                    throw new AwsException("InvalidParameterValue",
+                            "Invalid binary value for message attribute '" + entry.getKey() + "': not valid base64.", 400);
+                }
+                attributes.put(entry.getKey(), new MessageAttributeValue(binaryValue, dataType));
+            } else {
+                String stringValue = valueNode.path("StringValue").asText();
+                attributes.put(entry.getKey(), new MessageAttributeValue(stringValue, dataType));
+            }
+        });
+        return attributes;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvokerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvokerTest.java
@@ -15,6 +15,7 @@ import io.github.hectorvent.floci.services.scheduler.model.SqsParameters;
 import io.github.hectorvent.floci.services.scheduler.model.Target;
 import io.github.hectorvent.floci.services.sns.SnsService;
 import io.github.hectorvent.floci.services.sqs.SqsService;
+import io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -28,6 +29,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -55,6 +57,45 @@ class ScheduleInvokerTest {
         when(config.baseUrl()).thenReturn("http://localhost:4566");
         invoker = new ScheduleInvoker(sqsService, lambdaService, snsService,
                 eventBridgeService, ecsService, new ObjectMapper(), config);
+    }
+
+    @Test
+    void universalSnsPublishForwardsMessageAttributes() {
+        Target target = new Target();
+        target.setArn("arn:aws:scheduler:::aws-sdk:sns:publish");
+        target.setRoleArn("arn:aws:iam::000000000000:role/x");
+        target.setInput("{\"TopicArn\":\"" + TOPIC_ARN + "\","
+                + "\"Message\":\"{}\","
+                + "\"Subject\":\"my-subject\","
+                + "\"MessageAttributes\":{"
+                + "\"EventName\":{\"DataType\":\"String\",\"StringValue\":\"my-subject\"}"
+                + "}}");
+
+        invoker.invoke(target, "us-east-1");
+
+        verify(snsService).publish(
+                eq(TOPIC_ARN), isNull(), isNull(),
+                eq("{}"), eq("my-subject"),
+                argThat((Map<String, MessageAttributeValue> attrs) ->
+                        attrs != null
+                        && attrs.containsKey("EventName")
+                        && "my-subject".equals(attrs.get("EventName").getStringValue())
+                        && "String".equals(attrs.get("EventName").getDataType())),
+                isNull(), isNull(), eq("us-east-1"));
+    }
+
+    @Test
+    void universalSnsPublishWithNoMessageAttributesPassesNull() {
+        Target target = new Target();
+        target.setArn("arn:aws:scheduler:::aws-sdk:sns:publish");
+        target.setRoleArn("arn:aws:iam::000000000000:role/x");
+        target.setInput("{\"TopicArn\":\"" + TOPIC_ARN + "\",\"Message\":\"hello\"}");
+
+        invoker.invoke(target, "us-east-1");
+
+        verify(snsService).publish(eq(TOPIC_ARN), isNull(), isNull(),
+                eq("hello"), isNull(), isNull(),
+                isNull(), isNull(), eq("us-east-1"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvokerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvokerTest.java
@@ -85,7 +85,32 @@ class ScheduleInvokerTest {
     }
 
     @Test
-    void universalSnsPublishWithNoMessageAttributesPassesNull() {
+    void universalSnsPublishForwardsBinaryMessageAttributes() {
+        Target target = new Target();
+        target.setArn("arn:aws:scheduler:::aws-sdk:sns:publish");
+        target.setRoleArn("arn:aws:iam::000000000000:role/x");
+        // "aGVsbG8=" is base64 for "hello"
+        target.setInput("{\"TopicArn\":\"" + TOPIC_ARN + "\","
+                + "\"Message\":\"payload\","
+                + "\"MessageAttributes\":{"
+                + "\"BinAttr\":{\"DataType\":\"Binary\",\"BinaryValue\":\"aGVsbG8=\"}"
+                + "}}");
+
+        invoker.invoke(target, "us-east-1");
+
+        verify(snsService).publish(
+                eq(TOPIC_ARN), isNull(), isNull(),
+                eq("payload"), isNull(),
+                argThat((Map<String, MessageAttributeValue> attrs) ->
+                        attrs != null
+                        && attrs.containsKey("BinAttr")
+                        && "Binary".equals(attrs.get("BinAttr").getDataType())
+                        && java.util.Arrays.equals("hello".getBytes(), attrs.get("BinAttr").getBinaryValue())),
+                isNull(), isNull(), eq("us-east-1"));
+    }
+
+    @Test
+    void universalSnsPublishWithNoMessageAttributesPassesNullOrEmpty() {
         Target target = new Target();
         target.setArn("arn:aws:scheduler:::aws-sdk:sns:publish");
         target.setRoleArn("arn:aws:iam::000000000000:role/x");
@@ -94,7 +119,8 @@ class ScheduleInvokerTest {
         invoker.invoke(target, "us-east-1");
 
         verify(snsService).publish(eq(TOPIC_ARN), isNull(), isNull(),
-                eq("hello"), isNull(), isNull(),
+                eq("hello"), isNull(),
+                argThat(attrs -> attrs == null || attrs.isEmpty()),
                 isNull(), isNull(), eq("us-east-1"));
     }
 
@@ -109,7 +135,8 @@ class ScheduleInvokerTest {
 
         // The real TopicArn from Input must be used, NOT the universal-target ARN.
         verify(snsService).publish(eq(TOPIC_ARN), isNull(), isNull(),
-                eq("scheduled-universal-target"), isNull(), isNull(),
+                eq("scheduled-universal-target"), isNull(),
+                argThat(attrs -> attrs == null || attrs.isEmpty()),
                 isNull(), isNull(), eq("us-east-1"));
         verify(snsService, never()).publish(eq("arn:aws:scheduler:::aws-sdk:sns:publish"),
                 any(), any(), any(), any());


### PR DESCRIPTION
## Summary

Fixes #1669.

When a schedule fires with a universal `arn:aws:scheduler:::aws-sdk:sns:publish` target, `MessageAttributes` supplied in the target `Input` were silently dropped. The message was delivered with the correct `Subject` and `Message`, but subscribers received an empty attribute map — breaking any SQS subscription with a `FilterPolicy` that matches on `MessageAttributes`.

The root cause: `invokeUniversalTarget` parsed `TopicArn`, `Message`, `Subject`, and FIFO parameters from `Input` but never read `MessageAttributes`, hardcoding `null` when calling `SnsService.publish`. A direct `sns:Publish` API call preserved attributes correctly, confirming the loss was specific to the scheduler's universal-target path.

The fix reads `MessageAttributes` from `Input` using the same `DataType`/`StringValue` per-entry format that `SnsJsonHandler` uses for direct publish calls, then forwards them through to `SnsService.publish`.

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

AWS EventBridge Scheduler universal targets pass `MessageAttributes` through to SNS on publish. Subscribers with `FilterPolicy` scoped to `MessageAttributes` receive messages as expected. This change aligns the emulator with that behavior.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)