### PR TITLE
fix(dynamodb): support ADD for nested map paths (#1756)

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/dynamodb.bats
+++ b/compatibility-tests/sdk-test-awscli/test/dynamodb.bats
@@ -767,3 +767,48 @@ teardown() {
     [ "$foo" = "null" ]
     [ "$bar" = "3" ]
 }
+
+# --- DynamoDB ADD nested map path tests (GH #1756) ---
+
+@test "DynamoDB: ADD on nested map path with expression attribute names" {
+    aws_cmd dynamodb create-table \
+        --table-name "$TABLE_NAME" \
+        --attribute-definitions AttributeName=pk,AttributeType=S \
+        --key-schema AttributeName=pk,KeyType=HASH \
+        --billing-mode PAY_PER_REQUEST >/dev/null
+
+    ddb_wait_table "$TABLE_NAME"
+
+    # Seed the nested map — SET + if_not_exists on nested placeholder paths works fine
+    aws_cmd dynamodb update-item \
+        --table-name "$TABLE_NAME" \
+        --key '{"pk":{"S":"item1"}}' \
+        --update-expression 'SET #fis = if_not_exists(#fis, :empty)' \
+        --expression-attribute-names '{"#fis":"functionInvocationSummaries"}' \
+        --expression-attribute-values '{":empty":{"M":{}}}' >/dev/null
+
+    aws_cmd dynamodb update-item \
+        --table-name "$TABLE_NAME" \
+        --key '{"pk":{"S":"item1"}}' \
+        --update-expression 'SET #fis.#isa = if_not_exists(#fis.#isa, :seed)' \
+        --expression-attribute-names '{"#fis":"functionInvocationSummaries","#isa":"ISA_10136"}' \
+        --expression-attribute-values '{":seed":{"M":{"eventsAvailable":{"N":"0"}}}}' >/dev/null
+
+    # ADD on the nested placeholder path
+    aws_cmd dynamodb update-item \
+        --table-name "$TABLE_NAME" \
+        --key '{"pk":{"S":"item1"}}' \
+        --update-expression 'ADD #fis.#isa.#ea :one' \
+        --expression-attribute-names '{"#fis":"functionInvocationSummaries","#isa":"ISA_10136","#ea":"eventsAvailable"}' \
+        --expression-attribute-values '{":one":{"N":"1"}}' >/dev/null
+
+    run aws_cmd dynamodb get-item \
+        --table-name "$TABLE_NAME" \
+        --key '{"pk":{"S":"item1"}}' \
+        --consistent-read
+    assert_success
+    ea=$(echo "$output" | jq -r '.Item.functionInvocationSummaries.M.ISA_10136.M.eventsAvailable.N')
+    phantom=$(echo "$output" | jq -r '.Item["#fis.#isa.#ea"] // "null"')
+    [ "$ea" = "1" ]
+    [ "$phantom" = "null" ]
+}

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -1710,15 +1710,15 @@ public class DynamoDbService {
             String[] parts = clause.split("\\s+", 3);
             if (parts.length < 2) break;
 
-            String attrName = resolveAttributeName(parts[0], exprAttrNames);
+            String attrPath = parts[0].trim();
             String valuePlaceholder = parts[1].replaceAll(",.*", "").trim();
 
             if (valuePlaceholder.startsWith(":") && exprAttrValues != null) {
                 JsonNode addValue = exprAttrValues.get(valuePlaceholder);
                 if (addValue != null) {
-                    JsonNode existingValue = item.get(attrName);
+                    JsonNode existingValue = getValueAtPath(item, attrPath, exprAttrNames);
                     JsonNode newValue = applyAddOperation(existingValue, addValue);
-                    item.set(attrName, newValue);
+                    setValueAtPath(item, attrPath, newValue, exprAttrNames);
                 }
             }
 

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -2348,4 +2348,127 @@ class DynamoDbServiceTest {
         JsonNode stored = service.getItem("Users", item("userId", "u1"), "us-east-1");
         assertEquals("2", stored.get("counter").get("N").asText());
     }
+
+    private void seedNestedCounterItem(String id, String region) {
+        ObjectNode inner = mapper.createObjectNode();
+        inner.set("eventsAvailable", attributeValue("N", "0"));
+        ObjectNode innerWrapper = mapper.createObjectNode();
+        innerWrapper.set("M", inner);
+
+        ObjectNode summaries = mapper.createObjectNode();
+        summaries.set("ISA_10136", innerWrapper);
+        ObjectNode summariesWrapper = mapper.createObjectNode();
+        summariesWrapper.set("M", summaries);
+
+        ObjectNode initialItem = mapper.createObjectNode();
+        initialItem.set("userId", attributeValue("S", id));
+        initialItem.set("functionInvocationSummaries", summariesWrapper);
+        service.putItem("Users", initialItem, region);
+    }
+
+    /**
+     * Reproduces GitHub issue #1756: ADD on a nested map path expressed with
+     * ExpressionAttributeNames placeholders ("ADD #fis.#isa.#ea :one") must
+     * resolve the placeholders, traverse the map, and increment the nested
+     * numeric attribute — not create a phantom top-level attribute.
+     */
+    @Test
+    void addOnNestedPathWithExpressionNamesIncrementsNestedCounter() {
+        String region = "eu-west-1";
+        createUsersTable(region);
+        seedNestedCounterItem("nested-1", region);
+
+        ObjectNode names = mapper.createObjectNode();
+        names.put("#fis", "functionInvocationSummaries");
+        names.put("#isa", "ISA_10136");
+        names.put("#ea", "eventsAvailable");
+        ObjectNode values = mapper.createObjectNode();
+        values.set(":one", attributeValue("N", "1"));
+
+        service.updateItem("Users", userIdKey("nested-1"), null,
+                "ADD #fis.#isa.#ea :one", names, values, "ALL_NEW", region);
+
+        JsonNode stored = service.getItem("Users", userIdKey("nested-1"), region);
+        assertEquals("1", stored.get("functionInvocationSummaries").get("M")
+                        .get("ISA_10136").get("M").get("eventsAvailable").get("N").asText(),
+                "ADD must increment the nested counter");
+        assertFalse(stored.has("#fis.#isa.#ea"),
+                "ADD must not create a phantom top-level attribute named after the raw expression");
+    }
+
+    /**
+     * ADD on a nested map path expressed as a literal dotted path (no
+     * ExpressionAttributeNames) must also traverse the map and increment the
+     * nested numeric attribute.
+     */
+    @Test
+    void addOnNestedPathWithLiteralNamesIncrementsNestedCounter() {
+        String region = "eu-west-1";
+        createUsersTable(region);
+        seedNestedCounterItem("nested-2", region);
+
+        ObjectNode values = mapper.createObjectNode();
+        values.set(":one", attributeValue("N", "2"));
+
+        service.updateItem("Users", userIdKey("nested-2"), null,
+                "ADD functionInvocationSummaries.ISA_10136.eventsAvailable :one",
+                null, values, "ALL_NEW", region);
+
+        JsonNode stored = service.getItem("Users", userIdKey("nested-2"), region);
+        assertEquals("2", stored.get("functionInvocationSummaries").get("M")
+                        .get("ISA_10136").get("M").get("eventsAvailable").get("N").asText(),
+                "ADD on a literal dotted path must increment the nested counter");
+        assertFalse(stored.has("functionInvocationSummaries.ISA_10136.eventsAvailable"),
+                "ADD must not create a phantom top-level attribute named after the dotted path");
+    }
+
+    /**
+     * ADD on a nested numeric attribute that does not yet exist must create it
+     * (treating the missing value as 0) rather than a phantom top-level attribute.
+     */
+    @Test
+    void addOnMissingNestedNumberCreatesNestedAttribute() {
+        String region = "eu-west-1";
+        createUsersTable(region);
+        seedNestedCounterItem("nested-3", region);
+
+        ObjectNode names = mapper.createObjectNode();
+        names.put("#fis", "functionInvocationSummaries");
+        names.put("#isa", "ISA_10136");
+        names.put("#nc", "newCounter");
+        ObjectNode values = mapper.createObjectNode();
+        values.set(":one", attributeValue("N", "1"));
+
+        service.updateItem("Users", userIdKey("nested-3"), null,
+                "ADD #fis.#isa.#nc :one", names, values, "ALL_NEW", region);
+
+        JsonNode stored = service.getItem("Users", userIdKey("nested-3"), region);
+        JsonNode isa = stored.get("functionInvocationSummaries").get("M").get("ISA_10136").get("M");
+        assertEquals("1", isa.get("newCounter").get("N").asText(),
+                "ADD on a missing nested number must initialize it from 0");
+        assertEquals("0", isa.get("eventsAvailable").get("N").asText(),
+                "existing sibling attribute must be untouched");
+    }
+
+    /**
+     * Regression guard: ADD on a plain top-level attribute must keep working
+     * exactly as before the nested-path fix.
+     */
+    @Test
+    void addOnTopLevelAttributeStillIncrements() {
+        String region = "eu-west-1";
+        createUsersTable(region);
+        seedCounterItem("nested-4", 5L, "old");
+
+        ObjectNode names = mapper.createObjectNode();
+        names.put("#c", "counter");
+        ObjectNode values = mapper.createObjectNode();
+        values.set(":inc", attributeValue("N", "3"));
+
+        service.updateItem("Users", userIdKey("nested-4"), null,
+                "ADD #c :inc", names, values, "ALL_NEW", region);
+
+        JsonNode stored = service.getItem("Users", userIdKey("nested-4"), region);
+        assertEquals("8", stored.get("counter").get("N").asText());
+    }
 }


### PR DESCRIPTION
## Summary
- `applyAddClause()` resolved the whole document path as a single top-level attribute name via `resolveAttributeName()` and read/wrote it with `item.get()`/`item.set()`, so `ExpressionAttributeNames` placeholders in dotted paths were never expanded and nested maps were never traversed
- `ADD #fis.#isa.#ea :one` therefore created a phantom top-level attribute literally named `#fis.#isa.#ea` instead of incrementing the nested counter; literal dotted paths (`a.b.c`) failed the same way
- Route ADD through `getValueAtPath()`/`setValueAtPath()` — the same path navigation used by SET and by REMOVE since #421 — so placeholders resolve, nested `M` wrappers are traversed, and existing `applyAddOperation()` semantics (number add, set union) are preserved. Top-level ADD behavior is unchanged (single-segment paths take the same code path as before)

Fixes #1756

## Changes
- `DynamoDbService.java`: use `getValueAtPath()`/`setValueAtPath()` in `applyAddClause()` instead of `resolveAttributeName()` + top-level `item.get()`/`item.set()`
- `DynamoDbServiceTest.java`: 4 unit tests covering nested placeholder paths (the exact shape from #1756), literal dotted paths, ADD to a missing nested number, and a top-level ADD regression guard
- `dynamodb.bats`: AWS CLI compat test reproducing the #1756 scenario

## Test plan
- [x] 4 new unit tests (DynamoDbServiceTest); the placeholder-path test fails without the fix (`expected: <1> but was: <0>`) and passes with it
- [x] 1 new AWS CLI compat test (dynamodb.bats) mirroring the #402 bats test
- [x] `mvn test -Dtest=DynamoDbServiceTest`: 97 tests, 0 failures
- [x] Full test suite: 7380 run, 0 DynamoDB failures; the only 2 failures (ElbV2LambdaTargetDataPlane, NeptuneOpenCypher) are Docker-environment integration tests that fail identically on a clean main checkout
- [x] Manual end-to-end verification: ran the emulator and replayed the exact CLI repro from #1756 — nested counter increments to 1, no phantom `#fis.#isa.#ea` attribute, output identical to real DynamoDB

Note: `applyDeleteClause` appears to have the same nested-path gap for DELETE on set types — happy to file a follow-up issue or extend this PR if preferred.