### PR TITLE
test(ec2): filter default VPC/subnet lookups to fix flaky describeDefaultVpc

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -83,9 +83,9 @@ class Ec2IntegrationTest {
     @Test
     @Order(2)
     void describeDefaultSubnets() {
-        // Filter to the default VPC's subnets rather than assuming a default subnet is item[0]:
-        // another test class sharing the in-memory EC2 store may leave subnets in this region, so
-        // an unfiltered list could otherwise flake on ordering.
+        // Assert that default subnets are present rather than relying on position: filtering to
+        // vpc-default still returns any non-default subnet another test created there (e.g.
+        // ElbV2IntegrationTest), which could otherwise land at item[0] and flake this assertion.
         given()
             .formParam("Action", "DescribeSubnets")
             .formParam("Filter.1.Name", "vpc-id")
@@ -96,9 +96,10 @@ class Ec2IntegrationTest {
         .then()
             .statusCode(200)
             .contentType("application/xml")
-            .body("DescribeSubnetsResponse.subnetSet.item.size()", greaterThanOrEqualTo(3))
-            .body("DescribeSubnetsResponse.subnetSet.item[0].defaultForAz", equalTo("true"))
-            .body("DescribeSubnetsResponse.subnetSet.item[0].mapPublicIpOnLaunch", equalTo("true"));
+            .body("DescribeSubnetsResponse.subnetSet.item.findAll { it.defaultForAz == 'true' }.size()",
+                greaterThanOrEqualTo(3))
+            .body("DescribeSubnetsResponse.subnetSet.item.find { it.defaultForAz == 'true' }.mapPublicIpOnLaunch",
+                equalTo("true"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -61,8 +61,14 @@ class Ec2IntegrationTest {
     @Test
     @Order(1)
     void describeDefaultVpc() {
+        // Filter to the default VPC rather than assuming it is item[0] of an unfiltered list:
+        // DescribeVpcs returns every VPC in the store's iteration order, so a VPC left behind by
+        // another test class sharing the in-memory EC2 store could otherwise land at item[0] and
+        // flake this assertion (mirrors the approach in describeDefaultSecurityGroup).
         given()
             .formParam("Action", "DescribeVpcs")
+            .formParam("Filter.1.Name", "is-default")
+            .formParam("Filter.1.Value.1", "true")
             .header("Authorization", AUTH_HEADER)
         .when()
             .post("/")
@@ -77,8 +83,13 @@ class Ec2IntegrationTest {
     @Test
     @Order(2)
     void describeDefaultSubnets() {
+        // Filter to the default VPC's subnets rather than assuming a default subnet is item[0]:
+        // another test class sharing the in-memory EC2 store may leave subnets in this region, so
+        // an unfiltered list could otherwise flake on ordering.
         given()
             .formParam("Action", "DescribeSubnets")
+            .formParam("Filter.1.Name", "vpc-id")
+            .formParam("Filter.1.Value.1", "vpc-default")
             .header("Authorization", AUTH_HEADER)
         .when()
             .post("/")


### PR DESCRIPTION
## Summary

Fixes #1725. `Ec2IntegrationTest.describeDefaultVpc` (and the latent `describeDefaultSubnets`) assert on `item[0]` of an unfiltered `DescribeVpcs` / `DescribeSubnets` response. Those calls return every VPC/subnet in the region in the shared store's `ConcurrentHashMap` iteration order, so a VPC leaked into the shared in-memory `us-east-1` store by another test class can land at `item[0]` and flake the assertion.

This filters both lookups to the default resources, mirroring the existing `describeDefaultSecurityGroup`:
- `describeDefaultVpc` → `Filter.Name=is-default, Value=true`
- `describeDefaultSubnets` → `Filter.Name=vpc-id, Value=vpc-default`

Both filters are already supported by `Ec2Service`.

### Scope

This addresses only the first cause in #1725 (the positional assertion), which makes the tests robust regardless of store ordering or leftover VPCs. It deliberately does **not** touch the other two contributors:

- **Cause 2 — `DescribeVpcs` ordering:** left unsorted. AWS itself doesn't guarantee an order for `DescribeVpcs`, so sorting production code purely for test convenience isn't warranted; filtering makes ordering moot for these tests.
- **Cause 3 — cross-test VPC leaks:** the leaking test classes are left as-is, consistent with the existing `describeDefaultSecurityGroup` approach of defending at the assertion. Removing the leaks (`@AfterAll` cleanup) is a broader hygiene change better done separately.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore  (test-only; commit uses `test:`)

## AWS Compatibility

No behaviour change — test-only. The `is-default` (DescribeVpcs) and `vpc-id` (DescribeSubnets) filters used here are already implemented in `Ec2Service`.

## Checklist

- [x] `./mvnw test` passes locally (the previously ~1-in-6 flaky combo `ElbV2IntegrationTest,Ec2FlowLogIntegrationTest,Ec2IntegrationTest` now passes 8/8)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
