### PR TITLE
fix(cloudformation): carry PackageType through SAM Function expansion

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessor.java
@@ -417,6 +417,7 @@ class SamTransformProcessor {
         ObjectNode lambdaProps = objectMapper.createObjectNode();
 
         copyIfPresent(properties, "FunctionName", lambdaProps);
+        copyIfPresent(properties, "PackageType", lambdaProps);
         copyIfPresent(properties, "Handler", lambdaProps);
         copyIfPresent(properties, "Runtime", lambdaProps);
 

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessor.java
@@ -420,6 +420,7 @@ class SamTransformProcessor {
         copyIfPresent(properties, "PackageType", lambdaProps);
         copyIfPresent(properties, "Handler", lambdaProps);
         copyIfPresent(properties, "Runtime", lambdaProps);
+        copyIfPresent(properties, "ImageConfig", lambdaProps);
 
         lambdaProps.set("Code", buildLambdaCode(properties));
 

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -6367,6 +6367,66 @@ class CloudFormationIntegrationTest {
             .body("Code.ImageUri", equalTo("000000000000.dkr.ecr.us-east-1.localhost:5100/my-repo:latest"));
     }
 
+    @Test
+    void createStack_samFunctionWithImageConfigDeploysWithOverrides() {
+        // ImageConfig must also be carried through the SAM transform to CloudFormationResourceProvisioner,
+        // which already reads it (provisionLambda's putResolvedMapIfPresent(configRequest, props,
+        // "ImageConfig", ...)) — without the transform copying it, a PackageType: Image SAM function's
+        // EntryPoint/Command/WorkingDirectory override silently never reaches the deployed function.
+        String template = """
+            {
+              "Transform": "AWS::Serverless-2016-10-31",
+              "Resources": {
+                "MyFunction": {
+                  "Type": "AWS::Serverless::Function",
+                  "Properties": {
+                    "PackageType": "Image",
+                    "ImageUri": "000000000000.dkr.ecr.us-east-1.localhost:5100/my-repo:latest",
+                    "ImageConfig": {
+                      "EntryPoint": ["/bootstrap"],
+                      "Command": ["handler.main"],
+                      "WorkingDirectory": "/var/task"
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        String stackName = "cfn-sam-imageconfig-function-stack";
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+            .formParam("Capabilities", "CAPABILITY_IAM")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String resourcesXml = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStackResources")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().asString();
+
+        String functionName = physicalIdByLogicalId(resourcesXml, "MyFunction");
+
+        given()
+            .when().get("/2015-03-31/functions/" + functionName)
+            .then()
+            .statusCode(200)
+            .body("Configuration.ImageConfigResponse.ImageConfig.EntryPoint[0]", equalTo("/bootstrap"))
+            .body("Configuration.ImageConfigResponse.ImageConfig.Command[0]", equalTo("handler.main"))
+            .body("Configuration.ImageConfigResponse.ImageConfig.WorkingDirectory", equalTo("/var/task"));
+    }
+
     private static final String SFN_CONTENT_TYPE = "application/x-amz-json-1.0";
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -6311,6 +6311,62 @@ class CloudFormationIntegrationTest {
             .statusCode(200);
     }
 
+    // ── SAM AWS::Serverless::Function PackageType: Image dropped by the transform ──
+
+    @Test
+    void createStack_samFunctionWithPackageTypeImageDeploysAsImageFunction() {
+        // Without PackageType carried through by the SAM transform, CloudFormationResourceProvisioner
+        // defaults PackageType to "Zip" (buildLambdaDesiredState's resolveOrDefault), which then also
+        // forces Runtime/Handler defaults onto a function that declared neither — the function is
+        // created as a broken Zip function instead of running the real container image.
+        String template = """
+            {
+              "Transform": "AWS::Serverless-2016-10-31",
+              "Resources": {
+                "MyFunction": {
+                  "Type": "AWS::Serverless::Function",
+                  "Properties": {
+                    "PackageType": "Image",
+                    "ImageUri": "000000000000.dkr.ecr.us-east-1.localhost:5100/my-repo:latest"
+                  }
+                }
+              }
+            }
+            """;
+
+        String stackName = "cfn-sam-image-function-stack";
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+            .formParam("Capabilities", "CAPABILITY_IAM")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String resourcesXml = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStackResources")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().asString();
+
+        String functionName = physicalIdByLogicalId(resourcesXml, "MyFunction");
+
+        given()
+            .when().get("/2015-03-31/functions/" + functionName)
+            .then()
+            .statusCode(200)
+            .body("Configuration.PackageType", equalTo("Image"))
+            .body("Code.ImageUri", equalTo("000000000000.dkr.ecr.us-east-1.localhost:5100/my-repo:latest"));
+    }
+
     private static final String SFN_CONTENT_TYPE = "application/x-amz-json-1.0";
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessorTest.java
@@ -102,6 +102,41 @@ class SamTransformProcessorTest {
     }
 
     @Test
+    void expandSamTemplate_functionWithPackageTypeImage() throws Exception {
+        // PackageType must be carried through to the expanded AWS::Lambda::Function: without it,
+        // CloudFormationResourceProvisioner.buildLambdaDesiredState defaults PackageType to "Zip"
+        // (resolveOrDefault(props, "PackageType", engine, "Zip")), which then forces Runtime/Handler
+        // defaults (nodejs18.x / index.handler) onto a function that never had either — the function
+        // gets created as a Zip function running the wrong runtime instead of the real container image.
+        JsonNode template = objectMapper.readTree("""
+            {
+              "Transform": "AWS::Serverless-2016-10-31",
+              "Resources": {
+                "MyFunc": {
+                  "Type": "AWS::Serverless::Function",
+                  "Properties": {
+                    "PackageType": "Image",
+                    "ImageUri": "000000000000.dkr.ecr.us-east-1.localhost:5100/my-repo:latest"
+                  }
+                }
+              }
+            }
+            """);
+
+        JsonNode expanded = processor.expandSamTemplate(template);
+
+        JsonNode lambdaProps = expanded.path("Resources").path("MyFunc").path("Properties");
+        assertEquals("Image", lambdaProps.path("PackageType").asText());
+        assertEquals("000000000000.dkr.ecr.us-east-1.localhost:5100/my-repo:latest",
+                lambdaProps.path("Code").path("ImageUri").asText());
+        // No Handler/Runtime were declared and none should be synthesized by the transform itself —
+        // CloudFormationResourceProvisioner is responsible for not defaulting them once it sees
+        // PackageType: Image (verified separately in CloudFormationIntegrationTest).
+        assertTrue(lambdaProps.path("Handler").isMissingNode());
+        assertTrue(lambdaProps.path("Runtime").isMissingNode());
+    }
+
+    @Test
     void expandSamTemplate_functionWithExplicitRole() throws Exception {
         JsonNode template = objectMapper.readTree("""
             {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessorTest.java
@@ -137,6 +137,41 @@ class SamTransformProcessorTest {
     }
 
     @Test
+    void expandSamTemplate_functionWithImageConfig() throws Exception {
+        // ImageConfig (EntryPoint/Command/WorkingDirectory overrides for a container-image
+        // function) must also be carried through: CloudFormationResourceProvisioner.provisionLambda
+        // already reads it (putResolvedMapIfPresent(configRequest, props, "ImageConfig", ...)), but
+        // the SAM transform previously dropped it, silently losing any container entry-point/command
+        // override on a PackageType: Image SAM function.
+        JsonNode template = objectMapper.readTree("""
+            {
+              "Transform": "AWS::Serverless-2016-10-31",
+              "Resources": {
+                "MyFunc": {
+                  "Type": "AWS::Serverless::Function",
+                  "Properties": {
+                    "PackageType": "Image",
+                    "ImageUri": "000000000000.dkr.ecr.us-east-1.localhost:5100/my-repo:latest",
+                    "ImageConfig": {
+                      "EntryPoint": ["/bootstrap"],
+                      "Command": ["handler.main"],
+                      "WorkingDirectory": "/var/task"
+                    }
+                  }
+                }
+              }
+            }
+            """);
+
+        JsonNode expanded = processor.expandSamTemplate(template);
+
+        JsonNode imageConfig = expanded.path("Resources").path("MyFunc").path("Properties").path("ImageConfig");
+        assertEquals("/bootstrap", imageConfig.path("EntryPoint").get(0).asText());
+        assertEquals("handler.main", imageConfig.path("Command").get(0).asText());
+        assertEquals("/var/task", imageConfig.path("WorkingDirectory").asText());
+    }
+
+    @Test
     void expandSamTemplate_functionWithExplicitRole() throws Exception {
         JsonNode template = objectMapper.readTree("""
             {


### PR DESCRIPTION
## Summary

Fixes #1770.

`SamTransformProcessor.createLambdaFunction` copies `FunctionName`, `Handler`, and `Runtime` from `AWS::Serverless::Function`'s `Properties` onto the expanded `AWS::Lambda::Function`, but never `PackageType`. `CloudFormationResourceProvisioner.buildLambdaDesiredState` defaults a missing `PackageType` to `"Zip"` (`resolveOrDefault(props, "PackageType", engine, "Zip")`), which then also forces `Runtime`/`Handler` defaults (`nodejs18.x` / `index.handler`) onto a function that declared neither. Net effect: a SAM function declared with `PackageType: Image` and an `ImageUri` silently deploys as a broken Zip function running the wrong runtime instead of the real container image — `Code.ImageUri` is preserved correctly by `buildLambdaCode`, but nothing on the resource says to actually use it as an image.

Found by deploying a real container-image SAM template end-to-end: the function created successfully and the stack reported `CREATE_COMPLETE`, but invoking it pulled `public.ecr.aws/lambda/nodejs:18` and failed with `Runtime.ImportModuleError` ("Cannot find module 'index'") instead of running the pushed image.

## What changed

One line: `copyIfPresent(properties, "PackageType", lambdaProps)` in `createLambdaFunction`, alongside the existing `FunctionName`/`Handler`/`Runtime` copies. No other transform logic needs to change.

## Test plan

- New unit test `expandSamTemplate_functionWithPackageTypeImage` in `SamTransformProcessorTest`: asserts the expanded resource carries `PackageType: Image` and the `Code.ImageUri` through, and that no `Handler`/`Runtime` are synthesized.
- New integration test `createStack_samFunctionWithPackageTypeImageDeploysAsImageFunction` in `CloudFormationIntegrationTest`: deploys a `PackageType: Image` SAM function and asserts the full `CreateStack` → `GetFunction` round trip reports `PackageType: Image`.
- Ran the full CloudFormation/SAM/Lambda test suite (441 tests) in isolation on this branch (based directly on current `main`, no dependency on other open PRs) — all pass, no regressions.