### PR TITLE
fix(emr): return AWS client-error codes instead of 500 InternalServerError

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/emr/EmrService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/emr/EmrService.java
@@ -50,7 +50,9 @@ public class EmrService {
     // ──────────────────────────── Cluster lifecycle ────────────────────────────
 
     public EmrCluster runJobFlow(EmrCluster cluster, String region) {
-        if (cluster.getName() == null || cluster.getName().isBlank()) {
+        // Only a missing Name fails AWS's framework validation: the member is REQUIRED but its
+        // constraint is len=[0..256], so an explicit empty string is accepted by real EMR.
+        if (cluster.getName() == null) {
             throw new AwsException("ValidationException",
                     "1 validation error detected: Value null at 'name' failed to satisfy constraint: "
                             + "Member must not be null", 400);

--- a/src/main/java/io/github/hectorvent/floci/services/emr/EmrService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/emr/EmrService.java
@@ -51,7 +51,9 @@ public class EmrService {
 
     public EmrCluster runJobFlow(EmrCluster cluster, String region) {
         if (cluster.getName() == null || cluster.getName().isBlank()) {
-            throw new AwsException("InternalServerError", "Name is required.", 500);
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value null at 'name' failed to satisfy constraint: "
+                            + "Member must not be null", 400);
         }
         String id = "j-" + randomId(13);
         cluster.setId(id);
@@ -104,14 +106,17 @@ public class EmrService {
     }
 
     public void terminateJobFlows(List<String> ids) {
+        // AWS terminates the unprotected clusters in the request and then fails it with a
+        // ValidationException if any were termination protected.
+        boolean anyProtected = false;
         for (String id : ids) {
             EmrCluster cluster = clusterStore.get(id).orElse(null);
             if (cluster == null) {
                 continue;
             }
             if (cluster.isTerminationProtected()) {
-                throw new AwsException("InternalServerError",
-                        "Cluster " + id + " is protected from termination.", 500);
+                anyProtected = true;
+                continue;
             }
             if ("TERMINATED".equals(cluster.getState())) {
                 continue;
@@ -121,6 +126,10 @@ public class EmrService {
             cluster.setStateChangeMessage("Terminated by user request");
             cluster.setEndDateTime(Instant.now());
             clusterStore.put(id, cluster);
+        }
+        if (anyProtected) {
+            throw new AwsException("ValidationException",
+                    "Could not shut down one or more job flows since they are termination protected.", 400);
         }
     }
 
@@ -156,7 +165,7 @@ public class EmrService {
 
     public List<String> addJobFlowSteps(String clusterId, List<EmrStep> steps) {
         EmrCluster cluster = clusterStore.get(clusterId).orElseThrow(() -> new AwsException(
-                "InternalServerError", "Cluster " + clusterId + " does not exist.", 500));
+                "InvalidRequestException", "Cluster id '" + clusterId + "' is not valid.", 400));
         List<String> ids = new ArrayList<>();
         for (EmrStep step : steps) {
             initStep(step);

--- a/src/test/java/io/github/hectorvent/floci/services/emr/EmrIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/emr/EmrIntegrationTest.java
@@ -184,4 +184,52 @@ class EmrIntegrationTest {
                 .then().statusCode(400)
                 .body("__type", equalTo("InvalidRequestException"));
     }
+
+    @Test
+    @Order(14)
+    void runJobFlowWithoutNameIsValidationException() {
+        call("RunJobFlow", "{\"ReleaseLabel\":\"emr-7.5.0\",\"Instances\":{}}")
+                .then().statusCode(400)
+                .body("__type", equalTo("ValidationException"));
+    }
+
+    @Test
+    @Order(15)
+    void addStepsToUnknownClusterIsInvalidRequest() {
+        call("AddJobFlowSteps",
+                "{\"JobFlowId\":\"j-DOESNOTEXIST0\",\"Steps\":[{\"Name\":\"s\","
+                        + "\"HadoopJarStep\":{\"Jar\":\"command-runner.jar\"}}]}")
+                .then().statusCode(400)
+                .body("__type", equalTo("InvalidRequestException"))
+                .body("message", equalTo("Cluster id 'j-DOESNOTEXIST0' is not valid."));
+    }
+
+    @Test
+    @Order(16)
+    void terminationProtectionIsValidationExceptionAndUnprotectedStillTerminate() {
+        String protectedId = call("RunJobFlow",
+                "{\"Name\":\"protected\",\"Instances\":{\"KeepJobFlowAliveWhenNoSteps\":true}}")
+                .jsonPath().getString("JobFlowId");
+        String unprotectedId = call("RunJobFlow",
+                "{\"Name\":\"unprotected\",\"Instances\":{\"KeepJobFlowAliveWhenNoSteps\":true}}")
+                .jsonPath().getString("JobFlowId");
+        call("SetTerminationProtection",
+                "{\"JobFlowIds\":[\"" + protectedId + "\"],\"TerminationProtected\":true}")
+                .then().statusCode(200);
+
+        // AWS terminates the unprotected clusters in the request and then fails it.
+        call("TerminateJobFlows",
+                "{\"JobFlowIds\":[\"" + unprotectedId + "\",\"" + protectedId + "\"]}")
+                .then().statusCode(400)
+                .body("__type", equalTo("ValidationException"))
+                .body("message", equalTo(
+                        "Could not shut down one or more job flows since they are termination protected."));
+
+        call("DescribeCluster", "{\"ClusterId\":\"" + unprotectedId + "\"}")
+                .then().statusCode(200)
+                .body("Cluster.Status.State", equalTo("TERMINATED"));
+        call("DescribeCluster", "{\"ClusterId\":\"" + protectedId + "\"}")
+                .then().statusCode(200)
+                .body("Cluster.Status.State", equalTo("WAITING"));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/emr/EmrIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/emr/EmrIntegrationTest.java
@@ -190,11 +190,24 @@ class EmrIntegrationTest {
     void runJobFlowWithoutNameIsValidationException() {
         call("RunJobFlow", "{\"ReleaseLabel\":\"emr-7.5.0\",\"Instances\":{}}")
                 .then().statusCode(400)
-                .body("__type", equalTo("ValidationException"));
+                .body("__type", equalTo("ValidationException"))
+                .body("message", equalTo(
+                        "1 validation error detected: Value null at 'name' failed to satisfy constraint: "
+                                + "Member must not be null"));
     }
 
     @Test
     @Order(15)
+    void runJobFlowWithEmptyNameIsAccepted() {
+        // The Name member is REQUIRED but its model constraint is len=[0..256], so real EMR
+        // accepts an explicit empty string; only a missing Name fails framework validation.
+        call("RunJobFlow", "{\"Name\":\"\",\"Instances\":{\"KeepJobFlowAliveWhenNoSteps\":true}}")
+                .then().statusCode(200)
+                .body("JobFlowId", startsWith("j-"));
+    }
+
+    @Test
+    @Order(16)
     void addStepsToUnknownClusterIsInvalidRequest() {
         call("AddJobFlowSteps",
                 "{\"JobFlowId\":\"j-DOESNOTEXIST0\",\"Steps\":[{\"Name\":\"s\","
@@ -205,7 +218,7 @@ class EmrIntegrationTest {
     }
 
     @Test
-    @Order(16)
+    @Order(17)
     void terminationProtectionIsValidationExceptionAndUnprotectedStillTerminate() {
         String protectedId = call("RunJobFlow",
                 "{\"Name\":\"protected\",\"Instances\":{\"KeepJobFlowAliveWhenNoSteps\":true}}")


### PR DESCRIPTION
## Summary

Three EMR paths returned 500 `InternalServerError` for pure client errors, which SDK retry policies treat as retryable server faults:

- `RunJobFlow` with a missing `Name` now returns 400 `ValidationException` in the AWS validation-message format ("1 validation error detected: Value null at 'name' failed to satisfy constraint: Member must not be null").
- `AddJobFlowSteps` with an unknown cluster now returns 400 `InvalidRequestException` with "Cluster id 'X' is not valid.", the same message the `DescribeCluster` path already used.
- `TerminateJobFlows` on a termination-protected cluster now returns 400 `ValidationException` with the message "Could not shut down one or more job flows since they are termination protected." and matches AWS semantics: unprotected clusters in the same request are terminated before the request fails (previously the loop threw midway, leaving later clusters running).

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

Verified against botocore emr/2009-03-31 (`InvalidRequestException` is declared on the cluster operations; `ValidationException` is the framework-level validation error on AWS JSON services) and against moto's EMR implementation for the termination-protection message and terminate-then-fail semantics. The correct 400 pattern already existed in newer paths of the same file; this aligns the older sites.

## Checklist

- [x] `./mvnw test` passes locally (`EmrIntegrationTest` 16/16)
- [x] New or updated integration test added (4 wire-level error tests: missing Name, unknown cluster with exact message, and the protected/unprotected termination scenario asserting the protected cluster stays WAITING while the unprotected one reaches TERMINATED)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
