### PR TITLE
fix(ecs): pass LaunchedContainerAwsEnv to EcsContainerManager in volumes test

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerVolumesTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerVolumesTest.java
@@ -50,6 +50,7 @@ class EcsContainerManagerVolumesTest {
     private ContainerBuilder containerBuilder;
     private ContainerBuilder.Builder builder;
     private ContainerLifecycleManager lifecycleManager;
+    private LaunchedContainerAwsEnv awsEnv;
     private EcsContainerManager manager;
 
     @BeforeEach
@@ -66,7 +67,7 @@ class EcsContainerManagerVolumesTest {
         ContainerDetector containerDetector = mock(ContainerDetector.class);
         EmulatorConfig config = mock(EmulatorConfig.class, RETURNS_DEEP_STUBS);
         RegionResolver regionResolver = mock(RegionResolver.class);
-        LaunchedContainerAwsEnv awsEnv = mock(LaunchedContainerAwsEnv.class);
+        awsEnv = mock(LaunchedContainerAwsEnv.class);
         when(awsEnv.sdkBaselineEnv(any(), any())).thenReturn(List.of());
 
         manager = new EcsContainerManager(containerBuilder, lifecycleManager, logStreamer,
@@ -159,7 +160,7 @@ class EcsContainerManagerVolumesTest {
         when(cfg.storage().efs().initImage()).thenReturn("busybox:stable");
         EcsContainerManager configured = new EcsContainerManager(containerBuilder, lifecycleManager,
                 mock(ContainerLogStreamer.class), mock(ContainerDetector.class), cfg,
-                mock(RegionResolver.class));
+                mock(RegionResolver.class), awsEnv);
 
         ContainerDefinition app = new ContainerDefinition();
         app.setName("app");
@@ -192,7 +193,7 @@ class EcsContainerManagerVolumesTest {
         when(cfg.storage().efs().mountGroupAdd()).thenReturn(OptionalInt.of(2000));
         EcsContainerManager configured = new EcsContainerManager(containerBuilder, lifecycleManager,
                 mock(ContainerLogStreamer.class), mock(ContainerDetector.class), cfg,
-                mock(RegionResolver.class));
+                mock(RegionResolver.class), awsEnv);
 
         ContainerDefinition app = new ContainerDefinition();
         app.setName("app");


### PR DESCRIPTION
## Problem

`main` does not compile at HEAD. The [nightly run](https://github.com/floci-io/floci/actions/runs/28995892162) failed both native build jobs at `maven-compiler-plugin:testCompile`, before native compilation even started:

```
EcsContainerManagerVolumesTest.java:[160,42] constructor EcsContainerManager cannot be applied to given types;
  required: ContainerBuilder,ContainerLifecycleManager,ContainerLogStreamer,ContainerDetector,EmulatorConfig,RegionResolver,LaunchedContainerAwsEnv
  found:    ContainerBuilder,ContainerLifecycleManager,ContainerLogStreamer,ContainerDetector,EmulatorConfig,RegionResolver
```

Any `./mvnw test` or `./mvnw clean package` on `main` fails the same way.

## Cause

A semantic merge conflict between two PRs that merged an hour apart, neither of which conflicted textually:

- **#1686** (merged 04:24 UTC) added two tests, each constructing an `EcsContainerManager` inline with the then-current six-parameter constructor.
- **#1697** (merged 05:19 UTC) added a seventh constructor parameter, `LaunchedContainerAwsEnv awsEnv`, and updated the one call site it knew about — the one in `setUp()`.

#1697 was branched from `f5d8748` (the 1.5.31 release commit), which predates #1686. Its own CI was green because the two new call sites did not exist on its branch. The nightly kicked off one minute after #1697 landed and was the first build to see merged `main`.

## Fix

Hoist the `LaunchedContainerAwsEnv` mock that `setUp()` already creates into a field, and pass it at the two inline call sites.

Reusing the field rather than re-mocking matters: `startTask` iterates the return of `awsEnv.sdkBaselineEnv(region, Optional.empty())` at `EcsContainerManager.java:347`, so a bare `mock(LaunchedContainerAwsEnv.class)` would compile but NPE at runtime. The field carries the `sdkBaselineEnv(any(), any()) -> List.of()` stub.

Test-only change. No production code, no wire-protocol surface, no config or storage impact.

## Verification

- `./mvnw test -Dtest=EcsContainerManagerVolumesTest` — 4 tests, 0 failures, 0 errors.
- `./mvnw test-compile` — exit 0, zero `[ERROR]` lines. This is the exact step the nightly died on.

Compatibility suite not run: the change touches no request/response handling.

## Follow-up worth considering

Requiring branches to be up to date with `main` before merge would have caught this. Separately, the nightly was the first build to notice `main` was red — a compile check on `main` after each merge would close that window.