### PR TITLE
fix(iam): pass S3 list condition context to IAM enforcement

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/IamEnforcementTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/IamEnforcementTest.java
@@ -1,6 +1,7 @@
 package com.floci.test;
 
 import org.junit.jupiter.api.*;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -8,9 +9,18 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.iam.IamClient;
 import software.amazon.awssdk.services.iam.model.*;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.*;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -31,11 +41,14 @@ import static org.assertj.core.api.Assertions.*;
  *   <li>Assumed role with no policies → DENY</li>
  *   <li>Assumed role with attached allow policy → ALLOW</li>
  *   <li>Assumed role session policy deny overrides role allow → DENY</li>
+ *   <li>Assumed role session policy ListBucket prefix condition → matching prefix only</li>
  * </ul>
  */
 @DisplayName("IAM Enforcement Mode")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class IamEnforcementTest {
+
+    private static final Logger LOG = Logger.getLogger(IamEnforcementTest.class.getName());
 
     // ── Resource names ─────────────────────────────────────────────────────────
     private static final String USER        = "iam-enf-test-user";
@@ -44,7 +57,7 @@ class IamEnforcementTest {
 
     private static final String TRUST_POLICY = """
             {"Version":"2012-10-17","Statement":[
-              {"Effect":"Allow","Principal":{"Service":"sts.amazonaws.com"},
+              {"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::000000000000:root"},
                "Action":"sts:AssumeRole"}
             ]}""";
 
@@ -68,6 +81,21 @@ class IamEnforcementTest {
             {"Version":"2012-10-17","Statement":[
               {"Effect":"Allow","Action":"s3:ListAllMyBuckets","Resource":"*"},
               {"Effect":"Deny","Action":"s3:ListAllMyBuckets","Resource":"*"}
+            ]}""";
+
+    private static final String ALLOW_S3_LIST_PREFIX_SESSION_POLICY = """
+            {"Version":"2012-10-17","Statement":[
+              {"Effect":"Allow","Action":"s3:ListBucket","Resource":"arn:aws:s3:::%s",
+               "Condition":{"StringLike":{"s3:prefix":["%s","%s*"]}}},
+              {"Effect":"Allow","Action":["s3:GetObject","s3:PutObject","s3:DeleteObject"],
+               "Resource":"arn:aws:s3:::%s/%s*"}
+            ]}""";
+
+    private static final String ALLOW_S3_BUCKET_POLICY = """
+            {"Version":"2012-10-17","Statement":[
+              {"Effect":"Allow","Action":"s3:ListBucket","Resource":"arn:aws:s3:::%s"},
+              {"Effect":"Allow","Action":["s3:GetObject","s3:PutObject","s3:DeleteObject"],
+               "Resource":"arn:aws:s3:::%s/*"}
             ]}""";
 
     // ── Shared state ───────────────────────────────────────────────────────────
@@ -122,6 +150,9 @@ class IamEnforcementTest {
                 .userName(USER).policyArn(allowPolicyArn).build()); } catch (Exception ignored) {}
         try { iam.deleteUserPolicy(DeleteUserPolicyRequest.builder()
                 .userName(USER).policyName("inline-deny").build()); } catch (Exception ignored) {}
+        cleanupResource("delete inline-prefix-allow policy from role " + ROLE,
+                () -> iam.deleteRolePolicy(DeleteRolePolicyRequest.builder()
+                        .roleName(ROLE).policyName("inline-prefix-allow").build()));
         try { iam.deleteAccessKey(DeleteAccessKeyRequest.builder()
                 .userName(USER).accessKeyId(userAccessKeyId).build()); } catch (Exception ignored) {}
         try { iam.deleteRole(DeleteRoleRequest.builder().roleName(ROLE).build()); } catch (Exception ignored) {}
@@ -325,5 +356,87 @@ class IamEnforcementTest {
                     .extracting(e -> ((S3Exception) e).statusCode())
                     .isEqualTo(403);
         }
+    }
+
+    @Test
+    @Order(8)
+    @DisplayName("assumed role session policy ListBucket prefix condition restricts ListObjectsV2")
+    void assumedRoleSessionPolicyListBucketPrefixConditionRestrictsListObjectsV2() {
+        assumeEnforcementEnabled();
+
+        String bucket = TestFixtures.uniqueName("iam-prefix");
+        String allowedPrefix = "my_namespace/table/";
+        String allowedKey = allowedPrefix + "metadata.json";
+        String deniedPrefix = "other_namespace/table/";
+        String deniedKey = deniedPrefix + "metadata.json";
+        String inlinePolicyName = "inline-prefix-allow";
+
+        try (S3Client adminS3 = TestFixtures.s3Client()) {
+            try {
+                adminS3.createBucket(CreateBucketRequest.builder().bucket(bucket).build());
+                iam.putRolePolicy(PutRolePolicyRequest.builder()
+                        .roleName(ROLE)
+                        .policyName(inlinePolicyName)
+                        .policyDocument(ALLOW_S3_BUCKET_POLICY.formatted(bucket, bucket))
+                        .build());
+                adminS3.putObject(PutObjectRequest.builder().bucket(bucket).key(allowedKey).build(),
+                        RequestBody.fromString("{}"));
+                adminS3.putObject(PutObjectRequest.builder().bucket(bucket).key(deniedKey).build(),
+                        RequestBody.fromString("{}"));
+
+                AssumeRoleResponse assumed = sts.assumeRole(AssumeRoleRequest.builder()
+                        .roleArn(roleArn)
+                        .roleSessionName("enf-test-prefix-condition")
+                        .policy(ALLOW_S3_LIST_PREFIX_SESSION_POLICY.formatted(
+                                bucket, allowedPrefix, allowedPrefix, bucket, allowedPrefix))
+                        .build());
+
+                try (S3Client s3 = s3WithSessionCredentials(
+                        assumed.credentials().accessKeyId(),
+                        assumed.credentials().secretAccessKey(),
+                        assumed.credentials().sessionToken())) {
+                    ListObjectsV2Response allowed = s3.listObjectsV2(ListObjectsV2Request.builder()
+                            .bucket(bucket)
+                            .prefix(allowedPrefix)
+                            .build());
+
+                    assertThat(allowed.contents())
+                            .anyMatch(object -> allowedKey.equals(object.key()));
+
+                    assertThatThrownBy(() -> s3.listObjectsV2(ListObjectsV2Request.builder()
+                            .bucket(bucket)
+                            .prefix(deniedPrefix)
+                            .build()))
+                            .isInstanceOf(S3Exception.class)
+                            .extracting(e -> ((S3Exception) e).statusCode())
+                            .isEqualTo(403);
+                }
+            } finally {
+                cleanupResource("delete inline role policy " + inlinePolicyName + " from role " + ROLE,
+                        () -> iam.deleteRolePolicy(DeleteRolePolicyRequest.builder()
+                                .roleName(ROLE).policyName(inlinePolicyName).build()));
+                cleanupResource("delete S3 object " + bucket + "/" + allowedKey,
+                        () -> adminS3.deleteObject(DeleteObjectRequest.builder()
+                                .bucket(bucket).key(allowedKey).build()));
+                cleanupResource("delete S3 object " + bucket + "/" + deniedKey,
+                        () -> adminS3.deleteObject(DeleteObjectRequest.builder()
+                                .bucket(bucket).key(deniedKey).build()));
+                cleanupResource("delete S3 bucket " + bucket,
+                        () -> adminS3.deleteBucket(DeleteBucketRequest.builder().bucket(bucket).build()));
+            }
+        }
+    }
+
+    private static void cleanupResource(String description, CleanupAction action) {
+        try {
+            action.run();
+        } catch (Exception e) {
+            LOG.log(Level.FINE, "Failed to " + description, e);
+        }
+    }
+
+    @FunctionalInterface
+    private interface CleanupAction {
+        void run() throws Exception;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/core/common/IamConditionContextResolver.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/IamConditionContextResolver.java
@@ -1,0 +1,42 @@
+package io.github.hectorvent.floci.core.common;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@ApplicationScoped
+public class IamConditionContextResolver {
+
+    public Map<String, String> resolve(String credentialScope, String action, ContainerRequestContext ctx) {
+        return switch (credentialScope) {
+            case "s3" -> s3ConditionContext(action, ctx);
+            default -> null;
+        };
+    }
+
+    private Map<String, String> s3ConditionContext(String action, ContainerRequestContext ctx) {
+        return switch (action) {
+            case "s3:ListBucket" -> s3BucketListConditionContext(ctx.getUriInfo().getQueryParameters());
+            default -> null;
+        };
+    }
+
+    Map<String, String> s3BucketListConditionContext(MultivaluedMap<String, String> queryParameters) {
+        Map<String, String> conditions = new LinkedHashMap<>();
+        addQueryCondition(conditions, "s3:prefix", queryParameters, "prefix");
+        addQueryCondition(conditions, "s3:delimiter", queryParameters, "delimiter");
+        addQueryCondition(conditions, "s3:max-keys", queryParameters, "max-keys");
+        return conditions.isEmpty() ? null : conditions;
+    }
+
+    private static void addQueryCondition(Map<String, String> conditions, String conditionKey,
+                                          MultivaluedMap<String, String> queryParameters, String queryParameter) {
+        String value = queryParameters.getFirst(queryParameter);
+        if (value != null) {
+            conditions.put(conditionKey, value);
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/core/common/IamEnforcementFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/IamEnforcementFilter.java
@@ -16,6 +16,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
 import org.jboss.logging.Logger;
 
+import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -53,6 +54,7 @@ public class IamEnforcementFilter implements ContainerRequestFilter {
     private final IamActionRegistry actionRegistry;
     private final ResourceArnBuilder arnBuilder;
     private final RequestContext requestContext;
+    private final IamConditionContextResolver conditionContextResolver;
 
     @Inject
     public IamEnforcementFilter(EmulatorConfig config,
@@ -61,7 +63,8 @@ public class IamEnforcementFilter implements ContainerRequestFilter {
                                 IamPolicyEvaluator evaluator,
                                 IamActionRegistry actionRegistry,
                                 ResourceArnBuilder arnBuilder,
-                                RequestContext requestContext) {
+                                RequestContext requestContext,
+                                IamConditionContextResolver conditionContextResolver) {
         this.config = config;
         this.accountResolver = accountResolver;
         this.iamService = iamService;
@@ -69,6 +72,7 @@ public class IamEnforcementFilter implements ContainerRequestFilter {
         this.actionRegistry = actionRegistry;
         this.arnBuilder = arnBuilder;
         this.requestContext = requestContext;
+        this.conditionContextResolver = conditionContextResolver;
     }
 
     @Override
@@ -108,7 +112,8 @@ public class IamEnforcementFilter implements ContainerRequestFilter {
                 : requestContext.getAccountId();
         String resource = arnBuilder.build(credentialScope, ctx, region, accountId);
 
-        Decision decision = evaluator.evaluate(caller, null, action, resource, null);
+        Map<String, String> conditionContext = conditionContextResolver.resolve(credentialScope, action, ctx);
+        Decision decision = evaluator.evaluate(caller, null, action, resource, conditionContext);
         if (decision == Decision.DENY) {
             LOG.infov("IAM enforcement DENY: akid={0} action={1} resource={2}", akid, action, resource);
             ctx.abortWith(accessDeniedResponse(action, credentialScope, ctx.getMediaType()));

--- a/src/test/java/io/github/hectorvent/floci/core/common/IamConditionContextResolverTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/IamConditionContextResolverTest.java
@@ -1,0 +1,51 @@
+package io.github.hectorvent.floci.core.common;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.UriInfo;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class IamConditionContextResolverTest {
+
+    private final IamConditionContextResolver resolver = new IamConditionContextResolver();
+
+    @Test
+    void resolvesS3ListBucketQueryConditionContext() {
+        ContainerRequestContext containerRequest = mock(ContainerRequestContext.class);
+        UriInfo uriInfo = mock(UriInfo.class);
+        MultivaluedMap<String, String> query = new MultivaluedHashMap<>();
+        query.add("prefix", "my_namespace/table/");
+        query.add("delimiter", "/");
+        query.add("max-keys", "100");
+
+        when(containerRequest.getUriInfo()).thenReturn(uriInfo);
+        when(uriInfo.getQueryParameters()).thenReturn(query);
+
+        Map<String, String> conditions = resolver.resolve("s3", "s3:ListBucket", containerRequest);
+
+        assertEquals("my_namespace/table/", conditions.get("s3:prefix"));
+        assertEquals("/", conditions.get("s3:delimiter"));
+        assertEquals("100", conditions.get("s3:max-keys"));
+    }
+
+    @Test
+    void s3BucketListConditionContextReturnsNullWhenNoSupportedQueryParametersArePresent() {
+        assertNull(resolver.s3BucketListConditionContext(new MultivaluedHashMap<>()));
+    }
+
+    @Test
+    void resolveReturnsNullForUnsupportedServiceOrAction() {
+        ContainerRequestContext containerRequest = mock(ContainerRequestContext.class);
+
+        assertNull(resolver.resolve("lambda", "lambda:InvokeFunction", containerRequest));
+        assertNull(resolver.resolve("s3", "s3:GetObject", containerRequest));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/core/common/IamEnforcementFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/IamEnforcementFilterTest.java
@@ -9,10 +9,12 @@ import io.github.hectorvent.floci.services.iam.model.CallerContext;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.container.ContainerRequestContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -33,17 +35,38 @@ import static org.mockito.Mockito.when;
  */
 class IamEnforcementFilterTest {
 
+    private EmulatorConfig config;
+    private EmulatorConfig.ServicesConfig services;
+    private EmulatorConfig.IamServiceConfig iamConfig;
+    private AccountResolver accountResolver;
+    private IamService iamService;
+    private IamPolicyEvaluator evaluator;
+    private IamActionRegistry actionRegistry;
+    private ResourceArnBuilder arnBuilder;
+    private RequestContext requestContext;
+    private IamConditionContextResolver conditionContextResolver;
+
+    @BeforeEach
+    void setUp() {
+        config = mock(EmulatorConfig.class);
+        services = mock(EmulatorConfig.ServicesConfig.class);
+        iamConfig = mock(EmulatorConfig.IamServiceConfig.class);
+        accountResolver = mock(AccountResolver.class);
+        iamService = mock(IamService.class);
+        evaluator = mock(IamPolicyEvaluator.class);
+        actionRegistry = mock(IamActionRegistry.class);
+        arnBuilder = mock(ResourceArnBuilder.class);
+        requestContext = new RequestContext();
+        conditionContextResolver = mock(IamConditionContextResolver.class);
+
+        when(config.services()).thenReturn(services);
+        when(services.iam()).thenReturn(iamConfig);
+        when(iamConfig.enforcementEnabled()).thenReturn(true);
+        when(config.defaultRegion()).thenReturn("us-east-1");
+    }
+
     @Test
     void filterBuildsResourceArnWithRequestContextAccount() {
-        EmulatorConfig config = mock(EmulatorConfig.class);
-        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
-        EmulatorConfig.IamServiceConfig iamConfig = mock(EmulatorConfig.IamServiceConfig.class);
-        AccountResolver accountResolver = mock(AccountResolver.class);
-        IamService iamService = mock(IamService.class);
-        IamPolicyEvaluator evaluator = mock(IamPolicyEvaluator.class);
-        IamActionRegistry actionRegistry = mock(IamActionRegistry.class);
-        ResourceArnBuilder arnBuilder = mock(ResourceArnBuilder.class);
-        RequestContext requestContext = new RequestContext();
         ContainerRequestContext containerRequest = mock(ContainerRequestContext.class);
 
         String auth = "AWS4-HMAC-SHA256 Credential=ASIASESSION/20260629/us-east-1/lambda/aws4_request, "
@@ -51,10 +74,6 @@ class IamEnforcementFilterTest {
         requestContext.setAccountId("222233334444");
         requestContext.setRegion("us-east-1");
 
-        when(config.services()).thenReturn(services);
-        when(services.iam()).thenReturn(iamConfig);
-        when(iamConfig.enforcementEnabled()).thenReturn(true);
-        when(config.defaultRegion()).thenReturn("us-east-1");
         when(accountResolver.extractAccessKeyId(auth)).thenReturn("ASIASESSION");
         when(accountResolver.resolve(auth)).thenReturn("000000000000");
         when(containerRequest.getHeaderString("Authorization")).thenReturn(auth);
@@ -74,13 +93,51 @@ class IamEnforcementFilterTest {
                 eq("arn:aws:lambda:us-east-1:222233334444:function:fn"),
                 isNull()))
                 .thenReturn(IamPolicyEvaluator.Decision.ALLOW);
+        when(conditionContextResolver.resolve("lambda", "lambda:InvokeFunction", containerRequest))
+                .thenReturn(null);
 
         IamEnforcementFilter filter = new IamEnforcementFilter(
-                config, accountResolver, iamService, evaluator, actionRegistry, arnBuilder, requestContext);
+                config, accountResolver, iamService, evaluator, actionRegistry, arnBuilder,
+                requestContext, conditionContextResolver);
 
         filter.filter(containerRequest);
 
         verify(arnBuilder).build("lambda", containerRequest, "us-east-1", "222233334444");
+    }
+
+    @Test
+    void filterPassesS3ListBucketConditionContext() {
+        ContainerRequestContext containerRequest = mock(ContainerRequestContext.class);
+        Map<String, String> conditions = Map.of("s3:prefix", "my_namespace/table/");
+
+        String auth = "AWS4-HMAC-SHA256 Credential=ASIASESSION/20260706/us-east-1/s3/aws4_request, "
+                + "SignedHeaders=host, Signature=abc";
+        requestContext.setAccountId("222233334444");
+        requestContext.setRegion("us-east-1");
+
+        when(accountResolver.extractAccessKeyId(auth)).thenReturn("ASIASESSION");
+        when(containerRequest.getHeaderString("Authorization")).thenReturn(auth);
+        when(actionRegistry.resolve("s3", containerRequest)).thenReturn("s3:ListBucket");
+        when(iamService.resolveCallerContext("ASIASESSION"))
+                .thenReturn(CallerContext.of(List.of("""
+                        {"Version":"2012-10-17","Statement":[
+                          {"Effect":"Allow","Action":"s3:ListBucket","Resource":"*"}
+                        ]}""")));
+        when(arnBuilder.build("s3", containerRequest, "us-east-1", "222233334444"))
+                .thenReturn("arn:aws:s3:::bucket");
+        when(conditionContextResolver.resolve("s3", "s3:ListBucket", containerRequest))
+                .thenReturn(conditions);
+        when(evaluator.evaluate(any(), isNull(), eq("s3:ListBucket"), eq("arn:aws:s3:::bucket"), eq(conditions)))
+                .thenReturn(IamPolicyEvaluator.Decision.ALLOW);
+
+        IamEnforcementFilter filter = new IamEnforcementFilter(
+                config, accountResolver, iamService, evaluator, actionRegistry, arnBuilder,
+                requestContext, conditionContextResolver);
+
+        filter.filter(containerRequest);
+
+        verify(evaluator).evaluate(any(), isNull(), eq("s3:ListBucket"),
+                eq("arn:aws:s3:::bucket"), eq(conditions));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/iam/StsSessionPolicyS3EnforcementIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/StsSessionPolicyS3EnforcementIntegrationTest.java
@@ -52,6 +52,42 @@ class StsSessionPolicyS3EnforcementIntegrationTest {
                 .body(containsString("<Code>AccessDenied</Code>"));
     }
 
+    @Test
+    void assumeRoleSessionPolicyListBucketPrefixConditionRestrictsListObjects() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String bucket = "session-policy-prefix-" + suffix;
+        String roleName = "SessionPolicyPrefixRole" + suffix;
+        String allowedPrefix = "my_namespace/table_" + suffix + "/";
+
+        createBucket(bucket);
+        createRole(roleName);
+        putBroadS3RolePolicy(roleName, bucket);
+        putObject(bucket, allowedPrefix + "metadata.json");
+        putObject(bucket, "other_namespace/table_" + suffix + "/metadata.json");
+
+        String accessKeyId = assumeRoleWithS3ListPrefixSessionPolicy(roleName, bucket, allowedPrefix);
+
+        given()
+                .header("Authorization", auth(accessKeyId, "s3"))
+                .queryParam("list-type", "2")
+                .queryParam("prefix", allowedPrefix)
+        .when()
+                .get("/" + bucket)
+        .then()
+                .statusCode(200)
+                .body(containsString("<Key>" + allowedPrefix + "metadata.json</Key>"));
+
+        given()
+                .header("Authorization", auth(accessKeyId, "s3"))
+                .queryParam("list-type", "2")
+                .queryParam("prefix", "other_namespace/table_" + suffix + "/")
+        .when()
+                .get("/" + bucket)
+        .then()
+                .statusCode(403)
+                .body(containsString("<Code>AccessDenied</Code>"));
+    }
+
     private static void createBucket(String bucket) {
         given()
                 .header("Authorization", auth(ROLE_ACCOUNT_ID, "s3"))
@@ -112,6 +148,17 @@ class StsSessionPolicyS3EnforcementIntegrationTest {
                 .statusCode(200);
     }
 
+    private static void putObject(String bucket, String key) {
+        given()
+                .header("Authorization", auth(ROLE_ACCOUNT_ID, "s3"))
+                .contentType("application/json")
+                .body("{}")
+        .when()
+                .put("/" + bucket + "/" + key)
+        .then()
+                .statusCode(200);
+    }
+
     private static String assumeRoleWithS3SessionPolicy(String roleName, String bucket) {
         return given()
                 .formParam("Action", "AssumeRole")
@@ -137,6 +184,50 @@ class StsSessionPolicyS3EnforcementIntegrationTest {
                       ]
                     }
                     """.formatted(bucket))
+                .header("Authorization", auth(CALLER_ACCOUNT_ID, "sts"))
+        .when()
+                .post("/")
+        .then()
+                .statusCode(200)
+                .body("AssumeRoleResponse.AssumeRoleResult.Credentials.AccessKeyId", startsWith("ASIA"))
+                .extract()
+                .path("AssumeRoleResponse.AssumeRoleResult.Credentials.AccessKeyId");
+    }
+
+    private static String assumeRoleWithS3ListPrefixSessionPolicy(String roleName, String bucket, String allowedPrefix) {
+        return given()
+                .formParam("Action", "AssumeRole")
+                .formParam("RoleArn", "arn:aws:iam::" + ROLE_ACCOUNT_ID + ":role/" + roleName)
+                .formParam("RoleSessionName", "session-policy-prefix-test")
+                .formParam("Policy", """
+                    {
+                      "Version": "2012-10-17",
+                      "Statement": [
+                        {
+                          "Effect": "Allow",
+                          "Action": "s3:ListBucket",
+                          "Resource": "arn:aws:s3:::%1$s",
+                          "Condition": {
+                            "StringLike": {
+                              "s3:prefix": [
+                                "%2$s",
+                                "%2$s*"
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "Effect": "Allow",
+                          "Action": [
+                            "s3:GetObject",
+                            "s3:PutObject",
+                            "s3:DeleteObject"
+                          ],
+                          "Resource": "arn:aws:s3:::%1$s/%2$s*"
+                        }
+                      ]
+                    }
+                    """.formatted(bucket, allowedPrefix))
                 .header("Authorization", auth(CALLER_ACCOUNT_ID, "sts"))
         .when()
                 .post("/")


### PR DESCRIPTION
## Summary

Pass S3 list request condition keys into IAM enforcement.

IAM policy evaluation already supports condition keys, but request-time enforcement did not pass S3 list request parameters into the evaluator. That meant assumed-role session policies allowing `s3:ListBucket` only for a matching `s3:prefix` were denied because the condition context was empty.

This adds an `IamConditionContextResolver` and wires `IamEnforcementFilter` to pass resolved condition context into `IamPolicyEvaluator`.

For S3 `ListBucket`, the resolver currently maps:

- `prefix` -> `s3:prefix`
- `delimiter` -> `s3:delimiter`
- `max-keys` -> `s3:max-keys`

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: prefix-restricted STS session policies for S3 bucket listing were evaluated without the request’s list condition keys, so a matching `s3:prefix` condition did not allow the request.

This was validated with an integration regression test and Java SDK compatibility coverage using assumed-role session credentials and `ListObjectsV2Request.prefix(...)`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
