### PR TITLE
docs: correct service count to 68 and add missing IoT and S3 Vectors entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ LocalStack's community edition [sunset in March 2026](https://blog.localstack.cl
 | CodeBuild | Real Docker execution | No |
 | Native binary | ~40 MB | No |
 
-**66 AWS services. Broad coverage. Free forever.**
+**68 AWS services. Broad coverage. Free forever.**
 
 ## Architecture Overview
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Floci is a fast, free, and open-source local AWS service emulator built for deve
 
 ## Supported Services
 
-Floci emulates 66 AWS services. See the [Services Overview](services/index.md) for per-service operation counts, endpoints, and full protocol details.
+Floci emulates 68 AWS services. See the [Services Overview](services/index.md) for per-service operation counts, endpoints, and full protocol details.
 
 | Service | Protocol |
 |---|---|
@@ -110,7 +110,7 @@ docker compose up -d
 aws --endpoint-url http://localhost:4566 s3 mb s3://my-bucket
 ```
 
-All 66 AWS services are immediately available at `http://localhost:4566`.
+All 68 AWS services are immediately available at `http://localhost:4566`.
 
 [Get started →](getting-started/quick-start.md){ .md-button .md-button--primary }
 [View services →](services/index.md){ .md-button }

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -1,6 +1,6 @@
 # Services Overview
 
-Floci emulates 66 AWS services on a single port (`4566`). All services use the real AWS wire protocol, your existing AWS CLI commands and SDK clients work without modification.
+Floci emulates 68 AWS services on a single port (`4566`). All services use the real AWS wire protocol, your existing AWS CLI commands and SDK clients work without modification.
 
 This page is the canonical reference for supported service and operation counts. Some services expose separate control-plane and data-plane rows below. Other docs (and the README) should link here rather than duplicating the table.
 
@@ -14,6 +14,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [SQS](sqs.md) | `POST /` with `Action=` param | Query / JSON | 20 |
 | [SNS](sns.md) | `POST /` with `Action=` param | Query / JSON | 17 |
 | [S3](s3.md) | `/{bucket}/{key}` | REST XML | 58 |
+| [S3 Vectors](s3vectors.md) | `POST /{OperationName}` | REST JSON | 12 |
 | [DynamoDB](dynamodb.md) | `POST /` + `X-Amz-Target: DynamoDB_20120810.*` | JSON 1.1 | 28 |
 | [DynamoDB Streams](dynamodb.md#streams) | `POST /` + `X-Amz-Target: DynamoDBStreams_20120810.*` | JSON 1.1 | 4 |
 | [Lambda](lambda.md) | `/2015-03-31/functions/...` | REST JSON | 30 |
@@ -78,6 +79,8 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [Cost and Usage Reports](cur.md) | `POST /` + `X-Amz-Target: AWSOrigamiServiceGatewayService.*` | JSON 1.1 | 6 |
 | [BCM Data Exports](bcm-data-exports.md) | `POST /` + `X-Amz-Target: AWSBillingAndCostManagementDataExports.*` | JSON 1.1 | 7 |
 | [Transfer Family](transfer.md) | `POST /` + `X-Amz-Target: TransferService.*` | JSON 1.1 | 17 |
+| [IoT Core](iot.md) | `/things/...`, `/endpoint`, rules/policies REST paths | REST JSON | 62 |
+| [IoT Data](iot.md) | `/things/{thingName}/shadow`, MQTT topics | REST JSON | 11 |
 
 **Lambda, ElastiCache, RDS, MSK, ECS, EKS, and OpenSearch** spin up real Docker containers and support IAM authentication and SigV4 request signing, the same auth flow as production AWS. **RDS Data API** executes SQL against the local RDS containers through AWS-compatible REST JSON routes.
 

--- a/docs/services/s3vectors.md
+++ b/docs/services/s3vectors.md
@@ -1,0 +1,36 @@
+# S3 Vectors
+
+**Protocol:** REST JSON
+**Endpoint:** `POST /{OperationName}` (e.g. `POST /CreateVectorBucket`)
+
+Floci emulates the S3 Vectors API: vector buckets, vector indexes, and vector
+storage with similarity queries. All operations use the AWS REST JSON wire
+shape, so the AWS SDK and CLI `s3vectors` clients work without modification.
+
+## Supported Operations
+
+| Category | Operations |
+|---|---|
+| **Vector buckets** | CreateVectorBucket, GetVectorBucket, ListVectorBuckets, DeleteVectorBucket |
+| **Indexes** | CreateIndex, GetIndex, ListIndexes, DeleteIndex |
+| **Vectors** | PutVectors, GetVectors, DeleteVectors, QueryVectors |
+
+## Example
+
+```bash
+aws s3vectors create-vector-bucket --vector-bucket-name my-vectors \
+  --endpoint-url http://localhost:4566
+
+aws s3vectors create-index --vector-bucket-name my-vectors \
+  --index-name embeddings --dimension 4 --distance-metric cosine \
+  --data-type float32 \
+  --endpoint-url http://localhost:4566
+
+aws s3vectors put-vectors --vector-bucket-name my-vectors --index-name embeddings \
+  --vectors '[{"key":"a","data":{"float32":[0.1,0.2,0.3,0.4]}}]' \
+  --endpoint-url http://localhost:4566
+
+aws s3vectors query-vectors --vector-bucket-name my-vectors --index-name embeddings \
+  --query-vector '{"float32":[0.1,0.2,0.3,0.4]}' --top-k 1 \
+  --endpoint-url http://localhost:4566
+```


### PR DESCRIPTION
## Summary

The documented service count stayed at 66 while the catalog grew to 68 status-visible services: S3 Vectors (#1435) and IoT Core / IoT Data (#1359) merged without rows in the services matrix, so the Amazon MQ count bump (#1642) was applied to an already stale number.

This audit-driven fix:

- adds the three missing matrix rows in `docs/services/index.md`: S3 Vectors (12 operations), IoT Core (62), IoT Data (11), linking the existing `iot.md` page that was orphaned;
- creates `docs/services/s3vectors.md`, the only service that had no documentation page at all;
- updates the count to **68** in the README, `docs/index.md` (both occurrences), and `docs/services/index.md`.

68 is the catalog's status-visible service count (70 descriptors minus the intentionally hidden `sts` and `ec2messages`), counting IoT Core and IoT Data separately per the AppConfig/AppConfigData precedent.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

Docs only, no wire-protocol change. Operation counts for the new rows were taken from the controllers (`S3VectorsController`: 12 operations, `IotController`: 62, `IotDataController`: 11).

## Checklist

- [x] `./mvnw test` passes locally (docs-only change, no code touched)
- [x] New or updated integration test added <!-- not applicable: documentation-only change -->
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
