### PR TITLE
fix(ecr): advertise published host port when adopting registry container

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
@@ -255,21 +255,25 @@ public class ContainerLifecycleManager {
         }
 
         Map<Integer, EndpointInfo> endpoints = new HashMap<>();
+        Map<Integer, Integer> publishedHostPorts = new HashMap<>();
         for (int port : ports) {
             endpoints.put(port, resolveEndpoint(inspect, port));
+            OptionalInt published = readPublishedHostPort(inspect, port);
+            if (published.isPresent()) {
+                publishedHostPorts.put(port, published.getAsInt());
+            }
         }
 
-        return new ContainerInfo(containerId, endpoints);
+        return new ContainerInfo(containerId, endpoints, publishedHostPorts);
     }
 
     /**
-     * Returns the host port a container's internal port is published on, independent of
-     * whether Floci itself runs inside a container. Unlike {@code adopt}'s endpoints —
-     * which switch to container-IP + internal port in container mode — this always reads
-     * the port binding, for URIs consumed by the host-side Docker daemon.
+     * Reads the host port a container's internal port is published on, independent of
+     * whether Floci itself runs inside a container. Unlike {@link #resolveEndpoint} —
+     * which switches to container-IP + internal port in container mode — this always
+     * reads the port binding, for URIs consumed by the host-side Docker daemon.
      */
