### PR TITLE
feat(ec2): added attach and detach volume support

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -170,7 +170,7 @@ public class AwsQueryController {
             "ModifyLaunchTemplate", "DeleteLaunchTemplate",
             "DescribeNetworkInterfaces",
             "CreateFlowLogs", "DescribeFlowLogs", "DeleteFlowLogs",
-            "CreateVolume", "DescribeVolumes", "DeleteVolume"
+            "CreateVolume", "DescribeVolumes", "DeleteVolume", "AttachVolume", "DetachVolume"
     );
 
     private final CloudFormationQueryHandler cloudFormationQueryHandler;

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -158,6 +158,8 @@ public class Ec2QueryHandler {
                 case "CreateVolume" -> handleCreateVolume(params, region);
                 case "DescribeVolumes" -> handleDescribeVolumes(params, region);
                 case "DeleteVolume" -> handleDeleteVolume(params, region);
+                case "AttachVolume" -> handleAttachVolume(params, region);
+                case "DetachVolume" -> handleDetachVolume(params, region);
                 // Spot Instances
                 case "RequestSpotInstances" -> handleRequestSpotInstances(params, region);
                 case "DescribeSpotInstanceRequests" -> handleDescribeSpotInstanceRequests(params, region);
@@ -2547,6 +2549,39 @@ public class Ec2QueryHandler {
     private Response handleDeleteVolume(MultivaluedMap<String, String> p, String region) {
         service.deleteVolume(region, p.getFirst("VolumeId"));
         return booleanResponse("DeleteVolume");
+    }
+
+    private Response handleAttachVolume(MultivaluedMap<String, String> p, String region) {
+        String volumeId = p.getFirst("VolumeId");
+        String instanceId = p.getFirst("InstanceId");
+        String device = p.getFirst("Device");
+        VolumeAttachment attachment = service.attachVolume(region, volumeId, instanceId, device);
+        return volumeAttachmentResponse("AttachVolume", attachment, "attaching");
+    }
+
+    private Response handleDetachVolume(MultivaluedMap<String, String> p, String region) {
+        String volumeId = p.getFirst("VolumeId");
+        String instanceId = p.getFirst("InstanceId");
+        String device = p.getFirst("Device");
+        boolean force = "true".equalsIgnoreCase(p.getFirst("Force"));
+        VolumeAttachment attachment = service.detachVolume(region, volumeId, instanceId, device, force);
+        return volumeAttachmentResponse("DetachVolume", attachment, "detaching");
+    }
+
+    private Response volumeAttachmentResponse(String action, VolumeAttachment attachment, String status) {
+        XmlBuilder xml = new XmlBuilder()
+                .start(action + "Response", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .elem("volumeId", attachment.getVolumeId())
+                .elem("instanceId", attachment.getInstanceId())
+                .elem("device", attachment.getDevice())
+                .elem("status", status)
+                .elem("deleteOnTermination", String.valueOf(attachment.isDeleteOnTermination()));
+        if (attachment.getAttachTime() != null) {
+            xml.elem("attachTime", ISO_FMT.format(attachment.getAttachTime()));
+        }
+        xml.end(action + "Response");
+        return xmlResponse(xml.build());
     }
 
     private String volumeXml(Volume vol) {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -2773,8 +2773,14 @@ public class Ec2Service {
                     "The parameter Device is missing", 400);
         }
         Volume volume = getRequiredVolume(region, volumeId);
-        getRequiredInstance(region, instanceId);
-
+        Instance inst = getRequiredInstance(region, instanceId);
+        if (!inst.getPlacement().getAvailabilityZone().equals(volume.getAvailabilityZone())) {
+            throw new AwsException(
+                    "InvalidParameterValue",
+                    "The volume '" + volume.getVolumeId() +
+                            "' and instance '" + inst.getInstanceId() +
+                            "' must be in the same Availability Zone", 400);
+        }
         if (!"available".equals(volume.getState())) {
             throw new AwsException("VolumeInUse",
                     "Volume '" + volumeId + "' is already attached", 400);

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -2758,6 +2758,81 @@ public class Ec2Service {
         volumes.delete(key(region, volumeId));
     }
 
+    public VolumeAttachment attachVolume(String region, String volumeId, String instanceId, String device) {
+        ensureDefaultResources(region);
+        if (volumeId == null || volumeId.isEmpty()) {
+            throw new AwsException("MissingParameter",
+                    "The parameter VolumeId is missing", 400);
+        }
+        if (instanceId == null || instanceId.isEmpty()) {
+            throw new AwsException("MissingParameter",
+                    "The parameter InstanceId is missing", 400);
+        }
+        if (device == null || device.isEmpty()) {
+            throw new AwsException("MissingParameter",
+                    "The parameter Device is missing", 400);
+        }
+        Volume volume = getRequiredVolume(region, volumeId);
+        getRequiredInstance(region, instanceId);
+
+        if (!"available".equals(volume.getState())) {
+            throw new AwsException("VolumeInUse",
+                    "Volume '" + volumeId + "' is already attached", 400);
+        }
+
+        VolumeAttachment attachment = new VolumeAttachment();
+        attachment.setVolumeId(volumeId);
+        attachment.setInstanceId(instanceId);
+        attachment.setDevice(device);
+        attachment.setState("attached");
+        attachment.setAttachTime(Instant.now());
+        attachment.setDeleteOnTermination(false); // Default for attached volumes
+
+        volume.getAttachments().add(attachment);
+        volume.setState("in-use");
+        volumes.put(key(region, volumeId), volume);
+        return attachment;
+    }
+
+    public VolumeAttachment detachVolume(String region, String volumeId, String instanceId, String device, boolean force) {
+        if (volumeId == null || volumeId.isEmpty()) {
+            throw new AwsException("MissingParameter", "The parameter VolumeId is missing", 400);
+        }
+        ensureDefaultResources(region);
+        Volume volume = getRequiredVolume(region, volumeId);
+
+        if ("available".equals(volume.getState()) || volume.getAttachments().isEmpty()) {
+            throw new AwsException("InvalidVolume.NotAttached",
+                    "Volume '" + volumeId + "' is not attached", 400);
+        }
+        VolumeAttachment target = volume.getAttachments().getFirst();
+        if (instanceId != null && !target.getInstanceId().equals(instanceId)) {
+            throw new AwsException("InvalidAttachment.NotFound",
+                    "Volume '" + volumeId + "' is not attached to instance '" + instanceId + "'", 400);
+        }
+        if (device != null && !target.getDevice().equals(device)) {
+            throw new AwsException("InvalidAttachment.NotFound",
+                    "Volume '" + volumeId + "' is not attached with device '" + device + "'", 400);
+        }
+        Instance inst = getRequiredInstance(region, target.getInstanceId());
+        if (!force && target.getDevice().equals(inst.getRootDeviceName())) {
+            throw new AwsException("InvalidParameterCombination",
+                    "Device " + inst.getRootDeviceName() + " has the root partition on it. Detaching it will damage the " +
+                            "filesystem/partition tables. To force detachment, use the force parameter", 400);
+        }
+        target.setState("detached");
+        volume.getAttachments().clear();
+        volume.setState("available");
+        volumes.put(key(region, volumeId), volume);
+        return target;
+    }
+
+    private Volume getRequiredVolume(String region, String volumeId) {
+        return volumes.get(key(region, volumeId)).orElseThrow(() ->
+                new AwsException("InvalidVolume.NotFound", "The volume '" + volumeId + "' does not exist", 400)
+        );
+    }
+
     // ─── Network Interfaces ─────────────────────────────────────────────────────
 
     public NetworkInterfaceListResult describeNetworkInterfaces(String region, List<String> networkInterfaceIds,

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -2774,6 +2774,10 @@ public class Ec2Service {
         }
         Volume volume = getRequiredVolume(region, volumeId);
         Instance inst = getRequiredInstance(region, instanceId);
+        if (!List.of("running", "stopped").contains(inst.getState().getName())) {
+            throw new AwsException("IncorrectInstanceState",
+                    "The instance '" + inst.getInstanceId() + "' is not in a state from which it can be attached", 400);
+        }
         if (!inst.getPlacement().getAvailabilityZone().equals(volume.getAvailabilityZone())) {
             throw new AwsException(
                     "InvalidParameterValue",
@@ -2825,6 +2829,10 @@ public class Ec2Service {
             throw new AwsException("InvalidParameterCombination",
                     "Device " + inst.getRootDeviceName() + " has the root partition on it. Detaching it will damage the " +
                             "filesystem/partition tables. To force detachment, use the force parameter", 400);
+        }
+        if (!inst.getState().getName().equals("stopped") && target.getDevice().equals(inst.getRootDeviceName())) {
+            throw new AwsException("OperationNotPermitted",
+                    "The root volume of an instance cannot be detached while the instance is running", 400);
         }
         target.setState("detached");
         volume.getAttachments().clear();

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -2825,14 +2825,14 @@ public class Ec2Service {
                     "Volume '" + volumeId + "' is not attached with device '" + device + "'", 400);
         }
         Instance inst = getRequiredInstance(region, target.getInstanceId());
+        if (!inst.getState().getName().equals("stopped") && target.getDevice().equals(inst.getRootDeviceName())) {
+            throw new AwsException("OperationNotPermitted",
+                    "The root volume of an instance cannot be detached while the instance is running", 400);
+        }
         if (!force && target.getDevice().equals(inst.getRootDeviceName())) {
             throw new AwsException("InvalidParameterCombination",
                     "Device " + inst.getRootDeviceName() + " has the root partition on it. Detaching it will damage the " +
                             "filesystem/partition tables. To force detachment, use the force parameter", 400);
-        }
-        if (!inst.getState().getName().equals("stopped") && target.getDevice().equals(inst.getRootDeviceName())) {
-            throw new AwsException("OperationNotPermitted",
-                    "The root volume of an instance cannot be detached while the instance is running", 400);
         }
         target.setState("detached");
         volume.getAttachments().clear();

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -18,6 +18,8 @@ import io.github.hectorvent.floci.services.ec2.model.SecurityGroup;
 import io.github.hectorvent.floci.services.ec2.model.Snapshot;
 import io.github.hectorvent.floci.services.ec2.model.Tag;
 import io.github.hectorvent.floci.services.ec2.model.VpcEndpoint;
+import io.github.hectorvent.floci.services.ec2.model.Volume;
+import io.github.hectorvent.floci.services.ec2.model.VolumeAttachment;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -313,6 +315,85 @@ class Ec2ServiceTest {
         mapping.setDeviceName("/dev/sda1");
         mapping.setEbs(ebs);
         return mapping;
+    }
+
+    @Test
+    void attachVolumeMarksVolumeInUseWithAttachmentDetails() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class), mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class),
+                new Ec2InstanceTypeCatalog(), new InMemoryStorageFactory());
+        Reservation reservation = service.runInstances("us-east-1", "ami-1234567890abcdef0", "t3.micro",
+                1, 1, null, List.of(), null, null, List.of(), null, null);
+        String instanceId = reservation.getInstances().getFirst().getInstanceId();
+        Volume volume = service.createVolume("us-east-1", "us-east-1a", "gp3", 8,
+                false, 0, null, null, List.of());
+
+        VolumeAttachment response = service.attachVolume("us-east-1", volume.getVolumeId(), instanceId, "/dev/sdf");
+
+        assertEquals(volume.getVolumeId(), response.getVolumeId());
+        assertEquals(instanceId, response.getInstanceId());
+        assertEquals("/dev/sdf", response.getDevice());
+        assertEquals("attached", response.getState());
+        assertFalse(response.isDeleteOnTermination());
+        assertEquals("in-use", volume.getState());
+        assertEquals(1, volume.getAttachments().size());
+        assertEquals(instanceId, volume.getAttachments().getFirst().getInstanceId());
+        assertEquals("/dev/sdf", volume.getAttachments().getFirst().getDevice());
+        assertEquals("attached", volume.getAttachments().getFirst().getState());
+        assertFalse(volume.getAttachments().getFirst().isDeleteOnTermination());
+    }
+
+    @Test
+    void detachVolumeMarksVolumeAvailableAndClearsAttachment() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class), mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class),
+                new Ec2InstanceTypeCatalog(), new InMemoryStorageFactory());
+        Reservation reservation = service.runInstances("us-east-1", "ami-1234567890abcdef0", "t3.micro",
+                1, 1, null, List.of(), null, null, List.of(), null, null);
+        String instanceId = reservation.getInstances().getFirst().getInstanceId();
+        Volume volume = service.createVolume("us-east-1", "us-east-1a", "gp3", 8,
+                false, 0, null, null, List.of());
+        service.attachVolume("us-east-1", volume.getVolumeId(), instanceId, "/dev/sdf");
+
+        VolumeAttachment response = service.detachVolume("us-east-1", volume.getVolumeId(), instanceId, "/dev/sdf", false);
+
+        assertEquals(volume.getVolumeId(), response.getVolumeId());
+        assertEquals(instanceId, response.getInstanceId());
+        assertEquals("/dev/sdf", response.getDevice());
+        assertEquals("detached", response.getState());
+        assertFalse(response.isDeleteOnTermination());
+        assertEquals("available", volume.getState());
+        assertTrue(volume.getAttachments().isEmpty());
+    }
+
+    @Test
+    void detachRootVolumeRequiresForce() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class), mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class),
+                new Ec2InstanceTypeCatalog(), new InMemoryStorageFactory());
+        Reservation reservation = service.runInstances("us-east-1", "ami-1234567890abcdef0", "t3.micro",
+                1, 1, null, List.of(), null, null, List.of(), null, null);
+        String instanceId = reservation.getInstances().getFirst().getInstanceId();
+        String rootVolumeId = reservation.getInstances().getFirst().getRootVolumeId();
+        String rootDeviceName = reservation.getInstances().getFirst().getRootDeviceName();
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.detachVolume("us-east-1", rootVolumeId, instanceId, rootDeviceName, false));
+
+        assertEquals("InvalidParameterCombination", error.getErrorCode());
+        AwsException errorWithoutInstanceId = assertThrows(AwsException.class,
+                () -> service.detachVolume("us-east-1", rootVolumeId, null, null, false));
+        assertEquals("InvalidParameterCombination", errorWithoutInstanceId.getErrorCode());
+
+        VolumeAttachment response = service.detachVolume("us-east-1", rootVolumeId, instanceId, rootDeviceName, true);
+        assertEquals(rootVolumeId, response.getVolumeId());
+        assertEquals(instanceId, response.getInstanceId());
+        assertEquals(rootDeviceName, response.getDevice());
+        assertEquals("detached", response.getState());
+        assertTrue(response.isDeleteOnTermination());
+
+        Volume detached = service.describeVolumes("us-east-1", List.of(rootVolumeId), Map.of()).getFirst();
+        assertEquals("available", detached.getState());
     }
 
     private static EmulatorConfig mockConfig(boolean ec2Mock) {

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -20,6 +20,7 @@ import io.github.hectorvent.floci.services.ec2.model.Tag;
 import io.github.hectorvent.floci.services.ec2.model.VpcEndpoint;
 import io.github.hectorvent.floci.services.ec2.model.Volume;
 import io.github.hectorvent.floci.services.ec2.model.VolumeAttachment;
+import io.github.hectorvent.floci.services.ec2.model.InstanceState;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -325,6 +326,7 @@ class Ec2ServiceTest {
         Reservation reservation = service.runInstances("us-east-1", "ami-1234567890abcdef0", "t3.micro",
                 1, 1, null, List.of(), null, null, List.of(), null, null);
         Instance inst = reservation.getInstances().getFirst();
+        inst.setState(InstanceState.running());
         String instanceId = inst.getInstanceId();
         String instanceAz = inst.getPlacement().getAvailabilityZone();
         Volume volume = service.createVolume("us-east-1", instanceAz, "gp3", 8,
@@ -353,6 +355,7 @@ class Ec2ServiceTest {
         Reservation reservation = service.runInstances("us-east-1", "ami-1234567890abcdef0", "t3.micro",
                 1, 1, null, List.of(), null, null, List.of(), null, null);
         Instance inst = reservation.getInstances().getFirst();
+        inst.setState(InstanceState.running());
         String instanceAz = inst.getPlacement().getAvailabilityZone();
         String volumeAz = List.of("us-east-1a", "us-east-1b", "us-east-1c").stream()
                 .filter(az -> !az.equals(instanceAz))
@@ -367,6 +370,23 @@ class Ec2ServiceTest {
     }
 
     @Test
+    void attachVolumeThrowsWithIncorrectInstanceState() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class), mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class),
+                new Ec2InstanceTypeCatalog(), new InMemoryStorageFactory());
+        Reservation reservation = service.runInstances("us-east-1", "ami-1234567890abcdef0", "t3.micro",
+                1, 1, null, List.of(), null, null, List.of(), null, null);
+        Instance inst = reservation.getInstances().getFirst();
+        inst.setState(InstanceState.pending());
+        String az = inst.getPlacement().getAvailabilityZone();
+        Volume volume = service.createVolume("us-east-1", az, "gp3", 8,
+                false, 0, null, null, List.of());
+        AwsException error = assertThrows(AwsException.class, () ->
+                service.attachVolume("us-east-1", volume.getVolumeId(), inst.getInstanceId(), "/dev/sdf"));
+        assertEquals("IncorrectInstanceState", error.getErrorCode());
+    }
+
+    @Test
     void detachVolumeMarksVolumeAvailableAndClearsAttachment() {
         Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
                 mock(Ec2PortForwardManager.class), mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class),
