### PR TITLE
chore(glue): fix GlueJsonHandlerEmptyListTest compile on main

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/glue/GlueJsonHandlerEmptyListTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/GlueJsonHandlerEmptyListTest.java
@@ -40,7 +40,7 @@ class GlueJsonHandlerEmptyListTest {
         GlueSchemaRegistryService schemaRegistryService =
                 new GlueSchemaRegistryService(storageFactory, regionResolver);
         GlueService glueService = new GlueService(
-                storageFactory, schemaRegistryService, regionResolver, new ResourceGroupsTaggingService());
+                storageFactory, schemaRegistryService, regionResolver, new ResourceGroupsTaggingService(storageFactory));
         handler = new GlueJsonHandler(glueService, schemaRegistryService, mapper);
     }
 


### PR DESCRIPTION
## Summary

`main` currently fails `./mvnw test-compile` (and therefore the Docker image build, which runs `mvn package -DskipTests`): #1711 changed `ResourceGroupsTaggingService` to require a `StorageFactory`, while #1581 merged a new test still calling the no-arg constructor. The two PRs merged past each other with no textual conflict.

One line: pass the test's existing `InMemoryStorageFactory` to the constructor.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

Not applicable, test-only compile fix; no wire behavior changes.

## Checklist

- [x] `./mvnw test` passes locally (`GlueJsonHandlerEmptyListTest` 4/4; full `test-compile` green; full Docker compatibility suite run against the patched tree: all 8 suites passed)
- [x] New or updated integration test added (existing test repaired; no behavior change to cover)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)