### PR TITLE
fix(route53): align ListHostedZonesByName pagination with AWS

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Route53PaginationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Route53PaginationTest.java
@@ -1,0 +1,79 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.route53.Route53Client;
+import software.amazon.awssdk.services.route53.model.CreateHostedZoneRequest;
+import software.amazon.awssdk.services.route53.model.CreateHostedZoneResponse;
+import software.amazon.awssdk.services.route53.model.ListHostedZonesByNameResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Route53 ListHostedZonesByName Pagination")
+class Route53PaginationTest {
+
+    private static Route53Client route53;
+    private static String firstZoneId;
+    private static String secondZoneId;
+
+    @BeforeAll
+    static void setup() {
+        route53 = TestFixtures.route53Client();
+
+        CreateHostedZoneResponse firstZone = route53.createHostedZone(CreateHostedZoneRequest.builder()
+                .name("zzz.com")
+                .callerReference(TestFixtures.uniqueName("route53-pagination-1"))
+                .build());
+        firstZoneId = stripHostedZonePrefix(firstZone.hostedZone().id());
+
+        CreateHostedZoneResponse secondZone = route53.createHostedZone(CreateHostedZoneRequest.builder()
+                .name("aaa.net")
+                .callerReference(TestFixtures.uniqueName("route53-pagination-2"))
+                .build());
+        secondZoneId = stripHostedZonePrefix(secondZone.hostedZone().id());
+    }
+
+    @AfterAll
+    static void cleanup() {
+        try {
+            route53.deleteHostedZone(r -> r.id(firstZoneId));
+        } catch (Exception ignored) {
+        }
+        try {
+            route53.deleteHostedZone(r -> r.id(secondZoneId));
+        } catch (Exception ignored) {
+        }
+        route53.close();
+    }
+
+    @Test
+    void listHostedZonesByName_returnsAndResumesPaginationCursors() {
+        ListHostedZonesByNameResponse firstPage = route53.listHostedZonesByName(r -> r
+                .maxItems("1"));
+
+        assertThat(firstPage.isTruncated()).isTrue();
+        assertThat(firstPage.hostedZones()).hasSize(1);
+        assertThat(firstPage.hostedZones().get(0).name()).isEqualTo("zzz.com.");
+        assertThat(firstPage.nextDNSName()).isEqualTo("aaa.net.");
+        assertThat(firstPage.nextHostedZoneId()).isEqualTo(secondZoneId);
+
+        ListHostedZonesByNameResponse secondPage = route53.listHostedZonesByName(r -> r
+                .dnsName(firstPage.nextDNSName())
+                .hostedZoneId(firstPage.nextHostedZoneId())
+                .maxItems("1"));
+
+        assertThat(secondPage.isTruncated()).isFalse();
+        assertThat(secondPage.hostedZones()).hasSize(1);
+        assertThat(secondPage.hostedZones().get(0).name()).isEqualTo("aaa.net.");
+        assertThat(secondPage.hostedZones().get(0).id()).isEqualTo("/hostedzone/" + secondZoneId);
+    }
+
+    private static String stripHostedZonePrefix(String hostedZoneId) {
+        String prefix = "/hostedzone/";
+        return hostedZoneId != null && hostedZoneId.startsWith(prefix)
+                ? hostedZoneId.substring(prefix.length())
+                : hostedZoneId;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/route53/Route53Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/route53/Route53Controller.java
@@ -5,6 +5,7 @@ import io.github.hectorvent.floci.core.common.AwsNamespaces;
 import io.github.hectorvent.floci.core.common.XmlBuilder;
 import io.github.hectorvent.floci.core.common.XmlParser;
 import io.github.hectorvent.floci.services.route53.Route53Service.CreateZoneResult;
+import io.github.hectorvent.floci.services.route53.Route53Service.ListHostedZonesByNameResult;
 import io.github.hectorvent.floci.services.route53.model.AliasTarget;
 import io.github.hectorvent.floci.services.route53.model.ChangeInfo;
 import io.github.hectorvent.floci.services.route53.model.HealthCheck;
@@ -151,11 +152,12 @@ public class Route53Controller {
     @GET
     @Path("/hostedzonesbyname")
     public Response listHostedZonesByName(@QueryParam("dnsname") String dnsName,
-                                           @QueryParam("maxitems") @DefaultValue("100") int maxItems) {
+                                          @QueryParam("hostedzoneid") String hostedZoneId,
+                                          @QueryParam("maxitems") @DefaultValue("100") int maxItems) {
         try {
-            List<HostedZone> zones = service.listHostedZonesByName(dnsName, maxItems);
-            long total = service.getHostedZoneCount();
-            boolean truncated = zones.size() == maxItems && zones.size() < total;
+            ListHostedZonesByNameResult result = service.listHostedZonesByName(dnsName, hostedZoneId, maxItems);
+            List<HostedZone> zones = result.hostedZones();
+            boolean truncated = result.nextDnsName() != null;
 
             XmlBuilder xml = new XmlBuilder()
                     .start("ListHostedZonesByNameResponse", NS)
@@ -164,10 +166,17 @@ public class Route53Controller {
                 xml.raw(xmlHostedZone(zone));
             }
             xml.end("HostedZones")
-               .elem("IsTruncated", String.valueOf(truncated))
-               .elem("MaxItems", String.valueOf(maxItems));
+                    .elem("IsTruncated", String.valueOf(truncated))
+                    .elem("MaxItems", String.valueOf(maxItems));
             if (dnsName != null && !dnsName.isEmpty()) {
                 xml.elem("DNSName", dnsName);
+            }
+            if (hostedZoneId != null && !hostedZoneId.isEmpty()) {
+                xml.elem("HostedZoneId", hostedZoneId);
+            }
+            if (truncated) {
+                xml.elem("NextDNSName", result.nextDnsName())
+                        .elem("NextHostedZoneId", result.nextHostedZoneId());
             }
             xml.end("ListHostedZonesByNameResponse");
 

--- a/src/main/java/io/github/hectorvent/floci/services/route53/Route53Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/route53/Route53Service.java
@@ -31,6 +31,10 @@ public class Route53Service {
 
     public record CreateZoneResult(HostedZone zone, ChangeInfo change) {}
 
+    public record ListHostedZonesByNameResult(List<HostedZone> hostedZones,
+                                              String nextDnsName,
+                                              String nextHostedZoneId) {}
+
     private final StorageBackend<String, HostedZone> zoneStore;
     private final StorageBackend<String, List<ResourceRecordSet>> recordStore;
     private final StorageBackend<String, HealthCheck> healthCheckStore;
@@ -127,23 +131,48 @@ public class Route53Service {
         return all;
     }
 
-    public List<HostedZone> listHostedZonesByName(String dnsName, int maxItems) {
+    public ListHostedZonesByNameResult listHostedZonesByName(String dnsName, String hostedZoneId, int maxItems) {
         List<HostedZone> all = new ArrayList<>(zoneStore.scan(k -> true));
-        all.sort((a, b) -> a.getName().compareTo(b.getName()));
+        all.sort((a, b) -> {
+            int cmp = compareDnsNames(a.getName(), b.getName());
+            if (cmp != 0) {
+                return cmp;
+            }
+            return a.getId().compareTo(b.getId());
+        });
         for (HostedZone zone : all) {
             zone.setResourceRecordSetCount(recordCount(zone.getId()));
         }
+        int startIndex = 0;
         if (dnsName != null && !dnsName.isEmpty()) {
             String normalized = normalizeName(dnsName);
-            all = all.stream()
-                    .filter(z -> z.getName().compareTo(normalized) >= 0)
-                    .toList();
-            all = new ArrayList<>(all);
+            startIndex = all.size();
+            for (int i = 0; i < all.size(); i++) {
+                HostedZone zone = all.get(i);
+                int cmp = compareDnsNames(zone.getName(), normalized);
+                if (cmp > 0) {
+                    startIndex = i;
+                    break;
+                }
+                if (cmp == 0) {
+                    if (hostedZoneId == null || hostedZoneId.isEmpty() || zone.getId().compareTo(hostedZoneId) >= 0) {
+                        startIndex = i;
+                        break;
+                    }
+                }
+            }
         }
-        if (maxItems > 0 && all.size() > maxItems) {
-            return all.subList(0, maxItems);
+
+        List<HostedZone> page = new ArrayList<>(all.subList(Math.min(startIndex, all.size()), all.size()));
+        String nextDnsName = null;
+        String nextHostedZoneId = null;
+        if (maxItems > 0 && page.size() > maxItems) {
+            HostedZone next = page.get(maxItems);
+            nextDnsName = next.getName();
+            nextHostedZoneId = next.getId();
+            page = page.subList(0, maxItems);
         }
-        return all;
+        return new ListHostedZonesByNameResult(page, nextDnsName, nextHostedZoneId);
     }
 
     public long getHostedZoneCount() {
@@ -410,5 +439,32 @@ public class Route53Service {
         if (a == null && b == null) return true;
         if (a == null || b == null) return false;
         return a.equals(b);
+    }
+
+    private static int compareDnsNames(String left, String right) {
+        if (left == null && right == null) {
+            return 0;
+        }
+        if (left == null) {
+            return -1;
+        }
+        if (right == null) {
+            return 1;
+        }
+
+        String[] leftLabels = normalizeName(left).split("\\.");
+        String[] rightLabels = normalizeName(right).split("\\.");
+
+        int leftIndex = leftLabels.length - 1;
+        int rightIndex = rightLabels.length - 1;
+        while (leftIndex >= 0 && rightIndex >= 0) {
+            int cmp = leftLabels[leftIndex].compareTo(rightLabels[rightIndex]);
+            if (cmp != 0) {
+                return cmp;
+            }
+            leftIndex--;
+            rightIndex--;
+        }
+        return Integer.compare(leftLabels.length, rightLabels.length);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/route53/Route53IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/route53/Route53IntegrationTest.java
@@ -96,6 +96,135 @@ class Route53IntegrationTest {
 
     @Test
     @Order(5)
+    void listHostedZonesByName_returnsPaginationCursor() {
+        String createBody = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <CreateHostedZoneRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+                  <Name>example.net</Name>
+                  <CallerReference>ref-pagination</CallerReference>
+                </CreateHostedZoneRequest>
+                """;
+
+        String loc = given()
+                .contentType(XML)
+                .body(createBody)
+                .when().post("/2013-04-01/hostedzone")
+                .then()
+                .statusCode(201)
+                .extract()
+                .header("Location");
+        String pagedZoneId = loc.substring(loc.lastIndexOf('/') + 1);
+
+        String body = given()
+                .queryParam("dnsname", "example.com.")
+                .queryParam("maxitems", 1)
+                .when().get("/2013-04-01/hostedzonesbyname")
+                .then()
+                .statusCode(200)
+                .contentType(XML)
+                .body("ListHostedZonesByNameResponse.IsTruncated", equalTo("true"))
+                .body("ListHostedZonesByNameResponse.NextDNSName", equalTo("example.net."))
+                .body("ListHostedZonesByNameResponse.NextHostedZoneId", equalTo(pagedZoneId))
+                .extract()
+                .body()
+                .asString();
+
+        assertThat(body, containsString("<Id>/hostedzone/" + zoneId + "</Id>"));
+        assertThat(body, not(containsString("<Id>/hostedzone/" + pagedZoneId + "</Id>")));
+
+        given()
+                .queryParam("dnsname", "example.net.")
+                .queryParam("hostedzoneid", pagedZoneId)
+                .queryParam("maxitems", 1)
+                .when().get("/2013-04-01/hostedzonesbyname")
+                .then()
+                .statusCode(200)
+                .contentType(XML)
+                .body("ListHostedZonesByNameResponse.IsTruncated", equalTo("false"))
+                .body("ListHostedZonesByNameResponse.HostedZoneId", equalTo(pagedZoneId))
+                .body("ListHostedZonesByNameResponse.HostedZones.HostedZone.Id", equalTo("/hostedzone/" + pagedZoneId));
+
+        given()
+                .when().delete("/2013-04-01/hostedzone/" + pagedZoneId)
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    @Order(6)
+    void listHostedZonesByName_usesAwsLexicographicOrdering() {
+        String createComZone = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <CreateHostedZoneRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+                  <Name>zzz.com</Name>
+                  <CallerReference>ref-zzz-com</CallerReference>
+                </CreateHostedZoneRequest>
+                """;
+        String createNetZone = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <CreateHostedZoneRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+                  <Name>aaa.net</Name>
+                  <CallerReference>ref-aaa-net</CallerReference>
+                </CreateHostedZoneRequest>
+                """;
+
+        String zzzLoc = given()
+                .contentType(XML)
+                .body(createComZone)
+                .when().post("/2013-04-01/hostedzone")
+                .then()
+                .statusCode(201)
+                .extract()
+                .header("Location");
+        String zzzZoneId = zzzLoc.substring(zzzLoc.lastIndexOf('/') + 1);
+
+        String aaaLoc = given()
+                .contentType(XML)
+                .body(createNetZone)
+                .when().post("/2013-04-01/hostedzone")
+                .then()
+                .statusCode(201)
+                .extract()
+                .header("Location");
+        String aaaZoneId = aaaLoc.substring(aaaLoc.lastIndexOf('/') + 1);
+
+        try {
+            String firstPage = given()
+                    .queryParam("maxitems", 1)
+                    .when().get("/2013-04-01/hostedzonesbyname")
+                    .then()
+                    .statusCode(200)
+                    .contentType(XML)
+                    .body("ListHostedZonesByNameResponse.IsTruncated", equalTo("true"))
+                    .body("ListHostedZonesByNameResponse.HostedZones.HostedZone.Name", equalTo("example.com."))
+                    .body("ListHostedZonesByNameResponse.NextDNSName", equalTo("zzz.com."))
+                    .body("ListHostedZonesByNameResponse.NextHostedZoneId", equalTo(zzzZoneId))
+                    .extract()
+                    .body()
+                    .asString();
+
+            assertThat(firstPage, not(containsString(aaaZoneId)));
+
+            given()
+                    .queryParam("dnsname", "zzz.com.")
+                    .queryParam("hostedzoneid", zzzZoneId)
+                    .queryParam("maxitems", 1)
+                    .when().get("/2013-04-01/hostedzonesbyname")
+                    .then()
+                    .statusCode(200)
+                    .contentType(XML)
+                    .body("ListHostedZonesByNameResponse.IsTruncated", equalTo("true"))
+                    .body("ListHostedZonesByNameResponse.HostedZones.HostedZone.Name", equalTo("zzz.com."))
+                    .body("ListHostedZonesByNameResponse.NextDNSName", equalTo("aaa.net."))
+                    .body("ListHostedZonesByNameResponse.NextHostedZoneId", equalTo(aaaZoneId));
+        } finally {
+            given().delete("/2013-04-01/hostedzone/" + zzzZoneId).then().statusCode(200);
+            given().delete("/2013-04-01/hostedzone/" + aaaZoneId).then().statusCode(200);
+        }
+    }
+
+    @Test
+    @Order(7)
     void getHostedZoneCount_includesZone() {
         given()
                 .when().get("/2013-04-01/hostedzonecount")
@@ -107,7 +236,7 @@ class Route53IntegrationTest {
     // ── Resource Record Sets ──────────────────────────────────────────────────
 
     @Test
-    @Order(6)
+    @Order(8)
     void listResourceRecordSets_autoCreatedSOAandNS() {
         String body = given()
                 .when().get("/2013-04-01/hostedzone/" + zoneId + "/rrset")
@@ -122,7 +251,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(7)
+    @Order(9)
     void changeResourceRecordSets_createARecord() {
         String body = """
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -165,7 +294,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(8)
+    @Order(10)
     void listResourceRecordSets_includesARecord() {
         String body = given()
                 .when().get("/2013-04-01/hostedzone/" + zoneId + "/rrset")
@@ -178,7 +307,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(9)
+    @Order(11)
     void changeResourceRecordSets_deleteSOA_fails() {
         String body = """
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -211,7 +340,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(10)
+    @Order(12)
     void getChange_returnsInsync() {
         if (changeId == null) return;
         given()
@@ -223,7 +352,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(11)
+    @Order(13)
     void changeResourceRecordSets_deleteARecord() {
         String body = """
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -256,7 +385,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(12)
+    @Order(14)
     void deleteHostedZone_failsWhenNonDefaultRecordsExist() {
         String createBody = """
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -312,7 +441,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(13)
+    @Order(15)
     void deleteHostedZone_succeedsAfterRecordsRemoved() {
         given()
                 .when().delete("/2013-04-01/hostedzone/" + zoneId)
@@ -322,7 +451,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(14)
+    @Order(16)
     void getHostedZone_returns404AfterDelete() {
         given()
                 .when().get("/2013-04-01/hostedzone/" + zoneId)
@@ -334,7 +463,7 @@ class Route53IntegrationTest {
     // ── Health Checks ─────────────────────────────────────────────────────────
 
     @Test
-    @Order(15)
+    @Order(17)
     void createHealthCheck_returns201() {
         String body = """
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -366,7 +495,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(16)
+    @Order(18)
     void getHealthCheck_returnsCreated() {
         given()
                 .when().get("/2013-04-01/healthcheck/" + healthCheckId)
@@ -377,7 +506,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(17)
+    @Order(19)
     void listHealthChecks_includesCreated() {
         String body = given()
                 .when().get("/2013-04-01/healthcheck")
@@ -389,7 +518,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(18)
+    @Order(20)
     void deleteHealthCheck_returns200() {
         given()
                 .when().delete("/2013-04-01/healthcheck/" + healthCheckId)
@@ -406,7 +535,7 @@ class Route53IntegrationTest {
     // ── Tags ──────────────────────────────────────────────────────────────────
 
     @Test
-    @Order(19)
+    @Order(21)
     void tagging_addListRemove() {
         String createBody = """
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -474,7 +603,7 @@ class Route53IntegrationTest {
     // ── Limits ────────────────────────────────────────────────────────────────
 
     @Test
-    @Order(20)
+    @Order(22)
     void getAccountLimit_returnsValue() {
         given()
                 .when().get("/2013-04-01/accountlimit/MAX_HOSTED_ZONES_BY_OWNER")


### PR DESCRIPTION
Resolves #1745.

Fixed Route53 `ListHostedZonesByName` pagination so it now matches AWS behavior:
- supports the optional `hostedzoneid` resume cursor
- returns `NextDNSName` and `NextHostedZoneId` when truncated
- uses AWS-compatible DNS ordering when selecting the next page

Reference:
- AWS Route 53 API: https://docs.aws.amazon.com/Route53/latest/APIReference/API_ListHostedZonesByName.html

Added regression coverage for both truncation and cursor-based resume.
