### PR TITLE
feat(cloudformation): support AWS::Events::EventBus and EventBusPolicy

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -390,6 +390,14 @@ public class CloudFormationResourceProvisioner {
             }
             return;
         }
+        // Rule deletion needs the rule's event bus (stored as an attribute at provision time),
+        // which the type/physicalId delete path can't provide; a custom-bus rule looked up under
+        // the default bus would silently no-op and leave the rule (and its bus) live.
+        if ("AWS::Events::Rule".equals(resourceType)) {
+            deleteEventBridgeRuleSafe(resource.getPhysicalId(),
+                    resource.getAttributes().get("EventBusName"), region);
+            return;
+        }
         delete(resourceType, resource.getPhysicalId(), region);
     }
 
@@ -417,7 +425,7 @@ public class CloudFormationResourceProvisioner {
             } // KMS keys can't be immediately deleted; skip
             case "AWS::KMS::Alias" -> kmsService.deleteAlias(physicalId, region);
             case "AWS::SecretsManager::Secret" -> deleteSecretSafe(physicalId, region);
-            case "AWS::Events::Rule" -> deleteEventBridgeRuleSafe(physicalId, region);
+            case "AWS::Events::Rule" -> deleteEventBridgeRuleSafe(physicalId, null, region);
             case "AWS::Events::EventBus" -> deleteEventBusSafe(physicalId, region);
             case "AWS::ApiGateway::RestApi" -> apiGatewayService.deleteRestApi(region, physicalId);
             case "AWS::ApiGatewayV2::Api" -> apiGatewayV2Service.deleteApi(region, physicalId);
@@ -2100,6 +2108,9 @@ public class CloudFormationResourceProvisioner {
                 state, description, roleArn, Map.of(), region);
         r.setPhysicalId(ruleName);
         r.getAttributes().put("Arn", rule.getArn());
+        if (busName != null && !busName.isBlank()) {
+            r.getAttributes().put("EventBusName", busName);
+        }
 
         // Provision inline targets
         if (props != null && props.has("Targets")) {
@@ -2144,15 +2155,15 @@ public class CloudFormationResourceProvisioner {
         }
     }
 
