### PR TITLE
feat(eventbridge): deliver events to Firehose delivery stream targets

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeInvoker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeInvoker.java
@@ -7,6 +7,8 @@ import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.services.batch.BatchService;
 import io.github.hectorvent.floci.services.eventbridge.model.InputTransformer;
 import io.github.hectorvent.floci.services.eventbridge.model.Target;
+import io.github.hectorvent.floci.services.firehose.FirehoseService;
+import io.github.hectorvent.floci.services.firehose.model.Record;
 import io.github.hectorvent.floci.services.lambda.LambdaService;
 import io.github.hectorvent.floci.services.lambda.model.InvocationType;
 import io.github.hectorvent.floci.services.sns.SnsService;
@@ -15,6 +17,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -27,6 +30,7 @@ public class EventBridgeInvoker {
     private final SqsService sqsService;
     private final SnsService snsService;
     private final BatchService batchService;
+    private final FirehoseService firehoseService;
     private final ObjectMapper objectMapper;
     private final String baseUrl;
 
@@ -35,12 +39,14 @@ public class EventBridgeInvoker {
                               SqsService sqsService,
                               SnsService snsService,
                               BatchService batchService,
+                              FirehoseService firehoseService,
                               ObjectMapper objectMapper,
                               EmulatorConfig config) {
         this.lambdaService = lambdaService;
         this.sqsService = sqsService;
         this.snsService = snsService;
         this.batchService = batchService;
+        this.firehoseService = firehoseService;
         this.objectMapper = objectMapper;
         this.baseUrl = config.baseUrl();
     }
@@ -50,7 +56,7 @@ public class EventBridgeInvoker {
                        SnsService snsService,
                        ObjectMapper objectMapper,
                        EmulatorConfig config) {
-        this(lambdaService, sqsService, snsService, null, objectMapper, config);
+        this(lambdaService, sqsService, snsService, null, null, objectMapper, config);
     }
 
     public void invokeTarget(Target target, String eventJson, String region) {
@@ -97,6 +103,19 @@ public class EventBridgeInvoker {
                         targetRegion
                 );
                 LOG.debugv("EventBridge delivered to Batch: {0}", arn);
+            } else if (arn.contains(":firehose:") && arn.contains(":deliverystream/")) {
+                if (firehoseService == null) {
+                    LOG.warnv("EventBridge Firehose target missing Firehose service: {0}", arn);
+                    return;
+                }
+                String streamName = arn.substring(
+                        arn.indexOf(":deliverystream/") + ":deliverystream/".length());
+                // AWS puts the (input-transformed) event JSON as the record Data verbatim,
+                // without appending a newline; the delivery-side NDJSON flush handles separation.
+                Record record = new Record();
+                record.setData(payload.getBytes(StandardCharsets.UTF_8));
+                firehoseService.putRecord(streamName, record);
+                LOG.debugv("EventBridge delivered to Firehose: {0}", arn);
             } else {
                 LOG.warnv("EventBridge: unsupported target ARN type: {0}", arn);
             }

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeInvoker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeInvoker.java
@@ -112,9 +112,7 @@ public class EventBridgeInvoker {
                         arn.indexOf(":deliverystream/") + ":deliverystream/".length());
                 // AWS puts the (input-transformed) event JSON as the record Data verbatim,
                 // without appending a newline; the delivery-side NDJSON flush handles separation.
-                Record record = new Record();
-                record.setData(payload.getBytes(StandardCharsets.UTF_8));
-                firehoseService.putRecord(streamName, record);
+                firehoseService.putRecord(streamName, new Record(payload.getBytes(StandardCharsets.UTF_8)));
                 LOG.debugv("EventBridge delivered to Firehose: {0}", arn);
             } else {
                 LOG.warnv("EventBridge: unsupported target ARN type: {0}", arn);

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeFirehoseTargetIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeFirehoseTargetIntegrationTest.java
@@ -1,0 +1,121 @@
+package io.github.hectorvent.floci.services.eventbridge;
+
+import io.github.hectorvent.floci.services.firehose.FirehoseService;
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * End to end EventBridge → Firehose target delivery: rule matches a PutEvents event,
+ * the invoker puts the event JSON as a Firehose record, and the stream's S3 flush
+ * lands it in the destination bucket.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class EventBridgeFirehoseTargetIntegrationTest {
+
+    private static final String BUCKET = "eb-firehose-target-bucket";
+    private static final String STREAM = "eb-firehose-target-stream";
+    private static final String RULE = "eb-firehose-target-rule";
+    private static final String JSON_CT = "application/x-amz-json-1.1";
+
+    @Inject
+    FirehoseService firehoseService;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    @Order(1)
+    void setupBucketStreamAndRule() {
+        given().when().put("/" + BUCKET).then().statusCode(200);
+
+        given()
+            .contentType(JSON_CT)
+            .header("X-Amz-Target", "Firehose_20150804.CreateDeliveryStream")
+            .body("""
+                    {
+                      "DeliveryStreamName": "%s",
+                      "ExtendedS3DestinationConfiguration": {
+                        "RoleARN": "arn:aws:iam::000000000000:role/firehose-delivery-role",
+                        "BucketARN": "arn:aws:s3:::%s",
+                        "Prefix": "events/"
+                      }
+                    }
+                    """.formatted(STREAM, BUCKET))
+        .when().post("/")
+        .then().statusCode(200);
+
+        given()
+            .contentType(JSON_CT)
+            .header("X-Amz-Target", "AWSEvents.PutRule")
+            .body("""
+                    {
+                      "Name": "%s",
+                      "EventPattern": "{\\"source\\": [\\"local.orders\\"]}"
+                    }
+                    """.formatted(RULE))
+        .when().post("/")
+        .then().statusCode(200);
+
+        given()
+            .contentType(JSON_CT)
+            .header("X-Amz-Target", "AWSEvents.PutTargets")
+            .body("""
+                    {
+                      "Rule": "%s",
+                      "Targets": [{
+                        "Id": "firehose-target",
+                        "Arn": "arn:aws:firehose:us-east-1:000000000000:deliverystream/%s"
+                      }]
+                    }
+                    """.formatted(RULE, STREAM))
+        .when().post("/")
+        .then().statusCode(200)
+            .body("FailedEntryCount", equalTo(0));
+    }
+
+    @Test
+    @Order(2)
+    void putEventIsDeliveredToS3ThroughFirehose() {
+        given()
+            .contentType(JSON_CT)
+            .header("X-Amz-Target", "AWSEvents.PutEvents")
+            .body("""
+                    {
+                      "Entries": [{
+                        "Source": "local.orders",
+                        "DetailType": "OrderPlaced",
+                        "Detail": "{\\"orderId\\": \\"order-eb-fh-1\\"}"
+                      }]
+                    }
+                    """)
+        .when().post("/")
+        .then().statusCode(200)
+            .body("FailedEntryCount", equalTo(0));
+
+        // The record sits in the stream buffer until size/interval flush; force it so
+        // the assertion is deterministic (same mechanism the scheduled flusher uses).
+        firehoseService.flush(STREAM);
+
+        String key = given().when().get("/" + BUCKET + "?prefix=events/")
+                .then().statusCode(200)
+                .extract().xmlPath().getString("ListBucketResult.Contents[0].Key");
+
+        given().when().get("/" + BUCKET + "/" + key)
+                .then().statusCode(200)
+                .body(containsString("order-eb-fh-1"))
+                .body(containsString("\"detail-type\":\"OrderPlaced\""));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeInvokerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeInvokerTest.java
@@ -6,13 +6,18 @@ import io.github.hectorvent.floci.services.batch.BatchService;
 import io.github.hectorvent.floci.services.eventbridge.model.BatchParameters;
 import io.github.hectorvent.floci.services.eventbridge.model.InputTransformer;
 import io.github.hectorvent.floci.services.eventbridge.model.Target;
+import io.github.hectorvent.floci.services.firehose.FirehoseService;
+import io.github.hectorvent.floci.services.firehose.model.Record;
 import io.github.hectorvent.floci.services.lambda.LambdaService;
 import io.github.hectorvent.floci.services.sns.SnsService;
 import io.github.hectorvent.floci.services.sqs.SqsService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
+
+import org.mockito.ArgumentCaptor;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -23,6 +28,7 @@ class EventBridgeInvokerTest {
     private EventBridgeInvoker invoker;
     private SqsService sqsService;
     private BatchService batchService;
+    private FirehoseService firehoseService;
 
     @BeforeEach
     void setUp() {
@@ -30,11 +36,13 @@ class EventBridgeInvokerTest {
         sqsService = mock(SqsService.class);
         SnsService snsService = mock(SnsService.class);
         batchService = mock(BatchService.class);
+        firehoseService = mock(FirehoseService.class);
         invoker = new EventBridgeInvoker(
                 lambdaService,
                 sqsService,
                 snsService,
                 batchService,
+                firehoseService,
                 new ObjectMapper(),
                 mock(io.github.hectorvent.floci.config.EmulatorConfig.class)
         );
@@ -121,6 +129,34 @@ class EventBridgeInvokerTest {
                 isNull(),
                 eq("us-west-2")
         );
+    }
+
+    @Test
+    void invokeTarget_firehoseTarget_putsEventJsonAsRecordData() {
+        Target target = new Target("id1",
+                "arn:aws:firehose:us-east-1:000000000000:deliverystream/my-stream", null, null);
+        String event = "{\"source\":\"local.test\",\"detail\":{\"orderId\":\"o-1\"}}";
+
+        invoker.invokeTarget(target, event, "us-east-1");
+
+        ArgumentCaptor<Record> captor = ArgumentCaptor.forClass(Record.class);
+        verify(firehoseService).putRecord(eq("my-stream"), captor.capture());
+        // The event JSON is the record Data verbatim: no wrapping, no trailing newline.
+        assertEquals(event, new String(captor.getValue().getData(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void invokeTarget_firehoseTarget_deliversInputOverrideNotEnvelope() {
+        Target target = new Target("id1",
+                "arn:aws:firehose:us-east-1:000000000000:deliverystream/my-stream",
+                "{\"custom\":\"payload\"}", null);
+
+        invoker.invokeTarget(target, "{\"ignored\":true}", "us-east-1");
+
+        ArgumentCaptor<Record> captor = ArgumentCaptor.forClass(Record.class);
+        verify(firehoseService).putRecord(eq("my-stream"), captor.capture());
+        assertEquals("{\"custom\":\"payload\"}",
+                new String(captor.getValue().getData(), StandardCharsets.UTF_8));
     }
 
     @Test


### PR DESCRIPTION
## Summary

`EventBridgeInvoker` supported Lambda, SQS, SNS, and Batch targets but silently dropped events aimed at Firehose delivery streams with an unsupported-ARN warning. This adds the `:firehose:` branch: the (input-transformed) event JSON is put as the record `Data` verbatim through the existing `FirehoseService.putRecord`, with no appended newline — matching real AWS, where the delivery-side buffering handles separation. This is the declared follow-up from the #1043 investigation (the extended_s3 read-back half shipped in #1710).

## Related issue

Refs #1043

## Type of change

- [x] New feature (`feat:`)

## AWS Compatibility

The event JSON becomes the Firehose record data verbatim per AWS's documented EventBridge→Firehose target behavior; `Input`/`InputPath`/`InputTransformer` apply before delivery like every other target type. No wire-shape changes.

## Checklist

- [x] `./mvnw test` passes locally (206 eventbridge-package tests; 34 affected tests re-verified on the consolidated branch against latest main)
- [x] New or updated integration test added (end-to-end PutEvents → rule → Firehose → S3 asserting the delivered object contains the event detail, plus invoker unit tests for stream-name extraction and Input overrides)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
