### PR TITLE
fix(rds): preserve network placement metadata

### DIFF
--- a/docs/services/docdb.md
+++ b/docs/services/docdb.md
@@ -21,6 +21,7 @@ The management API shares the RDS Query endpoint (`POST /` with an `Action=` par
 | --- | --- |
 | `CreateDBCluster` | Create a DocumentDB cluster and start a MongoDB container |
 | `DescribeDBClusters` | List clusters and their connection details |
+| `DescribeDBClusterSnapshots` | - |
 | `DeleteDBCluster` | Stop and remove a cluster (must have no instances) |
 | `ModifyDBCluster` | Update engine version or IAM auth setting |
 | `CreateDBInstance` | Add an instance to a cluster |

--- a/docs/services/elasticache.md
+++ b/docs/services/elasticache.md
@@ -23,6 +23,8 @@ Floci manages real Valkey/Redis Docker containers and proxies TCP connections to
 | `CreateCacheCluster` | - |
 | `DescribeCacheClusters` | - |
 | `DeleteCacheCluster` | - |
+| `DescribeCacheSubnetGroups` | - |
+| `DescribeCacheParameterGroups` | - |
 <!-- floci:actions:end -->
 
 ## Configuration

--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -43,8 +43,6 @@ RDS Data API (`rds-data`) is documented separately because it uses REST JSON rou
 | `AddTagsToResource` | Add tags to a DB resource |
 | `ListTagsForResource` | List tags for a DB resource |
 | `RemoveTagsFromResource` | Remove tags from a DB resource |
-| `SubnetIds` | - |
-| `VpcSecurityGroupIds` | - |
 <!-- floci:actions:end -->
 
 ## Configuration

--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -37,9 +37,14 @@ RDS Data API (`rds-data`) is documented separately because it uses REST JSON rou
 | `DeleteDBClusterParameterGroup` | - |
 | `ModifyDBClusterParameterGroup` | - |
 | `DescribeDBClusterParameters` | - |
+| `DescribeDBSnapshots` | - |
+| `DescribeDBProxies` | - |
+| `DescribeDBClusterSnapshots` | - |
 | `AddTagsToResource` | Add tags to a DB resource |
 | `ListTagsForResource` | List tags for a DB resource |
 | `RemoveTagsFromResource` | Remove tags from a DB resource |
+| `SubnetIds` | - |
+| `VpcSecurityGroupIds` | - |
 <!-- floci:actions:end -->
 
 ## Configuration

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -281,7 +281,7 @@ public class AwsQueryController {
                        || docDbService.hasInstance(instanceId)) {
                         yield docDbQueryHandler.handle(action, formParams);
                 }
-                yield rdsQueryHandler.handle(action, formParams);
+                yield rdsQueryHandler.handle(action, formParams, region);
             }
             case "neptune" -> neptuneQueryHandler.handle(action, formParams);
             case "docdb" -> docDbQueryHandler.handle(action, formParams);

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -326,12 +326,12 @@ public class CloudFormationResourceProvisioner {
                         provisionFirehoseDeliveryStream(resource, properties, engine, stackName);
                 case "AWS::EC2::Instance" -> provisionEc2Instance(resource, properties, engine, region);
                 // RDS. DBInstance/DBCluster start real RDS containers (same as the direct API).
-                case "AWS::RDS::DBSubnetGroup" -> provisionDbSubnetGroup(resource, properties, engine, stackName);
+                case "AWS::RDS::DBSubnetGroup" -> provisionDbSubnetGroup(resource, properties, engine, stackName, region);
                 case "AWS::RDS::DBParameterGroup" -> provisionDbParameterGroup(resource, properties, engine, stackName);
                 case "AWS::RDS::DBClusterParameterGroup" ->
                         provisionDbClusterParameterGroup(resource, properties, engine, stackName);
-                case "AWS::RDS::DBInstance" -> provisionDbInstance(resource, properties, engine, stackName);
-                case "AWS::RDS::DBCluster" -> provisionDbCluster(resource, properties, engine, stackName);
+                case "AWS::RDS::DBInstance" -> provisionDbInstance(resource, properties, engine, stackName, region);
+                case "AWS::RDS::DBCluster" -> provisionDbCluster(resource, properties, engine, stackName, region);
                 case "AWS::EKS::Cluster" -> provisionEksCluster(resource, properties, engine, stackName);
                 case "AWS::EKS::Nodegroup" -> provisionEksNodegroup(resource, properties, engine, stackName);
                 case "AWS::Logs::LogGroup" -> provisionLogGroup(resource, properties, engine, region, accountId, stackName);
@@ -937,7 +937,7 @@ public class CloudFormationResourceProvisioner {
     // ── RDS ─────────────────────────────────────────────────────────────────────
 
     private void provisionDbSubnetGroup(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
-                                        String stackName) {
+                                        String stackName, String region) {
         String name = resolveOptional(props, "DBSubnetGroupName", engine);
         if (name == null || name.isBlank()) {
             name = generatePhysicalName(stackName, r.getLogicalId(), 60, true);
@@ -950,7 +950,7 @@ public class CloudFormationResourceProvisioner {
                 subnetIds.add(engine.resolve(subnet));
             }
         }
-        var group = rdsService.createDbSubnetGroup(name, description, subnetIds);
+        var group = rdsService.createDbSubnetGroup(name, description, subnetIds, region);
         r.setPhysicalId(group.getDbSubnetGroupName());
         r.getAttributes().put("DBSubnetGroupName", group.getDbSubnetGroupName());
     }
@@ -984,7 +984,7 @@ public class CloudFormationResourceProvisioner {
     }
 
     private void provisionDbInstance(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
-                                     String stackName) {
+                                     String stackName, String region) {
         String id = resolveOptional(props, "DBInstanceIdentifier", engine);
         if (id == null || id.isBlank()) {
             id = generatePhysicalName(stackName, r.getLogicalId(), 60, true);
@@ -1001,7 +1001,8 @@ public class CloudFormationResourceProvisioner {
                 parseBoolProp(props, "EnableIAMDatabaseAuthentication", engine),
                 resolveOptional(props, "DBParameterGroupName", engine),
                 resolveOptional(props, "DBSubnetGroupName", engine),
-                resolveOptional(props, "DBClusterIdentifier", engine));
+                resolveOptional(props, "DBClusterIdentifier", engine),
+                null, false, false, null, Map.of(), region);
         r.setPhysicalId(instance.getDbInstanceIdentifier());
         r.getAttributes().put("DBInstanceIdentifier", instance.getDbInstanceIdentifier());
         if (instance.getEndpoint() != null) {
@@ -1014,7 +1015,7 @@ public class CloudFormationResourceProvisioner {
     }
 
     private void provisionDbCluster(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
-                                    String stackName) {
+                                    String stackName, String region) {
         String id = resolveOptional(props, "DBClusterIdentifier", engine);
         if (id == null || id.isBlank()) {
             id = generatePhysicalName(stackName, r.getLogicalId(), 60, true);
@@ -1027,7 +1028,8 @@ public class CloudFormationResourceProvisioner {
                 resolveOptional(props, "MasterUserPassword", engine),
                 resolveOptional(props, "DatabaseName", engine),
                 parseBoolProp(props, "EnableIAMDatabaseAuthentication", engine),
-                resolveOptional(props, "DBClusterParameterGroupName", engine));
+                resolveOptional(props, "DBClusterParameterGroupName", engine),
+                null, null, false, region);
         r.setPhysicalId(cluster.getDbClusterIdentifier());
         r.getAttributes().put("DBClusterIdentifier", cluster.getDbClusterIdentifier());
         if (cluster.getEndpoint() != null) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -181,9 +181,8 @@ public class RdsQueryHandler {
         String dbSubnetGroupName = params.getFirst("DBSubnetGroupName");
         try {
             List<String> vpcSecurityGroupIds = vpcSecurityGroupIds(params);
-            DbInstance instance = vpcSecurityGroupIds.isEmpty()
-                    ? service.modifyDbInstance(id, newPassword, iamEnabled, dbSubnetGroupName)
-                    : service.modifyDbInstance(id, newPassword, iamEnabled, dbSubnetGroupName, vpcSecurityGroupIds);
+            DbInstance instance = service.modifyDbInstance(
+                    id, newPassword, iamEnabled, dbSubnetGroupName, vpcSecurityGroupIds);
             String result = dbInstanceXml(instance);
             return Response.ok(AwsQueryResponse.envelope("ModifyDBInstance", AwsNamespaces.RDS, result)).build();
         } catch (AwsException e) {
@@ -256,9 +255,7 @@ public class RdsQueryHandler {
         String description = params.getFirst("DBSubnetGroupDescription");
         List<String> subnetIds = memberList(params, "SubnetIds");
         try {
-            DbSubnetGroup group = region == null
-                    ? service.createDbSubnetGroup(name, description, subnetIds)
-                    : service.createDbSubnetGroup(name, description, subnetIds, region);
+            DbSubnetGroup group = service.createDbSubnetGroup(name, description, subnetIds, region);
             return Response.ok(AwsQueryResponse.envelope("CreateDBSubnetGroup",
                     AwsNamespaces.RDS, dbSubnetGroupXml(group))).build();
         } catch (AwsException e) {
@@ -289,9 +286,7 @@ public class RdsQueryHandler {
         }
         List<String> subnetIds = memberList(params, "SubnetIds");
         try {
-            DbSubnetGroup group = region == null
-                    ? service.modifyDbSubnetGroup(name, subnetIds)
-                    : service.modifyDbSubnetGroup(name, subnetIds, region);
+            DbSubnetGroup group = service.modifyDbSubnetGroup(name, subnetIds, region);
             return Response.ok(AwsQueryResponse.envelope("ModifyDBSubnetGroup",
                     AwsNamespaces.RDS, dbSubnetGroupXml(group))).build();
         } catch (AwsException e) {
@@ -351,13 +346,9 @@ public class RdsQueryHandler {
         }
 
         try {
-            DbCluster cluster = region == null
-                    ? service.createDbCluster(id, engine, engineVersion, masterUsername,
-                            masterPassword, databaseName, iamEnabled, paramGroupName,
-                            dbSubnetGroupName, availabilityZone, multiAz)
-                    : service.createDbCluster(id, engine, engineVersion, masterUsername,
-                            masterPassword, databaseName, iamEnabled, paramGroupName,
-                            dbSubnetGroupName, availabilityZone, multiAz, region);
+            DbCluster cluster = service.createDbCluster(id, engine, engineVersion, masterUsername,
+                    masterPassword, databaseName, iamEnabled, paramGroupName,
+                    dbSubnetGroupName, availabilityZone, multiAz, region);
             String result = dbClusterXml(cluster);
             return Response.ok(AwsQueryResponse.envelope("CreateDBCluster", AwsNamespaces.RDS, result)).build();
         } catch (AwsException e) {
@@ -847,25 +838,9 @@ public class RdsQueryHandler {
     private DbSubnetGroup dbSubnetGroupForInstance(DbInstance instance) {
         String groupName = instance.getDbSubnetGroupName();
         if (groupName == null || groupName.isBlank() || "default".equalsIgnoreCase(groupName)) {
-            return fallbackSubnetGroup(instance, "default", "default");
+            return fallbackSubnetGroup(instance, "default", "default subnet group");
         }
-        if (groupName != null && !groupName.isBlank()) {
-            try {
-                DbSubnetGroup group = service.getDbSubnetGroup(groupName);
-                if (group != null) {
-                    return group;
-                }
-            } catch (AwsException ignored) {
-            }
-        }
-        try {
-            DbSubnetGroup group = service.resolveDbSubnetGroupView(groupName);
-            if (group != null) {
-                return group;
-            }
-        } catch (AwsException ignored) {
-        }
-        return fallbackSubnetGroup(instance, groupName, "DB subnet group " + groupName);
+        return service.getDbSubnetGroup(groupName);
     }
 
     private DbSubnetGroup fallbackSubnetGroup(DbInstance instance, String name, String description) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -42,20 +42,24 @@ public class RdsQueryHandler {
     }
 
     public Response handle(String action, MultivaluedMap<String, String> params) {
+        return handle(action, params, null);
+    }
+
+    public Response handle(String action, MultivaluedMap<String, String> params, String region) {
         LOG.infov("RDS action: {0}", action);
         try {
             return switch (action) {
-                case "CreateDBInstance" -> handleCreateDbInstance(params);
+                case "CreateDBInstance" -> handleCreateDbInstance(params, region);
                 case "DescribeDBInstances" -> handleDescribeDbInstances(params);
                 case "DeleteDBInstance" -> handleDeleteDbInstance(params);
                 case "ModifyDBInstance" -> handleModifyDbInstance(params);
                 case "RebootDBInstance" -> handleRebootDbInstance(params);
                 case "DescribeOrderableDBInstanceOptions" -> handleDescribeOrderableDbInstanceOptions(params);
-                case "CreateDBSubnetGroup" -> handleCreateDbSubnetGroup(params);
+                case "CreateDBSubnetGroup" -> handleCreateDbSubnetGroup(params, region);
                 case "DescribeDBSubnetGroups" -> handleDescribeDbSubnetGroups(params);
-                case "ModifyDBSubnetGroup" -> handleModifyDbSubnetGroup(params);
+                case "ModifyDBSubnetGroup" -> handleModifyDbSubnetGroup(params, region);
                 case "DeleteDBSubnetGroup" -> handleDeleteDbSubnetGroup(params);
-                case "CreateDBCluster" -> handleCreateDbCluster(params);
+                case "CreateDBCluster" -> handleCreateDbCluster(params, region);
                 case "DescribeDBClusters" -> handleDescribeDbClusters(params);
                 case "DeleteDBCluster" -> handleDeleteDbCluster(params);
                 case "ModifyDBCluster" -> handleModifyDbCluster(params);
@@ -88,7 +92,7 @@ public class RdsQueryHandler {
 
     // ── DB Instances ──────────────────────────────────────────────────────────
 
-    private Response handleCreateDbInstance(MultivaluedMap<String, String> params) {
+    private Response handleCreateDbInstance(MultivaluedMap<String, String> params, String region) {
         String id = params.getFirst("DBInstanceIdentifier");
         if (id == null || id.isBlank()) {
             return AwsQueryResponse.error("InvalidParameterValue",
@@ -121,10 +125,15 @@ public class RdsQueryHandler {
         }
 
         try {
-            DbInstance instance = service.createDbInstance(id, engine, engineVersion, masterUsername,
-                    masterPassword, dbName, dbInstanceClass, allocatedStorage, iamEnabled,
-                    paramGroupName, dbSubnetGroupName, dbClusterIdentifier, availabilityZone, multiAz,
-                    manageMasterUserPassword, masterUserSecretKmsKeyId, tags);
+            DbInstance instance = region == null
+                    ? service.createDbInstance(id, engine, engineVersion, masterUsername,
+                            masterPassword, dbName, dbInstanceClass, allocatedStorage, iamEnabled,
+                            paramGroupName, dbSubnetGroupName, dbClusterIdentifier, availabilityZone, multiAz,
+                            manageMasterUserPassword, masterUserSecretKmsKeyId, tags)
+                    : service.createDbInstance(id, engine, engineVersion, masterUsername,
+                            masterPassword, dbName, dbInstanceClass, allocatedStorage, iamEnabled,
+                            paramGroupName, dbSubnetGroupName, dbClusterIdentifier, availabilityZone, multiAz,
+                            manageMasterUserPassword, masterUserSecretKmsKeyId, tags, region);
             String result = dbInstanceXml(instance);
             return Response.ok(AwsQueryResponse.envelope("CreateDBInstance", AwsNamespaces.RDS, result)).build();
         } catch (AwsException e) {
@@ -239,7 +248,7 @@ public class RdsQueryHandler {
         }
     }
 
-    private Response handleCreateDbSubnetGroup(MultivaluedMap<String, String> params) {
+    private Response handleCreateDbSubnetGroup(MultivaluedMap<String, String> params, String region) {
         String name = params.getFirst("DBSubnetGroupName");
         if (name == null || name.isBlank()) {
             return AwsQueryResponse.error("MissingParameter",
@@ -248,7 +257,9 @@ public class RdsQueryHandler {
         String description = params.getFirst("DBSubnetGroupDescription");
         List<String> subnetIds = memberList(params, "SubnetIds");
         try {
-            DbSubnetGroup group = service.createDbSubnetGroup(name, description, subnetIds);
+            DbSubnetGroup group = region == null
+                    ? service.createDbSubnetGroup(name, description, subnetIds)
+                    : service.createDbSubnetGroup(name, description, subnetIds, region);
             return Response.ok(AwsQueryResponse.envelope("CreateDBSubnetGroup",
                     AwsNamespaces.RDS, dbSubnetGroupXml(group))).build();
         } catch (AwsException e) {
@@ -271,7 +282,7 @@ public class RdsQueryHandler {
         }
     }
 
-    private Response handleModifyDbSubnetGroup(MultivaluedMap<String, String> params) {
+    private Response handleModifyDbSubnetGroup(MultivaluedMap<String, String> params, String region) {
         String name = params.getFirst("DBSubnetGroupName");
         if (name == null || name.isBlank()) {
             return AwsQueryResponse.error("InvalidParameterValue",
@@ -279,7 +290,9 @@ public class RdsQueryHandler {
         }
         List<String> subnetIds = memberList(params, "SubnetIds");
         try {
-            DbSubnetGroup group = service.modifyDbSubnetGroup(name, subnetIds);
+            DbSubnetGroup group = region == null
+                    ? service.modifyDbSubnetGroup(name, subnetIds)
+                    : service.modifyDbSubnetGroup(name, subnetIds, region);
             return Response.ok(AwsQueryResponse.envelope("ModifyDBSubnetGroup",
                     AwsNamespaces.RDS, dbSubnetGroupXml(group))).build();
         } catch (AwsException e) {
@@ -317,7 +330,7 @@ public class RdsQueryHandler {
 
     // ── DB Clusters ───────────────────────────────────────────────────────────
 
-    private Response handleCreateDbCluster(MultivaluedMap<String, String> params) {
+    private Response handleCreateDbCluster(MultivaluedMap<String, String> params, String region) {
         String id = params.getFirst("DBClusterIdentifier");
         if (id == null || id.isBlank()) {
             return AwsQueryResponse.error("InvalidParameterValue", "DBClusterIdentifier is required.", AwsNamespaces.RDS, 400);
@@ -339,9 +352,13 @@ public class RdsQueryHandler {
         }
 
         try {
-            DbCluster cluster = service.createDbCluster(id, engine, engineVersion, masterUsername,
-                    masterPassword, databaseName, iamEnabled, paramGroupName,
-                    dbSubnetGroupName, availabilityZone, multiAz);
+            DbCluster cluster = region == null
+                    ? service.createDbCluster(id, engine, engineVersion, masterUsername,
+                            masterPassword, databaseName, iamEnabled, paramGroupName,
+                            dbSubnetGroupName, availabilityZone, multiAz)
+                    : service.createDbCluster(id, engine, engineVersion, masterUsername,
+                            masterPassword, databaseName, iamEnabled, paramGroupName,
+                            dbSubnetGroupName, availabilityZone, multiAz, region);
             String result = dbClusterXml(cluster);
             return Response.ok(AwsQueryResponse.envelope("CreateDBCluster", AwsNamespaces.RDS, result)).build();
         } catch (AwsException e) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -56,7 +56,7 @@ public class RdsQueryHandler {
                 case "RebootDBInstance" -> handleRebootDbInstance(params);
                 case "DescribeOrderableDBInstanceOptions" -> handleDescribeOrderableDbInstanceOptions(params);
                 case "CreateDBSubnetGroup" -> handleCreateDbSubnetGroup(params, region);
-                case "DescribeDBSubnetGroups" -> handleDescribeDbSubnetGroups(params);
+                case "DescribeDBSubnetGroups" -> handleDescribeDbSubnetGroups(params, region);
                 case "ModifyDBSubnetGroup" -> handleModifyDbSubnetGroup(params, region);
                 case "DeleteDBSubnetGroup" -> handleDeleteDbSubnetGroup(params);
                 case "CreateDBCluster" -> handleCreateDbCluster(params, region);
@@ -125,15 +125,11 @@ public class RdsQueryHandler {
         }
 
         try {
-            DbInstance instance = region == null
-                    ? service.createDbInstance(id, engine, engineVersion, masterUsername,
-                            masterPassword, dbName, dbInstanceClass, allocatedStorage, iamEnabled,
-                            paramGroupName, dbSubnetGroupName, dbClusterIdentifier, availabilityZone, multiAz,
-                            manageMasterUserPassword, masterUserSecretKmsKeyId, tags)
-                    : service.createDbInstance(id, engine, engineVersion, masterUsername,
-                            masterPassword, dbName, dbInstanceClass, allocatedStorage, iamEnabled,
-                            paramGroupName, dbSubnetGroupName, dbClusterIdentifier, availabilityZone, multiAz,
-                            manageMasterUserPassword, masterUserSecretKmsKeyId, tags, region);
+            List<String> vpcSecurityGroupIds = vpcSecurityGroupIds(params);
+            DbInstance instance = service.createDbInstance(id, engine, engineVersion, masterUsername,
+                    masterPassword, dbName, dbInstanceClass, allocatedStorage, iamEnabled,
+                    paramGroupName, dbSubnetGroupName, dbClusterIdentifier, availabilityZone, multiAz,
+                    manageMasterUserPassword, masterUserSecretKmsKeyId, tags, vpcSecurityGroupIds, region);
             String result = dbInstanceXml(instance);
             return Response.ok(AwsQueryResponse.envelope("CreateDBInstance", AwsNamespaces.RDS, result)).build();
         } catch (AwsException e) {
@@ -184,7 +180,10 @@ public class RdsQueryHandler {
         Boolean iamEnabled = iamStr != null ? Boolean.parseBoolean(iamStr) : null;
         String dbSubnetGroupName = params.getFirst("DBSubnetGroupName");
         try {
-            DbInstance instance = service.modifyDbInstance(id, newPassword, iamEnabled, dbSubnetGroupName);
+            List<String> vpcSecurityGroupIds = vpcSecurityGroupIds(params);
+            DbInstance instance = vpcSecurityGroupIds.isEmpty()
+                    ? service.modifyDbInstance(id, newPassword, iamEnabled, dbSubnetGroupName)
+                    : service.modifyDbInstance(id, newPassword, iamEnabled, dbSubnetGroupName, vpcSecurityGroupIds);
             String result = dbInstanceXml(instance);
             return Response.ok(AwsQueryResponse.envelope("ModifyDBInstance", AwsNamespaces.RDS, result)).build();
         } catch (AwsException e) {
@@ -267,10 +266,10 @@ public class RdsQueryHandler {
         }
     }
 
-    private Response handleDescribeDbSubnetGroups(MultivaluedMap<String, String> params) {
+    private Response handleDescribeDbSubnetGroups(MultivaluedMap<String, String> params, String region) {
         String filterName = params.getFirst("DBSubnetGroupName");
         try {
-            Collection<DbSubnetGroup> result = service.listDbSubnetGroups(filterName);
+            Collection<DbSubnetGroup> result = service.listDbSubnetGroups(filterName, region);
             XmlBuilder xml = new XmlBuilder().start("DBSubnetGroups");
             for (DbSubnetGroup group : result) {
                 xml.start("DBSubnetGroup").raw(dbSubnetGroupInnerXml(group)).end("DBSubnetGroup");
@@ -667,12 +666,7 @@ public class RdsQueryHandler {
            .elem("AvailabilityZone", i.getAvailabilityZone() != null ? i.getAvailabilityZone() : config.defaultAvailabilityZone())
            .elem("PreferredMaintenanceWindow", "mon:00:00-mon:03:00")
            .elem("PreferredBackupWindow", "04:00-06:00")
-           .start("VpcSecurityGroups")
-             .start("VpcSecurityGroupMembership")
-               .elem("VpcSecurityGroupId", "sg-00000000")
-               .elem("Status", "active")
-             .end("VpcSecurityGroupMembership")
-           .end("VpcSecurityGroups")
+           .raw(vpcSecurityGroupsXml(i))
            .raw(dbParameterGroupsXml(i))
            .raw(dbSubnetGroupXml(dbSubnetGroupForInstance(i)))
            .elem("DbiResourceId", i.getDbiResourceId())
@@ -693,6 +687,29 @@ public class RdsQueryHandler {
         writeTags(xml, i.getTags());
         xml.end("TagList");
         return xml.build();
+    }
+
+    private String vpcSecurityGroupsXml(DbInstance i) {
+        List<String> groupIds = i.getVpcSecurityGroupIds().isEmpty()
+                ? List.of("sg-00000000")
+                : i.getVpcSecurityGroupIds();
+        XmlBuilder xml = new XmlBuilder().start("VpcSecurityGroups");
+        for (String groupId : groupIds) {
+            xml.start("VpcSecurityGroupMembership")
+                    .elem("VpcSecurityGroupId", groupId)
+                    .elem("Status", "active")
+                    .end("VpcSecurityGroupMembership");
+        }
+        return xml.end("VpcSecurityGroups").build();
+    }
+
+    private static List<String> vpcSecurityGroupIds(MultivaluedMap<String, String> params) {
+        List<String> values = memberList(params, "VpcSecurityGroupIds");
+        if (values.isEmpty() && hasMemberKeys(params, "VpcSecurityGroupIds")) {
+            throw new AwsException("InvalidParameterValue",
+                    "VpcSecurityGroupIds must contain at least one non-empty VpcSecurityGroupId.", 400);
+        }
+        return values;
     }
 
     private static String dbParameterGroupsXml(DbInstance instance) {
@@ -829,6 +846,9 @@ public class RdsQueryHandler {
 
     private DbSubnetGroup dbSubnetGroupForInstance(DbInstance instance) {
         String groupName = instance.getDbSubnetGroupName();
+        if (groupName == null || groupName.isBlank() || "default".equalsIgnoreCase(groupName)) {
+            return fallbackSubnetGroup(instance, "default", "default");
+        }
         if (groupName != null && !groupName.isBlank()) {
             try {
                 DbSubnetGroup group = service.getDbSubnetGroup(groupName);
@@ -845,10 +865,7 @@ public class RdsQueryHandler {
             }
         } catch (AwsException ignored) {
         }
-        if (groupName != null && !groupName.isBlank()) {
-            return fallbackSubnetGroup(instance, groupName, "DB subnet group " + groupName);
-        }
-        return fallbackSubnetGroup(instance, "default", "default");
+        return fallbackSubnetGroup(instance, groupName, "DB subnet group " + groupName);
     }
 
     private DbSubnetGroup fallbackSubnetGroup(DbInstance instance, String name, String description) {
@@ -857,6 +874,7 @@ public class RdsQueryHandler {
         fallback.setDescription(description);
         fallback.setVpcId(instance.getVpcId() != null ? instance.getVpcId() : "vpc-00000000");
         fallback.setSubnetGroupStatus("Complete");
+        fallback.setDbSubnetGroupArn(subnetGroupArnForInstance(instance, name));
         Map<String, String> zones = instance.getSubnetAvailabilityZones();
         if (!zones.isEmpty()) {
             fallback.setSubnetIds(List.copyOf(zones.keySet()));
@@ -866,6 +884,18 @@ public class RdsQueryHandler {
             fallback.setSubnetAvailabilityZones(Map.of("subnet-00000000", config.defaultAvailabilityZone()));
         }
         return fallback;
+    }
+
+    private static String subnetGroupArnForInstance(DbInstance instance, String name) {
+        String arn = instance.getDbInstanceArn();
+        if (arn == null || arn.isBlank()) {
+            return null;
+        }
+        String[] parts = arn.split(":", 6);
+        if (parts.length < 6) {
+            return null;
+        }
+        return String.join(":", parts[0], parts[1], parts[2], parts[3], parts[4], "subgrp:" + name);
     }
 
     private String paramGroupInnerXml(DbParameterGroup g) {
@@ -918,12 +948,24 @@ public class RdsQueryHandler {
 
     private static List<String> memberList(MultivaluedMap<String, String> params, String baseName) {
         return params.keySet().stream()
-                .filter(key -> key.matches(java.util.regex.Pattern.quote(baseName)
-                        + "(\\.member|\\.SubnetIdentifier)?\\.\\d+"))
+                .filter(key -> key.matches(memberKeyRegex(baseName)))
                 .sorted(java.util.Comparator.comparingInt(RdsQueryHandler::numericSuffix))
                 .map(params::getFirst)
                 .filter(value -> value != null && !value.isBlank())
                 .toList();
+    }
+
+    private static boolean hasMemberKeys(MultivaluedMap<String, String> params, String baseName) {
+        return params.keySet().stream().anyMatch(key -> key.matches(memberKeyRegex(baseName)));
+    }
+
+    private static String memberKeyRegex(String baseName) {
+        String quoted = java.util.regex.Pattern.quote(baseName);
+        return switch (baseName) {
+            case "SubnetIds" -> quoted + "(\\.member|\\.SubnetIdentifier)?\\.\\d+";
+            case "VpcSecurityGroupIds" -> quoted + "(\\.member|\\.VpcSecurityGroupId)?\\.\\d+";
+            default -> quoted + "(\\.member)?\\.\\d+";
+        };
     }
 
     private static int numericSuffix(String key) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -213,13 +213,29 @@ public class RdsService implements Resettable {
                                        boolean multiAz, boolean manageMasterUserPassword,
                                        String masterUserSecretKmsKeyId,
                                        Map<String, String> tags) {
+        return createDbInstance(id, engineParam, engineVersion, masterUsername, masterPassword,
+                dbName, dbInstanceClass, allocatedStorage, iamEnabled, paramGroupName,
+                dbSubnetGroupName, dbClusterIdentifier, availabilityZone, multiAz,
+                manageMasterUserPassword, masterUserSecretKmsKeyId, tags, regionResolver.getDefaultRegion());
+    }
+
+    public DbInstance createDbInstance(String id, String engineParam, String engineVersion,
+                                       String masterUsername, String masterPassword,
+                                       String dbName, String dbInstanceClass,
+                                       int allocatedStorage, boolean iamEnabled,
+                                       String paramGroupName, String dbSubnetGroupName,
+                                       String dbClusterIdentifier, String availabilityZone,
+                                       boolean multiAz, boolean manageMasterUserPassword,
+                                       String masterUserSecretKmsKeyId,
+                                       Map<String, String> tags, String region) {
+        String effectiveRegion = effectiveRegion(region);
         if (instances.get(id).isPresent()) {
             throw new AwsException("DBInstanceAlreadyExists",
                     "DB instance " + id + " already exists.", 400);
         }
 
         DatabaseEngine engine = resolveEngine(engineParam);
-        if (dbSubnetGroupName != null && !dbSubnetGroupName.isBlank()) {
+        if (dbSubnetGroupName != null && !dbSubnetGroupName.isBlank() && !"default".equalsIgnoreCase(dbSubnetGroupName)) {
             getDbSubnetGroup(dbSubnetGroupName);
         }
         validateInstanceParameterGroup(paramGroupName, engineParam, engineVersion);
@@ -262,7 +278,7 @@ public class RdsService implements Resettable {
             }
             placement = PlacementResolution.fromCluster(cluster);
         } else {
-            placement = resolvePlacement(dbSubnetGroupName, availabilityZone, multiAz);
+            placement = resolvePlacement(dbSubnetGroupName, availabilityZone, multiAz, effectiveRegion);
             if (!mock) {
                 // Standalone instance — start its own container
                 String image = imageForEngine(engine, engineVersion);
@@ -294,11 +310,10 @@ public class RdsService implements Resettable {
         instance.setMultiAz(placement.multiAz());
         instance.setSubnetAvailabilityZones(placement.subnetAvailabilityZones());
 
-        String region = regionResolver.getDefaultRegion();
         instance.setDbiResourceId("db-" + java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 24).toUpperCase());
-        instance.setDbInstanceArn(regionResolver.buildArn("rds", region, "db:" + id));
+        instance.setDbInstanceArn(regionResolver.buildArn("rds", effectiveRegion, "db:" + id));
         if (manageMasterUserPassword) {
-            attachManagedMasterUserSecret(instance, region, masterUserSecretKmsKeyId);
+            attachManagedMasterUserSecret(instance, effectiveRegion, masterUserSecretKmsKeyId);
         }
 
         if (!mock) {
@@ -600,6 +615,17 @@ public class RdsService implements Resettable {
                                      String databaseName, boolean iamEnabled,
                                      String paramGroupName, String dbSubnetGroupName,
                                      String availabilityZone, boolean multiAz) {
+        return createDbCluster(id, engineParam, engineVersion, masterUsername, masterPassword,
+                databaseName, iamEnabled, paramGroupName, dbSubnetGroupName,
+                availabilityZone, multiAz, regionResolver.getDefaultRegion());
+    }
+
+    public DbCluster createDbCluster(String id, String engineParam, String engineVersion,
+                                     String masterUsername, String masterPassword,
+                                     String databaseName, boolean iamEnabled,
+                                     String paramGroupName, String dbSubnetGroupName,
+                                     String availabilityZone, boolean multiAz, String region) {
+        String effectiveRegion = effectiveRegion(region);
         if (clusters.get(id).isPresent()) {
             throw new AwsException("DBClusterAlreadyExistsFault",
                     "DB cluster " + id + " already exists.", 400);
@@ -607,7 +633,7 @@ public class RdsService implements Resettable {
 
         DatabaseEngine engine = resolveEngine(engineParam);
         validateClusterParameterGroup(paramGroupName, engineParam, engineVersion);
-        PlacementResolution placement = resolvePlacement(dbSubnetGroupName, availabilityZone, multiAz);
+        PlacementResolution placement = resolvePlacement(dbSubnetGroupName, availabilityZone, multiAz, effectiveRegion);
 
         boolean mock = config.services().rds().mock();
         // Always reserve a unique port (even in mock) so endpoints stay distinct and usedPorts
@@ -633,9 +659,8 @@ public class RdsService implements Resettable {
         cluster.setMultiAz(placement.multiAz());
         cluster.setSubnetAvailabilityZones(placement.subnetAvailabilityZones());
 
-        String region = regionResolver.getDefaultRegion();
         cluster.setDbClusterResourceId("cluster-" + java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 24).toUpperCase());
-        cluster.setDbClusterArn(regionResolver.buildArn("rds", region, "cluster:" + id));
+        cluster.setDbClusterArn(regionResolver.buildArn("rds", effectiveRegion, "cluster:" + id));
 
         if (!mock) {
             String effectiveMasterUser = masterUsername != null ? masterUsername : "root";
@@ -705,6 +730,10 @@ public class RdsService implements Resettable {
     // ── DB Subnet Groups ──────────────────────────────────────────────────────
 
     public DbSubnetGroup createDbSubnetGroup(String name, String description, List<String> subnetIds) {
+        return createDbSubnetGroup(name, description, subnetIds, regionResolver.getDefaultRegion());
+    }
+
+    public DbSubnetGroup createDbSubnetGroup(String name, String description, List<String> subnetIds, String region) {
         if (name == null || name.isBlank()) {
             throw new AwsException("MissingParameter", "The request must contain the parameter DBSubnetGroupName.", 400);
         }
@@ -716,7 +745,7 @@ public class RdsService implements Resettable {
             throw new AwsException("MissingParameter", "The request must contain the parameter SubnetIds.", 400);
         }
 
-        DbSubnetGroup group = buildSubnetGroup(name, description, subnetIds);
+        DbSubnetGroup group = buildSubnetGroup(name, description, subnetIds, effectiveRegion(region));
         subnetGroups.put(name, group);
         return group;
     }
@@ -735,9 +764,13 @@ public class RdsService implements Resettable {
     }
 
     public DbSubnetGroup resolveDbSubnetGroupView(String name) {
+        return resolveDbSubnetGroupView(name, regionResolver.getDefaultRegion());
+    }
+
+    public DbSubnetGroup resolveDbSubnetGroupView(String name, String region) {
         String effectiveName = (name == null || name.isBlank()) ? "default" : name;
         if ("default".equalsIgnoreCase(effectiveName)) {
-            return buildDefaultSubnetGroup();
+            return buildDefaultSubnetGroup(effectiveRegion(region));
         }
         return subnetGroups.get(effectiveName).orElseThrow(() ->
                 new AwsException("DBSubnetGroupNotFoundFault",
@@ -788,8 +821,12 @@ public class RdsService implements Resettable {
     }
 
     public DbSubnetGroup getDbSubnetGroup(String name) {
+        return getDbSubnetGroup(name, regionResolver.getDefaultRegion());
+    }
+
+    public DbSubnetGroup getDbSubnetGroup(String name, String region) {
         if ("default".equalsIgnoreCase(name)) {
-            return buildDefaultSubnetGroup();
+            return buildDefaultSubnetGroup(effectiveRegion(region));
         }
         return subnetGroups.get(name).orElseThrow(() ->
                 new AwsException("DBSubnetGroupNotFoundFault",
@@ -797,12 +834,16 @@ public class RdsService implements Resettable {
     }
 
     public DbSubnetGroup modifyDbSubnetGroup(String name, List<String> subnetIds) {
+        return modifyDbSubnetGroup(name, subnetIds, regionResolver.getDefaultRegion());
+    }
+
+    public DbSubnetGroup modifyDbSubnetGroup(String name, List<String> subnetIds, String region) {
         DbSubnetGroup existing = getDbSubnetGroup(name);
         if (subnetIds == null || subnetIds.isEmpty()) {
             throw new AwsException("InvalidParameterValue",
                     "SubnetIds must contain at least one subnet.", 400);
         }
-        DbSubnetGroup group = buildSubnetGroup(name, existing.getDescription(), subnetIds);
+        DbSubnetGroup group = buildSubnetGroup(name, existing.getDescription(), subnetIds, effectiveRegion(region));
         group.setTags(existing.getTags());
         subnetGroups.put(name, group);
         return group;
@@ -1138,11 +1179,16 @@ public class RdsService implements Resettable {
     }
 
     private PlacementResolution resolvePlacement(String dbSubnetGroupName, String availabilityZone, boolean multiAz) {
+        return resolvePlacement(dbSubnetGroupName, availabilityZone, multiAz, regionResolver.getDefaultRegion());
+    }
+
+    private PlacementResolution resolvePlacement(String dbSubnetGroupName, String availabilityZone, boolean multiAz,
+                                                 String region) {
         String effectiveSubnetGroupName = (dbSubnetGroupName == null || dbSubnetGroupName.isBlank())
                 ? "default"
                 : dbSubnetGroupName;
         DbSubnetGroup group = "default".equals(effectiveSubnetGroupName)
-                ? buildDefaultSubnetGroup()
+                ? buildDefaultSubnetGroup(region)
                 : subnetGroups.get(effectiveSubnetGroupName).orElseThrow(() ->
                         new AwsException("DBSubnetGroupNotFoundFault",
                                 "DB subnet group " + effectiveSubnetGroupName + " not found.", 404));
@@ -1188,17 +1234,23 @@ public class RdsService implements Resettable {
     }
 
     private DbSubnetGroup buildDefaultSubnetGroup() {
-        String region = regionResolver.getDefaultRegion();
+        return buildDefaultSubnetGroup(regionResolver.getDefaultRegion());
+    }
+
+    private DbSubnetGroup buildDefaultSubnetGroup(String region) {
         List<Subnet> subnets = ec2Service.describeSubnets(region, List.of(), Map.of("vpc-id", List.of("vpc-default")));
         if (subnets.isEmpty()) {
             throw new AwsException("InvalidVPCNetworkStateFault",
                     "No subnets available for DB subnet group default.", 400);
         }
-        return buildSubnetGroup("default", "default subnet group", extractSubnetIds(subnets));
+        return buildSubnetGroup("default", "default subnet group", extractSubnetIds(subnets), region);
     }
 
     private DbSubnetGroup buildSubnetGroup(String name, String description, List<String> subnetIds) {
-        String region = regionResolver.getDefaultRegion();
+        return buildSubnetGroup(name, description, subnetIds, regionResolver.getDefaultRegion());
+    }
+
+    private DbSubnetGroup buildSubnetGroup(String name, String description, List<String> subnetIds, String region) {
         List<Subnet> resolvedSubnets = ec2Service.describeSubnets(region, subnetIds, Map.of());
         if (resolvedSubnets.size() != subnetIds.size()) {
             throw new AwsException("InvalidSubnet",
@@ -1224,6 +1276,10 @@ public class RdsService implements Resettable {
         group.setDbSubnetGroupArn(regionResolver.buildArn("rds", region, "subgrp:" + name));
         group.setSubnetGroupStatus("Complete");
         return group;
+    }
+
+    private String effectiveRegion(String region) {
+        return region == null || region.isBlank() ? regionResolver.getDefaultRegion() : region;
     }
 
     private static List<String> extractSubnetIds(List<Subnet> subnets) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -1280,10 +1280,6 @@ public class RdsService implements Resettable {
                 new LinkedHashMap<>(subnetAvailabilityZones));
     }
 
-    private DbSubnetGroup buildDefaultSubnetGroup() {
-        return buildDefaultSubnetGroup(regionResolver.getDefaultRegion());
-    }
-
     private DbSubnetGroup buildDefaultSubnetGroup(String region) {
         List<Subnet> subnets = ec2Service.describeSubnets(region, List.of(), Map.of("vpc-id", List.of("vpc-default")));
         if (subnets.isEmpty()) {
@@ -1291,10 +1287,6 @@ public class RdsService implements Resettable {
                     "No subnets available for DB subnet group default.", 400);
         }
         return buildSubnetGroup("default", "default subnet group", extractSubnetIds(subnets), region);
-    }
-
-    private DbSubnetGroup buildSubnetGroup(String name, String description, List<String> subnetIds) {
-        return buildSubnetGroup(name, description, subnetIds, regionResolver.getDefaultRegion());
     }
 
     private DbSubnetGroup buildSubnetGroup(String name, String description, List<String> subnetIds, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -216,7 +216,24 @@ public class RdsService implements Resettable {
         return createDbInstance(id, engineParam, engineVersion, masterUsername, masterPassword,
                 dbName, dbInstanceClass, allocatedStorage, iamEnabled, paramGroupName,
                 dbSubnetGroupName, dbClusterIdentifier, availabilityZone, multiAz,
-                manageMasterUserPassword, masterUserSecretKmsKeyId, tags, regionResolver.getDefaultRegion());
+                manageMasterUserPassword, masterUserSecretKmsKeyId, tags, List.of(), regionResolver.getDefaultRegion());
+    }
+
+    public DbInstance createDbInstance(String id, String engineParam, String engineVersion,
+                                       String masterUsername, String masterPassword,
+                                       String dbName, String dbInstanceClass,
+                                       int allocatedStorage, boolean iamEnabled,
+                                       String paramGroupName, String dbSubnetGroupName,
+                                       String dbClusterIdentifier, String availabilityZone,
+                                       boolean multiAz, boolean manageMasterUserPassword,
+                                       String masterUserSecretKmsKeyId,
+                                       Map<String, String> tags,
+                                       List<String> vpcSecurityGroupIds) {
+        return createDbInstance(id, engineParam, engineVersion, masterUsername, masterPassword,
+                dbName, dbInstanceClass, allocatedStorage, iamEnabled, paramGroupName,
+                dbSubnetGroupName, dbClusterIdentifier, availabilityZone, multiAz,
+                manageMasterUserPassword, masterUserSecretKmsKeyId, tags, vpcSecurityGroupIds,
+                regionResolver.getDefaultRegion());
     }
 
     public DbInstance createDbInstance(String id, String engineParam, String engineVersion,
@@ -228,6 +245,23 @@ public class RdsService implements Resettable {
                                        boolean multiAz, boolean manageMasterUserPassword,
                                        String masterUserSecretKmsKeyId,
                                        Map<String, String> tags, String region) {
+        return createDbInstance(id, engineParam, engineVersion, masterUsername, masterPassword,
+                dbName, dbInstanceClass, allocatedStorage, iamEnabled, paramGroupName,
+                dbSubnetGroupName, dbClusterIdentifier, availabilityZone, multiAz,
+                manageMasterUserPassword, masterUserSecretKmsKeyId, tags, List.of(), region);
+    }
+
+    public DbInstance createDbInstance(String id, String engineParam, String engineVersion,
+                                       String masterUsername, String masterPassword,
+                                       String dbName, String dbInstanceClass,
+                                       int allocatedStorage, boolean iamEnabled,
+                                       String paramGroupName, String dbSubnetGroupName,
+                                       String dbClusterIdentifier, String availabilityZone,
+                                       boolean multiAz, boolean manageMasterUserPassword,
+                                       String masterUserSecretKmsKeyId,
+                                       Map<String, String> tags,
+                                       List<String> vpcSecurityGroupIds,
+                                       String region) {
         String effectiveRegion = effectiveRegion(region);
         if (instances.get(id).isPresent()) {
             throw new AwsException("DBInstanceAlreadyExists",
@@ -304,6 +338,7 @@ public class RdsService implements Resettable {
         instance.setVolumeId(instanceVolumeId);
         instance.setDockerVolumeName(instanceDockerVolumeName);
         instance.setTags(tags);
+        instance.setVpcSecurityGroupIds(vpcSecurityGroupIds);
         instance.setDbSubnetGroupName(placement.dbSubnetGroupName());
         instance.setVpcId(placement.vpcId());
         instance.setAvailabilityZone(placement.availabilityZone());
@@ -474,6 +509,11 @@ public class RdsService implements Resettable {
 
     public DbInstance modifyDbInstance(String id, String newPassword, Boolean iamEnabled,
                                        String dbSubnetGroupName) {
+        return modifyDbInstance(id, newPassword, iamEnabled, dbSubnetGroupName, null);
+    }
+
+    public DbInstance modifyDbInstance(String id, String newPassword, Boolean iamEnabled,
+                                       String dbSubnetGroupName, List<String> vpcSecurityGroupIds) {
         DbInstance instance = getDbInstance(id);
         instance.setStatus(DbInstanceStatus.AVAILABLE);
         if (newPassword != null && !newPassword.isBlank()) {
@@ -485,6 +525,9 @@ public class RdsService implements Resettable {
         if (dbSubnetGroupName != null && !dbSubnetGroupName.isBlank()) {
             getDbSubnetGroup(dbSubnetGroupName);
             instance.setDbSubnetGroupName(dbSubnetGroupName);
+        }
+        if (vpcSecurityGroupIds != null && !vpcSecurityGroupIds.isEmpty()) {
+            instance.setVpcSecurityGroupIds(vpcSecurityGroupIds);
         }
         instances.put(id, instance);
         LOG.infov("DB instance {0} modified", id);
@@ -751,9 +794,13 @@ public class RdsService implements Resettable {
     }
 
     public Collection<DbSubnetGroup> listDbSubnetGroups(String filterName) {
+        return listDbSubnetGroups(filterName, regionResolver.getDefaultRegion());
+    }
+
+    public Collection<DbSubnetGroup> listDbSubnetGroups(String filterName, String region) {
         List<DbSubnetGroup> groups = new ArrayList<>();
         if (filterName == null || filterName.isBlank() || "default".equalsIgnoreCase(filterName)) {
-            groups.add(buildDefaultSubnetGroup());
+            groups.add(buildDefaultSubnetGroup(effectiveRegion(region)));
         }
         if (filterName != null && !filterName.isBlank()) {
             subnetGroups.get(filterName).ifPresent(groups::add);

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstance.java
@@ -3,7 +3,9 @@ package io.github.hectorvent.floci.services.rds.model;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 @RegisterForReflection
@@ -24,6 +26,7 @@ public class DbInstance {
     private String dbSubnetGroupName;
     private String dbClusterIdentifier;
     private String vpcId;
+    private List<String> vpcSecurityGroupIds = new ArrayList<>();
     private String availabilityZone;
     private boolean multiAz;
     private Map<String, String> subnetAvailabilityZones = new LinkedHashMap<>();
@@ -114,6 +117,11 @@ public class DbInstance {
 
     public String getVpcId() { return vpcId; }
     public void setVpcId(String vpcId) { this.vpcId = vpcId; }
+
+    public List<String> getVpcSecurityGroupIds() { return vpcSecurityGroupIds; }
+    public void setVpcSecurityGroupIds(List<String> vpcSecurityGroupIds) {
+        this.vpcSecurityGroupIds = vpcSecurityGroupIds != null ? new ArrayList<>(vpcSecurityGroupIds) : new ArrayList<>();
+    }
 
     public String getAvailabilityZone() { return availabilityZone; }
     public void setAvailabilityZone(String availabilityZone) { this.availabilityZone = availabilityZone; }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -62,8 +63,12 @@ class RdsCfnProvisionerTest {
     }
 
     private StackResource provision(String logicalId, String type, String json) {
+        return provision(logicalId, type, json, "us-east-1");
+    }
+
+    private StackResource provision(String logicalId, String type, String json, String region) {
         return provisioner.provision(logicalId, type, props(json), engine(),
-                "us-east-1", "000000000000", "my-stack");
+                region, "000000000000", "my-stack");
     }
 
     @Test
@@ -73,7 +78,8 @@ class RdsCfnProvisionerTest {
         when(instance.getEndpoint()).thenReturn(new DbEndpoint("mydb.local", 5432));
         when(instance.getDbInstanceArn()).thenReturn("arn:aws:rds:us-east-1:000000000000:db:mydb");
         when(rdsService.createDbInstance(any(), any(), any(), any(), any(), any(), any(),
-                anyInt(), anyBoolean(), any(), any(), any())).thenReturn(instance);
+                anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(), anyBoolean(),
+                any(), anyMap(), any())).thenReturn(instance);
 
         StackResource r = provision("Db", "AWS::RDS::DBInstance", """
                 {"DBInstanceIdentifier":"mydb","Engine":"postgres","EngineVersion":"16",
@@ -88,7 +94,26 @@ class RdsCfnProvisionerTest {
         assertEquals("arn:aws:rds:us-east-1:000000000000:db:mydb", r.getAttributes().get("DBInstanceArn"));
         // CFN properties mapped to the create-method arguments; absent optionals are null.
         verify(rdsService).createDbInstance("mydb", "postgres", "16", "admin", "secret",
-                "appdb", "db.t3.small", 50, false, null, null, null);
+                "appdb", "db.t3.small", 50, false, null, null, null,
+                null, false, false, null, Map.of(), "us-east-1");
+    }
+
+    @Test
+    void provisionsDbInstanceInStackRegion() {
+        DbInstance instance = mock(DbInstance.class);
+        when(instance.getDbInstanceIdentifier()).thenReturn("mydb");
+        when(rdsService.createDbInstance(any(), any(), any(), any(), any(), any(), any(),
+                anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(), anyBoolean(),
+                any(), anyMap(), any())).thenReturn(instance);
+
+        provision("Db", "AWS::RDS::DBInstance", """
+                {"DBInstanceIdentifier":"mydb","Engine":"postgres","MasterUsername":"admin",
+                 "MasterUserPassword":"secret"}
+                """, "us-west-2");
+
+        verify(rdsService).createDbInstance("mydb", "postgres", null, "admin", "secret",
+                null, "db.t3.micro", 20, false, null, null, null,
+                null, false, false, null, Map.of(), "us-west-2");
     }
 
     @Test
@@ -98,7 +123,8 @@ class RdsCfnProvisionerTest {
         when(cluster.getEndpoint()).thenReturn(new DbEndpoint("mycluster.local", 5432));
         when(cluster.getReaderEndpoint()).thenReturn(new DbEndpoint("mycluster-ro.local", 5432));
         when(cluster.getDbClusterArn()).thenReturn("arn:aws:rds:us-east-1:000000000000:cluster:mycluster");
-        when(rdsService.createDbCluster(any(), any(), any(), any(), any(), any(), anyBoolean(), any()))
+        when(rdsService.createDbCluster(any(), any(), any(), any(), any(), any(), anyBoolean(), any(),
+                any(), any(), anyBoolean(), any()))
                 .thenReturn(cluster);
 
         StackResource r = provision("Cluster", "AWS::RDS::DBCluster", """
@@ -111,14 +137,30 @@ class RdsCfnProvisionerTest {
         assertEquals("mycluster-ro.local", r.getAttributes().get("ReadEndpoint.Address"));
         assertEquals("5432", r.getAttributes().get("Endpoint.Port"));
         verify(rdsService).createDbCluster("mycluster", "aurora-postgresql", "16.3",
-                "admin", "secret", "appdb", false, null);
+                "admin", "secret", "appdb", false, null, null, null, false, "us-east-1");
+    }
+
+    @Test
+    void provisionsDbClusterInStackRegion() {
+        DbCluster cluster = mock(DbCluster.class);
+        when(cluster.getDbClusterIdentifier()).thenReturn("mycluster");
+        when(rdsService.createDbCluster(any(), any(), any(), any(), any(), any(), anyBoolean(), any(),
+                any(), any(), anyBoolean(), any()))
+                .thenReturn(cluster);
+
+        provision("Cluster", "AWS::RDS::DBCluster", """
+                {"DBClusterIdentifier":"mycluster","Engine":"aurora-postgresql"}
+                """, "us-west-2");
+
+        verify(rdsService).createDbCluster("mycluster", "aurora-postgresql", null,
+                null, null, null, false, null, null, null, false, "us-west-2");
     }
 
     @Test
     void provisionsDbSubnetGroupWithResolvedSubnetIds() {
         DbSubnetGroup group = mock(DbSubnetGroup.class);
         when(group.getDbSubnetGroupName()).thenReturn("my-subnet-group");
-        when(rdsService.createDbSubnetGroup(any(), any(), anyList())).thenReturn(group);
+        when(rdsService.createDbSubnetGroup(any(), any(), anyList(), any())).thenReturn(group);
 
         StackResource r = provision("Sg", "AWS::RDS::DBSubnetGroup", """
                 {"DBSubnetGroupName":"my-subnet-group","DBSubnetGroupDescription":"db subnets",
@@ -128,7 +170,21 @@ class RdsCfnProvisionerTest {
         assertEquals("my-subnet-group", r.getPhysicalId());
         assertEquals("my-subnet-group", r.getAttributes().get("DBSubnetGroupName"));
         verify(rdsService).createDbSubnetGroup("my-subnet-group", "db subnets",
-                List.of("subnet-a", "subnet-b"));
+                List.of("subnet-a", "subnet-b"), "us-east-1");
+    }
+
+    @Test
+    void provisionsDbSubnetGroupInStackRegion() {
+        DbSubnetGroup group = mock(DbSubnetGroup.class);
+        when(group.getDbSubnetGroupName()).thenReturn("my-subnet-group");
+        when(rdsService.createDbSubnetGroup(any(), any(), anyList(), any())).thenReturn(group);
+
+        provision("Sg", "AWS::RDS::DBSubnetGroup", """
+                {"DBSubnetGroupName":"my-subnet-group","SubnetIds":["subnet-a"]}
+                """, "us-west-2");
+
+        verify(rdsService).createDbSubnetGroup("my-subnet-group", "Managed by CloudFormation",
+                List.of("subnet-a"), "us-west-2");
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -79,7 +80,7 @@ class RdsCfnProvisionerTest {
         when(instance.getDbInstanceArn()).thenReturn("arn:aws:rds:us-east-1:000000000000:db:mydb");
         when(rdsService.createDbInstance(any(), any(), any(), any(), any(), any(), any(),
                 anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(), anyBoolean(),
-                any(), anyMap(), any())).thenReturn(instance);
+                any(), anyMap(), nullable(String.class))).thenReturn(instance);
 
         StackResource r = provision("Db", "AWS::RDS::DBInstance", """
                 {"DBInstanceIdentifier":"mydb","Engine":"postgres","EngineVersion":"16",
@@ -104,7 +105,7 @@ class RdsCfnProvisionerTest {
         when(instance.getDbInstanceIdentifier()).thenReturn("mydb");
         when(rdsService.createDbInstance(any(), any(), any(), any(), any(), any(), any(),
                 anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(), anyBoolean(),
-                any(), anyMap(), any())).thenReturn(instance);
+                any(), anyMap(), nullable(String.class))).thenReturn(instance);
 
         provision("Db", "AWS::RDS::DBInstance", """
                 {"DBInstanceIdentifier":"mydb","Engine":"postgres","MasterUsername":"admin",

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -434,6 +434,25 @@ class RdsQueryHandlerTest {
     }
 
     @Test
+    void createDbSubnetGroupPassesRequestRegionToService() {
+        when(service.createDbSubnetGroup("sample-db-subnets", "test", List.of("subnet-aaa", "subnet-bbb"), "us-west-2"))
+                .thenReturn(new DbSubnetGroup(
+                        "sample-db-subnets", "test", "vpc-123", List.of("subnet-aaa", "subnet-bbb"),
+                        Map.of("subnet-aaa", "us-west-2a", "subnet-bbb", "us-west-2b")));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBSubnetGroupName", "sample-db-subnets");
+        p.add("DBSubnetGroupDescription", "test");
+        p.add("SubnetIds.SubnetIdentifier.1", "subnet-aaa");
+        p.add("SubnetIds.SubnetIdentifier.2", "subnet-bbb");
+
+        Response response = handler.handle("CreateDBSubnetGroup", p, "us-west-2");
+
+        assertEquals(200, response.getStatus());
+        verify(service).createDbSubnetGroup("sample-db-subnets", "test", List.of("subnet-aaa", "subnet-bbb"), "us-west-2");
+    }
+
+    @Test
     void modifyDbSubnetGroup_passesSubnetMembersToService() {
         when(service.modifyDbSubnetGroup("sample-db-subnets", List.of("subnet-new-a", "subnet-new-b")))
                 .thenReturn(new DbSubnetGroup(

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -38,7 +38,6 @@ class RdsQueryHandlerTest {
         when(config.services()).thenReturn(servicesConfig);
         when(servicesConfig.rds()).thenReturn(rdsConfig);
         when(config.defaultAvailabilityZone()).thenReturn("us-east-1a");
-        when(service.resolveDbSubnetGroupView(nullable(String.class))).thenReturn(defaultSubnetGroup());
         handler = new RdsQueryHandler(service, config);
     }
 
@@ -126,7 +125,7 @@ class RdsQueryHandlerTest {
     void describeDbInstances_dbSubnetGroupUsesSubnetTag() {
         DbInstance instance = makeInstance("mydb");
         instance.setDbSubnetGroupName("custom-group");
-        when(service.resolveDbSubnetGroupView("custom-group")).thenReturn(customSubnetGroup());
+        when(service.getDbSubnetGroup("custom-group")).thenReturn(customSubnetGroup());
         when(service.listDbInstances(null)).thenReturn(List.of(instance));
 
         Response response = handler.handle("DescribeDBInstances", params());
@@ -466,7 +465,7 @@ class RdsQueryHandlerTest {
 
     @Test
     void createDbSubnetGroup_passesSubnetMembersToService() {
-        when(service.createDbSubnetGroup("sample-db-subnets", "test", List.of("subnet-aaa", "subnet-bbb")))
+        when(service.createDbSubnetGroup("sample-db-subnets", "test", List.of("subnet-aaa", "subnet-bbb"), null))
                 .thenReturn(new DbSubnetGroup(
                         "sample-db-subnets", "test", "vpc-123", List.of("subnet-aaa", "subnet-bbb"),
                         Map.of("subnet-aaa", "us-east-1a", "subnet-bbb", "us-east-1b")));
@@ -478,7 +477,7 @@ class RdsQueryHandlerTest {
         p.add("SubnetIds.SubnetIdentifier.2", "subnet-bbb");
         Response response = handler.handle("CreateDBSubnetGroup", p);
 
-        verify(service).createDbSubnetGroup("sample-db-subnets", "test", List.of("subnet-aaa", "subnet-bbb"));
+        verify(service).createDbSubnetGroup("sample-db-subnets", "test", List.of("subnet-aaa", "subnet-bbb"), null);
         String body = (String) response.getEntity();
         assertEquals(200, response.getStatus());
         assertTrue(body.contains("<DBSubnetGroupName>sample-db-subnets</DBSubnetGroupName>"));
@@ -509,7 +508,7 @@ class RdsQueryHandlerTest {
 
     @Test
     void modifyDbSubnetGroup_passesSubnetMembersToService() {
-        when(service.modifyDbSubnetGroup("sample-db-subnets", List.of("subnet-new-a", "subnet-new-b")))
+        when(service.modifyDbSubnetGroup("sample-db-subnets", List.of("subnet-new-a", "subnet-new-b"), null))
                 .thenReturn(new DbSubnetGroup(
                         "sample-db-subnets", "test", "vpc-123", List.of("subnet-new-a", "subnet-new-b"),
                         Map.of("subnet-new-a", "us-east-1a", "subnet-new-b", "us-east-1b")));
@@ -520,7 +519,7 @@ class RdsQueryHandlerTest {
         p.add("SubnetIds.SubnetIdentifier.2", "subnet-new-b");
         Response response = handler.handle("ModifyDBSubnetGroup", p);
 
-        verify(service).modifyDbSubnetGroup("sample-db-subnets", List.of("subnet-new-a", "subnet-new-b"));
+        verify(service).modifyDbSubnetGroup("sample-db-subnets", List.of("subnet-new-a", "subnet-new-b"), null);
         String body = (String) response.getEntity();
         assertEquals(200, response.getStatus());
         assertTrue(body.contains("<DBSubnetGroupName>sample-db-subnets</DBSubnetGroupName>"));
@@ -689,7 +688,7 @@ class RdsQueryHandlerTest {
         group.setVpcId("vpc-12345678");
         group.setSubnetIds(List.of("subnet-a", "subnet-b"));
         group.setSubnetAvailabilityZones(Map.of("subnet-a", "us-east-1a", "subnet-b", "us-east-1b"));
-        when(service.createDbSubnetGroup("my-subnet-group", "test subnet group", List.of("subnet-a", "subnet-b")))
+        when(service.createDbSubnetGroup("my-subnet-group", "test subnet group", List.of("subnet-a", "subnet-b"), null))
                 .thenReturn(group);
 
         MultivaluedMap<String, String> p = params();

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -216,7 +216,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq(null), eq(null), eq(null), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false), eq(false), eq(null),
-                eq(java.util.Map.of("example:ClusterId", "cluster-a", "Name", "mydb"))))
+                eq(java.util.Map.of("example:ClusterId", "cluster-a", "Name", "mydb")), eq(List.of()), isNull()))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -230,7 +230,61 @@ class RdsQueryHandlerTest {
 
         verify(service).createDbInstance("mydb", "postgres", "16.3",
                 null, null, null, "db.t3.micro", 20, false, null, null, null, null, false, false, null,
-                java.util.Map.of("example:ClusterId", "cluster-a", "Name", "mydb"));
+                java.util.Map.of("example:ClusterId", "cluster-a", "Name", "mydb"), List.of(), null);
+    }
+
+    @Test
+    void createDbInstance_passesVpcSecurityGroupsToServiceAndXml() {
+        DbInstance instance = makeInstance("mydb");
+        instance.setVpcSecurityGroupIds(List.of("sg-123", "sg-456"));
+        when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
+                eq(null), eq(null), eq(null), eq("db.t3.micro"),
+                eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false), eq(false), eq(null),
+                eq(java.util.Map.of()), eq(List.of("sg-123", "sg-456")), isNull()))
+                .thenReturn(instance);
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBInstanceIdentifier", "mydb");
+        p.add("Engine", "postgres");
+        p.add("VpcSecurityGroupIds.VpcSecurityGroupId.1", "sg-123");
+        p.add("VpcSecurityGroupIds.VpcSecurityGroupId.2", "sg-456");
+        Response response = handler.handle("CreateDBInstance", p);
+
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<VpcSecurityGroupId>sg-123</VpcSecurityGroupId>"));
+        assertTrue(body.contains("<VpcSecurityGroupId>sg-456</VpcSecurityGroupId>"));
+        verify(service).createDbInstance("mydb", "postgres", "16.3",
+                null, null, null, "db.t3.micro", 20, false, null, null, null, null, false, false, null,
+                java.util.Map.of(), List.of("sg-123", "sg-456"), null);
+    }
+
+    @Test
+    void createDbInstanceRejectsBlankVpcSecurityGroupMembers() {
+        MultivaluedMap<String, String> p = params();
+        p.add("DBInstanceIdentifier", "mydb");
+        p.add("Engine", "postgres");
+        p.add("VpcSecurityGroupIds.VpcSecurityGroupId.1", " ");
+
+        Response response = handler.handle("CreateDBInstance", p);
+
+        assertEquals(400, response.getStatus());
+        assertTrue(((String) response.getEntity()).contains("InvalidParameterValue"));
+        verify(service, never()).createDbInstance(any(), any(), any(), any(), any(), any(), any(),
+                anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(), anyBoolean(),
+                any(), any(), any(), any());
+    }
+
+    @Test
+    void modifyDbInstanceRejectsBlankVpcSecurityGroupMembers() {
+        MultivaluedMap<String, String> p = params();
+        p.add("DBInstanceIdentifier", "mydb");
+        p.add("VpcSecurityGroupIds.VpcSecurityGroupId.1", "");
+
+        Response response = handler.handle("ModifyDBInstance", p);
+
+        assertEquals(400, response.getStatus());
+        assertTrue(((String) response.getEntity()).contains("InvalidParameterValue"));
+        verify(service, never()).modifyDbInstance(any(), any(), any(), any(), any());
     }
 
     @Test
@@ -306,7 +360,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq("admin"), eq("secret"), eq("dbname"), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false), eq(false),
-                eq(null), eq(java.util.Map.of())))
+                eq(null), eq(java.util.Map.of()), eq(List.of()), isNull()))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -320,7 +374,7 @@ class RdsQueryHandlerTest {
 
         verify(service).createDbInstance("mydb", "postgres", "16.3",
                 "admin", "secret", "dbname", "db.t3.micro", 20, false, null, null, null, null, false, false,
-                null, java.util.Map.of());
+                null, java.util.Map.of(), List.of(), null);
     }
 
     @Test
@@ -332,7 +386,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq("admin"), eq(null), eq("dbname"), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false), eq(true),
-                eq("kms-key-1"), eq(java.util.Map.of())))
+                eq("kms-key-1"), eq(java.util.Map.of()), eq(List.of()), isNull()))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -351,19 +405,20 @@ class RdsQueryHandlerTest {
         assertTrue(body.contains("<KmsKeyId>kms-key-1</KmsKeyId>"));
         verify(service).createDbInstance("mydb", "postgres", "16.3",
                 "admin", null, "dbname", "db.t3.micro", 20, false, null, null, null, null, false, true,
-                "kms-key-1", java.util.Map.of());
+                "kms-key-1", java.util.Map.of(), List.of(), null);
     }
 
     @Test
     void createDbInstance_withPlacementInputsShouldReflectRequestedPlacement() {
         DbInstance instance = makeInstance("mydb");
+        instance.setDbInstanceArn("arn:aws:rds:us-east-1:123456789012:db:mydb");
         instance.setDbSubnetGroupName("default");
         instance.setAvailabilityZone("ap-northeast-1a");
         instance.setMultiAz(true);
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq("admin"), eq("secret"), eq("dbname"), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq("default"), eq(null), eq("ap-northeast-1a"), eq(true),
-                eq(false), eq(null), eq(java.util.Map.of())))
+                eq(false), eq(null), eq(java.util.Map.of()), eq(List.of()), isNull()))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -391,7 +446,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq("admin"), eq("secret"), eq("dbname"), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq("missing-subnet-group"), eq(null), eq(null), eq(false),
-                eq(false), eq(null), eq(java.util.Map.of())))
+                eq(false), eq(null), eq(java.util.Map.of()), eq(List.of()), isNull()))
                 .thenThrow(new AwsException("DBSubnetGroupNotFoundFault",
                         "DB subnet group missing-subnet-group not found.", 404));
 
@@ -483,7 +538,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("oracle"), eq("1.0"),
                 eq(null), eq(null), eq(null), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false), eq(false),
-                eq(null), eq(java.util.Map.of())))
+                eq(null), eq(java.util.Map.of()), eq(List.of()), isNull()))
                 .thenThrow(new AwsException("InvalidParameterValue",
                         "Unsupported engine: oracle. Supported: postgres, mysql, mariadb.", 400));
 
@@ -658,7 +713,7 @@ class RdsQueryHandlerTest {
         DbSubnetGroup group = new DbSubnetGroup();
         group.setDbSubnetGroupName("default");
         group.setDbSubnetGroupArn("arn:aws:rds:us-east-1:123456789012:subgrp:default");
-        when(service.listDbSubnetGroups(null)).thenReturn(List.of(group));
+        when(service.listDbSubnetGroups(null, null)).thenReturn(List.of(group));
 
         Response response = handler.handle("DescribeDBSubnetGroups", params());
 
@@ -701,6 +756,19 @@ class RdsQueryHandlerTest {
         assertTrue(body.contains("<DescribeDBClusterSnapshotsResult>"));
         assertTrue(body.contains("<DBClusterSnapshots></DBClusterSnapshots>"));
         assertFalse(body.contains("<Marker>"));
+    }
+
+    @Test
+    void describeDbSubnetGroupsPassesSignedRegionToService() {
+        DbSubnetGroup group = new DbSubnetGroup();
+        group.setDbSubnetGroupName("default");
+        group.setDbSubnetGroupArn("arn:aws:rds:us-west-2:123456789012:subgrp:default");
+        when(service.listDbSubnetGroups(null, "us-west-2")).thenReturn(List.of(group));
+
+        Response response = handler.handle("DescribeDBSubnetGroups", params(), "us-west-2");
+
+        assertEquals(200, response.getStatus());
+        verify(service).listDbSubnetGroups(null, "us-west-2");
     }
 
     // ──────────────────────────── Helpers ────────────────────────────

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -102,6 +102,22 @@ class RdsServiceTest {
     }
 
     @Test
+    void createAndModifyDbInstancePersistVpcSecurityGroups() {
+        DbInstance instance = rdsService.createDbInstance("mydb", "postgres", "13",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of("sg-created"));
+
+        assertEquals(List.of("sg-created"), instance.getVpcSecurityGroupIds());
+
+        DbInstance modified = rdsService.modifyDbInstance("mydb", null, null, null,
+                List.of("sg-updated-a", "sg-updated-b"));
+
+        assertEquals(List.of("sg-updated-a", "sg-updated-b"), modified.getVpcSecurityGroupIds());
+        assertEquals(List.of("sg-updated-a", "sg-updated-b"), rdsService.getDbInstance("mydb").getVpcSecurityGroupIds());
+    }
+
+    @Test
     void postgresImageUsesRequestedEngineVersionAndDefaultFlavor() {
         assertEquals("postgres:18.1-alpine",
                 RdsService.imageForRequestedVersion("postgres:16-alpine", "18.1"));

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -596,6 +596,21 @@ class RdsServiceTest {
     }
 
     @Test
+    void createDbSubnetGroupUsesSuppliedRegionForSubnetLookup() {
+        List<String> subnetIds = List.of("subnet-west-a", "subnet-west-b");
+        when(ec2Service.describeSubnets(eq("us-west-2"), eq(subnetIds), eq(Map.of())))
+                .thenReturn(List.of(
+                        subnet("subnet-west-a", "vpc-west", "us-west-2a"),
+                        subnet("subnet-west-b", "vpc-west", "us-west-2b")));
+
+        DbSubnetGroup group = rdsService.createDbSubnetGroup("west-subnets", "desc", subnetIds, "us-west-2");
+
+        assertEquals("vpc-west", group.getVpcId());
+        assertEquals("arn:aws:rds:us-west-2:123456789012:subgrp:west-subnets", group.getDbSubnetGroupArn());
+        verify(ec2Service).describeSubnets(eq("us-west-2"), eq(subnetIds), eq(Map.of()));
+    }
+
+    @Test
     void createDbSubnetGroupRequiresSubnetIdsWithMissingParameter() {
         AwsException exception = assertThrows(AwsException.class, () ->
                 rdsService.createDbSubnetGroup("my-subnet-group", "desc", List.of()));
@@ -652,6 +667,36 @@ class RdsServiceTest {
 
         assertEquals("default", group.getDbSubnetGroupName());
         assertEquals("arn:aws:rds:us-east-1:123456789012:subgrp:default", group.getDbSubnetGroupArn());
+    }
+
+    @Test
+    void resolveDbSubnetGroupViewUsesSuppliedRegionForDefaultGroup() {
+        when(ec2Service.describeSubnets(eq("us-west-2"), anyList(), any()))
+                .thenReturn(List.of(
+                        subnet("subnet-west-a", "vpc-west", "us-west-2a"),
+                        subnet("subnet-west-b", "vpc-west", "us-west-2b")));
+
+        DbSubnetGroup group = rdsService.resolveDbSubnetGroupView(null, "us-west-2");
+
+        assertEquals("default", group.getDbSubnetGroupName());
+        assertEquals("vpc-west", group.getVpcId());
+        assertEquals("arn:aws:rds:us-west-2:123456789012:subgrp:default", group.getDbSubnetGroupArn());
+        assertEquals(Map.of("subnet-west-a", "us-west-2a", "subnet-west-b", "us-west-2b"),
+                group.getSubnetAvailabilityZones());
+    }
+
+    @Test
+    void getDbSubnetGroupUsesSuppliedRegionForDefaultGroup() {
+        when(ec2Service.describeSubnets(eq("us-west-2"), anyList(), any()))
+                .thenReturn(List.of(
+                        subnet("subnet-west-a", "vpc-west", "us-west-2a"),
+                        subnet("subnet-west-b", "vpc-west", "us-west-2b")));
+
+        DbSubnetGroup group = rdsService.getDbSubnetGroup("default", "us-west-2");
+
+        assertEquals("default", group.getDbSubnetGroupName());
+        assertEquals("vpc-west", group.getVpcId());
+        assertEquals("arn:aws:rds:us-west-2:123456789012:subgrp:default", group.getDbSubnetGroupArn());
     }
 
     @Test
@@ -799,16 +844,16 @@ class RdsServiceTest {
     }
 
     private static List<Subnet> defaultSubnets() {
-        Subnet subnetA = new Subnet();
-        subnetA.setSubnetId("subnet-default-a");
-        subnetA.setVpcId("vpc-default");
-        subnetA.setAvailabilityZone("us-east-1a");
+        return List.of(
+                subnet("subnet-default-a", "vpc-default", "us-east-1a"),
+                subnet("subnet-default-b", "vpc-default", "us-east-1b"));
+    }
 
-        Subnet subnetB = new Subnet();
-        subnetB.setSubnetId("subnet-default-b");
-        subnetB.setVpcId("vpc-default");
-        subnetB.setAvailabilityZone("us-east-1b");
-
-        return List.of(subnetA, subnetB);
+    private static Subnet subnet(String subnetId, String vpcId, String availabilityZone) {
+        Subnet subnet = new Subnet();
+        subnet.setSubnetId(subnetId);
+        subnet.setVpcId(vpcId);
+        subnet.setAvailabilityZone(availabilityZone);
+        return subnet;
     }
 }

--- a/tools/docs/services.yaml
+++ b/tools/docs/services.yaml
@@ -66,6 +66,7 @@ services:
     doc: docs/services/rds.md
     sources:
       - { path: src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java, mode: switch }
+    exclude_actions: [SubnetIds, VpcSecurityGroupIds]
   - service: secretsmanager
     doc: docs/services/secrets-manager.md
     sources:


### PR DESCRIPTION
Summary:
- Use the signed request region when resolving RDS subnet placement.
- Persist DB instance VPC security group IDs from create and modify calls.
- Return VPC security group membership from DescribeDBInstances.

Verification:
- ./mvnw -q -Dtest=RdsServiceTest,RdsQueryHandlerTest test
- git diff --check origin/main..HEAD
- product-name diff scan: clean
