### PR TITLE
fix(ses): populate VerificationStatus in v2 ListEmailIdentities

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesIdentityAttributesTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesIdentityAttributesTest.java
@@ -190,6 +190,9 @@ class SesIdentityAttributesTest {
             // Regression: VerificationStatus used to be null in the list response.
             assertThat(emailIdentity.verificationStatus()).isEqualTo(VerificationStatus.SUCCESS);
             assertThat(domainIdentity.verificationStatus()).isEqualTo(VerificationStatus.PENDING);
+            // SendingEnabled tracks verification status on AWS: SUCCESS -> true, PENDING -> false.
+            assertThat(emailIdentity.sendingEnabled()).isTrue();
+            assertThat(domainIdentity.sendingEnabled()).isFalse();
         } finally {
             sesV2.deleteEmailIdentity(DeleteEmailIdentityRequest.builder().emailIdentity(email).build());
             sesV2.deleteEmailIdentity(DeleteEmailIdentityRequest.builder().emailIdentity(domain).build());

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesIdentityAttributesTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesIdentityAttributesTest.java
@@ -28,7 +28,12 @@ import software.amazon.awssdk.services.sesv2.model.CreateEmailIdentityRequest;
 import software.amazon.awssdk.services.sesv2.model.DeleteEmailIdentityRequest;
 import software.amazon.awssdk.services.sesv2.model.GetEmailIdentityRequest;
 import software.amazon.awssdk.services.sesv2.model.GetEmailIdentityResponse;
+import software.amazon.awssdk.services.sesv2.model.IdentityInfo;
+import software.amazon.awssdk.services.sesv2.model.ListEmailIdentitiesRequest;
 import software.amazon.awssdk.services.sesv2.model.PutEmailIdentityMailFromAttributesRequest;
+import software.amazon.awssdk.services.sesv2.model.VerificationStatus;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -166,5 +171,28 @@ class SesIdentityAttributesTest {
                 .isInstanceOf(BadRequestException.class)
                 .extracting(e -> ((AwsServiceException) e).statusCode())
                 .isEqualTo(400);
+    }
+
+    @Test
+    @Order(12)
+    void listEmailIdentities_populatesVerificationStatus() {
+        String email = TestFixtures.uniqueName("lei") + "@example.com";
+        String domain = TestFixtures.uniqueName("lei") + ".example.com";
+        sesV2.createEmailIdentity(CreateEmailIdentityRequest.builder().emailIdentity(email).build());
+        sesV2.createEmailIdentity(CreateEmailIdentityRequest.builder().emailIdentity(domain).build());
+        try {
+            List<IdentityInfo> identities = sesV2.listEmailIdentities(
+                    ListEmailIdentitiesRequest.builder().build()).emailIdentities();
+            IdentityInfo emailIdentity = identities.stream()
+                    .filter(i -> email.equals(i.identityName())).findFirst().orElseThrow();
+            IdentityInfo domainIdentity = identities.stream()
+                    .filter(i -> domain.equals(i.identityName())).findFirst().orElseThrow();
+            // Regression: VerificationStatus used to be null in the list response.
+            assertThat(emailIdentity.verificationStatus()).isEqualTo(VerificationStatus.SUCCESS);
+            assertThat(domainIdentity.verificationStatus()).isEqualTo(VerificationStatus.PENDING);
+        } finally {
+            sesV2.deleteEmailIdentity(DeleteEmailIdentityRequest.builder().emailIdentity(email).build());
+            sesV2.deleteEmailIdentity(DeleteEmailIdentityRequest.builder().emailIdentity(domain).build());
+        }
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -127,10 +127,20 @@ public class SesController {
         ObjectNode result = objectMapper.createObjectNode();
         ArrayNode items = result.putArray("EmailIdentities");
         for (Identity id : identities) {
+            // Only a not-yet-verified domain can still transition (via its DKIM records),
+            // so refresh just those; refreshing every identity would scan Route53 per call.
+            Identity current = id;
+            if ("Domain".equals(id.getIdentityType()) && !"Success".equals(id.getVerificationStatus())) {
+                Identity refreshed = sesService.getIdentityVerificationAttributes(id.getIdentity(), region);
+                if (refreshed != null) {
+                    current = refreshed;
+                }
+            }
             ObjectNode item = objectMapper.createObjectNode();
-            item.put("IdentityType", toV2IdentityType(id.getIdentityType()));
-            item.put("IdentityName", id.getIdentity());
+            item.put("IdentityType", toV2IdentityType(current.getIdentityType()));
+            item.put("IdentityName", current.getIdentity());
             item.put("SendingEnabled", true);
+            item.put("VerificationStatus", toV2Status(current.getVerificationStatus()));
             items.add(item);
         }
         return Response.ok(result).build();

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -139,7 +139,7 @@ public class SesController {
             ObjectNode item = objectMapper.createObjectNode();
             item.put("IdentityType", toV2IdentityType(current.getIdentityType()));
             item.put("IdentityName", current.getIdentity());
-            item.put("SendingEnabled", true);
+            item.put("SendingEnabled", "Success".equals(current.getVerificationStatus()));
             item.put("VerificationStatus", toV2Status(current.getVerificationStatus()));
             items.add(item);
         }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
@@ -91,7 +91,12 @@ class SesV2IntegrationTest {
             .body("EmailIdentities.find { it.IdentityName == 'v2sender@example.com' }.VerificationStatus",
                     equalTo("SUCCESS"))
             .body("EmailIdentities.find { it.IdentityName == 'v2example.com' }.VerificationStatus",
-                    equalTo("PENDING"));
+                    equalTo("PENDING"))
+            // SendingEnabled tracks verification: SUCCESS -> true, PENDING -> false (matches AWS).
+            .body("EmailIdentities.find { it.IdentityName == 'v2sender@example.com' }.SendingEnabled",
+                    equalTo(true))
+            .body("EmailIdentities.find { it.IdentityName == 'v2example.com' }.SendingEnabled",
+                    equalTo(false));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesV2IntegrationTest.java
@@ -85,7 +85,13 @@ class SesV2IntegrationTest {
             .body("EmailIdentities", notNullValue())
             .body("EmailIdentities.size()", greaterThanOrEqualTo(2))
             .body("EmailIdentities.IdentityName", hasItem("v2sender@example.com"))
-            .body("EmailIdentities.IdentityName", hasItem("v2example.com"));
+            .body("EmailIdentities.IdentityName", hasItem("v2example.com"))
+            // VerificationStatus must be populated per identity (never null), matching AWS.
+            .body("EmailIdentities.VerificationStatus", everyItem(notNullValue()))
+            .body("EmailIdentities.find { it.IdentityName == 'v2sender@example.com' }.VerificationStatus",
+                    equalTo("SUCCESS"))
+            .body("EmailIdentities.find { it.IdentityName == 'v2example.com' }.VerificationStatus",
+                    equalTo("PENDING"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #1721. SES v2 `ListEmailIdentities` returned every identity with `VerificationStatus: null`, forcing clients to call `GetEmailIdentity` per identity to learn the verification state.

- `listEmailIdentities` now sets `VerificationStatus` on each item (mapped to the v2 enum via the existing `toV2Status`, e.g. `SUCCESS` / `PENDING`).
- A not-yet-verified domain is refreshed through the same path `GetEmailIdentity` uses, so the list reflects DKIM-driven transitions; email identities and already-verified domains use the value from `listIdentities` directly, so no Route53 scan runs per identity on every list call.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Per the AWS `ListEmailIdentities` API, each `IdentityInfo` carries `IdentityName`, `IdentityType`, `SendingEnabled`, and `VerificationStatus`. Floci previously omitted `VerificationStatus` (null). It now returns the identity's verification status — `SUCCESS` for a verified email identity, `PENDING` for a freshly created domain identity — matching `GetEmailIdentity`. This is a v2-only fix: the SES v1 `ListIdentities` returns names only (as on AWS) and `GetIdentityVerificationAttributes` already surfaces the status.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
