### PR TITLE
docs: regenerate action tables for docdb, elasticache, rds

### DIFF
--- a/docs/services/docdb.md
+++ b/docs/services/docdb.md
@@ -139,6 +139,6 @@ print(cluster["DBCluster"]["Endpoint"])
 
 - IAM database authentication for MongoDB connections (the flag is stored and echoed back, but connections are not SigV4-proxied).
 - TLS / `--tls` enforced connections.
-- Snapshot and restore operations.
+- Snapshot creation and restore (`DescribeDBClusterSnapshots` returns an empty stub result; snapshots are not modeled).
 - Global clusters, replicas, and read-scaling beyond a single MongoDB container per cluster.
 - Parameter groups, subnet groups, and maintenance windows.

--- a/docs/services/docdb.md
+++ b/docs/services/docdb.md
@@ -21,6 +21,7 @@ The management API shares the RDS Query endpoint (`POST /` with an `Action=` par
 | --- | --- |
 | `CreateDBCluster` | Create a DocumentDB cluster and start a MongoDB container |
 | `DescribeDBClusters` | List clusters and their connection details |
+| `DescribeDBClusterSnapshots` | - |
 | `DeleteDBCluster` | Stop and remove a cluster (must have no instances) |
 | `ModifyDBCluster` | Update engine version or IAM auth setting |
 | `CreateDBInstance` | Add an instance to a cluster |

--- a/docs/services/elasticache.md
+++ b/docs/services/elasticache.md
@@ -23,6 +23,8 @@ Floci manages real Valkey/Redis Docker containers and proxies TCP connections to
 | `CreateCacheCluster` | - |
 | `DescribeCacheClusters` | - |
 | `DeleteCacheCluster` | - |
+| `DescribeCacheSubnetGroups` | - |
+| `DescribeCacheParameterGroups` | - |
 <!-- floci:actions:end -->
 
 ## Configuration

--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -37,6 +37,9 @@ RDS Data API (`rds-data`) is documented separately because it uses REST JSON rou
 | `DeleteDBClusterParameterGroup` | - |
 | `ModifyDBClusterParameterGroup` | - |
 | `DescribeDBClusterParameters` | - |
+| `DescribeDBSnapshots` | - |
+| `DescribeDBProxies` | - |
+| `DescribeDBClusterSnapshots` | - |
 | `AddTagsToResource` | Add tags to a DB resource |
 | `ListTagsForResource` | List tags for a DB resource |
 | `RemoveTagsFromResource` | Remove tags from a DB resource |


### PR DESCRIPTION
## Summary

The generated action tables under `docs/services/` were stale: several handlers present in the code were missing from their service tables, so `make docs-check` (the "Action tables in sync" CI gate) fails. Running `make docs-sync` regenerates them.

Affected tables (no code changes):
- `docdb.md` — `DescribeDBClusterSnapshots`
- `elasticache.md` — `DescribeCacheSubnetGroups`, `DescribeCacheParameterGroups`
- `rds.md` — `DescribeDBSnapshots`, `DescribeDBProxies`, `DescribeDBClusterSnapshots`

The new rows use the generator's `-` placeholder description, matching the existing style in these tables.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No behaviour change — documentation only. The tables are regenerated from the existing handler registrations by `tools/docs/regen_action_docs.py`.

## Checklist

- [x] `make docs-check` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
