### PR TITLE
feat(scheduler): dispatch ECS targets to RunTask

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SchedulerTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SchedulerTest.java
@@ -6,6 +6,7 @@ import software.amazon.awssdk.services.scheduler.model.*;
 import software.amazon.awssdk.services.scheduler.model.Tag;
 
 import java.time.Instant;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -342,8 +343,27 @@ class SchedulerTest {
                         .arn("arn:aws:ecs:us-east-1:000000000000:cluster/proof")
                         .roleArn("arn:aws:iam::000000000000:role/scheduler-role")
                         .ecsParameters(EcsParameters.builder()
+                                .capacityProviderStrategy(CapacityProviderStrategyItem.builder()
+                                        .capacityProvider("FARGATE")
+                                        .base(0)
+                                        .weight(1)
+                                        .build())
+                                .enableECSManagedTags(true)
+                                .enableExecuteCommand(true)
+                                .group("batch-group")
                                 .taskDefinitionArn("arn:aws:ecs:us-east-1:000000000000:task-definition/proof:1")
                                 .launchType(LaunchType.FARGATE)
+                                .placementConstraints(PlacementConstraint.builder()
+                                        .type(PlacementConstraintType.DISTINCT_INSTANCE)
+                                        .build())
+                                .placementStrategy(PlacementStrategy.builder()
+                                        .type(PlacementStrategyType.SPREAD)
+                                        .field("attribute:ecs.availability-zone")
+                                        .build())
+                                .platformVersion("1.4.0")
+                                .propagateTags(PropagateTags.TASK_DEFINITION)
+                                .referenceId("ref-123")
+                                .tags(Map.of("Key", "env", "Value", "test"))
                                 .taskCount(1)
                                 .networkConfiguration(NetworkConfiguration.builder()
                                         .awsvpcConfiguration(AwsVpcConfiguration.builder()
@@ -362,7 +382,22 @@ class SchedulerTest {
                 .name("ecs-schedule").build());
         assertThat(get.target().ecsParameters().taskDefinitionArn())
                 .isEqualTo("arn:aws:ecs:us-east-1:000000000000:task-definition/proof:1");
+        assertThat(get.target().ecsParameters().capacityProviderStrategy()).hasSize(1);
+        assertThat(get.target().ecsParameters().capacityProviderStrategy().get(0).capacityProvider()).isEqualTo("FARGATE");
+        assertThat(get.target().ecsParameters().enableECSManagedTags()).isTrue();
+        assertThat(get.target().ecsParameters().enableExecuteCommand()).isTrue();
+        assertThat(get.target().ecsParameters().group()).isEqualTo("batch-group");
         assertThat(get.target().ecsParameters().launchType()).isEqualTo(LaunchType.FARGATE);
+        assertThat(get.target().ecsParameters().placementConstraints()).hasSize(1);
+        assertThat(get.target().ecsParameters().placementConstraints().get(0).type())
+                .isEqualTo(PlacementConstraintType.DISTINCT_INSTANCE);
+        assertThat(get.target().ecsParameters().placementStrategy()).hasSize(1);
+        assertThat(get.target().ecsParameters().placementStrategy().get(0).type())
+                .isEqualTo(PlacementStrategyType.SPREAD);
+        assertThat(get.target().ecsParameters().platformVersion()).isEqualTo("1.4.0");
+        assertThat(get.target().ecsParameters().propagateTags()).isEqualTo(PropagateTags.TASK_DEFINITION);
+        assertThat(get.target().ecsParameters().referenceId()).isEqualTo("ref-123");
+        assertThat(get.target().ecsParameters().tags()).containsExactly(Map.of("Key", "env", "Value", "test"));
         assertThat(get.target().ecsParameters().taskCount()).isEqualTo(1);
         assertThat(get.target().ecsParameters().networkConfiguration().awsvpcConfiguration().subnets())
                 .containsExactly("subnet-a");

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SchedulerTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SchedulerTest.java
@@ -43,6 +43,10 @@ class SchedulerTest {
             } catch (Exception ignored) {}
             try {
                 scheduler.deleteSchedule(DeleteScheduleRequest.builder()
+                        .name("ecs-schedule").build());
+            } catch (Exception ignored) {}
+            try {
+                scheduler.deleteSchedule(DeleteScheduleRequest.builder()
                         .name("grouped-schedule").groupName(GROUP_NAME).build());
             } catch (Exception ignored) {}
             try {
@@ -327,6 +331,52 @@ class SchedulerTest {
 
     @Test
     @Order(20)
+    @DisplayName("CreateSchedule - with ECS target parameters")
+    void createScheduleWithEcsParameters() {
+        CreateScheduleResponse resp = scheduler.createSchedule(CreateScheduleRequest.builder()
+                .name("ecs-schedule")
+                .scheduleExpression("rate(1 day)")
+                .flexibleTimeWindow(FlexibleTimeWindow.builder().mode(FlexibleTimeWindowMode.OFF).build())
+                .state(ScheduleState.DISABLED)
+                .target(Target.builder()
+                        .arn("arn:aws:ecs:us-east-1:000000000000:cluster/proof")
+                        .roleArn("arn:aws:iam::000000000000:role/scheduler-role")
+                        .ecsParameters(EcsParameters.builder()
+                                .taskDefinitionArn("arn:aws:ecs:us-east-1:000000000000:task-definition/proof:1")
+                                .launchType(LaunchType.FARGATE)
+                                .taskCount(1)
+                                .networkConfiguration(NetworkConfiguration.builder()
+                                        .awsvpcConfiguration(AwsVpcConfiguration.builder()
+                                                .subnets("subnet-a")
+                                                .securityGroups("sg-a")
+                                                .assignPublicIp(AssignPublicIp.DISABLED)
+                                                .build())
+                                        .build())
+                                .build())
+                        .build())
+                .build());
+
+        assertThat(resp.scheduleArn()).isNotNull().contains("ecs-schedule");
+
+        GetScheduleResponse get = scheduler.getSchedule(GetScheduleRequest.builder()
+                .name("ecs-schedule").build());
+        assertThat(get.target().ecsParameters().taskDefinitionArn())
+                .isEqualTo("arn:aws:ecs:us-east-1:000000000000:task-definition/proof:1");
+        assertThat(get.target().ecsParameters().launchType()).isEqualTo(LaunchType.FARGATE);
+        assertThat(get.target().ecsParameters().taskCount()).isEqualTo(1);
+        assertThat(get.target().ecsParameters().networkConfiguration().awsvpcConfiguration().subnets())
+                .containsExactly("subnet-a");
+        assertThat(get.target().ecsParameters().networkConfiguration().awsvpcConfiguration().securityGroups())
+                .containsExactly("sg-a");
+        assertThat(get.target().ecsParameters().networkConfiguration().awsvpcConfiguration().assignPublicIp())
+                .isEqualTo(AssignPublicIp.DISABLED);
+
+        scheduler.deleteSchedule(DeleteScheduleRequest.builder()
+                .name("ecs-schedule").build());
+    }
+
+    @Test
+    @Order(21)
     @DisplayName("CreateSchedule - with StartDate and EndDate")
     void createScheduleWithStartAndEndDate() {
         Instant start = Instant.parse("2026-06-01T00:00:00Z");

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvoker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvoker.java
@@ -109,7 +109,7 @@ public class ScheduleInvoker {
                 ecs.getTaskCount() != null ? ecs.getTaskCount() : 1,
                 parseLaunchType(ecs.getLaunchType()),
                 null,
-                "scheduler",
+                ecs.getGroup() != null ? ecs.getGroup() : "scheduler",
                 List.of(),
                 ecsNetworkConfiguration(ecs.getNetworkConfiguration()),
                 region);

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvoker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvoker.java
@@ -4,9 +4,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.services.ecs.EcsService;
+import io.github.hectorvent.floci.services.ecs.model.LaunchType;
 import io.github.hectorvent.floci.services.eventbridge.EventBridgeService;
 import io.github.hectorvent.floci.services.lambda.LambdaService;
 import io.github.hectorvent.floci.services.lambda.model.InvocationType;
+import io.github.hectorvent.floci.services.scheduler.model.EcsParameters;
 import io.github.hectorvent.floci.services.scheduler.model.Target;
 import io.github.hectorvent.floci.services.sns.SnsService;
 import io.github.hectorvent.floci.services.sqs.SqsService;
@@ -35,6 +38,7 @@ public class ScheduleInvoker {
     private final LambdaService lambdaService;
     private final SnsService snsService;
     private final EventBridgeService eventBridgeService;
+    private final EcsService ecsService;
     private final ObjectMapper objectMapper;
     private final String baseUrl;
 
@@ -43,12 +47,14 @@ public class ScheduleInvoker {
                            LambdaService lambdaService,
                            SnsService snsService,
                            EventBridgeService eventBridgeService,
+                           EcsService ecsService,
                            ObjectMapper objectMapper,
                            EmulatorConfig config) {
         this.sqsService = sqsService;
         this.lambdaService = lambdaService;
         this.snsService = snsService;
         this.eventBridgeService = eventBridgeService;
+        this.ecsService = ecsService;
         this.objectMapper = objectMapper;
         this.baseUrl = config.baseUrl();
     }
@@ -84,12 +90,59 @@ public class ScheduleInvoker {
         } else if (arn.contains(":sns:")) {
             snsService.publish(arn, null, payload, "Scheduler", targetRegion);
             LOG.debugv("Scheduler delivered to SNS: {0}", arn);
+        } else if (arn.contains(":ecs:") && target.getEcsParameters() != null) {
+            deliverToEcsRunTask(target, targetRegion);
+            LOG.debugv("Scheduler delivered to ECS RunTask: {0}", arn);
         } else if (isEventBridgePutEventsArn(arn)) {
             deliverToEventBridge(arn, payload, targetRegion);
             LOG.debugv("Scheduler delivered to EventBridge: {0}", arn);
         } else {
             LOG.warnv("Scheduler: unsupported target ARN type: {0}", arn);
         }
+    }
+
+    private void deliverToEcsRunTask(Target target, String region) {
+        EcsParameters ecs = target.getEcsParameters();
+        ecsService.runTask(
+                target.getArn(),
+                ecs.getTaskDefinitionArn(),
+                ecs.getTaskCount() != null ? ecs.getTaskCount() : 1,
+                parseLaunchType(ecs.getLaunchType()),
+                null,
+                "scheduler",
+                List.of(),
+                ecsNetworkConfiguration(ecs.getNetworkConfiguration()),
+                region);
+    }
+
+    private static LaunchType parseLaunchType(String launchType) {
+        if (launchType == null || launchType.isBlank()) {
+            return null;
+        }
+        try {
+            return LaunchType.valueOf(launchType);
+        } catch (IllegalArgumentException e) {
+            LOG.warnv("Scheduler: unsupported ECS LaunchType: {0}", launchType);
+            return null;
+        }
+    }
+
+    private static io.github.hectorvent.floci.services.ecs.model.NetworkConfiguration ecsNetworkConfiguration(
+            io.github.hectorvent.floci.services.scheduler.model.NetworkConfiguration source) {
+        if (source == null || source.getAwsvpcConfiguration() == null) {
+            return null;
+        }
+        io.github.hectorvent.floci.services.scheduler.model.AwsVpcConfiguration sourceVpc = source.getAwsvpcConfiguration();
+        io.github.hectorvent.floci.services.ecs.model.AwsVpcConfiguration targetVpc =
+                new io.github.hectorvent.floci.services.ecs.model.AwsVpcConfiguration();
+        targetVpc.setSubnets(sourceVpc.getSubnets());
+        targetVpc.setSecurityGroups(sourceVpc.getSecurityGroups());
+        targetVpc.setAssignPublicIp(sourceVpc.getAssignPublicIp());
+
+        io.github.hectorvent.floci.services.ecs.model.NetworkConfiguration target =
+                new io.github.hectorvent.floci.services.ecs.model.NetworkConfiguration();
+        target.setAwsvpcConfiguration(targetVpc);
+        return target;
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
@@ -419,11 +419,29 @@ public class SchedulerController {
 
     private EcsParameters parseEcsParameters(JsonNode node) {
         EcsParameters ecs = new EcsParameters();
+        if (node.has("CapacityProviderStrategy") && node.get("CapacityProviderStrategy").isArray()) {
+            ecs.setCapacityProviderStrategy(mapList(node.get("CapacityProviderStrategy")));
+        }
+        if (node.has("EnableECSManagedTags") && !node.get("EnableECSManagedTags").isNull()) {
+            ecs.setEnableECSManagedTags(node.get("EnableECSManagedTags").asBoolean());
+        }
+        if (node.has("EnableExecuteCommand") && !node.get("EnableExecuteCommand").isNull()) {
+            ecs.setEnableExecuteCommand(node.get("EnableExecuteCommand").asBoolean());
+        }
+        if (node.has("Group") && !node.get("Group").isNull()) {
+            ecs.setGroup(node.get("Group").asText());
+        }
         if (node.has("TaskDefinitionArn") && !node.get("TaskDefinitionArn").isNull()) {
             ecs.setTaskDefinitionArn(node.get("TaskDefinitionArn").asText());
         }
         if (node.has("LaunchType") && !node.get("LaunchType").isNull()) {
             ecs.setLaunchType(node.get("LaunchType").asText());
+        }
+        if (node.has("PlacementConstraints") && node.get("PlacementConstraints").isArray()) {
+            ecs.setPlacementConstraints(mapList(node.get("PlacementConstraints")));
+        }
+        if (node.has("PlacementStrategy") && node.get("PlacementStrategy").isArray()) {
+            ecs.setPlacementStrategy(mapList(node.get("PlacementStrategy")));
         }
         if (node.has("TaskCount") && !node.get("TaskCount").isNull()) {
             ecs.setTaskCount(node.get("TaskCount").asInt());
@@ -431,10 +449,25 @@ public class SchedulerController {
         if (node.has("PlatformVersion") && !node.get("PlatformVersion").isNull()) {
             ecs.setPlatformVersion(node.get("PlatformVersion").asText());
         }
+        if (node.has("PropagateTags") && !node.get("PropagateTags").isNull()) {
+            ecs.setPropagateTags(node.get("PropagateTags").asText());
+        }
+        if (node.has("ReferenceId") && !node.get("ReferenceId").isNull()) {
+            ecs.setReferenceId(node.get("ReferenceId").asText());
+        }
+        if (node.has("Tags") && node.get("Tags").isArray()) {
+            ecs.setTags(mapList(node.get("Tags")));
+        }
         if (node.has("NetworkConfiguration") && !node.get("NetworkConfiguration").isNull()) {
             ecs.setNetworkConfiguration(parseNetworkConfiguration(node.get("NetworkConfiguration")));
         }
         return ecs;
+    }
+
+    private List<Map<String, Object>> mapList(JsonNode node) {
+        return objectMapper.convertValue(node,
+                objectMapper.getTypeFactory().constructCollectionType(List.class,
+                        objectMapper.getTypeFactory().constructMapType(Map.class, String.class, Object.class)));
     }
 
     private NetworkConfiguration parseNetworkConfiguration(JsonNode node) {
@@ -461,17 +494,44 @@ public class SchedulerController {
 
     private Map<String, Object> buildEcsParametersResponse(EcsParameters ecs) {
         Map<String, Object> ep = new HashMap<>();
+        if (ecs.getCapacityProviderStrategy() != null && !ecs.getCapacityProviderStrategy().isEmpty()) {
+            ep.put("CapacityProviderStrategy", ecs.getCapacityProviderStrategy());
+        }
+        if (ecs.getEnableECSManagedTags() != null) {
+            ep.put("EnableECSManagedTags", ecs.getEnableECSManagedTags());
+        }
+        if (ecs.getEnableExecuteCommand() != null) {
+            ep.put("EnableExecuteCommand", ecs.getEnableExecuteCommand());
+        }
+        if (ecs.getGroup() != null) {
+            ep.put("Group", ecs.getGroup());
+        }
         if (ecs.getTaskDefinitionArn() != null) {
             ep.put("TaskDefinitionArn", ecs.getTaskDefinitionArn());
         }
         if (ecs.getLaunchType() != null) {
             ep.put("LaunchType", ecs.getLaunchType());
         }
+        if (ecs.getPlacementConstraints() != null && !ecs.getPlacementConstraints().isEmpty()) {
+            ep.put("PlacementConstraints", ecs.getPlacementConstraints());
+        }
+        if (ecs.getPlacementStrategy() != null && !ecs.getPlacementStrategy().isEmpty()) {
+            ep.put("PlacementStrategy", ecs.getPlacementStrategy());
+        }
         if (ecs.getTaskCount() != null) {
             ep.put("TaskCount", ecs.getTaskCount());
         }
         if (ecs.getPlatformVersion() != null) {
             ep.put("PlatformVersion", ecs.getPlatformVersion());
+        }
+        if (ecs.getPropagateTags() != null) {
+            ep.put("PropagateTags", ecs.getPropagateTags());
+        }
+        if (ecs.getReferenceId() != null) {
+            ep.put("ReferenceId", ecs.getReferenceId());
+        }
+        if (ecs.getTags() != null && !ecs.getTags().isEmpty()) {
+            ep.put("Tags", ecs.getTags());
         }
         if (ecs.getNetworkConfiguration() != null) {
             Map<String, Object> network = buildNetworkConfigurationResponse(ecs.getNetworkConfiguration());

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerController.java
@@ -2,8 +2,11 @@ package io.github.hectorvent.floci.services.scheduler;
 
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.scheduler.model.AwsVpcConfiguration;
 import io.github.hectorvent.floci.services.scheduler.model.DeadLetterConfig;
+import io.github.hectorvent.floci.services.scheduler.model.EcsParameters;
 import io.github.hectorvent.floci.services.scheduler.model.FlexibleTimeWindow;
+import io.github.hectorvent.floci.services.scheduler.model.NetworkConfiguration;
 import io.github.hectorvent.floci.services.scheduler.model.RetryPolicy;
 import io.github.hectorvent.floci.services.scheduler.model.Schedule;
 import io.github.hectorvent.floci.services.scheduler.model.ScheduleGroup;
@@ -267,6 +270,12 @@ public class SchedulerController {
                 sp.put("MessageGroupId", s.getTarget().getSqsParameters().getMessageGroupId());
                 t.put("SqsParameters", sp);
             }
+            if (s.getTarget().getEcsParameters() != null) {
+                Map<String, Object> ep = buildEcsParametersResponse(s.getTarget().getEcsParameters());
+                if (!ep.isEmpty()) {
+                    t.put("EcsParameters", ep);
+                }
+            }
             r.put("Target", t);
         }
         if (s.getDescription() != null) {
@@ -402,7 +411,94 @@ public class SchedulerController {
             }
             target.setSqsParameters(sp);
         }
+        if (node.has("EcsParameters") && !node.get("EcsParameters").isNull()) {
+            target.setEcsParameters(parseEcsParameters(node.get("EcsParameters")));
+        }
         return target;
+    }
+
+    private EcsParameters parseEcsParameters(JsonNode node) {
+        EcsParameters ecs = new EcsParameters();
+        if (node.has("TaskDefinitionArn") && !node.get("TaskDefinitionArn").isNull()) {
+            ecs.setTaskDefinitionArn(node.get("TaskDefinitionArn").asText());
+        }
+        if (node.has("LaunchType") && !node.get("LaunchType").isNull()) {
+            ecs.setLaunchType(node.get("LaunchType").asText());
+        }
+        if (node.has("TaskCount") && !node.get("TaskCount").isNull()) {
+            ecs.setTaskCount(node.get("TaskCount").asInt());
+        }
+        if (node.has("PlatformVersion") && !node.get("PlatformVersion").isNull()) {
+            ecs.setPlatformVersion(node.get("PlatformVersion").asText());
+        }
+        if (node.has("NetworkConfiguration") && !node.get("NetworkConfiguration").isNull()) {
+            ecs.setNetworkConfiguration(parseNetworkConfiguration(node.get("NetworkConfiguration")));
+        }
+        return ecs;
+    }
+
+    private NetworkConfiguration parseNetworkConfiguration(JsonNode node) {
+        NetworkConfiguration network = new NetworkConfiguration();
+        if (node.has("awsvpcConfiguration") && !node.get("awsvpcConfiguration").isNull()) {
+            network.setAwsvpcConfiguration(parseAwsVpcConfiguration(node.get("awsvpcConfiguration")));
+        }
+        return network;
+    }
+
+    private AwsVpcConfiguration parseAwsVpcConfiguration(JsonNode node) {
+        AwsVpcConfiguration vpc = new AwsVpcConfiguration();
+        if (node.has("Subnets") && node.get("Subnets").isArray()) {
+            vpc.setSubnets(objectMapper.convertValue(node.get("Subnets"), objectMapper.getTypeFactory().constructCollectionType(List.class, String.class)));
+        }
+        if (node.has("SecurityGroups") && node.get("SecurityGroups").isArray()) {
+            vpc.setSecurityGroups(objectMapper.convertValue(node.get("SecurityGroups"), objectMapper.getTypeFactory().constructCollectionType(List.class, String.class)));
+        }
+        if (node.has("AssignPublicIp") && !node.get("AssignPublicIp").isNull()) {
+            vpc.setAssignPublicIp(node.get("AssignPublicIp").asText());
+        }
+        return vpc;
+    }
+
+    private Map<String, Object> buildEcsParametersResponse(EcsParameters ecs) {
+        Map<String, Object> ep = new HashMap<>();
+        if (ecs.getTaskDefinitionArn() != null) {
+            ep.put("TaskDefinitionArn", ecs.getTaskDefinitionArn());
+        }
+        if (ecs.getLaunchType() != null) {
+            ep.put("LaunchType", ecs.getLaunchType());
+        }
+        if (ecs.getTaskCount() != null) {
+            ep.put("TaskCount", ecs.getTaskCount());
+        }
+        if (ecs.getPlatformVersion() != null) {
+            ep.put("PlatformVersion", ecs.getPlatformVersion());
+        }
+        if (ecs.getNetworkConfiguration() != null) {
+            Map<String, Object> network = buildNetworkConfigurationResponse(ecs.getNetworkConfiguration());
+            if (!network.isEmpty()) {
+                ep.put("NetworkConfiguration", network);
+            }
+        }
+        return ep;
+    }
+
+    private Map<String, Object> buildNetworkConfigurationResponse(NetworkConfiguration network) {
+        Map<String, Object> result = new HashMap<>();
+        if (network.getAwsvpcConfiguration() != null) {
+            AwsVpcConfiguration vpc = network.getAwsvpcConfiguration();
+            Map<String, Object> awsvpc = new HashMap<>();
+            if (vpc.getSubnets() != null && !vpc.getSubnets().isEmpty()) {
+                awsvpc.put("Subnets", vpc.getSubnets());
+            }
+            if (vpc.getSecurityGroups() != null && !vpc.getSecurityGroups().isEmpty()) {
+                awsvpc.put("SecurityGroups", vpc.getSecurityGroups());
+            }
+            if (vpc.getAssignPublicIp() != null) {
+                awsvpc.put("AssignPublicIp", vpc.getAssignPublicIp());
+            }
+            result.put("awsvpcConfiguration", awsvpc);
+        }
+        return result;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/model/AwsVpcConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/model/AwsVpcConfiguration.java
@@ -1,0 +1,23 @@
+package io.github.hectorvent.floci.services.scheduler.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RegisterForReflection
+public class AwsVpcConfiguration {
+
+    private List<String> subnets = new ArrayList<>();
+    private List<String> securityGroups = new ArrayList<>();
+    private String assignPublicIp;
+
+    public List<String> getSubnets() { return subnets; }
+    public void setSubnets(List<String> subnets) { this.subnets = subnets; }
+
+    public List<String> getSecurityGroups() { return securityGroups; }
+    public void setSecurityGroups(List<String> securityGroups) { this.securityGroups = securityGroups; }
+
+    public String getAssignPublicIp() { return assignPublicIp; }
+    public void setAssignPublicIp(String assignPublicIp) { this.assignPublicIp = assignPublicIp; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/model/EcsParameters.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/model/EcsParameters.java
@@ -2,14 +2,38 @@ package io.github.hectorvent.floci.services.scheduler.model;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
+import java.util.List;
+import java.util.Map;
+
 @RegisterForReflection
 public class EcsParameters {
 
+    private List<Map<String, Object>> capacityProviderStrategy;
+    private Boolean enableECSManagedTags;
+    private Boolean enableExecuteCommand;
+    private String group;
     private String taskDefinitionArn;
     private String launchType;
+    private List<Map<String, Object>> placementConstraints;
+    private List<Map<String, Object>> placementStrategy;
     private Integer taskCount;
     private String platformVersion;
+    private String propagateTags;
+    private String referenceId;
+    private List<Map<String, Object>> tags;
     private NetworkConfiguration networkConfiguration;
+
+    public List<Map<String, Object>> getCapacityProviderStrategy() { return capacityProviderStrategy; }
+    public void setCapacityProviderStrategy(List<Map<String, Object>> capacityProviderStrategy) { this.capacityProviderStrategy = capacityProviderStrategy; }
+
+    public Boolean getEnableECSManagedTags() { return enableECSManagedTags; }
+    public void setEnableECSManagedTags(Boolean enableECSManagedTags) { this.enableECSManagedTags = enableECSManagedTags; }
+
+    public Boolean getEnableExecuteCommand() { return enableExecuteCommand; }
+    public void setEnableExecuteCommand(Boolean enableExecuteCommand) { this.enableExecuteCommand = enableExecuteCommand; }
+
+    public String getGroup() { return group; }
+    public void setGroup(String group) { this.group = group; }
 
     public String getTaskDefinitionArn() { return taskDefinitionArn; }
     public void setTaskDefinitionArn(String taskDefinitionArn) { this.taskDefinitionArn = taskDefinitionArn; }
@@ -17,11 +41,26 @@ public class EcsParameters {
     public String getLaunchType() { return launchType; }
     public void setLaunchType(String launchType) { this.launchType = launchType; }
 
+    public List<Map<String, Object>> getPlacementConstraints() { return placementConstraints; }
+    public void setPlacementConstraints(List<Map<String, Object>> placementConstraints) { this.placementConstraints = placementConstraints; }
+
+    public List<Map<String, Object>> getPlacementStrategy() { return placementStrategy; }
+    public void setPlacementStrategy(List<Map<String, Object>> placementStrategy) { this.placementStrategy = placementStrategy; }
+
     public Integer getTaskCount() { return taskCount; }
     public void setTaskCount(Integer taskCount) { this.taskCount = taskCount; }
 
     public String getPlatformVersion() { return platformVersion; }
     public void setPlatformVersion(String platformVersion) { this.platformVersion = platformVersion; }
+
+    public String getPropagateTags() { return propagateTags; }
+    public void setPropagateTags(String propagateTags) { this.propagateTags = propagateTags; }
+
+    public String getReferenceId() { return referenceId; }
+    public void setReferenceId(String referenceId) { this.referenceId = referenceId; }
+
+    public List<Map<String, Object>> getTags() { return tags; }
+    public void setTags(List<Map<String, Object>> tags) { this.tags = tags; }
 
     public NetworkConfiguration getNetworkConfiguration() { return networkConfiguration; }
     public void setNetworkConfiguration(NetworkConfiguration networkConfiguration) { this.networkConfiguration = networkConfiguration; }

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/model/EcsParameters.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/model/EcsParameters.java
@@ -1,0 +1,28 @@
+package io.github.hectorvent.floci.services.scheduler.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class EcsParameters {
+
+    private String taskDefinitionArn;
+    private String launchType;
+    private Integer taskCount;
+    private String platformVersion;
+    private NetworkConfiguration networkConfiguration;
+
+    public String getTaskDefinitionArn() { return taskDefinitionArn; }
+    public void setTaskDefinitionArn(String taskDefinitionArn) { this.taskDefinitionArn = taskDefinitionArn; }
+
+    public String getLaunchType() { return launchType; }
+    public void setLaunchType(String launchType) { this.launchType = launchType; }
+
+    public Integer getTaskCount() { return taskCount; }
+    public void setTaskCount(Integer taskCount) { this.taskCount = taskCount; }
+
+    public String getPlatformVersion() { return platformVersion; }
+    public void setPlatformVersion(String platformVersion) { this.platformVersion = platformVersion; }
+
+    public NetworkConfiguration getNetworkConfiguration() { return networkConfiguration; }
+    public void setNetworkConfiguration(NetworkConfiguration networkConfiguration) { this.networkConfiguration = networkConfiguration; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/model/NetworkConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/model/NetworkConfiguration.java
@@ -1,0 +1,12 @@
+package io.github.hectorvent.floci.services.scheduler.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class NetworkConfiguration {
+
+    private AwsVpcConfiguration awsvpcConfiguration;
+
+    public AwsVpcConfiguration getAwsvpcConfiguration() { return awsvpcConfiguration; }
+    public void setAwsvpcConfiguration(AwsVpcConfiguration awsvpcConfiguration) { this.awsvpcConfiguration = awsvpcConfiguration; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/model/Target.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/model/Target.java
@@ -11,6 +11,7 @@ public class Target {
     private RetryPolicy retryPolicy;
     private DeadLetterConfig deadLetterConfig;
     private SqsParameters sqsParameters;
+    private EcsParameters ecsParameters;
 
     public Target() {}
 
@@ -38,4 +39,7 @@ public class Target {
 
     public SqsParameters getSqsParameters() { return sqsParameters; }
     public void setSqsParameters(SqsParameters sqsParameters) { this.sqsParameters = sqsParameters; }
+
+    public EcsParameters getEcsParameters() { return ecsParameters; }
+    public void setEcsParameters(EcsParameters ecsParameters) { this.ecsParameters = ecsParameters; }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvokerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvokerTest.java
@@ -2,14 +2,23 @@ package io.github.hectorvent.floci.services.scheduler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.ecs.EcsService;
+import io.github.hectorvent.floci.services.ecs.model.ContainerOverride;
+import io.github.hectorvent.floci.services.ecs.model.LaunchType;
 import io.github.hectorvent.floci.services.eventbridge.EventBridgeService;
 import io.github.hectorvent.floci.services.lambda.LambdaService;
+import io.github.hectorvent.floci.services.scheduler.model.AwsVpcConfiguration;
+import io.github.hectorvent.floci.services.scheduler.model.EcsParameters;
+import io.github.hectorvent.floci.services.scheduler.model.NetworkConfiguration;
 import io.github.hectorvent.floci.services.scheduler.model.SqsParameters;
 import io.github.hectorvent.floci.services.scheduler.model.Target;
 import io.github.hectorvent.floci.services.sns.SnsService;
 import io.github.hectorvent.floci.services.sqs.SqsService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -29,6 +38,7 @@ class ScheduleInvokerTest {
     private LambdaService lambdaService;
     private SnsService snsService;
     private EventBridgeService eventBridgeService;
+    private EcsService ecsService;
     private ScheduleInvoker invoker;
 
     @BeforeEach
@@ -37,10 +47,11 @@ class ScheduleInvokerTest {
         lambdaService = mock(LambdaService.class);
         snsService = mock(SnsService.class);
         eventBridgeService = mock(EventBridgeService.class);
+        ecsService = mock(EcsService.class);
         EmulatorConfig config = mock(EmulatorConfig.class);
         when(config.baseUrl()).thenReturn("http://localhost:4566");
         invoker = new ScheduleInvoker(sqsService, lambdaService, snsService,
-                eventBridgeService, new ObjectMapper(), config);
+                eventBridgeService, ecsService, new ObjectMapper(), config);
     }
 
     @Test
@@ -97,6 +108,67 @@ class ScheduleInvokerTest {
 
         verify(snsService).publish(eq(TOPIC_ARN), isNull(), eq("{\"hello\":\"world\"}"),
                 eq("Scheduler"), eq("us-east-1"));
+    }
+
+    @Test
+    void ecsSchedulerTargetRunsTaskWithNetworkConfiguration() {
+        Target target = new Target();
+        target.setArn("arn:aws:ecs:us-east-1:000000000000:cluster/proof");
+        EcsParameters ecsParameters = new EcsParameters();
+        ecsParameters.setTaskDefinitionArn("arn:aws:ecs:us-east-1:000000000000:task-definition/proof:1");
+        ecsParameters.setLaunchType("FARGATE");
+        ecsParameters.setTaskCount(2);
+        AwsVpcConfiguration vpc = new AwsVpcConfiguration();
+        vpc.setSubnets(List.of("subnet-a", "subnet-b"));
+        vpc.setSecurityGroups(List.of("sg-a"));
+        vpc.setAssignPublicIp("DISABLED");
+        NetworkConfiguration network = new NetworkConfiguration();
+        network.setAwsvpcConfiguration(vpc);
+        ecsParameters.setNetworkConfiguration(network);
+        target.setEcsParameters(ecsParameters);
+
+        invoker.invoke(target, "us-west-2");
+
+        ArgumentCaptor<io.github.hectorvent.floci.services.ecs.model.NetworkConfiguration> networkCaptor =
+                ArgumentCaptor.forClass(io.github.hectorvent.floci.services.ecs.model.NetworkConfiguration.class);
+        verify(ecsService).runTask(
+                eq("arn:aws:ecs:us-east-1:000000000000:cluster/proof"),
+                eq("arn:aws:ecs:us-east-1:000000000000:task-definition/proof:1"),
+                eq(2),
+                eq(LaunchType.FARGATE),
+                isNull(),
+                eq("scheduler"),
+                eq(List.<ContainerOverride>of()),
+                networkCaptor.capture(),
+                eq("us-east-1"));
+        io.github.hectorvent.floci.services.ecs.model.AwsVpcConfiguration awsvpc =
+                networkCaptor.getValue().getAwsvpcConfiguration();
+        org.junit.jupiter.api.Assertions.assertEquals(List.of("subnet-a", "subnet-b"), awsvpc.getSubnets());
+        org.junit.jupiter.api.Assertions.assertEquals(List.of("sg-a"), awsvpc.getSecurityGroups());
+        org.junit.jupiter.api.Assertions.assertEquals("DISABLED", awsvpc.getAssignPublicIp());
+    }
+
+    @Test
+    void ecsSchedulerTargetIgnoresUnsupportedLaunchType() {
+        Target target = new Target();
+        target.setArn("arn:aws:ecs:us-east-1:000000000000:cluster/proof");
+        EcsParameters ecsParameters = new EcsParameters();
+        ecsParameters.setTaskDefinitionArn("arn:aws:ecs:us-east-1:000000000000:task-definition/proof:1");
+        ecsParameters.setLaunchType("UNKNOWN");
+        target.setEcsParameters(ecsParameters);
+
+        invoker.invoke(target, "us-east-1");
+
+        verify(ecsService).runTask(
+                eq("arn:aws:ecs:us-east-1:000000000000:cluster/proof"),
+                eq("arn:aws:ecs:us-east-1:000000000000:task-definition/proof:1"),
+                eq(1),
+                isNull(),
+                isNull(),
+                eq("scheduler"),
+                eq(List.<ContainerOverride>of()),
+                isNull(),
+                eq("us-east-1"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvokerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/ScheduleInvokerTest.java
@@ -117,6 +117,7 @@ class ScheduleInvokerTest {
         EcsParameters ecsParameters = new EcsParameters();
         ecsParameters.setTaskDefinitionArn("arn:aws:ecs:us-east-1:000000000000:task-definition/proof:1");
         ecsParameters.setLaunchType("FARGATE");
+        ecsParameters.setGroup("batch-group");
         ecsParameters.setTaskCount(2);
         AwsVpcConfiguration vpc = new AwsVpcConfiguration();
         vpc.setSubnets(List.of("subnet-a", "subnet-b"));
@@ -137,7 +138,7 @@ class ScheduleInvokerTest {
                 eq(2),
                 eq(LaunchType.FARGATE),
                 isNull(),
-                eq("scheduler"),
+                eq("batch-group"),
                 eq(List.<ContainerOverride>of()),
                 networkCaptor.capture(),
                 eq("us-east-1"));

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerIntegrationTest.java
@@ -407,6 +407,59 @@ class SchedulerIntegrationTest {
 
     @Test
     @Order(21)
+    void createScheduleWithEcsParametersRoundTrips() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "ScheduleExpression": "rate(1 day)",
+                    "FlexibleTimeWindow": {"Mode": "OFF"},
+                    "State": "DISABLED",
+                    "Target": {
+                        "Arn": "arn:aws:ecs:us-east-1:000000000000:cluster/proof",
+                        "RoleArn": "arn:aws:iam::000000000000:role/scheduler-role",
+                        "EcsParameters": {
+                            "TaskDefinitionArn": "arn:aws:ecs:us-east-1:000000000000:task-definition/proof:1",
+                            "LaunchType": "FARGATE",
+                            "TaskCount": 1,
+                            "NetworkConfiguration": {
+                                "awsvpcConfiguration": {
+                                    "Subnets": ["subnet-a"],
+                                    "SecurityGroups": ["sg-a"],
+                                    "AssignPublicIp": "DISABLED"
+                                }
+                            }
+                        }
+                    }
+                }
+                """)
+        .when()
+            .post("/schedules/ecs-schedule")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/schedules/ecs-schedule")
+        .then()
+            .statusCode(200)
+            .body("State", equalTo("DISABLED"))
+            .body("Target.EcsParameters.TaskDefinitionArn", equalTo("arn:aws:ecs:us-east-1:000000000000:task-definition/proof:1"))
+            .body("Target.EcsParameters.LaunchType", equalTo("FARGATE"))
+            .body("Target.EcsParameters.TaskCount", equalTo(1))
+            .body("Target.EcsParameters.NetworkConfiguration.awsvpcConfiguration.Subnets", contains("subnet-a"))
+            .body("Target.EcsParameters.NetworkConfiguration.awsvpcConfiguration.SecurityGroups", contains("sg-a"))
+            .body("Target.EcsParameters.NetworkConfiguration.awsvpcConfiguration.AssignPublicIp", equalTo("DISABLED"));
+
+        given()
+        .when()
+            .delete("/schedules/ecs-schedule")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(22)
     void createScheduleInGroup() {
         // First create the group
         given()
@@ -441,7 +494,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(22)
+    @Order(23)
     void createScheduleDuplicateReturns409() {
         given()
             .contentType("application/json")
@@ -459,7 +512,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(23)
+    @Order(24)
     void getSchedule() {
         given()
         .when()
@@ -478,7 +531,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(24)
+    @Order(25)
     void getScheduleInGroup() {
         given()
             .queryParam("groupName", "sched-test-group")
@@ -493,7 +546,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(25)
+    @Order(26)
     void getScheduleNotFoundReturns404() {
         given()
         .when()
@@ -503,7 +556,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(26)
+    @Order(27)
     void listSchedules() {
         given()
         .when()
@@ -515,7 +568,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(27)
+    @Order(28)
     void listSchedulesInGroup() {
         given()
             .queryParam("ScheduleGroup", "sched-test-group")
@@ -528,7 +581,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(28)
+    @Order(29)
     void createScheduleWithDeadLetterConfig() {
         given()
             .contentType("application/json")
@@ -568,7 +621,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(29)
+    @Order(30)
     void createScheduleWithRetryPolicy() {
         given()
             .contentType("application/json")
@@ -608,7 +661,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(30)
+    @Order(31)
     void createScheduleWithStartAndEndDate() {
         given()
             .contentType("application/json")
@@ -646,7 +699,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(31)
+    @Order(32)
     void updateSchedule() {
         given()
             .contentType("application/json")
@@ -682,7 +735,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(32)
+    @Order(33)
     void updateScheduleNotFoundReturns404() {
         given()
             .contentType("application/json")
@@ -700,7 +753,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(33)
+    @Order(34)
     void deleteSchedule() {
         given()
         .when()
@@ -716,7 +769,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(34)
+    @Order(35)
     void deleteScheduleNotFoundReturns404() {
         given()
         .when()
@@ -726,7 +779,7 @@ class SchedulerIntegrationTest {
     }
 
     @Test
-    @Order(35)
+    @Order(36)
     void deleteScheduleInGroup() {
         given()
             .queryParam("groupName", "sched-test-group")
@@ -746,7 +799,7 @@ class SchedulerIntegrationTest {
     // ──────────────────────────── Tag validation tests ────────────────────────────
 
     @Test
-    @Order(36)
+    @Order(37)
     void tagResourceEntryMissingKeyOrValueReturns400() {
         // AWS Tag shape requires both Key and Value; entries with either missing
         // must surface as ValidationException, not be silently dropped.

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerIntegrationTest.java
@@ -419,9 +419,19 @@ class SchedulerIntegrationTest {
                         "Arn": "arn:aws:ecs:us-east-1:000000000000:cluster/proof",
                         "RoleArn": "arn:aws:iam::000000000000:role/scheduler-role",
                         "EcsParameters": {
+                            "CapacityProviderStrategy": [{"CapacityProvider": "FARGATE", "Weight": 1, "Base": 0}],
+                            "EnableECSManagedTags": true,
+                            "EnableExecuteCommand": true,
+                            "Group": "batch-group",
                             "TaskDefinitionArn": "arn:aws:ecs:us-east-1:000000000000:task-definition/proof:1",
                             "LaunchType": "FARGATE",
+                            "PlacementConstraints": [{"Type": "distinctInstance"}],
+                            "PlacementStrategy": [{"Type": "spread", "Field": "attribute:ecs.availability-zone"}],
                             "TaskCount": 1,
+                            "PlatformVersion": "1.4.0",
+                            "PropagateTags": "TASK_DEFINITION",
+                            "ReferenceId": "ref-123",
+                            "Tags": [{"Key": "env", "Value": "test"}],
                             "NetworkConfiguration": {
                                 "awsvpcConfiguration": {
                                     "Subnets": ["subnet-a"],
@@ -444,9 +454,20 @@ class SchedulerIntegrationTest {
         .then()
             .statusCode(200)
             .body("State", equalTo("DISABLED"))
+            .body("Target.EcsParameters.CapacityProviderStrategy[0].CapacityProvider", equalTo("FARGATE"))
+            .body("Target.EcsParameters.CapacityProviderStrategy[0].Weight", equalTo(1))
+            .body("Target.EcsParameters.EnableECSManagedTags", equalTo(true))
+            .body("Target.EcsParameters.EnableExecuteCommand", equalTo(true))
+            .body("Target.EcsParameters.Group", equalTo("batch-group"))
             .body("Target.EcsParameters.TaskDefinitionArn", equalTo("arn:aws:ecs:us-east-1:000000000000:task-definition/proof:1"))
             .body("Target.EcsParameters.LaunchType", equalTo("FARGATE"))
+            .body("Target.EcsParameters.PlacementConstraints[0].Type", equalTo("distinctInstance"))
+            .body("Target.EcsParameters.PlacementStrategy[0].Type", equalTo("spread"))
             .body("Target.EcsParameters.TaskCount", equalTo(1))
+            .body("Target.EcsParameters.PlatformVersion", equalTo("1.4.0"))
+            .body("Target.EcsParameters.PropagateTags", equalTo("TASK_DEFINITION"))
+            .body("Target.EcsParameters.ReferenceId", equalTo("ref-123"))
+            .body("Target.EcsParameters.Tags[0].Key", equalTo("env"))
             .body("Target.EcsParameters.NetworkConfiguration.awsvpcConfiguration.Subnets", contains("subnet-a"))
             .body("Target.EcsParameters.NetworkConfiguration.awsvpcConfiguration.SecurityGroups", contains("sg-a"))
             .body("Target.EcsParameters.NetworkConfiguration.awsvpcConfiguration.AssignPublicIp", equalTo("DISABLED"));


### PR DESCRIPTION
Summary:
- Add EventBridge Scheduler ECS target parameter parsing and response round-tripping.
- Dispatch ECS scheduler targets through ECS RunTask with awsvpc network configuration.
- Add unit, integration, and Java SDK coverage for ECS target parameters.

Verification:
- ./mvnw -q -Dtest=ScheduleInvokerTest,SchedulerIntegrationTest test
- git diff --check origin/main..HEAD
- product-name diff scan: clean