-    public OptionalInt publishedHostPort(String containerId, int containerPort) {
-        InspectContainerResponse inspect = dockerClient.inspectContainerCmd(containerId).exec();
+    private static OptionalInt readPublishedHostPort(InspectContainerResponse inspect, int containerPort) {
         Ports ports = inspect.getNetworkSettings().getPorts();
         if (ports != null) {
             Ports.Binding[] binding = ports.getBindings().get(ExposedPort.tcp(containerPort));
@@ -522,16 +526,32 @@ public class ContainerLifecycleManager {
      *
      * @param containerId the Docker container ID
      * @param endpoints map of container port to resolved endpoint (host:port for connection)
+     * @param publishedHostPorts map of container port to the host port it is published on;
+     *                           a port without a binding is absent
      */
     public record ContainerInfo(
             String containerId,
-            Map<Integer, EndpointInfo> endpoints
+            Map<Integer, EndpointInfo> endpoints,
+            Map<Integer, Integer> publishedHostPorts
     ) {
+        public ContainerInfo(String containerId, Map<Integer, EndpointInfo> endpoints) {
+            this(containerId, endpoints, Map.of());
+        }
+
         /**
          * Gets the endpoint for a specific container port.
          */
         public EndpointInfo getEndpoint(int containerPort) {
             return endpoints.get(containerPort);
+        }
+
+        /**
+         * Gets the host port a container port is published on, regardless of whether
+         * Floci itself runs inside a container. Empty when the port has no binding.
+         */
+        public OptionalInt publishedHostPort(int containerPort) {
+            Integer published = publishedHostPorts.get(containerPort);
+            return published != null ? OptionalInt.of(published) : OptionalInt.empty();
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 /**
  * Manages Docker container lifecycle operations including create, start, stop, and remove.
@@ -259,6 +260,27 @@ public class ContainerLifecycleManager {
         }
 
         return new ContainerInfo(containerId, endpoints);
+    }
+
+    /**
+     * Returns the host port a container's internal port is published on, independent of
+     * whether Floci itself runs inside a container. Unlike {@code adopt}'s endpoints —
+     * which switch to container-IP + internal port in container mode — this always reads
+     * the port binding, for URIs consumed by the host-side Docker daemon.
+     */
+    public OptionalInt publishedHostPort(String containerId, int containerPort) {
+        InspectContainerResponse inspect = dockerClient.inspectContainerCmd(containerId).exec();
+        Ports ports = inspect.getNetworkSettings().getPorts();
+        if (ports != null) {
+            Ports.Binding[] binding = ports.getBindings().get(ExposedPort.tcp(containerPort));
+            if (binding != null && binding.length > 0) {
+                try {
+                    return OptionalInt.of(Integer.parseInt(binding[0].getHostPortSpec()));
+                } catch (NumberFormatException ignored) {
+                }
+            }
+        }
+        return OptionalInt.empty();
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManager.java
@@ -336,11 +336,11 @@ public class EcrRegistryManager {
     private void adoptExisting(Container existing) {
         this.containerId = existing.getId();
         try {
-            lifecycleManager.adopt(containerId, List.of(CONTAINER_INTERNAL_PORT));
+            ContainerInfo info = lifecycleManager.adopt(containerId, List.of(CONTAINER_INTERNAL_PORT));
             // getRepositoryUri/getProxyEndpoint are consumed by the host-side docker
             // daemon, so hostPort must be the published binding — adopt's endpoint
             // resolves to the container-internal port when Floci runs inside Docker.
-            var published = lifecycleManager.publishedHostPort(containerId, CONTAINER_INTERNAL_PORT);
+            var published = info.publishedHostPort(CONTAINER_INTERNAL_PORT);
             if (published.isPresent()) {
                 this.hostPort = published.getAsInt();
             } else {

--- a/src/main/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManager.java
@@ -336,10 +336,16 @@ public class EcrRegistryManager {
     private void adoptExisting(Container existing) {
         this.containerId = existing.getId();
         try {
-            ContainerInfo info = lifecycleManager.adopt(containerId, List.of(CONTAINER_INTERNAL_PORT));
-            var endpoint = info.getEndpoint(CONTAINER_INTERNAL_PORT);
-            if (endpoint != null) {
-                this.hostPort = endpoint.port();
+            lifecycleManager.adopt(containerId, List.of(CONTAINER_INTERNAL_PORT));
+            // getRepositoryUri/getProxyEndpoint are consumed by the host-side docker
+            // daemon, so hostPort must be the published binding — adopt's endpoint
+            // resolves to the container-internal port when Floci runs inside Docker.
+            var published = lifecycleManager.publishedHostPort(containerId, CONTAINER_INTERNAL_PORT);
+            if (published.isPresent()) {
+                this.hostPort = published.getAsInt();
+            } else {
+                LOG.warnv("Adopted ECR registry container {0} has no published binding for port {1}; keeping configured port {2}",
+                        containerId, String.valueOf(CONTAINER_INTERNAL_PORT), String.valueOf(hostPort));
             }
             this.started = true;
             LOG.infov("Adopted existing ECR registry container {0} on host port {1}",

--- a/src/test/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManagerTest.java
@@ -17,7 +17,6 @@ import org.mockito.Mockito;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalInt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -116,9 +115,8 @@ class EcrRegistryManagerTest {
         when(lifecycleManager.findByName(REGISTRY_NAME)).thenReturn(Optional.of(existing));
         when(lifecycleManager.adopt("0123456789abcdef", List.of(5000)))
                 .thenReturn(new ContainerLifecycleManager.ContainerInfo("0123456789abcdef",
-                        Map.of(5000, new ContainerLifecycleManager.EndpointInfo("172.17.0.5", 5000))));
-        when(lifecycleManager.publishedHostPort("0123456789abcdef", 5000))
-                .thenReturn(OptionalInt.of(BASE_PORT + 1));
+                        Map.of(5000, new ContainerLifecycleManager.EndpointInfo("172.17.0.5", 5000)),
+                        Map.of(5000, BASE_PORT + 1)));
 
         manager.ensureStarted();
 
@@ -133,8 +131,6 @@ class EcrRegistryManagerTest {
         when(lifecycleManager.findByName(REGISTRY_NAME)).thenReturn(Optional.of(existing));
         when(lifecycleManager.adopt("0123456789abcdef", List.of(5000)))
                 .thenReturn(new ContainerLifecycleManager.ContainerInfo("0123456789abcdef", Map.of()));
-        when(lifecycleManager.publishedHostPort("0123456789abcdef", 5000))
-                .thenReturn(OptionalInt.empty());
 
         manager.ensureStarted();
 

--- a/src/test/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManagerTest.java
@@ -9,11 +9,15 @@ import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.CurrentContainerNetworkResolver;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
 import io.github.hectorvent.floci.core.common.docker.PortAllocator;
+import com.github.dockerjava.api.model.Container;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -99,5 +103,41 @@ class EcrRegistryManagerTest {
         when(containerDetector.isRunningInContainer()).thenReturn(true);
 
         assertEquals("http://" + REGISTRY_NAME + ":5000", manager.httpClient().baseUrl());
+    }
+
+    @Test
+    void adoptUsesPublishedHostPortEvenWhenRunningInsideDocker() {
+        // Regression: in container mode adopt()'s endpoint resolves to the registry's
+        // internal port (5000); the advertised proxy endpoint must use the published
+        // host binding instead, or docker login from the host daemon fails.
+        when(containerDetector.isRunningInContainer()).thenReturn(true);
+        Container existing = Mockito.mock(Container.class);
+        when(existing.getId()).thenReturn("0123456789abcdef");
+        when(lifecycleManager.findByName(REGISTRY_NAME)).thenReturn(Optional.of(existing));
+        when(lifecycleManager.adopt("0123456789abcdef", List.of(5000)))
+                .thenReturn(new ContainerLifecycleManager.ContainerInfo("0123456789abcdef",
+                        Map.of(5000, new ContainerLifecycleManager.EndpointInfo("172.17.0.5", 5000))));
+        when(lifecycleManager.publishedHostPort("0123456789abcdef", 5000))
+                .thenReturn(OptionalInt.of(BASE_PORT + 1));
+
+        manager.ensureStarted();
+
+        assertEquals(BASE_PORT + 1, manager.effectivePort());
+        assertEquals("http://localhost:" + (BASE_PORT + 1), manager.getProxyEndpoint());
+    }
+
+    @Test
+    void adoptKeepsConfiguredPortWhenNoPublishedBindingExists() {
+        Container existing = Mockito.mock(Container.class);
+        when(existing.getId()).thenReturn("0123456789abcdef");
+        when(lifecycleManager.findByName(REGISTRY_NAME)).thenReturn(Optional.of(existing));
+        when(lifecycleManager.adopt("0123456789abcdef", List.of(5000)))
+                .thenReturn(new ContainerLifecycleManager.ContainerInfo("0123456789abcdef", Map.of()));
+        when(lifecycleManager.publishedHostPort("0123456789abcdef", 5000))
+                .thenReturn(OptionalInt.empty());
+
+        manager.ensureStarted();
+
+        assertEquals(BASE_PORT, manager.effectivePort());
     }
 }


### PR DESCRIPTION
## Summary

Adopting an existing ECR registry container while Floci itself runs inside Docker advertised the registry's internal port (5000) instead of the published host binding (e.g. 5100) in `GetAuthorizationToken`'s proxy endpoint and repository URIs. Since those URIs are consumed by the host-side Docker daemon, `docker login`/`docker push` against the advertised endpoint failed.

Adds `ContainerLifecycleManager.publishedHostPort()`, which always reads the host-side port binding regardless of whether Floci is containerized, and uses it in `EcrRegistryManager.adoptExisting()`. When no published binding exists, the configured port is kept and a warning is logged.

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

For bug fixes: the ECR proxy endpoint / repository URI pointed at an unreachable port after container adoption, breaking real `docker login` against the emulated registry. Reproduced and verified end to end by the `compat-cdk` suite (CDK asset publishing), which failed before this change and passes after (the adoption log shows the published port 5100).

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (`EcrRegistryManagerTest`: adoption uses the published binding in container mode; falls back to the configured port when no binding exists)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
