### PR TITLE
feat(secretsmanager): support Filters and pagination in BatchGetSecretValue

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.secretsmanager;
 
 import io.github.hectorvent.floci.core.common.AwsErrorResponse;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.secretsmanager.model.Secret;
 import io.github.hectorvent.floci.services.secretsmanager.model.SecretVersion;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -64,13 +65,66 @@ public class SecretsManagerJsonHandler {
                     .build();
         }
 
-        List<String> secretIdList = new ArrayList<>();
-        if (request.has("SecretIdList")) {
-            request.path("SecretIdList").forEach(id -> secretIdList.add(id.asText()));
+        if (request.has("SecretIdList") && request.has("Filters")) {
+            return Response.status(400)
+                    .entity(new AwsErrorResponse("InvalidParameterException", "You cannot specify both SecretIdList and Filters."))
+                    .build();
         }
 
-        // Filters are not fully implemented yet, but for now we only support SecretIdList
-        List<SecretsManagerService.BatchSecretValue> values = service.batchGetSecretValue(secretIdList, region);
+        List<SecretsManagerService.BatchSecretValue> values;
+        String nextToken = null;
+
+        if (request.has("SecretIdList")) {
+            List<String> secretIdList = new ArrayList<>();
+            request.path("SecretIdList").forEach(id -> secretIdList.add(id.asText()));
+            try {
+                values = service.batchGetSecretValue(secretIdList, region);
+            } catch (AwsException e) {
+                return Response.status(e.getHttpStatus())
+                        .entity(new AwsErrorResponse(e.jsonType(), e.getMessage()))
+                        .build();
+            }
+        } else {
+            List<SecretsManagerService.Filter> filters = new ArrayList<>();
+            JsonNode filtersNode = request.path("Filters");
+            if (filtersNode.isArray()) {
+                for (JsonNode f : filtersNode) {
+                    String key = f.path("Key").asText();
+                    List<String> filterValues = new ArrayList<>();
+                    f.path("Values").forEach(v -> filterValues.add(v.asText()));
+                    filters.add(new SecretsManagerService.Filter(key, filterValues));
+                }
+            }
+            List<SecretsManagerService.BatchSecretValue> allFilteredValues = service.batchGetSecretValueByFilters(filters, region);
+
+            int maxResults = request.has("MaxResults") ? request.path("MaxResults").asInt() : 20;
+            if (maxResults < 1 || maxResults > 20) {
+                return Response.status(400)
+                        .entity(new AwsErrorResponse("ValidationException", "MaxResults must be between 1 and 20."))
+                        .build();
+            }
+
+            int startIndex = 0;
+            if (request.has("NextToken")) {
+                try {
+                    startIndex = Integer.parseInt(request.path("NextToken").asText());
+                } catch (NumberFormatException e) {
+                    return Response.status(400)
+                            .entity(new AwsErrorResponse("InvalidNextTokenException", "The NextToken value is invalid."))
+                            .build();
+                }
+            }
+
+            if (startIndex < 0 || startIndex > allFilteredValues.size()) {
+                values = List.of();
+            } else {
+                int endIndex = Math.min(startIndex + maxResults, allFilteredValues.size());
+                values = allFilteredValues.subList(startIndex, endIndex);
+                if (endIndex < allFilteredValues.size()) {
+                    nextToken = String.valueOf(endIndex);
+                }
+            }
+        }
 
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode secretValues = objectMapper.createArrayNode();
@@ -96,6 +150,10 @@ public class SecretsManagerJsonHandler {
             secretValues.add(node);
         }
         response.set("SecretValues", secretValues);
+        if (nextToken != null) {
+            response.put("NextToken", nextToken);
+        }
+        response.set("Errors", objectMapper.createArrayNode());
         return Response.ok(response).build();
     }
 
