### PR TITLE
Fix/1790 better populate describe alarm responses

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsJsonHandler.java
@@ -148,6 +148,10 @@ public class CloudWatchMetricsJsonHandler {
         if (okActions.isArray()) {
             okActions.forEach(a -> alarm.getOkActions().add(a.asText()));
         }
+        JsonNode insufficientDataActions = request.path("InsufficientDataActions");
+        if (insufficientDataActions.isArray()) {
+            insufficientDataActions.forEach(a -> alarm.getInsufficientDataActions().add(a.asText()));
+        }
 
         JsonNode tagsNode = request.has("Tags") ? request.path("Tags") : request.path("tags");
         if (tagsNode.isArray()) {
@@ -194,7 +198,7 @@ public class CloudWatchMetricsJsonHandler {
             if (a.getStateValue() != null) node.put("StateValue", a.getStateValue());
             if (a.getStateReason() != null) node.put("StateReason", a.getStateReason());
             if (a.getStateReasonData() != null) node.put("StateReasonData", a.getStateReasonData());
-            if (a.getStateUpdatedTimestamp() >  0) node.put("StateUpdatedTimestamp", a.getStateUpdatedTimestamp());
+            node.put("StateUpdatedTimestamp", a.getStateUpdatedTimestamp());
 
         }
         return Response.ok(response).build();

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsJsonHandler.java
@@ -11,13 +11,12 @@ import io.github.hectorvent.floci.services.cloudwatch.metrics.model.MetricDatum;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
-import org.jboss.logging.Logger;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.jboss.logging.Logger;
 
 /**
  * Handles CloudWatch Metrics requests via the JSON 1.0 protocol.
@@ -178,6 +177,12 @@ public class CloudWatchMetricsJsonHandler {
             node.put("AlarmName", a.getAlarmName());
             if (a.getAlarmArn() != null) node.put("AlarmArn", a.getAlarmArn());
             if (a.getAlarmDescription() != null) node.put("AlarmDescription", a.getAlarmDescription());
+            ArrayNode alarmActions = node.putArray("AlarmActions");
+            a.getAlarmActions().forEach(alarmActions::add);
+            ArrayNode okActions = node.putArray("OKActions");
+            a.getOkActions().forEach(okActions::add);
+            ArrayNode insufficientDataActions = node.putArray("InsufficientDataActions");
+            a.getInsufficientDataActions().forEach(insufficientDataActions::add);
             if (a.getMetricName() != null) node.put("MetricName", a.getMetricName());
             if (a.getNamespace() != null) node.put("Namespace", a.getNamespace());
             if (a.getStatistic() != null) node.put("Statistic", a.getStatistic());
@@ -187,6 +192,10 @@ public class CloudWatchMetricsJsonHandler {
             if (a.getComparisonOperator() != null) node.put("ComparisonOperator", a.getComparisonOperator());
             node.put("ActionsEnabled", a.isActionsEnabled());
             if (a.getStateValue() != null) node.put("StateValue", a.getStateValue());
+            if (a.getStateReason() != null) node.put("StateReason", a.getStateReason());
+            if (a.getStateReasonData() != null) node.put("StateReasonData", a.getStateReasonData());
+            if (a.getStateUpdatedTimestamp() >  0) node.put("StateUpdatedTimestamp", a.getStateUpdatedTimestamp());
+
         }
         return Response.ok(response).build();
     }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsJsonHandler.java
@@ -190,6 +190,12 @@ public class CloudWatchMetricsJsonHandler {
             if (a.getMetricName() != null) node.put("MetricName", a.getMetricName());
             if (a.getNamespace() != null) node.put("Namespace", a.getNamespace());
             if (a.getStatistic() != null) node.put("Statistic", a.getStatistic());
+            ArrayNode dimensions = node.putArray("Dimensions");
+            a.getDimensions().forEach(d -> {
+                ObjectNode dimNode = dimensions.addObject();
+                dimNode.put("Name", d.name());
+                dimNode.put("Value", d.value());
+            });
             node.put("Period", a.getPeriod());
             node.put("EvaluationPeriods", a.getEvaluationPeriods());
             node.put("Threshold", a.getThreshold());

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsQueryHandler.java
@@ -10,14 +10,13 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
-import org.jboss.logging.Logger;
-
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.jboss.logging.Logger;
 
 @ApplicationScoped
 public class CloudWatchMetricsQueryHandler {
@@ -408,11 +407,28 @@ public class CloudWatchMetricsQueryHandler {
     private void toAlarmXml(XmlBuilder xml, MetricAlarm a) {
         xml.start("member")
                 .elem("AlarmName", a.getAlarmName())
+                .elem("AlarmDescription", a.getAlarmDescription());
+        xml.start("AlarmActions");
+        a.getAlarmActions().forEach(act -> xml.elem("member", act));
+        xml.end("AlarmActions");
+        xml.elem("EvaluationPeriods", a.getEvaluationPeriods())
                 .elem("AlarmArn", a.getAlarmArn())
-                .elem("AlarmDescription", a.getAlarmDescription())
                 .elem("AlarmConfigurationUpdatedTimestamp", Instant.ofEpochSecond(a.getAlarmConfigurationUpdatedTimestamp()).toString())
-                .elem("ActionsEnabled", String.valueOf(a.isActionsEnabled()))
-                .elem("StateValue", a.getStateValue())
+                .elem("ActionsEnabled", String.valueOf(a.isActionsEnabled()));
+
+        xml.start("OKActions");
+        a.getOkActions().forEach(act -> xml.elem("member", act));
+        xml.end("OKActions");
+        xml.start("InsufficientDataActions");
+        a.getInsufficientDataActions().forEach(act -> xml.elem("member", act));
+        xml.end("InsufficientDataActions");
+        xml.start("Dimensions");
+        for (Dimension d : a.getDimensions()) {
+            xml.start("member").elem("Name", d.name()).elem("Value", d.value()).end("member");
+        }
+        xml.end("Dimensions");
+
+        xml.elem("StateValue", a.getStateValue())
                 .elem("StateReason", a.getStateReason())
                 .elem("StateReasonData", a.getStateReasonData())
                 .elem("StateUpdatedTimestamp", Instant.ofEpochSecond(a.getStateUpdatedTimestamp()).toString())
@@ -427,29 +443,6 @@ public class CloudWatchMetricsQueryHandler {
                 .elem("ComparisonOperator", a.getComparisonOperator())
                 .elem("TreatMissingData", a.getTreatMissingData());
 
-        if (!a.getOkActions().isEmpty()) {
-            xml.start("OKActions");
-            a.getOkActions().forEach(act -> xml.elem("member", act));
-            xml.end("OKActions");
-        }
-        if (!a.getAlarmActions().isEmpty()) {
-            xml.start("AlarmActions");
-            a.getAlarmActions().forEach(act -> xml.elem("member", act));
-            xml.end("AlarmActions");
-        }
-        if (!a.getInsufficientDataActions().isEmpty()) {
-            xml.start("InsufficientDataActions");
-            a.getInsufficientDataActions().forEach(act -> xml.elem("member", act));
-            xml.end("InsufficientDataActions");
-        }
-
-        if (!a.getDimensions().isEmpty()) {
-            xml.start("Dimensions");
-            for (Dimension d : a.getDimensions()) {
-                xml.start("member").elem("Name", d.name()).elem("Value", d.value()).end("member");
-            }
-            xml.end("Dimensions");
-        }
         xml.end("member");
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsQueryHandler.java
@@ -410,8 +410,7 @@ public class CloudWatchMetricsQueryHandler {
                 .elem("AlarmDescription", a.getAlarmDescription());
         xml.start("AlarmActions");
         a.getAlarmActions().forEach(act -> xml.elem("member", act));
-        xml.end("AlarmActions");
-        xml.elem("EvaluationPeriods", a.getEvaluationPeriods())
+        xml.end("AlarmActions")
                 .elem("AlarmArn", a.getAlarmArn())
                 .elem("AlarmConfigurationUpdatedTimestamp", Instant.ofEpochSecond(a.getAlarmConfigurationUpdatedTimestamp()).toString())
                 .elem("ActionsEnabled", String.valueOf(a.isActionsEnabled()));

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsQueryHandler.java
@@ -407,11 +407,11 @@ public class CloudWatchMetricsQueryHandler {
     private void toAlarmXml(XmlBuilder xml, MetricAlarm a) {
         xml.start("member")
                 .elem("AlarmName", a.getAlarmName())
+                .elem("AlarmArn", a.getAlarmArn())
                 .elem("AlarmDescription", a.getAlarmDescription());
         xml.start("AlarmActions");
         a.getAlarmActions().forEach(act -> xml.elem("member", act));
         xml.end("AlarmActions")
-                .elem("AlarmArn", a.getAlarmArn())
                 .elem("AlarmConfigurationUpdatedTimestamp", Instant.ofEpochSecond(a.getAlarmConfigurationUpdatedTimestamp()).toString())
                 .elem("ActionsEnabled", String.valueOf(a.isActionsEnabled()));
 

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsJsonHandlerTest.java
@@ -130,6 +130,7 @@ class CloudWatchMetricsJsonHandlerTest {
         assertEquals(true, alarmData.path("OKActions").isArray());
         assertEquals(true, alarmData.path("InsufficientDataActions").isArray());
         assertEquals(true, alarmData.path("StateUpdatedTimestamp").asLong() > 0);
+    }
 
     @Test
     void getMetricStatistics_decimalEpochStartEndTime_filtersOutOfRangeDatapoints() {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsJsonHandlerTest.java
@@ -113,18 +113,23 @@ class CloudWatchMetricsJsonHandlerTest {
         alarmReq.put("AlarmName", "TestAlarm");
         alarmReq.put("StateValue", "ALARM");
         alarmReq.put("StateReason", "Test reason");
+        alarmReq.put("StateReasonData", "{\"k\":\"v\"}");
         Response resp = handler.handle("SetAlarmState", alarmReq, REGION);
         assertEquals(200, resp.getStatus());
 
         // Verify that the alarm state is reflected in the metrics service
         ObjectNode getAlarmReq = MAPPER.createObjectNode();
-        getAlarmReq.put("AlarmName", "TestAlarm");
+        getAlarmReq.putArray("AlarmNames").add("TestAlarm");
         Response getResp = handler.handle("DescribeAlarms", getAlarmReq, REGION);
         assertEquals(200, getResp.getStatus());
         ObjectNode alarmData = (ObjectNode) ((ObjectNode) getResp.getEntity()).get("MetricAlarms").get(0);
         assertEquals("ALARM", alarmData.get("StateValue").asText());
         assertEquals("Test reason", alarmData.get("StateReason").asText());
-    }
+        assertEquals("{\"k\":\"v\"}", alarmData.get("StateReasonData").asText());
+        assertEquals(true, alarmData.path("AlarmActions").isArray());
+        assertEquals(true, alarmData.path("OKActions").isArray());
+        assertEquals(true, alarmData.path("InsufficientDataActions").isArray());
+        assertEquals(true, alarmData.path("StateUpdatedTimestamp").asLong() > 0);
 
     @Test
     void getMetricStatistics_decimalEpochStartEndTime_filtersOutOfRangeDatapoints() {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsJsonHandlerTest.java
@@ -1,17 +1,16 @@
 package io.github.hectorvent.floci.services.cloudwatch.metrics;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import jakarta.ws.rs.core.Response;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import java.math.BigDecimal;
 import java.time.Instant;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Handler-level tests for CloudWatchMetricsJsonHandler.
@@ -97,6 +96,34 @@ class CloudWatchMetricsJsonHandlerTest {
                 EPOCH_NOW.minusSeconds(10), EPOCH_NOW.plusSeconds(10), 60);
         assertEquals(0, narrow.get("Datapoints").size(),
                 "metric stored with 24h-ago timestamp must not appear in a 20-second window around now");
+    }
+
+    @Test
+    void setAlarmState_updatesFieldsCorrectly() {
+        putMetric("NS", "M", "type", "current", 100.0, EPOCH_NOW);
+
+        ObjectNode putAlarmReq = MAPPER.createObjectNode();
+        putAlarmReq.put("AlarmName", "TestAlarm");
+        putAlarmReq.put("MetricName", "M");
+        putAlarmReq.put("Namespace", "NS");
+        Response putAlarmResp = handler.handle("PutMetricAlarm", putAlarmReq, REGION);
+        assertEquals(200, putAlarmResp.getStatus());
+
+        ObjectNode alarmReq = MAPPER.createObjectNode();
+        alarmReq.put("AlarmName", "TestAlarm");
+        alarmReq.put("StateValue", "ALARM");
+        alarmReq.put("StateReason", "Test reason");
+        Response resp = handler.handle("SetAlarmState", alarmReq, REGION);
+        assertEquals(200, resp.getStatus());
+
+        // Verify that the alarm state is reflected in the metrics service
+        ObjectNode getAlarmReq = MAPPER.createObjectNode();
+        getAlarmReq.put("AlarmName", "TestAlarm");
+        Response getResp = handler.handle("DescribeAlarms", getAlarmReq, REGION);
+        assertEquals(200, getResp.getStatus());
+        ObjectNode alarmData = (ObjectNode) ((ObjectNode) getResp.getEntity()).get("MetricAlarms").get(0);
+        assertEquals("ALARM", alarmData.get("StateValue").asText());
+        assertEquals("Test reason", alarmData.get("StateReason").asText());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsJsonHandlerTest.java
@@ -1,8 +1,11 @@
 package io.github.hectorvent.floci.services.cloudwatch.metrics;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
@@ -106,6 +109,12 @@ class CloudWatchMetricsJsonHandlerTest {
         putAlarmReq.put("AlarmName", "TestAlarm");
         putAlarmReq.put("MetricName", "M");
         putAlarmReq.put("Namespace", "NS");
+        putAlarmReq.putArray("AlarmActions").add("alarm-action");
+        putAlarmReq.putArray("OKActions").add("ok-action");
+        putAlarmReq.putArray("InsufficientDataActions").add("insufficient-action");
+        ArrayNode dimensions = putAlarmReq.putArray("Dimensions");
+        dimensions.addObject().put("Name", "period").put("Value", "60");
+        dimensions.addObject().put("Name", "count").put("Value", "2");
         Response putAlarmResp = handler.handle("PutMetricAlarm", putAlarmReq, REGION);
         assertEquals(200, putAlarmResp.getStatus());
 
@@ -126,10 +135,20 @@ class CloudWatchMetricsJsonHandlerTest {
         assertEquals("ALARM", alarmData.get("StateValue").asText());
         assertEquals("Test reason", alarmData.get("StateReason").asText());
         assertEquals("{\"k\":\"v\"}", alarmData.get("StateReasonData").asText());
-        assertEquals(true, alarmData.path("AlarmActions").isArray());
-        assertEquals(true, alarmData.path("OKActions").isArray());
-        assertEquals(true, alarmData.path("InsufficientDataActions").isArray());
-        assertEquals(true, alarmData.path("StateUpdatedTimestamp").asLong() > 0);
+        assertTrue(alarmData.path("AlarmActions").isArray());
+        assertEquals("alarm-action", alarmData.path("AlarmActions").get(0).asText());
+        assertTrue(alarmData.path("OKActions").isArray());
+        assertEquals("ok-action", alarmData.path("OKActions").get(0).asText());
+        assertTrue(alarmData.path("InsufficientDataActions").isArray());
+        assertEquals("insufficient-action", alarmData.path("InsufficientDataActions").get(0).asText());
+        assertTrue(alarmData.path("StateUpdatedTimestamp").asLong() > 0);
+        assertTrue(alarmData.path("Dimensions").isArray());
+        JsonNode dimensionPeriod = alarmData.path("Dimensions").get(0);
+        assertEquals("period", dimensionPeriod.get("Name").asText());
+        assertEquals("60", dimensionPeriod.get("Value").asText());
+        JsonNode dimensionCount = alarmData.path("Dimensions").get(1);
+        assertEquals("count", dimensionCount.get("Name").asText());
+        assertEquals("2", dimensionCount.get("Value").asText());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes https://github.com/floci-io/floci/issues/1790

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

what was the incorrect behavior?
fields StateReason, StateReasonData, StateUpdatedTimestamp and the actions arrays were not populated in on clientside in pojo MetricAlarm.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