@@ -374,6 +394,7 @@ class Ec2ServiceTest {
         Reservation reservation = service.runInstances("us-east-1", "ami-1234567890abcdef0", "t3.micro",
                 1, 1, null, List.of(), null, null, List.of(), null, null);
         Instance inst = reservation.getInstances().getFirst();
+        inst.setState(InstanceState.running());
         String instanceId = inst.getInstanceId();
         String instanceAz = inst.getPlacement().getAvailabilityZone();
         Volume volume = service.createVolume("us-east-1", instanceAz, "gp3", 8,
@@ -393,24 +414,36 @@ class Ec2ServiceTest {
     }
 
     @Test
-    void detachRootVolumeRequiresForce() {
+    void detachRootVolumeRequiresForceAndStopped() {
         Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
                 mock(Ec2PortForwardManager.class), mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class),
                 new Ec2InstanceTypeCatalog(), new InMemoryStorageFactory());
         Reservation reservation = service.runInstances("us-east-1", "ami-1234567890abcdef0", "t3.micro",
                 1, 1, null, List.of(), null, null, List.of(), null, null);
-        String instanceId = reservation.getInstances().getFirst().getInstanceId();
-        String rootVolumeId = reservation.getInstances().getFirst().getRootVolumeId();
-        String rootDeviceName = reservation.getInstances().getFirst().getRootDeviceName();
+        Instance inst = reservation.getInstances().getFirst();
+        String instanceId = inst.getInstanceId();
+        String rootVolumeId = inst.getRootVolumeId();
+        String rootDeviceName = inst.getRootDeviceName();
 
+        // forced but not stopped
+        inst.setState(InstanceState.running());
         AwsException error = assertThrows(AwsException.class,
-                () -> service.detachVolume("us-east-1", rootVolumeId, instanceId, rootDeviceName, false));
-
-        assertEquals("InvalidParameterCombination", error.getErrorCode());
+                () -> service.detachVolume("us-east-1", rootVolumeId, instanceId, rootDeviceName, true));
+        assertEquals("OperationNotPermitted", error.getErrorCode());
         AwsException errorWithoutInstanceId = assertThrows(AwsException.class,
+                () -> service.detachVolume("us-east-1", rootVolumeId, null, null, true));
+        assertEquals("OperationNotPermitted", errorWithoutInstanceId.getErrorCode());
+
+        // stopped but not forced
+        inst.setState(InstanceState.stopped());
+        error = assertThrows(AwsException.class,
+                () -> service.detachVolume("us-east-1", rootVolumeId, instanceId, rootDeviceName, false));
+        assertEquals("InvalidParameterCombination", error.getErrorCode());
+        errorWithoutInstanceId = assertThrows(AwsException.class,
                 () -> service.detachVolume("us-east-1", rootVolumeId, null, null, false));
         assertEquals("InvalidParameterCombination", errorWithoutInstanceId.getErrorCode());
 
+        // success
         VolumeAttachment response = service.detachVolume("us-east-1", rootVolumeId, instanceId, rootDeviceName, true);
         assertEquals(rootVolumeId, response.getVolumeId());
         assertEquals(instanceId, response.getInstanceId());

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -324,10 +324,11 @@ class Ec2ServiceTest {
                 new Ec2InstanceTypeCatalog(), new InMemoryStorageFactory());
         Reservation reservation = service.runInstances("us-east-1", "ami-1234567890abcdef0", "t3.micro",
                 1, 1, null, List.of(), null, null, List.of(), null, null);
-        String instanceId = reservation.getInstances().getFirst().getInstanceId();
-        Volume volume = service.createVolume("us-east-1", "us-east-1a", "gp3", 8,
+        Instance inst = reservation.getInstances().getFirst();
+        String instanceId = inst.getInstanceId();
+        String instanceAz = inst.getPlacement().getAvailabilityZone();
+        Volume volume = service.createVolume("us-east-1", instanceAz, "gp3", 8,
                 false, 0, null, null, List.of());
-
         VolumeAttachment response = service.attachVolume("us-east-1", volume.getVolumeId(), instanceId, "/dev/sdf");
 
         assertEquals(volume.getVolumeId(), response.getVolumeId());
@@ -335,12 +336,34 @@ class Ec2ServiceTest {
         assertEquals("/dev/sdf", response.getDevice());
         assertEquals("attached", response.getState());
         assertFalse(response.isDeleteOnTermination());
-        assertEquals("in-use", volume.getState());
-        assertEquals(1, volume.getAttachments().size());
-        assertEquals(instanceId, volume.getAttachments().getFirst().getInstanceId());
-        assertEquals("/dev/sdf", volume.getAttachments().getFirst().getDevice());
-        assertEquals("attached", volume.getAttachments().getFirst().getState());
-        assertFalse(volume.getAttachments().getFirst().isDeleteOnTermination());
+        Volume attached = service.describeVolumes("us-east-1", List.of(volume.getVolumeId()), Map.of()).getFirst();
+        assertEquals("in-use", attached.getState());
+        assertEquals(1, attached.getAttachments().size());
+        assertEquals(instanceId, attached.getAttachments().getFirst().getInstanceId());
+        assertEquals("/dev/sdf", attached.getAttachments().getFirst().getDevice());
+        assertEquals("attached", attached.getAttachments().getFirst().getState());
+        assertFalse(attached.getAttachments().getFirst().isDeleteOnTermination());
+    }
+
+    @Test
+    void attachVolumeThrowsWithDifferentAZ() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class), mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class),
+                new Ec2InstanceTypeCatalog(), new InMemoryStorageFactory());
+        Reservation reservation = service.runInstances("us-east-1", "ami-1234567890abcdef0", "t3.micro",
+                1, 1, null, List.of(), null, null, List.of(), null, null);
+        Instance inst = reservation.getInstances().getFirst();
+        String instanceAz = inst.getPlacement().getAvailabilityZone();
+        String volumeAz = List.of("us-east-1a", "us-east-1b", "us-east-1c").stream()
+                .filter(az -> !az.equals(instanceAz))
+                .findFirst()
+                .orElseThrow();
+        Volume volume = service.createVolume("us-east-1", volumeAz, "gp3", 8,
+                false, 0, null, null, List.of());
+
+        AwsException error = assertThrows(AwsException.class, () ->
+                service.attachVolume("us-east-1", volume.getVolumeId(), inst.getInstanceId(), "/dev/sdf"));
+        assertEquals("InvalidParameterValue", error.getErrorCode());
     }
 
     @Test
