### PR TITLE
fix(ec2): return groupSet from DescribeInstanceAttribute

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2InstanceResponseShapeTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2InstanceResponseShapeTest.java
@@ -299,6 +299,44 @@ class Ec2InstanceResponseShapeTest {
                 .isTrue();
     }
 
+    // ── Security groups (issue #1644) ────────────────────────────────────────
+
+    @Test
+    @Order(17)
+    @DisplayName("instance and primary ENI expose security groups")
+    void securityGroupsOnInstanceAndEni() {
+        assertThat(instance.securityGroups())
+                .as("instance securityGroups must not be empty")
+                .isNotEmpty();
+        assertThat(instance.securityGroups().get(0).groupId()).isNotBlank();
+        assertThat(instance.securityGroups().get(0).groupName()).isNotBlank();
+
+        InstanceNetworkInterface primaryEni = instance.networkInterfaces().get(0);
+        assertThat(primaryEni.groups())
+                .as("primary ENI groups must not be empty")
+                .isNotEmpty();
+        assertThat(primaryEni.groups().get(0).groupId()).isNotBlank();
+    }
+
+    @Test
+    @Order(18)
+    @DisplayName("DescribeInstanceAttribute groupSet returns Groups (Ansible ec2_instance path)")
+    void describeInstanceAttributeGroupSet() {
+        DescribeInstanceAttributeResponse attr = ec2.describeInstanceAttribute(
+                DescribeInstanceAttributeRequest.builder()
+                        .instanceId(instanceId)
+                        .attribute(InstanceAttributeName.GROUP_SET)
+                        .build());
+
+        assertThat(attr.instanceId()).isEqualTo(instanceId);
+        assertThat(attr.groups())
+                .as("groupSet attribute must return the instance security groups"
+                        + " — amazon.aws ec2_instance reads value['Groups'] from this call")
+                .isNotEmpty();
+        assertThat(attr.groups().get(0).groupId()).isNotBlank();
+        assertThat(attr.groups().get(0).groupName()).isNotBlank();
+    }
+
     // ── TerminateInstances state transitions ─────────────────────────────────
 
     @Test

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -601,6 +601,15 @@ public class Ec2QueryHandler {
             xml.start("disableApiStop").elem("value", String.valueOf(inst.isDisableApiStop())).end("disableApiStop");
         } else if ("disableApiTermination".equals(attribute)) {
             xml.start("disableApiTermination").elem("value", String.valueOf(inst.isDisableApiTermination())).end("disableApiTermination");
+        } else if ("groupSet".equals(attribute)) {
+            xml.start("groupSet");
+            for (GroupIdentifier gi : inst.getSecurityGroups()) {
+                xml.start("item")
+                        .elem("groupId", gi.getGroupId())
+                        .elem("groupName", gi.getGroupName())
+                        .end("item");
+            }
+            xml.end("groupSet");
         }
         xml.end("DescribeInstanceAttributeResponse");
         return xmlResponse(xml.build());

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.ec2;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThan;
@@ -1328,6 +1329,23 @@ class Ec2IntegrationTest {
                     equalTo(instanceId))
             .body("DescribeInstancesResponse.reservationSet.item.instancesSet.item.instanceState.name",
                     equalTo("running"));
+    }
+
+    @Test
+    @Order(81)
+    void describeInstanceAttributeGroupSet() {
+        given()
+            .formParam("Action", "DescribeInstanceAttribute")
+            .formParam("InstanceId", instanceId)
+            .formParam("Attribute", "groupSet")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeInstanceAttributeResponse.instanceId", equalTo(instanceId))
+            .body("DescribeInstanceAttributeResponse.groupSet.item.groupId", equalTo(securityGroupId))
+            .body("DescribeInstanceAttributeResponse.groupSet.item.groupName", not(emptyOrNullString()));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -1332,7 +1332,7 @@ class Ec2IntegrationTest {
     }
 
     @Test
-    @Order(81)
+    @Order(87)
     void describeInstanceAttributeGroupSet() {
         given()
             .formParam("Action", "DescribeInstanceAttribute")
@@ -1453,7 +1453,7 @@ class Ec2IntegrationTest {
     }
 
     @Test
-    @Order(87)
+    @Order(88)
     void describeInstancesByFilter() {
         given()
             .formParam("Action", "DescribeInstances")


### PR DESCRIPTION
## Summary

Closes #1644.

The issue reports Ansible's `amazon.aws.ec2_instance` failing with `KeyError: 'Groups'` and points at DescribeInstances. Investigation showed DescribeInstances already returns instance-level `groupSet` and `networkInterfaceSet[].groupSet` (since #213/#883). The module's actual failing call (ec2_instance.py `diff_instance_and_params`) is `DescribeInstanceAttribute` with `Attribute=groupSet`, for which Floci returned only `instanceId` — no `groupSet` element, so boto3 yields no `Groups` key. This adds the missing `groupSet` branch, reusing the instance's stored security group identifiers (id + resolved name).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against botocore ec2/2016-11-15: `InstanceAttribute.Groups`
serializes as `groupSet`, a list of `GroupIdentifier` items with
`groupId`/`groupName`. The Ansible module's other attribute queries
(`instanceType`, `ebsOptimized`, `disableApiTermination`) were already
supported. Also adds DescribeInstances coverage for `SecurityGroups` and
`NetworkInterfaces[].Groups` (typed SDK assertions), closing the coverage
gap that let the issue's original diagnosis go unverified.

## Checklist

- [x] `./mvnw test` passes locally (Ec2IntegrationTest 129/129; full suite not run)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