-    private void deleteEventBridgeRuleSafe(String ruleName, String region) {
+    private void deleteEventBridgeRuleSafe(String ruleName, String busName, String region) {
         try {
             // Remove all targets before deleting the rule
-            var targets = eventBridgeService.listTargetsByRule(ruleName, null, region);
+            var targets = eventBridgeService.listTargetsByRule(ruleName, busName, region);
             if (!targets.isEmpty()) {
                 List<String> targetIds = targets.stream().map(Target::getId).toList();
-                eventBridgeService.removeTargets(ruleName, null, targetIds, region);
+                eventBridgeService.removeTargets(ruleName, busName, targetIds, region);
             }
-            eventBridgeService.deleteRule(ruleName, null, region);
+            eventBridgeService.deleteRule(ruleName, busName, region);
         } catch (Exception e) {
             LOG.debugv("Could not delete EventBridge rule {0}: {1}", ruleName, e.getMessage());
         }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
 import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
 import io.github.hectorvent.floci.services.eventbridge.EventBridgeService;
 import io.github.hectorvent.floci.services.eventbridge.model.BatchParameters;
+import io.github.hectorvent.floci.services.eventbridge.model.EventBus;
 import io.github.hectorvent.floci.services.eventbridge.model.RuleState;
 import io.github.hectorvent.floci.services.eventbridge.model.SqsParameters;
 import io.github.hectorvent.floci.services.eventbridge.model.Target;
@@ -270,6 +271,7 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::Route53::HostedZone" -> provisionRoute53HostedZone(resource, properties, engine);
                 case "AWS::Route53::RecordSet" -> provisionRoute53RecordSet(resource, properties, engine);
                 case "AWS::Events::Rule" -> provisionEventBridgeRule(resource, properties, engine, region, stackName);
+                case "AWS::Events::EventBus" -> provisionEventBus(resource, properties, engine, region, stackName);
                 case "AWS::ApiGateway::RestApi" -> provisionApiGatewayRestApi(resource, properties, engine, region, accountId, stackName);
                 case "AWS::ApiGateway::Resource" -> provisionApiGatewayResource(resource, properties, engine, region);
                 case "AWS::ApiGateway::Authorizer" -> provisionApiGatewayAuthorizer(resource, properties, engine, region);
@@ -416,6 +418,7 @@ public class CloudFormationResourceProvisioner {
             case "AWS::KMS::Alias" -> kmsService.deleteAlias(physicalId, region);
             case "AWS::SecretsManager::Secret" -> deleteSecretSafe(physicalId, region);
             case "AWS::Events::Rule" -> deleteEventBridgeRuleSafe(physicalId, region);
+            case "AWS::Events::EventBus" -> deleteEventBusSafe(physicalId, region);
             case "AWS::ApiGateway::RestApi" -> apiGatewayService.deleteRestApi(region, physicalId);
             case "AWS::ApiGatewayV2::Api" -> apiGatewayV2Service.deleteApi(region, physicalId);
             case "AWS::ECR::Repository" ->
@@ -2152,6 +2155,54 @@ public class CloudFormationResourceProvisioner {
             eventBridgeService.deleteRule(ruleName, null, region);
         } catch (Exception e) {
             LOG.debugv("Could not delete EventBridge rule {0}: {1}", ruleName, e.getMessage());
+        }
+    }
+
+    private void provisionEventBus(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                   String region, String stackName) {
+        String name = resolveOptional(props, "Name", engine);
+        if (name == null || name.isBlank()) {
+            name = generatePhysicalName(stackName, r.getLogicalId(), 256, false);
+        }
+        String description = resolveOptional(props, "Description", engine);
+
+        Map<String, String> tags = new HashMap<>();
+        if (props != null && props.has("Tags") && props.get("Tags").isArray()) {
+            for (JsonNode tag : props.get("Tags")) {
+                String key = engine.resolve(tag.path("Key"));
+                if (!key.isEmpty()) {
+                    tags.put(key, engine.resolve(tag.path("Value")));
+                }
+            }
+        }
+
+        EventBus bus;
+        try {
+            bus = eventBridgeService.createEventBus(name, description, tags, region);
+        } catch (AwsException e) {
+            if ("ResourceAlreadyExistsException".equals(e.getErrorCode())) {
+                bus = eventBridgeService.describeEventBus(name, region);
+            } else {
+                throw e;
+            }
+        }
+
+        // Optional inline resource policy (rare for CDK EventBus constructs).
+        if (props != null && props.has("Policy") && !props.get("Policy").isNull()) {
+            String policyJson = engine.resolveNode(props.get("Policy")).toString();
+            eventBridgeService.putPermission(name, null, null, null, null, policyJson, region);
+        }
+
+        r.setPhysicalId(name);
+        r.getAttributes().put("Arn", bus.getArn());
+        r.getAttributes().put("Name", name);
+    }
+
+    private void deleteEventBusSafe(String name, String region) {
+        try {
+            eventBridgeService.deleteEventBus(name, region);
+        } catch (Exception e) {
+            LOG.debugv("Could not delete event bus {0}: {1}", name, e.getMessage());
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -2227,6 +2227,43 @@ public class CloudFormationResourceProvisioner {
             throw new AwsException("ValidationException", "EventBusPolicy StatementId is required.", 400);
         }
 
+        if (props != null && props.has("Statement") && props.get("Statement").isObject()) {
+            // Statement form: merge the full statement into the bus policy, keyed by Sid,
+            // so multiple EventBusPolicy resources on the same bus coexist.
+            try {
+                ObjectNode statement = (ObjectNode) engine.resolveNode(props.get("Statement")).deepCopy();
+                statement.put("Sid", statementId);
+
+                EventBus bus = eventBridgeService.describeEventBus(busName, region);
+                ObjectNode policy;
+                String current = bus.getPolicy();
+                if (current != null && !current.isBlank()) {
+                    policy = (ObjectNode) objectMapper.readTree(current);
+                } else {
+                    policy = objectMapper.createObjectNode();
+                    policy.put("Version", "2012-10-17");
+                    policy.putArray("Statement");
+                }
+                ArrayNode statements = policy.withArray("Statement");
+                for (int i = 0; i < statements.size(); i++) {
+                    if (statementId.equals(statements.get(i).path("Sid").asText(null))) {
+                        statements.remove(i);
+                        break;
+                    }
+                }
+                statements.add(statement);
+                eventBridgeService.putPermission(busName, null, null, statementId, null,
+                        objectMapper.writeValueAsString(policy), region);
+            } catch (AwsException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new AwsException("ValidationException",
+                        "Invalid EventBusPolicy Statement: " + e.getMessage(), 400);
+            }
+            r.setPhysicalId(busName + "|" + statementId);
+            return;
+        }
+
         // Individual form: Action + Principal (+ optional Condition {Type, Key, Value}).
         String action = resolveOptional(props, "Action", engine);
         String principal = resolveOptional(props, "Principal", engine);
@@ -2236,7 +2273,7 @@ public class CloudFormationResourceProvisioner {
             String type = c.path("Type").asText(null);
             String key = c.path("Key").asText(null);
             String value = c.path("Value").asText(null);
-            if (type != null && key != null) {
+            if (type != null && key != null && value != null) {
                 ObjectNode condition = objectMapper.createObjectNode();
                 condition.set(type, objectMapper.createObjectNode().put(key, value));
                 conditionJson = condition.toString();

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -2215,7 +2215,10 @@ public class CloudFormationResourceProvisioner {
         try {
             eventBridgeService.deleteEventBus(name, region);
         } catch (Exception e) {
-            LOG.debugv("Could not delete event bus {0}: {1}", name, e.getMessage());
+            // Warn (not debug): the stack still records the resource as DELETE_COMPLETE, so a bus
+            // left alive here (e.g. rules deleted out of dependency order) is a silent divergence
+            // that must stay diagnosable.
+            LOG.warnv("Could not delete event bus {0}: {1}", name, e.getMessage());
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -272,6 +272,7 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::Route53::RecordSet" -> provisionRoute53RecordSet(resource, properties, engine);
                 case "AWS::Events::Rule" -> provisionEventBridgeRule(resource, properties, engine, region, stackName);
                 case "AWS::Events::EventBus" -> provisionEventBus(resource, properties, engine, region, stackName);
+                case "AWS::Events::EventBusPolicy" -> provisionEventBusPolicy(resource, properties, engine, region);
                 case "AWS::ApiGateway::RestApi" -> provisionApiGatewayRestApi(resource, properties, engine, region, accountId, stackName);
                 case "AWS::ApiGateway::Resource" -> provisionApiGatewayResource(resource, properties, engine, region);
                 case "AWS::ApiGateway::Authorizer" -> provisionApiGatewayAuthorizer(resource, properties, engine, region);
@@ -427,6 +428,7 @@ public class CloudFormationResourceProvisioner {
             case "AWS::SecretsManager::Secret" -> deleteSecretSafe(physicalId, region);
             case "AWS::Events::Rule" -> deleteEventBridgeRuleSafe(physicalId, null, region);
             case "AWS::Events::EventBus" -> deleteEventBusSafe(physicalId, region);
+            case "AWS::Events::EventBusPolicy" -> removeEventBusPolicySafe(physicalId, region);
             case "AWS::ApiGateway::RestApi" -> apiGatewayService.deleteRestApi(region, physicalId);
             case "AWS::ApiGatewayV2::Api" -> apiGatewayV2Service.deleteApi(region, physicalId);
             case "AWS::ECR::Repository" ->
@@ -2214,6 +2216,45 @@ public class CloudFormationResourceProvisioner {
             eventBridgeService.deleteEventBus(name, region);
         } catch (Exception e) {
             LOG.debugv("Could not delete event bus {0}: {1}", name, e.getMessage());
+        }
+    }
+
+    private void provisionEventBusPolicy(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                         String region) {
+        String busName = resolveOrDefault(props, "EventBusName", engine, "default");
+        String statementId = resolveOptional(props, "StatementId", engine);
+        if (statementId == null || statementId.isBlank()) {
+            throw new AwsException("ValidationException", "EventBusPolicy StatementId is required.", 400);
+        }
+
+        // Individual form: Action + Principal (+ optional Condition {Type, Key, Value}).
+        String action = resolveOptional(props, "Action", engine);
+        String principal = resolveOptional(props, "Principal", engine);
+        String conditionJson = null;
+        if (props != null && props.has("Condition") && !props.get("Condition").isNull()) {
+            JsonNode c = engine.resolveNode(props.get("Condition"));
+            String type = c.path("Type").asText(null);
+            String key = c.path("Key").asText(null);
+            String value = c.path("Value").asText(null);
+            if (type != null && key != null) {
+                ObjectNode condition = objectMapper.createObjectNode();
+                condition.set(type, objectMapper.createObjectNode().put(key, value));
+                conditionJson = condition.toString();
+            }
+        }
+        eventBridgeService.putPermission(busName, action, principal, statementId, conditionJson, null, region);
+
+        r.setPhysicalId(busName + "|" + statementId);
+    }
+
+    private void removeEventBusPolicySafe(String physicalId, String region) {
+        try {
+            int sep = physicalId.lastIndexOf('|');
+            String busName = sep >= 0 ? physicalId.substring(0, sep) : "default";
+            String statementId = sep >= 0 ? physicalId.substring(sep + 1) : physicalId;
+            eventBridgeService.removePermission(busName, statementId, false, region);
+        } catch (Exception e) {
+            LOG.debugv("Could not remove event bus policy {0}: {1}", physicalId, e.getMessage());
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
@@ -612,7 +612,7 @@ public class CloudFormationService {
             if (resource.getPhysicalId() != null && "CREATE_COMPLETE".equals(resource.getStatus())) {
                 addEvent(stack, resource.getLogicalId(), resource.getPhysicalId(),
                         resource.getResourceType(), "DELETE_IN_PROGRESS", null);
-                provisioner.delete(resource.getResourceType(), resource.getPhysicalId(), region);
+                provisioner.delete(resource, region);
                 resource.setStatus("DELETE_COMPLETE");
                 addEvent(stack, resource.getLogicalId(), resource.getPhysicalId(),
                         resource.getResourceType(), "DELETE_COMPLETE", null);

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -6732,4 +6732,85 @@ class CloudFormationIntegrationTest {
                 .body("endpointConfiguration.vpcEndpointIds", contains("vpce-12345678"));
     }
 
+    @Test
+    void createStack_withEventBus_createsRealBusAndResolvesRefAndGetAtt() {
+        String template = """
+            {
+              "Resources": {
+                "MyBus": {
+                  "Type": "AWS::Events::EventBus",
+                  "Properties": {
+                    "Name": "cfn-custom-bus",
+                    "Description": "Custom bus created via CloudFormation",
+                    "Tags": [ { "Key": "env", "Value": "test" } ]
+                  }
+                }
+              },
+              "Outputs": {
+                "BusRef":  { "Value": { "Ref": "MyBus" } },
+                "BusArn":  { "Value": { "Fn::GetAtt": ["MyBus", "Arn"] } },
+                "BusName": { "Value": { "Fn::GetAtt": ["MyBus", "Name"] } }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-eventbus-stack")
+            .formParam("TemplateBody", template)
+        .when().post("/")
+        .then().statusCode(200).body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-eventbus-stack")
+        .when().post("/")
+        .then().statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"))
+            .body(containsString("<OutputKey>BusRef</OutputKey>"))
+            .body(containsString("<OutputValue>cfn-custom-bus</OutputValue>"))
+            .body(containsString("event-bus/cfn-custom-bus"));
+
+        // The bus really exists in EventBridge, not a stub.
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.DescribeEventBus")
+            .body("{\"Name\":\"cfn-custom-bus\"}")
+        .when().post("/")
+        .then().statusCode(200)
+            .body("Name", equalTo("cfn-custom-bus"))
+            .body("Arn", containsString("event-bus/cfn-custom-bus"));
+    }
+
+    @Test
+    void deleteStack_withEventBus_removesBus() {
+        String template = """
+            { "Resources": { "MyBus": { "Type": "AWS::Events::EventBus",
+              "Properties": { "Name": "cfn-bus-to-delete" } } } }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-eventbus-delete-stack")
+            .formParam("TemplateBody", template)
+        .when().post("/").then().statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DeleteStack")
+            .formParam("StackName", "cfn-eventbus-delete-stack")
+        .when().post("/").then().statusCode(200);
+
+        // The bus is gone.
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.DescribeEventBus")
+            .body("{\"Name\":\"cfn-bus-to-delete\"}")
+        .when().post("/")
+        .then().body(containsString("ResourceNotFoundException"));
+    }
+
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -6813,4 +6813,60 @@ class CloudFormationIntegrationTest {
         .then().body(containsString("ResourceNotFoundException"));
     }
 
+    @Test
+    void deleteStack_customBusWithRule_removesBusAndRule() {
+        String template = """
+            {
+              "Resources": {
+                "MyBus": {
+                  "Type": "AWS::Events::EventBus",
+                  "Properties": { "Name": "cfn-teardown-bus" }
+                },
+                "MyRule": {
+                  "Type": "AWS::Events::Rule",
+                  "Properties": {
+                    "Name": "cfn-teardown-rule",
+                    "EventBusName": { "Ref": "MyBus" },
+                    "EventPattern": { "source": ["teardown.test"] }
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-teardown-stack")
+            .formParam("TemplateBody", template)
+        .when().post("/").then().statusCode(200).body(containsString("<StackId>"));
+
+        // Sanity: the rule exists on the custom bus before teardown.
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.DescribeRule")
+            .body("{\"Name\":\"cfn-teardown-rule\",\"EventBusName\":\"cfn-teardown-bus\"}")
+        .when().post("/").then().statusCode(200).body("Name", equalTo("cfn-teardown-rule"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DeleteStack")
+            .formParam("StackName", "cfn-teardown-stack")
+        .when().post("/").then().statusCode(200);
+
+        // The rule is gone from the custom bus...
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.DescribeRule")
+            .body("{\"Name\":\"cfn-teardown-rule\",\"EventBusName\":\"cfn-teardown-bus\"}")
+        .when().post("/").then().body(containsString("ResourceNotFoundException"));
+
+        // ...and so is the bus.
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.DescribeEventBus")
+            .body("{\"Name\":\"cfn-teardown-bus\"}")
+        .when().post("/").then().body(containsString("ResourceNotFoundException"));
+    }
+
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -6869,4 +6869,89 @@ class CloudFormationIntegrationTest {
         .when().post("/").then().body(containsString("ResourceNotFoundException"));
     }
 
+    @Test
+    void createStack_customBusRuleDeliversEventToSqs() {
+        String template = """
+            {
+              "Resources": {
+                "MyBus": {
+                  "Type": "AWS::Events::EventBus",
+                  "Properties": { "Name": "cfn-e2e-bus" }
+                },
+                "TargetQueue": {
+                  "Type": "AWS::SQS::Queue",
+                  "Properties": { "QueueName": "cfn-e2e-queue" }
+                },
+                "MyRule": {
+                  "Type": "AWS::Events::Rule",
+                  "Properties": {
+                    "Name": "cfn-e2e-rule",
+                    "EventBusName": { "Ref": "MyBus" },
+                    "EventPattern": { "source": ["my.e2e.app"] },
+                    "Targets": [
+                      { "Id": "Target0", "Arn": { "Fn::GetAtt": ["TargetQueue", "Arn"] } }
+                    ]
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-e2e-stack")
+            .formParam("TemplateBody", template)
+        .when().post("/").then().statusCode(200).body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-e2e-stack")
+        .when().post("/")
+        .then().statusCode(200).body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        // The rule is attached to the custom bus.
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.ListTargetsByRule")
+            .body("{\"Rule\":\"cfn-e2e-rule\",\"EventBusName\":\"cfn-e2e-bus\"}")
+        .when().post("/")
+        .then().statusCode(200)
+            .body("Targets[0].Arn", equalTo("arn:aws:sqs:us-east-1:000000000000:cfn-e2e-queue"));
+
+        // Send a matching event to the custom bus.
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.PutEvents")
+            .body("""
+                {"Entries":[{"Source":"my.e2e.app","DetailType":"t",
+                 "Detail":"{\\"hello\\":\\"world\\"}","EventBusName":"cfn-e2e-bus"}]}
+                """)
+        .when().post("/")
+        .then().statusCode(200).body("FailedEntryCount", equalTo(0));
+
+        // Resolve the queue URL, then confirm the message was delivered.
+        String getUrlXml = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "GetQueueUrl")
+            .formParam("QueueName", "cfn-e2e-queue")
+        .when().post("/")
+        .then().statusCode(200).extract().body().asString();
+        String queueUrl = getUrlXml.substring(
+                getUrlXml.indexOf("<QueueUrl>") + "<QueueUrl>".length(),
+                getUrlXml.indexOf("</QueueUrl>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ReceiveMessage")
+            .formParam("QueueUrl", queueUrl)
+            .formParam("MaxNumberOfMessages", "1")
+            .formParam("WaitTimeSeconds", "0")
+        .when().post("/")
+        .then().statusCode(200)
+            .body(containsString("my.e2e.app"))
+            .body(containsString("hello"));
+    }
+
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -6629,6 +6629,69 @@ class CloudFormationIntegrationTest {
     }
 
     @Test
+    void rollbackStack_customBusWithRule_rollsBackBusAndRule() {
+        // RbBus provisions first, RbRule (on that custom bus) second, then BadSecret fails
+        // (SecretString + GenerateSecretString is invalid), forcing a CREATE rollback. The rule
+        // and its custom bus must both be cleaned up, not leaked.
+        String failingTemplate = """
+            {
+              "Resources": {
+                "RbBus": {
+                  "Type": "AWS::Events::EventBus",
+                  "Properties": { "Name": "cfn-rb-bus" }
+                },
+                "RbRule": {
+                  "Type": "AWS::Events::Rule",
+                  "DependsOn": "RbBus",
+                  "Properties": {
+                    "Name": "cfn-rb-rule",
+                    "EventBusName": { "Ref": "RbBus" },
+                    "EventPattern": { "source": ["rb.test"] }
+                  }
+                },
+                "BadSecret": {
+                  "Type": "AWS::SecretsManager::Secret",
+                  "DependsOn": "RbRule",
+                  "Properties": {
+                    "Name": "cfn-rb-secret",
+                    "SecretString": "explicit",
+                    "GenerateSecretString": { "PasswordLength": 32 }
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-rb-stack")
+            .formParam("TemplateBody", failingTemplate)
+        .when().post("/").then().statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-rb-stack")
+        .when().post("/")
+        .then().statusCode(200).body(containsString("<StackStatus>ROLLBACK_COMPLETE</StackStatus>"));
+
+        // The rule created on the custom bus was rolled back...
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.DescribeRule")
+            .body("{\"Name\":\"cfn-rb-rule\",\"EventBusName\":\"cfn-rb-bus\"}")
+        .when().post("/").then().body(containsString("ResourceNotFoundException"));
+
+        // ...and so was the custom bus.
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.DescribeEventBus")
+            .body("{\"Name\":\"cfn-rb-bus\"}")
+        .when().post("/").then().body(containsString("ResourceNotFoundException"));
+    }
+
+    @Test
     void createStack_resourceFailure_setsRollbackComplete_singleResource() {
         // A lone failing resource still moves the stack to ROLLBACK_COMPLETE (no orphaned state).
         String template = """

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -7000,4 +7000,70 @@ class CloudFormationIntegrationTest {
             .body("Policy", containsString("111122223333"));
     }
 
+    @Test
+    void createStack_withEventBusPolicyStatementForm_mergesMultipleStatements() {
+        String template = """
+            {
+              "Resources": {
+                "MyBus": {
+                  "Type": "AWS::Events::EventBus",
+                  "Properties": { "Name": "cfn-stmt-bus" }
+                },
+                "PolicyA": {
+                  "Type": "AWS::Events::EventBusPolicy",
+                  "Properties": {
+                    "EventBusName": { "Ref": "MyBus" },
+                    "StatementId": "StmtA",
+                    "Statement": {
+                      "Effect": "Allow",
+                      "Principal": { "AWS": "arn:aws:iam::111111111111:root" },
+                      "Action": "events:PutEvents",
+                      "Resource": { "Fn::GetAtt": ["MyBus", "Arn"] }
+                    }
+                  }
+                },
+                "PolicyB": {
+                  "Type": "AWS::Events::EventBusPolicy",
+                  "Properties": {
+                    "EventBusName": { "Ref": "MyBus" },
+                    "StatementId": "StmtB",
+                    "Statement": {
+                      "Effect": "Allow",
+                      "Principal": { "AWS": "arn:aws:iam::222222222222:root" },
+                      "Action": "events:PutEvents",
+                      "Resource": { "Fn::GetAtt": ["MyBus", "Arn"] }
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-stmt-stack")
+            .formParam("TemplateBody", template)
+        .when().post("/").then().statusCode(200).body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-stmt-stack")
+        .when().post("/")
+        .then().statusCode(200).body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        // Both statements must be present — a naive whole-policy replace would keep only one.
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.DescribeEventBus")
+            .body("{\"Name\":\"cfn-stmt-bus\"}")
+        .when().post("/")
+        .then().statusCode(200)
+            .body("Policy", containsString("StmtA"))
+            .body("Policy", containsString("StmtB"))
+            .body("Policy", containsString("111111111111"))
+            .body("Policy", containsString("222222222222"));
+    }
+
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -6954,4 +6954,50 @@ class CloudFormationIntegrationTest {
             .body(containsString("hello"));
     }
 
+    @Test
+    void createStack_withEventBusPolicyIndividualForm_writesStatement() {
+        String template = """
+            {
+              "Resources": {
+                "MyBus": {
+                  "Type": "AWS::Events::EventBus",
+                  "Properties": { "Name": "cfn-policy-bus" }
+                },
+                "MyPolicy": {
+                  "Type": "AWS::Events::EventBusPolicy",
+                  "Properties": {
+                    "EventBusName": { "Ref": "MyBus" },
+                    "StatementId": "AllowAcct",
+                    "Action": "events:PutEvents",
+                    "Principal": "111122223333"
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-eventbuspolicy-stack")
+            .formParam("TemplateBody", template)
+        .when().post("/").then().statusCode(200).body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-eventbuspolicy-stack")
+        .when().post("/")
+        .then().statusCode(200).body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "AWSEvents.DescribeEventBus")
+            .body("{\"Name\":\"cfn-policy-bus\"}")
+        .when().post("/")
+        .then().statusCode(200)
+            .body("Policy", containsString("AllowAcct"))
+            .body("Policy", containsString("111122223333"));
+    }
+
 }


### PR DESCRIPTION
## Summary

AWS CDK stacks that define a custom EventBridge event bus did not work against Floci. `AWS::Events::EventBus` was not handled by the CloudFormation provisioner, so it fell through the `default` branch and was only *stubbed* (a fake `arn:aws:stub:::` and a random physical id) — the bus was never created in `EventBridgeService`. As a result `PutEvents` to that bus failed with `EventBus not found`, no rule ever matched, and nothing reached the targets, even though `cdk deploy` reported `CREATE_COMPLETE` and the bus was absent from `ListEventBuses`.

This wires real CloudFormation provisioning for `AWS::Events::EventBus` and `AWS::Events::EventBusPolicy`, reusing the existing `EventBridgeService`. No new endpoints, wire protocol, or configuration — this is CloudFormation resource-type coverage on top of the already-complete EventBridge service.

- **`AWS::Events::EventBus`** — provisions via `EventBridgeService.createEventBus` (`Name`, `Description`, `Tags`, optional inline `Policy`). `Ref` returns the bus name; `Fn::GetAtt` resolves `Arn` and `Name`; re-deploy is idempotent (`ResourceAlreadyExistsException` → `DescribeEventBus`).
- **`AWS::Events::EventBusPolicy`** — both the individual `Action`/`Principal`/`Condition` form and the full `Statement` object form; Statement-form policies are merged by `Sid` so multiple resources on one bus coexist.

It also fixes a latent bug the feature surfaces: `AWS::Events::Rule` resources on a **custom** bus were deleted against the `default` bus (bus argument hardcoded to `null`), so the delete silently no-opped and the rule — and its bus — leaked while the stack recorded `DELETE_COMPLETE`. The rule's `EventBusName` is now stored as a resource attribute at provision time and read back at delete time, mirroring the existing `AWS::EKS::Nodegroup` attribute-aware delete. The `rollbackCreatedResources` path is fixed the same way (it used the type-based delete overload instead of the resource-aware one).

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

This PR adds CloudFormation resource-type coverage; it does not introduce a new AWS wire action, so there is no new SDK/CLI request shape to pin.

**Incorrect behavior fixed:**
- A CDK/CloudFormation stack with a custom `AWS::Events::EventBus` deployed but the bus was never created in the emulator — `ListEventBuses` did not show it and `PutEvents` to it returned `EventBus not found`, so events were never delivered to rule targets. Real CloudFormation creates the bus and CDK stacks route events through it.
- Deleting (teardown or CREATE rollback) a stack with a custom bus + a rule left both resources live while reporting `DELETE_COMPLETE`, because the rule was deleted against the `default` bus. Real CloudFormation removes the rule and the bus.

**Verification:** deployed an EventBus + Rule + SQS-target stack with AWS CDK (`aws-cdk-lib`, via `cdklocal`) against a local Floci — `CREATE_COMPLETE`, no rollback — then `aws events put-events` for a matching event returned `FailedEntryCount 0` and `aws sqs receive-message` returned the event, confirming the bus, rule/target, and routing are all real. `Ref`/`Fn::GetAtt` are exercised via a template `Outputs` block in the integration tests.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Tests: 7 new cases in `CloudFormationIntegrationTest` (RestAssured over the real wire protocol — Query for CloudFormation/SQS, JSON 1.1 for EventBridge): EventBus create + `Ref`/`GetAtt`, delete, end-to-end delivery to SQS, both `EventBusPolicy` forms (individual and two coexisting Statements), custom-bus teardown, and CREATE-rollback cleanup. Full `CloudFormationIntegrationTest` class: 99/99 green.

## Notes for the reviewer

Scope kept deliberately narrow; three things flagged rather than expanded:

- **Statement-form policy merge is a client-side read-modify-write** (`describeEventBus` → splice by `Sid` → write whole policy). It is not atomic, but CloudFormation provisions resources sequentially per stack, so there is no concurrent writer today. It is not routed through `EventBridgeService.putPermission`'s server-side merge because that path rebuilds a statement from scalar `action`/`principal` and cannot ingest a full IAM `Statement` object (`Principal:{AWS:[...]}`, multiple actions, `Resource`, arbitrary `Condition`). The atomic fix, if parallel provisioning ever lands, would be a server-side full-statement merge on `EventBridgeService` (which would also remove the small duplication).
- **`deleteEventBusSafe` swallows-and-logs at `warnv`.** Consistent with the sibling `*Safe` delete helpers (which log at `debugv`), but bumped to `warn` here specifically because a bus left alive while the stack says `DELETE_COMPLETE` is a state divergence worth surfacing.
- **Inline `Policy` and `Tags` on `AWS::Events::EventBus`** are provisioned but only exercised indirectly by the tests (the `Policy` branch reuses the well-covered `putPermission` `policyJson` path; `Tags` are parsed in the create test). Out of scope and unimplemented: `AWS::Events::ApiDestination`, `AWS::Events::Connection`, `AWS::Events::Archive`, `AWS::Scheduler::Schedule` (no underlying service support), and enforcing the bus resource policy at delivery time.