@@ -350,8 +373,10 @@ class Ec2ServiceTest {
                 new Ec2InstanceTypeCatalog(), new InMemoryStorageFactory());
         Reservation reservation = service.runInstances("us-east-1", "ami-1234567890abcdef0", "t3.micro",
                 1, 1, null, List.of(), null, null, List.of(), null, null);
-        String instanceId = reservation.getInstances().getFirst().getInstanceId();
-        Volume volume = service.createVolume("us-east-1", "us-east-1a", "gp3", 8,
+        Instance inst = reservation.getInstances().getFirst();
+        String instanceId = inst.getInstanceId();
+        String instanceAz = inst.getPlacement().getAvailabilityZone();
+        Volume volume = service.createVolume("us-east-1", instanceAz, "gp3", 8,
                 false, 0, null, null, List.of());
         service.attachVolume("us-east-1", volume.getVolumeId(), instanceId, "/dev/sdf");
 
@@ -362,8 +387,9 @@ class Ec2ServiceTest {
         assertEquals("/dev/sdf", response.getDevice());
         assertEquals("detached", response.getState());
         assertFalse(response.isDeleteOnTermination());
-        assertEquals("available", volume.getState());
-        assertTrue(volume.getAttachments().isEmpty());
+        Volume detached = service.describeVolumes("us-east-1", List.of(volume.getVolumeId()), Map.of()).getFirst();
+        assertEquals("available", detached.getState());
+        assertTrue(detached.getAttachments().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

Added support for Ec2 AttachVolume and DetachVolume.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

Verified JSON responses for `attach-volume` and `detach-volume` match aws cli.
Version: aws-cli/2.35.5

## Checklist

- [x] `./mvnw test` passes locally
- [] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
Added unit tests only since only individual handlers/methods changed. 
The added unit tests verifies
- volume and attachment state updated
- number of volume attachments capped at one and cleared when the volume is detached
- root volume detached only in force  mode

## Note
Assume our EC2 emulation is not supporting the aws multi-attach feature.