### PR TITLE
fix(lambda): return a downloadable GetFunction Code.Location

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -24,6 +24,8 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriInfo;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
@@ -79,6 +81,7 @@ public class LambdaController {
     @GET
     @Path("/functions/{functionName}")
     public Response getFunction(@Context HttpHeaders headers,
+                                @Context UriInfo uriInfo,
                                 @PathParam("functionName") String functionName) {
         String region = regionResolver.resolveRegion(headers);
         LambdaFunction fn = lambdaService.getFunction(region, functionName);
@@ -91,8 +94,13 @@ public class LambdaController {
             code.put("ImageUri", fn.getImageUri());
             code.put("ResolvedImageUri", fn.getImageUri());
         } else {
-            code.put("Location", "https://awslambda-" + region + "-tasks.s3." + region
-                    + ".amazonaws.com/" + fn.getFunctionName());
+            // Path-style URL to the package in Floci's own S3, built from the
+            // request so it targets the same endpoint the client is talking to.
+            String location = UriBuilder.fromUri(uriInfo.getBaseUri())
+                    .path(LambdaService.tasksBucketName(region))
+                    .path(LambdaService.codeObjectKey(fn))
+                    .build().toString();
+            code.put("Location", location);
             code.put("RepositoryType", "S3");
         }
 

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -558,8 +558,9 @@ public class LambdaService {
         if (s3Service != null) {
             try {
                 s3Service.deleteObject(tasksBucketName(region), codeObjectKey(fn));
-            } catch (Exception ignored) {
-                // best-effort cleanup
+            } catch (Exception e) {
+                LOG.warnv("Could not delete deployment package for {0}: {1}",
+                        functionName, e.getMessage());
             }
         }
         LOG.infov("Deleted Lambda function: {0}", functionName);

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -314,7 +314,7 @@ public class LambdaService {
             if (zipFileBase64 != null) {
                 fn.setS3Bucket(null);
                 fn.setS3Key(null);
-                extractZipCode(fn, zipFileBase64);
+                extractZipCode(fn, zipFileBase64, region);
             }
             String s3Bucket = (String) code.get("S3Bucket");
             String s3Key = (String) code.get("S3Key");
@@ -322,7 +322,7 @@ public class LambdaService {
                 if ("hot-reload".equals(s3Bucket)) {
                     applyHotReload(fn, s3Key);
                 } else {
-                    extractZipCodeFromS3(fn, s3Bucket, s3Key);
+                    extractZipCodeFromS3(fn, s3Bucket, s3Key, region);
                 }
             }
         }
@@ -384,7 +384,7 @@ public class LambdaService {
         if (zipFileBase64 != null) {
             fn.setS3Bucket(null);
             fn.setS3Key(null);
-            extractZipCode(fn, zipFileBase64);
+            extractZipCode(fn, zipFileBase64, region);
         }
         if (imageUri != null) {
             fn.setImageUri(imageUri);
@@ -393,7 +393,7 @@ public class LambdaService {
             if ("hot-reload".equals(s3Bucket)) {
                 applyHotReload(fn, s3Key);
             } else {
-                extractZipCodeFromS3(fn, s3Bucket, s3Key);
+                extractZipCodeFromS3(fn, s3Bucket, s3Key, region);
             }
         }
 
@@ -552,6 +552,14 @@ public class LambdaService {
                 for (LambdaAlias alias : aliasStore.list(region, functionName)) {
                     aliasStore.delete(region, functionName, alias.getName());
                 }
+            }
+        }
+        // Best-effort: drop the stored deployment package.
+        if (s3Service != null) {
+            try {
+                s3Service.deleteObject(tasksBucketName(region), codeObjectKey(fn));
+            } catch (Exception ignored) {
+                // best-effort cleanup
             }
         }
         LOG.infov("Deleted Lambda function: {0}", functionName);
@@ -1134,11 +1142,23 @@ public class LambdaService {
         return null;
     }
 
-    private void extractZipCode(LambdaFunction fn, String zipFileBase64) {
-        extractZipCodeBytes(fn, Base64.getDecoder().decode(zipFileBase64));
+    /** Per-region bucket that mirrors AWS's Lambda code bucket naming. */
+    public static String tasksBucketName(String region) {
+        String r = (region == null || region.isBlank()) ? "us-east-1" : region;
+        return "awslambda-" + r + "-tasks";
     }
 
-    private void extractZipCodeBytes(LambdaFunction fn, byte[] zipBytes) {
+    /** Stable, account-scoped S3 key for a function's current deployment package. */
+    public static String codeObjectKey(LambdaFunction fn) {
+        String account = fn.getAccountId() != null ? fn.getAccountId() : "000000000000";
+        return "snapshots/" + account + "/" + fn.getFunctionName();
+    }
+
+    private void extractZipCode(LambdaFunction fn, String zipFileBase64, String region) {
+        extractZipCodeBytes(fn, Base64.getDecoder().decode(zipFileBase64), region);
+    }
+
+    private void extractZipCodeBytes(LambdaFunction fn, byte[] zipBytes, String region) {
         Path codePath = codeStore.getCodePath(fn.getFunctionName());
         try {
             zipExtractor.extractTo(zipBytes, codePath);
@@ -1172,6 +1192,10 @@ public class LambdaService {
                             "Handler file '" + handlerFile + "' not found in deployment package", 400);
                 }
             }
+
+            // Deploy succeeded: keep the exact package so GetFunction can serve
+            // a real Code.Location.
+            storeDeploymentPackage(fn, zipBytes, region);
         } catch (AwsException e) {
             throw e;
         } catch (IOException e) {
@@ -1180,7 +1204,30 @@ public class LambdaService {
         }
     }
 
-    private void extractZipCodeFromS3(LambdaFunction fn, String s3Bucket, String s3Key) {
+    private void storeDeploymentPackage(LambdaFunction fn, byte[] zipBytes, String region) {
+        if (s3Service == null) {
+            return;
+        }
+        String bucket = tasksBucketName(region);
+        try {
+            try {
+                s3Service.createBucket(bucket, region);
+            } catch (AwsException e) {
+                // createBucket is idempotent only in us-east-1; elsewhere it 409s if it exists.
+                if (!"BucketAlreadyOwnedByYou".equals(e.getErrorCode())) {
+                    throw e;
+                }
+            }
+            s3Service.putObject(bucket, codeObjectKey(fn), zipBytes,
+                    "application/zip", java.util.Map.of());
+        } catch (Exception e) {
+            // Never fail a deploy because the convenience copy failed.
+            LOG.warnv("Could not store deployment package for {0}: {1}",
+                    fn.getFunctionName(), e.getMessage());
+        }
+    }
+
+    private void extractZipCodeFromS3(LambdaFunction fn, String s3Bucket, String s3Key, String region) {
         if (s3Service == null) {
             throw new AwsException("ServiceUnavailableException", "S3 service not available", 503);
         }
@@ -1194,7 +1241,7 @@ public class LambdaService {
             throw new AwsException("InvalidParameterValueException",
                     "Unable to fetch code from s3://" + s3Bucket + "/" + s3Key + ": " + e.getMessage(), 400);
         }
-        extractZipCodeBytes(fn, obj.getData());
+        extractZipCodeBytes(fn, obj.getData(), region);
     }
 
     private String resolveHandlerFilePath(LambdaFunction fn) {
@@ -1485,7 +1532,7 @@ public class LambdaService {
                         fn.getFunctionName(), event.bucketName(), event.key());
                 try {
                     S3Object obj = s3Service.getObject(event.bucketName(), event.key());
-                    extractZipCodeBytes(fn, obj.getData());
+                    extractZipCodeBytes(fn, obj.getData(), region);
                     fn.setLastModified(Instant.now().toEpochMilli());
                     fn.setRevisionId(UUID.randomUUID().toString());
                     functionStore.save(region, fn);

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaIntegrationTest.java
@@ -452,4 +452,103 @@ class LambdaIntegrationTest {
         .then()
             .statusCode(not(413));
     }
+
+    // ── GetFunction Code.Location downloadability ──────────────────────────────
+
+    @Test
+    @Order(40)
+    void getFunction_codeLocation_isDownloadableAndByteExact() throws Exception {
+        // Build a real zip with a nodejs handler file (extractZipCode verifies it).
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry("index.js"));
+            zos.write("exports.handler = async () => ({ statusCode: 200 });\n".getBytes());
+            zos.closeEntry();
+        }
+        String zipB64 = Base64.getEncoder().encodeToString(baos.toByteArray());
+
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "code-dl-fn",
+                    "Runtime": "nodejs20.x",
+                    "Role": "arn:aws:iam::000000000000:role/lambda-role",
+                    "Handler": "index.handler",
+                    "Code": {
+                        "ZipFile": "%s"
+                    }
+                }
+                """.formatted(zipB64))
+        .when()
+            .post(BASE_PATH + "/functions")
+        .then()
+            .statusCode(201);
+
+        // GetFunction → Code.Location must be an S3-style URL on this endpoint.
+        String location = given()
+            .when()
+            .get(BASE_PATH + "/functions/code-dl-fn")
+        .then()
+            .statusCode(200)
+            .body("Code.RepositoryType", equalTo("S3"))
+            .extract().path("Code.Location");
+
+        String expectedSha256 = given()
+            .when()
+            .get(BASE_PATH + "/functions/code-dl-fn/configuration")
+        .then()
+            .statusCode(200)
+            .extract().path("CodeSha256");
+
+        // Follow Code.Location against the same test server via its path.
+        String path = java.net.URI.create(location).getRawPath();
+        byte[] pkg = given()
+            .when()
+            .get(path)
+        .then()
+            .statusCode(200)
+            .extract().asByteArray();
+
+        // Valid zip → local file header magic "PK\003\004".
+        org.junit.jupiter.api.Assertions.assertTrue(pkg.length > 0, "package must not be empty");
+        org.junit.jupiter.api.Assertions.assertEquals('P', pkg[0]);
+        org.junit.jupiter.api.Assertions.assertEquals('K', pkg[1]);
+
+        // Byte-exact: downloaded package hashes to the stored CodeSha256.
+        byte[] digest = java.security.MessageDigest.getInstance("SHA-256").digest(pkg);
+        String downloadedSha256 = Base64.getEncoder().encodeToString(digest);
+        org.junit.jupiter.api.Assertions.assertEquals(expectedSha256, downloadedSha256,
+                "downloaded package must be byte-identical to the uploaded zip");
+
+        // Redeploy overwrites in place (stable key), no stale package accumulates.
+        ByteArrayOutputStream baos2 = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos2)) {
+            zos.putNextEntry(new ZipEntry("index.js"));
+            zos.write("exports.handler = async () => ({ statusCode: 201 });\n".getBytes());
+            zos.closeEntry();
+        }
+        given()
+            .contentType("application/json")
+            .body("{ \"ZipFile\": \"%s\" }".formatted(Base64.getEncoder().encodeToString(baos2.toByteArray())))
+        .when()
+            .put(BASE_PATH + "/functions/code-dl-fn/code")
+        .then()
+            .statusCode(200);
+        byte[] pkg2 = given().when().get(path).then().statusCode(200).extract().asByteArray();
+        org.junit.jupiter.api.Assertions.assertFalse(java.util.Arrays.equals(pkg, pkg2),
+                "redeploy must replace the stored package");
+
+        // Deleting the function removes the stored package (Code.Location 404s).
+        given()
+            .when()
+            .delete(BASE_PATH + "/functions/code-dl-fn")
+        .then()
+            .statusCode(anyOf(is(200), is(204)));
+        given()
+            .when()
+            .get(path)
+        .then()
+            .statusCode(404);
+    }
 }


### PR DESCRIPTION
## Summary

`GetFunction` (`GET /2015-03-31/functions/{name}`) returned a hardcoded, fabricated real-AWS URL for `Code.Location`:

```java
code.put("Location", "https://awslambda-" + region + "-tasks.s3." + region
        + ".amazonaws.com/" + fn.getFunctionName());
```

That URL points at real AWS S3, is not presigned, and 404s. Any client that follows `Code.Location` to download the deployment package — CLIs, tooling, and browser-only UIs — cannot fetch the code. Real AWS and LocalStack both return a working, downloadable URL.

**Root cause:** Floci extracts the uploaded zip to a directory and discards the original bytes, so there was nothing to serve.

**Fix:** on every *successful* code deploy, persist the exact original zip bytes into Floci's own S3 under a per-region tasks bucket (`awslambda-<region>-tasks`), keyed by `snapshots/<account>/<functionName>`. `GetFunction` now builds a **path-style URL on the local endpoint** from the incoming request via `UriInfo`, so it targets the same Floci the client is already talking to (mirrors LocalStack). `RepositoryType: "S3"` stays truthful.

- **Byte-exact:** the served package hashes to the already-stored `CodeSha256` (`sha256(originalZipBytes)`). Re-zipping the extracted dir would break that.
- **Reuses existing infra:** internal `S3Service` + `S3Controller`'s path-style `GET /{bucket}/{key:.+}` + global CORS. No new endpoint, no new serving code.
- **Centralized** in `extractZipCode`, so it covers `ZipFile`, `S3Bucket`/`S3Key` source, and the reactive S3-update listener with one change. Stored only *after* handler-file verification passes, so a rejected deploy leaves no orphan object.

**Lifecycle:** the stable key means redeploys overwrite in place (no stale accumulation), and `DeleteFunction` best-effort deletes the object.

**Scope / tradeoffs:**
- Hot-reload functions (`S3Bucket == "hot-reload"`) have no zip, so no object is stored — `Code.Location` 404s for them, matching the "no downloadable package" reality.
- Functions deployed **before** this change 404 until their next deploy (both `NoSuchBucket`/`NoSuchKey` → clean 404, same "can't download" state as before, just against the local endpoint).
- The `awslambda-<region>-tasks` bucket becomes visible in `ListBuckets` (same as LocalStack). Hiding service buckets is a separate follow-up, out of scope here.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

- **Incorrect behavior:** `GetFunction` returned a fabricated real-AWS S3 URL for `Code.Location` that 404s and is not presigned, so the deployment package could not be downloaded by any client following the URL.
- **Verified against:** AWS CLI `aws-cli/2.31.38` (`create-function` with `--zip-file`, then `get-function`), following the returned `Code.Location` with `curl`. Response is `200 application/zip` and the downloaded bytes' SHA-256 matches the function's `CodeSha256` (byte-exact). Behavior mirrors LocalStack's path-style `Code.Location`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)