### PR TITLE
fix(autoscaling): propagate ASG tags at launch

### DIFF
--- a/docs/services/docdb.md
+++ b/docs/services/docdb.md
@@ -21,6 +21,7 @@ The management API shares the RDS Query endpoint (`POST /` with an `Action=` par
 | --- | --- |
 | `CreateDBCluster` | Create a DocumentDB cluster and start a MongoDB container |
 | `DescribeDBClusters` | List clusters and their connection details |
+| `DescribeDBClusterSnapshots` | - |
 | `DeleteDBCluster` | Stop and remove a cluster (must have no instances) |
 | `ModifyDBCluster` | Update engine version or IAM auth setting |
 | `CreateDBInstance` | Add an instance to a cluster |

--- a/docs/services/elasticache.md
+++ b/docs/services/elasticache.md
@@ -23,6 +23,8 @@ Floci manages real Valkey/Redis Docker containers and proxies TCP connections to
 | `CreateCacheCluster` | - |
 | `DescribeCacheClusters` | - |
 | `DeleteCacheCluster` | - |
+| `DescribeCacheSubnetGroups` | - |
+| `DescribeCacheParameterGroups` | - |
 <!-- floci:actions:end -->
 
 ## Configuration

--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -37,6 +37,9 @@ RDS Data API (`rds-data`) is documented separately because it uses REST JSON rou
 | `DeleteDBClusterParameterGroup` | - |
 | `ModifyDBClusterParameterGroup` | - |
 | `DescribeDBClusterParameters` | - |
+| `DescribeDBSnapshots` | - |
+| `DescribeDBProxies` | - |
+| `DescribeDBClusterSnapshots` | - |
 | `AddTagsToResource` | Add tags to a DB resource |
 | `ListTagsForResource` | List tags for a DB resource |
 | `RemoveTagsFromResource` | Remove tags from a DB resource |

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java
@@ -151,7 +151,8 @@ public class AutoScalingQueryHandler {
     // ── Auto Scaling Group ────────────────────────────────────────────────────
 
     private Response handleCreateAutoScalingGroup(MultivaluedMap<String, String> p, String region) {
-        service.createAutoScalingGroup(region,
+        ParsedTags parsedTags = parseTags(p);
+        AutoScalingGroup asg = service.createAutoScalingGroup(region,
                 p.getFirst("AutoScalingGroupName"),
                 p.getFirst("LaunchConfigurationName"),
                 p.getFirst("LaunchTemplate.LaunchTemplateId"),
@@ -169,7 +170,8 @@ public class AutoScalingQueryHandler {
                 p.getFirst("HealthCheckType"),
                 intParam(p, "HealthCheckGracePeriod", 0),
                 memberList(p, "TerminationPolicies"),
-                parseTags(p));
+                parsedTags.tags(),
+                parsedTags.propagateAtLaunch());
         return ok(new XmlBuilder()
                 .start("CreateAutoScalingGroupResponse", NS)
                   .raw(AwsQueryResponse.responseMetadata())
@@ -304,7 +306,7 @@ public class AutoScalingQueryHandler {
                .elem("Value", tag.getValue())
                .elem("ResourceId", asg.getAutoScalingGroupName())
                .elem("ResourceType", "auto-scaling-group")
-               .elem("PropagateAtLaunch", "false")
+               .elem("PropagateAtLaunch", String.valueOf(asg.getTagPropagateAtLaunch().getOrDefault(tag.getKey(), false)))
                .end("member");
         }
         xml.end("Tags");
@@ -413,7 +415,12 @@ public class AutoScalingQueryHandler {
 
     private Response handleCreateOrUpdateTags(MultivaluedMap<String, String> p, String region) {
         for (TagRequest tag : parseTagRequests(p)) {
-            service.createOrUpdateTags(region, tag.resourceId(), tag.resourceType(), Map.of(tag.key(), tag.value()));
+            service.createOrUpdateTags(
+                    region,
+                    tag.resourceId(),
+                    tag.resourceType(),
+                    Map.of(tag.key(), tag.value()),
+                    Map.of(tag.key(), tag.propagateAtLaunch()));
         }
         return ok(new XmlBuilder()
                 .start("CreateOrUpdateTagsResponse", NS)
@@ -1036,15 +1043,18 @@ public class AutoScalingQueryHandler {
         return result;
     }
 
-    private Map<String, String> parseTags(MultivaluedMap<String, String> p) {
-        Map<String, String> result = new LinkedHashMap<>();
+    private ParsedTags parseTags(MultivaluedMap<String, String> p) {
+        Map<String, String> tags = new LinkedHashMap<>();
+        Map<String, Boolean> propagateAtLaunch = new LinkedHashMap<>();
         for (int i = 1; ; i++) {
             String key = p.getFirst("Tags.member." + i + ".Key");
             if (key == null) { break; }
             String value = p.getFirst("Tags.member." + i + ".Value");
-            result.put(key, value != null ? value : "");
+            tags.put(key, value != null ? value : "");
+            propagateAtLaunch.put(key,
+                    Boolean.parseBoolean(p.getFirst("Tags.member." + i + ".PropagateAtLaunch")));
         }
-        return result;
+        return new ParsedTags(tags, propagateAtLaunch);
     }
 
     private List<TagRequest> parseTagRequests(MultivaluedMap<String, String> p) {
@@ -1055,12 +1065,15 @@ public class AutoScalingQueryHandler {
             String resourceId = p.getFirst("Tags.member." + i + ".ResourceId");
             String resourceType = p.getFirst("Tags.member." + i + ".ResourceType");
             String value = p.getFirst("Tags.member." + i + ".Value");
-            result.add(new TagRequest(resourceId, resourceType, key, value != null ? value : ""));
+            boolean propagateAtLaunch = Boolean.parseBoolean(p.getFirst("Tags.member." + i + ".PropagateAtLaunch"));
+            result.add(new TagRequest(resourceId, resourceType, key, value != null ? value : "", propagateAtLaunch));
         }
         return result;
     }
 
-    private record TagRequest(String resourceId, String resourceType, String key, String value) {}
+    private record TagRequest(String resourceId, String resourceType, String key, String value, boolean propagateAtLaunch) {}
+
+    private record ParsedTags(Map<String, String> tags, Map<String, Boolean> propagateAtLaunch) {}
 
     private InstanceRefresh parseInstanceRefresh(MultivaluedMap<String, String> p) {
         InstanceRefresh refresh = new InstanceRefresh();

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
@@ -19,6 +19,7 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 import io.quarkus.runtime.StartupEvent;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -293,7 +294,7 @@ public class AutoScalingReconciler {
                     launchSource.securityGroupIds(),
                     subnetId,
                     null,
-                    launchSource.instanceTags(),
+                    propagatedInstanceTags(asg, launchSource),
                     launchSource.userData(),
                     launchSource.iamInstanceProfile());
 
@@ -317,6 +318,23 @@ public class AutoScalingReconciler {
             LOG.warnv("ASG {0}: failed to launch instances: {1}",
                     asg.getAutoScalingGroupName(), e.getMessage());
         }
+    }
+
+    private static List<io.github.hectorvent.floci.services.ec2.model.Tag> propagatedInstanceTags(
+            AutoScalingGroup asg,
+            LaunchSource launchSource) {
+        Map<String, String> tags = new LinkedHashMap<>();
+        for (io.github.hectorvent.floci.services.ec2.model.Tag tag : launchSource.instanceTags()) {
+            tags.put(tag.getKey(), tag.getValue());
+        }
+        asg.getTags().forEach((key, value) -> {
+            if (asg.getTagPropagateAtLaunch().getOrDefault(key, false)) {
+                tags.put(key, value);
+            }
+        });
+        return tags.entrySet().stream()
+                .map(entry -> new io.github.hectorvent.floci.services.ec2.model.Tag(entry.getKey(), entry.getValue()))
+                .toList();
     }
 
     private void scaleIn(AutoScalingGroup asg, int count) {

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
@@ -164,7 +164,8 @@ public class AutoScalingService {
                                                     List<String> targetGroupArns, List<String> lbNames,
                                                     String healthCheckType, int healthCheckGracePeriod,
                                                     List<String> terminationPolicies,
-                                                    Map<String, String> tags) {
+                                                    Map<String, String> tags,
+                                                    Map<String, Boolean> tagPropagateAtLaunch) {
         String key = asgKey(region, name);
         if (groups.containsKey(key)) {
             throw new AwsException("AlreadyExists",
@@ -205,6 +206,9 @@ public class AutoScalingService {
         asg.setRegion(region);
         if (tags != null) {
             asg.getTags().putAll(tags);
+        }
+        if (tagPropagateAtLaunch != null) {
+            asg.getTagPropagateAtLaunch().putAll(tagPropagateAtLaunch);
         }
         groups.put(key, asg);
         return asg;
@@ -326,15 +330,22 @@ public class AutoScalingService {
         groups.put(asgKey(region, name), asg);
     }
 
-    public void createOrUpdateTags(String region, String resourceId, String resourceType, Map<String, String> tags) {
+    public void createOrUpdateTags(
+            String region,
+            String resourceId,
+            String resourceType,
+            Map<String, String> tags,
+            Map<String, Boolean> tagPropagateAtLaunch) {
         AutoScalingGroup asg = requireTaggableGroup(region, resourceId, resourceType);
         asg.getTags().putAll(tags);
+        asg.getTagPropagateAtLaunch().putAll(tagPropagateAtLaunch);
         groups.put(asgKey(region, asg.getAutoScalingGroupName()), asg);
     }
 
     public void deleteTags(String region, String resourceId, String resourceType, List<String> tagKeys) {
         AutoScalingGroup asg = requireTaggableGroup(region, resourceId, resourceType);
         tagKeys.forEach(asg.getTags()::remove);
+        tagKeys.forEach(asg.getTagPropagateAtLaunch()::remove);
         groups.put(asgKey(region, asg.getAutoScalingGroupName()), asg);
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/AutoScalingGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/AutoScalingGroup.java
@@ -35,6 +35,7 @@ public class AutoScalingGroup {
     private Instant createdTime;
     private String region;
     private Map<String, String> tags = new ConcurrentHashMap<>();
+    private Map<String, Boolean> tagPropagateAtLaunch = new ConcurrentHashMap<>();
     private String status;  // null = active, "Delete in progress" = deleting
 
     public AutoScalingGroup() {}
@@ -104,6 +105,9 @@ public class AutoScalingGroup {
 
     public Map<String, String> getTags() { return tags; }
     public void setTags(Map<String, String> v) { this.tags = v; }
+
+    public Map<String, Boolean> getTagPropagateAtLaunch() { return tagPropagateAtLaunch; }
+    public void setTagPropagateAtLaunch(Map<String, Boolean> v) { this.tagPropagateAtLaunch = v; }
 
     public String getStatus() { return status; }
     public void setStatus(String v) { this.status = v; }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -847,7 +847,8 @@ public class CloudFormationResourceProvisioner {
                 resolveOptional(props, "HealthCheckType", engine),
                 parseIntProp(props, "HealthCheckGracePeriod", engine, 0),
                 resolveStringList(props, "TerminationPolicies", engine),
-                resolveAsgTags(props, engine));
+                resolveAsgTags(props, engine),
+                resolveAsgTagPropagation(props, engine));
         // Ref returns the Auto Scaling group name; Fn::GetAtt Arn returns the ASG ARN.
         r.setPhysicalId(name);
         r.getAttributes().put("Arn", asg.getAutoScalingGroupArn());
@@ -864,6 +865,19 @@ public class CloudFormationResourceProvisioner {
             }
         }
         return tags;
+    }
+
+    private Map<String, Boolean> resolveAsgTagPropagation(JsonNode props, CloudFormationTemplateEngine engine) {
+        Map<String, Boolean> propagation = new LinkedHashMap<>();
+        if (props != null && props.has("Tags") && props.get("Tags").isArray()) {
+            for (JsonNode tag : props.get("Tags")) {
+                String key = engine.resolve(tag.path("Key"));
+                if (!key.isEmpty()) {
+                    propagation.put(key, Boolean.parseBoolean(engine.resolve(tag.path("PropagateAtLaunch"))));
+                }
+            }
+        }
+        return propagation;
     }
 
     private List<String> resolveStringList(JsonNode props, String field, CloudFormationTemplateEngine engine) {

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingIntegrationTest.java
@@ -465,6 +465,11 @@ class AutoScalingIntegrationTest {
                 .formParam("Tags.member.1.Key", "owner")
                 .formParam("Tags.member.1.Value", "sample-app")
                 .formParam("Tags.member.1.PropagateAtLaunch", "true")
+                .formParam("Tags.member.2.ResourceId", "my-lt-asg")
+                .formParam("Tags.member.2.ResourceType", "auto-scaling-group")
+                .formParam("Tags.member.2.Key", "control-plane-only")
+                .formParam("Tags.member.2.Value", "true")
+                .formParam("Tags.member.2.PropagateAtLaunch", "false")
                 .header("Authorization", AUTH)
             .when()
                 .post("/")
@@ -489,7 +494,10 @@ class AutoScalingIntegrationTest {
                 .body(containsString("<Version>$Latest</Version>"))
                 .body(containsString("<VPCZoneIdentifier>subnet-12345678,subnet-87654321</VPCZoneIdentifier>"))
                 .body(containsString("owner"))
-                .body(containsString("sample-app"));
+                .body(containsString("sample-app"))
+                .body(containsString("<PropagateAtLaunch>true</PropagateAtLaunch>"))
+                .body(containsString("control-plane-only"))
+                .body(containsString("<PropagateAtLaunch>false</PropagateAtLaunch>"));
 
         given()
                 .formParam("Action", "DeleteTags")

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandlerTest.java
@@ -37,7 +37,7 @@ class AutoScalingQueryHandlerTest {
                 "EC2",
                 0,
                 List.of("Default"),
-                java.util.Map.of());
+                java.util.Map.of(), java.util.Map.of());
 
         AutoScalingQueryHandler handler = new AutoScalingQueryHandler(service);
         MultivaluedHashMap<String, String> startParams = new MultivaluedHashMap<>();
@@ -102,6 +102,7 @@ class AutoScalingQueryHandlerTest {
                 "EC2",
                 0,
                 List.of("Default"),
+                java.util.Map.of(),
                 java.util.Map.of());
         AsgInstance instance = new AsgInstance();
         instance.setInstanceId("i-original");
@@ -157,7 +158,7 @@ class AutoScalingQueryHandlerTest {
                 "EC2",
                 0,
                 List.of("Default"),
-                java.util.Map.of());
+                java.util.Map.of(), java.util.Map.of());
         AsgInstance instance = new AsgInstance();
         instance.setInstanceId("i-current");
         instance.setAvailabilityZone("us-east-1a");
@@ -206,7 +207,7 @@ class AutoScalingQueryHandlerTest {
                 "EC2",
                 0,
                 List.of("Default"),
-                java.util.Map.of());
+                java.util.Map.of(), java.util.Map.of());
 
         AutoScalingQueryHandler handler = new AutoScalingQueryHandler(service);
         MultivaluedHashMap<String, String> putParams = new MultivaluedHashMap<>();

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconcilerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconcilerTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -70,6 +71,10 @@ class AutoScalingReconcilerTest {
         asg.setDesiredCapacity(1);
         asg.setLaunchTemplateId("lt-123");
         asg.setLaunchTemplateVersion("1");
+        asg.getTags().put("job-id", "2001");
+        asg.getTags().put("control-plane-only", "true");
+        asg.getTagPropagateAtLaunch().put("job-id", true);
+        asg.getTagPropagateAtLaunch().put("control-plane-only", false);
 
         LaunchTemplate launchTemplate = new LaunchTemplate();
         launchTemplate.setLaunchTemplateId("lt-123");
@@ -79,6 +84,7 @@ class AutoScalingReconcilerTest {
         version.setInstanceType("t3.micro");
         version.setIamInstanceProfileArn("arn:aws:iam::000000000000:instance-profile/app-profile");
         List<Tag> instanceTags = List.of(new Tag("app.ClusterId", "development"));
+        List<Tag> propagatedTags = List.of(new Tag("app.ClusterId", "development"), new Tag("job-id", "2001"));
         version.setInstanceTags(instanceTags);
         when(ec2Service.describeLaunchTemplates("us-east-1", List.of("lt-123"), List.of(), Map.of()))
                 .thenReturn(List.of(launchTemplate));
@@ -90,7 +96,7 @@ class AutoScalingReconcilerTest {
         reservation.setInstances(List.of(ec2Instance));
         when(ec2Service.runInstances(eq("us-east-1"), eq("ami-version-1"), eq("t3.micro"),
                 eq(1), eq(1), eq(null), eq(List.of()), eq(null), eq(null),
-                eq(instanceTags), eq(null), eq("arn:aws:iam::000000000000:instance-profile/app-profile"))).thenReturn(reservation);
+                anyList(), eq(null), eq("arn:aws:iam::000000000000:instance-profile/app-profile"))).thenReturn(reservation);
 
         reconciler.reconcile(asg);
 
@@ -98,9 +104,15 @@ class AutoScalingReconcilerTest {
         assertEquals("i-launched", asg.getInstances().getFirst().getInstanceId());
         assertEquals("lt-123", asg.getInstances().getFirst().getLaunchTemplateId());
         assertEquals("1", asg.getInstances().getFirst().getLaunchTemplateVersion());
+        ArgumentCaptor<List<Tag>> tags = ArgumentCaptor.captor();
         verify(ec2Service).runInstances(eq("us-east-1"), eq("ami-version-1"), eq("t3.micro"),
                 eq(1), eq(1), eq(null), eq(List.of()), eq(null), eq(null),
-                eq(instanceTags), eq(null), eq("arn:aws:iam::000000000000:instance-profile/app-profile"));
+                tags.capture(), eq(null), eq("arn:aws:iam::000000000000:instance-profile/app-profile"));
+        assertEquals(propagatedTags.size(), tags.getValue().size());
+        assertEquals("app.ClusterId", tags.getValue().get(0).getKey());
+        assertEquals("development", tags.getValue().get(0).getValue());
+        assertEquals("job-id", tags.getValue().get(1).getKey());
+        assertEquals("2001", tags.getValue().get(1).getValue());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingServiceTest.java
@@ -48,7 +48,7 @@ class AutoScalingServiceTest {
                 "EC2",
                 0,
                 List.of("Default"),
-                java.util.Map.of());
+                java.util.Map.of(), java.util.Map.of());
     }
 
     @Test
@@ -120,7 +120,7 @@ class AutoScalingServiceTest {
                 "EC2",
                 0,
                 List.of("Default"),
-                java.util.Map.of()));
+                java.util.Map.of(), java.util.Map.of()));
 
         assertEquals("ValidationError", error.getErrorCode());
         assertEquals(AutoScalingService.MISSING_LAUNCH_TEMPLATE_IMAGE_ID_MESSAGE, error.getMessage());
@@ -229,7 +229,7 @@ class AutoScalingServiceTest {
                 "EC2",
                 0,
                 List.of("Default"),
-                java.util.Map.of()));
+                java.util.Map.of(), java.util.Map.of()));
 
         assertEquals("ValidationError", error.getErrorCode());
         assertEquals(AutoScalingService.INVALID_LAUNCH_TEMPLATE_MESSAGE, error.getMessage());
@@ -633,7 +633,7 @@ class AutoScalingServiceTest {
                 "EC2",
                 0,
                 List.of("Default"),
-                java.util.Map.of());
+                java.util.Map.of(), java.util.Map.of());
     }
 
     private static final class AutoScalingGroupFixture {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationAutoScalingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationAutoScalingIntegrationTest.java
@@ -46,7 +46,11 @@ class CloudFormationAutoScalingIntegrationTest {
                         "MinSize": 1,
                         "MaxSize": 3,
                         "DesiredCapacity": 2,
-                        "AvailabilityZones": ["us-east-1a"]
+                        "AvailabilityZones": ["us-east-1a"],
+                        "Tags": [
+                          {"Key": "cluster", "Value": "demo", "PropagateAtLaunch": true},
+                          {"Key": "control-plane", "Value": "only", "PropagateAtLaunch": false}
+                        ]
                       }
                     }
                   },
@@ -91,6 +95,12 @@ class CloudFormationAutoScalingIntegrationTest {
         .then()
             .statusCode(200)
             .body(containsString(asgName))
-            .body(containsString(lcName));
+            .body(containsString(lcName))
+            .body(containsString("<Key>cluster</Key>"))
+            .body(containsString("<Value>demo</Value>"))
+            .body(containsString("<PropagateAtLaunch>true</PropagateAtLaunch>"))
+            .body(containsString("<Key>control-plane</Key>"))
+            .body(containsString("<Value>only</Value>"))
+            .body(containsString("<PropagateAtLaunch>false</PropagateAtLaunch>"));
     }
 }


### PR DESCRIPTION
Summary:
- Preserve Auto Scaling tag PropagateAtLaunch metadata on groups.
- Apply launch-propagated Auto Scaling tags to created EC2 instances.
- Add service/query coverage for propagated and non-propagated tags.

Verification:
- ./mvnw -q -Dtest=AutoScalingServiceTest,AutoScalingQueryHandlerTest test
- git diff --check origin/main..HEAD
- product-name diff scan: clean
