### PR TITLE
fix(s3): honor ACL headers and explicit grants

### DIFF
--- a/docs/services/docdb.md
+++ b/docs/services/docdb.md
@@ -21,6 +21,7 @@ The management API shares the RDS Query endpoint (`POST /` with an `Action=` par
 | --- | --- |
 | `CreateDBCluster` | Create a DocumentDB cluster and start a MongoDB container |
 | `DescribeDBClusters` | List clusters and their connection details |
+| `DescribeDBClusterSnapshots` | - |
 | `DeleteDBCluster` | Stop and remove a cluster (must have no instances) |
 | `ModifyDBCluster` | Update engine version or IAM auth setting |
 | `CreateDBInstance` | Add an instance to a cluster |

--- a/docs/services/elasticache.md
+++ b/docs/services/elasticache.md
@@ -23,6 +23,8 @@ Floci manages real Valkey/Redis Docker containers and proxies TCP connections to
 | `CreateCacheCluster` | - |
 | `DescribeCacheClusters` | - |
 | `DeleteCacheCluster` | - |
+| `DescribeCacheSubnetGroups` | - |
+| `DescribeCacheParameterGroups` | - |
 <!-- floci:actions:end -->
 
 ## Configuration

--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -37,6 +37,9 @@ RDS Data API (`rds-data`) is documented separately because it uses REST JSON rou
 | `DeleteDBClusterParameterGroup` | - |
 | `ModifyDBClusterParameterGroup` | - |
 | `DescribeDBClusterParameters` | - |
+| `DescribeDBSnapshots` | - |
+| `DescribeDBProxies` | - |
+| `DescribeDBClusterSnapshots` | - |
 | `AddTagsToResource` | Add tags to a DB resource |
 | `ListTagsForResource` | List tags for a DB resource |
 | `RemoveTagsFromResource` | Remove tags from a DB resource |

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -222,7 +222,13 @@ public class S3Controller {
                         .build();
             }
             if (hasQueryParam(uriInfo, "acl")) {
-                s3Service.putBucketAcl(bucket, new String(body, StandardCharsets.UTF_8));
+                s3Service.putBucketAcl(bucket, new String(body, StandardCharsets.UTF_8),
+                        httpHeaders.getHeaderString("x-amz-acl"),
+                        httpHeaders.getHeaderString("x-amz-grant-read"),
+                        httpHeaders.getHeaderString("x-amz-grant-write"),
+                        httpHeaders.getHeaderString("x-amz-grant-full-control"),
+                        httpHeaders.getHeaderString("x-amz-grant-read-acp"),
+                        httpHeaders.getHeaderString("x-amz-grant-write-acp"));
                 return Response.ok().build();
             }
             if (hasQueryParam(uriInfo, "encryption")) {
@@ -508,7 +514,13 @@ public class S3Controller {
             }
             if (hasQueryParam(uriInfo, "acl")) {
                 s3Service.putObjectAcl(bucket, key, uriInfo.getQueryParameters().getFirst("versionId"),
-                        new String(body, StandardCharsets.UTF_8));
+                        new String(body, StandardCharsets.UTF_8),
+                        httpHeaders.getHeaderString("x-amz-acl"),
+                        httpHeaders.getHeaderString("x-amz-grant-read"),
+                        httpHeaders.getHeaderString("x-amz-grant-write"),
+                        httpHeaders.getHeaderString("x-amz-grant-full-control"),
+                        httpHeaders.getHeaderString("x-amz-grant-read-acp"),
+                        httpHeaders.getHeaderString("x-amz-grant-write-acp"));
                 return Response.ok().build();
             }
 
@@ -565,6 +577,11 @@ public class S3Controller {
                             .withSseCustomerKey(sseCustomerKey)
                             .withSseCustomerKeyMd5(sseCustomerKeyMd5)
                             .withAcl(cannedAcl)
+                            .withGrantRead(httpHeaders.getHeaderString("x-amz-grant-read"))
+                            .withGrantWrite(httpHeaders.getHeaderString("x-amz-grant-write"))
+                            .withGrantFullControl(httpHeaders.getHeaderString("x-amz-grant-full-control"))
+                            .withGrantReadAcp(httpHeaders.getHeaderString("x-amz-grant-read-acp"))
+                            .withGrantWriteAcp(httpHeaders.getHeaderString("x-amz-grant-write-acp"))
                             .withChecksumAlgorithm(checksumAlgorithm)
                             .withClientChecksum(extractChecksumFromHeaders(httpHeaders))
                             .withIfMatch(ifMatch)
@@ -1806,7 +1823,12 @@ public class S3Controller {
                         .withCopySourceSseCustomerKey(httpHeaders.getHeaderString("x-amz-copy-source-server-side-encryption-customer-key"))
                         .withCopySourceSseCustomerKeyMd5(httpHeaders.getHeaderString("x-amz-copy-source-server-side-encryption-customer-key-MD5"))
                         .withChecksumAlgorithm(getChecksumAlgorithm(httpHeaders))
-                        .withAcl(cannedAcl));
+                        .withAcl(cannedAcl)
+                        .withGrantRead(httpHeaders.getHeaderString("x-amz-grant-read"))
+                        .withGrantWrite(httpHeaders.getHeaderString("x-amz-grant-write"))
+                        .withGrantFullControl(httpHeaders.getHeaderString("x-amz-grant-full-control"))
+                        .withGrantReadAcp(httpHeaders.getHeaderString("x-amz-grant-read-acp"))
+                        .withGrantWriteAcp(httpHeaders.getHeaderString("x-amz-grant-write-acp")));
         String xml = new XmlBuilder()
                 .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
                 .start("CopyObjectResult", AwsNamespaces.S3)

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -1624,7 +1624,7 @@ public class S3Service implements Resettable {
         Bucket bucket = bucketStore.get(bucketName)
                 .orElseThrow(() -> new AwsException("NoSuchBucket", "The specified bucket does not exist.", 404));
         String resolvedAcl = resolveObjectAclXml(cannedAcl, grantRead, grantWrite, grantFullControl, grantReadAcp, grantWriteAcp);
-        bucket.setAcl(resolvedAcl != null ? resolvedAcl : bodyAcl);
+        bucket.setAcl(resolvedAcl != null ? resolvedAcl : (bodyAcl.isBlank() ? null : bodyAcl));
         bucketStore.put(bucketName, bucket);
     }
 
@@ -1638,7 +1638,7 @@ public class S3Service implements Resettable {
                               String grantReadAcp, String grantWriteAcp) {
         S3Object obj = getObject(bucketName, key, versionId);
         String resolvedAcl = resolveObjectAclXml(cannedAcl, grantRead, grantWrite, grantFullControl, grantReadAcp, grantWriteAcp);
-        obj.setAcl(resolvedAcl != null ? resolvedAcl : bodyAcl);
+        obj.setAcl(resolvedAcl != null ? resolvedAcl : (bodyAcl.isBlank() ? null : bodyAcl));
         String storeKey = (versionId != null) ? versionedKey(bucketName, key, versionId) : objectKey(bucketName, key);
         objectStore.put(storeKey, obj);
     }
@@ -1784,9 +1784,10 @@ public class S3Service implements Resettable {
     /**
      * Resolves the ACL to store for an object/bucket from a canned ACL and/or the explicit
      * ACL grant headers (x-amz-grant-read, x-amz-grant-write, x-amz-grant-full-control,
-     * x-amz-grant-read-acp, x-amz-grant-write-acp). A canned ACL takes precedence if both are
-     * somehow present (matches S3's own precedence). Returns null if neither is set, so callers
-     * can fall back to a pre-existing ACL (e.g. an explicit AccessControlPolicy XML body).
+     * x-amz-grant-read-acp, x-amz-grant-write-acp). If both are somehow present, the canned ACL
+     * takes precedence - real S3 instead rejects that combination with 400 "Conflicting header
+     * values", but Floci doesn't model that validation yet. Returns null if neither is set, so
+     * callers can fall back to a pre-existing ACL (e.g. an explicit AccessControlPolicy XML body).
      */
     String resolveObjectAclXml(String cannedAcl, String grantRead, String grantWrite,
                                 String grantFullControl, String grantReadAcp, String grantWriteAcp) {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -39,6 +39,8 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @ApplicationScoped
 public class S3Service implements Resettable {
@@ -356,7 +358,9 @@ public class S3Service implements Resettable {
             object.setSseCustomerAlgorithm(sseCustomerKey.algorithm());
             object.setSseCustomerKeyMd5(sseCustomerKey.keyMd5());
         }
-        object.setAcl(cannedObjectAclXml(effectiveOptions.getAcl()));
+        object.setAcl(resolveObjectAclXml(effectiveOptions.getAcl(), effectiveOptions.getGrantRead(),
+                effectiveOptions.getGrantWrite(), effectiveOptions.getGrantFullControl(),
+                effectiveOptions.getGrantReadAcp(), effectiveOptions.getGrantWriteAcp()));
         if (effectiveOptions.getTagging() != null && !effectiveOptions.getTagging().isEmpty()) {
             object.setTags(new HashMap<>(effectiveOptions.getTagging()));
         }
@@ -1615,10 +1619,12 @@ public class S3Service implements Resettable {
         return bucket.getAcl() != null ? bucket.getAcl() : defaultAclXml(ownerId(), DEFAULT_OWNER_DISPLAY_NAME);
     }
 
-    public void putBucketAcl(String bucketName, String acl) {
+    public void putBucketAcl(String bucketName, String bodyAcl, String cannedAcl, String grantRead,
+                              String grantWrite, String grantFullControl, String grantReadAcp, String grantWriteAcp) {
         Bucket bucket = bucketStore.get(bucketName)
                 .orElseThrow(() -> new AwsException("NoSuchBucket", "The specified bucket does not exist.", 404));
-        bucket.setAcl(acl);
+        String resolvedAcl = resolveObjectAclXml(cannedAcl, grantRead, grantWrite, grantFullControl, grantReadAcp, grantWriteAcp);
+        bucket.setAcl(resolvedAcl != null ? resolvedAcl : bodyAcl);
         bucketStore.put(bucketName, bucket);
     }
 
@@ -1627,9 +1633,12 @@ public class S3Service implements Resettable {
         return obj.getAcl() != null ? obj.getAcl() : defaultAclXml(ownerId(), DEFAULT_OWNER_DISPLAY_NAME);
     }
 
-    public void putObjectAcl(String bucketName, String key, String versionId, String acl) {
+    public void putObjectAcl(String bucketName, String key, String versionId, String bodyAcl, String cannedAcl,
+                              String grantRead, String grantWrite, String grantFullControl,
+                              String grantReadAcp, String grantWriteAcp) {
         S3Object obj = getObject(bucketName, key, versionId);
-        obj.setAcl(acl);
+        String resolvedAcl = resolveObjectAclXml(cannedAcl, grantRead, grantWrite, grantFullControl, grantReadAcp, grantWriteAcp);
+        obj.setAcl(resolvedAcl != null ? resolvedAcl : bodyAcl);
         String storeKey = (versionId != null) ? versionedKey(bucketName, key, versionId) : objectKey(bucketName, key);
         objectStore.put(storeKey, obj);
     }
@@ -1770,6 +1779,67 @@ public class S3Service implements Resettable {
                   .end("AccessControlList")
                 .end("AccessControlPolicy")
                 .build();
+    }
+
+    /**
+     * Resolves the ACL to store for an object/bucket from a canned ACL and/or the explicit
+     * ACL grant headers (x-amz-grant-read, x-amz-grant-write, x-amz-grant-full-control,
+     * x-amz-grant-read-acp, x-amz-grant-write-acp). A canned ACL takes precedence if both are
+     * somehow present (matches S3's own precedence). Returns null if neither is set, so callers
+     * can fall back to a pre-existing ACL (e.g. an explicit AccessControlPolicy XML body).
+     */
+    String resolveObjectAclXml(String cannedAcl, String grantRead, String grantWrite,
+                                String grantFullControl, String grantReadAcp, String grantWriteAcp) {
+        if (cannedAcl != null && !cannedAcl.isBlank()) {
+            return cannedObjectAclXml(cannedAcl);
+        }
+        if (isBlank(grantRead) && isBlank(grantWrite) && isBlank(grantFullControl)
+                && isBlank(grantReadAcp) && isBlank(grantWriteAcp)) {
+            return null;
+        }
+        List<String> grants = new ArrayList<>();
+        grants.add(ownerFullControlGrant());
+        appendGrantHeader(grants, grantRead, "READ");
+        appendGrantHeader(grants, grantWrite, "WRITE");
+        appendGrantHeader(grants, grantFullControl, "FULL_CONTROL");
+        appendGrantHeader(grants, grantReadAcp, "READ_ACP");
+        appendGrantHeader(grants, grantWriteAcp, "WRITE_ACP");
+        return objectAclXml(grants.toArray(new String[0]));
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    // Matches a single grantee token from an x-amz-grant-* header value, e.g.
+    // uri="http://acs.amazonaws.com/groups/global/AllUsers" or id="<canonical-id>". AWS allows
+    // a comma-separated list of these per header.
+    private static final Pattern GRANTEE_TOKEN_PATTERN = Pattern.compile("(uri|id|emailAddress)=\"([^\"]*)\"");
+
+    private void appendGrantHeader(List<String> grants, String headerValue, String permission) {
+        if (isBlank(headerValue)) {
+            return;
+        }
+        Matcher matcher = GRANTEE_TOKEN_PATTERN.matcher(headerValue);
+        boolean matched = false;
+        while (matcher.find()) {
+            matched = true;
+            grants.add(granteeGrant(matcher.group(1), matcher.group(2), permission));
+        }
+        if (!matched) {
+            throw new AwsException("InvalidArgument", "Malformed ACL grant header: " + headerValue, 400);
+        }
+    }
+
+    private String granteeGrant(String granteeType, String granteeValue, String permission) {
+        return switch (granteeType) {
+            case "uri" -> groupGrant(granteeValue, permission);
+            // Floci has no directory of external accounts, so an explicit CanonicalUser grant is
+            // stored using the caller-supplied ID verbatim as both ID and display name.
+            case "id" -> canonicalUserGrant(granteeValue, granteeValue, permission);
+            default -> throw new AwsException("NotImplemented",
+                    "Explicit ACL grants by emailAddress are not supported.", 501);
+        };
     }
 
     String cannedObjectAclXml(String cannedAcl) {
@@ -2473,6 +2543,11 @@ public class S3Service implements Resettable {
                         .withSseCustomerKey(effectiveOptions.getSseCustomerKey())
                         .withSseCustomerKeyMd5(effectiveOptions.getSseCustomerKeyMd5())
                         .withAcl(effectiveOptions.getAcl())
+                        .withGrantRead(effectiveOptions.getGrantRead())
+                        .withGrantWrite(effectiveOptions.getGrantWrite())
+                        .withGrantFullControl(effectiveOptions.getGrantFullControl())
+                        .withGrantReadAcp(effectiveOptions.getGrantReadAcp())
+                        .withGrantWriteAcp(effectiveOptions.getGrantWriteAcp())
                         .withChecksumAlgorithm(copyChecksumAlgorithm)
                         .withTagging(effectiveTags));
         copy.setETag(source.getETag());

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/CopyObjectOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/CopyObjectOptions.java
@@ -20,6 +20,11 @@ public class CopyObjectOptions {
     private String copySourceSseCustomerKey;
     private String copySourceSseCustomerKeyMd5;
     private String acl;
+    private String grantRead;
+    private String grantWrite;
+    private String grantFullControl;
+    private String grantReadAcp;
+    private String grantWriteAcp;
     private String checksumAlgorithm;
 
     public String getMetadataDirective() { return metadataDirective; }
@@ -72,6 +77,21 @@ public class CopyObjectOptions {
 
     public String getAcl() { return acl; }
     public CopyObjectOptions withAcl(String acl) { this.acl = acl; return this; }
+
+    public String getGrantRead() { return grantRead; }
+    public CopyObjectOptions withGrantRead(String grantRead) { this.grantRead = grantRead; return this; }
+
+    public String getGrantWrite() { return grantWrite; }
+    public CopyObjectOptions withGrantWrite(String grantWrite) { this.grantWrite = grantWrite; return this; }
+
+    public String getGrantFullControl() { return grantFullControl; }
+    public CopyObjectOptions withGrantFullControl(String grantFullControl) { this.grantFullControl = grantFullControl; return this; }
+
+    public String getGrantReadAcp() { return grantReadAcp; }
+    public CopyObjectOptions withGrantReadAcp(String grantReadAcp) { this.grantReadAcp = grantReadAcp; return this; }
+
+    public String getGrantWriteAcp() { return grantWriteAcp; }
+    public CopyObjectOptions withGrantWriteAcp(String grantWriteAcp) { this.grantWriteAcp = grantWriteAcp; return this; }
 
     public String getChecksumAlgorithm() { return checksumAlgorithm; }
     public CopyObjectOptions withChecksumAlgorithm(String checksumAlgorithm) { this.checksumAlgorithm = checksumAlgorithm; return this; }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/PutObjectOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/PutObjectOptions.java
@@ -16,6 +16,11 @@ public class PutObjectOptions {
     private String sseCustomerKey;
     private String sseCustomerKeyMd5;
     private String acl;
+    private String grantRead;
+    private String grantWrite;
+    private String grantFullControl;
+    private String grantReadAcp;
+    private String grantWriteAcp;
     private String checksumAlgorithm;
     private String ifMatch;
     private String ifNoneMatch;
@@ -56,6 +61,21 @@ public class PutObjectOptions {
 
     public String getAcl() { return acl; }
     public PutObjectOptions withAcl(String acl) { this.acl = acl; return this; }
+
+    public String getGrantRead() { return grantRead; }
+    public PutObjectOptions withGrantRead(String grantRead) { this.grantRead = grantRead; return this; }
+
+    public String getGrantWrite() { return grantWrite; }
+    public PutObjectOptions withGrantWrite(String grantWrite) { this.grantWrite = grantWrite; return this; }
+
+    public String getGrantFullControl() { return grantFullControl; }
+    public PutObjectOptions withGrantFullControl(String grantFullControl) { this.grantFullControl = grantFullControl; return this; }
+
+    public String getGrantReadAcp() { return grantReadAcp; }
+    public PutObjectOptions withGrantReadAcp(String grantReadAcp) { this.grantReadAcp = grantReadAcp; return this; }
+
+    public String getGrantWriteAcp() { return grantWriteAcp; }
+    public PutObjectOptions withGrantWriteAcp(String grantWriteAcp) { this.grantWriteAcp = grantWriteAcp; return this; }
 
     public String getChecksumAlgorithm() { return checksumAlgorithm; }
     public PutObjectOptions withChecksumAlgorithm(String checksumAlgorithm) { this.checksumAlgorithm = checksumAlgorithm; return this; }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3AclIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3AclIntegrationTest.java
@@ -326,4 +326,52 @@ class S3AclIntegrationTest {
             .statusCode(501)
             .body(containsString("NotImplemented"));
     }
+
+    // Regression coverage for a second empty-body pitfall found in review: calling PutObjectAcl/
+    // PutBucketAcl with neither a canned/explicit ACL header NOR a body must not store the empty
+    // body as the ACL (that would break the next GetObjectAcl/GetBucketAcl the same way the
+    // header-with-empty-body bug did).
+
+    @Test
+    @Order(15)
+    void putObjectAclWithNoHeadersAndNoBodyKeepsDefaultAcl() {
+        given()
+            .body("acl no-op target")
+        .when()
+            .put("/" + BUCKET + "/acl-noop.txt")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .put("/" + BUCKET + "/acl-noop.txt?acl")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "/acl-noop.txt?acl")
+        .then()
+            .statusCode(200)
+            .body(not(containsString(ALL_USERS_GROUP_URI)))
+            .body(containsString("<Permission>FULL_CONTROL</Permission>"));
+    }
+
+    @Test
+    @Order(16)
+    void putBucketAclWithNoHeadersAndNoBodyKeepsDefaultAcl() {
+        given()
+        .when()
+            .put("/" + BUCKET + "?acl")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "?acl")
+        .then()
+            .statusCode(200)
+            .body(not(containsString(ALL_USERS_GROUP_URI)))
+            .body(containsString("<Permission>FULL_CONTROL</Permission>"));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3AclIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3AclIntegrationTest.java
@@ -163,4 +163,167 @@ class S3AclIntegrationTest {
             .body(containsString("InvalidArgument"))
             .body(containsString("Unsupported x-amz-acl value"));
     }
+
+    // Regression coverage for PutObjectAcl/PutBucketAcl not reading canned/explicit ACL headers:
+    // AWS SDKs send canned and explicit-grant ACLs to the ?acl subresource as headers with an
+    // EMPTY body (there is no XML for those forms - only for a raw AccessControlPolicy document).
+    // Before this fix, the empty body was stored verbatim as the object's ACL, and the next
+    // GetObjectAcl returned that empty string, which SDK XML parsers reject outright.
+
+    @Test
+    @Order(8)
+    void putObjectAclAppliesCannedAclFromHeaderWithEmptyBody() {
+        given()
+            .body("acl subresource body")
+        .when()
+            .put("/" + BUCKET + "/acl-subresource.txt")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("x-amz-acl", "public-read")
+        .when()
+            .put("/" + BUCKET + "/acl-subresource.txt?acl")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "/acl-subresource.txt?acl")
+        .then()
+            .statusCode(200)
+            .body(containsString(ALL_USERS_GROUP_URI))
+            .body(containsString("<Permission>READ</Permission>"))
+            .body(containsString("<Permission>FULL_CONTROL</Permission>"));
+    }
+
+    @Test
+    @Order(9)
+    void putObjectAclBucketOwnerFullControlReplacesPriorGrants() {
+        given()
+            .header("x-amz-acl", "public-read")
+            .body("owner-full-control target")
+        .when()
+            .put("/" + BUCKET + "/owner-full-control.txt")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "/owner-full-control.txt?acl")
+        .then()
+            .statusCode(200)
+            .body(containsString(ALL_USERS_GROUP_URI));
+
+        given()
+            .header("x-amz-acl", "bucket-owner-full-control")
+        .when()
+            .put("/" + BUCKET + "/owner-full-control.txt?acl")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "/owner-full-control.txt?acl")
+        .then()
+            .statusCode(200)
+            .body(not(containsString(ALL_USERS_GROUP_URI)))
+            .body(containsString("<Permission>FULL_CONTROL</Permission>"));
+    }
+
+    @Test
+    @Order(10)
+    void putBucketAclAppliesCannedAclFromHeaderWithEmptyBody() {
+        given()
+            .header("x-amz-acl", "public-read")
+        .when()
+            .put("/" + BUCKET + "?acl")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "?acl")
+        .then()
+            .statusCode(200)
+            .body(containsString(ALL_USERS_GROUP_URI))
+            .body(containsString("<Permission>READ</Permission>"));
+    }
+
+    // Regression coverage for explicit ACL grant headers (x-amz-grant-*) being ignored entirely
+    // on PutObject/CopyObject - previously only canned ACLs (x-amz-acl) were applied.
+
+    @Test
+    @Order(11)
+    void putObjectAppliesExplicitGrantReadHeaderToAllUsersGroup() {
+        given()
+            .header("x-amz-grant-read", "uri=\"" + ALL_USERS_GROUP_URI + "\"")
+            .body("explicit grant body")
+        .when()
+            .put("/" + BUCKET + "/explicit-grant-put.txt")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "/explicit-grant-put.txt?acl")
+        .then()
+            .statusCode(200)
+            .body(containsString(ALL_USERS_GROUP_URI))
+            .body(containsString("<Permission>READ</Permission>"))
+            .body(containsString("<Permission>FULL_CONTROL</Permission>"));
+    }
+
+    @Test
+    @Order(12)
+    void copyObjectAppliesExplicitGrantReadHeaderToAllUsersGroup() {
+        given()
+            .header("x-amz-copy-source", "/" + BUCKET + "/copy-source.txt")
+            .header("x-amz-grant-read", "uri=\"" + ALL_USERS_GROUP_URI + "\"")
+        .when()
+            .put("/" + BUCKET + "/explicit-grant-copy.txt")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "/explicit-grant-copy.txt?acl")
+        .then()
+            .statusCode(200)
+            .body(containsString(ALL_USERS_GROUP_URI))
+            .body(containsString("<Permission>READ</Permission>"));
+    }
+
+    @Test
+    @Order(13)
+    void putObjectAppliesExplicitGrantHeaderWithMultipleGrantees() {
+        given()
+            .header("x-amz-grant-read", "uri=\"" + ALL_USERS_GROUP_URI + "\", uri=\"" + AUTHENTICATED_USERS_GROUP_URI + "\"")
+            .body("multi-grantee body")
+        .when()
+            .put("/" + BUCKET + "/explicit-grant-multi.txt")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "/explicit-grant-multi.txt?acl")
+        .then()
+            .statusCode(200)
+            .body(containsString(ALL_USERS_GROUP_URI))
+            .body(containsString(AUTHENTICATED_USERS_GROUP_URI));
+    }
+
+    @Test
+    @Order(14)
+    void putObjectRejectsExplicitGrantByEmailAddress() {
+        given()
+            .header("x-amz-grant-read", "emailAddress=\"someone@example.com\"")
+            .body("unsupported grantee")
+        .when()
+            .put("/" + BUCKET + "/explicit-grant-email.txt")
+        .then()
+            .statusCode(501)
+            .body(containsString("NotImplemented"));
+    }
 }


### PR DESCRIPTION
Closes #1766 #1767 

PutObjectAcl/PutBucketAcl ignored x-amz-acl and x-amz-grant-* headers, storing the raw (often empty) request body as the ACL verbatim. AWS SDKs send canned ACLs to these endpoints as a header with an empty body, so a canned-ACL update corrupted the stored ACL and the next GetObjectAcl failed client-side XML parsing with "Premature end of file".

PutObject/CopyObject also silently dropped x-amz-grant-* (explicit ACL grant) headers - no error, just a missing grant.

Add resolveObjectAclXml() to parse canned ACLs and explicit grant headers (uri=/id=/emailAddress= tokens, comma-separated per grantee header) into proper Grant XML, and wire it into all four call sites: PutObject, CopyObject, PutObjectAcl, PutBucketAcl. emailAddress grantees return 501 (no account directory to resolve them against).

Add regression coverage in S3AclIntegrationTest for both the header-with-empty-body case and explicit multi-grantee headers.

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [X] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [X] `./mvnw test` passes locally
- [X] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
