### PR TITLE
fix(docker): enable TLS and sync docker test runner with compatibility workflow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ services:
       # TLS proxy serves HTTP and HTTPS on the same port 4566 (first-byte sniffing),
       # so no extra port mapping is needed — this is what makes the TLS/HTTPS suites pass.
       FLOCI_TLS_ENABLED: "true"
-      FLOCI_SERVICES_EC2_MOCK: "true"
     networks:
       floci_default:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,12 @@ services:
       FLOCI_HOSTNAME: floci
       FLOCI_BASE_URL: http://floci:4566
       FLOCI_SERVICES_LAMBDA_HOT_RELOAD_ENABLED: "true"
+      # Match the compatibility workflow (.github/workflows/compatibility.yml) so the
+      # local Docker test run exercises the same Floci configuration as CI.
+      # TLS proxy serves HTTP and HTTPS on the same port 4566 (first-byte sniffing),
+      # so no extra port mapping is needed — this is what makes the TLS/HTTPS suites pass.
+      FLOCI_TLS_ENABLED: "true"
+      FLOCI_SERVICES_EC2_MOCK: "true"
     networks:
       floci_default:
         aliases:

--- a/docker/run-docker-tests.sh
+++ b/docker/run-docker-tests.sh
@@ -63,6 +63,15 @@ for suite in "${SUITES[@]}"; do
     DNS_ARGS=(--dns "$FLOCI_IP")
   fi
 
+  # Per-suite extra args, mirroring .github/workflows/compatibility.yml.
+  # sdk-test-java's Lambda hot-reload test needs a host directory that the Docker
+  # daemon can bind-mount into the hot-reload Lambda container.
+  EXTRA_ARGS=()
+  if [ "$suite" = "sdk-test-java" ]; then
+    mkdir -p /tmp/floci-hot-reload
+    EXTRA_ARGS=(-v /tmp/floci-hot-reload:/tmp/floci-hot-reload -e HOT_RELOAD_BASE_DIR=/tmp/floci-hot-reload)
+  fi
+
   # Run
   docker run --rm --network "$NETWORK" \
     "${DNS_ARGS[@]}" \
@@ -71,6 +80,7 @@ for suite in "${SUITES[@]}"; do
     -v "$(pwd)/test-results:/results" \
     -v /var/run/docker.sock:/var/run/docker.sock \
     --group-add "$DOCKER_GID" \
+    "${EXTRA_ARGS[@]}" \
     "$IMAGE_NAME" || echo "Test suite $suite failed"
 done
 


### PR DESCRIPTION
## Summary

The local Docker test environment (`docker-compose.yml` + `docker/run-docker-tests.sh`) drifted from `.github/workflows/compatibility.yml`: the compose stack ran without `FLOCI_TLS_ENABLED`, and the runner lacked the hot-reload bind mount `sdk-test-java` needs. This made the node TLS/WSS suites (14 tests) and the Java Lambda hot-reload tests (2 tests) fail locally while passing in CI. This syncs the local setup with the workflow so local compat runs exercise the same Floci configuration as CI.

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

No wire-protocol changes; this is local test environment configuration only. Incorrect behavior: local compat runs reported failures that were environment drift, not product bugs.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added — n/a, config/script only; validated by full local compat runs (all 8 suites green after the change)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
