### PR TITLE
fix: register persisted model types for native-image reflection

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/model/Account.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/model/Account.java
@@ -1,11 +1,14 @@
 package io.github.hectorvent.floci.services.apigateway.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@RegisterForReflection
 public class Account {
 
     private String apiKeyVersion = "4";

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/model/ApiGatewayResource.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/model/ApiGatewayResource.java
@@ -1,11 +1,14 @@
 package io.github.hectorvent.floci.services.apigateway.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@RegisterForReflection
 public class ApiGatewayResource {
 
     private String id;

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/model/Deployment.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/model/Deployment.java
@@ -1,8 +1,11 @@
 package io.github.hectorvent.floci.services.apigateway.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@RegisterForReflection
 public record Deployment(
         String id,
         String description,

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/model/EndpointConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/model/EndpointConfiguration.java
@@ -1,11 +1,14 @@
 package io.github.hectorvent.floci.services.apigateway.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@RegisterForReflection
 public class EndpointConfiguration {
 
     private List<EndpointType> types = new ArrayList<>();

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/model/EndpointType.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/model/EndpointType.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.apigateway.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public enum EndpointType {
     REGIONAL,
     EDGE,

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/model/Integration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/model/Integration.java
@@ -1,11 +1,14 @@
 package io.github.hectorvent.floci.services.apigateway.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@RegisterForReflection
 public class Integration {
 
     private String type;          // MOCK, HTTP, AWS, HTTP_PROXY, AWS_PROXY

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/model/IntegrationResponse.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/model/IntegrationResponse.java
@@ -1,10 +1,13 @@
 package io.github.hectorvent.floci.services.apigateway.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@RegisterForReflection
 public record IntegrationResponse(
         String statusCode,
         String selectionPattern,

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/model/MethodConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/model/MethodConfig.java
@@ -1,11 +1,14 @@
 package io.github.hectorvent.floci.services.apigateway.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@RegisterForReflection
 public class MethodConfig {
 
     private String httpMethod;

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/model/MethodResponse.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/model/MethodResponse.java
@@ -1,10 +1,13 @@
 package io.github.hectorvent.floci.services.apigateway.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@RegisterForReflection
 public record MethodResponse(
         String statusCode,
         Map<String, Boolean> responseParameters

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/model/MethodSetting.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/model/MethodSetting.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.services.apigateway.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
@@ -14,6 +16,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  * mean "no override").
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@RegisterForReflection
 public class MethodSetting {
 
     private static final int UNSET_THROTTLING_BURST_LIMIT = -1;

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/model/RestApi.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/model/RestApi.java
@@ -1,11 +1,14 @@
 package io.github.hectorvent.floci.services.apigateway.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@RegisterForReflection
 public class RestApi {
 
     private String id;

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/model/Stage.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/model/Stage.java
@@ -1,11 +1,14 @@
 package io.github.hectorvent.floci.services.apigateway.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@RegisterForReflection
 public class Stage {
 
     private String stageName;

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/model/ThrottleSettings.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/model/ThrottleSettings.java
@@ -1,8 +1,11 @@
 package io.github.hectorvent.floci.services.apigateway.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@RegisterForReflection
 public class ThrottleSettings {
 
     private Integer burstLimit = 5000;

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/AuthenticationType.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/AuthenticationType.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.appsync.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public enum AuthenticationType {
     API_KEY,
     AWS_IAM,

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/DataSourceType.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/DataSourceType.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.appsync.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public enum DataSourceType {
     NONE,
     AWS_LAMBDA,

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/ResolverKind.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/ResolverKind.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.appsync.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public enum ResolverKind {
     UNIT,
     PIPELINE

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/ResolverRuntimeName.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/ResolverRuntimeName.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.appsync.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public enum ResolverRuntimeName {
     APPSYNC_JS,
     VTL

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/SchemaCreationStatusType.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/SchemaCreationStatusType.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.appsync.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public enum SchemaCreationStatusType {
     PROCESSING,
     ACTIVE,

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/model/TypeFormat.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/model/TypeFormat.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.appsync.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public enum TypeFormat {
     SDL,
     JSON

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/CacheBehavior.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/CacheBehavior.java
@@ -1,8 +1,11 @@
 package io.github.hectorvent.floci.services.cloudfront.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.util.List;
 import java.util.Map;
 
+@RegisterForReflection
 public class CacheBehavior {
 
     private String pathPattern;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/CachePolicy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/CachePolicy.java
@@ -1,8 +1,11 @@
 package io.github.hectorvent.floci.services.cloudfront.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.Map;
 
+@RegisterForReflection
 public class CachePolicy {
 
     private String id;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/CloudFrontFunction.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/CloudFrontFunction.java
@@ -1,7 +1,10 @@
 package io.github.hectorvent.floci.services.cloudfront.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 
+@RegisterForReflection
 public class CloudFrontFunction {
 
     private String name;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/CloudFrontOriginAccessIdentity.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/CloudFrontOriginAccessIdentity.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.cloudfront.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public class CloudFrontOriginAccessIdentity {
 
     private String id;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/ContinuousDeploymentPolicy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/ContinuousDeploymentPolicy.java
@@ -1,8 +1,11 @@
 package io.github.hectorvent.floci.services.cloudfront.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.List;
 
+@RegisterForReflection
 public class ContinuousDeploymentPolicy {
 
     private String id;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/DefaultCacheBehavior.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/DefaultCacheBehavior.java
@@ -1,8 +1,11 @@
 package io.github.hectorvent.floci.services.cloudfront.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.util.List;
 import java.util.Map;
 
+@RegisterForReflection
 public class DefaultCacheBehavior {
 
     private String targetOriginId;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/Distribution.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/Distribution.java
@@ -1,8 +1,11 @@
 package io.github.hectorvent.floci.services.cloudfront.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.Map;
 
+@RegisterForReflection
 public class Distribution {
 
     private String id;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/DistributionConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/DistributionConfig.java
@@ -1,8 +1,11 @@
 package io.github.hectorvent.floci.services.cloudfront.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.util.List;
 import java.util.Map;
 
+@RegisterForReflection
 public class DistributionConfig {
 
     private String callerReference;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/FieldLevelEncryptionConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/FieldLevelEncryptionConfig.java
@@ -1,7 +1,10 @@
 package io.github.hectorvent.floci.services.cloudfront.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 
+@RegisterForReflection
 public class FieldLevelEncryptionConfig {
 
     private String id;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/FieldLevelEncryptionProfile.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/FieldLevelEncryptionProfile.java
@@ -1,7 +1,10 @@
 package io.github.hectorvent.floci.services.cloudfront.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 
+@RegisterForReflection
 public class FieldLevelEncryptionProfile {
 
     private String id;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/Invalidation.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/Invalidation.java
@@ -1,8 +1,11 @@
 package io.github.hectorvent.floci.services.cloudfront.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.List;
 
+@RegisterForReflection
 public class Invalidation {
 
     private String id;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/KeyGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/KeyGroup.java
@@ -1,8 +1,11 @@
 package io.github.hectorvent.floci.services.cloudfront.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.List;
 
+@RegisterForReflection
 public class KeyGroup {
 
     private String id;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/MonitoringSubscription.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/MonitoringSubscription.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.cloudfront.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public class MonitoringSubscription {
 
     private String distributionId;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/Origin.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/Origin.java
@@ -1,8 +1,11 @@
 package io.github.hectorvent.floci.services.cloudfront.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.util.List;
 import java.util.Map;
 
+@RegisterForReflection
 public class Origin {
 
     private String id;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/OriginAccessControl.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/OriginAccessControl.java
@@ -1,7 +1,10 @@
 package io.github.hectorvent.floci.services.cloudfront.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 
+@RegisterForReflection
 public class OriginAccessControl {
 
     private String id;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/OriginRequestPolicy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/OriginRequestPolicy.java
@@ -1,8 +1,11 @@
 package io.github.hectorvent.floci.services.cloudfront.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.Map;
 
+@RegisterForReflection
 public class OriginRequestPolicy {
 
     private String id;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/PublicKey.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/PublicKey.java
@@ -1,7 +1,10 @@
 package io.github.hectorvent.floci.services.cloudfront.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 
+@RegisterForReflection
 public class PublicKey {
 
     private String id;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/RealtimeLogConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/RealtimeLogConfig.java
@@ -1,8 +1,11 @@
 package io.github.hectorvent.floci.services.cloudfront.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.util.List;
 import java.util.Map;
 
+@RegisterForReflection
 public class RealtimeLogConfig {
 
     private String arn;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/ResponseHeadersPolicy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/ResponseHeadersPolicy.java
@@ -1,8 +1,11 @@
 package io.github.hectorvent.floci.services.cloudfront.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.Map;
 
+@RegisterForReflection
 public class ResponseHeadersPolicy {
 
     private String id;

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/StreamingDistribution.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/StreamingDistribution.java
@@ -1,8 +1,11 @@
 package io.github.hectorvent.floci.services.cloudfront.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.List;
 
+@RegisterForReflection
 public class StreamingDistribution {
 
     private String id;

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/model/RevokedTokenInfo.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/model/RevokedTokenInfo.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.services.cognito.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -7,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Information about a revoked token for tracking and validation purposes.
  * Used to implement AWS Cognito AdminUserGlobalSignOut token revocation behavior.
  */
+@RegisterForReflection
 public class RevokedTokenInfo {
     
     private final String jti;

--- a/src/main/java/io/github/hectorvent/floci/services/iot/model/IotCertificate.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/model/IotCertificate.java
@@ -1,9 +1,12 @@
 package io.github.hectorvent.floci.services.iot.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.Map;
 import java.util.TreeMap;
 
+@RegisterForReflection
 public class IotCertificate {
     private String certificateId;
     private String certificateArn;

--- a/src/main/java/io/github/hectorvent/floci/services/iot/model/IotJob.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/model/IotJob.java
@@ -1,9 +1,12 @@
 package io.github.hectorvent.floci.services.iot.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
+@RegisterForReflection
 public class IotJob {
 
     private String jobId;

--- a/src/main/java/io/github/hectorvent/floci/services/iot/model/IotJobExecution.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/model/IotJobExecution.java
@@ -1,9 +1,12 @@
 package io.github.hectorvent.floci.services.iot.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
+@RegisterForReflection
 public class IotJobExecution {
 
     private String jobId;

--- a/src/main/java/io/github/hectorvent/floci/services/iot/model/IotPolicy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/model/IotPolicy.java
@@ -1,11 +1,14 @@
 package io.github.hectorvent.floci.services.iot.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+@RegisterForReflection
 public class IotPolicy {
     private String policyName;
     private String policyArn;
@@ -30,6 +33,7 @@ public class IotPolicy {
     public Map<String, String> getTags() { return tags == null ? Map.of() : tags; }
     public void setTags(Map<String, String> tags) { this.tags = tags == null ? new TreeMap<>() : new TreeMap<>(tags); }
 
+    @RegisterForReflection
     public static class PolicyVersion {
         private String versionId;
         private String document;

--- a/src/main/java/io/github/hectorvent/floci/services/iot/model/IotRetainedMessage.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/model/IotRetainedMessage.java
@@ -1,7 +1,10 @@
 package io.github.hectorvent.floci.services.iot.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 
+@RegisterForReflection
 public class IotRetainedMessage {
     private String topic;
     private String payload;

--- a/src/main/java/io/github/hectorvent/floci/services/iot/model/IotShadow.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/model/IotShadow.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.iot.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public class IotShadow {
     private String thingName;
     private String shadowName;

--- a/src/main/java/io/github/hectorvent/floci/services/iot/model/IotThingGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/model/IotThingGroup.java
@@ -1,9 +1,12 @@
 package io.github.hectorvent.floci.services.iot.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
+@RegisterForReflection
 public class IotThingGroup {
 
     private String thingGroupName;

--- a/src/main/java/io/github/hectorvent/floci/services/iot/model/IotThingType.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/model/IotThingType.java
@@ -1,9 +1,12 @@
 package io.github.hectorvent.floci.services.iot.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
+@RegisterForReflection
 public class IotThingType {
 
     private String thingTypeName;

--- a/src/main/java/io/github/hectorvent/floci/services/iot/model/IotTopicRule.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/model/IotTopicRule.java
@@ -1,9 +1,12 @@
 package io.github.hectorvent.floci.services.iot.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.Map;
 import java.util.TreeMap;
 
+@RegisterForReflection
 public class IotTopicRule {
     private String ruleName;
     private String ruleArn;

--- a/src/main/java/io/github/hectorvent/floci/services/iot/model/Thing.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/model/Thing.java
@@ -1,9 +1,12 @@
 package io.github.hectorvent.floci.services.iot.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
+@RegisterForReflection
 public class Thing {
 
     private String thingName;

--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/model/KinesisShard.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/model/KinesisShard.java
@@ -51,6 +51,9 @@ public class KinesisShard {
     public Instant getCreationTimestamp() { return creationTimestamp; }
     public void setCreationTimestamp(Instant timestamp) { this.creationTimestamp = timestamp; }
 
+    @RegisterForReflection
     public record HashKeyRange(String startingHashKey, String endingHashKey) {}
+
+    @RegisterForReflection
     public record SequenceNumberRange(String startingSequenceNumber, String endingSequenceNumber) {}
 }

--- a/src/main/java/io/github/hectorvent/floci/services/memorydb/model/Endpoint.java
+++ b/src/main/java/io/github/hectorvent/floci/services/memorydb/model/Endpoint.java
@@ -1,3 +1,6 @@
 package io.github.hectorvent.floci.services.memorydb.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public record Endpoint(String address, int port) {}

--- a/src/main/java/io/github/hectorvent/floci/services/route53/model/AliasTarget.java
+++ b/src/main/java/io/github/hectorvent/floci/services/route53/model/AliasTarget.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.route53.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public class AliasTarget {
 
     private String hostedZoneId;

--- a/src/main/java/io/github/hectorvent/floci/services/route53/model/ChangeInfo.java
+++ b/src/main/java/io/github/hectorvent/floci/services/route53/model/ChangeInfo.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.route53.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public class ChangeInfo {
 
     private String id;

--- a/src/main/java/io/github/hectorvent/floci/services/route53/model/HealthCheck.java
+++ b/src/main/java/io/github/hectorvent/floci/services/route53/model/HealthCheck.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.route53.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public class HealthCheck {
 
     private String id;

--- a/src/main/java/io/github/hectorvent/floci/services/route53/model/HealthCheckConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/services/route53/model/HealthCheckConfig.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.route53.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public class HealthCheckConfig {
 
     private String type;

--- a/src/main/java/io/github/hectorvent/floci/services/route53/model/HostedZone.java
+++ b/src/main/java/io/github/hectorvent/floci/services/route53/model/HostedZone.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.route53.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public class HostedZone {
 
     private String id;

--- a/src/main/java/io/github/hectorvent/floci/services/route53/model/ResourceRecord.java
+++ b/src/main/java/io/github/hectorvent/floci/services/route53/model/ResourceRecord.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.route53.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public class ResourceRecord {
 
     private String value;

--- a/src/main/java/io/github/hectorvent/floci/services/route53/model/ResourceRecordSet.java
+++ b/src/main/java/io/github/hectorvent/floci/services/route53/model/ResourceRecordSet.java
@@ -1,7 +1,10 @@
 package io.github.hectorvent.floci.services.route53.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.util.List;
 
+@RegisterForReflection
 public class ResourceRecordSet {
 
     private String name;

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/ObjectLockRetention.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/ObjectLockRetention.java
@@ -1,3 +1,6 @@
 package io.github.hectorvent.floci.services.s3.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public record ObjectLockRetention(String mode, String unit, int value) {}

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/model/Secret.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/model/Secret.java
@@ -29,6 +29,7 @@ public class Secret {
     private Instant lastRotatedDate;
     private Instant nextRotationDate;
 
+    @RegisterForReflection
     public record RotationRules(
             @JsonProperty("AutomaticallyAfterDays") Integer automaticallyAfterDays,
             @JsonProperty("Duration") String duration,
@@ -38,6 +39,7 @@ public class Secret {
     public Secret() {
     }
 
+    @RegisterForReflection
     public record Tag(
             @JsonProperty("Key") String key,
             @JsonProperty("Value") String value) {

--- a/src/main/java/io/github/hectorvent/floci/services/transfer/model/HomeDirectoryMapping.java
+++ b/src/main/java/io/github/hectorvent/floci/services/transfer/model/HomeDirectoryMapping.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.transfer.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
 public class HomeDirectoryMapping {
 
     private String entry;

--- a/src/main/java/io/github/hectorvent/floci/services/transfer/model/Server.java
+++ b/src/main/java/io/github/hectorvent/floci/services/transfer/model/Server.java
@@ -1,9 +1,12 @@
 package io.github.hectorvent.floci.services.transfer.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+@RegisterForReflection
 public class Server {
 
     private String serverId;

--- a/src/main/java/io/github/hectorvent/floci/services/transfer/model/SshPublicKey.java
+++ b/src/main/java/io/github/hectorvent/floci/services/transfer/model/SshPublicKey.java
@@ -1,7 +1,10 @@
 package io.github.hectorvent.floci.services.transfer.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.time.Instant;
 
+@RegisterForReflection
 public class SshPublicKey {
 
     private String sshPublicKeyId;

--- a/src/main/java/io/github/hectorvent/floci/services/transfer/model/User.java
+++ b/src/main/java/io/github/hectorvent/floci/services/transfer/model/User.java
@@ -1,8 +1,11 @@
 package io.github.hectorvent.floci.services.transfer.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.util.List;
 import java.util.Map;
 
+@RegisterForReflection
 public class User {
 
     private String userName;

--- a/src/test/java/io/github/hectorvent/floci/core/storage/PersistedModelReflectionTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/storage/PersistedModelReflectionTest.java
@@ -1,0 +1,200 @@
+package io.github.hectorvent.floci.core.storage;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Guards against the native-image persistence bug class fixed in PR #1695: every type
+ * reachable from a {@link StorageFactory#create} {@code TypeReference<Map<String, V>>}
+ * must carry {@code @RegisterForReflection} (directly or via a {@code targets = ...}
+ * registration), or native-image builds fail to deserialize persisted state on restart.
+ *
+ * <p>Persistence roots are detected statically: anonymous {@link TypeReference} subclasses
+ * whose enclosing class owns a {@link StorageBackend}/{@link StorageBackedMap} field or a
+ * {@link StorageFactory} constructor parameter, and whose captured type has the persistence
+ * shape {@code Map<String, V>}. The reachable graph then follows non-static, non-transient,
+ * non-{@code @JsonIgnore} fields (including generic type arguments and superclasses) within
+ * the project package.
+ */
+class PersistedModelReflectionTest {
+
+    private static final String BASE_PACKAGE = "io.github.hectorvent.floci";
+
+    @Test
+    void persistedTypesAreRegisteredForReflection() throws Exception {
+        List<Class<?>> projectClasses = loadProjectClasses();
+        assertFalse(projectClasses.isEmpty(), "Project class scan found nothing — scan is broken");
+
+        Set<Class<?>> registered = collectRegistered(projectClasses);
+        Set<Class<?>> roots = findPersistenceRoots(projectClasses);
+        assertFalse(roots.isEmpty(), "No persistence roots found — root detection is broken");
+
+        Set<Class<?>> reachable = walkReachable(roots);
+        List<String> violations = reachable.stream()
+                .filter(c -> !c.isInterface())
+                .filter(c -> !registered.contains(c))
+                .map(Class::getName)
+                .sorted()
+                .toList();
+
+        assertTrue(violations.isEmpty(), () ->
+                "Types reachable from persisted storage are missing @RegisterForReflection"
+                        + " (native-image persistence breaks on restart without it):\n  "
+                        + String.join("\n  ", violations));
+    }
+
+    private List<Class<?>> loadProjectClasses() throws Exception {
+        URI codeSource = StorageFactory.class.getProtectionDomain().getCodeSource().getLocation().toURI();
+        Path classesDir = Path.of(codeSource);
+        List<Class<?>> classes = new ArrayList<>();
+        try (Stream<Path> paths = Files.walk(classesDir)) {
+            paths.filter(p -> p.toString().endsWith(".class"))
+                    .forEach(p -> {
+                        String name = classesDir.relativize(p).toString()
+                                .replace(java.io.File.separatorChar, '.')
+                                .replaceAll("\\.class$", "");
+                        if (!name.startsWith(BASE_PACKAGE)) {
+                            return;
+                        }
+                        try {
+                            classes.add(Class.forName(name, false, getClass().getClassLoader()));
+                        } catch (Throwable ignored) {
+                            // Optional dependencies may be absent at test time; such classes
+                            // cannot host persisted state reachable from a loadable root.
+                        }
+                    });
+        }
+        return classes;
+    }
+
+    private Set<Class<?>> collectRegistered(List<Class<?>> projectClasses) {
+        Set<Class<?>> registered = new LinkedHashSet<>();
+        for (Class<?> c : projectClasses) {
+            RegisterForReflection annotation = c.getAnnotation(RegisterForReflection.class);
+            if (annotation == null) {
+                continue;
+            }
+            registered.add(c);
+            for (Class<?> target : annotation.targets()) {
+                registered.add(target);
+            }
+        }
+        return registered;
+    }
+
+    private Set<Class<?>> findPersistenceRoots(List<Class<?>> projectClasses) {
+        Set<Class<?>> roots = new LinkedHashSet<>();
+        for (Class<?> c : projectClasses) {
+            if (!TypeReference.class.isAssignableFrom(c) || c == TypeReference.class) {
+                continue;
+            }
+            Class<?> enclosing = c.getEnclosingClass();
+            if (enclosing == null || !ownsStorage(enclosing)) {
+                continue;
+            }
+            Type captured = capturedType(c);
+            if (captured instanceof ParameterizedType map
+                    && map.getRawType() == Map.class
+                    && map.getActualTypeArguments()[0] == String.class) {
+                collectProjectTypes(map.getActualTypeArguments()[1], roots);
+            }
+        }
+        return roots;
+    }
+
+    private static boolean ownsStorage(Class<?> enclosing) {
+        for (Class<?> c = enclosing; c != null && c.getName().startsWith(BASE_PACKAGE); c = c.getSuperclass()) {
+            for (Field f : c.getDeclaredFields()) {
+                if (f.getType() == StorageBackend.class || f.getType() == StorageBackedMap.class) {
+                    return true;
+                }
+            }
+            for (var constructor : c.getDeclaredConstructors()) {
+                for (Class<?> param : constructor.getParameterTypes()) {
+                    if (param == StorageFactory.class) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private static Type capturedType(Class<?> typeReferenceSubclass) {
+        Type superType = typeReferenceSubclass.getGenericSuperclass();
+        if (superType instanceof ParameterizedType p && p.getRawType() == TypeReference.class) {
+            return p.getActualTypeArguments()[0];
+        }
+        return null;
+    }
+
+    private Set<Class<?>> walkReachable(Set<Class<?>> roots) {
+        Set<Class<?>> visited = new LinkedHashSet<>();
+        Deque<Class<?>> queue = new ArrayDeque<>(roots);
+        while (!queue.isEmpty()) {
+            Class<?> c = queue.pop();
+            if (!visited.add(c) || c.isEnum()) {
+                continue;
+            }
+            for (Field f : c.getDeclaredFields()) {
+                if (Modifier.isStatic(f.getModifiers())
+                        || Modifier.isTransient(f.getModifiers())
+                        || f.isAnnotationPresent(JsonIgnore.class)) {
+                    continue;
+                }
+                Set<Class<?>> fieldTypes = new LinkedHashSet<>();
+                collectProjectTypes(f.getGenericType(), fieldTypes);
+                queue.addAll(fieldTypes);
+            }
+            Class<?> superclass = c.getSuperclass();
+            if (superclass != null && superclass.getName().startsWith(BASE_PACKAGE)) {
+                queue.add(superclass);
+            }
+        }
+        return visited;
+    }
+
+    private static void collectProjectTypes(Type type, Set<Class<?>> out) {
+        if (type instanceof Class<?> c) {
+            if (c.isArray()) {
+                collectProjectTypes(c.getComponentType(), out);
+            } else if (c.getName().startsWith(BASE_PACKAGE)) {
+                out.add(c);
+            }
+        } else if (type instanceof ParameterizedType p) {
+            collectProjectTypes(p.getRawType(), out);
+            for (Type arg : p.getActualTypeArguments()) {
+                collectProjectTypes(arg, out);
+            }
+        } else if (type instanceof GenericArrayType g) {
+            collectProjectTypes(g.getGenericComponentType(), out);
+        } else if (type instanceof WildcardType w) {
+            for (Type bound : w.getUpperBounds()) {
+                collectProjectTypes(bound, out);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Registers 69 persisted model types for native-image reflection that #1695's sweep missed, and adds a recurrence guard so this class of bug fails the build instead of silently breaking persistence. Refs #1695 (no open issue tracks the remainder).

Affected: iot (all 10 persisted roots), cloudfront (20 types), apigateway (13), route53 (7), transfer (4), appsync enums (6), plus nested inner types that file-level sweeps structurally miss (memorydb `Endpoint` — reachable via `Cluster.clusterEndpoint`, missed inside #1695 itself — `Secret$RotationRules`/`$Tag`, `KinesisShard$HashKeyRange`/`$SequenceNumberRange`, `IotPolicy$PolicyVersion`).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: in native-image persistent mode, any restart failed to deserialize state for the services above — the same failure mode #1695 fixed for seven other services. JVM mode was unaffected, which is why in-tree tests never caught it.

The new `PersistedModelReflectionTest` is a plain-JUnit classpath scan (no new dependencies): it discovers every persistence-root `TypeReference<Map<String, V>>` in a storage-owning class, walks V's reachable field graph (generics, arrays, superclasses; skipping static/transient/`@JsonIgnore`), and fails with the exact list of unregistered types. It independently re-derived all 69 violations, including five inner classes a manual audit missed.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
