### PR TITLE
fix(rds): fault with DBInstanceNotFound/DBClusterNotFoundFault for missing identifiers in Describe*

### DIFF
--- a/compatibility-tests/sdk-test-go/tests/rds_test.go
+++ b/compatibility-tests/sdk-test-go/tests/rds_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
+	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -106,7 +107,9 @@ func TestRDSInstance(t *testing.T) {
 		assert.Equal(t, 1, result)
 	})
 
-	// Fix #567: deleting an instance must remove it from the describe list.
+	// Fix #567: deleting an instance must remove it from the describe list. Real AWS
+	// faults DBInstanceNotFound when describing a deleted instance by identifier —
+	// this is what lets the DBInstanceDeleted waiter complete.
 	t.Run("DeleteDBInstance", func(t *testing.T) {
 		_, err := svc.DeleteDBInstance(ctx, &rds.DeleteDBInstanceInput{
 			DBInstanceIdentifier: aws.String(instanceId),
@@ -114,11 +117,12 @@ func TestRDSInstance(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		out, err := svc.DescribeDBInstances(ctx, &rds.DescribeDBInstancesInput{
+		_, err = svc.DescribeDBInstances(ctx, &rds.DescribeDBInstancesInput{
 			DBInstanceIdentifier: aws.String(instanceId),
 		})
-		require.NoError(t, err)
-		assert.Empty(t, out.DBInstances, "deleted instance must not appear in describe")
+		var notFound *types.DBInstanceNotFoundFault
+		require.ErrorAs(t, err, &notFound,
+			"describe of a deleted instance must fault DBInstanceNotFound")
 	})
 }
 
@@ -167,7 +171,9 @@ func TestRDSCluster(t *testing.T) {
 			"DBCluster.DBSubnetGroup must be a non-nil string (shape: String in AWS service model)")
 	})
 
-	// Fix #567: deleting a cluster must remove it from the describe list.
+	// Fix #567: deleting a cluster must remove it from the describe list. Real AWS
+	// faults DBClusterNotFoundFault when describing a deleted cluster by identifier —
+	// this is what lets the DBClusterDeleted waiter complete.
 	t.Run("DeleteDBCluster", func(t *testing.T) {
 		_, err := svc.DeleteDBCluster(ctx, &rds.DeleteDBClusterInput{
 			DBClusterIdentifier: aws.String(clusterId),
@@ -175,11 +181,12 @@ func TestRDSCluster(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		out, err := svc.DescribeDBClusters(ctx, &rds.DescribeDBClustersInput{
+		_, err = svc.DescribeDBClusters(ctx, &rds.DescribeDBClustersInput{
 			DBClusterIdentifier: aws.String(clusterId),
 		})
-		require.NoError(t, err)
-		assert.Empty(t, out.DBClusters, "deleted cluster must not appear in describe")
+		var notFound *types.DBClusterNotFoundFault
+		require.ErrorAs(t, err, &notFound,
+			"describe of a deleted cluster must fault DBClusterNotFoundFault")
 	})
 }
 

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/RdsJdbcCompatTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/RdsJdbcCompatTest.java
@@ -15,9 +15,9 @@ import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceResponse;
 import software.amazon.awssdk.services.rds.model.DBInstance;
+import software.amazon.awssdk.services.rds.model.DbInstanceNotFoundException;
 import software.amazon.awssdk.services.rds.model.DeleteDbInstanceRequest;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesRequest;
-import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
 import software.amazon.awssdk.services.rds.model.GenerateAuthenticationTokenRequest;
 import software.amazon.awssdk.services.rds.model.ModifyDbInstanceRequest;
 
@@ -306,10 +306,13 @@ class RdsJdbcCompatTest {
                 .build());
         instanceCreated = false;
 
-        DescribeDbInstancesResponse afterDelete = rds.describeDBInstances(DescribeDbInstancesRequest.builder()
-                .dbInstanceIdentifier(instanceId)
-                .build());
-        assertThat(afterDelete.dbInstances()).isEmpty();
+        // Real AWS faults DBInstanceNotFound when describing a deleted instance by
+        // identifier — this is what lets the DBInstanceDeleted waiter complete.
+        String deletedId = instanceId;
+        assertThatThrownBy(() -> rds.describeDBInstances(DescribeDbInstancesRequest.builder()
+                .dbInstanceIdentifier(deletedId)
+                .build()))
+                .isInstanceOf(DbInstanceNotFoundException.class);
 
         String replacementId = TestFixtures.uniqueName("rds-pg");
         CreateDbInstanceResponse replacement = rds.createDBInstance(CreateDbInstanceRequest.builder()

--- a/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbQueryHandler.java
@@ -75,14 +75,17 @@ public class DocDbQueryHandler {
     }
 
     private Response handleDescribeDbClusters(MultivaluedMap<String, String> params) {
-        String filterId = params.getFirst("DBClusterIdentifier");
+        String identifier = params.getFirst("DBClusterIdentifier");
+        String filterId = identifier;
         if (filterId == null || filterId.isBlank()) {
             filterId = extractFilterValue(params, "db-cluster-id");
         }
 
-        // When a specific cluster ID is requested, AWS returns 404 if not found
-        if (filterId != null && !filterId.isBlank()) {
-            service.getDbCluster(filterId); // throws DBClusterNotFoundFault if absent
+        // AWS parity: the DBClusterIdentifier parameter faults with
+        // DBClusterNotFoundFault when no cluster matches, while the
+        // db-cluster-id Filters form returns an empty list.
+        if (identifier != null && !identifier.isBlank()) {
+            service.getDbCluster(identifier); // throws DBClusterNotFoundFault if absent
         }
 
         Collection<DocDbCluster> result = service.listDbClusters(filterId);
@@ -154,13 +157,17 @@ public class DocDbQueryHandler {
     }
 
     private Response handleDescribeDbInstances(MultivaluedMap<String, String> params) {
-        String filterId = params.getFirst("DBInstanceIdentifier");
+        String identifier = params.getFirst("DBInstanceIdentifier");
+        String filterId = identifier;
         if (filterId == null || filterId.isBlank()) {
             filterId = extractFilterValue(params, "db-instance-id");
         }
 
-        if (filterId != null && !filterId.isBlank()) {
-            service.getDbInstance(filterId); // throws DBInstanceNotFound if absent
+        // AWS parity: the DBInstanceIdentifier parameter faults with
+        // DBInstanceNotFound when no instance matches, while the
+        // db-instance-id Filters form returns an empty list.
+        if (identifier != null && !identifier.isBlank()) {
+            service.getDbInstance(identifier); // throws DBInstanceNotFound if absent
         }
 
         Collection<DocDbInstance> result = service.listDbInstances(filterId);

--- a/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbService.java
@@ -116,6 +116,15 @@ public class DocDbService {
 
     public Collection<DocDbCluster> listDbClusters(String filterId) {
         if (filterId != null && !filterId.isBlank()) {
+            // The db-cluster-id filter accepts ARNs as well as identifiers. Match the
+            // full ARN against each cluster's stored ARN rather than reducing it to
+            // the bare identifier, so a cross-account or cross-region ARN does not
+            // resolve a same-named local cluster.
+            if (filterId.startsWith("arn:")) {
+                return clusters.scan(k -> true).stream()
+                        .filter(c -> filterId.equalsIgnoreCase(c.getDbClusterArn()))
+                        .toList();
+            }
             return clusters.scan(k -> k.equalsIgnoreCase(filterId));
         }
         return clusters.scan(k -> true);
@@ -200,6 +209,13 @@ public class DocDbService {
 
     public Collection<DocDbInstance> listDbInstances(String filterId) {
         if (filterId != null && !filterId.isBlank()) {
+            // The db-instance-id filter accepts ARNs as well as identifiers; see
+            // listDbClusters for why the match is against the stored ARN.
+            if (filterId.startsWith("arn:")) {
+                return instances.scan(k -> true).stream()
+                        .filter(i -> filterId.equalsIgnoreCase(i.getDbInstanceArn()))
+                        .toList();
+            }
             return instances.scan(k -> k.equalsIgnoreCase(filterId));
         }
         return instances.scan(k -> true);

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneQueryHandler.java
@@ -69,14 +69,17 @@ public class NeptuneQueryHandler {
     }
 
     private Response handleDescribeDbClusters(MultivaluedMap<String, String> params) {
-        String filterId = params.getFirst("DBClusterIdentifier");
+        String identifier = params.getFirst("DBClusterIdentifier");
+        String filterId = identifier;
         if (filterId == null || filterId.isBlank()) {
             filterId = extractFilterValue(params, "db-cluster-id");
         }
 
-        // When a specific cluster ID is requested, AWS returns 404 if not found
-        if (filterId != null && !filterId.isBlank()) {
-            service.getDbCluster(filterId); // throws DBClusterNotFoundFault if absent
+        // AWS parity: the DBClusterIdentifier parameter faults with
+        // DBClusterNotFoundFault when no cluster matches, while the
+        // db-cluster-id Filters form returns an empty list.
+        if (identifier != null && !identifier.isBlank()) {
+            service.getDbCluster(identifier); // throws DBClusterNotFoundFault if absent
         }
 
         Collection<NeptuneCluster> result = service.listDbClusters(filterId);
@@ -140,13 +143,17 @@ public class NeptuneQueryHandler {
     }
 
     private Response handleDescribeDbInstances(MultivaluedMap<String, String> params) {
-        String filterId = params.getFirst("DBInstanceIdentifier");
+        String identifier = params.getFirst("DBInstanceIdentifier");
+        String filterId = identifier;
         if (filterId == null || filterId.isBlank()) {
             filterId = extractFilterValue(params, "db-instance-id");
         }
 
-        if (filterId != null && !filterId.isBlank()) {
-            service.getDbInstance(filterId); // throws DBInstanceNotFound if absent
+        // AWS parity: the DBInstanceIdentifier parameter faults with
+        // DBInstanceNotFound when no instance matches, while the
+        // db-instance-id Filters form returns an empty list.
+        if (identifier != null && !identifier.isBlank()) {
+            service.getDbInstance(identifier); // throws DBInstanceNotFound if absent
         }
 
         Collection<NeptuneInstance> result = service.listDbInstances(filterId);

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneService.java
@@ -173,6 +173,15 @@ public class NeptuneService {
 
     public Collection<NeptuneCluster> listDbClusters(String filterId) {
         if (filterId != null && !filterId.isBlank()) {
+            // The db-cluster-id filter accepts ARNs as well as identifiers. Match the
+            // full ARN against each cluster's stored ARN rather than reducing it to
+            // the bare identifier, so a cross-account or cross-region ARN does not
+            // resolve a same-named local cluster.
+            if (filterId.startsWith("arn:")) {
+                return clusters.scan(k -> true).stream()
+                        .filter(c -> filterId.equalsIgnoreCase(c.getDbClusterArn()))
+                        .toList();
+            }
             return clusters.scan(k -> k.equalsIgnoreCase(filterId));
         }
         return clusters.scan(k -> true);
@@ -260,6 +269,13 @@ public class NeptuneService {
 
     public Collection<NeptuneInstance> listDbInstances(String filterId) {
         if (filterId != null && !filterId.isBlank()) {
+            // The db-instance-id filter accepts ARNs as well as identifiers; see
+            // listDbClusters for why the match is against the stored ARN.
+            if (filterId.startsWith("arn:")) {
+                return instances.scan(k -> true).stream()
+                        .filter(i -> filterId.equalsIgnoreCase(i.getDbInstanceArn()))
+                        .toList();
+            }
             return instances.scan(k -> k.equalsIgnoreCase(filterId));
         }
         return instances.scan(k -> true);

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -138,12 +138,20 @@ public class RdsQueryHandler {
     }
 
     private Response handleDescribeDbInstances(MultivaluedMap<String, String> params) {
-        String filterId = params.getFirst("DBInstanceIdentifier");
+        String identifier = params.getFirst("DBInstanceIdentifier");
+        String filterId = identifier;
         if (filterId == null || filterId.isBlank()) {
             filterId = extractRdsFilterValue(params, "db-instance-id");
         }
         try {
             Collection<DbInstance> result = service.listDbInstances(filterId);
+            // AWS parity: the DBInstanceIdentifier PARAMETER faults with
+            // DBInstanceNotFound when no instance matches, while the
+            // db-instance-id Filters form returns an empty list.
+            if (identifier != null && !identifier.isBlank() && result.isEmpty()) {
+                throw new AwsException("DBInstanceNotFound",
+                        "DBInstance " + identifier + " not found.", 404);
+            }
             XmlBuilder xml = new XmlBuilder().start("DBInstances");
             for (DbInstance i : result) {
                 xml.start("DBInstance").raw(dbInstanceInnerXml(i)).end("DBInstance");
@@ -357,12 +365,20 @@ public class RdsQueryHandler {
     }
 
     private Response handleDescribeDbClusters(MultivaluedMap<String, String> params) {
-        String filterId = params.getFirst("DBClusterIdentifier");
+        String identifier = params.getFirst("DBClusterIdentifier");
+        String filterId = identifier;
         if (filterId == null || filterId.isBlank()) {
             filterId = extractRdsFilterValue(params, "db-cluster-id");
         }
         try {
             Collection<DbCluster> result = service.listDbClusters(filterId);
+            // AWS parity: the DBClusterIdentifier PARAMETER faults with
+            // DBClusterNotFoundFault when no cluster matches, while the
+            // db-cluster-id Filters form returns an empty list.
+            if (identifier != null && !identifier.isBlank() && result.isEmpty()) {
+                throw new AwsException("DBClusterNotFoundFault",
+                        "DBCluster " + identifier + " not found.", 404);
+            }
             XmlBuilder xml = new XmlBuilder().start("DBClusters");
             for (DbCluster c : result) {
                 xml.start("DBCluster").raw(dbClusterInnerXml(c)).end("DBCluster");

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -502,6 +502,15 @@ public class RdsService implements Resettable {
 
     public Collection<DbInstance> listDbInstances(String filterId) {
         if (filterId != null && !filterId.isBlank()) {
+            // DBInstanceIdentifier also accepts an ARN per the AWS model. Match the
+            // full ARN against each instance's stored ARN rather than reducing it to
+            // the bare identifier, so a cross-account or cross-region ARN does not
+            // resolve a same-named local instance.
+            if (filterId.startsWith("arn:")) {
+                return instances.scan(k -> true).stream()
+                        .filter(i -> filterId.equalsIgnoreCase(i.getDbInstanceArn()))
+                        .toList();
+            }
             return instances.scan(k -> k.equalsIgnoreCase(filterId));
         }
         return instances.scan(k -> true);
@@ -726,6 +735,15 @@ public class RdsService implements Resettable {
 
     public Collection<DbCluster> listDbClusters(String filterId) {
         if (filterId != null && !filterId.isBlank()) {
+            // DBClusterIdentifier also accepts an ARN per the AWS model. Match the
+            // full ARN against each cluster's stored ARN rather than reducing it to
+            // the bare identifier, so a cross-account or cross-region ARN does not
+            // resolve a same-named local cluster.
+            if (filterId.startsWith("arn:")) {
+                return clusters.scan(k -> true).stream()
+                        .filter(c -> filterId.equalsIgnoreCase(c.getDbClusterArn()))
+                        .toList();
+            }
             return clusters.scan(k -> k.equalsIgnoreCase(filterId));
         }
         return clusters.scan(k -> true);

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbIntegrationTest.java
@@ -334,4 +334,40 @@ class DocDbIntegrationTest {
             .statusCode(200)
             .body(containsString(RDS_SCOPE_CLUSTER_ID));
     }
+
+    // The db-cluster-id / db-instance-id Filters form returns an empty list for a
+    // missing id, unlike the DBClusterIdentifier / DBInstanceIdentifier parameter
+    // which faults with 404. Mirrors AWS and the RDS behaviour.
+
+    @Test
+    @Order(20)
+    void describeClustersByFilterReturnsEmptyForMissing() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType(FORM)
+            .formParam("Action", "DescribeDBClusters")
+            .formParam("Filters.Filter.1.Name", "db-cluster-id")
+            .formParam("Filters.Filter.1.Values.Value.1", "nonexistent-cluster")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<DBClusters"))
+            .body(not(containsString("DBClusterNotFoundFault")));
+    }
+
+    @Test
+    @Order(21)
+    void describeInstancesByFilterReturnsEmptyForMissing() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType(FORM)
+            .formParam("Action", "DescribeDBInstances")
+            .formParam("Filters.Filter.1.Name", "db-instance-id")
+            .formParam("Filters.Filter.1.Values.Value.1", "nonexistent-instance")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<DBInstances"))
+            .body(not(containsString("DBInstanceNotFound")));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbServiceTest.java
@@ -83,6 +83,33 @@ class DocDbServiceTest {
     }
 
     @Test
+    void listDbClustersMatchesByArnButNotForeignArn() {
+        DocDbCluster cluster = docDbService.createDbCluster(
+                "mock-cluster", null, "admin", "secret", false);
+
+        String arn = cluster.getDbClusterArn();
+        assertEquals(1, docDbService.listDbClusters(arn).size());
+        assertTrue(docDbService.listDbClusters(arn.replace("000000000000", "999999999999")).isEmpty(),
+                "cross-account ARN must not match");
+        assertTrue(docDbService.listDbClusters(arn.replace("us-east-1", "eu-west-1")).isEmpty(),
+                "cross-region ARN must not match");
+    }
+
+    @Test
+    void listDbInstancesMatchesByArnButNotForeignArn() {
+        docDbService.createDbCluster("mock-cluster", null, "admin", "secret", false);
+        DocDbInstance instance = docDbService.createDbInstance(
+                "mock-instance", "mock-cluster", "db.r5.large", null, false);
+
+        String arn = instance.getDbInstanceArn();
+        assertEquals(1, docDbService.listDbInstances(arn).size());
+        assertTrue(docDbService.listDbInstances(arn.replace("000000000000", "999999999999")).isEmpty(),
+                "cross-account ARN must not match");
+        assertTrue(docDbService.listDbInstances(arn.replace("us-east-1", "eu-west-1")).isEmpty(),
+                "cross-region ARN must not match");
+    }
+
+    @Test
     void deleteClusterInMockModeSkipsContainerStop() {
         docDbService.createDbCluster("mock-cluster", null, "admin", "secret", false);
 

--- a/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneIntegrationTest.java
@@ -263,4 +263,40 @@ class NeptuneIntegrationTest {
             .statusCode(400)
             .body(containsString("UnsupportedOperation"));
     }
+
+    // The db-cluster-id / db-instance-id Filters form returns an empty list for a
+    // missing id, unlike the DBClusterIdentifier / DBInstanceIdentifier parameter
+    // which faults with 404. Mirrors AWS and the RDS behaviour.
+
+    @Test
+    @Order(17)
+    void describeClustersByFilterReturnsEmptyForMissing() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType(FORM)
+            .formParam("Action", "DescribeDBClusters")
+            .formParam("Filters.Filter.1.Name", "db-cluster-id")
+            .formParam("Filters.Filter.1.Values.Value.1", "nonexistent-cluster")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<DBClusters"))
+            .body(not(containsString("DBClusterNotFoundFault")));
+    }
+
+    @Test
+    @Order(18)
+    void describeInstancesByFilterReturnsEmptyForMissing() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType(FORM)
+            .formParam("Action", "DescribeDBInstances")
+            .formParam("Filters.Filter.1.Name", "db-instance-id")
+            .formParam("Filters.Filter.1.Values.Value.1", "nonexistent-instance")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<DBInstances"))
+            .body(not(containsString("DBInstanceNotFound")));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneServiceTest.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.services.neptune.container.NeptuneContainerHan
 import io.github.hectorvent.floci.services.neptune.container.NeptuneContainerManager;
 import io.github.hectorvent.floci.services.neptune.model.NeptuneCluster;
 import io.github.hectorvent.floci.services.neptune.model.NeptuneDbType;
+import io.github.hectorvent.floci.services.neptune.model.NeptuneInstance;
 import io.github.hectorvent.floci.services.neptune.proxy.NeptuneProxyManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,6 +18,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -41,7 +43,7 @@ class NeptuneServiceTest {
         proxyManager = mock(NeptuneProxyManager.class);
         StorageFactory storageFactory = mock(StorageFactory.class);
         EmulatorConfig config = mock(EmulatorConfig.class);
-        RegionResolver regionResolver = mock(RegionResolver.class);
+        RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
 
         EmulatorConfig.ServicesConfig servicesConfig = mock(EmulatorConfig.ServicesConfig.class);
         neptuneConfig = mock(EmulatorConfig.NeptuneServiceConfig.class);
@@ -53,10 +55,6 @@ class NeptuneServiceTest {
         when(neptuneConfig.defaultImage()).thenReturn("tinkerpop/gremlin-server:3.7");
         when(neptuneConfig.defaultNeo4jImage()).thenReturn("neo4j:5");
         when(config.hostname()).thenReturn(Optional.of("localhost"));
-
-        when(regionResolver.getDefaultRegion()).thenReturn("us-east-1");
-        when(regionResolver.buildArn(anyString(), anyString(), anyString()))
-                .thenReturn("arn:aws:neptune:us-east-1:000000000000:cluster:c");
 
         when(storageFactory.create(anyString(), anyString(), any()))
                 .thenAnswer(inv -> new InMemoryStorage<>());
@@ -141,6 +139,32 @@ class NeptuneServiceTest {
         NeptuneCluster recovered = service.createDbCluster("c2", "1.3.2.1", false);
         assertEquals(18182, recovered.getProxyPort(),
                 "Port from the failed create must be released so the next cluster reuses it");
+    }
+
+    @Test
+    void listDbClustersMatchesByArnButNotForeignArn() {
+        NeptuneCluster cluster = service.createDbCluster("my-cluster", "1.3.2.1", false);
+
+        String arn = cluster.getDbClusterArn();
+        assertEquals(1, service.listDbClusters(arn).size());
+        assertTrue(service.listDbClusters(arn.replace("000000000000", "999999999999")).isEmpty(),
+                "cross-account ARN must not match");
+        assertTrue(service.listDbClusters(arn.replace("us-east-1", "eu-west-1")).isEmpty(),
+                "cross-region ARN must not match");
+    }
+
+    @Test
+    void listDbInstancesMatchesByArnButNotForeignArn() {
+        service.createDbCluster("my-cluster", "1.3.2.1", false);
+        NeptuneInstance instance = service.createDbInstance(
+                "my-instance", "my-cluster", "db.r5.large", null, false);
+
+        String arn = instance.getDbInstanceArn();
+        assertEquals(1, service.listDbInstances(arn).size());
+        assertTrue(service.listDbInstances(arn.replace("000000000000", "999999999999")).isEmpty(),
+                "cross-account ARN must not match");
+        assertTrue(service.listDbInstances(arn.replace("us-east-1", "eu-west-1")).isEmpty(),
+                "cross-region ARN must not match");
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -785,6 +785,72 @@ class RdsQueryHandlerTest {
         assertTrue(((String) response.getEntity()).contains("DBSubnetGroupNotFoundFault"));
     }
 
+    // ─────────────── NotFound faults for missing identifiers (AWS parity) ───────────────
+
+    @Test
+    void describeDbInstances_missingIdentifierFaultsWithDbInstanceNotFound() {
+        when(service.listDbInstances("missing")).thenReturn(List.of());
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBInstanceIdentifier", "missing");
+        Response response = handler.handle("DescribeDBInstances", p);
+
+        assertEquals(404, response.getStatus());
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<Code>DBInstanceNotFound</Code>"),
+                "Expected DBInstanceNotFound error code, got: " + body);
+        assertTrue(body.contains("DBInstance missing not found."),
+                "Expected AWS-style message, got: " + body);
+    }
+
+    @Test
+    void describeDbInstances_filtersFormReturnsEmptyListForMissing() {
+        when(service.listDbInstances("missing")).thenReturn(List.of());
+
+        MultivaluedMap<String, String> p = params();
+        p.add("Filters.Filter.1.Name", "db-instance-id");
+        p.add("Filters.Filter.1.Values.Value.1", "missing");
+        Response response = handler.handle("DescribeDBInstances", p);
+
+        assertEquals(200, response.getStatus());
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<DBInstances>"),
+                "Filters form must return an empty list, not fault: " + body);
+        assertFalse(body.contains("DBInstanceNotFound"));
+    }
+
+    @Test
+    void describeDbClusters_missingIdentifierFaultsWithDbClusterNotFoundFault() {
+        when(service.listDbClusters("missing")).thenReturn(List.of());
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBClusterIdentifier", "missing");
+        Response response = handler.handle("DescribeDBClusters", p);
+
+        assertEquals(404, response.getStatus());
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<Code>DBClusterNotFoundFault</Code>"),
+                "Expected DBClusterNotFoundFault error code, got: " + body);
+        assertTrue(body.contains("DBCluster missing not found."),
+                "Expected AWS-style message, got: " + body);
+    }
+
+    @Test
+    void describeDbClusters_filtersFormReturnsEmptyListForMissing() {
+        when(service.listDbClusters("missing")).thenReturn(List.of());
+
+        MultivaluedMap<String, String> p = params();
+        p.add("Filters.Filter.1.Name", "db-cluster-id");
+        p.add("Filters.Filter.1.Values.Value.1", "missing");
+        Response response = handler.handle("DescribeDBClusters", p);
+
+        assertEquals(200, response.getStatus());
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<DBClusters>"),
+                "Filters form must return an empty list, not fault: " + body);
+        assertFalse(body.contains("DBClusterNotFoundFault"));
+    }
+
     // ──────────────────────────── Helpers ────────────────────────────
 
     private static MultivaluedMap<String, String> params() {

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -248,6 +248,50 @@ class RdsServiceTest {
     }
 
     @Test
+    void listDbInstancesMatchesByArn() {
+        DbInstance created = rdsService.createDbInstance("mydb", "postgres", "13",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false);
+
+        Collection<DbInstance> result = rdsService.listDbInstances(created.getDbInstanceArn());
+        assertEquals(1, result.size());
+        assertEquals("mydb", result.iterator().next().getDbInstanceIdentifier());
+    }
+
+    @Test
+    void listDbClustersMatchesByArn() {
+        DbCluster created = rdsService.createDbCluster("cluster1", "aurora-postgresql", "16.3",
+                "admin", "password", "dbname", false, null);
+
+        Collection<DbCluster> result = rdsService.listDbClusters(created.getDbClusterArn());
+        assertEquals(1, result.size());
+        assertEquals("cluster1", result.iterator().next().getDbClusterIdentifier());
+    }
+
+    @Test
+    void listDbInstancesDoesNotMatchForeignArn() {
+        rdsService.createDbInstance("mydb", "postgres", "13",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false);
+
+        assertTrue(rdsService.listDbInstances(
+                "arn:aws:rds:us-east-1:999999999999:db:mydb").isEmpty(), "cross-account ARN must not match");
+        assertTrue(rdsService.listDbInstances(
+                "arn:aws:rds:eu-west-1:123456789012:db:mydb").isEmpty(), "cross-region ARN must not match");
+    }
+
+    @Test
+    void listDbClustersDoesNotMatchForeignArn() {
+        rdsService.createDbCluster("cluster1", "aurora-postgresql", "16.3",
+                "admin", "password", "dbname", false, null);
+
+        assertTrue(rdsService.listDbClusters(
+                "arn:aws:rds:us-east-1:999999999999:cluster:cluster1").isEmpty(), "cross-account ARN must not match");
+        assertTrue(rdsService.listDbClusters(
+                "arn:aws:rds:eu-west-1:123456789012:cluster:cluster1").isEmpty(), "cross-region ARN must not match");
+    }
+
+    @Test
     void modifyDbInstanceBlankPasswordDoesNotOverwriteExistingPassword() {
         rdsService.createDbInstance("mydb", "postgres", "13",
                 "admin", "original-password", "dbname", "db.t3.micro",


### PR DESCRIPTION
## Problem

`DescribeDBInstances` / `DescribeDBClusters` return **HTTP 200 with an empty list** when the identifier *parameter* matches nothing. Real AWS **faults** in that case, and only returns empty lists for the `Filters` form:

```console
# real AWS (verified live):
$ aws rds describe-db-instances --db-instance-identifier does-not-exist
An error occurred (DBInstanceNotFound) when calling the DescribeDBInstances
operation: DBInstance does-not-exist not found.

# floci 1.5.30:
$ aws --endpoint-url http://localhost:4566 rds describe-db-instances \
    --db-instance-identifier does-not-exist
{ "DBInstances": [] }        # exit 0
```

### Why it bites

Provision-then-create scripts use the standard idiom `describe || create`. Against floci the describe "succeeds", the script concludes the resource exists, skips creation, and then waits forever on a resource that was never created. We hit exactly this bringing a docker-compose stack up from zero state.

### Root cause

`RdsQueryHandler.handleDescribeDbInstances` merges the `DBInstanceIdentifier` **parameter** and the `db-instance-id` **filter** into a single filter path, losing the semantic difference — `RdsService.listDbInstances` is a pure filter with no fault path:

https://github.com/floci-io/floci/blob/main/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java#L132-L148

Notably, `ElbV2Service.describeLoadBalancers` already implements the correct pattern (filter, then throw `LoadBalancerNotFound` on empty-with-criteria), so this brings RDS in line with the codebase's own precedent — and with the AWS-parity direction of fixes like #1431.

## Fix

In both RDS handlers: track whether the identifier came from the *parameter*; after listing, fault when the parameter form matched nothing. The `Filters` form keeps returning empty lists (matching AWS). Error codes, messages, and 404 status match live AWS (`DBInstanceNotFound` / `DBClusterNotFoundFault`, `"DBInstance <id> not found."`).

- No change for describes of existing resources.
- No change for the unfiltered list form.
- No change for the `Filters` form.

## Follow-ups (addressed in this PR)

Both raised in review; folded in here rather than deferred.

**1. Identifier parameter and id filters now also accept an ARN (RDS, DocDB, Neptune).** Per the AWS model `DBInstanceIdentifier` / `DBClusterIdentifier` and the `db-instance-id` / `db-cluster-id` filters accept an ARN, but the list methods matched on the identifier key only — so an ARN for an instance that *exists* would now (post-fix) fault `DBInstanceNotFound`. All three services' list methods match an ARN against each resource's **stored** ARN (rather than reducing it to the bare identifier), so a cross-account or cross-region ARN does not resolve a same-named local resource.

**2. DocDB / Neptune now honour the `Filters` vs parameter split too.** `DocDbQueryHandler` and `NeptuneQueryHandler` guarded on the *merged* id, so they faulted on the `Filters` form as well — the mirror image of the RDS bug. They now fault only for the identifier **parameter**; the `db-cluster-id` / `db-instance-id` `Filters` form returns an empty list. (DocDB/Neptune already faulted correctly on the parameter form — this only fixes the over-eager `Filters`-form fault.)

## Bonus: deletion waiters

[waiters-2.json](https://github.com/boto/botocore/blob/develop/botocore/data/rds/2014-10-31/waiters-2.json) treats `DBInstanceNotFound` as success for `DBInstanceDeleted` and `DBClusterNotFoundFault` as success for `DBClusterDeleted`, so `aws rds wait db-instance-deleted` never completed against floci before this fix.

## Tests

- `RdsQueryHandlerTest`: parameter-form faults (404 + error code + message) and `Filters`-form still returns empty 200, for both instances and clusters.
- `RdsServiceTest` / `DocDbServiceTest` / `NeptuneServiceTest`: `listDbInstances` / `listDbClusters` match by ARN; cross-account and cross-region ARNs do **not** match.
- `DocDbIntegrationTest` / `NeptuneIntegrationTest`: `Filters` form returns an empty list (200, no fault) for a missing id.

`./mvnw test -Dtest=RdsServiceTest,RdsQueryHandlerTest,DocDbServiceTest,NeptuneServiceTest,DocDbIntegrationTest,NeptuneIntegrationTest` green locally (JDK 25), rebased on current `main`.