@@ -270,7 +328,20 @@ public class SecretsManagerJsonHandler {
     }
 
     private Response handleListSecrets(JsonNode request, String region) {
-        List<Secret> secrets = new ArrayList<>(service.listSecrets(region));
+        List<SecretsManagerService.Filter> filters = new ArrayList<>();
+        if (request.has("Filters")) {
+            JsonNode filtersNode = request.path("Filters");
+            if (filtersNode.isArray()) {
+                for (JsonNode f : filtersNode) {
+                    String key = f.path("Key").asText();
+                    List<String> filterValues = new ArrayList<>();
+                    f.path("Values").forEach(v -> filterValues.add(v.asText()));
+                    filters.add(new SecretsManagerService.Filter(key, filterValues));
+                }
+            }
+        }
+
+        List<Secret> secrets = new ArrayList<>(service.listSecrets(region, filters));
         // AWS lists secrets by CreatedDate when SortBy is absent; sort on it (name as a
         // tiebreaker) for AWS-matching, stable pagination across calls.
         secrets.sort(Comparator.comparing(Secret::getCreatedDate, Comparator.nullsLast(Comparator.naturalOrder()))

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
@@ -100,7 +100,7 @@ public class SecretsManagerJsonHandler {
             int maxResults = request.has("MaxResults") ? request.path("MaxResults").asInt() : 20;
             if (maxResults < 1 || maxResults > 20) {
                 return Response.status(400)
-                        .entity(new AwsErrorResponse("ValidationException", "MaxResults must be between 1 and 20."))
+                        .entity(new AwsErrorResponse("InvalidParameterException", "MaxResults must be between 1 and 20."))
                         .build();
             }
 

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
@@ -85,18 +85,7 @@ public class SecretsManagerJsonHandler {
                         .build();
             }
         } else {
-            List<SecretsManagerService.Filter> filters = new ArrayList<>();
-            JsonNode filtersNode = request.path("Filters");
-            if (filtersNode.isArray()) {
-                for (JsonNode f : filtersNode) {
-                    String key = f.path("Key").asText();
-                    List<String> filterValues = new ArrayList<>();
-                    f.path("Values").forEach(v -> filterValues.add(v.asText()));
-                    filters.add(new SecretsManagerService.Filter(key, filterValues));
-                }
-            }
-            List<SecretsManagerService.BatchSecretValue> allFilteredValues = service.batchGetSecretValueByFilters(filters, region);
-
+            // Validate paging inputs before the service scans and filters the whole store.
             int maxResults = request.has("MaxResults") ? request.path("MaxResults").asInt() : 20;
             if (maxResults < 1 || maxResults > 20) {
                 return Response.status(400)
@@ -108,6 +97,9 @@ public class SecretsManagerJsonHandler {
             if (request.has("NextToken")) {
                 try {
                     startIndex = Integer.parseInt(request.path("NextToken").asText());
+                    if (startIndex < 0) {
+                        throw new NumberFormatException("negative NextToken");
+                    }
                 } catch (NumberFormatException e) {
                     return Response.status(400)
                             .entity(new AwsErrorResponse("InvalidNextTokenException", "The NextToken value is invalid."))
@@ -115,7 +107,10 @@ public class SecretsManagerJsonHandler {
                 }
             }
 
-            if (startIndex < 0 || startIndex > allFilteredValues.size()) {
+            List<SecretsManagerService.BatchSecretValue> allFilteredValues =
+                    service.batchGetSecretValueByFilters(parseFilters(request), region);
+
+            if (startIndex > allFilteredValues.size()) {
                 values = List.of();
             } else {
                 int endIndex = Math.min(startIndex + maxResults, allFilteredValues.size());
@@ -327,21 +322,23 @@ public class SecretsManagerJsonHandler {
         return Response.ok(response).build();
     }
 
-    private Response handleListSecrets(JsonNode request, String region) {
+    /** Parses the request's {@code Filters} array, shared by BatchGetSecretValue and ListSecrets. */
+    private List<SecretsManagerService.Filter> parseFilters(JsonNode request) {
         List<SecretsManagerService.Filter> filters = new ArrayList<>();
-        if (request.has("Filters")) {
-            JsonNode filtersNode = request.path("Filters");
-            if (filtersNode.isArray()) {
-                for (JsonNode f : filtersNode) {
-                    String key = f.path("Key").asText();
-                    List<String> filterValues = new ArrayList<>();
-                    f.path("Values").forEach(v -> filterValues.add(v.asText()));
-                    filters.add(new SecretsManagerService.Filter(key, filterValues));
-                }
+        JsonNode filtersNode = request.path("Filters");
+        if (filtersNode.isArray()) {
+            for (JsonNode f : filtersNode) {
+                String key = f.path("Key").asText();
+                List<String> filterValues = new ArrayList<>();
+                f.path("Values").forEach(v -> filterValues.add(v.asText()));
+                filters.add(new SecretsManagerService.Filter(key, filterValues));
             }
         }
+        return filters;
+    }
 
-        List<Secret> secrets = new ArrayList<>(service.listSecrets(region, filters));
+    private Response handleListSecrets(JsonNode request, String region) {
+        List<Secret> secrets = new ArrayList<>(service.listSecrets(region, parseFilters(request)));
         // AWS lists secrets by CreatedDate when SortBy is absent; sort on it (name as a
         // tiebreaker) for AWS-matching, stable pagination across calls.
         secrets.sort(Comparator.comparing(Secret::getCreatedDate, Comparator.nullsLast(Comparator.naturalOrder()))

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
@@ -292,6 +292,102 @@ public class SecretsManagerService {
                 .orElse(false));
     }
 
+    public List<Secret> listSecrets(String region, List<Filter> filters) {
+        List<Secret> allSecrets = listSecrets(region);
+        if (filters == null || filters.isEmpty()) {
+            return allSecrets;
+        }
+        List<Secret> result = new ArrayList<>();
+        for (Secret secret : allSecrets) {
+            if (matchesFilters(secret, filters, region)) {
+                result.add(secret);
+            }
+        }
+        return result;
+    }
+
+    public List<BatchSecretValue> batchGetSecretValueByFilters(List<Filter> filters, String region) {
+        List<BatchSecretValue> result = new ArrayList<>();
+        List<Secret> allSecrets = listSecrets(region);
+        for (Secret secret : allSecrets) {
+            if (secret.getDeletedDate() != null) {
+                continue;
+            }
+            if (matchesFilters(secret, filters, region)) {
+                SecretVersion version = findVersionByStage(secret, AWSCURRENT);
+                if (version != null) {
+                    result.add(new BatchSecretValue(
+                            secret.getArn(),
+                            secret.getName(),
+                            version.getSecretString(),
+                            version.getSecretBinary(),
+                            version.getVersionId(),
+                            version.getVersionStages(),
+                            version.getCreatedDate()
+                    ));
+                }
+            }
+        }
+        return result;
+    }
+
+    private boolean matchesFilters(Secret secret, List<Filter> filters, String region) {
+        if (filters == null || filters.isEmpty()) {
+            return true;
+        }
+        for (Filter filter : filters) {
+            if (!matchesFilter(secret, filter, region)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean matchesFilter(Secret secret, Filter filter, String region) {
+        String key = filter.key();
+        List<String> values = filter.values();
+        if (values == null || values.isEmpty()) {
+            return true;
+        }
+
+        for (String val : values) {
+            if (matchesValue(secret, key, val, region)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean matchesValue(Secret secret, String key, String filterVal, String region) {
+        boolean negate = filterVal.startsWith("!");
+        String targetVal = negate ? filterVal.substring(1) : filterVal;
+
+        boolean matched = matchesTarget(secret, key, targetVal, region);
+        return negate ? !matched : matched;
+    }
+
+    private boolean matchesTarget(Secret secret, String key, String targetVal, String region) {
+        return switch (key) {
+            case "name" -> secret.getName() != null && secret.getName().startsWith(targetVal);
+            case "description" -> secret.getDescription() != null && secret.getDescription().toLowerCase().startsWith(targetVal.toLowerCase());
+            case "tag-key" -> secret.getTags() != null && secret.getTags().stream().anyMatch(t -> t.key() != null && t.key().startsWith(targetVal));
+            case "tag-value" -> secret.getTags() != null && secret.getTags().stream().anyMatch(t -> t.value() != null && t.value().startsWith(targetVal));
+            case "primary-region" -> region != null && region.startsWith(targetVal);
+            case "owning-service" -> false;
+            case "all" -> {
+                String lowerVal = targetVal.toLowerCase();
+                boolean nameMatch = secret.getName() != null && secret.getName().toLowerCase().startsWith(lowerVal);
+                boolean descMatch = secret.getDescription() != null && secret.getDescription().toLowerCase().startsWith(lowerVal);
+                boolean tagKeyMatch = secret.getTags() != null && secret.getTags().stream().anyMatch(t -> t.key() != null && t.key().toLowerCase().startsWith(lowerVal));
+                boolean tagValueMatch = secret.getTags() != null && secret.getTags().stream().anyMatch(t -> t.value() != null && t.value().toLowerCase().startsWith(lowerVal));
+                yield nameMatch || descMatch || tagKeyMatch || tagValueMatch;
+            }
+            default -> false;
+        };
+    }
+
+    public record Filter(String key, List<String> values) {}
+
     public Secret deleteSecret(String secretId, Integer recoveryWindowInDays, boolean forceDelete, String region) {
         Secret secret = resolveSecret(secretId, region);
         String storageKey = regionKey(region, secret.getName());

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Executors;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -325,6 +326,11 @@ public class SecretsManagerService {
                 }
             }
         }
+        // Stable order (created date, then name) so offset-based pagination in the handler
+        // never skips or duplicates entries across calls — same contract as ListSecrets.
+        result.sort(Comparator.comparing(BatchSecretValue::createdDate,
+                        Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(BatchSecretValue::name, Comparator.nullsLast(Comparator.naturalOrder())));
         return result;
     }
 
@@ -369,6 +375,9 @@ public class SecretsManagerService {
             case "description" -> secret.getDescription() != null && secret.getDescription().toLowerCase().startsWith(targetVal.toLowerCase());
             case "tag-key" -> secret.getTags() != null && secret.getTags().stream().anyMatch(t -> t.key() != null && t.key().startsWith(targetVal));
             case "tag-value" -> secret.getTags() != null && secret.getTags().stream().anyMatch(t -> t.value() != null && t.value().startsWith(targetVal));
+            // Floci does not model cross-region replication, so every secret's primary region
+            // IS the region it lives in — comparing the request region is equivalent to a
+            // per-secret attribute here (all match when the prefix fits, none otherwise).
             case "primary-region" -> region != null && region.startsWith(targetVal);
             // owning-service is a valid Filter.Key enum value but is currently deferred (always returning false)
             case "owning-service" -> false;

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
@@ -310,9 +310,6 @@ public class SecretsManagerService {
         List<BatchSecretValue> result = new ArrayList<>();
         List<Secret> allSecrets = listSecrets(region);
         for (Secret secret : allSecrets) {
-            if (secret.getDeletedDate() != null) {
-                continue;
-            }
             if (matchesFilters(secret, filters, region)) {
                 SecretVersion version = findVersionByStage(secret, AWSCURRENT);
                 if (version != null) {

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
@@ -373,6 +373,7 @@ public class SecretsManagerService {
             case "tag-key" -> secret.getTags() != null && secret.getTags().stream().anyMatch(t -> t.key() != null && t.key().startsWith(targetVal));
             case "tag-value" -> secret.getTags() != null && secret.getTags().stream().anyMatch(t -> t.value() != null && t.value().startsWith(targetVal));
             case "primary-region" -> region != null && region.startsWith(targetVal);
+            // owning-service is a valid Filter.Key enum value but is currently deferred (always returning false)
             case "owning-service" -> false;
             case "all" -> {
                 String lowerVal = targetVal.toLowerCase();

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
@@ -358,6 +358,17 @@ class SecretsManagerJsonHandlerTest {
     }
 
     @Test
+    void batchGetSecretValueRejectsNegativeNextToken() {
+        // A negative offset is an invalid token, not a valid query with no results.
+        ObjectNode filterReq = MAPPER.createObjectNode();
+        filterReq.putArray("Filters").addObject().put("Key", "name").putArray("Values").add("any");
+        filterReq.put("NextToken", "-1");
+        Response response = handler.handle("BatchGetSecretValue", filterReq, REGION);
+        assertThat(response.getStatus(), is(400));
+        assertThat(((AwsErrorResponse) response.getEntity()).type(), containsString("InvalidNextTokenException"));
+    }
+
+    @Test
     void listSecretsWithFilters() {
         ObjectNode createReq1 = MAPPER.createObjectNode();
         createReq1.put("Name", "test-secret-a");

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.secretsmanager;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.common.AwsErrorResponse;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -246,6 +247,135 @@ class SecretsManagerJsonHandlerTest {
         ObjectNode batchReq = MAPPER.createObjectNode();
         Response response = handler.handle("BatchGetSecretValue", batchReq, REGION);
         assertThat(response.getStatus(), is(400));
+        assertThat(((AwsErrorResponse) response.getEntity()).message(), containsString("You must specify either SecretIdList or Filters"));
+    }
+
+    @Test
+    void batchGetSecretValueMutuallyExclusiveParameters() {
+        ObjectNode batchReq = MAPPER.createObjectNode();
+        batchReq.putArray("SecretIdList").add("secret1");
+        batchReq.putArray("Filters").addObject().put("Key", "name").putArray("Values").add("secret1");
+        Response response = handler.handle("BatchGetSecretValue", batchReq, REGION);
+        assertThat(response.getStatus(), is(400));
+        assertThat(((AwsErrorResponse) response.getEntity()).message(), containsString("You cannot specify both SecretIdList and Filters"));
+    }
+
+    @Test
+    void batchGetSecretValueWithFilters() {
+        // Create matching/non-matching secrets
+        ObjectNode createReq1 = MAPPER.createObjectNode();
+        createReq1.put("Name", "prod-db-url");
+        createReq1.put("Description", "Production Database URL");
+        createReq1.put("SecretString", "postgres://prod");
+        createReq1.putArray("Tags").addObject().put("Key", "Env").put("Value", "Production");
+        handler.handle("CreateSecret", createReq1, REGION);
+
+        ObjectNode createReq2 = MAPPER.createObjectNode();
+        createReq2.put("Name", "dev-db-url");
+        createReq2.put("Description", "Development Database URL");
+        createReq2.put("SecretString", "postgres://dev");
+        createReq2.putArray("Tags").addObject().put("Key", "Env").put("Value", "Development");
+        handler.handle("CreateSecret", createReq2, REGION);
+
+        // Filter by name (begins with)
+        ObjectNode filterReq = MAPPER.createObjectNode();
+        filterReq.putArray("Filters").addObject().put("Key", "name").putArray("Values").add("prod");
+        Response response = handler.handle("BatchGetSecretValue", filterReq, REGION);
+        assertThat(response.getStatus(), is(200));
+        ObjectNode body = (ObjectNode) response.getEntity();
+        assertThat(body.get("SecretValues").size(), is(1));
+        assertThat(body.get("SecretValues").get(0).get("Name").asText(), is("prod-db-url"));
+
+        // Filter by description (case-insensitive)
+        filterReq = MAPPER.createObjectNode();
+        filterReq.putArray("Filters").addObject().put("Key", "description").putArray("Values").add("production");
+        response = handler.handle("BatchGetSecretValue", filterReq, REGION);
+        assertThat(response.getStatus(), is(200));
+        body = (ObjectNode) response.getEntity();
+        assertThat(body.get("SecretValues").size(), is(1));
+        assertThat(body.get("SecretValues").get(0).get("Name").asText(), is("prod-db-url"));
+
+        // Filter by tag-key
+        filterReq = MAPPER.createObjectNode();
+        filterReq.putArray("Filters").addObject().put("Key", "tag-key").putArray("Values").add("Env");
+        response = handler.handle("BatchGetSecretValue", filterReq, REGION);
+        assertThat(response.getStatus(), is(200));
+        body = (ObjectNode) response.getEntity();
+        assertThat(body.get("SecretValues").size(), is(2));
+
+        // Filter by tag-value negation
+        filterReq = MAPPER.createObjectNode();
+        filterReq.putArray("Filters").addObject().put("Key", "tag-value").putArray("Values").add("!Production");
+        response = handler.handle("BatchGetSecretValue", filterReq, REGION);
+        assertThat(response.getStatus(), is(200));
+        body = (ObjectNode) response.getEntity();
+        assertThat(body.get("SecretValues").size(), is(1));
+        assertThat(body.get("SecretValues").get(0).get("Name").asText(), is("dev-db-url"));
+    }
+
+    @Test
+    void batchGetSecretValueWithFiltersPagination() {
+        for (int i = 0; i < 5; i++) {
+            ObjectNode createReq = MAPPER.createObjectNode();
+            createReq.put("Name", "paged-secret-" + i);
+            createReq.put("SecretString", "val-" + i);
+            handler.handle("CreateSecret", createReq, REGION);
+        }
+
+        // Fetch page 1 (MaxResults = 2)
+        ObjectNode filterReq = MAPPER.createObjectNode();
+        filterReq.putArray("Filters").addObject().put("Key", "name").putArray("Values").add("paged-");
+        filterReq.put("MaxResults", 2);
+        Response response = handler.handle("BatchGetSecretValue", filterReq, REGION);
+        assertThat(response.getStatus(), is(200));
+        ObjectNode body = (ObjectNode) response.getEntity();
+        assertThat(body.get("SecretValues").size(), is(2));
+        assertThat(body.has("NextToken"), is(true));
+        String nextToken = body.get("NextToken").asText();
+
+        // Fetch page 2
+        filterReq = MAPPER.createObjectNode();
+        filterReq.putArray("Filters").addObject().put("Key", "name").putArray("Values").add("paged-");
+        filterReq.put("MaxResults", 2);
+        filterReq.put("NextToken", nextToken);
+        response = handler.handle("BatchGetSecretValue", filterReq, REGION);
+        assertThat(response.getStatus(), is(200));
+        body = (ObjectNode) response.getEntity();
+        assertThat(body.get("SecretValues").size(), is(2));
+        assertThat(body.has("NextToken"), is(true));
+        nextToken = body.get("NextToken").asText();
+
+        // Fetch page 3 (remaining 1)
+        filterReq = MAPPER.createObjectNode();
+        filterReq.putArray("Filters").addObject().put("Key", "name").putArray("Values").add("paged-");
+        filterReq.put("MaxResults", 2);
+        filterReq.put("NextToken", nextToken);
+        response = handler.handle("BatchGetSecretValue", filterReq, REGION);
+        assertThat(response.getStatus(), is(200));
+        body = (ObjectNode) response.getEntity();
+        assertThat(body.get("SecretValues").size(), is(1));
+        assertThat(body.has("NextToken"), is(false));
+    }
+
+    @Test
+    void listSecretsWithFilters() {
+        ObjectNode createReq1 = MAPPER.createObjectNode();
+        createReq1.put("Name", "test-secret-a");
+        createReq1.put("SecretString", "valA");
+        handler.handle("CreateSecret", createReq1, REGION);
+
+        ObjectNode createReq2 = MAPPER.createObjectNode();
+        createReq2.put("Name", "test-secret-b");
+        createReq2.put("SecretString", "valB");
+        handler.handle("CreateSecret", createReq2, REGION);
+
+        ObjectNode listReq = MAPPER.createObjectNode();
+        listReq.putArray("Filters").addObject().put("Key", "name").putArray("Values").add("test-secret-a");
+        Response response = handler.handle("ListSecrets", listReq, REGION);
+        assertThat(response.getStatus(), is(200));
+        ObjectNode body = (ObjectNode) response.getEntity();
+        assertThat(body.get("SecretList").size(), is(1));
+        assertThat(body.get("SecretList").get(0).get("Name").asText(), is("test-secret-a"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Supersedes #1275 (rebased onto current main; all credit to @iam-ssrivastav, whose commits carry through with authorship intact). Closes #1267.

Implements filter support and pagination for Secrets Manager `BatchGetSecretValue` and shares the filter engine with `ListSecrets`:

- Filter matching engine for keys `name`, `description`, `tag-key`, `tag-value`, `primary-region`, and `all`, with AWS case-sensitivity, prefix-matching, and `!` negation rules (value OR within a filter, AND across filters). `owning-service` is a documented known gap.
- `SecretIdList` vs `Filters` mutual exclusivity returns `InvalidParameterException`.
- `MaxResults` (1–20) + `NextToken` pagination for filtered batch queries.

The rebase resolves the one conflict against main: `ListSecrets` gained CreatedDate-sorted pagination after the original PR was written, so filters now apply first and the sort + MaxResults validation + NextToken pagination run on the filtered list — both features compose.

The review feedback from #1275 is included (`ValidationException` → `InvalidParameterException` for the MaxResults range check, per the declared error list in `service-2.json`).

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Filter semantics and error codes verified against the Secrets Manager `service-2.json` during the original review: all thrown codes (`InvalidParameterException`, `InvalidNextTokenException`) are declared for `BatchGetSecretValue`.

## Checklist

- [x] `./mvnw test` passes locally (77 secretsmanager tests green, incl. the 130-line handler filter suite)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
