### PR TITLE
fix(sqs): render Query-protocol errors as XML instead of leaking JSON

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
@@ -35,6 +35,20 @@ public class SqsQueryHandler {
     public Response handle(String action, MultivaluedMap<String, String> params, String region) {
         LOG.debugv("SQS action: {0}", action);
 
+        // Wrap like every other Query handler: without this, AwsExceptions escape to the
+        // global JAX-RS mapper, which renders a JSON error body on this XML protocol.
+        try {
+            return dispatch(action, params, region);
+        } catch (AwsException e) {
+            return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.SQS, e.getHttpStatus());
+        } catch (Exception e) {
+            LOG.errorv(e, "Unexpected error in SQS {0}", action);
+            return AwsQueryResponse.error("InternalError",
+                    "Unexpected error: " + e.getMessage(), AwsNamespaces.SQS, 500);
+        }
+    }
+
+    private Response dispatch(String action, MultivaluedMap<String, String> params, String region) {
         return switch (action) {
             case "CreateQueue" -> handleCreateQueue(params, region);
             case "DeleteQueue" -> handleDeleteQueue(params, region);

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationStackSetsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationStackSetsIntegrationTest.java
@@ -53,7 +53,11 @@ class CloudFormationStackSetsIntegrationTest {
             .formParam("QueueName", queueName)
             .header("Authorization", auth(account, "sqs"))
         .when().post("/")
-        .then().body(containsString("QueueDoesNotExist"));
+        .then()
+            .statusCode(400)
+            // Query protocol renders the XML ErrorResponse with the legacy Query code;
+            // QueueDoesNotExist is its JSON-protocol __type equivalent (see AwsException).
+            .body(containsString("AWS.SimpleQueueService.NonExistentQueue"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
@@ -483,7 +483,10 @@ class SqsIntegrationTest {
             .post("/")
         .then()
             .statusCode(400)
-            .body(containsString("QueueNameExists"));
+            // Query protocol renders the XML ErrorResponse with the legacy Query code;
+            // QueueNameExists is its JSON-protocol __type equivalent (see AwsException).
+            .contentType(containsString("xml"))
+            .body("ErrorResponse.Error.Code", equalTo("QueueAlreadyExists"));
 
         given()
             .contentType("application/x-www-form-urlencoded")
@@ -610,6 +613,25 @@ class SqsIntegrationTest {
                 .formParam("QueueUrl", traceQueueUrl)
             .when().post("/");
         }
+    }
+
+    @Test
+    void queryProtocolErrorsAreXmlNotJson() {
+        // Regression: AwsExceptions escaping SqsQueryHandler used to reach the global
+        // JAX-RS mapper and render a JSON body on this XML protocol.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "GetQueueUrl")
+            .formParam("QueueName", "does-not-exist-queue")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .contentType(containsString("xml"))
+            .body("ErrorResponse.Error.Type", equalTo("Sender"))
+            .body("ErrorResponse.Error.Code", equalTo("AWS.SimpleQueueService.NonExistentQueue"))
+            .body("ErrorResponse.Error.Message",
+                    equalTo("The specified queue does not exist for this wsdl version."));
     }
 
     @Test


### PR DESCRIPTION
## Summary

`SqsQueryHandler` was the only Query handler (vs RDS, IAM, CloudFormation, EC2, SNS, ELBv2, ElastiCache) without top-level error wrapping, so any `AwsException` escaped to the global JAX-RS mapper and rendered a JSON error body (`application/json`, `{"__type":…}`) on the XML Query protocol. Legacy Query clients received malformed errors. The handler now wraps its dispatch like every other Query handler and emits the standard `ErrorResponse` XML envelope with the legacy Query error codes.

An existing test was pinning the bug: `createQueue_conflictingAttributes_returns400` asserted `QueueNameExists`, which is the JSON-protocol `__type` produced by the leaked mapper rendering. On the Query path the correct legacy code is `QueueAlreadyExists` (the dual mapping is documented in `AwsException` itself); the test now asserts the XML shape with the Query code.

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

For bug fixes: JSON error bodies on the XML Query path. The codes now on the wire (`QueueAlreadyExists`, `AWS.SimpleQueueService.NonExistentQueue`, message "The specified queue does not exist for this wsdl version.") are the legacy Query-protocol forms. The modern JSON path and its `__type` mapping are untouched (`SqsJsonProtocolTest` 17/17).

## Checklist

- [x] `./mvnw test` passes locally (120 SQS tests across both protocol paths)
- [x] New or updated integration test added (XML error-shape regression test on `GetQueueUrl` for a missing queue; conflicting-attributes test corrected from the leaked JSON shape)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
