### PR TITLE
feat(resourceexplorer2): Add AWS Resource Explorer 2 with cross-service resource discovery

### DIFF
--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -342,6 +342,20 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>backup</artifactId>
         </dependency>
+        <!-- Resource Explorer 2 client -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>resourceexplorer2</artifactId>
+        </dependency>
+        <!-- SSO credential support (needed for FLOCI_TARGET=aws with SSO profiles) -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sso</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ssooidc</artifactId>
+        </dependency>
         <!-- AppSync client -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.services.opensearch.OpenSearchClient;
 import software.amazon.awssdk.services.neptune.NeptuneClient;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rum.RumClient;
+import software.amazon.awssdk.services.resourceexplorer2.ResourceExplorer2Client;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.endpoints.Endpoint;
 import software.amazon.awssdk.services.s3control.S3ControlClient;
@@ -862,6 +863,23 @@ public final class TestFixtures {
                 .region(REGION)
                 .credentialsProvider(CREDENTIALS)
                 .build();
+    }
+
+    public static ResourceExplorer2Client resourceExplorer2Client() {
+        return resourceExplorer2Client(REGION);
+    }
+
+    /**
+     * Resource Explorer 2 client bound to an explicit region. The emulator auto-provisions an
+     * index only in the default region, so CreateIndex/DeleteIndex tests use a different region
+     * to exercise a real create against a region that starts with no index.
+     */
+    public static ResourceExplorer2Client resourceExplorer2Client(Region region) {
+        var builder = ResourceExplorer2Client.builder().region(region);
+        if (!isRealAws()) {
+            builder.endpointOverride(ENDPOINT).credentialsProvider(CREDENTIALS);
+        }
+        return builder.build();
     }
 
     public static AppSyncClient appSyncClient() {

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/ResourceExplorer2Test.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/ResourceExplorer2Test.java
@@ -1,0 +1,587 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.EnabledIf;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.resourceexplorer2.ResourceExplorer2Client;
+import software.amazon.awssdk.services.resourceexplorer2.model.*;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * SDK compatibility tests for Resource Explorer 2.
+ *
+ * <p>Every test deserializes the response through the real AWS SDK and asserts
+ * on EVERY field. If the wire format is wrong (wrong casing, wrong structure,
+ * missing fields), the SDK will return null for that field and the test fails.
+ *
+ * <p>This is the safety net that prevents wire format regressions.
+ */
+@DisplayName("Resource Explorer 2")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ResourceExplorer2Test {
+
+    private static ResourceExplorer2Client client;
+    // The emulator auto-provisions an index only in the default region (us-east-1). CreateIndex
+    // there is a no-op/conflict, so index create+delete is exercised against a second region
+    // that starts with no index, matching AWS's one-index-per-region rule.
+    private static ResourceExplorer2Client altRegionClient;
+    private static S3Client s3;
+
+    private static String defaultViewArn;
+    private static String autoProvisionedIndexArn;
+    private static String createdViewArn;
+    private static String createdIndexArn;
+
+    @BeforeAll
+    static void setup() {
+        client = TestFixtures.resourceExplorer2Client();
+        altRegionClient = TestFixtures.resourceExplorer2Client(Region.US_WEST_2);
+        s3 = TestFixtures.s3Client();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (client != null) client.close();
+        if (altRegionClient != null) altRegionClient.close();
+        if (s3 != null) s3.close();
+    }
+
+    // -----------------------------------------------------------------------
+    // GetIndex — every field must deserialize
+    // -----------------------------------------------------------------------
+
+    @Test
+    @Order(1)
+    void getIndexDeserializesAllFields() {
+        GetIndexResponse response = client.getIndex(GetIndexRequest.builder().build());
+
+        // Every field the SDK model exposes must be non-null and correctly typed
+        assertThat(response.arn()).as("GetIndex.Arn").isNotBlank();
+        assertThat(response.type()).as("GetIndex.Type").isNotNull();
+        assertThat(response.type()).isIn(IndexType.LOCAL, IndexType.AGGREGATOR);
+        assertThat(response.state()).as("GetIndex.State").isNotNull();
+        assertThat(response.state()).isEqualTo(IndexState.ACTIVE);
+        assertThat(response.createdAt()).as("GetIndex.CreatedAt").isNotNull();
+        assertThat(response.lastUpdatedAt()).as("GetIndex.LastUpdatedAt").isNotNull();
+        assertThat(response.tags()).as("GetIndex.Tags").isNotNull();
+        assertThat(response.replicatingFrom()).as("GetIndex.ReplicatingFrom").isNotNull();
+        assertThat(response.replicatingTo()).as("GetIndex.ReplicatingTo").isNotNull();
+
+        autoProvisionedIndexArn = response.arn();
+    }
+
+    // -----------------------------------------------------------------------
+    // GetDefaultView
+    // -----------------------------------------------------------------------
+
+    @Test
+    @Order(2)
+    void getDefaultViewReturnsViewArn() {
+        GetDefaultViewResponse response = client.getDefaultView(GetDefaultViewRequest.builder().build());
+        assertThat(response.viewArn()).as("GetDefaultView.ViewArn").isNotBlank();
+        defaultViewArn = response.viewArn();
+    }
+
+    // -----------------------------------------------------------------------
+    // GetView — every field of the View object
+    // -----------------------------------------------------------------------
+
+    @Test
+    @Order(3)
+    void getViewDeserializesAllFields() {
+        GetViewResponse response = client.getView(GetViewRequest.builder()
+                .viewArn(defaultViewArn).build());
+        View view = response.view();
+
+        assertThat(view).as("GetView.View").isNotNull();
+        assertThat(view.viewArn()).as("View.ViewArn").isEqualTo(defaultViewArn);
+        assertThat(view.viewName()).as("View.ViewName").isNotBlank();
+        assertThat(view.owner()).as("View.Owner").isNotBlank();
+        assertThat(view.scope()).as("View.Scope").isNotBlank();
+        assertThat(view.lastUpdatedAt()).as("View.LastUpdatedAt").isNotNull();
+        assertThat(view.includedProperties()).as("View.IncludedProperties").isNotNull();
+        assertThat(view.filters()).as("View.Filters").isNotNull();
+        assertThat(view.filters().filterString()).as("View.Filters.FilterString").isNotNull();
+
+        // GetViewResponse has root-level Tags (separate from View)
+        assertThat(response.tags()).as("GetViewResponse.Tags").isNotNull();
+    }
+
+    // -----------------------------------------------------------------------
+    // ListSupportedResourceTypes — field-level assertions
+    // -----------------------------------------------------------------------
+
+    @Test
+    @Order(4)
+    void listSupportedResourceTypesDeserializesAllFields() {
+        ListSupportedResourceTypesResponse response = client.listSupportedResourceTypes(
+                ListSupportedResourceTypesRequest.builder().maxResults(50).build());
+
+        assertThat(response.resourceTypes()).as("ResourceTypes").isNotEmpty();
+        for (var rt : response.resourceTypes()) {
+            assertThat(rt.resourceType()).as("SupportedResourceType.ResourceType").isNotBlank();
+            assertThat(rt.service()).as("SupportedResourceType.Service").isNotBlank();
+            // Verify format: "service:type"
+            assertThat(rt.resourceType()).contains(":");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Cross-service setup
+    // -----------------------------------------------------------------------
+
+    @Test
+    @Order(5)
+    void createS3BucketForDiscovery() {
+        assumeFalse(TestFixtures.isRealAws(), "Skip resource creation against real AWS");
+        String bucketName = TestFixtures.uniqueName("re2");
+        s3.createBucket(b -> b.bucket(bucketName));
+    }
+
+    // -----------------------------------------------------------------------
+    // ListResources — every field of Resource objects
+    // -----------------------------------------------------------------------
+
+    @Test
+    @Order(10)
+    void listResourcesDeserializesAllResourceFields() {
+        ListResourcesResponse response = client.listResources(ListResourcesRequest.builder().build());
+
+        assertThat(response.viewArn()).as("ListResources.ViewArn").isNotBlank();
+        assertThat(response.resources()).as("ListResources.Resources").isNotNull();
+
+        // Must have at least one resource (the S3 bucket we created)
+        assertThat(response.resources()).isNotEmpty();
+
+        for (Resource resource : response.resources()) {
+            assertThat(resource.arn()).as("Resource.Arn").isNotBlank();
+            assertThat(resource.resourceType()).as("Resource.ResourceType").isNotBlank();
+            assertThat(resource.service()).as("Resource.Service").isNotBlank();
+            assertThat(resource.region()).as("Resource.Region").isNotBlank();
+            assertThat(resource.owningAccountId()).as("Resource.OwningAccountId").isNotBlank();
+            assertThat(resource.lastReportedAt()).as("Resource.LastReportedAt").isNotNull();
+            assertThat(resource.properties()).as("Resource.Properties").isNotNull();
+        }
+    }
+
+    @Test
+    @Order(11)
+    void listResourcesWithFilterReturnsCorrectTypes() {
+        ListResourcesResponse response = client.listResources(ListResourcesRequest.builder()
+                .filters(SearchFilter.builder().filterString("service:s3").build())
+                .build());
+
+        assertThat(response.resources()).isNotEmpty();
+        for (Resource resource : response.resources()) {
+            assertThat(resource.service()).as("Filtered resource service").isEqualTo("s3");
+            assertThat(resource.resourceType()).startsWith("s3:");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Search — Count object structure is critical
+    // -----------------------------------------------------------------------
+
+    @Test
+    @Order(12)
+    void searchCountIsObjectWithTotalResourcesAndComplete() {
+        SearchResponse response = client.search(SearchRequest.builder()
+                .queryString("service:s3")
+                .build());
+
+        // Count must be an object, not an integer
+        assertThat(response.count()).as("Search.Count").isNotNull();
+        assertThat(response.count().totalResources()).as("Count.TotalResources").isNotNull();
+        assertThat(response.count().totalResources()).isGreaterThanOrEqualTo(0L);
+        assertThat(response.count().complete()).as("Count.Complete").isNotNull();
+
+        assertThat(response.resources()).as("Search.Resources").isNotNull();
+        assertThat(response.viewArn()).as("Search.ViewArn").isNotBlank();
+    }
+
+    @Test
+    @Order(13)
+    void searchCountTotalMatchesActualResourceCount() {
+        SearchResponse response = client.search(SearchRequest.builder()
+                .queryString("service:s3")
+                .build());
+
+        // TotalResources should match the number of matching resources
+        assertThat(response.count().totalResources())
+                .as("Count.TotalResources matches filtered count")
+                .isEqualTo((long) response.resources().size());
+    }
+
+    // -----------------------------------------------------------------------
+    // CreateView — response shape
+    // -----------------------------------------------------------------------
+
+    @Test
+    @Order(20)
+    void createViewResponseContainsViewObject() {
+        assumeFalse(TestFixtures.isRealAws(), "Skip view mutation against real AWS");
+        CreateViewResponse response = client.createView(CreateViewRequest.builder()
+                .viewName("sdk-compat-view")
+                .filters(SearchFilter.builder().filterString("service:s3").build())
+                .includedProperties(IncludedProperty.builder().name("tags").build())
+                .tags(Map.of("testKey", "testValue"))
+                .build());
+
+        View view = response.view();
+        assertThat(view).as("CreateView.View").isNotNull();
+        assertThat(view.viewArn()).as("View.ViewArn").isNotBlank();
+        assertThat(view.owner()).as("View.Owner").isNotBlank();
+        assertThat(view.lastUpdatedAt()).as("View.LastUpdatedAt").isNotNull();
+        assertThat(view.includedProperties()).as("View.IncludedProperties").isNotEmpty();
+
+        createdViewArn = view.viewArn();
+    }
+
+    // -----------------------------------------------------------------------
+    // ListViews
+    // -----------------------------------------------------------------------
+
+    @Test
+    @Order(21)
+    void listViewsReturnsArns() {
+        ListViewsResponse response = client.listViews(ListViewsRequest.builder().build());
+        assertThat(response.views()).as("ListViews.Views").isNotEmpty();
+        if (!TestFixtures.isRealAws()) {
+            assertThat(response.views()).contains(createdViewArn);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // BatchGetView — must have both Views and Errors
+    // -----------------------------------------------------------------------
+
+    @Test
+    @Order(22)
+    void batchGetViewReturnsViewsAndErrorsForMissing() {
+        assumeFalse(TestFixtures.isRealAws(), "Depends on created view");
+        String bogusArn = "arn:aws:resource-explorer-2:us-east-1:000000000000:view/does-not-exist/00000000-0000-0000-0000-000000000000";
+
+        BatchGetViewResponse response = client.batchGetView(BatchGetViewRequest.builder()
+                .viewArns(createdViewArn, bogusArn)
+                .build());
+
+        // Found views
+        assertThat(response.views()).as("BatchGetView.Views").isNotEmpty();
+        assertThat(response.views().get(0).viewArn())
+                .as("BatchGetView found view")
+                .isEqualTo(createdViewArn);
+
+        // Errors for missing
+        assertThat(response.errors()).as("BatchGetView.Errors").isNotEmpty();
+        assertThat(response.errors().get(0).viewArn())
+                .as("BatchGetView error ViewArn")
+                .isEqualTo(bogusArn);
+        assertThat(response.errors().get(0).errorMessage())
+                .as("BatchGetView error message")
+                .isNotBlank();
+    }
+
+    // -----------------------------------------------------------------------
+    // UpdateView
+    // -----------------------------------------------------------------------
+
+    @Test
+    @Order(23)
+    void updateViewReturnsUpdatedView() {
+        assumeFalse(TestFixtures.isRealAws(), "Depends on created view");
+        UpdateViewResponse response = client.updateView(UpdateViewRequest.builder()
+                .viewArn(createdViewArn)
+                .includedProperties(IncludedProperty.builder().name("tags").build())
+                .build());
+
+        assertThat(response.view()).as("UpdateView.View").isNotNull();
+        assertThat(response.view().viewArn()).isEqualTo(createdViewArn);
+        assertThat(response.view().lastUpdatedAt()).as("Updated.LastUpdatedAt").isNotNull();
+    }
+
+    // -----------------------------------------------------------------------
+    // DeleteView
+    // -----------------------------------------------------------------------
+
+    @Test
+    @Order(24)
+    void deleteViewReturnsViewArn() {
+        assumeFalse(TestFixtures.isRealAws(), "Depends on created view");
+        DeleteViewResponse response = client.deleteView(DeleteViewRequest.builder()
+                .viewArn(createdViewArn).build());
+        assertThat(response.viewArn()).as("DeleteView.ViewArn").isEqualTo(createdViewArn);
+    }
+
+    // -----------------------------------------------------------------------
+    // CreateIndex — response must be trimmed to {Arn, State, CreatedAt}
+    // -----------------------------------------------------------------------
+
+    @Test
+    @Order(30)
+    void createIndexReturnsArnStateCreatedAt() {
+        assumeFalse(TestFixtures.isRealAws(), "Skip index mutation against real AWS");
+        CreateIndexResponse response = altRegionClient.createIndex(CreateIndexRequest.builder()
+                .tags(Map.of("env", "test"))
+                .build());
+
+        assertThat(response.arn()).as("CreateIndex.Arn").isNotBlank();
+        assertThat(response.state()).as("CreateIndex.State").isNotNull();
+        assertThat(response.createdAt()).as("CreateIndex.CreatedAt").isNotNull();
+
+        createdIndexArn = response.arn();
+    }
+
+    // -----------------------------------------------------------------------
+    // ListIndexes — each item has Arn, Region, Type
+    // -----------------------------------------------------------------------
+
+    @Test
+    @Order(31)
+    void listIndexesDeserializesItemFields() {
+        ListIndexesResponse response = client.listIndexes(ListIndexesRequest.builder().build());
+
+        assertThat(response.indexes()).as("ListIndexes.Indexes").isNotEmpty();
+        for (var idx : response.indexes()) {
+            assertThat(idx.arn()).as("Index.Arn").isNotBlank();
+            assertThat(idx.region()).as("Index.Region").isNotBlank();
+            assertThat(idx.type()).as("Index.Type").isNotNull();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // UpdateIndexType — PascalCase response fields
+    // -----------------------------------------------------------------------
+
+    @Test
+    @Order(32)
+    void updateIndexTypeDeserializesAllFields() {
+        assumeFalse(TestFixtures.isRealAws(), "Skip index mutation against real AWS");
+        UpdateIndexTypeResponse response = client.updateIndexType(UpdateIndexTypeRequest.builder()
+                .arn(autoProvisionedIndexArn)
+                .type(IndexType.AGGREGATOR)
+                .build());
+
+        assertThat(response.arn()).as("UpdateIndexType.Arn").isNotBlank();
+        assertThat(response.state()).as("UpdateIndexType.State").isNotNull();
+        assertThat(response.type()).as("UpdateIndexType.Type").isNotNull();
+        assertThat(response.lastUpdatedAt()).as("UpdateIndexType.LastUpdatedAt").isNotNull();
+    }
+
+    // -----------------------------------------------------------------------
+    // DeleteIndex — must include LastUpdatedAt
+    // -----------------------------------------------------------------------
+
+    @Test
+    @Order(33)
+    void deleteIndexReturnsArnLastUpdatedAtState() {
+        assumeFalse(TestFixtures.isRealAws(), "Depends on created index");
+        DeleteIndexResponse response = altRegionClient.deleteIndex(DeleteIndexRequest.builder()
+                .arn(createdIndexArn)
+                .build());
+
+        assertThat(response.arn()).as("DeleteIndex.Arn").isEqualTo(createdIndexArn);
+        assertThat(response.state()).as("DeleteIndex.State").isNotNull();
+        assertThat(response.lastUpdatedAt()).as("DeleteIndex.LastUpdatedAt").isNotNull();
+    }
+
+    // -----------------------------------------------------------------------
+    // Error handling — invalid input must return proper error, not 500
+    // -----------------------------------------------------------------------
+
+    @Test
+    @Order(40)
+    void getMissingViewReturnsError() {
+        // Real AWS: 401 UnauthorizedException (auth checked before existence for wrong-account ARN)
+        // Floci: 404 ResourceNotFoundException
+        assertThatThrownBy(() -> client.getView(GetViewRequest.builder()
+                .viewArn("arn:aws:resource-explorer-2:us-east-1:000000000000:view/nope/00000000-0000-0000-0000-000000000000")
+                .build()))
+                .isInstanceOf(ResourceExplorer2Exception.class);
+    }
+
+    @Test
+    @Order(41)
+    void deleteMissingIndexReturnsError() {
+        // Real AWS: 403 AccessDeniedException (auth checked before existence for wrong-account ARN)
+        // Floci: 404 ResourceNotFoundException
+        assertThatThrownBy(() -> client.deleteIndex(DeleteIndexRequest.builder()
+                .arn("arn:aws:resource-explorer-2:us-east-1:000000000000:index/nonexistent")
+                .build()))
+                .isInstanceOf(ResourceExplorer2Exception.class);
+    }
+
+    // -----------------------------------------------------------------------
+    // CLASS 3: Wire Format — Nested Structure Deserialization
+    // Drills into nested objects to verify the SDK can parse every level.
+    // If any nested field uses wrong casing or wrong structure, the SDK
+    // returns null and these tests fail.
+    // -----------------------------------------------------------------------
+
+    @Test
+    @Order(50)
+    void viewFiltersFilterStringDeserializes() {
+        assumeFalse(TestFixtures.isRealAws(), "Creates/deletes views");
+        // Create view with filter, then get it and drill into nested Filters object
+        CreateViewResponse createResp = client.createView(CreateViewRequest.builder()
+                .viewName("nested-test-view")
+                .filters(SearchFilter.builder().filterString("service:s3").build())
+                .includedProperties(IncludedProperty.builder().name("tags").build())
+                .build());
+        String arn = createResp.view().viewArn();
+
+        GetViewResponse getResp = client.getView(GetViewRequest.builder().viewArn(arn).build());
+        View view = getResp.view();
+
+        // Drill into nested Filters.FilterString
+        assertThat(view.filters()).as("View.Filters").isNotNull();
+        assertThat(view.filters().filterString()).as("Filters.FilterString").isEqualTo("service:s3");
+
+        // Drill into nested IncludedProperties[].Name
+        assertThat(view.includedProperties()).as("View.IncludedProperties").hasSize(1);
+        assertThat(view.includedProperties().get(0).name())
+                .as("IncludedProperty.Name").isEqualTo("tags");
+
+        // Drill into scope
+        assertThat(view.scope()).as("View.Scope").contains("arn:aws:iam:");
+
+        // Cleanup
+        client.deleteView(DeleteViewRequest.builder().viewArn(arn).build());
+    }
+
+    @Test
+    @Order(51)
+    void resourcePropertiesTagDataDeserializes() {
+        // List resources — S3 bucket should have tag Properties
+        ListResourcesResponse response = client.listResources(ListResourcesRequest.builder()
+                .filters(SearchFilter.builder().filterString("service:s3").build())
+                .build());
+
+        assertThat(response.resources()).isNotEmpty();
+        Resource s3Resource = response.resources().get(0);
+
+        // Properties is a list of ResourceProperty
+        assertThat(s3Resource.properties()).as("Resource.Properties").isNotNull();
+        // Note: Properties may be empty if no tags — we just verify the list itself deserializes.
+        // The integration test handles tag-specific assertions.
+    }
+
+    @Test
+    @Order(52)
+    void searchCountNestedFieldsDeserialize() {
+        SearchResponse response = client.search(SearchRequest.builder()
+                .queryString("")
+                .maxResults(1)
+                .build());
+
+        ResourceCount count = response.count();
+        assertThat(count).as("Search.Count object").isNotNull();
+
+        // These would be null if Count was an integer instead of an object
+        assertThat(count.totalResources()).as("Count.TotalResources").isNotNull();
+        assertThat(count.totalResources()).isGreaterThanOrEqualTo(0L);
+
+        // Complete is a boolean — just verify it deserializes (not null)
+        // Value depends on whether there are >1 matching resources
+        assertThat(count.complete()).as("Count.Complete").isNotNull();
+    }
+
+    @Test
+    @Order(53)
+    void searchCountCompleteIsTrueWhenAllResultsFit() {
+        SearchResponse response = client.search(SearchRequest.builder()
+                .queryString("")
+                .maxResults(1000)
+                .build());
+
+        assertThat(response.count().complete())
+                .as("Count.Complete when not paginating").isTrue();
+        assertThat(response.nextToken()).as("NextToken absent on last page").isNull();
+    }
+
+    @Test
+    @Order(54)
+    void indexReplicatingFieldsAreEmptyLists() {
+        GetIndexResponse response = client.getIndex(GetIndexRequest.builder().build());
+
+        // ReplicatingFrom and ReplicatingTo should deserialize as lists, not null
+        assertThat(response.replicatingFrom())
+                .as("GetIndex.ReplicatingFrom").isNotNull().isEmpty();
+        assertThat(response.replicatingTo())
+                .as("GetIndex.ReplicatingTo").isNotNull().isEmpty();
+    }
+
+    @Test
+    @Order(55)
+    void batchGetViewErrorFieldsDeserialize() {
+        assumeFalse(TestFixtures.isRealAws(), "Uses floci-specific bogus ARN format");
+        String bogus = "arn:aws:resource-explorer-2:us-east-1:000000000000:view/x/00000000-0000-0000-0000-000000000000";
+
+        BatchGetViewResponse response = client.batchGetView(BatchGetViewRequest.builder()
+                .viewArns(bogus)
+                .build());
+
+        assertThat(response.errors()).as("Errors list").hasSize(1);
+        BatchGetViewError error = response.errors().get(0);
+        assertThat(error.viewArn()).as("Error.ViewArn").isEqualTo(bogus);
+        assertThat(error.errorMessage()).as("Error.ErrorMessage").isNotBlank();
+    }
+
+    @Test
+    @Order(56)
+    void listResourcesPaginationTokenRoundTrips() {
+        assumeFalse(TestFixtures.isRealAws(), "Floci-specific pagination behavior");
+        // Page 1
+        ListResourcesResponse page1 = client.listResources(ListResourcesRequest.builder()
+                .maxResults(1)
+                .build());
+        assertThat(page1.resources()).hasSize(1);
+        assertThat(page1.nextToken()).as("Page1 NextToken").isNotNull();
+
+        // Page 2 using token from page 1
+        ListResourcesResponse page2 = client.listResources(ListResourcesRequest.builder()
+                .maxResults(1)
+                .nextToken(page1.nextToken())
+                .build());
+        assertThat(page2.resources()).hasSize(1);
+
+        // Page 1 and Page 2 should return different resources
+        assertThat(page2.resources().get(0).arn())
+                .as("Page 2 returns different resource")
+                .isNotEqualTo(page1.resources().get(0).arn());
+    }
+
+    @Test
+    @Order(57)
+    void updateViewNestedFieldsDeserialize() {
+        assumeFalse(TestFixtures.isRealAws(), "Creates/deletes views");
+        // Create, update, verify nested fields roundtrip
+        CreateViewResponse created = client.createView(CreateViewRequest.builder()
+                .viewName("update-nested-test")
+                .build());
+        String arn = created.view().viewArn();
+
+        UpdateViewResponse updated = client.updateView(UpdateViewRequest.builder()
+                .viewArn(arn)
+                .filters(SearchFilter.builder().filterString("region:us-east-1").build())
+                .includedProperties(IncludedProperty.builder().name("tags").build())
+                .build());
+
+        View view = updated.view();
+        assertThat(view.viewArn()).isEqualTo(arn);
+        assertThat(view.filters()).as("Updated Filters").isNotNull();
+        assertThat(view.filters().filterString())
+                .as("Updated FilterString").isEqualTo("region:us-east-1");
+        assertThat(view.includedProperties()).hasSize(1);
+        assertThat(view.includedProperties().get(0).name()).isEqualTo("tags");
+
+        client.deleteView(DeleteViewRequest.builder().viewArn(arn).build());
+    }
+}

--- a/docker/Dockerfile.localdev
+++ b/docker/Dockerfile.localdev
@@ -1,0 +1,59 @@
+# Local-dev runtime image: reuses a host-built target/quarkus-app (deps cached in
+# host ~/.m2) so the k3d dev cluster gets the patched Floci without the slow
+# in-container maven build. Functionally identical runtime to docker/Dockerfile's
+# stage 2. Used only for the local Crossplane+Floci dev env; the published
+# floci/floci image is still built from docker/Dockerfile in pkware/floci CI.
+FROM eclipse-temurin:25-jre-alpine
+
+ARG VERSION=localdev
+ENV FLOCI_VERSION=${VERSION}
+ENV FLOCI_STORAGE_PERSISTENT_PATH=/app/data
+
+ENV AWS_DEFAULT_REGION=us-east-1
+ENV AWS_ACCESS_KEY_ID=test
+ENV AWS_SECRET_ACCESS_KEY=test
+ENV AWS_CONFIG_FILE=/etc/floci/aws/config
+
+ENV GOSU_VERSION=1.17
+ENV GOSU_AMD64_SHA256=bbc4136d03ab138b1ad66fa4fc051bafc6cc7ffae632b069a53657279a450de3
+ENV GOSU_ARM64_SHA256=c3805a85d17f4454c23d7059bcb97e1ec1af272b90126e79ed002342de08389b
+RUN set -eux; \
+    apk add --no-cache shadow ca-certificates python3 py3-pip; \
+    pip3 install --no-cache-dir --break-system-packages awscli boto3; \
+    mv /usr/bin/aws /usr/bin/aws.real; \
+    printf '#!/bin/sh\nexec /usr/bin/aws.real --endpoint-url=http://localhost:4566 "$@"\n' > /usr/bin/aws; \
+    chmod +x /usr/bin/aws; \
+    useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci; \
+    arch="$(apk --print-arch)"; \
+    case "$arch" in \
+        x86_64) gosuArch='amd64'; gosuSha256="$GOSU_AMD64_SHA256" ;; \
+        aarch64) gosuArch='arm64'; gosuSha256="$GOSU_ARM64_SHA256" ;; \
+        *) echo >&2 "unsupported arch: $arch"; exit 1 ;; \
+    esac; \
+    wget -q -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${gosuArch}"; \
+    echo "${gosuSha256}  /usr/local/bin/gosu" | sha256sum -c -; \
+    chmod +x /usr/local/bin/gosu
+
+WORKDIR /app
+
+RUN mkdir -p /app/data /etc/floci/aws \
+    && printf '[default]\nendpoint_url = http://localhost:4566\n' > /etc/floci/aws/config \
+    && chown 1001:root /app \
+    && chmod "g+rwX" /app \
+    && chown 1001:root /app/data
+
+COPY target/quarkus-app/ quarkus-app/
+RUN chown -R 1001:root /app/quarkus-app
+
+COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY --chmod=755 docker/localstack-parity.sh /usr/local/bin/localstack-parity.sh
+
+VOLUME /app/data
+
+EXPOSE 4566 6379-6399
+
+HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
+    CMD wget -q --spider http://localhost:4566/_floci/health || exit 1
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["java", "--enable-native-access=ALL-UNNAMED", "-jar", "/app/quarkus-app/quarkus-run.jar"]

--- a/docs/services/docdb.md
+++ b/docs/services/docdb.md
@@ -21,7 +21,7 @@ The management API shares the RDS Query endpoint (`POST /` with an `Action=` par
 | --- | --- |
 | `CreateDBCluster` | Create a DocumentDB cluster and start a MongoDB container |
 | `DescribeDBClusters` | List clusters and their connection details |
-| `DescribeDBClusterSnapshots` | - |
+| `DescribeDBClusterSnapshots` | Return an empty cluster-snapshot list (snapshots are not modeled) |
 | `DeleteDBCluster` | Stop and remove a cluster (must have no instances) |
 | `ModifyDBCluster` | Update engine version or IAM auth setting |
 | `CreateDBInstance` | Add an instance to a cluster |
@@ -139,6 +139,6 @@ print(cluster["DBCluster"]["Endpoint"])
 
 - IAM database authentication for MongoDB connections (the flag is stored and echoed back, but connections are not SigV4-proxied).
 - TLS / `--tls` enforced connections.
-- Snapshot creation and restore (`DescribeDBClusterSnapshots` returns an empty stub result; snapshots are not modeled).
+- Snapshot and restore operations.
 - Global clusters, replicas, and read-scaling beyond a single MongoDB container per cluster.
 - Parameter groups, subnet groups, and maintenance windows.

--- a/docs/services/elasticache.md
+++ b/docs/services/elasticache.md
@@ -23,8 +23,8 @@ Floci manages real Valkey/Redis Docker containers and proxies TCP connections to
 | `CreateCacheCluster` | - |
 | `DescribeCacheClusters` | - |
 | `DeleteCacheCluster` | - |
-| `DescribeCacheSubnetGroups` | - |
-| `DescribeCacheParameterGroups` | - |
+| `DescribeCacheSubnetGroups` | Return an empty subnet-group list (subnet groups are not modeled) |
+| `DescribeCacheParameterGroups` | Return an empty parameter-group list (parameter groups are not modeled) |
 <!-- floci:actions:end -->
 
 ## Configuration

--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -37,9 +37,9 @@ RDS Data API (`rds-data`) is documented separately because it uses REST JSON rou
 | `DeleteDBClusterParameterGroup` | - |
 | `ModifyDBClusterParameterGroup` | - |
 | `DescribeDBClusterParameters` | - |
-| `DescribeDBSnapshots` | - |
-| `DescribeDBProxies` | - |
-| `DescribeDBClusterSnapshots` | - |
+| `DescribeDBSnapshots` | Return an empty snapshot list (snapshots are not modeled) |
+| `DescribeDBProxies` | Return an empty DB proxy list (proxies are not modeled) |
+| `DescribeDBClusterSnapshots` | Return an empty cluster-snapshot list (snapshots are not modeled) |
 | `AddTagsToResource` | Add tags to a DB resource |
 | `ListTagsForResource` | List tags for a DB resource |
 | `RemoveTagsFromResource` | Remove tags from a DB resource |

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -267,6 +267,7 @@ public interface EmulatorConfig {
         NeptuneStorageConfig neptune();
         BackupStorageConfig backup();
         CloudFrontStorageConfig cloudfront();
+        ResourceExplorer2StorageConfig resourceexplorer2();
         AppSyncStorageConfig appsync();
         BatchStorageConfig batch();
         LightsailStorageConfig lightsail();
@@ -403,6 +404,13 @@ public interface EmulatorConfig {
 
     interface CloudFrontStorageConfig {
         Optional<String> mode();
+    }
+
+    interface ResourceExplorer2StorageConfig {
+        Optional<String> mode();
+
+        @WithDefault("5000")
+        long flushIntervalMs();
     }
 
     interface AppSyncStorageConfig {
@@ -585,6 +593,7 @@ public interface EmulatorConfig {
         ConfigServiceConfig configservice();
         CloudTrailServiceConfig cloudtrail();
         CloudControlServiceConfig cloudcontrol();
+        ResourceExplorer2ServiceConfig resourceexplorer2();
         CloudFrontServiceConfig cloudfront();
         AppSyncServiceConfig appsync();
         BatchServiceConfig batch();
@@ -685,6 +694,11 @@ public interface EmulatorConfig {
          *  default here is 60s so dev/CI feedback loops stay fast. */
         @WithDefault("60")
         int flushIntervalSeconds();
+    }
+
+    interface ResourceExplorer2ServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
     }
 
     interface AutoScalingServiceConfig {

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -282,8 +282,8 @@ public class AwsQueryController {
             case "sns" -> snsQueryHandler.handle(action, formParams, region);
             case "iam" -> iamQueryHandler.handle(action, formParams, authorization);
             case "sts" -> stsQueryHandler.handle(action, formParams);
-            case "elasticache" -> elastiCacheQueryHandler.handle(action, formParams);
-            case "rds" -> { 
+            case "elasticache" -> elastiCacheQueryHandler.handle(action, formParams, region);
+            case "rds" -> {
                 // Neptune signs requests with "rds" credential scope (same wire protocol).
                 // Route to Neptune when Engine=neptune (create ops) or when the cluster/instance
                 // already exists in Neptune storage (describe/modify/delete ops).

--- a/src/main/java/io/github/hectorvent/floci/core/common/RegionResolver.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/RegionResolver.java
@@ -71,6 +71,10 @@ public class RegionResolver {
         return defaultRegion;
     }
 
+    public String getDefaultAccountId() {
+        return defaultAccountId;
+    }
+
     /**
      * Returns the account ID for the current request when called from a request context,
      * or the configured default account ID otherwise (async workers, startup, tests).

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.core.common;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.services.appconfig.AppConfigController;
 import io.github.hectorvent.floci.services.backup.BackupController;
+import io.github.hectorvent.floci.services.resourceexplorer2.ResourceExplorer2Controller;
 import io.github.hectorvent.floci.services.appconfig.AppConfigDataController;
 import io.github.hectorvent.floci.services.batch.BatchController;
 import io.github.hectorvent.floci.services.bedrockruntime.BedrockRuntimeController;
@@ -331,6 +332,15 @@ public class ResolvedServiceCatalog {
                         config.storage().services().backup().flushIntervalMs(), null, ServiceProtocol.REST_JSON,
                         protocols(ServiceProtocol.REST_JSON),
                         Set.of(), Set.of("backup"), Set.of(), Set.of(BackupController.class)),
+                descriptor("resource-explorer-2", "resourceexplorer2",
+                        config.services().resourceexplorer2().enabled(), true,
+                        "resourceexplorer2",
+                        storageMode(config.storage().services().resourceexplorer2().mode(), config.storage().mode()),
+                        config.storage().services().resourceexplorer2().flushIntervalMs(),
+                        null, ServiceProtocol.REST_JSON,
+                        protocols(ServiceProtocol.REST_JSON),
+                        Set.of(), Set.of("resource-explorer-2"), Set.of(),
+                        Set.of(ResourceExplorer2Controller.class)),
                 descriptor("ec2messages", "ec2messages", config.services().ssm().enabled(), false,
                         null, null, 5000L, null, ServiceProtocol.JSON,
                         protocols(ServiceProtocol.JSON),

--- a/src/main/java/io/github/hectorvent/floci/core/common/SigV4CredentialScope.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/SigV4CredentialScope.java
@@ -9,14 +9,14 @@ import java.util.regex.Pattern;
  * Extracts the SigV4 signing service name from an Authorization header's
  * credential scope ({@code Credential=<key>/<date>/<region>/<service>/aws4_request}).
  */
-final class SigV4CredentialScope {
+public final class SigV4CredentialScope {
 
     private static final Pattern SERVICE_PATTERN = Pattern.compile("Credential=\\S+/\\d{8}/[^/]+/([^/]+)/");
 
     private SigV4CredentialScope() {
     }
 
-    static Optional<String> serviceName(String authorization) {
+    public static Optional<String> serviceName(String authorization) {
         if (authorization == null) {
             return Optional.empty();
         }

--- a/src/main/java/io/github/hectorvent/floci/core/resource/ExplorerResource.java
+++ b/src/main/java/io/github/hectorvent/floci/core/resource/ExplorerResource.java
@@ -1,0 +1,54 @@
+package io.github.hectorvent.floci.core.resource;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * A single resource made visible to Resource Explorer 2.
+ * <p>
+ * One instance describes one AWS resource (a certificate, a queue, a cluster, etc.)
+ *
+ * <p>The fields are what the query language filters and keywords match against, so they
+ * must be populated with real, consistent values for search to work. Filterable attributes:
+ * {@code resourcetype:}, {@code service:}, {@code region:}, {@code accountid:}, {@code id:} (the
+ * ARN), and the tag attributes ({@code tag:}, {@code tag.key:}, {@code tag.value:},
+ * {@code application:} — the last reads the {@code awsApplication} tag). A bare keyword matches a
+ * case-insensitive substring of {@link #arn}, {@link #resourceType}, {@link #service}, or
+ * {@link #region}. See {@code ResourceFilter} for the exact matching rules.
+ *
+ * @param arn             full ARN of the resource, e.g.
+ *                        {@code arn:aws:acm:us-east-1:123456789012:certificate/abc}. Doubles as the
+ *                        resource's unique id ({@code id:} filter) and is matched by keyword search.
+ * @param resourceType    Resource Explorer's type identifier in {@code service:subtype} form, e.g.
+ *                        {@code acm:certificate}, {@code kafka:cluster}, {@code iam:user}. Must be
+ *                        identical to the {@link SupportedResourceType#resourceType()} the provider
+ *                        advertises for this resource, and unique across all providers.
+ * @param service         AWS service namespace — the service segment of the ARN, e.g. {@code acm},
+ *                        {@code kafka}, {@code cognito-idp}. This is the prefix of
+ *                        {@link #resourceType}, not necessarily the floci module name.
+ * @param owningAccountId 12-digit account id that owns the resource; usually
+ *                        {@code AwsArnUtils.parse(arn).accountId()}.
+ * @param region          AWS region the resource lives in, e.g. {@code us-east-1}; usually
+ *                        {@code AwsArnUtils.parse(arn).region()}.
+ * @param lastReportedAt  when Resource Explorer last observed the resource. floci has no scan
+ *                        pipeline, so providers pass the resource's creation timestamp (falling back
+ *                        to {@code Instant.now()} when unknown).
+ * @param tags            resource tags as key→value; drives the tag filters and is emitted as the
+ *                        {@code tags} property. Never {@code null} — pass {@code Map.of()} when the
+ *                        resource has no tags.
+ * @see SupportedResourceType
+ * @see <a href="https://docs.aws.amazon.com/resource-explorer/latest/apireference/API_Resource.html">AWS API: Resource</a>
+ * @see <a href="https://docs.aws.amazon.com/resource-explorer/latest/userguide/using-search-query-syntax.html">Resource Explorer search query syntax</a>
+ */
+@RegisterForReflection
+public record ExplorerResource(
+        String arn,
+        String resourceType,
+        String service,
+        String region,
+        String owningAccountId,
+        Instant lastReportedAt,
+        Map<String, String> tags
+) {}

--- a/src/main/java/io/github/hectorvent/floci/core/resource/ResourceProvider.java
+++ b/src/main/java/io/github/hectorvent/floci/core/resource/ResourceProvider.java
@@ -1,0 +1,62 @@
+package io.github.hectorvent.floci.core.resource;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Extension point that lets an individual AWS service emulator expose its resources to the Resource
+ * Explorer 2 emulator. Implement this on a service that owns resources you want to be discoverable
+ * via {@code Search}, {@code ListResources}, and {@code ListSupportedResourceTypes}.
+ * <p>
+ * Implementations must be CDI beans (usually {@code @ApplicationScoped} service classes).
+ * {@code ResourceExplorer2Service} iterates {@code ResourceProvider}s:
+ * <ul>
+ *   <li>{@code Search} / {@code ListResources} concatenate {@link #getResources()} from all
+ *       providers, apply the query filter, then paginate. {@code Search} returns at most the first
+ *       1000 matches; {@code ListResources} has no such cap and pages through every match, but omits
+ *       its {@code NextToken} when {@code MaxResults} is 1000. floci mirrors both behaviors.</li>
+ *   <li>{@code ListSupportedResourceTypes} concatenates {@link #getSupportedResourceTypes()} from
+ *       all providers and deduplicates by {@link SupportedResourceType#resourceType()}.</li>
+ * </ul>
+ *
+ * <h2>Implementing</h2>
+ * <ol>
+ *   <li>{@link #getResources()}: scan your storage backend and map each stored entity to an
+ *       {@link ExplorerResource}.</li>
+ *   <li>{@link #getSupportedResourceTypes()}: return one {@link SupportedResourceType} per distinct
+ *       {@code resourceType} string you emit.</li>
+ *   <li>Keep the {@code resourceType} string identical between the two methods — a resource whose
+ *       type is not advertised will still be searchable, but callers listing supported types would
+ *       not see it, which is inconsistent with AWS.</li>
+ * </ol>
+ *
+ * <p>See {@code AcmService}, {@code MskService}, or {@code IamService} (which exposes two types)
+ * for reference implementations.
+ *
+ * @see ExplorerResource
+ * @see SupportedResourceType
+ * @see <a href="https://docs.aws.amazon.com/resource-explorer/latest/userguide/getting-started-terms-and-concepts.html">Resource Explorer terms and concepts</a>
+ * @see <a href="https://docs.aws.amazon.com/resource-explorer/latest/apireference/API_Search.html">AWS API: Search</a>
+ */
+public interface ResourceProvider {
+
+    /**
+     * All resources this service currently own.
+     * <p>
+     * Build the list from live storage rather
+     * than caching. Return an empty list when the service holds nothing; never return {@code null}.
+     * Ordering is not significant — the service applies its own pagination.
+     */
+    List<ExplorerResource> getResources();
+
+    /**
+     * The resource types this provider can produce.
+     * <p>
+     * One entry per distinct
+     * {@link ExplorerResource#resourceType()} value returned by {@link #getResources()}.
+     * The set is fixed for a given service, so returning a
+     * literal {@code Set.of(...)} is the norm. Each {@code resourceType} must be globally unique
+     * across providers.
+     */
+    Set<SupportedResourceType> getSupportedResourceTypes();
+}

--- a/src/main/java/io/github/hectorvent/floci/core/resource/SupportedResourceType.java
+++ b/src/main/java/io/github/hectorvent/floci/core/resource/SupportedResourceType.java
@@ -1,0 +1,33 @@
+package io.github.hectorvent.floci.core.resource;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * One resource type a {@link ResourceProvider} can produce.
+ * <p>
+ * This is the type-level counterpart to {@link ExplorerResource}
+ * (which is an instance): a provider returns one of these per distinct
+ * {@link ExplorerResource#resourceType()} value it emits.
+ *
+ * <p>The Resource Explorer 2 service collects these from every provider, deduplicates by {@link #resourceType}.
+ *
+ * @param resourceType type identifier in {@code service:subtype} form, e.g. {@code acm:certificate},
+ *                     {@code kafka:cluster}, {@code iam:user}. Must exactly match the
+ *                     {@link ExplorerResource#resourceType()} used for the corresponding resources,
+ *                     and be unique across all providers — the service uses this string as the
+ *                     deduplication key.
+ * @param service      AWS service namespace, i.e. the segment before the colon in
+ *                     {@link #resourceType} (e.g. {@code acm}, {@code kafka}, {@code cognito-idp}).
+ * @param supportsTags whether this type carries tags. Advisory metadata describing the type; the
+ *                     Resource Explorer emulator currently treats every exposed type as taggable
+ *                     regardless (the {@code resourcetype:supports=tags} filter is a pass-through),
+ *                     so set it truthfully but do not expect it to gate behavior today.
+ * @see ExplorerResource
+ * @see <a href="https://docs.aws.amazon.com/resource-explorer/latest/apireference/API_ListSupportedResourceTypes.html">AWS API: ListSupportedResourceTypes</a>
+ */
+@RegisterForReflection
+public record SupportedResourceType(
+        String resourceType,
+        String service,
+        boolean supportsTags
+) {}

--- a/src/main/java/io/github/hectorvent/floci/services/acm/AcmService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/acm/AcmService.java
@@ -4,6 +4,9 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.acm.model.*;
@@ -35,7 +38,7 @@ import java.util.stream.Collectors;
  * @see <a href="https://docs.aws.amazon.com/acm/latest/APIReference/Welcome.html">AWS ACM API Reference</a>
  */
 @ApplicationScoped
-public class AcmService {
+public class AcmService implements ResourceProvider {
 
     private static final Logger LOG = Logger.getLogger(AcmService.class);
     private static final int MAX_TAGS = 50;
@@ -479,6 +482,27 @@ public class AcmService {
                 "DaysBeforeExpiry must be between 1 and 90", 400);
         }
         this.accountDaysBeforeExpiry.set(daysBeforeExpiry);
+    }
+
+    @Override
+    public List<ExplorerResource> getResources() {
+        List<ExplorerResource> resources = new ArrayList<>();
+        for (Certificate cert : store.scan(k -> true)) {
+            String arn = cert.getArn();
+            if (arn == null) continue;
+            AwsArnUtils.Arn parsed = AwsArnUtils.parse(arn);
+            resources.add(new ExplorerResource(
+                    arn, "acm:certificate", "acm",
+                    parsed.region(), parsed.accountId(),
+                    cert.getCreatedAt() != null ? cert.getCreatedAt() : Instant.now(),
+                    cert.getTags() != null ? cert.getTags() : Map.of()));
+        }
+        return resources;
+    }
+
+    @Override
+    public Set<SupportedResourceType> getSupportedResourceTypes() {
+        return Set.of(new SupportedResourceType("acm:certificate", "acm", true));
     }
 
     // ============ Helper Methods ============

--- a/src/main/java/io/github/hectorvent/floci/services/amazonmq/AmazonMqService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/amazonmq/AmazonMqService.java
@@ -5,6 +5,9 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
@@ -20,17 +23,19 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.security.SecureRandom;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 @ApplicationScoped
-public class AmazonMqService {
+public class AmazonMqService implements ResourceProvider {
 
     private static final Logger LOG = Logger.getLogger(AmazonMqService.class);
     private static final String ENGINE_RABBITMQ = "RABBITMQ";
@@ -152,6 +157,27 @@ public class AmazonMqService {
 
     public List<Broker> listBrokers() {
         return storage.scan(k -> true);
+    }
+
+    @Override
+    public List<ExplorerResource> getResources() {
+        List<ExplorerResource> resources = new ArrayList<>();
+        for (Broker broker : storage.scan(k -> true)) {
+            String arn = broker.getBrokerArn();
+            if (arn == null) continue;
+            AwsArnUtils.Arn parsed = AwsArnUtils.parse(arn);
+            resources.add(new ExplorerResource(
+                    arn, "mq:broker", "mq",
+                    parsed.region(), parsed.accountId(),
+                    broker.getCreated() != null ? broker.getCreated() : Instant.now(),
+                    broker.getTags() != null ? broker.getTags() : Map.of()));
+        }
+        return resources;
+    }
+
+    @Override
+    public Set<SupportedResourceType> getSupportedResourceTypes() {
+        return Set.of(new SupportedResourceType("mq:broker", "mq", true));
     }
 
     public void deleteBroker(String brokerId) {

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -8,6 +8,9 @@ import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.ReservedTags;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.cognito.model.*;
@@ -30,12 +33,13 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 
 import static io.github.hectorvent.floci.core.common.ReservedTags.rejectUnknownReservedTags;
 
 @ApplicationScoped
-public class CognitoService {
+public class CognitoService implements ResourceProvider {
     private static final int DEFAULT_REFRESH_TOKEN_VALIDITY_DAYS = 30;
 
     private static final Logger LOG = Logger.getLogger(CognitoService.class);
@@ -269,6 +273,27 @@ public class CognitoService {
 
     public List<UserPool> listUserPools() {
         return poolStore.scan(k -> true);
+    }
+
+    @Override
+    public List<ExplorerResource> getResources() {
+        List<ExplorerResource> resources = new ArrayList<>();
+        for (UserPool pool : poolStore.scan(k -> true)) {
+            String arn = pool.getArn();
+            if (arn == null) continue;
+            AwsArnUtils.Arn parsed = AwsArnUtils.parse(arn);
+            resources.add(new ExplorerResource(
+                    arn, "cognito-idp:userpool", "cognito-idp",
+                    parsed.region(), parsed.accountId(),
+                    pool.getCreationDate() > 0 ? Instant.ofEpochSecond(pool.getCreationDate()) : Instant.now(),
+                    pool.getUserPoolTags() != null ? pool.getUserPoolTags() : Map.of()));
+        }
+        return resources;
+    }
+
+    @Override
+    public Set<SupportedResourceType> getSupportedResourceTypes() {
+        return Set.of(new SupportedResourceType("cognito-idp:userpool", "cognito-idp", true));
     }
 
     private UserPool describeUserPoolByArn(String resourceArn) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -48,9 +48,12 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 import java.util.zip.GZIPOutputStream;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
 
 @ApplicationScoped
-public class DynamoDbService {
+public class DynamoDbService implements ResourceProvider {
 
     private static final Logger LOG = Logger.getLogger(DynamoDbService.class);
 
@@ -2814,5 +2817,25 @@ public class DynamoDbService {
                 .toList();
 
         return new ListExportsResult(summaries, newNextToken);
+    }
+
+    @Override
+    public List<ExplorerResource> getResources() {
+        List<ExplorerResource> resources = new ArrayList<>();
+        for (TableDefinition table : tableStore.scan(k -> true)) {
+            if (table.getTableArn() == null) continue;
+            AwsArnUtils.Arn parsed = AwsArnUtils.parse(table.getTableArn());
+            resources.add(new ExplorerResource(
+                    table.getTableArn(), "dynamodb:table", "dynamodb",
+                    parsed.region(), parsed.accountId(),
+                    table.getCreationDateTime() != null ? table.getCreationDateTime() : Instant.now(),
+                    table.getTags() != null ? table.getTags() : Map.of()));
+        }
+        return resources;
+    }
+
+    @Override
+    public Set<SupportedResourceType> getSupportedResourceTypes() {
+        return Set.of(new SupportedResourceType("dynamodb:table", "dynamodb", true));
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ecr/EcrService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecr/EcrService.java
@@ -4,6 +4,9 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ecr.model.AuthorizationData;
@@ -26,10 +29,11 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 @ApplicationScoped
-public class EcrService {
+public class EcrService implements ResourceProvider {
 
     private static final Logger LOG = Logger.getLogger(EcrService.class);
     private static final Pattern REPO_NAME = Pattern.compile(
@@ -483,6 +487,27 @@ public class EcrService {
         repo.setRepositoryPolicyText(null);
         repoStore.put(key(region, repo.getRegistryId(), repoName), repo);
         return repo;
+    }
+
+    @Override
+    public List<ExplorerResource> getResources() {
+        List<ExplorerResource> resources = new ArrayList<>();
+        for (Repository repo : repoStore.scan(k -> true)) {
+            String arn = repo.getRepositoryArn();
+            if (arn == null) continue;
+            AwsArnUtils.Arn parsed = AwsArnUtils.parse(arn);
+            resources.add(new ExplorerResource(
+                    arn, "ecr:repository", "ecr",
+                    parsed.region(), parsed.accountId(),
+                    repo.getCreatedAt() != null ? repo.getCreatedAt() : Instant.now(),
+                    repo.getTags() != null ? repo.getTags() : Map.of()));
+        }
+        return resources;
+    }
+
+    @Override
+    public Set<SupportedResourceType> getSupportedResourceTypes() {
+        return Set.of(new SupportedResourceType("ecr:repository", "ecr", true));
     }
 
     // ============================================================

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandler.java
@@ -47,11 +47,11 @@ public class ElastiCacheQueryHandler {
         this.regionResolver = regionResolver;
     }
 
-    public Response handle(String action, MultivaluedMap<String, String> params) {
+    public Response handle(String action, MultivaluedMap<String, String> params, String region) {
         LOG.debugv("ElastiCache action: {0}", action);
         return switch (action) {
             case "ValidateIamAuthToken"       -> handleValidateIamAuthToken(params);
-            case "CreateReplicationGroup"     -> handleCreateReplicationGroup(params);
+            case "CreateReplicationGroup"     -> handleCreateReplicationGroup(params, region);
             case "DescribeReplicationGroups"  -> handleDescribeReplicationGroups(params);
             case "ModifyReplicationGroup"     -> handleModifyReplicationGroup(params);
             case "DeleteReplicationGroup"     -> handleDeleteReplicationGroup(params);
@@ -71,7 +71,7 @@ public class ElastiCacheQueryHandler {
 
     // ── Replication Groups ────────────────────────────────────────────────────
 
-    private Response handleCreateReplicationGroup(MultivaluedMap<String, String> params) {
+    private Response handleCreateReplicationGroup(MultivaluedMap<String, String> params, String region) {
         String groupId = params.getFirst("ReplicationGroupId");
         String description = params.getFirst("ReplicationGroupDescription");
         String authToken = params.getFirst("AuthToken");
@@ -93,7 +93,7 @@ public class ElastiCacheQueryHandler {
 
         try {
             ReplicationGroup group = service.createReplicationGroup(
-                    groupId, description != null ? description : "", authMode, authToken);
+                    groupId, description != null ? description : "", authMode, authToken, region);
             String result = replicationGroupXml(group);
             return Response.ok(AwsQueryResponse.envelope("CreateReplicationGroup", AwsNamespaces.EC, result)).build();
         } catch (AwsException e) {

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
@@ -2,7 +2,9 @@ package io.github.hectorvent.floci.services.elasticache;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheContainerHandle;
@@ -18,18 +20,22 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
 
 /**
  * Core ElastiCache business logic — replication groups and users.
  * Creates Valkey containers and auth proxies on group creation.
  */
 @ApplicationScoped
-public class ElastiCacheService {
+public class ElastiCacheService implements ResourceProvider {
 
     private static final Logger LOG = Logger.getLogger(ElastiCacheService.class);
 
@@ -38,16 +44,19 @@ public class ElastiCacheService {
     private final ElastiCacheContainerManager containerManager;
     private final ElastiCacheProxyManager proxyManager;
     private final EmulatorConfig config;
+    private final RegionResolver regionResolver;
     private final Set<Integer> usedPorts = ConcurrentHashMap.newKeySet();
 
     @Inject
     public ElastiCacheService(ElastiCacheContainerManager containerManager,
                               ElastiCacheProxyManager proxyManager,
                               StorageFactory storageFactory,
-                              EmulatorConfig config) {
+                              EmulatorConfig config,
+                              RegionResolver regionResolver) {
         this.containerManager = containerManager;
         this.proxyManager = proxyManager;
         this.config = config;
+        this.regionResolver = regionResolver;
         this.groups = storageFactory.create("elasticache", "elasticache-groups.json",
                 new TypeReference<Map<String, ReplicationGroup>>() {});
         this.users = storageFactory.create("elasticache", "elasticache-users.json",
@@ -55,7 +64,7 @@ public class ElastiCacheService {
     }
 
     public ReplicationGroup createReplicationGroup(String groupId, String description,
-                                                   AuthMode authMode, String authToken) {
+                                                   AuthMode authMode, String authToken, String region) {
         if (groups.get(groupId).isPresent()) {
             throw new AwsException("ReplicationGroupAlreadyExistsFault",
                     "Replication group " + groupId + " already exists.", 400);
@@ -80,6 +89,8 @@ public class ElastiCacheService {
             group.setContainerHost(handle.getHost());
             group.setContainerPort(handle.getPort());
             group.setAuthToken(authToken);
+            group.setArn(regionResolver.buildArn("elasticache", region, "replicationgroup:" + groupId));
+            group.setRegion(region);
 
             proxyManager.startProxy(groupId, authMode, proxyPort,
                     handle.getHost(), handle.getPort(),
@@ -271,5 +282,25 @@ public class ElastiCacheService {
 
     private void releaseProxyPort(int port) {
         usedPorts.remove(port);
+    }
+
+    @Override
+    public List<ExplorerResource> getResources() {
+        List<ExplorerResource> resources = new ArrayList<>();
+        for (ReplicationGroup group : groups.scan(k -> true)) {
+            if (group.getArn() == null) continue;
+            AwsArnUtils.Arn parsed = AwsArnUtils.parse(group.getArn());
+            resources.add(new ExplorerResource(
+                    group.getArn(), "elasticache:cluster", "elasticache",
+                    parsed.region(), parsed.accountId(),
+                    group.getCreatedAt() != null ? group.getCreatedAt() : Instant.now(),
+                    Map.of()));
+        }
+        return resources;
+    }
+
+    @Override
+    public Set<SupportedResourceType> getSupportedResourceTypes() {
+        return Set.of(new SupportedResourceType("elasticache:cluster", "elasticache", true));
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/model/ReplicationGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/model/ReplicationGroup.java
@@ -18,6 +18,8 @@ public class ReplicationGroup {
     private int proxyPort;
     private String authToken; // stored plain-text for PASSWORD auth validation in the proxy
     private Set<String> associatedUserIds = new HashSet<>();
+    private String arn;
+    private String region;
 
     // Transient fields — not persisted, restored on container restart
     private transient String containerId;
@@ -75,4 +77,10 @@ public class ReplicationGroup {
 
     public int getContainerPort() { return containerPort; }
     public void setContainerPort(int containerPort) { this.containerPort = containerPort; }
+
+    public String getArn() { return arn; }
+    public void setArn(String arn) { this.arn = arn; }
+
+    public String getRegion() { return region; }
+    public void setRegion(String region) { this.region = region; }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
@@ -5,6 +5,9 @@ import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.SessionAccountLookup;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
@@ -26,6 +29,7 @@ import org.jboss.logging.Logger;
 
 import java.time.Instant;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -44,7 +48,7 @@ import java.util.Map;
  */
 @Startup
 @ApplicationScoped
-public class IamService implements SessionAccountLookup {
+public class IamService implements SessionAccountLookup, ResourceProvider {
 
     private static final Logger LOG = Logger.getLogger(IamService.class);
     private static final String CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
@@ -973,6 +977,41 @@ public class IamService implements SessionAccountLookup {
         return instanceProfiles.scan(k -> true).stream()
                 .filter(p -> p.getRoleNames().contains(roleName))
                 .toList();
+    }
+
+    @Override
+    public List<ExplorerResource> getResources() {
+        List<ExplorerResource> resources = new ArrayList<>();
+        for (IamUser user : users.scan(k -> true)) {
+            addIamResource(resources, user.getArn(), "iam:user", user.getCreateDate(), user.getTags());
+        }
+        for (IamRole role : roles.scan(k -> true)) {
+            addIamResource(resources, role.getArn(), "iam:role", role.getCreateDate(), role.getTags());
+        }
+        return resources;
+    }
+
+    private void addIamResource(List<ExplorerResource> out, String arn, String type,
+                                Instant createDate, Map<String, String> tags) {
+        if (arn == null) return;
+        AwsArnUtils.Arn parsed = AwsArnUtils.parse(arn);
+        // IAM is a global service: its ARNs carry no region. Resource Explorer reports
+        // global resources with the region "global" (not an empty string).
+        String region = parsed.region() == null || parsed.region().isEmpty()
+                ? "global"
+                : parsed.region();
+        out.add(new ExplorerResource(
+                arn, type, "iam",
+                region, parsed.accountId(),
+                createDate != null ? createDate : Instant.now(),
+                tags != null ? tags : Map.of()));
+    }
+
+    @Override
+    public Set<SupportedResourceType> getSupportedResourceTypes() {
+        return Set.of(
+                new SupportedResourceType("iam:user", "iam", true),
+                new SupportedResourceType("iam:role", "iam", true));
     }
 
     // =========================================================================

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -1,9 +1,13 @@
 package io.github.hectorvent.floci.services.kms;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.ReservedTags;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.kms.model.KmsAlias;
@@ -58,7 +62,7 @@ import static io.github.hectorvent.floci.services.kms.model.KmsMessageType.DIGES
 import static io.github.hectorvent.floci.services.kms.model.KmsMessageType.RAW;
 
 @ApplicationScoped
-public class KmsService {
+public class KmsService implements ResourceProvider {
 
     private static final Logger LOG = Logger.getLogger(KmsService.class);
 
@@ -1069,5 +1073,26 @@ public class KmsService {
         // Key id
         return keyStore.get(region + "::" + id)
                 .orElseThrow(() -> new AwsException("NotFoundException", "Key not found: " + keyIdOrArn, 404));
+    }
+
+    @Override
+    public List<ExplorerResource> getResources() {
+        List<ExplorerResource> resources = new ArrayList<>();
+        for (KmsKey key : keyStore.scan(k -> true)) {
+            String arn = key.getArn();
+            if (arn == null) continue;
+            AwsArnUtils.Arn parsed = AwsArnUtils.parse(arn);
+            resources.add(new ExplorerResource(
+                    arn, "kms:key", "kms",
+                    parsed.region(), parsed.accountId(),
+                    key.getCreationDate() > 0 ? Instant.ofEpochSecond(key.getCreationDate()) : Instant.now(),
+                    key.getTags() != null ? key.getTags() : Map.of()));
+        }
+        return resources;
+    }
+
+    @Override
+    public Set<SupportedResourceType> getSupportedResourceTypes() {
+        return Set.of(new SupportedResourceType("kms:key", "kms", true));
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -7,6 +7,9 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackedMap;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
 import io.github.hectorvent.floci.services.lambda.model.EventSourceMapping;
 import io.github.hectorvent.floci.services.lambda.model.FunctionEventInvokeConfig;
 import io.github.hectorvent.floci.services.lambda.model.InvocationType;
@@ -38,6 +41,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -45,7 +49,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * Business logic for Lambda function management and invocation.
  */
 @ApplicationScoped
-public class LambdaService {
+public class LambdaService implements ResourceProvider {
 
     private static final Logger LOG = Logger.getLogger(LambdaService.class);
 
@@ -222,6 +226,28 @@ public class LambdaService {
         if (count > 0) {
             LOG.infov("Restored reserved concurrency for {0} function(s)", count);
         }
+    }
+
+    @Override
+    public List<ExplorerResource> getResources() {
+        List<ExplorerResource> resources = new ArrayList<>();
+        for (LambdaFunction fn : functionStore.listAll()) {
+            if (!"$LATEST".equals(fn.getVersion())) continue;
+            String arn = fn.getFunctionArn();
+            if (arn == null) continue;
+            AwsArnUtils.Arn parsed = AwsArnUtils.parse(arn);
+            resources.add(new ExplorerResource(
+                    arn, "lambda:function", "lambda",
+                    parsed.region(), parsed.accountId(),
+                    fn.getLastModified() > 0 ? Instant.ofEpochMilli(fn.getLastModified()) : Instant.now(),
+                    fn.getTags() != null ? fn.getTags() : Map.of()));
+        }
+        return resources;
+    }
+
+    @Override
+    public Set<SupportedResourceType> getSupportedResourceTypes() {
+        return Set.of(new SupportedResourceType("lambda:function", "lambda", true));
     }
 
     public LambdaFunction createFunction(String region, Map<String, Object> request) {

--- a/src/main/java/io/github/hectorvent/floci/services/lightsail/LightsailService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lightsail/LightsailService.java
@@ -5,8 +5,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -17,12 +21,14 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 @ApplicationScoped
-public class LightsailService {
+public class LightsailService implements ResourceProvider {
 
     private static final String SERVICE = "lightsail";
     private static final String RESOURCE_INSTANCE = "Instance";
@@ -495,6 +501,51 @@ public class LightsailService {
 
     public ObjectNode isVpcPeered() {
         return mapper.createObjectNode().put("isPeered", false);
+    }
+
+    @Override
+    public List<ExplorerResource> getResources() {
+        List<ExplorerResource> resources = new ArrayList<>();
+        for (ObjectNode node : resourceStore.scan(key -> true)) {
+            String arn = node.path("arn").asText(null);
+            if (arn == null) continue;
+            AwsArnUtils.Arn parsed = AwsArnUtils.parse(arn);
+            resources.add(new ExplorerResource(
+                    arn,
+                    SERVICE + ":" + node.path("resourceType").asText(),
+                    SERVICE,
+                    parsed.region(),
+                    parsed.accountId(),
+                    reportedAt(node),
+                    tagsOf(node)));
+        }
+        return resources;
+    }
+
+    @Override
+    public Set<SupportedResourceType> getSupportedResourceTypes() {
+        return Set.of(
+                new SupportedResourceType(SERVICE + ":" + RESOURCE_INSTANCE, SERVICE, true),
+                new SupportedResourceType(SERVICE + ":" + RESOURCE_DISK, SERVICE, true),
+                new SupportedResourceType(SERVICE + ":" + RESOURCE_KEY_PAIR, SERVICE, true),
+                // Lightsail static IPs are not taggable in AWS.
+                new SupportedResourceType(SERVICE + ":" + RESOURCE_STATIC_IP, SERVICE, false));
+    }
+
+    private static Instant reportedAt(ObjectNode node) {
+        double createdAt = node.path("createdAt").asDouble(0);
+        return createdAt > 0 ? Instant.ofEpochMilli(Math.round(createdAt * 1000)) : Instant.now();
+    }
+
+    private static Map<String, String> tagsOf(ObjectNode node) {
+        Map<String, String> tags = new LinkedHashMap<>();
+        for (JsonNode tag : node.path("tags")) {
+            String key = tag.path("key").asText(null);
+            if (key != null) {
+                tags.put(key, tag.path("value").asText(""));
+            }
+        }
+        return tags;
     }
 
     private ObjectNode baseResource(String region, String availabilityZone, String resourceType, String name) {

--- a/src/main/java/io/github/hectorvent/floci/services/msk/MskService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/MskService.java
@@ -4,6 +4,9 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
@@ -17,14 +20,17 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 @ApplicationScoped
-public class MskService {
+public class MskService implements ResourceProvider {
 
     private static final Logger LOG = Logger.getLogger(MskService.class);
     private static final String DEFAULT_KAFKA_VERSION = "3.6.0";
@@ -143,5 +149,26 @@ public class MskService {
         } else {
             storage.put(cluster.getClusterArn(), cluster);
         }
+    }
+
+    @Override
+    public List<ExplorerResource> getResources() {
+        List<ExplorerResource> resources = new ArrayList<>();
+        for (MskCluster cluster : storage.scan(k -> true)) {
+            String arn = cluster.getClusterArn();
+            if (arn == null) continue;
+            AwsArnUtils.Arn parsed = AwsArnUtils.parse(arn);
+            resources.add(new ExplorerResource(
+                    arn, "kafka:cluster", "kafka",
+                    parsed.region(), parsed.accountId(),
+                    cluster.getCreationTime() != null ? cluster.getCreationTime() : Instant.now(),
+                    cluster.getTags() != null ? cluster.getTags() : Map.of()));
+        }
+        return resources;
+    }
+
+    @Override
+    public Set<SupportedResourceType> getSupportedResourceTypes() {
+        return Set.of(new SupportedResourceType("kafka:cluster", "kafka", true));
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchService.java
@@ -24,14 +24,19 @@ import org.jboss.logging.Logger;
 
 import java.security.SecureRandom;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
 
 @ApplicationScoped
-public class OpenSearchService {
+public class OpenSearchService implements ResourceProvider {
 
     private static final Logger LOG = Logger.getLogger(OpenSearchService.class);
 
@@ -362,5 +367,25 @@ public class OpenSearchService {
         } else {
             domainStore.put(domain.getDomainName(), domain);
         }
+    }
+
+    @Override
+    public List<ExplorerResource> getResources() {
+        List<ExplorerResource> resources = new ArrayList<>();
+        for (Domain domain : listDomainNames(null)) {
+            if (domain.getArn() == null) continue;
+            AwsArnUtils.Arn parsed = AwsArnUtils.parse(domain.getArn());
+            resources.add(new ExplorerResource(
+                    domain.getArn(), "es:domain", "es",
+                    parsed.region(), parsed.accountId(),
+                    domain.getCreatedAt() != null ? domain.getCreatedAt() : Instant.now(),
+                    domain.getTags() != null ? domain.getTags() : Map.of()));
+        }
+        return resources;
+    }
+
+    @Override
+    public Set<SupportedResourceType> getSupportedResourceTypes() {
+        return Set.of(new SupportedResourceType("es:domain", "es", true));
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/pipes/PipesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesService.java
@@ -4,6 +4,9 @@ import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.TagHandler;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
@@ -17,13 +20,15 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
-public class PipesService implements TagHandler {
+public class PipesService implements TagHandler, ResourceProvider {
 
     private static final Logger LOG = Logger.getLogger(PipesService.class);
 
@@ -202,6 +207,27 @@ public class PipesService implements TagHandler {
         storage.put(key, pipe);
         LOG.infov("Stopped pipe: {0}", name);
         return pipe;
+    }
+
+    @Override
+    public List<ExplorerResource> getResources() {
+        List<ExplorerResource> resources = new ArrayList<>();
+        for (Pipe pipe : storage.scan(k -> true)) {
+            String arn = pipe.getArn();
+            if (arn == null) continue;
+            AwsArnUtils.Arn parsed = AwsArnUtils.parse(arn);
+            resources.add(new ExplorerResource(
+                    arn, "pipes:pipe", "pipes",
+                    parsed.region(), parsed.accountId(),
+                    pipe.getCreationTime() != null ? pipe.getCreationTime() : Instant.now(),
+                    pipe.getTags() != null ? pipe.getTags() : Map.of()));
+        }
+        return resources;
+    }
+
+    @Override
+    public Set<SupportedResourceType> getSupportedResourceTypes() {
+        return Set.of(new SupportedResourceType("pipes:pipe", "pipes", true));
     }
 
     @Override

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -9,6 +9,9 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
 import io.github.hectorvent.floci.core.common.docker.DockerHostResolver;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
@@ -25,6 +28,7 @@ import io.github.hectorvent.floci.services.rds.model.DbInstanceStatus;
 import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
 import io.github.hectorvent.floci.services.rds.model.DbSubnetGroup;
 import io.github.hectorvent.floci.services.rds.proxy.RdsProxyManager;
+import io.github.hectorvent.floci.services.resourcegroupstagging.ResourceGroupsTaggingService;
 import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerService;
 import io.github.hectorvent.floci.services.secretsmanager.model.Secret;
 import io.github.hectorvent.floci.core.common.Resettable;
@@ -50,7 +54,7 @@ import java.util.regex.Pattern;
  * Starts DB containers and auth proxies on creation.
  */
 @ApplicationScoped
-public class RdsService implements Resettable {
+public class RdsService implements Resettable, ResourceProvider {
 
     private static final Logger LOG = Logger.getLogger(RdsService.class);
     private static final ObjectMapper JSON = new ObjectMapper();
@@ -67,6 +71,7 @@ public class RdsService implements Resettable {
     private final EmulatorConfig config;
     private final SecretsManagerService secretsManagerService;
     private final DockerHostResolver dockerHostResolver;
+    private final ResourceGroupsTaggingService taggingService;
     private final Set<Integer> usedPorts = ConcurrentHashMap.newKeySet();
     private static final Pattern IMAGE_TAG_VERSION_PATTERN = Pattern.compile("^(\\d+(?:\\.\\d+)*)(.*)$");
     private static final Pattern SAFE_IMAGE_TAG_PATTERN = Pattern.compile("[A-Za-z0-9._-]+");
@@ -79,7 +84,8 @@ public class RdsService implements Resettable {
                       EmulatorConfig config,
                       StorageFactory storageFactory,
                       SecretsManagerService secretsManagerService,
-                      DockerHostResolver dockerHostResolver) {
+                      DockerHostResolver dockerHostResolver,
+                      ResourceGroupsTaggingService taggingService) {
         this.containerManager = containerManager;
         this.proxyManager = proxyManager;
         this.ec2Service = ec2Service;
@@ -87,6 +93,7 @@ public class RdsService implements Resettable {
         this.config = config;
         this.secretsManagerService = secretsManagerService;
         this.dockerHostResolver = dockerHostResolver;
+        this.taggingService = taggingService;
         this.instances = storageFactory.create("rds", "rds-instances.json",
                 new TypeReference<Map<String, DbInstance>>() {});
         this.clusters = storageFactory.create("rds", "rds-clusters.json",
@@ -111,7 +118,7 @@ public class RdsService implements Resettable {
                StorageBackend<String, DbSubnetGroup> subnetGroups) {
         this(containerManager, proxyManager, ec2Service, regionResolver, config,
                 instances, clusters, parameterGroups, clusterParameterGroups, subnetGroups,
-                null, null);
+                null, null, null);
     }
 
     RdsService(RdsContainerManager containerManager,
@@ -125,7 +132,8 @@ public class RdsService implements Resettable {
                StorageBackend<String, DbClusterParameterGroup> clusterParameterGroups,
                StorageBackend<String, DbSubnetGroup> subnetGroups,
                SecretsManagerService secretsManagerService,
-               DockerHostResolver dockerHostResolver) {
+               DockerHostResolver dockerHostResolver,
+               ResourceGroupsTaggingService taggingService) {
         this.containerManager = containerManager;
         this.proxyManager = proxyManager;
         this.ec2Service = ec2Service;
@@ -138,6 +146,7 @@ public class RdsService implements Resettable {
         this.parameterGroups = parameterGroups;
         this.clusterParameterGroups = clusterParameterGroups;
         this.subnetGroups = subnetGroups;
+        this.taggingService = taggingService;
     }
 
     public void restorePersistedRuntime() {
@@ -1352,5 +1361,45 @@ public class RdsService implements Resettable {
                     cluster.isMultiAz(),
                     cluster.getSubnetAvailabilityZones());
         }
+    }
+
+    @Override
+    public List<ExplorerResource> getResources() {
+        List<ExplorerResource> resources = new ArrayList<>();
+        for (DbInstance instance : listDbInstances(null)) {
+            String arn = instance.getDbInstanceArn();
+            if (arn == null) continue;
+            AwsArnUtils.Arn parsed = AwsArnUtils.parse(arn);
+            resources.add(new ExplorerResource(arn, "rds:db", "rds",
+                    parsed.region(), parsed.accountId(),
+                    instance.getCreatedAt() != null ? instance.getCreatedAt() : Instant.now(),
+                    tagsFor(parsed.region(), arn)));
+        }
+        for (DbCluster cluster : listDbClusters(null)) {
+            String arn = cluster.getDbClusterArn();
+            if (arn == null) continue;
+            AwsArnUtils.Arn parsed = AwsArnUtils.parse(arn);
+            resources.add(new ExplorerResource(arn, "rds:cluster", "rds",
+                    parsed.region(), parsed.accountId(),
+                    cluster.getCreatedAt() != null ? cluster.getCreatedAt() : Instant.now(),
+                    tagsFor(parsed.region(), arn)));
+        }
+        return resources;
+    }
+
+    /**
+     * Resolves tags for a resource, tolerating a null taggingService. The CDI constructor always
+     * supplies one; the storage-backed test constructors pass null, and unit tests that exercise
+     * getResources() would otherwise NPE.
+     */
+    private Map<String, String> tagsFor(String region, String arn) {
+        return taggingService != null ? taggingService.getTagsForResource(region, arn) : Map.of();
+    }
+
+    @Override
+    public Set<SupportedResourceType> getSupportedResourceTypes() {
+        return Set.of(
+                new SupportedResourceType("rds:db", "rds", true),
+                new SupportedResourceType("rds:cluster", "rds", true));
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2Controller.java
@@ -1,0 +1,306 @@
+package io.github.hectorvent.floci.services.resourceexplorer2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.resourceexplorer2.model.*;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class ResourceExplorer2Controller {
+
+    private final ResourceExplorer2Service service;
+    private final RegionResolver regionResolver;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public ResourceExplorer2Controller(ResourceExplorer2Service service,
+                                        RegionResolver regionResolver,
+                                        ObjectMapper objectMapper) {
+        this.service = service;
+        this.regionResolver = regionResolver;
+        this.objectMapper = objectMapper;
+    }
+
+    @POST
+    @Path("/ListResources")
+    public Response listResources(@Context HttpHeaders headers, String body) throws IOException {
+        JsonNode req = parseBody(body);
+        String region = regionResolver.resolveRegion(headers);
+        String filterString = req.has("Filters") && req.get("Filters").has("FilterString")
+                ? req.get("Filters").get("FilterString").asText(null) : null;
+        Integer maxResults = validatedMaxResults(req, 1000);
+        String nextToken = optString(req, "NextToken");
+        String viewArn = optString(req, "ViewArn");
+        try {
+            return Response.ok(service.listResources(filterString, maxResults, nextToken, viewArn, region)).build();
+        } catch (IllegalArgumentException e) {
+            throw new AwsException("ValidationException", e.getMessage(), 400);
+        }
+    }
+
+    @POST
+    @Path("/Search")
+    public Response search(@Context HttpHeaders headers, String body) throws IOException {
+        JsonNode req = parseBody(body);
+        if (!req.has("QueryString")) throw new AwsException("ValidationException", "QueryString is required", 400);
+        String queryString = req.get("QueryString").asText(null);
+        Integer maxResults = validatedMaxResults(req, 1000);
+        String nextToken = optString(req, "NextToken");
+        String viewArn = optString(req, "ViewArn");
+        String region = regionResolver.resolveRegion(headers);
+        return Response.ok(service.search(queryString, maxResults, nextToken, viewArn, region)).build();
+    }
+
+    @POST
+    @Path("/ListSupportedResourceTypes")
+    public Response listSupportedResourceTypes(String body) throws IOException {
+        JsonNode req = parseBody(body);
+        Integer maxResults = validatedMaxResults(req, 100);
+        String nextToken = optString(req, "NextToken");
+        return Response.ok(service.listSupportedResourceTypes(maxResults, nextToken)).build();
+    }
+
+    @POST
+    @Path("/re2/CreateIndex")
+    public Response createIndex(@Context HttpHeaders headers, String body) throws IOException {
+        JsonNode req = parseBody(body);
+        String region = regionResolver.resolveRegion(headers);
+        Map<String, String> tags = parseTags(req);
+        Index index = service.createIndex(region, tags);
+        var result = objectMapper.createObjectNode();
+        result.put("Arn", index.arn());
+        result.put("CreatedAt", index.createdAt().toString());
+        // Real AWS returns CREATING immediately; we store ACTIVE synchronously but the
+        // caller must see CREATING as the initial state per the AWS API contract.
+        result.put("State", "CREATING");
+        return Response.ok(result).build();
+    }
+
+    @POST
+    @Path("/re2/GetIndex")
+    public Response getIndex(@Context HttpHeaders headers) {
+        String region = regionResolver.resolveRegion(headers);
+        Index index = service.getIndex(region);
+        var result = objectMapper.createObjectNode();
+        result.put("Arn", index.arn());
+        result.put("CreatedAt", index.createdAt().toString());
+        result.put("LastUpdatedAt", index.lastUpdatedAt().toString());
+        result.set("ReplicatingFrom", objectMapper.valueToTree(index.replicatingFrom()));
+        result.set("ReplicatingTo", objectMapper.valueToTree(index.replicatingTo()));
+        result.put("State", index.state().name());
+        result.set("Tags", objectMapper.valueToTree(index.tags()));
+        result.put("Type", index.type().name());
+        return Response.ok(result).build();
+    }
+
+    @POST
+    @Path("/re2/DeleteIndex")
+    public Response deleteIndex(String body) throws IOException {
+        JsonNode req = parseBody(body);
+        String indexArn = optString(req, "Arn");
+        if (indexArn == null) throw new AwsException("ValidationException", "Arn is required", 400);
+        Index deleted = service.deleteIndex(indexArn);
+        var result = objectMapper.createObjectNode();
+        result.put("Arn", deleted.arn());
+        result.put("LastUpdatedAt", deleted.lastUpdatedAt().toString());
+        result.put("State", deleted.state().name());
+        return Response.ok(result).build();
+    }
+
+    @POST
+    @Path("/re2/ListIndexes")
+    public Response listIndexes(String body) throws IOException {
+        JsonNode req = parseBody(body);
+        String type = optString(req, "Type");
+        List<String> regions = new ArrayList<>();
+        if (req.has("Regions") && req.get("Regions").isArray()) {
+            for (var r : req.get("Regions")) regions.add(r.asText());
+        }
+        Integer maxResults = validatedMaxResults(req, 100);
+        String nextToken = optString(req, "NextToken");
+        return Response.ok(service.listIndexes(type, regions, maxResults, nextToken)).build();
+    }
+
+    @POST
+    @Path("/UpdateIndexType")
+    public Response updateIndexType(String body) throws IOException {
+        JsonNode req = parseBody(body);
+        String arn = optString(req, "Arn");
+        if (arn == null) throw new AwsException("ValidationException", "Arn is required", 400);
+        if (!req.has("Type")) throw new AwsException("ValidationException", "Type is required", 400);
+        IndexType type;
+        try {
+            type = IndexType.valueOf(req.get("Type").asText());
+        } catch (IllegalArgumentException e) {
+            throw new AwsException("ValidationException", "Invalid index type: " + req.get("Type").asText(), 400);
+        }
+        Index index = service.updateIndexType(arn, type);
+        var result = objectMapper.createObjectNode();
+        result.put("Arn", index.arn());
+        result.put("LastUpdatedAt", index.lastUpdatedAt().toString());
+        result.put("State", index.state().name());
+        result.put("Type", index.type().name());
+        return Response.ok(result).build();
+    }
+
+    @POST
+    @Path("/CreateView")
+    public Response createView(@Context HttpHeaders headers, String body) throws IOException {
+        JsonNode req = parseBody(body);
+        String region = regionResolver.resolveRegion(headers);
+        String viewName = optString(req, "ViewName");
+        String scope = optString(req, "Scope");
+        SearchFilter filters = parseFilters(req);
+        List<IncludedProperty> includedProperties = parseIncludedProperties(req);
+        Map<String, String> tags = parseTags(req);
+        View view = service.createView(region, viewName, scope, filters, includedProperties, tags);
+        var result = objectMapper.createObjectNode();
+        result.set("View", service.buildViewNode(view));
+        return Response.ok(result).build();
+    }
+
+    @POST
+    @Path("/GetView")
+    public Response getView(String body) throws IOException {
+        JsonNode req = parseBody(body);
+        String viewArn = optString(req, "ViewArn");
+        if (viewArn == null) throw new AwsException("ValidationException", "ViewArn is required", 400);
+        View view = service.getView(viewArn);
+        var result = objectMapper.createObjectNode();
+        result.set("View", service.buildViewNode(view));
+        result.set("Tags", objectMapper.valueToTree(
+                view.tags() != null ? view.tags() : Map.of()));
+        return Response.ok(result).build();
+    }
+
+    @POST
+    @Path("/DeleteView")
+    public Response deleteView(String body) throws IOException {
+        JsonNode req = parseBody(body);
+        String viewArn = optString(req, "ViewArn");
+        if (viewArn == null) throw new AwsException("ValidationException", "ViewArn is required", 400);
+        service.deleteView(viewArn);
+        var result = objectMapper.createObjectNode();
+        result.put("ViewArn", viewArn);
+        return Response.ok(result).build();
+    }
+
+    @POST
+    @Path("/UpdateView")
+    public Response updateView(String body) throws IOException {
+        JsonNode req = parseBody(body);
+        String viewArn = optString(req, "ViewArn");
+        if (viewArn == null) throw new AwsException("ValidationException", "ViewArn is required", 400);
+        SearchFilter filters = parseFilters(req);
+        List<IncludedProperty> includedProperties = parseIncludedProperties(req);
+        View view = service.updateView(viewArn, filters, includedProperties);
+        var result = objectMapper.createObjectNode();
+        result.set("View", service.buildViewNode(view));
+        return Response.ok(result).build();
+    }
+
+    @POST
+    @Path("/ListViews")
+    public Response listViews(String body) throws IOException {
+        JsonNode req = parseBody(body);
+        Integer maxResults = validatedMaxResults(req, 100);
+        String nextToken = optString(req, "NextToken");
+        return Response.ok(service.listViews(maxResults, nextToken)).build();
+    }
+
+    @POST
+    @Path("/BatchGetView")
+    public Response batchGetView(String body) throws IOException {
+        JsonNode req = parseBody(body);
+        List<String> arns = new ArrayList<>();
+        if (req.has("ViewArns") && req.get("ViewArns").isArray()) {
+            for (var v : req.get("ViewArns")) arns.add(v.asText());
+        }
+        return Response.ok(service.batchGetView(arns)).build();
+    }
+
+    @POST
+    @Path("/AssociateDefaultView")
+    public Response associateDefaultView(@Context HttpHeaders headers, String body) throws IOException {
+        JsonNode req = parseBody(body);
+        String viewArn = optString(req, "ViewArn");
+        if (viewArn == null) throw new AwsException("ValidationException", "ViewArn is required", 400);
+        service.associateDefaultView(regionResolver.resolveRegion(headers), viewArn);
+        var result = objectMapper.createObjectNode();
+        result.put("ViewArn", viewArn);
+        return Response.ok(result).build();
+    }
+
+    @POST
+    @Path("/DisassociateDefaultView")
+    public Response disassociateDefaultView(@Context HttpHeaders headers) {
+        service.disassociateDefaultView(regionResolver.resolveRegion(headers));
+        return Response.ok("{}").build();
+    }
+
+    @POST
+    @Path("/GetDefaultView")
+    public Response getDefaultView(@Context HttpHeaders headers) {
+        String viewArn = service.getDefaultView(regionResolver.resolveRegion(headers));
+        var result = objectMapper.createObjectNode();
+        if (viewArn != null) result.put("ViewArn", viewArn);
+        return Response.ok(result).build();
+    }
+
+
+    private static String optString(JsonNode req, String field) {
+        return req.has(field) ? req.get(field).asText(null) : null;
+    }
+
+    private JsonNode parseBody(String body) throws IOException {
+        return objectMapper.readTree(body == null || body.isBlank() ? "{}" : body);
+    }
+
+    private Map<String, String> parseTags(JsonNode req) {
+        Map<String, String> tags = new HashMap<>();
+        if (req.has("Tags") && req.get("Tags").isObject()) {
+            req.get("Tags").fields().forEachRemaining(e -> tags.put(e.getKey(), e.getValue().asText()));
+        }
+        return tags;
+    }
+
+    private SearchFilter parseFilters(JsonNode req) {
+        return req.has("Filters") && req.get("Filters").has("FilterString")
+                ? new SearchFilter(req.get("Filters").get("FilterString").asText()) : null;
+    }
+
+    private List<IncludedProperty> parseIncludedProperties(JsonNode req) {
+        List<IncludedProperty> includedProperties = new ArrayList<>();
+        if (req.has("IncludedProperties") && req.get("IncludedProperties").isArray()) {
+            for (var p : req.get("IncludedProperties")) {
+                includedProperties.add(new IncludedProperty(p.has("Name") ? p.get("Name").asText() : ""));
+            }
+        }
+        return includedProperties;
+    }
+
+    private Integer validatedMaxResults(JsonNode req, int max) {
+        if (!req.has("MaxResults")) return null;
+        int value = req.get("MaxResults").intValue();
+        if (value < 1 || value > max) {
+            throw new AwsException("ValidationException", "MaxResults must be between 1 and " + max, 400);
+        }
+        return value;
+    }
+
+}

--- a/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2PathRewriteFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2PathRewriteFilter.java
@@ -1,0 +1,75 @@
+package io.github.hectorvent.floci.services.resourceexplorer2;
+
+import io.github.hectorvent.floci.core.common.ResolvedServiceCatalog;
+import io.github.hectorvent.floci.core.common.ServiceDescriptor;
+import io.github.hectorvent.floci.core.common.SigV4CredentialScope;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.ext.Provider;
+
+import java.util.Set;
+
+/**
+ * Pre-matching filter that disambiguates Resource Explorer 2 endpoints from S3 Vectors
+ * endpoints that share the same JAX-RS path names ({@code /CreateIndex}, {@code /GetIndex},
+ * {@code /ListIndexes}, {@code /DeleteIndex}).
+ *
+ * <p>Both are REST-JSON services rooted at {@code /}, so JAX-RS cannot tell their identically
+ * named operations apart. Floci resolves this the same way {@code AwsQueryController} resolves
+ * query-protocol services: by the SigV4 credential scope, looked up in the
+ * {@link ResolvedServiceCatalog}. When the scope resolves to the Resource Explorer 2 service,
+ * the conflicting path is rewritten to the {@code /re2/} prefix so it reaches
+ * {@link ResourceExplorer2Controller}; otherwise it falls through to the S3 Vectors controller.
+ *
+ * <p>All other Resource Explorer 2 paths (e.g. {@code /ListResources}, {@code /Search}) are
+ * unique across controllers and need no rewriting.
+ */
+@Provider
+@PreMatching
+public class ResourceExplorer2PathRewriteFilter implements ContainerRequestFilter {
+
+    private static final String RESOURCE_EXPLORER_2 = "resource-explorer-2";
+
+    // Mirror of the index operation paths declared by S3VectorsController. A colliding path missing
+    // from this set falls through to S3 Vectors even for Resource Explorer 2 callers.
+    private static final Set<String> AMBIGUOUS_PATHS = Set.of(
+            "/CreateIndex",
+            "/GetIndex",
+            "/ListIndexes",
+            "/DeleteIndex"
+    );
+
+    private final ResolvedServiceCatalog catalog;
+
+    @Inject
+    public ResourceExplorer2PathRewriteFilter(ResolvedServiceCatalog catalog) {
+        this.catalog = catalog;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext ctx) {
+        String path = ctx.getUriInfo().getPath();
+        String normalizedPath = path.startsWith("/") ? path : "/" + path;
+
+        if (!AMBIGUOUS_PATHS.contains(normalizedPath)) {
+            return;
+        }
+
+        boolean targetsResourceExplorer2 =
+                SigV4CredentialScope.serviceName(ctx.getHeaderString("Authorization"))
+                        .flatMap(catalog::byCredentialScope)
+                        .map(ServiceDescriptor::externalKey)
+                        .filter(RESOURCE_EXPLORER_2::equals)
+                        .isPresent();
+
+        if (!targetsResourceExplorer2) {
+            return;
+        }
+
+        ctx.setRequestUri(ctx.getUriInfo().getRequestUriBuilder()
+                .replacePath("/re2" + normalizedPath)
+                .build());
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2Service.java
@@ -1,0 +1,643 @@
+package io.github.hectorvent.floci.services.resourceexplorer2;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.resourceexplorer2.model.IncludedProperty;
+import io.github.hectorvent.floci.services.resourceexplorer2.model.Index;
+import io.github.hectorvent.floci.services.resourceexplorer2.model.IndexState;
+import io.github.hectorvent.floci.services.resourceexplorer2.model.IndexType;
+import io.github.hectorvent.floci.services.resourceexplorer2.model.SearchFilter;
+import io.github.hectorvent.floci.services.resourceexplorer2.model.Taggable;
+import io.github.hectorvent.floci.services.resourceexplorer2.model.View;
+import io.github.hectorvent.floci.services.resourceexplorer2.query.ParsedQuery;
+import io.github.hectorvent.floci.services.resourceexplorer2.query.QueryParser;
+import io.github.hectorvent.floci.services.resourceexplorer2.query.ResourceFilter;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+
+@ApplicationScoped
+public class ResourceExplorer2Service {
+
+    private static final Logger LOG = Logger.getLogger(ResourceExplorer2Service.class);
+
+    private final Instance<ResourceProvider> providers;
+    private final RegionResolver regionResolver;
+    private final ObjectMapper objectMapper;
+    private final StorageBackend<String, Index> indexStore;
+    private final StorageBackend<String, View> viewStore;
+    /** Default view ARN per region. Persisted, not derived, so an explicit choice survives restarts. */
+    private final StorageBackend<String, String> defaultViewStore;
+
+    /**
+     * The maximum number of matching resources {@code Search} returns across all pages. Per the AWS
+     * API reference: "The operation can return only the first 1,000 results." Also the maximum
+     * {@code MaxResults} page size accepted by both operations, and the page size at which
+     * {@code ListResources} suppresses its {@code NextToken}.
+     *
+     * @see <a href="https://docs.aws.amazon.com/resource-explorer/latest/apireference/API_Search.html">AWS API: Search</a>
+     */
+    static final int MAX_RESOURCE_RESULTS = 1000;
+
+    /**
+     * Sentinel result cap for {@code ListResources}, which — unlike {@code Search} — has no total cap
+     * and pages through every match. {@code Integer.MAX_VALUE} is safe as "unlimited": {@code pageBounds}
+     * caps {@code total} at {@code min(size, cap)}, and a {@link java.util.List} size can never exceed
+     * it, so {@code total == size}. Passing this instead of {@link #MAX_RESOURCE_RESULTS} is what
+     * distinguishes ListResources' contract from Search's.
+     *
+     * @see <a href="https://docs.aws.amazon.com/resource-explorer/latest/apireference/API_ListResources.html">AWS API: ListResources</a>
+     */
+    private static final int UNLIMITED_RESULTS = Integer.MAX_VALUE;
+    /** Allowed view name characters per the CreateView API: letters, digits, hyphen, 1-64 chars. */
+    private static final Pattern VIEW_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9\\-]{1,64}");
+
+    @Inject
+    public ResourceExplorer2Service(Instance<ResourceProvider> providers,
+                                     RegionResolver regionResolver,
+                                     ObjectMapper objectMapper,
+                                     StorageFactory storageFactory) {
+        this.providers = providers;
+        this.regionResolver = regionResolver;
+        this.objectMapper = objectMapper;
+        this.indexStore = storageFactory.create("resourceexplorer2",
+                "resourceexplorer2-indexes.json",
+                new TypeReference<>() {});
+        this.viewStore = storageFactory.create("resourceexplorer2",
+                "resourceexplorer2-views.json",
+                new TypeReference<>() {});
+        this.defaultViewStore = storageFactory.create("resourceexplorer2",
+                "resourceexplorer2-default-views.json",
+                new TypeReference<>() {});
+    }
+
+    /**
+     * Visible for testing. Injects storage backends directly so a test can share them across two
+     * service instances — modeling a restart where persisted state survives but in-memory state does not.
+     */
+    ResourceExplorer2Service(Instance<ResourceProvider> providers,
+                             RegionResolver regionResolver,
+                             ObjectMapper objectMapper,
+                             StorageBackend<String, Index> indexStore,
+                             StorageBackend<String, View> viewStore,
+                             StorageBackend<String, String> defaultViewStore) {
+        this.providers = providers;
+        this.regionResolver = regionResolver;
+        this.objectMapper = objectMapper;
+        this.indexStore = indexStore;
+        this.viewStore = viewStore;
+        this.defaultViewStore = defaultViewStore;
+    }
+
+    void onStartup(@Observes StartupEvent event) {
+        ensureDefaultRegionProvisioned();
+    }
+
+    /**
+     * Ensures the default region has an active index and default view. Called at startup and lazily
+     * before every operation that needs that baseline. The lazy calls matter because a LocalStack
+     * {@code state/reset} wipes all storage in-process (see {@code EmulatorInfoController}) without a
+     * restart, so {@code onStartup} never re-runs; without this, GetIndex/GetDefaultView/Search/
+     * ListResources would fail for the whole service until the process is restarted.
+     *
+     * <p>The guard keys on an ACTIVE index, not "store is empty": a restart with persisted storage
+     * keeps the index active, so this is a no-op and an explicit DisassociateDefaultView stays in
+     * effect. Only a genuine loss of the index (fresh boot or a reset) triggers re-provisioning.
+     */
+    private void ensureDefaultRegionProvisioned() {
+        String region = regionResolver.getDefaultRegion();
+        String accountId = regionResolver.getAccountId();
+        boolean hasActiveDefaultRegionIndex = indexStore.scan(_ -> true).stream()
+                .anyMatch(i -> region.equals(i.region()) && i.state() != IndexState.DELETED);
+        if (hasActiveDefaultRegionIndex) {
+            return;
+        }
+        String indexArn = regionResolver.buildArn("resource-explorer-2", region,
+                "index/" + UUID.randomUUID());
+        Index index = new Index(indexArn, region, IndexType.AGGREGATOR,
+                IndexState.ACTIVE, new HashMap<>(), Instant.now());
+        indexStore.put(indexArn, index);
+
+        String viewId = UUID.randomUUID().toString();
+        String viewArn = regionResolver.buildArn("resource-explorer-2", region,
+                "view/default-view/" + viewId);
+        View view = new View(viewArn, "default-view", accountId,
+                "arn:aws:iam::" + accountId + ":root",
+                null,
+                List.of(new IncludedProperty("tags")),
+                new HashMap<>(), Instant.now());
+        viewStore.put(viewArn, view);
+        defaultViewStore.put(region, viewArn);
+    }
+
+    private static String regionOf(View view) {
+        return AwsArnUtils.parse(view.viewArn()).region();
+    }
+
+    /** Creates a LOCAL index. Real AWS always creates LOCAL; promote via {@link #updateIndexType}. */
+    public Index createIndex(String region, Map<String, String> tags) {
+        boolean alreadyExists = !indexStore.scan(_ -> true).stream()
+                .filter(i -> region.equals(i.region()) && i.state() != IndexState.DELETED)
+                .toList()
+                .isEmpty();
+        if (alreadyExists) {
+            throw new AwsException("ConflictException",
+                    "An index already exists for region: " + region, 409);
+        }
+        String indexArn = regionResolver.buildArn("resource-explorer-2", region,
+                "index/" + UUID.randomUUID());
+        // Stored ACTIVE (floci is synchronous); the controller emits CREATING on the create response.
+        Index index = new Index(indexArn, region, IndexType.LOCAL, IndexState.ACTIVE,
+                tags != null ? new HashMap<>(tags) : new HashMap<>(), Instant.now());
+        indexStore.put(indexArn, index);
+        return index;
+    }
+
+    public Index getIndex(String region) {
+        ensureDefaultRegionProvisioned();
+        return indexStore.scan(_ -> true).stream()
+                .filter(i -> region.equals(i.region()) && i.state() != IndexState.DELETED)
+                .findFirst()
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "No index found for region: " + region, 404));
+    }
+
+    public Index deleteIndex(String indexArn) {
+        Index index = indexStore.get(indexArn)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "Index not found: " + indexArn, 404));
+        Index deleted = index.withState(IndexState.DELETED).withLastUpdatedAt(Instant.now());
+        indexStore.put(indexArn, deleted);
+
+        boolean hasOtherIndexes = indexStore.scan(_ -> true).stream()
+                .anyMatch(i -> !indexArn.equals(i.arn()) && i.state() != IndexState.DELETED);
+        if (!hasOtherIndexes) {
+            viewStore.scan(_ -> true).forEach(v -> viewStore.delete(v.viewArn()));
+            defaultViewStore.clear();
+        }
+        return deleted;
+    }
+
+    public Index updateIndexType(String indexArn, IndexType type) {
+        Index index = indexStore.get(indexArn)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "Index not found: " + indexArn, 404));
+        if (type == IndexType.AGGREGATOR) {
+            boolean aggregatorExistsElsewhere = indexStore.scan(_ -> true).stream()
+                    .anyMatch(i -> !indexArn.equals(i.arn())
+                            && i.type() == IndexType.AGGREGATOR
+                            && i.state() != IndexState.DELETED);
+            if (aggregatorExistsElsewhere) {
+                throw new AwsException("ConflictException",
+                        "You already have an AGGREGATOR index in a different AWS Region. "
+                                + "Only one aggregator index is allowed per account.", 409);
+            }
+        }
+        Index updated = index.withType(type).withLastUpdatedAt(Instant.now());
+        indexStore.put(indexArn, updated);
+        return updated;
+    }
+
+    private record Paginated<T>(List<T> items, String nextToken) {}
+
+    private <T> Paginated<T> paginate(List<T> all, Integer maxResults, String nextToken, int defaultMax) {
+        int effectiveMax = (maxResults != null && maxResults > 0) ? maxResults : defaultMax;
+        int offset = Math.min(decodeNextToken(nextToken), all.size());
+        int end = Math.min(offset + effectiveMax, all.size());
+        String outToken = (end < all.size()) ? encodeNextToken(end) : null;
+        return new Paginated<>(all.subList(offset, end), outToken);
+    }
+
+    public ObjectNode listIndexes(String type, List<String> regions, Integer maxResults, String nextToken) {
+        ensureDefaultRegionProvisioned();
+        List<Index> all = indexStore.scan(_ -> true).stream()
+                .filter(i -> i.state() != IndexState.DELETED)
+                .filter(i -> type == null || type.equalsIgnoreCase(i.type().name()))
+                .filter(i -> regions == null || regions.isEmpty() ||
+                        regions.stream().anyMatch(r -> r.equalsIgnoreCase(i.region())))
+                .toList();
+        Paginated<Index> page = paginate(all, maxResults, nextToken, 100);
+
+        ObjectNode result = objectMapper.createObjectNode();
+        ArrayNode arr = result.putArray("Indexes");
+        for (Index idx : page.items()) {
+            ObjectNode node = objectMapper.createObjectNode();
+            node.put("Arn", idx.arn());
+            node.put("Region", idx.region());
+            node.put("Type", idx.type().name());
+            arr.add(node);
+        }
+        if (page.nextToken() != null) {
+            result.put("NextToken", page.nextToken());
+        }
+        return result;
+    }
+
+    public View createView(String region, String viewName, String scope, SearchFilter filters,
+                           List<IncludedProperty> includedProperties, Map<String, String> tags) {
+        if (viewName == null || !VIEW_NAME_PATTERN.matcher(viewName).matches()) {
+            throw new AwsException("ValidationException",
+                    "View name must match [a-zA-Z0-9-] and be 1-64 characters: " + viewName, 400);
+        }
+        validateIncludedProperties(includedProperties);
+        boolean nameTaken = viewStore.scan(_ -> true).stream()
+                .anyMatch(v -> viewName.equals(v.viewName()) && region.equals(regionOf(v)));
+        if (nameTaken) {
+            throw new AwsException("ConflictException",
+                    "A view with the name " + viewName + " already exists in this AWS Region.", 409);
+        }
+        String accountId = regionResolver.getAccountId();
+        String viewArn = regionResolver.buildArn("resource-explorer-2", region,
+                "view/" + viewName + "/" + UUID.randomUUID());
+        String effectiveScope = (scope != null) ? scope : "arn:aws:iam::" + accountId + ":root";
+        View view = new View(viewArn, viewName, accountId,
+                effectiveScope,
+                filters, includedProperties,
+                tags != null ? new HashMap<>(tags) : new HashMap<>(),
+                Instant.now());
+        viewStore.put(viewArn, view);
+        return view;
+    }
+
+    private static void validateIncludedProperties(List<IncludedProperty> includedProperties) {
+        if (includedProperties == null) {
+            return;
+        }
+        for (IncludedProperty p : includedProperties) {
+            if (!"tags".equals(p.name())) {
+                throw new AwsException("ValidationException",
+                        "Invalid included property name: " + p.name() + ". The only valid value is 'tags'.", 400);
+            }
+        }
+    }
+
+    public View getView(String viewArn) {
+        return viewStore.get(viewArn)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "View not found: " + viewArn, 404));
+    }
+
+    public void deleteView(String viewArn) {
+        viewStore.get(viewArn)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "View not found: " + viewArn, 404));
+        viewStore.delete(viewArn);
+        // AWS allows deleting a view that is the default; the region is simply left without one.
+        for (String region : Set.copyOf(defaultViewStore.keys())) {
+            if (defaultViewStore.get(region).filter(viewArn::equals).isPresent()) {
+                defaultViewStore.delete(region);
+            }
+        }
+    }
+
+    public View updateView(String viewArn, SearchFilter filters,
+                           List<IncludedProperty> includedProperties) {
+        validateIncludedProperties(includedProperties);
+        View view = viewStore.get(viewArn)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "View not found: " + viewArn, 404));
+        View updated = view.withFilters(filters)
+                .withIncludedProperties(includedProperties)
+                .withLastUpdatedAt(Instant.now());
+        viewStore.put(viewArn, updated);
+        return updated;
+    }
+
+    public ObjectNode listViews(Integer maxResults, String nextToken) {
+        ensureDefaultRegionProvisioned();
+        List<String> all = viewStore.scan(_ -> true).stream()
+                .map(View::viewArn)
+                .toList();
+        Paginated<String> page = paginate(all, maxResults, nextToken, 100);
+
+        ObjectNode result = objectMapper.createObjectNode();
+        result.set("Views", objectMapper.valueToTree(page.items()));
+        if (page.nextToken() != null) {
+            result.put("NextToken", page.nextToken());
+        }
+        return result;
+    }
+
+    public ObjectNode batchGetView(List<String> viewArns) {
+        ObjectNode result = objectMapper.createObjectNode();
+        ArrayNode views = result.putArray("Views");
+        ArrayNode errors = result.putArray("Errors");
+        for (String arn : viewArns) {
+            Optional<View> view = viewStore.get(arn);
+            if (view.isPresent()) {
+                views.add(buildViewNode(view.get()));
+            } else {
+                ObjectNode error = objectMapper.createObjectNode();
+                error.put("ErrorMessage", "View not found: " + arn);
+                error.put("ViewArn", arn);
+                errors.add(error);
+            }
+        }
+        return result;
+    }
+
+    ObjectNode buildViewNode(View view) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("ViewArn", view.viewArn());
+        if (view.viewName() != null) {
+            node.put("ViewName", view.viewName());
+        }
+        node.put("Owner", view.owner());
+        node.put("Scope", view.scope());
+        node.put("LastUpdatedAt", view.lastUpdatedAt().toString());
+        ObjectNode filters = objectMapper.createObjectNode();
+        filters.put("FilterString",
+                view.filters() != null ? view.filters().filterString() : "");
+        node.set("Filters", filters);
+        if (view.includedProperties() != null) {
+            ArrayNode props = objectMapper.createArrayNode();
+            for (IncludedProperty p : view.includedProperties()) {
+                ObjectNode propNode = objectMapper.createObjectNode();
+                propNode.put("Name", p.name());
+                props.add(propNode);
+            }
+            node.set("IncludedProperties", props);
+        }
+        return node;
+    }
+
+    public void associateDefaultView(String region, String viewArn) {
+        View view = viewStore.get(viewArn)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "View not found: " + viewArn, 404));
+        // AWS scopes the default view per region: the view ARN's region must match the request
+        // region, otherwise it rejects the association with a ValidationException.
+        if (!region.equals(regionOf(view))) {
+            throw new AwsException("ValidationException",
+                    "View " + viewArn + " is in region " + regionOf(view)
+                            + " and cannot be the default view for region " + region + ".", 400);
+        }
+        defaultViewStore.put(region, viewArn);
+    }
+
+    public void disassociateDefaultView(String region) {
+        defaultViewStore.delete(region);
+    }
+
+    public String getDefaultView(String region) {
+        ensureDefaultRegionProvisioned();
+        return defaultViewStore.get(region).orElse(null);
+    }
+
+    public ObjectNode listResources(String filterString, Integer maxResults,
+                                     String nextToken, String viewArn, String region) {
+        View view = resolveView(viewArn, region);
+        ParsedQuery requestFilter = (filterString != null && !filterString.isBlank())
+                ? QueryParser.parseFilterOnly(filterString) : new ParsedQuery(List.of(), List.of());
+        ParsedQuery viewFilter = (view.filters() != null && view.filters().filterString() != null)
+                ? QueryParser.parseFilterOnly(view.filters().filterString())
+                : new ParsedQuery(List.of(), List.of());
+        Page p = paginateResources(ResourceFilter.combine(viewFilter, requestFilter), maxResults, nextToken, UNLIMITED_RESULTS);
+
+        ObjectNode result = objectMapper.createObjectNode();
+        ArrayNode resources = result.putArray("Resources");
+        for (ExplorerResource r : p.page()) {
+            resources.add(buildResourceNode(r, view.includesTags()));
+        }
+        if (listResourcesEmitsToken(p.end(), p.total(), maxResults)) {
+            result.put("NextToken", encodeNextToken(p.end()));
+        }
+        result.put("ViewArn", view.viewArn());
+        return result;
+    }
+
+    public ObjectNode search(String queryString, Integer maxResults,
+                              String nextToken, String viewArn, String region) {
+        View view = resolveView(viewArn, region);
+        ParsedQuery requestFilter = (queryString != null && !queryString.isBlank())
+                ? QueryParser.parse(queryString) : new ParsedQuery(List.of(), List.of());
+        ParsedQuery viewFilter = (view.filters() != null && view.filters().filterString() != null)
+                ? QueryParser.parse(view.filters().filterString())
+                : new ParsedQuery(List.of(), List.of());
+        Page p = paginateResources(ResourceFilter.combine(viewFilter, requestFilter), maxResults, nextToken, MAX_RESOURCE_RESULTS);
+
+        ObjectNode result = objectMapper.createObjectNode();
+        ArrayNode resources = result.putArray("Resources");
+        for (ExplorerResource r : p.page()) {
+            resources.add(buildResourceNode(r, view.includesTags()));
+        }
+        ObjectNode count = objectMapper.createObjectNode();
+        count.put("TotalResources", p.total());
+        count.put("Complete", p.uncappedTotal() <= MAX_RESOURCE_RESULTS);
+        result.set("Count", count);
+        if (p.end() < p.total()) {
+            result.put("NextToken", encodeNextToken(p.end()));
+        }
+        result.put("ViewArn", view.viewArn());
+        return result;
+    }
+
+    private record Page(List<ExplorerResource> page, int end, int total, int uncappedTotal) {}
+
+    /**
+     * Gathers every provider's resources, applies {@code combined}, and returns one page.
+     *
+     * @param resultCap the maximum number of matching resources the operation returns across all
+     *     pages. This is a real per-operation difference in the AWS API, not an internal tuning knob:
+     *     {@code Search} caps at {@link #MAX_RESOURCE_RESULTS}, while {@code ListResources} is uncapped
+     *     and passes {@link #UNLIMITED_RESULTS}. It is a parameter precisely because hardcoding a single
+     *     value here previously imposed Search's 1000-result cap on ListResources, silently dropping
+     *     every match beyond the first 1000.
+     * @see <a href="https://docs.aws.amazon.com/resource-explorer/latest/apireference/API_Search.html">AWS API: Search</a>
+     * @see <a href="https://docs.aws.amazon.com/resource-explorer/latest/apireference/API_ListResources.html">AWS API: ListResources</a>
+     */
+    private Page paginateResources(ParsedQuery combined, Integer maxResults, String nextToken, int resultCap) {
+        List<ExplorerResource> all = new ArrayList<>();
+        for (ResourceProvider provider : providers) {
+            try {
+                all.addAll(provider.getResources());
+            } catch (RuntimeException e) {
+                // One misbehaving provider must not fail discovery for every other service. Skip it
+                // and continue — Search/ListResources is best-effort, so a partial view beats a 500.
+                LOG.warnf(e, "ResourceProvider %s failed to supply resources; excluding it from this result",
+                        provider.getClass().getSimpleName());
+            }
+        }
+        List<ExplorerResource> filtered = all.stream()
+                .filter(r -> ResourceFilter.matches(r, combined))
+                .toList();
+        int uncappedTotal = filtered.size();
+        PageBounds b = pageBounds(filtered.size(), maxResults, nextToken, resultCap);
+        return new Page(filtered.subList(b.start(), b.end()), b.end(), b.total(), uncappedTotal);
+    }
+
+    record PageBounds(int start, int end, int total) {}
+
+    /**
+     * Computes pagination bounds: clamps the decoded offset into range (the live result set can shrink
+     * between paginated calls) and caps the total at {@code hardCap}. {@code Search} passes
+     * {@link #MAX_RESOURCE_RESULTS} — it "can return only the first 1,000 results"; {@code ListResources}
+     * has no total cap and passes {@link #UNLIMITED_RESULTS}.
+     *
+     * @see <a href="https://docs.aws.amazon.com/resource-explorer/latest/apireference/API_Search.html">AWS API: Search</a>
+     */
+    static PageBounds pageBounds(int size, Integer maxResults, String nextToken, int hardCap) {
+        int total = Math.min(size, hardCap);
+        int effectiveMax = (maxResults != null && maxResults > 0) ? maxResults : 100;
+        int start = Math.min(decodeNextToken(nextToken), total);
+        int end = Math.min(start + effectiveMax, total);
+        return new PageBounds(start, end, total);
+    }
+
+    /**
+     * Whether {@code ListResources} emits a {@code NextToken} for a page ending at {@code end} within
+     * {@code total} results. Reproduces a documented AWS quirk: "The ListResources operation does not
+     * generate a NextToken if you set MaxResults to 1000." At the maximum page size the caller silently
+     * receives at most 1000 results with no way to page further.
+     *
+     * @see <a href="https://docs.aws.amazon.com/resource-explorer/latest/apireference/API_ListResources.html">AWS API: ListResources (NextToken)</a>
+     */
+    static boolean listResourcesEmitsToken(int end, int total, Integer maxResults) {
+        if (maxResults != null && maxResults == MAX_RESOURCE_RESULTS) {
+            return false;
+        }
+        return end < total;
+    }
+
+    public ObjectNode listSupportedResourceTypes(Integer maxResults, String nextToken) {
+        List<SupportedResourceType> all = new ArrayList<>();
+        for (ResourceProvider provider : providers) {
+            all.addAll(provider.getSupportedResourceTypes());
+        }
+        Map<String, SupportedResourceType> deduplicated = new LinkedHashMap<>();
+        for (SupportedResourceType t : all) {
+            deduplicated.put(t.resourceType(), t);
+        }
+        List<SupportedResourceType> list = new ArrayList<>(deduplicated.values());
+        Paginated<SupportedResourceType> page = paginate(list, maxResults, nextToken, 100);
+
+        ObjectNode result = objectMapper.createObjectNode();
+        ArrayNode arr = result.putArray("ResourceTypes");
+        for (SupportedResourceType t : page.items()) {
+            ObjectNode node = objectMapper.createObjectNode();
+            node.put("ResourceType", t.resourceType());
+            node.put("Service", t.service());
+            arr.add(node);
+        }
+        if (page.nextToken() != null) {
+            result.put("NextToken", page.nextToken());
+        }
+        return result;
+    }
+
+    public Map<String, String> listTags(String arn) {
+        Map<String, String> tags = resolveTaggable(arn).entity().tags();
+        return tags != null ? tags : Map.of();
+    }
+
+    public void tagResource(String arn, Map<String, String> tags) {
+        mutateTags(arn, current -> current.putAll(tags));
+    }
+
+    public void untagResource(String arn, List<String> tagKeys) {
+        mutateTags(arn, current -> tagKeys.forEach(current::remove));
+    }
+
+    private void mutateTags(String arn, Consumer<Map<String, String>> mutation) {
+        StoredTaggable stored = resolveTaggable(arn);
+        Map<String, String> updated = stored.entity().tags() != null
+                ? new HashMap<>(stored.entity().tags()) : new HashMap<>();
+        mutation.accept(updated);
+        stored.persist().accept(stored.entity().withTags(updated));
+    }
+
+    /** A tagged entity (index or view) paired with the action that writes the updated copy back to its store. */
+    private record StoredTaggable(Taggable entity, Consumer<Taggable> persist) {}
+
+    private StoredTaggable resolveTaggable(String arn) {
+        Optional<Index> index = indexStore.get(arn);
+        if (index.isPresent()) {
+            return new StoredTaggable(index.get(), updated -> indexStore.put(arn, (Index) updated));
+        }
+        Optional<View> view = viewStore.get(arn);
+        if (view.isPresent()) {
+            return new StoredTaggable(view.get(), updated -> viewStore.put(arn, (View) updated));
+        }
+        throw new AwsException("ResourceNotFoundException", "Resource not found: " + arn, 404);
+    }
+
+    private View resolveView(String viewArn, String region) {
+        ensureDefaultRegionProvisioned();
+        String arn = (viewArn != null) ? viewArn : defaultViewStore.get(region).orElse(null);
+        if (arn == null) {
+            throw new AwsException("UnauthorizedException",
+                    "No default view is configured for region " + region
+                            + " and no view was specified.", 401);
+        }
+        return viewStore.get(arn)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "View not found: " + arn, 404));
+    }
+
+    private static int decodeNextToken(String token) {
+        if (token == null) return 0;
+        try {
+            return Integer.parseInt(new String(Base64.getDecoder().decode(token)));
+        } catch (Exception e) {
+            LOG.debugf("Invalid NextToken '%s', restarting from offset 0: %s", token, e.getMessage());
+            return 0;
+        }
+    }
+
+    private static String encodeNextToken(int offset) {
+        return Base64.getEncoder().encodeToString(String.valueOf(offset).getBytes());
+    }
+
+    private ObjectNode buildResourceNode(ExplorerResource r, boolean includeTags) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("Arn", r.arn());
+        node.put("LastReportedAt", r.lastReportedAt().toString());
+        node.put("OwningAccountId", r.owningAccountId());
+        node.put("Region", r.region());
+        node.put("ResourceType", r.resourceType());
+        node.put("Service", r.service());
+
+        ArrayNode properties = node.putArray("Properties");
+        if (includeTags && r.tags() != null && !r.tags().isEmpty()) {
+            ObjectNode tagProp = objectMapper.createObjectNode();
+            ArrayNode tagData = objectMapper.createArrayNode();
+            for (var entry : r.tags().entrySet()) {
+                ObjectNode tagEntry = objectMapper.createObjectNode();
+                tagEntry.put("Key", entry.getKey());
+                tagEntry.put("Value", entry.getValue());
+                tagData.add(tagEntry);
+            }
+            tagProp.set("Data", tagData);
+            tagProp.put("LastReportedAt", r.lastReportedAt().toString());
+            tagProp.put("Name", "tags");
+            properties.add(tagProp);
+        }
+        return node;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2TagHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2TagHandler.java
@@ -1,0 +1,46 @@
+package io.github.hectorvent.floci.services.resourceexplorer2;
+
+import io.github.hectorvent.floci.core.common.TagHandler;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Handles tag operations on Resource Explorer 2 indexes and views.
+ *
+ * <p>Discovered by {@link io.github.hectorvent.floci.core.common.SharedTagsController}
+ * via CDI. Routes {@code /tags/{arn}} requests where the ARN service segment is
+ * {@code "resource-explorer-2"}.
+ */
+@ApplicationScoped
+public class ResourceExplorer2TagHandler implements TagHandler {
+
+    private final ResourceExplorer2Service service;
+
+    @Inject
+    public ResourceExplorer2TagHandler(ResourceExplorer2Service service) {
+        this.service = service;
+    }
+
+    @Override
+    public String serviceKey() {
+        return "resource-explorer-2";
+    }
+
+    @Override
+    public Map<String, String> listTags(String region, String arn) {
+        return service.listTags(arn);
+    }
+
+    @Override
+    public void tagResource(String region, String arn, Map<String, String> tags) {
+        service.tagResource(arn, tags);
+    }
+
+    @Override
+    public void untagResource(String region, String arn, List<String> tagKeys) {
+        service.untagResource(arn, tagKeys);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/model/IncludedProperty.java
+++ b/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/model/IncludedProperty.java
@@ -1,0 +1,7 @@
+package io.github.hectorvent.floci.services.resourceexplorer2.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/** A property included in search results. Currently only {@code "tags"} is supported. */
+@RegisterForReflection
+public record IncludedProperty(String name) {}

--- a/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/model/Index.java
+++ b/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/model/Index.java
@@ -1,0 +1,43 @@
+package io.github.hectorvent.floci.services.resourceexplorer2.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@RegisterForReflection
+public record Index(
+        String arn,
+        String region,
+        IndexType type,
+        IndexState state,
+        Map<String, String> tags,
+        Instant createdAt,
+        Instant lastUpdatedAt,
+        List<String> replicatingFrom,
+        List<String> replicatingTo) implements Taggable {
+
+    /** New index: lastUpdatedAt tracks createdAt, replication lists start empty. */
+    public Index(String arn, String region, IndexType type, IndexState state,
+                 Map<String, String> tags, Instant createdAt) {
+        this(arn, region, type, state, tags, createdAt, createdAt, List.of(), List.of());
+    }
+
+    public Index withState(IndexState state) {
+        return new Index(arn, region, type, state, tags, createdAt, lastUpdatedAt, replicatingFrom, replicatingTo);
+    }
+
+    public Index withType(IndexType type) {
+        return new Index(arn, region, type, state, tags, createdAt, lastUpdatedAt, replicatingFrom, replicatingTo);
+    }
+
+    public Index withLastUpdatedAt(Instant lastUpdatedAt) {
+        return new Index(arn, region, type, state, tags, createdAt, lastUpdatedAt, replicatingFrom, replicatingTo);
+    }
+
+    @Override
+    public Index withTags(Map<String, String> tags) {
+        return new Index(arn, region, type, state, tags, createdAt, lastUpdatedAt, replicatingFrom, replicatingTo);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/model/IndexState.java
+++ b/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/model/IndexState.java
@@ -1,0 +1,24 @@
+package io.github.hectorvent.floci.services.resourceexplorer2.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public enum IndexState {
+    /** The index is being created and is not yet available for use. */
+    CREATING,
+
+    /** The index exists and is available to receive and respond to search queries. */
+    ACTIVE,
+
+    /** The index is being deleted and can no longer be used. */
+    DELETING,
+
+    /** The index has been deleted. */
+    DELETED,
+
+    /**
+     * The index is being changed, typically when converting between {@link IndexType#LOCAL} and
+     * {@link IndexType#AGGREGATOR}. The index remains usable during this transition.
+     */
+    UPDATING
+}

--- a/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/model/IndexType.java
+++ b/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/model/IndexType.java
@@ -1,0 +1,19 @@
+package io.github.hectorvent.floci.services.resourceexplorer2.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public enum IndexType {
+    /**
+     * A local index holds information only about resources in the same AWS Region as the index. An account can have one
+     * local index per Region.
+     */
+    LOCAL,
+
+    /**
+     * The aggregator index receives replicated copies of the local index data from all Regions in which the account has
+     * a local index. An account can have only one aggregator index, and it enables Resource Explorer to run
+     * cross-Region searches.
+     */
+    AGGREGATOR
+}

--- a/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/model/SearchFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/model/SearchFilter.java
@@ -1,0 +1,7 @@
+package io.github.hectorvent.floci.services.resourceexplorer2.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/** Filter string attached to a view or {@code ListResources} request. */
+@RegisterForReflection
+public record SearchFilter(String filterString) {}

--- a/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/model/Taggable.java
+++ b/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/model/Taggable.java
@@ -1,0 +1,9 @@
+package io.github.hectorvent.floci.services.resourceexplorer2.model;
+
+import java.util.Map;
+
+/** A resource carrying mutable tags. Implementations are immutable records; {@link #withTags} returns a copy. */
+public interface Taggable {
+    Map<String, String> tags();
+    Taggable withTags(Map<String, String> tags);
+}

--- a/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/model/View.java
+++ b/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/model/View.java
@@ -1,0 +1,42 @@
+package io.github.hectorvent.floci.services.resourceexplorer2.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@RegisterForReflection
+public record View(
+        String viewArn,
+        String viewName,
+        String owner,
+        String scope,
+        SearchFilter filters,
+        List<IncludedProperty> includedProperties,
+        Map<String, String> tags,
+        Instant lastUpdatedAt) implements Taggable {
+
+    public View withFilters(SearchFilter filters) {
+        return new View(viewArn, viewName, owner, scope, filters, includedProperties, tags, lastUpdatedAt);
+    }
+
+    public View withIncludedProperties(List<IncludedProperty> includedProperties) {
+        return new View(viewArn, viewName, owner, scope, filters, includedProperties, tags, lastUpdatedAt);
+    }
+
+    public View withLastUpdatedAt(Instant lastUpdatedAt) {
+        return new View(viewArn, viewName, owner, scope, filters, includedProperties, tags, lastUpdatedAt);
+    }
+
+    @Override
+    public View withTags(Map<String, String> tags) {
+        return new View(viewArn, viewName, owner, scope, filters, includedProperties, tags, lastUpdatedAt);
+    }
+
+    /** Whether this view includes tag data in results. */
+    public boolean includesTags() {
+        return includedProperties != null &&
+                includedProperties.stream().anyMatch(p -> "tags".equals(p.name()));
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/query/FilterAttribute.java
+++ b/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/query/FilterAttribute.java
@@ -1,0 +1,43 @@
+package io.github.hectorvent.floci.services.resourceexplorer2.query;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Known filter attributes in Resource Explorer query syntax.
+ */
+@RegisterForReflection
+public enum FilterAttribute {
+    ACCOUNT_ID("accountid"),
+    APPLICATION("application"),
+    ID("id"),
+    REGION("region"),
+    RESOURCE_TYPE("resourcetype"),
+    RESOURCE_TYPE_SUPPORTS("resourcetype.supports"),
+    SERVICE("service"),
+    TAG("tag"),
+    TAG_KEY("tag.key"),
+    TAG_VALUE("tag.value");
+
+    private static final Map<String, FilterAttribute> BY_PREFIX =
+            Stream.of(values()).collect(Collectors.toMap(
+                    a -> a.prefix.toLowerCase(Locale.ROOT), a -> a));
+
+    private final String prefix;
+
+    FilterAttribute(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String prefix() {
+        return prefix;
+    }
+
+    public static FilterAttribute fromPrefix(String prefix) {
+        return BY_PREFIX.get(prefix.toLowerCase(Locale.ROOT));
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/query/ParsedQuery.java
+++ b/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/query/ParsedQuery.java
@@ -1,0 +1,25 @@
+package io.github.hectorvent.floci.services.resourceexplorer2.query;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+
+@RegisterForReflection
+public record ParsedQuery(
+        List<Keyword> keywords,
+        List<Filter> filters
+) {
+
+    @RegisterForReflection
+    public record Keyword(String value, boolean negated) {}
+
+    @RegisterForReflection
+    public record Filter(
+            FilterAttribute attribute,
+            List<FilterValue> values,
+            boolean negated
+    ) {}
+
+    @RegisterForReflection
+    public record FilterValue(String value, boolean prefixMatch) {}
+}

--- a/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/query/QueryParser.java
+++ b/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/query/QueryParser.java
@@ -1,0 +1,164 @@
+package io.github.hectorvent.floci.services.resourceexplorer2.query;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Hand-written character-by-character parser for Resource Explorer query syntax.
+ *
+ * <p>Supports: filter prefixes ({@code service:}, {@code region:}, etc.),
+ * comma-OR, negation ({@code -}), wildcards ({@code *}), quoted strings,
+ * backslash escaping, and free-form text keywords.
+ *
+ * @see <a href="https://docs.aws.amazon.com/resource-explorer/latest/userguide/using-search-query-syntax.html">
+ *     Search query syntax reference</a>
+ */
+public final class QueryParser {
+
+    private QueryParser() {}
+
+    public static ParsedQuery parse(String input) {
+        if (input == null || input.isBlank()) {
+            return new ParsedQuery(List.of(), List.of());
+        }
+        List<String> tokens = tokenize(input);
+        return classify(tokens);
+    }
+
+    // Rejects free-form text — ListResources only accepts filter prefixes.
+    public static ParsedQuery parseFilterOnly(String input) {
+        ParsedQuery query = parse(input);
+        if (!query.keywords().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "ListResources FilterString does not support free-form text. " +
+                    "Use only filter prefixes (e.g., service:ec2, region:us-east-1).");
+        }
+        return query;
+    }
+
+    static List<String> tokenize(String input) {
+        List<String> tokens = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+        // Track whether the current token has any content (including quoted empty strings)
+        boolean hadContent = false;
+
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+
+            if (inQuotes) {
+                if (c == '\\' && i + 1 < input.length() && input.charAt(i + 1) == '"') {
+                    // Escaped quote inside quoted string
+                    current.append('"');
+                    i++;
+                    hadContent = true;
+                } else if (c == '"') {
+                    // Closing quote — mark that we had content even if the string is empty
+                    inQuotes = false;
+                    hadContent = true;
+                } else {
+                    current.append(c);
+                    hadContent = true;
+                }
+                continue;
+            }
+
+            // Unquoted context
+            if (c == '"') {
+                inQuotes = true;
+                continue;
+            }
+
+            if (Character.isWhitespace(c)) {
+                if (hadContent || !current.isEmpty()) {
+                    tokens.add(current.toString());
+                    current.setLength(0);
+                    hadContent = false;
+                }
+                continue;
+            }
+
+            current.append(c);
+            hadContent = true;
+        }
+
+        if (hadContent || !current.isEmpty()) {
+            tokens.add(current.toString());
+        }
+
+        return tokens;
+    }
+
+    private static ParsedQuery classify(List<String> tokens) {
+        List<ParsedQuery.Keyword> keywords = new ArrayList<>();
+        List<ParsedQuery.Filter> filters = new ArrayList<>();
+
+        for (String token : tokens) {
+            boolean negated = false;
+            String working = token;
+
+            if (working.startsWith("-")) {
+                negated = true;
+                working = working.substring(1);
+            }
+
+            int colonIndex = working.indexOf(':');
+            FilterAttribute attribute = colonIndex >= 0
+                    ? FilterAttribute.fromPrefix(working.substring(0, colonIndex))
+                    : null;
+            if (attribute != null) {
+                String valuePortion = working.substring(colonIndex + 1);
+                List<ParsedQuery.FilterValue> values = parseFilterValues(valuePortion);
+                filters.add(new ParsedQuery.Filter(attribute, values, negated));
+            } else {
+                keywords.add(new ParsedQuery.Keyword(working, negated));
+            }
+        }
+
+        return new ParsedQuery(keywords, filters);
+    }
+
+    private static List<ParsedQuery.FilterValue> parseFilterValues(String valuePortion) {
+        List<ParsedQuery.FilterValue> values = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean escaped = false;
+
+        for (int i = 0; i < valuePortion.length(); i++) {
+            char c = valuePortion.charAt(i);
+
+            if (escaped) {
+                current.append(c);
+                escaped = false;
+                continue;
+            }
+
+            if (c == '\\') {
+                if (i == valuePortion.length() - 1) {
+                    // Dangling backslash — treat literally
+                    current.append(c);
+                } else {
+                    escaped = true;
+                }
+                continue;
+            }
+
+            if (c == ',') {
+                values.add(toFilterValue(current.toString()));
+                current.setLength(0);
+                continue;
+            }
+
+            current.append(c);
+        }
+
+        values.add(toFilterValue(current.toString()));
+        return values;
+    }
+
+    private static ParsedQuery.FilterValue toFilterValue(String raw) {
+        if (raw.endsWith("*")) {
+            return new ParsedQuery.FilterValue(raw.substring(0, raw.length() - 1), true);
+        }
+        return new ParsedQuery.FilterValue(raw, false);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/query/ResourceFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/resourceexplorer2/query/ResourceFilter.java
@@ -1,0 +1,139 @@
+package io.github.hectorvent.floci.services.resourceexplorer2.query;
+
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Evaluates whether a resource matches a parsed query.
+ *
+ * <p>Filters are AND'd. Values within a filter are OR'd.
+ * Negation inverts the result. Keywords are used for relevance
+ * ranking but negated keywords exclude resources.
+ */
+public final class ResourceFilter {
+
+    private ResourceFilter() {}
+
+    public static boolean matches(ExplorerResource resource, ParsedQuery query) {
+        for (var filter : query.filters()) {
+            boolean anyValueMatches = filter.values().stream()
+                    .anyMatch(v -> matchesValue(resource, filter.attribute(), v));
+            if (filter.negated()) {
+                anyValueMatches = !anyValueMatches;
+            }
+            if (!anyValueMatches) {
+                return false;
+            }
+        }
+
+        for (var keyword : query.keywords()) {
+            if (keyword.negated()) {
+                if (matchesKeyword(resource, keyword.value())) {
+                    return false;
+                }
+            } else {
+                if (!matchesKeyword(resource, keyword.value())) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    public static ParsedQuery combine(ParsedQuery viewFilter, ParsedQuery requestFilter) {
+        List<ParsedQuery.Keyword> keywords = new ArrayList<>(viewFilter.keywords());
+        keywords.addAll(requestFilter.keywords());
+        List<ParsedQuery.Filter> filters = new ArrayList<>(viewFilter.filters());
+        filters.addAll(requestFilter.filters());
+        return new ParsedQuery(keywords, filters);
+    }
+
+    private static boolean matchesValue(ExplorerResource resource, FilterAttribute attr,
+                                         ParsedQuery.FilterValue filterValue) {
+        return switch (attr) {
+            case REGION -> compareString(resource.region(), filterValue);
+            case SERVICE -> compareString(resource.service(), filterValue);
+            case RESOURCE_TYPE -> compareString(resource.resourceType(), filterValue);
+            case ACCOUNT_ID -> compareString(resource.owningAccountId(), filterValue);
+            case ID -> compareString(resource.arn(), filterValue);
+            case APPLICATION -> matchesApplication(resource, filterValue);
+            case TAG -> matchesTag(resource, filterValue);
+            case TAG_KEY -> matchesTagKey(resource, filterValue);
+            case TAG_VALUE -> matchesTagValue(resource, filterValue);
+            // Every resource type floci exposes is taggable, so this is a pass-through today.
+            case RESOURCE_TYPE_SUPPORTS -> "tags".equalsIgnoreCase(filterValue.value());
+        };
+    }
+
+    private static boolean compareString(String actual, ParsedQuery.FilterValue filter) {
+        if (actual == null) return false;
+        String actualLower = actual.toLowerCase(Locale.ROOT);
+        String filterLower = filter.value().toLowerCase(Locale.ROOT);
+        if (filter.prefixMatch()) {
+            return actualLower.startsWith(filterLower);
+        }
+        return actualLower.equals(filterLower);
+    }
+
+    private static boolean matchesTag(ExplorerResource resource, ParsedQuery.FilterValue filterValue) {
+        String val = filterValue.value();
+        if ("all".equalsIgnoreCase(val)) {
+            return resource.tags() != null && !resource.tags().isEmpty();
+        }
+        if ("none".equalsIgnoreCase(val)) {
+            return resource.tags() == null || resource.tags().isEmpty();
+        }
+        int eq = val.indexOf('=');
+        if (eq < 0) return false;
+        String tagKey = val.substring(0, eq);
+        String tagValue = val.substring(eq + 1);
+        Map<String, String> tags = resource.tags();
+        if (tags == null) return false;
+        return tags.entrySet().stream().anyMatch(e ->
+                e.getKey().equalsIgnoreCase(tagKey) && e.getValue().equalsIgnoreCase(tagValue));
+    }
+
+    private static boolean matchesTagKey(ExplorerResource resource, ParsedQuery.FilterValue filterValue) {
+        Map<String, String> tags = resource.tags();
+        if (tags == null) return false;
+        return tags.keySet().stream().anyMatch(k ->
+                compareTagString(k, filterValue));
+    }
+
+    private static boolean matchesTagValue(ExplorerResource resource, ParsedQuery.FilterValue filterValue) {
+        Map<String, String> tags = resource.tags();
+        if (tags == null) return false;
+        return tags.values().stream().anyMatch(v ->
+                compareTagString(v, filterValue));
+    }
+
+    private static boolean compareTagString(String actual, ParsedQuery.FilterValue filter) {
+        String actualLower = actual.toLowerCase(Locale.ROOT);
+        String filterLower = filter.value().toLowerCase(Locale.ROOT);
+        if (filter.prefixMatch()) {
+            return actualLower.startsWith(filterLower);
+        }
+        return actualLower.equals(filterLower);
+    }
+
+    private static boolean matchesApplication(ExplorerResource resource, ParsedQuery.FilterValue filterValue) {
+        Map<String, String> tags = resource.tags();
+        if (tags == null) return false;
+        String appTag = tags.get("awsApplication");
+        if (appTag == null) return false;
+        return compareString(appTag, filterValue);
+    }
+
+    private static boolean matchesKeyword(ExplorerResource resource, String keyword) {
+        String lower = keyword.toLowerCase(Locale.ROOT);
+        return (resource.arn() != null && resource.arn().toLowerCase(Locale.ROOT).contains(lower))
+                || (resource.resourceType() != null && resource.resourceType().toLowerCase(Locale.ROOT).contains(lower))
+                || (resource.service() != null && resource.service().toLowerCase(Locale.ROOT).contains(lower))
+                || (resource.region() != null && resource.region().toLowerCase(Locale.ROOT).contains(lower));
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/resourcegroupstagging/ResourceGroupsTaggingService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/resourcegroupstagging/ResourceGroupsTaggingService.java
@@ -41,6 +41,14 @@ public class ResourceGroupsTaggingService implements Resettable {
         return region + "::" + arn;
     }
 
+    /**
+     * Returns the tags for a single resource, or an empty map if no tags have been applied.
+     */
+    public Map<String, String> getTagsForResource(String region, String arn) {
+        ResourceTagMapping mapping = store.get(key(region, arn));
+        return mapping != null ? Collections.unmodifiableMap(mapping.getTags()) : Map.of();
+    }
+
     // ─── TagResources ──────────────────────────────────────────────────────────
 
     // Mutators are synchronized: StorageBackedMap has no atomic computeIfAbsent, so

--- a/src/main/java/io/github/hectorvent/floci/services/rum/RumService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rum/RumService.java
@@ -4,7 +4,12 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.rum.model.AppMonitor;
@@ -13,6 +18,7 @@ import jakarta.inject.Inject;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -27,7 +33,10 @@ import java.util.regex.Pattern;
 
 /** CloudWatch RUM app-monitor lifecycle backed by the configured Floci storage mode. */
 @ApplicationScoped
-public class RumService {
+public class RumService implements ResourceProvider {
+
+    private static final String SERVICE = "rum";
+    private static final String RESOURCE_APP_MONITOR = "appmonitor";
 
     private static final int DEFAULT_MAX_RESULTS = 50;
     private static final int MAX_RESULTS = 100;
@@ -49,18 +58,20 @@ public class RumService {
     private static final Set<String> PLATFORMS = Set.of("Web", "Android", "iOS");
 
     private final StorageBackend<String, AppMonitor> monitorStore;
+    private final RegionResolver regionResolver;
 
     @Inject
-    public RumService(StorageFactory storageFactory) {
+    public RumService(StorageFactory storageFactory, RegionResolver regionResolver) {
         this(storageFactory.create(
                 "rum",
                 "rum-app-monitors.json",
                 new TypeReference<Map<String, AppMonitor>>() {
-                }));
+                }), regionResolver);
     }
 
-    RumService(StorageBackend<String, AppMonitor> monitorStore) {
+    RumService(StorageBackend<String, AppMonitor> monitorStore, RegionResolver regionResolver) {
         this.monitorStore = monitorStore;
+        this.regionResolver = regionResolver;
     }
 
     public synchronized AppMonitor createAppMonitor(String region, JsonNode request) {
@@ -97,6 +108,7 @@ public class RumService {
                 dataStorage(cwLogEnabled),
                 customEvents,
                 deobfuscation);
+        monitor.setOwnerAccountId(regionResolver.getAccountId());
         monitorStore.put(key, monitor);
         return monitor;
     }
@@ -173,6 +185,56 @@ public class RumService {
         int end = Math.min(offset + maxResults, monitors.size());
         String responseToken = end < monitors.size() ? encodeOffset(end) : null;
         return new Page(monitors.subList(offset, end), responseToken);
+    }
+
+    @Override
+    public List<ExplorerResource> getResources() {
+        // RUM's stored model carries neither an ARN nor a region (its GetAppMonitor response has no
+        // such fields), so the region is recovered from the storage key and the ARN is rebuilt here.
+        // The owning account is the one captured when the monitor was created, not the account of the
+        // caller listing resources, falling back to the default account for monitors reloaded from
+        // disk (where the transient owner account was not persisted).
+        List<ExplorerResource> resources = new ArrayList<>();
+        for (String key : monitorStore.keys()) {
+            AppMonitor monitor = monitorStore.get(key).orElse(null);
+            if (monitor == null) {
+                continue;
+            }
+            String region = regionFromKey(key);
+            String accountId = monitor.getOwnerAccountId() != null
+                    ? monitor.getOwnerAccountId()
+                    : regionResolver.getDefaultAccountId();
+            String arn = AwsArnUtils.Arn.of(SERVICE, region, accountId,
+                    RESOURCE_APP_MONITOR + "/" + monitor.getName()).toString();
+            resources.add(new ExplorerResource(
+                    arn, SERVICE + ":" + RESOURCE_APP_MONITOR, SERVICE,
+                    region, accountId,
+                    reportedAt(monitor.getCreated()),
+                    monitor.getTags() != null ? monitor.getTags() : Map.of()));
+        }
+        return resources;
+    }
+
+    private static String regionFromKey(String key) {
+        int separator = key.indexOf("::");
+        return separator > 0 ? key.substring(0, separator) : key;
+    }
+
+    @Override
+    public Set<SupportedResourceType> getSupportedResourceTypes() {
+        return Set.of(new SupportedResourceType(
+                SERVICE + ":" + RESOURCE_APP_MONITOR, SERVICE, true));
+    }
+
+    private static Instant reportedAt(String created) {
+        if (created == null) {
+            return Instant.now();
+        }
+        try {
+            return LocalDateTime.parse(created, TIMESTAMP_FORMATTER).toInstant(ZoneOffset.UTC);
+        } catch (RuntimeException e) {
+            return Instant.now();
+        }
     }
 
     private static String storageKey(String region, String name) {

--- a/src/main/java/io/github/hectorvent/floci/services/rum/model/AppMonitor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rum/model/AppMonitor.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.rum.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
@@ -27,6 +28,13 @@ public class AppMonitor {
     private JsonNode dataStorage;
     private JsonNode customEvents;
     private JsonNode deobfuscationConfiguration;
+
+    // The account that created this monitor, captured so Resource Explorer 2 can report the true
+    // owning account in the reconstructed ARN. RUM's GetAppMonitor response has no ARN or account
+    // field, so this is @JsonIgnore'd to keep it out of the API body; it is likewise not persisted,
+    // so getResources() falls back to the default account for monitors reloaded from disk.
+    @JsonIgnore
+    private String ownerAccountId;
 
     public AppMonitor() {
     }
@@ -162,6 +170,16 @@ public class AppMonitor {
 
     public void setDeobfuscationConfiguration(JsonNode deobfuscationConfiguration) {
         this.deobfuscationConfiguration = copy(deobfuscationConfiguration);
+    }
+
+    @JsonIgnore
+    public String getOwnerAccountId() {
+        return ownerAccountId;
+    }
+
+    @JsonIgnore
+    public void setOwnerAccountId(String ownerAccountId) {
+        this.ownerAccountId = ownerAccountId;
     }
 
     private static JsonNode copy(JsonNode value) {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -42,9 +42,12 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
 
 @ApplicationScoped
-public class S3Service implements Resettable {
+public class S3Service implements Resettable, ResourceProvider {
     private String ownerId() { return regionResolver != null ? regionResolver.getAccountId() : "000000000000"; }
     private static final String DEFAULT_OWNER_DISPLAY_NAME = "floci";
     private static final String AUTHENTICATED_USERS_GROUP_URI = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers";
@@ -2693,5 +2696,26 @@ public class S3Service implements Resettable {
         LOG.debugv("Copied object: {0}/{1} -> {2}/{3}", sourceBucket, sourceKey, destBucket, destKey);
         fireNotifications(destBucket, destKey, "ObjectCreated:Copy", copy);
         return copy;
+    }
+
+    @Override
+    public List<ExplorerResource> getResources() {
+        List<ExplorerResource> resources = new ArrayList<>();
+        for (Bucket bucket : listBuckets()) {
+            resources.add(new ExplorerResource(
+                    "arn:aws:s3:::" + bucket.getName(),
+                    "s3:bucket",
+                    "s3",
+                    bucket.getRegion() != null ? bucket.getRegion() : regionResolver.getDefaultRegion(),
+                    regionResolver.getAccountId(),
+                    bucket.getCreationDate() != null ? bucket.getCreationDate() : Instant.now(),
+                    bucket.getTags() != null ? bucket.getTags() : Map.of()));
+        }
+        return resources;
+    }
+
+    @Override
+    public Set<SupportedResourceType> getSupportedResourceTypes() {
+        return Set.of(new SupportedResourceType("s3:bucket", "s3", true));
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
@@ -5,6 +5,9 @@ import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.Resettable;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.lambda.LambdaService;
@@ -51,7 +54,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 @ApplicationScoped
-public class SnsService implements Resettable {
+public class SnsService implements Resettable, ResourceProvider {
 
     private static final Logger LOG = Logger.getLogger(SnsService.class);
     private static final Duration FIFO_DEDUP_WINDOW = Duration.ofMinutes(5);
@@ -844,6 +847,27 @@ public class SnsService implements Resettable {
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
                         "Resource does not exist.", 404));
         return new java.util.LinkedHashMap<>(topic.getTags());
+    }
+
+    @Override
+    public List<ExplorerResource> getResources() {
+        List<ExplorerResource> resources = new ArrayList<>();
+        for (Topic topic : topicStore.scan(k -> true)) {
+            String arn = topic.getTopicArn();
+            if (arn == null) continue;
+            AwsArnUtils.Arn parsed = AwsArnUtils.parse(arn);
+            resources.add(new ExplorerResource(
+                    arn, "sns:topic", "sns",
+                    parsed.region(), parsed.accountId(),
+                    topic.getCreatedAt() != null ? topic.getCreatedAt() : Instant.now(),
+                    topic.getTags() != null ? topic.getTags() : Map.of()));
+        }
+        return resources;
+    }
+
+    @Override
+    public Set<SupportedResourceType> getSupportedResourceTypes() {
+        return Set.of(new SupportedResourceType("sns:topic", "sns", true));
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -5,6 +5,9 @@ import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.Resettable;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
@@ -27,7 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 @ApplicationScoped
-public class SqsService implements Resettable {
+public class SqsService implements Resettable, ResourceProvider {
 
     private static final Logger LOG = Logger.getLogger(SqsService.class);
     private static final int DEDUP_WINDOW_SECONDS = 300; // 5 minutes
@@ -199,6 +202,31 @@ public class SqsService implements Resettable {
         } else {
             dedupStore.delete(storageKey);
         }
+    }
+
+    @Override
+    public List<ExplorerResource> getResources() {
+        List<ExplorerResource> resources = new ArrayList<>();
+        for (String key : queueStore.keys()) {
+            int sep = key.indexOf("::");
+            if (sep < 0) continue;
+            String region = key.substring(0, sep);
+            Queue queue = queueStore.get(key).orElse(null);
+            if (queue == null) continue;
+            String account = queue.getAccountId() != null ? queue.getAccountId() : regionResolver.getAccountId();
+            String arn = AwsArnUtils.Arn.of("sqs", region, account, queue.getQueueName()).toString();
+            resources.add(new ExplorerResource(
+                    arn, "sqs:queue", "sqs",
+                    region, account,
+                    queue.getCreatedTimestamp() != null ? queue.getCreatedTimestamp() : Instant.now(),
+                    queue.getTags() != null ? queue.getTags() : Map.of()));
+        }
+        return resources;
+    }
+
+    @Override
+    public Set<SupportedResourceType> getSupportedResourceTypes() {
+        return Set.of(new SupportedResourceType("sqs:queue", "sqs", true));
     }
 
     public Queue createQueue(String queueName, Map<String, String> attributes, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
@@ -1,7 +1,11 @@
 package io.github.hectorvent.floci.services.stepfunctions;
 
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -31,7 +35,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @ApplicationScoped
-public class StepFunctionsService implements Resettable {
+public class StepFunctionsService implements Resettable, ResourceProvider {
 
     private static final Logger LOG = Logger.getLogger(StepFunctionsService.class);
 
@@ -74,6 +78,27 @@ public class StepFunctionsService implements Resettable {
         activityQueues.clear();
         pendingTaskTokens.values().forEach(f -> f.completeExceptionally(new RuntimeException("StepFunctionsService cleared")));
         pendingTaskTokens.clear();
+    }
+
+    @Override
+    public List<ExplorerResource> getResources() {
+        List<ExplorerResource> resources = new ArrayList<>();
+        for (StateMachine sm : stateMachineStore.scan(k -> true)) {
+            String arn = sm.getStateMachineArn();
+            if (arn == null) continue;
+            AwsArnUtils.Arn parsed = AwsArnUtils.parse(arn);
+            resources.add(new ExplorerResource(
+                    arn, "states:stateMachine", "states",
+                    parsed.region(), parsed.accountId(),
+                    sm.getCreationDate() > 0 ? Instant.ofEpochMilli((long) (sm.getCreationDate() * 1000)) : Instant.now(),
+                    sm.getTags() != null ? sm.getTags() : Map.of()));
+        }
+        return resources;
+    }
+
+    @Override
+    public Set<SupportedResourceType> getSupportedResourceTypes() {
+        return Set.of(new SupportedResourceType("states:stateMachine", "states", true));
     }
 
     // ──────────────────────────── State Machines ────────────────────────────

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -138,6 +138,9 @@ floci:
         flush-interval-ms: 5000
       rum:
         flush-interval-ms: 5000
+      resourceexplorer2:
+        mode: hybrid
+        flush-interval-ms: 5000
 
   dns:
     # Extra hostname suffixes resolved to Floci's container IP by the embedded DNS server.
@@ -423,6 +426,8 @@ floci:
       enabled: true
     lightsail:
     cloudcontrol:
+      enabled: true
+    resourceexplorer2:
       enabled: true
     cloudfront:
       enabled: true

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandlerTest.java
@@ -30,7 +30,7 @@ class ElastiCacheQueryHandlerTest {
 
     @Test
     void describeCacheSubnetGroups_returnsEmptyWrapperWithoutMarker() {
-        Response response = handler.handle("DescribeCacheSubnetGroups", params());
+        Response response = handler.handle("DescribeCacheSubnetGroups", params(), "us-east-1");
 
         assertEquals(200, response.getStatus());
         String body = (String) response.getEntity();
@@ -41,7 +41,7 @@ class ElastiCacheQueryHandlerTest {
 
     @Test
     void describeCacheParameterGroups_returnsEmptyWrapperWithoutMarker() {
-        Response response = handler.handle("DescribeCacheParameterGroups", params());
+        Response response = handler.handle("DescribeCacheParameterGroups", params(), "us-east-1");
 
         assertEquals(200, response.getStatus());
         String body = (String) response.getEntity();
@@ -52,7 +52,7 @@ class ElastiCacheQueryHandlerTest {
 
     @Test
     void unsupportedOperationStillReturnsQueryError() {
-        Response response = handler.handle("NoSuchAction", params());
+        Response response = handler.handle("NoSuchAction", params(), "us-east-1");
 
         assertEquals(400, response.getStatus());
         assertTrue(((String) response.getEntity()).contains("UnsupportedOperation"));

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.elasticache;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheContainerHandle;
@@ -40,6 +41,7 @@ class ElastiCacheServiceTest {
         proxyManager = mock(ElastiCacheProxyManager.class);
         StorageFactory storageFactory = mock(StorageFactory.class);
         EmulatorConfig config = mock(EmulatorConfig.class);
+        RegionResolver regionResolver = mock(RegionResolver.class);
 
         EmulatorConfig.ServicesConfig servicesConfig = mock(EmulatorConfig.ServicesConfig.class);
         EmulatorConfig.ElastiCacheServiceConfig ecConfig = mock(EmulatorConfig.ElastiCacheServiceConfig.class);
@@ -54,13 +56,15 @@ class ElastiCacheServiceTest {
         when(containerManager.start(anyString(), anyString()))
                 .thenReturn(new ElastiCacheContainerHandle("cid", "grp", "localhost", 6379));
         doNothing().when(proxyManager).startProxy(anyString(), any(), anyInt(), anyString(), anyInt(), any());
+        when(regionResolver.buildArn(anyString(), anyString(), anyString()))
+                .thenAnswer(inv -> "arn:aws:" + inv.getArgument(0) + ":us-east-1:123456789012:" + inv.getArgument(2));
 
-        service = new ElastiCacheService(containerManager, proxyManager, storageFactory, config);
+        service = new ElastiCacheService(containerManager, proxyManager, storageFactory, config, regionResolver);
     }
 
     @Test
     void singleArgAuthMatchesDefaultUserOnly() {
-        service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, null);
+        service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, null, "us-east-1");
 
         service.createUser("default-user-id", "default", AuthMode.PASSWORD,
                 List.of("default-pass"), "on ~* +@all");
@@ -80,7 +84,7 @@ class ElastiCacheServiceTest {
 
     @Test
     void twoArgAuthMatchesNamedUser() {
-        service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, null);
+        service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, null, "us-east-1");
 
         service.createUser("other-user-id", "other", AuthMode.PASSWORD,
                 List.of("other-pass"), "on ~* +@all");
@@ -96,7 +100,7 @@ class ElastiCacheServiceTest {
 
     @Test
     void singleArgAuthFallsBackToGroupAuthToken() {
-        service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, "group-token");
+        service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, "group-token", "us-east-1");
 
         // Single-arg AUTH with group auth token should succeed
         assertTrue(service.validatePassword("grp", null, "group-token"));
@@ -117,7 +121,7 @@ class ElastiCacheServiceTest {
 
         // The original failure must propagate to the caller (we clean up, then rethrow).
         assertThrows(RuntimeException.class,
-                () -> service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, null));
+                () -> service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, null, "us-east-1"));
 
         // Rollback stopped the proxy and the already-started container.
         verify(proxyManager).stopProxy("grp");
@@ -128,7 +132,7 @@ class ElastiCacheServiceTest {
         doNothing().when(proxyManager)
                 .startProxy(anyString(), any(), anyInt(), anyString(), anyInt(), any());
         ReplicationGroup recovered =
-                service.createReplicationGroup("grp2", "test", AuthMode.PASSWORD, null);
+                service.createReplicationGroup("grp2", "test", AuthMode.PASSWORD, null, "us-east-1");
         assertEquals(16379, recovered.getProxyPort(),
                 "Port from the failed create must be released so the next group reuses it");
     }
@@ -141,7 +145,7 @@ class ElastiCacheServiceTest {
 
         // The original failure must propagate to the caller (we clean up, then rethrow).
         assertThrows(RuntimeException.class,
-                () -> service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, null));
+                () -> service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, null, "us-east-1"));
 
         // No container started and no proxy started, so rollback must not call either stop.
         verify(proxyManager, never()).stopProxy(anyString());
@@ -151,7 +155,7 @@ class ElastiCacheServiceTest {
         when(containerManager.start(anyString(), anyString()))
                 .thenReturn(new ElastiCacheContainerHandle("cid", "grp2", "localhost", 6379));
         ReplicationGroup recovered =
-                service.createReplicationGroup("grp2", "test", AuthMode.PASSWORD, null);
+                service.createReplicationGroup("grp2", "test", AuthMode.PASSWORD, null, "us-east-1");
         assertEquals(16379, recovered.getProxyPort(),
                 "Port from the failed create must be released so the next group reuses it");
     }

--- a/src/test/java/io/github/hectorvent/floci/services/lightsail/LightsailResourceProviderTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lightsail/LightsailResourceProviderTest.java
@@ -1,0 +1,119 @@
+package io.github.hectorvent.floci.services.lightsail;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LightsailResourceProviderTest {
+
+    private static final String REGION = "us-east-1";
+    private static final String ACCOUNT = "000000000000";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private LightsailService service;
+
+    @BeforeEach
+    void setUp() {
+        StorageFactory storageFactory = new StorageFactory(null, null) {
+            @Override
+            public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+                    TypeReference<Map<String, V>> typeReference) {
+                return new InMemoryStorage<>();
+            }
+        };
+        service = new LightsailService(storageFactory, mapper, new RegionResolver(REGION, ACCOUNT));
+    }
+
+    @Nested
+    class GetResources {
+
+        @Test
+        void emptyWhenNothingStored() {
+            assertTrue(service.getResources().isEmpty());
+        }
+
+        @Test
+        void surfacesInstanceWithArnTypeRegionAccountAndTags() {
+            ObjectNode request = mapper.createObjectNode()
+                    .put("availabilityZone", REGION + "a")
+                    .put("blueprintId", "ubuntu_22_04")
+                    .put("bundleId", "nano_3_0");
+            request.set("instanceNames", mapper.createArrayNode().add("web"));
+            request.set("tags", mapper.createArrayNode()
+                    .add(mapper.createObjectNode().put("key", "env").put("value", "prod")));
+            service.createInstances(REGION, request);
+
+            ExplorerResource instance = only(service.getResources(), "lightsail:Instance");
+            assertEquals("arn:aws:lightsail:" + REGION + ":" + ACCOUNT + ":Instance/web", instance.arn());
+            assertEquals("lightsail", instance.service());
+            assertEquals(REGION, instance.region());
+            assertEquals(ACCOUNT, instance.owningAccountId());
+            assertEquals(Map.of("env", "prod"), instance.tags());
+        }
+
+        @Test
+        void surfacesDiskInstanceStaticIpAndKeyPairTypes() {
+            service.createInstances(REGION, mapper.createObjectNode()
+                    .put("availabilityZone", REGION + "a")
+                    .put("blueprintId", "ubuntu_22_04")
+                    .put("bundleId", "nano_3_0")
+                    .set("instanceNames", mapper.createArrayNode().add("web")));
+            service.createDisk(REGION, mapper.createObjectNode()
+                    .put("diskName", "data")
+                    .put("availabilityZone", REGION + "a")
+                    .put("sizeInGb", 32));
+            service.allocateStaticIp(REGION, "ip1");
+            service.createKeyPair(REGION, mapper.createObjectNode().put("keyPairName", "kp1"));
+
+            Set<String> types = service.getResources().stream()
+                    .map(ExplorerResource::resourceType)
+                    .collect(Collectors.toSet());
+            assertEquals(Set.of("lightsail:Instance", "lightsail:Disk",
+                    "lightsail:StaticIp", "lightsail:KeyPair"), types);
+        }
+
+        @Test
+        void resourceWithoutTagsYieldsEmptyMapNotNull() {
+            service.allocateStaticIp(REGION, "ip1");
+            ExplorerResource ip = only(service.getResources(), "lightsail:StaticIp");
+            assertEquals(Map.of(), ip.tags());
+        }
+    }
+
+    @Nested
+    class GetSupportedResourceTypes {
+
+        @Test
+        void advertisesFourLightsailTypesAllUnderLightsailService() {
+            Set<SupportedResourceType> types = service.getSupportedResourceTypes();
+            assertEquals(Set.of("lightsail:Instance", "lightsail:Disk",
+                            "lightsail:StaticIp", "lightsail:KeyPair"),
+                    types.stream().map(SupportedResourceType::resourceType).collect(Collectors.toSet()));
+            assertTrue(types.stream().allMatch(t -> t.service().equals("lightsail")));
+        }
+    }
+
+    private static ExplorerResource only(List<ExplorerResource> resources, String resourceType) {
+        return resources.stream()
+                .filter(r -> r.resourceType().equals(resourceType))
+                .reduce((a, b) -> { throw new AssertionError("expected exactly one " + resourceType); })
+                .orElseThrow(() -> new AssertionError("no " + resourceType + " resource"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -164,7 +164,7 @@ class RdsServiceTest {
         when(dockerHostResolver.resolve()).thenReturn("floci.local");
         RdsService service = new RdsService(containerManager, proxyManager, ec2Service, regionResolver, config,
                 new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
-                new InMemoryStorage<>(), new InMemoryStorage<>(), null, dockerHostResolver);
+                new InMemoryStorage<>(), new InMemoryStorage<>(), null, dockerHostResolver, null);
 
         DbInstance instance = service.createDbInstance("mydb", "postgres", "13",
                 "admin", "password", "dbname", "db.t3.micro",
@@ -874,7 +874,7 @@ class RdsServiceTest {
                                   SecretsManagerService secretsManager) {
         return new RdsService(containerManager, proxyManager, ec2Service, regionResolver, config,
                 instances, clusters, parameterGroups, clusterParameterGroups, new InMemoryStorage<>(),
-                secretsManager, null);
+                secretsManager, null, null);
     }
 
     private static List<Subnet> defaultSubnets() {

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2DefaultViewPersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2DefaultViewPersistenceTest.java
@@ -1,0 +1,118 @@
+package io.github.hectorvent.floci.services.resourceexplorer2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.services.resourceexplorer2.model.Index;
+import io.github.hectorvent.floci.services.resourceexplorer2.model.IndexState;
+import io.github.hectorvent.floci.services.resourceexplorer2.model.IndexType;
+import io.github.hectorvent.floci.services.resourceexplorer2.model.View;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.inject.Instance;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+
+/**
+ * The default-view association is per-region state that must survive a process restart, the same
+ * way indexes and views do. These tests share the storage backends across two service instances —
+ * the second instance models a restart with persisted storage but fresh in-memory state.
+ */
+class ResourceExplorer2DefaultViewPersistenceTest {
+
+    private static final String REGION = "us-east-1";
+    private static final String ACCOUNT = "000000000000";
+
+    private final StorageBackend<String, Index> indexStore = new InMemoryStorage<>();
+    private final StorageBackend<String, View> viewStore = new InMemoryStorage<>();
+    private final StorageBackend<String, String> defaultViewStore = new InMemoryStorage<>();
+
+    @SuppressWarnings("unchecked")
+    private final Instance<ResourceProvider> providers = mock(Instance.class);
+    private final RegionResolver regionResolver = new RegionResolver(REGION, ACCOUNT);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private ResourceExplorer2Service newInstance() {
+        return new ResourceExplorer2Service(
+                providers, regionResolver, objectMapper, indexStore, viewStore, defaultViewStore);
+    }
+
+    @Test
+    void userChosenDefaultViewSurvivesRestart() {
+        ResourceExplorer2Service before = newInstance();
+        before.onStartup(new StartupEvent());
+        String autoProvisioned = before.getDefaultView(REGION);
+
+        // Point the regional default at a custom view, distinct from the auto-provisioned one.
+        View custom = before.createView(REGION, "custom-view", null, null, null, null);
+        before.associateDefaultView(REGION, custom.viewArn());
+        assertNotEquals(autoProvisioned, custom.viewArn());
+        assertEquals(custom.viewArn(), before.getDefaultView(REGION));
+
+        // Restart: fresh instance, same persisted storage.
+        ResourceExplorer2Service after = newInstance();
+        after.onStartup(new StartupEvent());
+
+        // The association must not silently reset to the auto-provisioned default view.
+        assertEquals(custom.viewArn(), after.getDefaultView(REGION));
+    }
+
+    @Test
+    void disassociatedDefaultViewStaysDisassociatedAfterRestart() {
+        ResourceExplorer2Service before = newInstance();
+        before.onStartup(new StartupEvent());
+        before.disassociateDefaultView(REGION);
+        assertNull(before.getDefaultView(REGION));
+
+        ResourceExplorer2Service after = newInstance();
+        after.onStartup(new StartupEvent());
+
+        // No view should be re-associated by a startup guess once the user removed the default.
+        assertNull(after.getDefaultView(REGION));
+    }
+
+    @Test
+    void reprovisionsWhenStorageHasNoActiveDefaultRegionIndex() {
+        // Boot against storage that carries only a leftover DELETED index — no ACTIVE index in the
+        // default region, which is what a persistent/hybrid store looks like after a prior run
+        // created and deleted indexes. The old "provision only when the store is empty" guard
+        // skipped provisioning here, leaving GetIndex 404 and no default view and failing the whole
+        // integration suite. Startup must recover by provisioning a fresh index and default view.
+        String staleArn = "arn:aws:resource-explorer-2:" + REGION + ":" + ACCOUNT + ":index/stale";
+        indexStore.put(staleArn, new Index(staleArn, REGION, IndexType.AGGREGATOR,
+                IndexState.DELETED, new HashMap<>(), Instant.now()));
+
+        ResourceExplorer2Service service = newInstance();
+        service.onStartup(new StartupEvent());
+
+        // getIndex throws when the region has no ACTIVE index, so a non-null return proves recovery.
+        assertNotNull(service.getIndex(REGION));
+        assertNotNull(service.getDefaultView(REGION));
+    }
+
+    @Test
+    void recoversAfterInProcessStorageResetWipesIndexAndView() {
+        // Models a LocalStack state/reset: StorageFactory.clearAll() wipes every backend in-process
+        // with NO Quarkus restart, so onStartup never re-runs. RE2 must lazily re-provision on the
+        // next operation — otherwise GetIndex/GetDefaultView/Search fail for the whole service until
+        // the process restarts (this is what broke the full CI suite when a reset test ran first).
+        ResourceExplorer2Service service = newInstance();
+        service.onStartup(new StartupEvent());
+
+        indexStore.clear();
+        viewStore.clear();
+        defaultViewStore.clear();
+
+        assertNotNull(service.getIndex(REGION));
+        assertNotNull(service.getDefaultView(REGION));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
@@ -269,6 +269,35 @@ class ResourceExplorer2IntegrationTest {
         .then()
             .statusCode(200);
 
+        // Lightsail instance + disk (Resource Explorer 2 provider coverage)
+        given()
+            .header("X-Amz-Target", "Lightsail_20161128.CreateInstances")
+            .contentType("application/x-amz-json-1.1")
+            .body("""
+                {
+                    "instanceNames": ["re2-test-instance"],
+                    "availabilityZone": "us-east-1a",
+                    "blueprintId": "ubuntu_22_04",
+                    "bundleId": "nano_3_0",
+                    "tags": [{"key": "env", "value": "test"}]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "Lightsail_20161128.CreateDisk")
+            .contentType("application/x-amz-json-1.1")
+            .body("""
+                {"diskName": "re2-test-disk", "availabilityZone": "us-east-1a", "sizeInGb": 8}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
         fixturesProvisioned = true;
     }
 
@@ -439,7 +468,7 @@ class ResourceExplorer2IntegrationTest {
                 .statusCode(200)
                 .body("ResourceTypes", notNullValue())
                 .body("ResourceTypes.size()", greaterThan(0))
-                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs", "ecr", "states", "kafka", "pipes", "acm", "cognito-idp", "iam", "mq"));
+                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs", "ecr", "states", "kafka", "pipes", "acm", "cognito-idp", "iam", "mq", "lightsail"));
         }
     }
 
@@ -458,7 +487,9 @@ class ResourceExplorer2IntegrationTest {
             "pipes,       pipes:pipe",
             "acm,         acm:certificate",
             "cognito-idp, cognito-idp:userpool",
-            "mq,          mq:broker"
+            "mq,          mq:broker",
+            "lightsail,   lightsail:Instance",
+            "lightsail,   lightsail:Disk"
         })
         void resourceSurfacesViaListResources(String service, String resourceType) {
             given()

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
@@ -230,6 +230,26 @@ class ResourceExplorer2IntegrationTest {
         .then()
             .statusCode(200);
 
+        // IAM user + role
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateUser")
+            .formParam("UserName", "re2-test-user")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateRole")
+            .formParam("RoleName", "re2-test-role-iam")
+            .formParam("AssumeRolePolicyDocument", "{\"Version\":\"2012-10-17\",\"Statement\":[]}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
         fixturesProvisioned = true;
     }
 
@@ -400,7 +420,7 @@ class ResourceExplorer2IntegrationTest {
                 .statusCode(200)
                 .body("ResourceTypes", notNullValue())
                 .body("ResourceTypes.size()", greaterThan(0))
-                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs", "ecr", "states", "kafka", "pipes", "acm", "cognito-idp"));
+                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs", "ecr", "states", "kafka", "pipes", "acm", "cognito-idp", "iam"));
         }
     }
 
@@ -601,6 +621,29 @@ class ResourceExplorer2IntegrationTest {
                 .body("Resources.size()", greaterThan(0))
                 .body("Resources.findAll { it.Service != 'cognito-idp' }.size()", equalTo(0))
                 .body("Resources.findAll { it.ResourceType == 'cognito-idp:userpool' && it.Region == 'us-east-1' }.size()", greaterThan(0));
+        }
+    }
+
+    @Nested
+    class IamResources {
+        @Test
+        void iamResourcesSurfaceViaListResources() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "service:iam"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0))
+                .body("Resources.findAll { it.Service != 'iam' }.size()", equalTo(0))
+                // IAM is global: Resource Explorer reports these with Region "global", never empty/null.
+                .body("Resources.findAll { it.Region != 'global' }.size()", equalTo(0))
+                .body("Resources.findAll { it.ResourceType == 'iam:user' && it.Region == 'global' }.size()", greaterThan(0))
+                .body("Resources.findAll { it.ResourceType == 'iam:role' && it.Region == 'global' }.size()", greaterThan(0));
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
@@ -130,6 +130,18 @@ class ResourceExplorer2IntegrationTest {
         .then()
             .statusCode(200);
 
+        // KMS key
+        given()
+            .header("X-Amz-Target", "TrentService.CreateKey")
+            .contentType("application/x-amz-json-1.1")
+            .body("""
+                {"Description": "re2-test-key", "KeyUsage": "ENCRYPT_DECRYPT", "KeySpec": "SYMMETRIC_DEFAULT"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
         fixturesProvisioned = true;
     }
 
@@ -300,7 +312,7 @@ class ResourceExplorer2IntegrationTest {
                 .statusCode(200)
                 .body("ResourceTypes", notNullValue())
                 .body("ResourceTypes.size()", greaterThan(0))
-                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns"));
+                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms"));
         }
     }
 
@@ -341,6 +353,26 @@ class ResourceExplorer2IntegrationTest {
                 .body("Resources.size()", greaterThan(0))
                 .body("Resources.findAll { it.Service != 'sns' }.size()", equalTo(0))
                 .body("Resources.findAll { it.ResourceType == 'sns:topic' && it.Region == 'us-east-1' }.size()", greaterThan(0));
+        }
+    }
+
+    @Nested
+    class KmsResources {
+        @Test
+        void kmsKeySurfacesViaListResources() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "service:kms"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0))
+                .body("Resources.findAll { it.Service != 'kms' }.size()", equalTo(0))
+                .body("Resources.findAll { it.ResourceType == 'kms:key' && it.Region == 'us-east-1' }.size()", greaterThan(0));
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -425,202 +427,34 @@ class ResourceExplorer2IntegrationTest {
     }
 
     @Nested
-    class LambdaResources {
-        @Test
-        void lambdaFunctionSurfacesViaListResources() {
-            given()
-                .header("Authorization", AUTH)
-                .contentType("application/json")
-                .body("""
-                    {"Filters": {"FilterString": "service:lambda"}}
-                    """)
-            .when()
-                .post("/ListResources")
-            .then()
-                .statusCode(200)
-                .body("Resources.size()", greaterThan(0))
-                .body("Resources.findAll { it.Service != 'lambda' }.size()", equalTo(0))
-                .body("Resources.findAll { it.ResourceType == 'lambda:function' && it.Region == 'us-east-1' }.size()", greaterThan(0));
-        }
-    }
+    class ServiceResources {
 
-    @Nested
-    class SnsResources {
-        @Test
-        void snsTopicSurfacesViaListResources() {
+        @ParameterizedTest(name = "{1} surfaces via ListResources")
+        @CsvSource({
+            "lambda,      lambda:function",
+            "sns,         sns:topic",
+            "kms,         kms:key",
+            "sqs,         sqs:queue",
+            "ecr,         ecr:repository",
+            "states,      states:stateMachine",
+            "kafka,       kafka:cluster",
+            "pipes,       pipes:pipe",
+            "acm,         acm:certificate",
+            "cognito-idp, cognito-idp:userpool"
+        })
+        void resourceSurfacesViaListResources(String service, String resourceType) {
             given()
                 .header("Authorization", AUTH)
                 .contentType("application/json")
-                .body("""
-                    {"Filters": {"FilterString": "service:sns"}}
-                    """)
+                .body("{\"Filters\": {\"FilterString\": \"service:" + service + "\"}}")
             .when()
                 .post("/ListResources")
             .then()
                 .statusCode(200)
                 .body("Resources.size()", greaterThan(0))
-                .body("Resources.findAll { it.Service != 'sns' }.size()", equalTo(0))
-                .body("Resources.findAll { it.ResourceType == 'sns:topic' && it.Region == 'us-east-1' }.size()", greaterThan(0));
-        }
-    }
-
-    @Nested
-    class KmsResources {
-        @Test
-        void kmsKeySurfacesViaListResources() {
-            given()
-                .header("Authorization", AUTH)
-                .contentType("application/json")
-                .body("""
-                    {"Filters": {"FilterString": "service:kms"}}
-                    """)
-            .when()
-                .post("/ListResources")
-            .then()
-                .statusCode(200)
-                .body("Resources.size()", greaterThan(0))
-                .body("Resources.findAll { it.Service != 'kms' }.size()", equalTo(0))
-                .body("Resources.findAll { it.ResourceType == 'kms:key' && it.Region == 'us-east-1' }.size()", greaterThan(0));
-        }
-    }
-
-    @Nested
-    class SqsResources {
-        @Test
-        void sqsQueueSurfacesViaListResources() {
-            given()
-                .header("Authorization", AUTH)
-                .contentType("application/json")
-                .body("""
-                    {"Filters": {"FilterString": "service:sqs"}}
-                    """)
-            .when()
-                .post("/ListResources")
-            .then()
-                .statusCode(200)
-                .body("Resources.size()", greaterThan(0))
-                .body("Resources.findAll { it.Service != 'sqs' }.size()", equalTo(0))
-                .body("Resources.findAll { it.ResourceType == 'sqs:queue' && it.Region == 'us-east-1' }.size()", greaterThan(0));
-        }
-    }
-
-    @Nested
-    class EcrResources {
-        @Test
-        void ecrRepositorySurfacesViaListResources() {
-            given()
-                .header("Authorization", AUTH)
-                .contentType("application/json")
-                .body("""
-                    {"Filters": {"FilterString": "service:ecr"}}
-                    """)
-            .when()
-                .post("/ListResources")
-            .then()
-                .statusCode(200)
-                .body("Resources.size()", greaterThan(0))
-                .body("Resources.findAll { it.Service != 'ecr' }.size()", equalTo(0))
-                .body("Resources.findAll { it.ResourceType == 'ecr:repository' && it.Region == 'us-east-1' }.size()", greaterThan(0));
-        }
-    }
-
-    @Nested
-    class StepFunctionsResources {
-        @Test
-        void stateMachineSurfacesViaListResources() {
-            given()
-                .header("Authorization", AUTH)
-                .contentType("application/json")
-                .body("""
-                    {"Filters": {"FilterString": "service:states"}}
-                    """)
-            .when()
-                .post("/ListResources")
-            .then()
-                .statusCode(200)
-                .body("Resources.size()", greaterThan(0))
-                .body("Resources.findAll { it.Service != 'states' }.size()", equalTo(0))
-                .body("Resources.findAll { it.ResourceType == 'states:stateMachine' && it.Region == 'us-east-1' }.size()", greaterThan(0));
-        }
-    }
-
-    @Nested
-    class MskResources {
-        @Test
-        void mskClusterSurfacesViaListResources() {
-            given()
-                .header("Authorization", AUTH)
-                .contentType("application/json")
-                .body("""
-                    {"Filters": {"FilterString": "service:kafka"}}
-                    """)
-            .when()
-                .post("/ListResources")
-            .then()
-                .statusCode(200)
-                .body("Resources.size()", greaterThan(0))
-                .body("Resources.findAll { it.Service != 'kafka' }.size()", equalTo(0))
-                .body("Resources.findAll { it.ResourceType == 'kafka:cluster' && it.Region == 'us-east-1' }.size()", greaterThan(0));
-        }
-    }
-
-    @Nested
-    class PipesResources {
-        @Test
-        void pipeSurfacesViaListResources() {
-            given()
-                .header("Authorization", AUTH)
-                .contentType("application/json")
-                .body("""
-                    {"Filters": {"FilterString": "service:pipes"}}
-                    """)
-            .when()
-                .post("/ListResources")
-            .then()
-                .statusCode(200)
-                .body("Resources.size()", greaterThan(0))
-                .body("Resources.findAll { it.Service != 'pipes' }.size()", equalTo(0))
-                .body("Resources.findAll { it.ResourceType == 'pipes:pipe' && it.Region == 'us-east-1' }.size()", greaterThan(0));
-        }
-    }
-
-    @Nested
-    class AcmResources {
-        @Test
-        void certificateSurfacesViaListResources() {
-            given()
-                .header("Authorization", AUTH)
-                .contentType("application/json")
-                .body("""
-                    {"Filters": {"FilterString": "service:acm"}}
-                    """)
-            .when()
-                .post("/ListResources")
-            .then()
-                .statusCode(200)
-                .body("Resources.size()", greaterThan(0))
-                .body("Resources.findAll { it.Service != 'acm' }.size()", equalTo(0))
-                .body("Resources.findAll { it.ResourceType == 'acm:certificate' && it.Region == 'us-east-1' }.size()", greaterThan(0));
-        }
-    }
-
-    @Nested
-    class CognitoResources {
-        @Test
-        void userPoolSurfacesViaListResources() {
-            given()
-                .header("Authorization", AUTH)
-                .contentType("application/json")
-                .body("""
-                    {"Filters": {"FilterString": "service:cognito-idp"}}
-                    """)
-            .when()
-                .post("/ListResources")
-            .then()
-                .statusCode(200)
-                .body("Resources.size()", greaterThan(0))
-                .body("Resources.findAll { it.Service != 'cognito-idp' }.size()", equalTo(0))
-                .body("Resources.findAll { it.ResourceType == 'cognito-idp:userpool' && it.Region == 'us-east-1' }.size()", greaterThan(0));
+                .body("Resources.findAll { it.Service != '" + service + "' }.size()", equalTo(0))
+                .body("Resources.findAll { it.ResourceType == '" + resourceType
+                        + "' && it.Region == 'us-east-1' }.size()", greaterThan(0));
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
@@ -152,6 +152,18 @@ class ResourceExplorer2IntegrationTest {
         .then()
             .statusCode(200);
 
+        // ECR repository
+        given()
+            .header("X-Amz-Target", "AmazonEC2ContainerRegistry_V20150921.CreateRepository")
+            .contentType("application/x-amz-json-1.1")
+            .body("""
+                {"repositoryName": "re2-test-repo"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
         fixturesProvisioned = true;
     }
 
@@ -322,7 +334,7 @@ class ResourceExplorer2IntegrationTest {
                 .statusCode(200)
                 .body("ResourceTypes", notNullValue())
                 .body("ResourceTypes.size()", greaterThan(0))
-                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs"));
+                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs", "ecr"));
         }
     }
 
@@ -403,6 +415,26 @@ class ResourceExplorer2IntegrationTest {
                 .body("Resources.size()", greaterThan(0))
                 .body("Resources.findAll { it.Service != 'sqs' }.size()", equalTo(0))
                 .body("Resources.findAll { it.ResourceType == 'sqs:queue' && it.Region == 'us-east-1' }.size()", greaterThan(0));
+        }
+    }
+
+    @Nested
+    class EcrResources {
+        @Test
+        void ecrRepositorySurfacesViaListResources() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "service:ecr"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0))
+                .body("Resources.findAll { it.Service != 'ecr' }.size()", equalTo(0))
+                .body("Resources.findAll { it.ResourceType == 'ecr:repository' && it.Region == 'us-east-1' }.size()", greaterThan(0));
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
@@ -252,6 +252,23 @@ class ResourceExplorer2IntegrationTest {
         .then()
             .statusCode(200);
 
+        // Amazon MQ broker (mocked in test config, so no backing container)
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "brokerName": "re2-test-broker",
+                    "engineType": "RABBITMQ",
+                    "deploymentMode": "SINGLE_INSTANCE",
+                    "hostInstanceType": "mq.t3.micro",
+                    "users": [{"username": "admin", "password": "re2BrokerPass99"}]
+                }
+                """)
+        .when()
+            .post("/v1/brokers")
+        .then()
+            .statusCode(200);
+
         fixturesProvisioned = true;
     }
 
@@ -422,7 +439,7 @@ class ResourceExplorer2IntegrationTest {
                 .statusCode(200)
                 .body("ResourceTypes", notNullValue())
                 .body("ResourceTypes.size()", greaterThan(0))
-                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs", "ecr", "states", "kafka", "pipes", "acm", "cognito-idp", "iam"));
+                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs", "ecr", "states", "kafka", "pipes", "acm", "cognito-idp", "iam", "mq"));
         }
     }
 
@@ -440,7 +457,8 @@ class ResourceExplorer2IntegrationTest {
             "kafka,       kafka:cluster",
             "pipes,       pipes:pipe",
             "acm,         acm:certificate",
-            "cognito-idp, cognito-idp:userpool"
+            "cognito-idp, cognito-idp:userpool",
+            "mq,          mq:broker"
         })
         void resourceSurfacesViaListResources(String service, String resourceType) {
             given()

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
@@ -142,6 +142,16 @@ class ResourceExplorer2IntegrationTest {
         .then()
             .statusCode(200);
 
+        // SQS queue
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", "re2-test-queue")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
         fixturesProvisioned = true;
     }
 
@@ -312,7 +322,7 @@ class ResourceExplorer2IntegrationTest {
                 .statusCode(200)
                 .body("ResourceTypes", notNullValue())
                 .body("ResourceTypes.size()", greaterThan(0))
-                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms"));
+                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs"));
         }
     }
 
@@ -373,6 +383,26 @@ class ResourceExplorer2IntegrationTest {
                 .body("Resources.size()", greaterThan(0))
                 .body("Resources.findAll { it.Service != 'kms' }.size()", equalTo(0))
                 .body("Resources.findAll { it.ResourceType == 'kms:key' && it.Region == 'us-east-1' }.size()", greaterThan(0));
+        }
+    }
+
+    @Nested
+    class SqsResources {
+        @Test
+        void sqsQueueSurfacesViaListResources() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "service:sqs"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0))
+                .body("Resources.findAll { it.Service != 'sqs' }.size()", equalTo(0))
+                .body("Resources.findAll { it.ResourceType == 'sqs:queue' && it.Region == 'us-east-1' }.size()", greaterThan(0));
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
@@ -103,6 +103,23 @@ class ResourceExplorer2IntegrationTest {
             .statusCode(200)
             .body("TableDescription.TableName", equalTo("re2-test-table"));
 
+        // Lambda function (Resource Explorer 2 provider coverage)
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "re2-test-fn",
+                    "Runtime": "python3.11",
+                    "Role": "arn:aws:iam::000000000000:role/re2-test-role",
+                    "Handler": "index.handler",
+                    "Tags": {"env": "test"}
+                }
+                """)
+        .when()
+            .post("/2015-03-31/functions")
+        .then()
+            .statusCode(201);
+
         fixturesProvisioned = true;
     }
 
@@ -273,7 +290,27 @@ class ResourceExplorer2IntegrationTest {
                 .statusCode(200)
                 .body("ResourceTypes", notNullValue())
                 .body("ResourceTypes.size()", greaterThan(0))
-                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es"));
+                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda"));
+        }
+    }
+
+    @Nested
+    class LambdaResources {
+        @Test
+        void lambdaFunctionSurfacesViaListResources() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "service:lambda"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0))
+                .body("Resources.findAll { it.Service != 'lambda' }.size()", equalTo(0))
+                .body("Resources.findAll { it.ResourceType == 'lambda:function' && it.Region == 'us-east-1' }.size()", greaterThan(0));
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
@@ -164,6 +164,22 @@ class ResourceExplorer2IntegrationTest {
         .then()
             .statusCode(200);
 
+        // Step Functions state machine
+        given()
+            .header("X-Amz-Target", "AWSStepFunctions.CreateStateMachine")
+            .contentType("application/x-amz-json-1.0")
+            .body("""
+                {
+                    "name": "re2-test-sm",
+                    "definition": "{\\"StartAt\\":\\"Done\\",\\"States\\":{\\"Done\\":{\\"Type\\":\\"Pass\\",\\"End\\":true}}}",
+                    "roleArn": "arn:aws:iam::000000000000:role/re2-test-role"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
         fixturesProvisioned = true;
     }
 
@@ -334,7 +350,7 @@ class ResourceExplorer2IntegrationTest {
                 .statusCode(200)
                 .body("ResourceTypes", notNullValue())
                 .body("ResourceTypes.size()", greaterThan(0))
-                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs", "ecr"));
+                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs", "ecr", "states"));
         }
     }
 
@@ -435,6 +451,26 @@ class ResourceExplorer2IntegrationTest {
                 .body("Resources.size()", greaterThan(0))
                 .body("Resources.findAll { it.Service != 'ecr' }.size()", equalTo(0))
                 .body("Resources.findAll { it.ResourceType == 'ecr:repository' && it.Region == 'us-east-1' }.size()", greaterThan(0));
+        }
+    }
+
+    @Nested
+    class StepFunctionsResources {
+        @Test
+        void stateMachineSurfacesViaListResources() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "service:states"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0))
+                .body("Resources.findAll { it.Service != 'states' }.size()", equalTo(0))
+                .body("Resources.findAll { it.ResourceType == 'states:stateMachine' && it.Region == 'us-east-1' }.size()", greaterThan(0));
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
@@ -218,6 +218,18 @@ class ResourceExplorer2IntegrationTest {
         .then()
             .statusCode(200);
 
+        // Cognito user pool
+        given()
+            .header("X-Amz-Target", "AWSCognitoIdentityProviderService.CreateUserPool")
+            .contentType("application/x-amz-json-1.1")
+            .body("""
+                {"PoolName": "re2-test-pool"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
         fixturesProvisioned = true;
     }
 
@@ -388,7 +400,7 @@ class ResourceExplorer2IntegrationTest {
                 .statusCode(200)
                 .body("ResourceTypes", notNullValue())
                 .body("ResourceTypes.size()", greaterThan(0))
-                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs", "ecr", "states", "kafka", "pipes", "acm"));
+                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs", "ecr", "states", "kafka", "pipes", "acm", "cognito-idp"));
         }
     }
 
@@ -569,6 +581,26 @@ class ResourceExplorer2IntegrationTest {
                 .body("Resources.size()", greaterThan(0))
                 .body("Resources.findAll { it.Service != 'acm' }.size()", equalTo(0))
                 .body("Resources.findAll { it.ResourceType == 'acm:certificate' && it.Region == 'us-east-1' }.size()", greaterThan(0));
+        }
+    }
+
+    @Nested
+    class CognitoResources {
+        @Test
+        void userPoolSurfacesViaListResources() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "service:cognito-idp"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0))
+                .body("Resources.findAll { it.Service != 'cognito-idp' }.size()", equalTo(0))
+                .body("Resources.findAll { it.ResourceType == 'cognito-idp:userpool' && it.Region == 'us-east-1' }.size()", greaterThan(0));
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
@@ -1,0 +1,1680 @@
+package io.github.hectorvent.floci.services.resourceexplorer2;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class ResourceExplorer2IntegrationTest {
+
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260528/us-east-1/resource-explorer-2/aws4_request";
+    private static final String DYNAMO_TYPE = "application/x-amz-json-1.0";
+
+    private static boolean fixturesProvisioned = false;
+
+    private record IndexRef(String auth, String arn) {}
+
+    private final List<String> viewArnsToCleanup = new ArrayList<>();
+    private final List<IndexRef> indexArnsToCleanup = new ArrayList<>();
+
+    private String trackView(String viewArn) {
+        viewArnsToCleanup.add(viewArn);
+        return viewArn;
+    }
+
+    private String trackIndex(String auth, String arn) {
+        indexArnsToCleanup.add(new IndexRef(auth, arn));
+        return arn;
+    }
+
+    @AfterEach
+    void cleanupEphemeralResources() {
+        // Best-effort teardown — no assertions. Runs even when the test failed,
+        // so ephemeral views/indexes never leak into later tests or reruns.
+        for (String viewArn : viewArnsToCleanup) {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"ViewArn\": \"" + viewArn + "\"}")
+            .when()
+                .post("/DeleteView");
+        }
+        viewArnsToCleanup.clear();
+
+        for (IndexRef ref : indexArnsToCleanup) {
+            given()
+                .header("Authorization", ref.auth())
+                .contentType("application/json")
+                .body("{\"Arn\": \"" + ref.arn() + "\"}")
+            .when()
+                .post("/DeleteIndex");
+        }
+        indexArnsToCleanup.clear();
+    }
+
+    @BeforeEach
+    void provisionFixturesOnce() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+        if (fixturesProvisioned) return;
+
+        // Create S3 bucket used by ListResources, DataProvenance, and FilterSemantics groups
+        given()
+        .when()
+            .put("/re2-test-bucket")
+        .then()
+            .statusCode(200);
+
+        // Create DynamoDB table with tags used by ListResources, DataProvenance, and FilterSemantics groups
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMO_TYPE)
+            .body("""
+                {
+                    "TableName": "re2-test-table",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "ProvisionedThroughput": {"ReadCapacityUnits": 1, "WriteCapacityUnits": 1},
+                    "Tags": [{"Key": "env", "Value": "test"}]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TableDescription.TableName", equalTo("re2-test-table"));
+
+        fixturesProvisioned = true;
+    }
+
+    @Nested
+    class AutoProvisioning {
+
+        @Test
+        void autoProvisionedIndexExists() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+            .when()
+                .post("/GetIndex")
+            .then()
+                .statusCode(200)
+                .body("Arn", notNullValue())
+                .body("Type", notNullValue())
+                .body("State", equalTo("ACTIVE"))
+                .body("CreatedAt", notNullValue())
+                .body("LastUpdatedAt", notNullValue())
+                .body("Tags", notNullValue())
+                .body("ReplicatingFrom", notNullValue())
+                .body("ReplicatingTo", notNullValue());
+        }
+
+        @Test
+        void autoProvisionedDefaultViewExists() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+            .when()
+                .post("/GetDefaultView")
+            .then()
+                .statusCode(200)
+                .body("ViewArn", notNullValue());
+        }
+    }
+
+    @Nested
+    class ListResources {
+
+        @Test
+        void listResourcesWithNoFilterReturnsAll() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{}")
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources", notNullValue())
+                .body("ViewArn", notNullValue());
+        }
+
+        @Test
+        void listResourcesFilteredByS3ResourceType() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "resourcetype:s3:bucket"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources", notNullValue())
+                .body("Resources.findAll { it.ResourceType != 's3:bucket' }.size()", equalTo(0));
+        }
+
+        @Test
+        void listResourcesFilteredByDynamoDbService() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "service:dynamodb"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.findAll { it.Service != 'dynamodb' }.size()", equalTo(0));
+        }
+
+        @Test
+        void listResourcesNegatedServiceExcludesS3() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "-service:s3"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.findAll { it.Service == 's3' }.size()", equalTo(0));
+        }
+
+        @Test
+        void listResourcesInvalidFilterReturns400() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "hello world"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(400);
+        }
+    }
+
+    @Nested
+    class Search {
+
+        @Test
+        void searchWithQueryStringReturnsCountObject() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"QueryString": "service:s3"}
+                    """)
+            .when()
+                .post("/Search")
+            .then()
+                .statusCode(200)
+                .body("Count.TotalResources", greaterThanOrEqualTo(0))
+                .body("Count.Complete", equalTo(true))
+                .body("Resources", notNullValue())
+                .body("ViewArn", notNullValue());
+        }
+
+        @Test
+        void searchWithEmptyQueryReturnsAllResources() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"QueryString": ""}
+                    """)
+            .when()
+                .post("/Search")
+            .then()
+                .statusCode(200)
+                .body("Count.TotalResources", greaterThanOrEqualTo(0))
+                .body("Count.Complete", equalTo(true))
+                .body("Resources", notNullValue());
+        }
+    }
+
+    @Nested
+    class ListSupportedResourceTypes {
+
+        @Test
+        void listSupportedResourceTypesReturnsKnownTypes() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{}")
+            .when()
+                .post("/ListSupportedResourceTypes")
+            .then()
+                .statusCode(200)
+                .body("ResourceTypes", notNullValue())
+                .body("ResourceTypes.size()", greaterThan(0))
+                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es"));
+        }
+    }
+
+    @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class ViewCrud {
+
+        private String viewArn;
+
+        @Test
+        @Order(1)
+        void createViewWithFilter() {
+            viewArn = given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {
+                        "ViewName": "test-view",
+                        "Filters": {"FilterString": "service:s3"},
+                        "IncludedProperties": [{"Name": "tags"}]
+                    }
+                    """)
+            .when()
+                .post("/CreateView")
+            .then()
+                .statusCode(200)
+                .body("View.ViewArn", notNullValue())
+                .body("View.Filters.FilterString", equalTo("service:s3"))
+                .extract().path("View.ViewArn");
+        }
+
+        @Test
+        @Order(2)
+        void getViewReturnsCreatedView() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"ViewArn\": \"" + viewArn + "\"}")
+            .when()
+                .post("/GetView")
+            .then()
+                .statusCode(200)
+                .body("View.ViewArn", equalTo(viewArn));
+        }
+
+        @Test
+        @Order(3)
+        void updateView() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {
+                        "ViewArn": "%s",
+                        "Filters": {"FilterString": "service:dynamodb"},
+                        "IncludedProperties": [{"Name": "tags"}]
+                    }
+                    """.formatted(viewArn))
+            .when()
+                .post("/UpdateView")
+            .then()
+                .statusCode(200)
+                .body("View.Filters.FilterString", equalTo("service:dynamodb"));
+        }
+
+        @Test
+        @Order(4)
+        void listViewsContainsCreatedView() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{}")
+            .when()
+                .post("/ListViews")
+            .then()
+                .statusCode(200)
+                .body("Views", hasItem(viewArn));
+        }
+
+        @Test
+        @Order(5)
+        void batchGetViewReturnsErrorsForMissingArns() {
+            String bogusArn = "arn:aws:resource-explorer-2:us-east-1:000000000000:view/nope/00000000-0000-0000-0000-000000000000";
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"ViewArns\": [\"" + viewArn + "\", \"" + bogusArn + "\"]}")
+            .when()
+                .post("/BatchGetView")
+            .then()
+                .statusCode(200)
+                .body("Views.size()", equalTo(1))
+                .body("Views[0].ViewArn", equalTo(viewArn))
+                .body("Errors.size()", equalTo(1))
+                .body("Errors[0].ViewArn", equalTo(bogusArn))
+                .body("Errors[0].ErrorMessage", notNullValue());
+        }
+
+        @Test
+        @Order(6)
+        void associateDefaultView() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"ViewArn\": \"" + viewArn + "\"}")
+            .when()
+                .post("/AssociateDefaultView")
+            .then()
+                .statusCode(200)
+                .body("ViewArn", equalTo(viewArn));
+        }
+
+        @Test
+        @Order(7)
+        void getDefaultViewReturnsMostRecent() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+            .when()
+                .post("/GetDefaultView")
+            .then()
+                .statusCode(200)
+                .body("ViewArn", equalTo(viewArn));
+        }
+
+        @Test
+        @Order(8)
+        void disassociateDefaultView() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+            .when()
+                .post("/DisassociateDefaultView")
+            .then()
+                .statusCode(200);
+        }
+
+        @Test
+        @Order(9)
+        void deleteView() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"ViewArn\": \"" + viewArn + "\"}")
+            .when()
+                .post("/DeleteView")
+            .then()
+                .statusCode(200)
+                .body("ViewArn", equalTo(viewArn));
+        }
+
+        @Test
+        @Order(10)
+        void restoreDefaultViewAfterCrudTests() {
+            // Re-associate the auto-provisioned default view so other groups work
+            String autoViewArn = given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{}")
+            .when()
+                .post("/ListViews")
+            .then()
+                .extract().path("Views[0]");
+
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"ViewArn\": \"" + autoViewArn + "\"}")
+            .when()
+                .post("/AssociateDefaultView")
+            .then()
+                .statusCode(200);
+        }
+    }
+
+    @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class IndexCrud {
+
+        @Test
+        @Order(1)
+        void listIndexesContainsAutoProvisionedIndex() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+            .when()
+                .post("/ListIndexes")
+            .then()
+                .statusCode(200)
+                .body("Indexes", notNullValue())
+                .body("Indexes.size()", greaterThan(0));
+        }
+
+        @Test
+        @Order(2)
+        void updateIndexType() {
+            String indexArn = given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+            .when()
+                .post("/GetIndex")
+            .then()
+                .statusCode(200)
+                .extract().path("Arn");
+
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"Arn\": \"" + indexArn + "\", \"Type\": \"LOCAL\"}")
+            .when()
+                .post("/UpdateIndexType")
+            .then()
+                .statusCode(200)
+                .body("Arn", equalTo(indexArn))
+                .body("Type", equalTo("LOCAL"))
+                .body("State", notNullValue())
+                .body("LastUpdatedAt", notNullValue());
+
+            // Restore to AGGREGATOR
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"Arn\": \"" + indexArn + "\", \"Type\": \"AGGREGATOR\"}")
+            .when()
+                .post("/UpdateIndexType")
+            .then()
+                .statusCode(200);
+        }
+    }
+
+    @Nested
+    class ErrorCases {
+
+        @Test
+        void getMissingViewReturns404() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"ViewArn\": \"arn:aws:resource-explorer-2:us-east-1:000000000000:view/nonexistent/abc\"}")
+            .when()
+                .post("/GetView")
+            .then()
+                .statusCode(404);
+        }
+
+        @Test
+        void invalidUpdateIndexTypeReturns400Not500() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"Arn\": \"some-arn\", \"Type\": \"INVALID_TYPE\"}")
+            .when()
+                .post("/UpdateIndexType")
+            .then()
+                .statusCode(400);
+        }
+
+        @Test
+        void deleteIndexIncludesLastUpdatedAt() {
+            String arn = given()
+                .header("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260528/eu-west-1/resource-explorer-2/aws4_request")
+                .contentType("application/json")
+                .body("{}")
+            .when()
+                .post("/CreateIndex")
+            .then()
+                .statusCode(200)
+                .body("Arn", notNullValue())
+                .body("State", notNullValue())
+                .body("CreatedAt", notNullValue())
+                .extract().path("Arn");
+
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"Arn\": \"" + arn + "\"}")
+            .when()
+                .post("/DeleteIndex")
+            .then()
+                .statusCode(200)
+                .body("Arn", equalTo(arn))
+                .body("State", notNullValue())
+                .body("LastUpdatedAt", notNullValue());
+        }
+    }
+
+    @Nested
+    class ConditionalResponseFields {
+
+        @Test
+        void searchCountCompleteIsTrueWhenFewResources() {
+            // Complete=true means total matched resources <= 1000 (no cap was applied).
+            // With only a handful of test resources, Complete must be TRUE on every page,
+            // even when MaxResults=1 causes pagination (NextToken is still emitted).
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"QueryString": "", "MaxResults": 1}
+                    """)
+            .when()
+                .post("/Search")
+            .then()
+                .statusCode(200)
+                .body("Count.Complete", equalTo(true))
+                .body("Count.TotalResources", greaterThan(1))
+                .body("NextToken", notNullValue());
+        }
+
+        @Test
+        void searchCountCompleteIsTrueWhenNotPaginating() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"QueryString": "", "MaxResults": 1000}
+                    """)
+            .when()
+                .post("/Search")
+            .then()
+                .statusCode(200)
+                .body("Count.Complete", equalTo(true))
+                .body("NextToken", nullValue());
+        }
+
+        @Test
+        void listResourcesNextTokenSuppressedAtMaxResults1000() {
+            // First confirm there are multiple pages when MaxResults=1 — this proves
+            // NextToken absence at MaxResults=1000 is NOT simply "everything fits on
+            // one page" but is the deliberate suppression rule for MaxResults==1000.
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"MaxResults": 1}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", equalTo(1))
+                .body("NextToken", notNullValue());
+
+            // Now verify that MaxResults=1000 suppresses NextToken even though more
+            // pages would exist at smaller page sizes. The production rule is:
+            // NextToken must be absent on ListResources when MaxResults==1000.
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"MaxResults": 1000}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("NextToken", nullValue());
+        }
+
+        @Test
+        void listResourcesNextTokenPresentWhenMorePages() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"MaxResults": 1}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", equalTo(1))
+                .body("NextToken", notNullValue());
+        }
+
+        @Test
+        void propertiesEmptyWhenViewExcludesTags() {
+            String noTagsViewArn = trackView(given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"ViewName": "no-tags-view", "IncludedProperties": []}
+                    """)
+            .when()
+                .post("/CreateView")
+            .then()
+                .statusCode(200)
+                .extract().path("View.ViewArn"));
+
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"ViewArn\": \"" + noTagsViewArn + "\"}")
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources[0].get('Properties').size()", equalTo(0));
+        }
+
+        @Test
+        void propertiesPopulatedWhenViewIncludesTags() {
+            // Target the known-tagged fixture table by ARN. A positional Resources[0] is
+            // unsafe: the full test suite shares one emulator instance, so other classes'
+            // untagged DynamoDB tables land in this same service:dynamodb result set and any
+            // of them may sort ahead of the tagged fixture.
+            String table = "Resources.find { it.Arn.contains('re2-test-table') }";
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "service:dynamodb"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body(table, notNullValue())
+                .body(table + ".get('Properties').size()", greaterThan(0))
+                .body(table + ".get('Properties')[0].Name", equalTo("tags"))
+                .body(table + ".get('Properties')[0].Data.size()", greaterThan(0))
+                .body(table + ".get('Properties')[0].Data[0].Key", notNullValue())
+                .body(table + ".get('Properties')[0].Data[0].Value", notNullValue())
+                .body(table + ".get('Properties')[0].LastReportedAt", notNullValue());
+        }
+    }
+
+    @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class DataProvenance {
+
+        @Test
+        @Order(1)
+        void s3BucketTagsAppearViaTagFilter() {
+            given()
+                .contentType("application/xml")
+                .body("""
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <Tagging xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                      <TagSet>
+                        <Tag><Key>env</Key><Value>staging</Value></Tag>
+                      </TagSet>
+                    </Tagging>
+                    """)
+            .when()
+                .put("/re2-test-bucket?tagging")
+            .then()
+                .statusCode(anyOf(equalTo(200), equalTo(204)));
+
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "tag:env=staging"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0))
+                .body("Resources.findAll { it.Service == 's3' }.size()", greaterThan(0));
+        }
+
+        @Test
+        @Order(2)
+        void dynamoDbTagsFromCreateTableAppearViaTagFilter() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "tag:env=test"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0))
+                .body("Resources.findAll { it.Service == 'dynamodb' }.size()", greaterThan(0));
+        }
+
+        @Test
+        @Order(3)
+        void dynamoDbTagResourceUpdatesResourceExplorer() {
+            String tableArn = given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "resourcetype:dynamodb:table"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .extract().path("Resources[0].Arn");
+
+            given()
+                .header("X-Amz-Target", "DynamoDB_20120810.TagResource")
+                .contentType(DYNAMO_TYPE)
+                .body("""
+                    {
+                        "ResourceArn": "%s",
+                        "Tags": [{"Key": "team", "Value": "platform"}]
+                    }
+                    """.formatted(tableArn))
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "tag:team=platform"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0));
+        }
+
+        @Test
+        @Order(4)
+        void tagFilterDoesNotMatchUntaggedResources() {
+            given()
+                .header("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260528/us-east-1/rds/aws4_request")
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "CreateDBInstance")
+                .formParam("DBInstanceIdentifier", "re2-untagged-db")
+                .formParam("Engine", "postgres")
+                .formParam("MasterUsername", "admin")
+                .formParam("MasterUserPassword", "password123")
+                .formParam("DBInstanceClass", "db.t3.micro")
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "tag:env=staging service:rds"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", equalTo(0));
+        }
+
+        @Test
+        @Order(5)
+        void tagAllMatchesOnlyTaggedResources() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "tag:all"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0))
+                .body("Resources.findAll { it.get('Properties').size() > 0 }.size()",
+                        equalTo((int) given()
+                            .header("Authorization", AUTH)
+                            .contentType("application/json")
+                            .body("{\"Filters\": {\"FilterString\": \"tag:all\"}}")
+                            .post("/ListResources")
+                            .then().extract().path("Resources.size()")));
+        }
+
+        @Test
+        @Order(6)
+        void tagNoneMatchesOnlyUntaggedResources() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "tag:none"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0))
+                .body("Resources.findAll { it.get('Properties').size() > 0 }.size()", equalTo(0));
+        }
+
+        @Test
+        @Order(7)
+        void tagKeyFilterMatchesAcrossServices() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "tag.key:env"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThanOrEqualTo(2))
+                .body("Resources.Service", hasItems("s3", "dynamodb"));
+        }
+
+        @Test
+        @Order(8)
+        void tagValueFilterMatchesCorrectValue() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "tag.value:staging"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0))
+                .body("Resources.findAll { it.Service == 'dynamodb' }.size()", equalTo(0));
+        }
+
+        @Test
+        @Order(9)
+        void rdsTagsViaResourceGroupsTaggingApi() {
+            String rdsArn = given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "resourcetype:rds:db"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .extract().path("Resources[0].Arn");
+
+            given()
+                .header("X-Amz-Target", "ResourceGroupsTaggingAPI_20170126.TagResources")
+                .contentType("application/x-amz-json-1.1")
+                .body("""
+                    {
+                        "ResourceARNList": ["%s"],
+                        "Tags": {"rgta-tag": "rgta-value"}
+                    }
+                    """.formatted(rdsArn))
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "tag:rgta-tag=rgta-value"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0))
+                .body("Resources[0].Arn", equalTo(rdsArn));
+        }
+    }
+
+    @Nested
+    class EdgeBoundaryBehavior {
+
+        @Test
+        void listResourcesMaxResults1ReturnsSingleResource() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"MaxResults": 1}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", equalTo(1))
+                .body("NextToken", notNullValue());
+        }
+
+        @Test
+        void listResourcesEmptyResultSet() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "service:nonexistent"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", equalTo(0))
+                .body("NextToken", nullValue());
+        }
+
+        @Test
+        void paginationReturnsAllResourcesAcrossPages() {
+            int totalCount = given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"MaxResults\": 1000}")
+            .when()
+                .post("/ListResources")
+            .then()
+                .extract().path("Resources.size()");
+
+            Set<String> allArns = new HashSet<>();
+            String nextToken = null;
+            int pages = 0;
+            int maxPages = totalCount + 5;
+
+            do {
+                String body = nextToken == null
+                        ? "{\"MaxResults\": 1}"
+                        : "{\"MaxResults\": 1, \"NextToken\": \"" + nextToken + "\"}";
+
+                var response = given()
+                    .header("Authorization", AUTH)
+                    .contentType("application/json")
+                    .body(body)
+                .when()
+                    .post("/ListResources")
+                .then()
+                    .statusCode(200)
+                    .extract().response();
+
+                List<String> arns = response.path("Resources.Arn");
+                allArns.addAll(arns);
+                nextToken = response.path("NextToken");
+                pages++;
+            } while (nextToken != null && pages < maxPages);
+
+            assertEquals(totalCount, allArns.size(), "Paginated results should cover all resources");
+        }
+
+        @Test
+        void listResourcesMaxResultsGreaterThanTotalReturnsAll() {
+            int totalCount = given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"MaxResults\": 1000}")
+            .when()
+                .post("/ListResources")
+            .then()
+                .extract().path("Resources.size()");
+
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"MaxResults\": 999}")
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", equalTo(totalCount))
+                .body("NextToken", nullValue());
+        }
+
+        @Test
+        void searchPaginationWithNextToken() {
+            String nextToken = given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"QueryString": "", "MaxResults": 1}
+                    """)
+            .when()
+                .post("/Search")
+            .then()
+                .statusCode(200)
+                .body("Count.Complete", equalTo(true))
+                .body("Resources.size()", equalTo(1))
+                .extract().path("NextToken");
+
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"QueryString\": \"\", \"MaxResults\": 1, \"NextToken\": \"" + nextToken + "\"}")
+            .when()
+                .post("/Search")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", equalTo(1))
+                .body("Count.TotalResources", greaterThan(1));
+        }
+
+        @Test
+        void listSupportedResourceTypesHasNextTokenWhenNeeded() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"MaxResults": 1}
+                    """)
+            .when()
+                .post("/ListSupportedResourceTypes")
+            .then()
+                .statusCode(200)
+                .body("ResourceTypes.size()", equalTo(1))
+                .body("NextToken", notNullValue());
+        }
+
+        @Test
+        void listViewsHasNextTokenWhenNeeded() {
+            String tempView = trackView(given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"ViewName\": \"temp-pagination-view\"}")
+            .when()
+                .post("/CreateView")
+            .then()
+                .extract().path("View.ViewArn"));
+
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"MaxResults\": 1}")
+            .when()
+                .post("/ListViews")
+            .then()
+                .statusCode(200)
+                .body("Views.size()", equalTo(1))
+                .body("NextToken", notNullValue());
+        }
+
+        @Test
+        void listIndexesHasNextTokenWhenNeeded() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"MaxResults\": 1}")
+            .when()
+                .post("/ListIndexes")
+            .then()
+                .statusCode(200)
+                .body("Indexes.size()", lessThanOrEqualTo(1));
+        }
+    }
+
+    @Nested
+    class CrossServiceDataConsistency {
+
+        @Test
+        void allResourcesHaveRequiredFields() {
+            List<Map<String, Object>> resources = given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"MaxResults\": 1000}")
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .extract().path("Resources");
+
+            for (var resource : resources) {
+                assertNotNull(resource.get("Arn"), "Resource missing Arn: " + resource);
+                assertNotNull(resource.get("ResourceType"), "Resource missing ResourceType: " + resource);
+                assertNotNull(resource.get("Service"), "Resource missing Service: " + resource);
+                assertNotNull(resource.get("Region"), "Resource missing Region: " + resource);
+                assertNotNull(resource.get("OwningAccountId"), "Resource missing OwningAccountId: " + resource);
+                assertNotNull(resource.get("LastReportedAt"), "Resource missing LastReportedAt: " + resource);
+                assertNotNull(resource.get("Properties"), "Resource missing Properties: " + resource);
+            }
+        }
+
+        @Test
+        void resourceTypeFormatIsServiceColonType() {
+            List<String> types = given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"MaxResults\": 1000}")
+            .when()
+                .post("/ListResources")
+            .then()
+                .extract().path("Resources.ResourceType");
+
+            for (String type : types) {
+                assertTrue(type.contains(":"), "ResourceType must be in service:type format, got: " + type);
+            }
+        }
+
+        @Test
+        void serviceFieldMatchesResourceTypePrefix() {
+            List<Map<String, Object>> resources = given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"MaxResults\": 1000}")
+            .when()
+                .post("/ListResources")
+            .then()
+                .extract().path("Resources");
+
+            for (var resource : resources) {
+                String service = (String) resource.get("Service");
+                String resourceType = (String) resource.get("ResourceType");
+                assertTrue(
+                        resourceType.startsWith(service + ":"),
+                        "Service '" + service + "' doesn't match ResourceType prefix '" + resourceType + "'");
+            }
+        }
+
+        @Test
+        void arnContainsServiceAndRegion() {
+            List<Map<String, Object>> resources = given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"MaxResults\": 1000}")
+            .when()
+                .post("/ListResources")
+            .then()
+                .extract().path("Resources");
+
+            for (var resource : resources) {
+                String arn = (String) resource.get("Arn");
+                String service = (String) resource.get("Service");
+                assertTrue(arn.startsWith("arn:aws:"),
+                        "ARN must start with arn:aws:, got: " + arn);
+                assertTrue(arn.contains(service),
+                        "ARN should contain service '" + service + "', got: " + arn);
+            }
+        }
+    }
+
+    @Nested
+    class FilterSemantics {
+
+        @Test
+        void filterByServiceReturnsOnlyThatService() {
+            for (String svc : List.of("s3", "dynamodb", "rds")) {
+                List<String> services = given()
+                    .header("Authorization", AUTH)
+                    .contentType("application/json")
+                    .body("{\"Filters\": {\"FilterString\": \"service:" + svc + "\"}}")
+                .when()
+                    .post("/ListResources")
+                .then()
+                    .statusCode(200)
+                    .extract().path("Resources.Service");
+
+                for (String s : services) {
+                    assertEquals(svc, s,
+                            "service:" + svc + " filter returned wrong service: " + s);
+                }
+            }
+        }
+
+        @Test
+        void filterByResourceTypeIsExact() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "resourcetype:dynamodb:table"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0))
+                .body("Resources.findAll { it.ResourceType != 'dynamodb:table' }.size()", equalTo(0));
+        }
+
+        @Test
+        void filterByResourceTypeCommaOr() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "resourcetype:s3:bucket,dynamodb:table"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThanOrEqualTo(2))
+                .body("Resources.ResourceType",
+                        everyItem(anyOf(equalTo("s3:bucket"), equalTo("dynamodb:table"))));
+        }
+
+        @Test
+        void filterByRegionExact() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "region:us-east-1"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.findAll { it.Region != 'us-east-1' }.size()", equalTo(0));
+        }
+
+        @Test
+        void filterByRegionWildcard() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "region:us*"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0))
+                .body("Resources.findAll { !it.Region.startsWith('us') }.size()", equalTo(0));
+        }
+
+        @Test
+        void negatedFilterExcludesCorrectly() {
+            // All three queries must use the same page size. ListResources defaults to a 100-result
+            // page; the full suite shares one emulator instance and can hold >100 resources, so an
+            // unspecified MaxResults would truncate the s3 and non-s3 counts inconsistently against
+            // the MaxResults:1000 total and break the arithmetic.
+            int s3Count = given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"MaxResults\": 1000, \"Filters\": {\"FilterString\": \"service:s3\"}}")
+            .when()
+                .post("/ListResources")
+            .then()
+                .extract().path("Resources.size()");
+
+            int total = given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"MaxResults\": 1000}")
+            .when()
+                .post("/ListResources")
+            .then()
+                .extract().path("Resources.size()");
+
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"MaxResults\": 1000, \"Filters\": {\"FilterString\": \"-service:s3\"}}")
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", equalTo(total - s3Count))
+                .body("Resources.findAll { it.Service == 's3' }.size()", equalTo(0));
+        }
+
+        @Test
+        void combinedFiltersAreAnded() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "service:s3 region:us-east-1"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.findAll { it.Service != 's3' }.size()", equalTo(0))
+                .body("Resources.findAll { it.Region != 'us-east-1' }.size()", equalTo(0));
+        }
+
+        @Test
+        void accountIdFilterMatchesCorrectAccount() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "accountid:000000000000"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0))
+                .body("Resources.findAll { it.OwningAccountId != '000000000000' }.size()", equalTo(0));
+        }
+
+        @Test
+        void idFilterMatchesExactArn() {
+            String arn = given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"MaxResults\": 1}")
+            .when()
+                .post("/ListResources")
+            .then()
+                .extract().path("Resources[0].Arn");
+
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"Filters\": {\"FilterString\": \"id:" + arn + "\"}}")
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", equalTo(1))
+                .body("Resources[0].Arn", equalTo(arn));
+        }
+
+        @Test
+        void searchFreeFormTextNarrowsResults() {
+            // AWS Search treats free-form text as a narrowing filter: resources whose
+            // attributes don't match the keyword are excluded. A keyword that matches
+            // nothing must therefore return zero resources — not the full set.
+            int totalCount = given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"QueryString\": \"\", \"MaxResults\": 1000}")
+            .when()
+                .post("/Search")
+            .then()
+                .body("Resources.size()", greaterThan(0))
+                .extract().path("Resources.size()");
+
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"QueryString\": \"xyznonexistent\", \"MaxResults\": 1000}")
+            .when()
+                .post("/Search")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", equalTo(0))
+                .body("Count.TotalResources", equalTo(0));
+        }
+    }
+
+    @Nested
+    class AwsApiFidelity {
+
+        private static String authFor(String region) {
+            return "AWS4-HMAC-SHA256 Credential=test/20260528/" + region + "/resource-explorer-2/aws4_request";
+        }
+
+        @Test
+        void listResourcesWithNoDefaultViewInRegionReturns401() {
+            // Only the startup region (us-east-1) has an auto-provisioned default view.
+            // A region that never had a default view must return UnauthorizedException (401),
+            // not ResourceNotFoundException (404).
+            given()
+                .header("Authorization", authFor("eu-central-1"))
+                .contentType("application/json")
+                .body("{}")
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(401)
+                .body("__type", equalTo("UnauthorizedException"));
+        }
+
+        @Test
+        void searchWithNoDefaultViewInRegionReturns401() {
+            given()
+                .header("Authorization", authFor("eu-central-1"))
+                .contentType("application/json")
+                .body("{\"QueryString\": \"\"}")
+            .when()
+                .post("/Search")
+            .then()
+                .statusCode(401)
+                .body("__type", equalTo("UnauthorizedException"));
+        }
+
+        @Test
+        void createViewWithDuplicateNameReturnsConflict() {
+            trackView(given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"ViewName\": \"fidelity-dup-view\"}")
+            .when()
+                .post("/CreateView")
+            .then()
+                .statusCode(200)
+                .extract().path("View.ViewArn"));
+
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"ViewName\": \"fidelity-dup-view\"}")
+            .when()
+                .post("/CreateView")
+            .then()
+                .statusCode(409)
+                .body("__type", equalTo("ConflictException"));
+        }
+
+        @Test
+        void createViewWithInvalidNameReturnsValidation() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"ViewName\": \"bad name with spaces!\"}")
+            .when()
+                .post("/CreateView")
+            .then()
+                .statusCode(400)
+                .body("__type", equalTo("ValidationException"));
+        }
+
+        @Test
+        void createViewWithoutNameReturnsValidation() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"Filters\": {\"FilterString\": \"service:s3\"}}")
+            .when()
+                .post("/CreateView")
+            .then()
+                .statusCode(400)
+                .body("__type", equalTo("ValidationException"));
+        }
+
+        @Test
+        void createViewWithInvalidIncludedPropertyReturnsValidation() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"ViewName": "fidelity-bad-prop-view",
+                     "IncludedProperties": [{"Name": "notavalidproperty"}]}
+                    """)
+            .when()
+                .post("/CreateView")
+            .then()
+                .statusCode(400)
+                .body("__type", equalTo("ValidationException"));
+        }
+
+        @Test
+        void associateDefaultViewCrossRegionReturnsValidation() {
+            // A view lives in one region; making it the default for a different region is rejected
+            // by AWS with a ValidationException (default views are scoped per region).
+            String euViewArn = trackView(given()
+                .header("Authorization", authFor("eu-central-1"))
+                .contentType("application/json")
+                .body("{\"ViewName\": \"fidelity-crossregion-view\"}")
+            .when()
+                .post("/CreateView")
+            .then()
+                .statusCode(200)
+                .extract().path("View.ViewArn"));
+
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"ViewArn\": \"" + euViewArn + "\"}")
+            .when()
+                .post("/AssociateDefaultView")
+            .then()
+                .statusCode(400)
+                .body("__type", equalTo("ValidationException"));
+        }
+
+        @Test
+        void promotingSecondIndexToAggregatorReturnsConflict() {
+            // us-east-1 has the auto-provisioned AGGREGATOR. A LOCAL index promoted in
+            // another region must fail with ConflictException — only one aggregator per account.
+            String arn = trackIndex(authFor("ap-southeast-2"), given()
+                .header("Authorization", authFor("ap-southeast-2"))
+                .contentType("application/json")
+                .body("{}")
+            .when()
+                .post("/CreateIndex")
+            .then()
+                .statusCode(200)
+                .extract().path("Arn"));
+
+            given()
+                .header("Authorization", authFor("ap-southeast-2"))
+                .contentType("application/json")
+                .body("{\"Arn\": \"" + arn + "\", \"Type\": \"AGGREGATOR\"}")
+            .when()
+                .post("/UpdateIndexType")
+            .then()
+                .statusCode(409)
+                .body("__type", equalTo("ConflictException"));
+        }
+
+        @Test
+        void searchWithoutQueryStringReturnsValidation() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{}")
+            .when()
+                .post("/Search")
+            .then()
+                .statusCode(400)
+                .body("__type", equalTo("ValidationException"));
+        }
+
+        @Test
+        void maxResultsAboveLimitReturnsValidation() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"MaxResults\": 1001}")
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(400)
+                .body("__type", equalTo("ValidationException"));
+        }
+
+        @Test
+        void maxResultsZeroReturnsValidation() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"MaxResults\": 0}")
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(400)
+                .body("__type", equalTo("ValidationException"));
+        }
+
+        @Test
+        void staleNextTokenBeyondResultSetReturnsEmptyPageNot500() {
+            // Base64("999999") — an offset far past any live result set. The result set is
+            // queried live and can shrink between paginated calls, so this must not 500.
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"NextToken\": \"OTk5OTk5\"}")
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", equalTo(0));
+        }
+
+        @Test
+        void createIndexReturns200WithCreatingState() {
+            // AWS botocore service-2.json: CreateIndex responseCode = 200.
+            String arn = trackIndex(authFor("ca-central-1"), given()
+                .header("Authorization", authFor("ca-central-1"))
+                .contentType("application/json")
+                .body("{}")
+            .when()
+                .post("/CreateIndex")
+            .then()
+                .statusCode(200)
+                .body("Arn", notNullValue())
+                .body("State", equalTo("CREATING"))
+                .body("CreatedAt", notNullValue())
+                .extract().path("Arn"));
+        }
+
+        @Test
+        void createViewResponseViewNodeHasNoTagsField() {
+            // AWS SDK View shape does NOT include Tags — Tags is only on GetViewResponse top-level.
+            String viewArn = trackView(given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"ViewName\": \"fidelity-notags-view\", \"Tags\": {\"owner\": \"team-a\"}}")
+            .when()
+                .post("/CreateView")
+            .then()
+                .statusCode(200)
+                .body("View", notNullValue())
+                .body("View.Tags", nullValue())
+                .extract().path("View.ViewArn"));
+        }
+
+        @Test
+        void getViewHasTopLevelTagsButViewNodeHasNone() {
+            // GetView response: top-level "Tags" present, but "View.Tags" absent.
+            String viewArn = trackView(given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"ViewName\": \"fidelity-topleveltags-view\", \"Tags\": {\"env\": \"prod\"}}")
+            .when()
+                .post("/CreateView")
+            .then()
+                .statusCode(200)
+                .extract().path("View.ViewArn"));
+
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("{\"ViewArn\": \"" + viewArn + "\"}")
+            .when()
+                .post("/GetView")
+            .then()
+                .statusCode(200)
+                .body("Tags", notNullValue())
+                .body("View.Tags", nullValue());
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
@@ -191,6 +191,21 @@ class ResourceExplorer2IntegrationTest {
         .then()
             .statusCode(200);
 
+        // EventBridge Pipes pipe
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "Source": "arn:aws:sqs:us-east-1:000000000000:re2-test-queue",
+                    "Target": "arn:aws:lambda:us-east-1:000000000000:function:re2-test-fn",
+                    "RoleArn": "arn:aws:iam::000000000000:role/re2-test-role"
+                }
+                """)
+        .when()
+            .post("/v1/pipes/re2-test-pipe")
+        .then()
+            .statusCode(200);
+
         fixturesProvisioned = true;
     }
 
@@ -361,7 +376,7 @@ class ResourceExplorer2IntegrationTest {
                 .statusCode(200)
                 .body("ResourceTypes", notNullValue())
                 .body("ResourceTypes.size()", greaterThan(0))
-                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs", "ecr", "states", "kafka"));
+                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs", "ecr", "states", "kafka", "pipes"));
         }
     }
 
@@ -502,6 +517,26 @@ class ResourceExplorer2IntegrationTest {
                 .body("Resources.size()", greaterThan(0))
                 .body("Resources.findAll { it.Service != 'kafka' }.size()", equalTo(0))
                 .body("Resources.findAll { it.ResourceType == 'kafka:cluster' && it.Region == 'us-east-1' }.size()", greaterThan(0));
+        }
+    }
+
+    @Nested
+    class PipesResources {
+        @Test
+        void pipeSurfacesViaListResources() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "service:pipes"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0))
+                .body("Resources.findAll { it.Service != 'pipes' }.size()", equalTo(0))
+                .body("Resources.findAll { it.ResourceType == 'pipes:pipe' && it.Region == 'us-east-1' }.size()", greaterThan(0));
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
@@ -206,6 +206,18 @@ class ResourceExplorer2IntegrationTest {
         .then()
             .statusCode(200);
 
+        // ACM certificate
+        given()
+            .header("X-Amz-Target", "CertificateManager.RequestCertificate")
+            .contentType("application/x-amz-json-1.1")
+            .body("""
+                {"DomainName": "re2-test.example.com", "ValidationMethod": "DNS"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
         fixturesProvisioned = true;
     }
 
@@ -376,7 +388,7 @@ class ResourceExplorer2IntegrationTest {
                 .statusCode(200)
                 .body("ResourceTypes", notNullValue())
                 .body("ResourceTypes.size()", greaterThan(0))
-                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs", "ecr", "states", "kafka", "pipes"));
+                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs", "ecr", "states", "kafka", "pipes", "acm"));
         }
     }
 
@@ -537,6 +549,26 @@ class ResourceExplorer2IntegrationTest {
                 .body("Resources.size()", greaterThan(0))
                 .body("Resources.findAll { it.Service != 'pipes' }.size()", equalTo(0))
                 .body("Resources.findAll { it.ResourceType == 'pipes:pipe' && it.Region == 'us-east-1' }.size()", greaterThan(0));
+        }
+    }
+
+    @Nested
+    class AcmResources {
+        @Test
+        void certificateSurfacesViaListResources() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "service:acm"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0))
+                .body("Resources.findAll { it.Service != 'acm' }.size()", equalTo(0))
+                .body("Resources.findAll { it.ResourceType == 'acm:certificate' && it.Region == 'us-east-1' }.size()", greaterThan(0));
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
@@ -180,6 +180,17 @@ class ResourceExplorer2IntegrationTest {
         .then()
             .statusCode(200);
 
+        // MSK cluster
+        given()
+            .contentType("application/json")
+            .body("""
+                {"clusterName": "re2-test-cluster", "kafkaVersion": "3.6.0"}
+                """)
+        .when()
+            .post("/v1/clusters")
+        .then()
+            .statusCode(200);
+
         fixturesProvisioned = true;
     }
 
@@ -350,7 +361,7 @@ class ResourceExplorer2IntegrationTest {
                 .statusCode(200)
                 .body("ResourceTypes", notNullValue())
                 .body("ResourceTypes.size()", greaterThan(0))
-                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs", "ecr", "states"));
+                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs", "ecr", "states", "kafka"));
         }
     }
 
@@ -471,6 +482,26 @@ class ResourceExplorer2IntegrationTest {
                 .body("Resources.size()", greaterThan(0))
                 .body("Resources.findAll { it.Service != 'states' }.size()", equalTo(0))
                 .body("Resources.findAll { it.ResourceType == 'states:stateMachine' && it.Region == 'us-east-1' }.size()", greaterThan(0));
+        }
+    }
+
+    @Nested
+    class MskResources {
+        @Test
+        void mskClusterSurfacesViaListResources() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "service:kafka"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0))
+                .body("Resources.findAll { it.Service != 'kafka' }.size()", equalTo(0))
+                .body("Resources.findAll { it.ResourceType == 'kafka:cluster' && it.Region == 'us-east-1' }.size()", greaterThan(0));
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
@@ -120,6 +120,16 @@ class ResourceExplorer2IntegrationTest {
         .then()
             .statusCode(201);
 
+        // SNS topic
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateTopic")
+            .formParam("Name", "re2-test-topic")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
         fixturesProvisioned = true;
     }
 
@@ -290,7 +300,7 @@ class ResourceExplorer2IntegrationTest {
                 .statusCode(200)
                 .body("ResourceTypes", notNullValue())
                 .body("ResourceTypes.size()", greaterThan(0))
-                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda"));
+                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns"));
         }
     }
 
@@ -311,6 +321,26 @@ class ResourceExplorer2IntegrationTest {
                 .body("Resources.size()", greaterThan(0))
                 .body("Resources.findAll { it.Service != 'lambda' }.size()", equalTo(0))
                 .body("Resources.findAll { it.ResourceType == 'lambda:function' && it.Region == 'us-east-1' }.size()", greaterThan(0));
+        }
+    }
+
+    @Nested
+    class SnsResources {
+        @Test
+        void snsTopicSurfacesViaListResources() {
+            given()
+                .header("Authorization", AUTH)
+                .contentType("application/json")
+                .body("""
+                    {"Filters": {"FilterString": "service:sns"}}
+                    """)
+            .when()
+                .post("/ListResources")
+            .then()
+                .statusCode(200)
+                .body("Resources.size()", greaterThan(0))
+                .body("Resources.findAll { it.Service != 'sns' }.size()", equalTo(0))
+                .body("Resources.findAll { it.ResourceType == 'sns:topic' && it.Region == 'us-east-1' }.size()", greaterThan(0));
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2IntegrationTest.java
@@ -298,6 +298,22 @@ class ResourceExplorer2IntegrationTest {
         .then()
             .statusCode(200);
 
+        // CloudWatch RUM app monitor (Resource Explorer 2 provider coverage)
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                    "Name": "re2-test-monitor",
+                    "Domain": "example.com",
+                    "Tags": {"env": "test"}
+                }
+                """)
+        .when()
+            .post("/appmonitor")
+        .then()
+            .statusCode(200);
+
         fixturesProvisioned = true;
     }
 
@@ -468,7 +484,7 @@ class ResourceExplorer2IntegrationTest {
                 .statusCode(200)
                 .body("ResourceTypes", notNullValue())
                 .body("ResourceTypes.size()", greaterThan(0))
-                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs", "ecr", "states", "kafka", "pipes", "acm", "cognito-idp", "iam", "mq", "lightsail"));
+                .body("ResourceTypes.Service", hasItems("s3", "rds", "dynamodb", "elasticache", "es", "lambda", "sns", "kms", "sqs", "ecr", "states", "kafka", "pipes", "acm", "cognito-idp", "iam", "mq", "lightsail", "rum"));
         }
     }
 
@@ -489,7 +505,8 @@ class ResourceExplorer2IntegrationTest {
             "cognito-idp, cognito-idp:userpool",
             "mq,          mq:broker",
             "lightsail,   lightsail:Instance",
-            "lightsail,   lightsail:Disk"
+            "lightsail,   lightsail:Disk",
+            "rum,         rum:appmonitor"
         })
         void resourceSurfacesViaListResources(String service, String resourceType) {
             given()

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2ListVsSearchCapTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2ListVsSearchCapTest.java
@@ -1,0 +1,180 @@
+package io.github.hectorvent.floci.services.resourceexplorer2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.ResourceProvider;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.services.resourceexplorer2.model.Index;
+import io.github.hectorvent.floci.services.resourceexplorer2.model.View;
+import io.quarkus.runtime.StartupEvent;
+import jakarta.enterprise.inject.Instance;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * ListResources and Search share floci's resource pagination but differ in AWS: Search caps the total
+ * result set at 1000, ListResources does not. These service-level tests pin that difference with a
+ * provider that exposes 1500 resources.
+ */
+class ResourceExplorer2ListVsSearchCapTest {
+
+    private static final String REGION = "us-east-1";
+    private static final String ACCOUNT = "000000000000";
+    private static final int RESOURCE_COUNT = 1500;
+
+    private final StorageBackend<String, Index> indexStore = new InMemoryStorage<>();
+    private final StorageBackend<String, View> viewStore = new InMemoryStorage<>();
+    private final StorageBackend<String, String> defaultViewStore = new InMemoryStorage<>();
+    private final RegionResolver regionResolver = new RegionResolver(REGION, ACCOUNT);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private ResourceExplorer2Service newServiceWith(int resourceCount) {
+        ResourceProvider provider = new ResourceProvider() {
+            @Override
+            public List<ExplorerResource> getResources() {
+                List<ExplorerResource> out = new ArrayList<>(resourceCount);
+                for (int i = 0; i < resourceCount; i++) {
+                    out.add(new ExplorerResource(
+                            "arn:aws:test:" + REGION + ":" + ACCOUNT + ":thing/" + i,
+                            "test:thing", "test", REGION, ACCOUNT, Instant.now(), Map.of()));
+                }
+                return out;
+            }
+
+            @Override
+            public Set<SupportedResourceType> getSupportedResourceTypes() {
+                return Set.of(new SupportedResourceType("test:thing", "test", true));
+            }
+        };
+        @SuppressWarnings("unchecked")
+        Instance<ResourceProvider> providers = mock(Instance.class);
+        // Enhanced-for calls iterator() once per pagination call; hand back a fresh iterator each time.
+        when(providers.iterator()).thenAnswer(inv -> List.of(provider).iterator());
+
+        ResourceExplorer2Service service = new ResourceExplorer2Service(
+                providers, regionResolver, objectMapper, indexStore, viewStore, defaultViewStore);
+        service.onStartup(new StartupEvent());
+        return service;
+    }
+
+    @Test
+    void listResourcesPagesThroughAllResourcesWithNoTotalCap() {
+        // ListResources has no 1000-result cap (unlike Search); page until NextToken is null.
+        // https://docs.aws.amazon.com/resource-explorer/latest/apireference/API_ListResources.html
+        ResourceExplorer2Service service = newServiceWith(RESOURCE_COUNT);
+
+        Set<String> seen = new HashSet<>();
+        String token = null;
+        int pages = 0;
+        do {
+            ObjectNode r = service.listResources(null, 500, token, null, REGION);
+            for (JsonNode n : r.get("Resources")) {
+                seen.add(n.get("Arn").asText());
+            }
+            token = r.has("NextToken") ? r.get("NextToken").asText() : null;
+            pages++;
+        } while (token != null);
+
+        assertEquals(RESOURCE_COUNT, seen.size());
+        assertEquals(3, pages);
+    }
+
+    @Test
+    void listResourcesAtMaxPageSizeTruncatesSilentlyWithNoNextToken() {
+        // Documented AWS quirk: "The ListResources operation does not generate a NextToken if you set
+        // MaxResults to 1000." So the caller silently gets at most 1000 with no way to page further.
+        // https://docs.aws.amazon.com/resource-explorer/latest/apireference/API_ListResources.html
+        ResourceExplorer2Service service = newServiceWith(RESOURCE_COUNT);
+
+        ObjectNode r = service.listResources(null, 1000, null, null, REGION);
+
+        assertEquals(1000, r.get("Resources").size());
+        assertFalse(r.has("NextToken"));
+    }
+
+    @Test
+    void searchCapsTotalAtOneThousandAndReportsIncomplete() {
+        // Search "can return only the first 1,000 results."
+        // https://docs.aws.amazon.com/resource-explorer/latest/apireference/API_Search.html
+        ResourceExplorer2Service service = newServiceWith(RESOURCE_COUNT);
+
+        Set<String> seen = new HashSet<>();
+        String token = null;
+        boolean lastComplete = true;
+        int lastTotal = -1;
+        do {
+            // Empty query string matches all resources (see search()'s blank-query branch).
+            ObjectNode r = service.search("", null, token, null, REGION);
+            for (JsonNode n : r.get("Resources")) {
+                seen.add(n.get("Arn").asText());
+            }
+            lastComplete = r.get("Count").get("Complete").asBoolean();
+            lastTotal = r.get("Count").get("TotalResources").asInt();
+            token = r.has("NextToken") ? r.get("NextToken").asText() : null;
+        } while (token != null);
+
+        assertEquals(1000, seen.size());
+        assertFalse(lastComplete);
+        assertEquals(1000, lastTotal);
+    }
+
+    @Test
+    void oneThrowingProviderIsSkippedAndHealthyProvidersStillSurface() {
+        // Discovery aggregates every provider. A single provider blowing up (bad stored data, a bug)
+        // must not turn Search/ListResources into a 500 for every other service — the failing
+        // provider is skipped and the healthy ones still surface.
+        ResourceProvider healthy = new ResourceProvider() {
+            @Override
+            public List<ExplorerResource> getResources() {
+                return List.of(new ExplorerResource(
+                        "arn:aws:test:" + REGION + ":" + ACCOUNT + ":thing/ok",
+                        "test:thing", "test", REGION, ACCOUNT, Instant.now(), Map.of()));
+            }
+
+            @Override
+            public Set<SupportedResourceType> getSupportedResourceTypes() {
+                return Set.of(new SupportedResourceType("test:thing", "test", true));
+            }
+        };
+        ResourceProvider broken = new ResourceProvider() {
+            @Override
+            public List<ExplorerResource> getResources() {
+                throw new IllegalStateException("provider is broken");
+            }
+
+            @Override
+            public Set<SupportedResourceType> getSupportedResourceTypes() {
+                return Set.of();
+            }
+        };
+        @SuppressWarnings("unchecked")
+        Instance<ResourceProvider> providers = mock(Instance.class);
+        when(providers.iterator()).thenAnswer(inv -> List.of(broken, healthy).iterator());
+
+        ResourceExplorer2Service service = new ResourceExplorer2Service(
+                providers, regionResolver, objectMapper, indexStore, viewStore, defaultViewStore);
+        service.onStartup(new StartupEvent());
+
+        ObjectNode r = service.listResources(null, 1000, null, null, REGION);
+
+        assertEquals(1, r.get("Resources").size());
+        assertEquals("arn:aws:test:" + REGION + ":" + ACCOUNT + ":thing/ok",
+                r.get("Resources").get(0).get("Arn").asText());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2PaginationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/ResourceExplorer2PaginationTest.java
@@ -1,0 +1,121 @@
+package io.github.hectorvent.floci.services.resourceexplorer2;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the pure pagination math behind ListResources/Search:
+ * {@link ResourceExplorer2Service#pageBounds} and
+ * {@link ResourceExplorer2Service#listResourcesEmitsToken}. Covers the offset clamp (live result sets
+ * can shrink between paginated calls), the 1000-result hard cap that real AWS enforces on Search, and
+ * the ListResources MaxResults=1000 no-NextToken quirk.
+ */
+class ResourceExplorer2PaginationTest {
+
+    private static final int CAP = ResourceExplorer2Service.MAX_RESOURCE_RESULTS;
+
+    private static String token(int offset) {
+        return Base64.getEncoder().encodeToString(String.valueOf(offset).getBytes());
+    }
+
+    @Test
+    void firstPageStartsAtZero() {
+        var b = ResourceExplorer2Service.pageBounds(50, 10, null, CAP);
+        assertEquals(0, b.start());
+        assertEquals(10, b.end());
+        assertEquals(50, b.total());
+    }
+
+    @Test
+    void secondPageOffsetsByToken() {
+        var b = ResourceExplorer2Service.pageBounds(50, 10, token(10), CAP);
+        assertEquals(10, b.start());
+        assertEquals(20, b.end());
+        assertEquals(50, b.total());
+    }
+
+    @Test
+    void lastPageIsPartial() {
+        var b = ResourceExplorer2Service.pageBounds(25, 10, token(20), CAP);
+        assertEquals(20, b.start());
+        assertEquals(25, b.end());
+    }
+
+    @Test
+    void nullMaxResultsDefaultsTo100() {
+        var b = ResourceExplorer2Service.pageBounds(200, null, null, CAP);
+        assertEquals(100, b.end());
+    }
+
+    @Test
+    void offsetBeyondSizeClampsToEmptyPageInsteadOfThrowing() {
+        // The live result set can shrink between calls; a stale offset must not produce
+        // subList(fromIndex > toIndex) which would throw and 500.
+        var b = ResourceExplorer2Service.pageBounds(10, 100, token(999), CAP);
+        assertEquals(10, b.start());
+        assertEquals(10, b.end());
+        assertEquals(0, b.end() - b.start());
+    }
+
+    @Test
+    void garbageTokenDecodesToZeroOffset() {
+        var b = ResourceExplorer2Service.pageBounds(50, 10, "!!!not-base64!!!", CAP);
+        assertEquals(0, b.start());
+    }
+
+    @Test
+    void totalIsCappedAt1000() {
+        var b = ResourceExplorer2Service.pageBounds(1500, 1000, null, CAP);
+        assertEquals(1000, b.total());
+        assertEquals(0, b.start());
+        assertEquals(1000, b.end());
+    }
+
+    @Test
+    void paginationStaysWithinTheCap() {
+        var b = ResourceExplorer2Service.pageBounds(1500, 100, token(950), CAP);
+        assertEquals(1000, b.total());
+        assertEquals(950, b.start());
+        assertEquals(1000, b.end());
+    }
+
+    @Test
+    void offsetBeyondCapClampsToEmpty() {
+        var b = ResourceExplorer2Service.pageBounds(1500, 100, token(1200), CAP);
+        assertEquals(1000, b.total());
+        assertEquals(1000, b.start());
+        assertEquals(1000, b.end());
+    }
+
+    @Test
+    void listResourcesSuppressesTokenAtMaxPageSize() {
+        // Documented AWS quirk: "The ListResources operation does not generate a NextToken if you set
+        // MaxResults to 1000."
+        // https://docs.aws.amazon.com/resource-explorer/latest/apireference/API_ListResources.html
+        assertFalse(ResourceExplorer2Service.listResourcesEmitsToken(1000, 1500, 1000));
+    }
+
+    @Test
+    void listResourcesSuppressesTokenAtMaxPageSizeRegardlessOfOffset() {
+        // The quirk is page-size-driven, not offset-driven: a caller who switches to MaxResults=1000
+        // mid-chain has the token suppressed even at a non-zero offset. The AWS docs describe the quirk
+        // purely in terms of MaxResults, so suppression must not depend on how far in the page starts.
+        // https://docs.aws.amazon.com/resource-explorer/latest/apireference/API_ListResources.html
+        assertFalse(ResourceExplorer2Service.listResourcesEmitsToken(1200, 1500, 1000));
+    }
+
+    @Test
+    void listResourcesEmitsTokenBelowMaxPageSizeWhenMoreRemain() {
+        assertTrue(ResourceExplorer2Service.listResourcesEmitsToken(500, 1500, 500));
+    }
+
+    @Test
+    void listResourcesOmitsTokenWhenResultsExhausted() {
+        assertFalse(ResourceExplorer2Service.listResourcesEmitsToken(1500, 1500, 500));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/query/QueryParserTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/query/QueryParserTest.java
@@ -1,0 +1,387 @@
+package io.github.hectorvent.floci.services.resourceexplorer2.query;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class QueryParserTest {
+
+    @Nested
+    class EmptyInput {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"   ", "\t"})
+        void emptyOrBlankReturnsEmptyQuery(String input) {
+            ParsedQuery query = QueryParser.parse(input);
+            assertTrue(query.keywords().isEmpty());
+            assertTrue(query.filters().isEmpty());
+        }
+    }
+
+    @Nested
+    class FreeFormKeywords {
+
+        @Test
+        void singleKeyword() {
+            ParsedQuery query = QueryParser.parse("ec2");
+            assertEquals(1, query.keywords().size());
+            assertEquals("ec2", query.keywords().getFirst().value());
+            assertFalse(query.keywords().getFirst().negated());
+            assertTrue(query.filters().isEmpty());
+        }
+
+        @Test
+        void multipleKeywordsAreSplitByWhitespace() {
+            ParsedQuery query = QueryParser.parse("ec2 billing test");
+            assertEquals(3, query.keywords().size());
+            assertEquals("ec2", query.keywords().get(0).value());
+            assertEquals("billing", query.keywords().get(1).value());
+            assertEquals("test", query.keywords().get(2).value());
+        }
+
+        @Test
+        void negatedKeyword() {
+            ParsedQuery query = QueryParser.parse("-forbidden");
+            assertEquals(1, query.keywords().size());
+            assertTrue(query.keywords().getFirst().negated());
+            assertEquals("forbidden", query.keywords().getFirst().value());
+        }
+
+        @Test
+        void quotedMultiWordKeyword() {
+            ParsedQuery query = QueryParser.parse("\"multi word phrase\"");
+            assertEquals(1, query.keywords().size());
+            assertEquals("multi word phrase", query.keywords().getFirst().value());
+        }
+
+        @Test
+        void negatedQuotedKeyword() {
+            ParsedQuery query = QueryParser.parse("-\"multi word\"");
+            assertEquals(1, query.keywords().size());
+            assertTrue(query.keywords().getFirst().negated());
+            assertEquals("multi word", query.keywords().getFirst().value());
+        }
+
+        @Test
+        void unknownPrefixTreatedAsKeyword() {
+            ParsedQuery query = QueryParser.parse("cat:blue");
+            assertEquals(1, query.keywords().size());
+            assertEquals("cat:blue", query.keywords().getFirst().value());
+            assertTrue(query.filters().isEmpty());
+        }
+    }
+
+    @Nested
+    class Filters {
+
+        @Test
+        void serviceFilter() {
+            ParsedQuery query = QueryParser.parse("service:ec2");
+            assertTrue(query.keywords().isEmpty());
+            assertEquals(1, query.filters().size());
+            var filter = query.filters().getFirst();
+            assertEquals(FilterAttribute.SERVICE, filter.attribute());
+            assertEquals(1, filter.values().size());
+            assertEquals("ec2", filter.values().getFirst().value());
+            assertFalse(filter.values().getFirst().prefixMatch());
+            assertFalse(filter.negated());
+        }
+
+        @Test
+        void regionFilter() {
+            ParsedQuery query = QueryParser.parse("region:us-east-1");
+            assertEquals(FilterAttribute.REGION, query.filters().getFirst().attribute());
+            assertEquals("us-east-1", query.filters().getFirst().values().getFirst().value());
+        }
+
+        @Test
+        void resourceTypeFilter() {
+            ParsedQuery query = QueryParser.parse("resourcetype:s3:bucket");
+            var filter = query.filters().getFirst();
+            assertEquals(FilterAttribute.RESOURCE_TYPE, filter.attribute());
+            assertEquals("s3:bucket", filter.values().getFirst().value());
+        }
+
+        @Test
+        void resourceTypeSupportsFilter() {
+            ParsedQuery query = QueryParser.parse("resourcetype.supports:tags");
+            assertEquals(FilterAttribute.RESOURCE_TYPE_SUPPORTS, query.filters().getFirst().attribute());
+            assertEquals("tags", query.filters().getFirst().values().getFirst().value());
+        }
+
+        @Test
+        void accountIdFilter() {
+            ParsedQuery query = QueryParser.parse("accountid:123456789012");
+            assertEquals(FilterAttribute.ACCOUNT_ID, query.filters().getFirst().attribute());
+            assertEquals("123456789012", query.filters().getFirst().values().getFirst().value());
+        }
+
+        @Test
+        void idFilterPreservesColonsInArn() {
+            ParsedQuery query = QueryParser.parse("id:arn:aws:s3:::my-bucket");
+            assertEquals(FilterAttribute.ID, query.filters().getFirst().attribute());
+            assertEquals("arn:aws:s3:::my-bucket", query.filters().getFirst().values().getFirst().value());
+        }
+
+        @Test
+        void tagKeyValueFilter() {
+            ParsedQuery query = QueryParser.parse("tag:environment=production");
+            assertEquals(FilterAttribute.TAG, query.filters().getFirst().attribute());
+            assertEquals("environment=production", query.filters().getFirst().values().getFirst().value());
+        }
+
+        @Test
+        void tagAllSpecialValue() {
+            ParsedQuery query = QueryParser.parse("tag:all");
+            assertEquals(FilterAttribute.TAG, query.filters().getFirst().attribute());
+            assertEquals("all", query.filters().getFirst().values().getFirst().value());
+        }
+
+        @Test
+        void tagNoneSpecialValue() {
+            ParsedQuery query = QueryParser.parse("tag:none");
+            assertEquals(FilterAttribute.TAG, query.filters().getFirst().attribute());
+            assertEquals("none", query.filters().getFirst().values().getFirst().value());
+        }
+
+        @Test
+        void tagKeyFilter() {
+            ParsedQuery query = QueryParser.parse("tag.key:environment");
+            assertEquals(FilterAttribute.TAG_KEY, query.filters().getFirst().attribute());
+            assertEquals("environment", query.filters().getFirst().values().getFirst().value());
+        }
+
+        @Test
+        void tagValueFilter() {
+            ParsedQuery query = QueryParser.parse("tag.value:production");
+            assertEquals(FilterAttribute.TAG_VALUE, query.filters().getFirst().attribute());
+            assertEquals("production", query.filters().getFirst().values().getFirst().value());
+        }
+
+        @Test
+        void applicationFilter() {
+            ParsedQuery query = QueryParser.parse("application:MyApp");
+            assertEquals(FilterAttribute.APPLICATION, query.filters().getFirst().attribute());
+            assertEquals("MyApp", query.filters().getFirst().values().getFirst().value());
+        }
+
+        @Test
+        void caseInsensitiveFilterPrefix() {
+            ParsedQuery query = QueryParser.parse("Service:EC2");
+            assertEquals(1, query.filters().size());
+            assertEquals(FilterAttribute.SERVICE, query.filters().getFirst().attribute());
+            assertEquals("EC2", query.filters().getFirst().values().getFirst().value());
+        }
+    }
+
+    @Nested
+    class CommaOrValues {
+
+        @Test
+        void twoValuesCommaOr() {
+            ParsedQuery query = QueryParser.parse("region:us-east-1,us-west-2");
+            var filter = query.filters().getFirst();
+            assertEquals(2, filter.values().size());
+            assertEquals("us-east-1", filter.values().get(0).value());
+            assertEquals("us-west-2", filter.values().get(1).value());
+        }
+
+        @Test
+        void threeValuesCommaOr() {
+            ParsedQuery query = QueryParser.parse("resourcetype:rds:db,s3:bucket,dynamodb:table");
+            var filter = query.filters().getFirst();
+            assertEquals(3, filter.values().size());
+            assertEquals("rds:db", filter.values().get(0).value());
+            assertEquals("s3:bucket", filter.values().get(1).value());
+            assertEquals("dynamodb:table", filter.values().get(2).value());
+        }
+
+        @Test
+        void doubleCommaProducesEmptySegment() {
+            ParsedQuery query = QueryParser.parse("region:us-east-1,,us-west-2");
+            var filter = query.filters().getFirst();
+            assertEquals(3, filter.values().size());
+            assertEquals("us-east-1", filter.values().get(0).value());
+            assertEquals("", filter.values().get(1).value());
+            assertEquals("us-west-2", filter.values().get(2).value());
+        }
+    }
+
+    @Nested
+    class Negation {
+
+        @Test
+        void negatedFilter() {
+            ParsedQuery query = QueryParser.parse("-service:ec2");
+            var filter = query.filters().getFirst();
+            assertTrue(filter.negated());
+            assertEquals(FilterAttribute.SERVICE, filter.attribute());
+            assertEquals("ec2", filter.values().getFirst().value());
+        }
+
+        @Test
+        void negatedFilterWithCommaOr() {
+            ParsedQuery query = QueryParser.parse("-region:us-east-1,us-west-2");
+            var filter = query.filters().getFirst();
+            assertTrue(filter.negated());
+            assertEquals(2, filter.values().size());
+        }
+    }
+
+    @Nested
+    class Wildcards {
+
+        @Test
+        void wildcardSuffix() {
+            ParsedQuery query = QueryParser.parse("region:us*");
+            var value = query.filters().getFirst().values().getFirst();
+            assertEquals("us", value.value());
+            assertTrue(value.prefixMatch());
+        }
+
+        @Test
+        void wildcardWithCommaOr() {
+            ParsedQuery query = QueryParser.parse("resourcetype:ec2:*,s3:bucket");
+            var values = query.filters().getFirst().values();
+            assertEquals("ec2:", values.get(0).value());
+            assertTrue(values.get(0).prefixMatch());
+            assertEquals("s3:bucket", values.get(1).value());
+            assertFalse(values.get(1).prefixMatch());
+        }
+    }
+
+    @Nested
+    class Escaping {
+
+        @Test
+        void escapedCommaInFilterValue() {
+            ParsedQuery query = QueryParser.parse("tag.key:comma\\,literal");
+            var filter = query.filters().getFirst();
+            assertEquals(1, filter.values().size());
+            assertEquals("comma,literal", filter.values().getFirst().value());
+        }
+
+        @Test
+        void escapedBackslash() {
+            ParsedQuery query = QueryParser.parse("tag.value:back\\\\slash");
+            assertEquals("back\\slash", query.filters().getFirst().values().getFirst().value());
+        }
+
+        @Test
+        void danglingEscapeAtEndOfInput() {
+            ParsedQuery query = QueryParser.parse("service:ec2\\");
+            assertEquals("ec2\\", query.filters().getFirst().values().getFirst().value());
+        }
+    }
+
+    @Nested
+    class QuotedStrings {
+
+        @Test
+        void quotedFilterValue() {
+            ParsedQuery query = QueryParser.parse("tag:\"key=value with spaces\"");
+            assertEquals("key=value with spaces", query.filters().getFirst().values().getFirst().value());
+        }
+
+        @Test
+        void escapedQuoteInsideQuotes() {
+            ParsedQuery query = QueryParser.parse("\"escaped \\\"inner\\\" quote\"");
+            assertEquals("escaped \"inner\" quote", query.keywords().getFirst().value());
+        }
+
+        @Test
+        void emptyQuotedStringAsToken() {
+            ParsedQuery query = QueryParser.parse("service:ec2 \"\" region:us-east-1");
+            assertEquals(2, query.filters().size());
+            assertEquals(1, query.keywords().size());
+            assertEquals("", query.keywords().getFirst().value());
+        }
+    }
+
+    @Nested
+    class Combined {
+
+        @Test
+        void keywordsAndFilters() {
+            ParsedQuery query = QueryParser.parse("test instance service:EC2 region:us-west-2");
+            assertEquals(2, query.keywords().size());
+            assertEquals("test", query.keywords().get(0).value());
+            assertEquals("instance", query.keywords().get(1).value());
+            assertEquals(2, query.filters().size());
+        }
+
+        @Test
+        void awsDocExample() {
+            ParsedQuery query = QueryParser.parse("region:us* service:ec2 -tag:stage=prod");
+            assertEquals(0, query.keywords().size());
+            assertEquals(3, query.filters().size());
+
+            var regionFilter = query.filters().stream()
+                    .filter(f -> f.attribute() == FilterAttribute.REGION).findFirst().orElseThrow();
+            assertTrue(regionFilter.values().getFirst().prefixMatch());
+            assertEquals("us", regionFilter.values().getFirst().value());
+            assertFalse(regionFilter.negated());
+
+            var serviceFilter = query.filters().stream()
+                    .filter(f -> f.attribute() == FilterAttribute.SERVICE).findFirst().orElseThrow();
+            assertEquals("ec2", serviceFilter.values().getFirst().value());
+
+            var tagFilter = query.filters().stream()
+                    .filter(f -> f.attribute() == FilterAttribute.TAG).findFirst().orElseThrow();
+            assertTrue(tagFilter.negated());
+            assertEquals("stage=prod", tagFilter.values().getFirst().value());
+        }
+
+        @Test
+        void multipleSpacesBetweenTokens() {
+            ParsedQuery query = QueryParser.parse("service:ec2   region:us-east-1");
+            assertEquals(2, query.filters().size());
+        }
+
+        @Test
+        void trailingWhitespace() {
+            ParsedQuery query = QueryParser.parse("service:ec2 ");
+            assertEquals(1, query.filters().size());
+        }
+    }
+
+    @Nested
+    class FilterWithEmptyValue {
+
+        @Test
+        void filterPrefixWithNoValue() {
+            ParsedQuery query = QueryParser.parse("service:");
+            assertEquals(1, query.filters().size());
+            assertEquals(1, query.filters().getFirst().values().size());
+            assertEquals("", query.filters().getFirst().values().getFirst().value());
+        }
+    }
+
+    @Nested
+    class ListResourcesMode {
+
+        @Test
+        void rejectsFreeFormTextInFilterOnlyMode() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> QueryParser.parseFilterOnly("hello world"));
+        }
+
+        @Test
+        void acceptsFiltersInFilterOnlyMode() {
+            ParsedQuery query = QueryParser.parseFilterOnly("service:ec2 region:us-east-1");
+            assertEquals(2, query.filters().size());
+            assertTrue(query.keywords().isEmpty());
+        }
+
+        @Test
+        void emptyStringAllowedInFilterOnlyMode() {
+            ParsedQuery query = QueryParser.parseFilterOnly("");
+            assertTrue(query.filters().isEmpty());
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/query/ResourceFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourceexplorer2/query/ResourceFilterTest.java
@@ -1,0 +1,290 @@
+package io.github.hectorvent.floci.services.resourceexplorer2.query;
+
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ResourceFilterTest {
+
+    private static final Instant NOW = Instant.now();
+
+    private static ExplorerResource resource(String arn, String resourceType, String service,
+                                              String region, String accountId, Map<String, String> tags) {
+        return new ExplorerResource(arn, resourceType, service, region, accountId, NOW, tags);
+    }
+
+    private static final ExplorerResource S3_BUCKET = resource(
+            "arn:aws:s3:::my-bucket", "s3:bucket", "s3", "us-east-1", "123456789012",
+            Map.of("env", "prod", "team", "platform"));
+
+    private static final ExplorerResource RDS_INSTANCE = resource(
+            "arn:aws:rds:us-west-2:123456789012:db:orders-db", "rds:db", "rds", "us-west-2", "123456789012",
+            Map.of());
+
+    private static final ExplorerResource DYNAMO_TABLE = resource(
+            "arn:aws:dynamodb:us-east-1:999999999999:table/users", "dynamodb:table", "dynamodb", "us-east-1", "999999999999",
+            Map.of("env", "staging"));
+
+    @Nested
+    class EmptyQuery {
+
+        @Test
+        void emptyQueryMatchesEverything() {
+            ParsedQuery query = QueryParser.parse("");
+            assertTrue(ResourceFilter.matches(S3_BUCKET, query));
+            assertTrue(ResourceFilter.matches(RDS_INSTANCE, query));
+        }
+    }
+
+    @Nested
+    class RegionFilter {
+
+        @Test
+        void exactRegionMatch() {
+            ParsedQuery query = QueryParser.parse("region:us-east-1");
+            assertTrue(ResourceFilter.matches(S3_BUCKET, query));
+            assertFalse(ResourceFilter.matches(RDS_INSTANCE, query));
+        }
+
+        @Test
+        void regionWildcard() {
+            ParsedQuery query = QueryParser.parse("region:us*");
+            assertTrue(ResourceFilter.matches(S3_BUCKET, query));
+            assertTrue(ResourceFilter.matches(RDS_INSTANCE, query));
+        }
+
+        @Test
+        void regionWildcardNoMatch() {
+            ParsedQuery query = QueryParser.parse("region:eu*");
+            assertFalse(ResourceFilter.matches(S3_BUCKET, query));
+        }
+    }
+
+    @Nested
+    class ServiceFilter {
+
+        @Test
+        void exactServiceMatch() {
+            ParsedQuery query = QueryParser.parse("service:s3");
+            assertTrue(ResourceFilter.matches(S3_BUCKET, query));
+            assertFalse(ResourceFilter.matches(RDS_INSTANCE, query));
+        }
+
+        @Test
+        void caseInsensitive() {
+            ParsedQuery query = QueryParser.parse("service:S3");
+            assertTrue(ResourceFilter.matches(S3_BUCKET, query));
+        }
+    }
+
+    @Nested
+    class ResourceTypeFilter {
+
+        @Test
+        void exactResourceTypeMatch() {
+            ParsedQuery query = QueryParser.parse("resourcetype:rds:db");
+            assertFalse(ResourceFilter.matches(S3_BUCKET, query));
+            assertTrue(ResourceFilter.matches(RDS_INSTANCE, query));
+        }
+
+        @Test
+        void commaOrResourceType() {
+            ParsedQuery query = QueryParser.parse("resourcetype:rds:db,s3:bucket");
+            assertTrue(ResourceFilter.matches(S3_BUCKET, query));
+            assertTrue(ResourceFilter.matches(RDS_INSTANCE, query));
+            assertFalse(ResourceFilter.matches(DYNAMO_TABLE, query));
+        }
+
+        @Test
+        void wildcardResourceType() {
+            ParsedQuery query = QueryParser.parse("resourcetype:rds:*");
+            assertTrue(ResourceFilter.matches(RDS_INSTANCE, query));
+            assertFalse(ResourceFilter.matches(S3_BUCKET, query));
+        }
+    }
+
+    @Nested
+    class TagFilters {
+
+        @Test
+        void tagKeyValue() {
+            ParsedQuery query = QueryParser.parse("tag:env=prod");
+            assertTrue(ResourceFilter.matches(S3_BUCKET, query));
+            assertFalse(ResourceFilter.matches(RDS_INSTANCE, query));
+            assertFalse(ResourceFilter.matches(DYNAMO_TABLE, query));
+        }
+
+        @Test
+        void tagKeyOnly() {
+            ParsedQuery query = QueryParser.parse("tag.key:env");
+            assertTrue(ResourceFilter.matches(S3_BUCKET, query));
+            assertFalse(ResourceFilter.matches(RDS_INSTANCE, query));
+            assertTrue(ResourceFilter.matches(DYNAMO_TABLE, query));
+        }
+
+        @Test
+        void tagValueOnly() {
+            ParsedQuery query = QueryParser.parse("tag.value:prod");
+            assertTrue(ResourceFilter.matches(S3_BUCKET, query));
+            assertFalse(ResourceFilter.matches(DYNAMO_TABLE, query));
+        }
+
+        @Test
+        void tagAll() {
+            ParsedQuery query = QueryParser.parse("tag:all");
+            assertTrue(ResourceFilter.matches(S3_BUCKET, query));
+            assertFalse(ResourceFilter.matches(RDS_INSTANCE, query));
+        }
+
+        @Test
+        void tagNone() {
+            ParsedQuery query = QueryParser.parse("tag:none");
+            assertFalse(ResourceFilter.matches(S3_BUCKET, query));
+            assertTrue(ResourceFilter.matches(RDS_INSTANCE, query));
+        }
+    }
+
+    @Nested
+    class NegationFilter {
+
+        @Test
+        void negatedServiceExcludes() {
+            ParsedQuery query = QueryParser.parse("-service:s3");
+            assertFalse(ResourceFilter.matches(S3_BUCKET, query));
+            assertTrue(ResourceFilter.matches(RDS_INSTANCE, query));
+        }
+    }
+
+    @Nested
+    class KeywordFilter {
+
+        @Test
+        void positiveKeywordMatchingArnNarrowsResults() {
+            // "orders-db" appears in RDS_INSTANCE arn; S3_BUCKET and DYNAMO_TABLE should be excluded
+            ParsedQuery query = QueryParser.parse("orders-db");
+            assertFalse(ResourceFilter.matches(S3_BUCKET, query));
+            assertTrue(ResourceFilter.matches(RDS_INSTANCE, query));
+            assertFalse(ResourceFilter.matches(DYNAMO_TABLE, query));
+        }
+
+        @Test
+        void positiveKeywordMatchingServiceNarrowsResults() {
+            // "dynamodb" appears in DYNAMO_TABLE service; other resources should be excluded
+            ParsedQuery query = QueryParser.parse("dynamodb");
+            assertFalse(ResourceFilter.matches(S3_BUCKET, query));
+            assertFalse(ResourceFilter.matches(RDS_INSTANCE, query));
+            assertTrue(ResourceFilter.matches(DYNAMO_TABLE, query));
+        }
+
+        @Test
+        void positiveKeywordMatchingRegionNarrowsResults() {
+            // "us-east-1" appears in region of S3_BUCKET and DYNAMO_TABLE
+            ParsedQuery query = QueryParser.parse("us-east-1");
+            assertTrue(ResourceFilter.matches(S3_BUCKET, query));
+            assertFalse(ResourceFilter.matches(RDS_INSTANCE, query));
+            assertTrue(ResourceFilter.matches(DYNAMO_TABLE, query));
+        }
+
+        @Test
+        void positiveKeywordMatchingNothingReturnsEmpty() {
+            ParsedQuery query = QueryParser.parse("xyzzy-no-such-resource");
+            assertFalse(ResourceFilter.matches(S3_BUCKET, query));
+            assertFalse(ResourceFilter.matches(RDS_INSTANCE, query));
+            assertFalse(ResourceFilter.matches(DYNAMO_TABLE, query));
+        }
+
+        @Test
+        void positiveKeywordIsCaseInsensitive() {
+            ParsedQuery query = QueryParser.parse("DYNAMODB");
+            assertFalse(ResourceFilter.matches(S3_BUCKET, query));
+            assertFalse(ResourceFilter.matches(RDS_INSTANCE, query));
+            assertTrue(ResourceFilter.matches(DYNAMO_TABLE, query));
+        }
+
+        @Test
+        void negatedKeywordStillExcludes() {
+            // regression guard: negated keyword excludes matching resources
+            ParsedQuery query = QueryParser.parse("-dynamodb");
+            assertTrue(ResourceFilter.matches(S3_BUCKET, query));
+            assertTrue(ResourceFilter.matches(RDS_INSTANCE, query));
+            assertFalse(ResourceFilter.matches(DYNAMO_TABLE, query));
+        }
+
+        @Test
+        void positiveKeywordAndAttributeFilterAreAnded() {
+            // "us-east-1" matches S3_BUCKET and DYNAMO_TABLE by region keyword,
+            // but service:s3 further restricts to only S3_BUCKET
+            ParsedQuery query = QueryParser.parse("us-east-1 service:s3");
+            assertTrue(ResourceFilter.matches(S3_BUCKET, query));
+            assertFalse(ResourceFilter.matches(RDS_INSTANCE, query));
+            assertFalse(ResourceFilter.matches(DYNAMO_TABLE, query));
+        }
+
+        @Test
+        void multiplePositiveKeywordsAllMustMatch() {
+            // "s3" matches S3_BUCKET; "us-east-1" also matches S3_BUCKET — both must match (AND)
+            ParsedQuery query = QueryParser.parse("s3 us-east-1");
+            assertTrue(ResourceFilter.matches(S3_BUCKET, query));
+            assertFalse(ResourceFilter.matches(RDS_INSTANCE, query));
+            assertFalse(ResourceFilter.matches(DYNAMO_TABLE, query));
+        }
+    }
+
+    @Nested
+    class AndSemantics {
+
+        @Test
+        void multipleFiltersMustAllMatch() {
+            ParsedQuery query = QueryParser.parse("service:s3 region:us-east-1");
+            assertTrue(ResourceFilter.matches(S3_BUCKET, query));
+            assertFalse(ResourceFilter.matches(RDS_INSTANCE, query));
+        }
+
+        @Test
+        void filterAndNegation() {
+            ParsedQuery query = QueryParser.parse("region:us-east-1 -service:dynamodb");
+            assertTrue(ResourceFilter.matches(S3_BUCKET, query));
+            assertFalse(ResourceFilter.matches(DYNAMO_TABLE, query));
+        }
+    }
+
+    @Nested
+    class AccountIdFilter {
+
+        @Test
+        void matchesAccountId() {
+            ParsedQuery query = QueryParser.parse("accountid:123456789012");
+            assertTrue(ResourceFilter.matches(S3_BUCKET, query));
+            assertFalse(ResourceFilter.matches(DYNAMO_TABLE, query));
+        }
+    }
+
+    @Nested
+    class IdFilter {
+
+        @Test
+        void matchesExactArn() {
+            ParsedQuery query = QueryParser.parse("id:arn:aws:s3:::my-bucket");
+            assertTrue(ResourceFilter.matches(S3_BUCKET, query));
+            assertFalse(ResourceFilter.matches(RDS_INSTANCE, query));
+        }
+    }
+
+    @Nested
+    class ViewFilterMerging {
+
+        @Test
+        void viewFilterAndRequestFilterAnded() {
+            ParsedQuery viewFilter = QueryParser.parse("service:s3");
+            ParsedQuery requestFilter = QueryParser.parse("region:us-east-1");
+            ParsedQuery combined = ResourceFilter.combine(viewFilter, requestFilter);
+            assertTrue(ResourceFilter.matches(S3_BUCKET, combined));
+            assertFalse(ResourceFilter.matches(RDS_INSTANCE, combined));
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/rum/RumResourceProviderTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rum/RumResourceProviderTest.java
@@ -1,0 +1,128 @@
+package io.github.hectorvent.floci.services.rum;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.resource.ExplorerResource;
+import io.github.hectorvent.floci.core.resource.SupportedResourceType;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RumResourceProviderTest {
+
+    private static final String REGION = "us-east-1";
+    private static final String ACCOUNT = "000000000000";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private RumService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new RumService(new InMemoryStorage<>(), new RegionResolver(REGION, ACCOUNT));
+    }
+
+    private ObjectNode monitorRequest(String name, String domain) {
+        return mapper.createObjectNode().put("Name", name).put("Domain", domain);
+    }
+
+    @Nested
+    class GetResources {
+
+        @Test
+        void emptyWhenNothingStored() {
+            assertTrue(service.getResources().isEmpty());
+        }
+
+        @Test
+        void surfacesAppMonitorWithArnTypeRegionAccountAndTags() {
+            ObjectNode request = monitorRequest("web", "example.com");
+            request.set("Tags", mapper.createObjectNode().put("env", "prod"));
+            service.createAppMonitor(REGION, request);
+
+            ExplorerResource monitor = only(service.getResources(), "rum:appmonitor");
+            assertEquals("arn:aws:rum:" + REGION + ":" + ACCOUNT + ":appmonitor/web", monitor.arn());
+            assertEquals("rum", monitor.service());
+            assertEquals(REGION, monitor.region());
+            assertEquals(ACCOUNT, monitor.owningAccountId());
+            assertEquals(Map.of("env", "prod"), monitor.tags());
+        }
+
+        @Test
+        void surfacesMonitorsFromMultipleRegions() {
+            service.createAppMonitor(REGION, monitorRequest("east", "example.com"));
+            service.createAppMonitor("eu-west-1", monitorRequest("west", "example.com"));
+
+            Map<String, String> arnsByType = service.getResources().stream()
+                    .collect(Collectors.toMap(ExplorerResource::region, ExplorerResource::arn));
+            assertEquals("arn:aws:rum:us-east-1:" + ACCOUNT + ":appmonitor/east",
+                    arnsByType.get("us-east-1"));
+            assertEquals("arn:aws:rum:eu-west-1:" + ACCOUNT + ":appmonitor/west",
+                    arnsByType.get("eu-west-1"));
+        }
+
+        @Test
+        void resourceWithoutTagsYieldsEmptyMapNotNull() {
+            service.createAppMonitor(REGION, monitorRequest("web", "example.com"));
+            ExplorerResource monitor = only(service.getResources(), "rum:appmonitor");
+            assertEquals(Map.of(), monitor.tags());
+        }
+
+        @Test
+        void reportsOwnerAccountCapturedAtCreationNotTheQueryingCaller() {
+            MutableAccountResolver resolver = new MutableAccountResolver();
+            RumService svc = new RumService(new InMemoryStorage<>(), resolver);
+
+            resolver.accountId = "111111111111";
+            svc.createAppMonitor(REGION, monitorRequest("web", "example.com"));
+
+            // A later ListResources arrives under a different principal.
+            resolver.accountId = "999999999999";
+            ExplorerResource monitor = only(svc.getResources(), "rum:appmonitor");
+            assertEquals("111111111111", monitor.owningAccountId());
+            assertEquals("arn:aws:rum:" + REGION + ":111111111111:appmonitor/web", monitor.arn());
+        }
+    }
+
+    private static final class MutableAccountResolver extends RegionResolver {
+        private String accountId = ACCOUNT;
+
+        MutableAccountResolver() {
+            super(REGION, ACCOUNT);
+        }
+
+        @Override
+        public String getAccountId() {
+            return accountId;
+        }
+    }
+
+    @Nested
+    class GetSupportedResourceTypes {
+
+        @Test
+        void advertisesAppMonitorTypeUnderRumService() {
+            Set<SupportedResourceType> types = service.getSupportedResourceTypes();
+            assertEquals(Set.of("rum:appmonitor"),
+                    types.stream().map(SupportedResourceType::resourceType).collect(Collectors.toSet()));
+            assertTrue(types.stream().allMatch(t -> t.service().equals("rum")));
+            assertTrue(types.stream().allMatch(SupportedResourceType::supportsTags));
+        }
+    }
+
+    private static ExplorerResource only(List<ExplorerResource> resources, String resourceType) {
+        return resources.stream()
+                .filter(r -> r.resourceType().equals(resourceType))
+                .reduce((a, b) -> { throw new AssertionError("expected exactly one " + resourceType); })
+                .orElseThrow(() -> new AssertionError("no " + resourceType + " resource"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/rum/RumServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rum/RumServiceTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.PersistentStorage;
 import io.github.hectorvent.floci.services.rum.model.AppMonitor;
@@ -23,8 +24,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class RumServiceTest {
 
     private static final String REGION = "us-east-1";
+    private static final RegionResolver REGION_RESOLVER = new RegionResolver(REGION, "000000000000");
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final RumService service = new RumService(new InMemoryStorage<>());
+    private final RumService service = new RumService(new InMemoryStorage<>(), REGION_RESOLVER);
+
+    @Test
+    void ownerAccountIsCapturedButNeverSerializedIntoTheApiBody() {
+        AppMonitor monitor = service.createAppMonitor(REGION,
+                objectMapper.createObjectNode().put("Name", "monitor").put("Domain", "example.com"));
+
+        assertEquals("000000000000", monitor.getOwnerAccountId());
+        JsonNode serialized = objectMapper.valueToTree(monitor);
+        serialized.fieldNames().forEachRemaining(field ->
+                assertTrue(!field.toLowerCase().contains("account"),
+                        "GetAppMonitor body must not expose the owner account: " + serialized));
+    }
 
     @Test
     void updateAppMonitorAtomicallyReplacesTheStoredSnapshot() throws Exception {
@@ -181,7 +195,7 @@ class RumServiceTest {
                 file, new TypeReference<Map<String, AppMonitor>>() {
                 });
         firstStore.load();
-        RumService firstService = new RumService(firstStore);
+        RumService firstService = new RumService(firstStore, REGION_RESOLVER);
         AppMonitor created = firstService.createAppMonitor(REGION, request("""
                 {
                   "Name":"persistent-monitor",
@@ -196,7 +210,7 @@ class RumServiceTest {
                 file, new TypeReference<Map<String, AppMonitor>>() {
                 });
         reloadedStore.load();
-        AppMonitor reloaded = new RumService(reloadedStore).getAppMonitor(REGION, "persistent-monitor");
+        AppMonitor reloaded = new RumService(reloadedStore, REGION_RESOLVER).getAppMonitor(REGION, "persistent-monitor");
 
         assertEquals(created.getId(), reloaded.getId());
         assertEquals(created.getCreated(), reloaded.getCreated());

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -63,6 +63,9 @@ floci:
         flush-interval-ms: 60000
       rum:
         flush-interval-ms: 60000
+      resourceexplorer2:
+        mode: memory
+        flush-interval-ms: 5000
 
   auth:
     validate-signatures: false
@@ -269,6 +272,8 @@ floci:
       enabled: true
     lightsail:
     cloudcontrol:
+      enabled: true
+    resourceexplorer2:
       enabled: true
     cloudfront:
       enabled: true


### PR DESCRIPTION
## Summary

Emulates AWS Resource Explorer 2: index and view lifecycle (`CreateIndex`, `UpdateIndexType`, `CreateView`, `AssociateDefaultView`, …), `Search` / `ListResources` with the Resource Explorer query grammar, `ListSupportedResourceTypes`, and tag operations. Seventeen existing services are made discoverable through it: ACM, Amazon MQ, Cognito, DynamoDB, ECR, ElastiCache, IAM, KMS, Lambda, MSK, OpenSearch, Pipes, RDS, S3, SNS, SQS, and Step Functions.

Fixes #1795

### Changes outside of`resourceexplorer2/`

- Each of the seventeen services gains `implements ResourceProvider` and two methods.
- `ResolvedServiceCatalog` registers one new service descriptor.
- `SigV4CredentialScope` is made `public` so `ResourceExplorer2PathRewriteFilter` can read the signing service from the `Authorization` header (see Notes).
- Two services need a little more to report accurate data: ElastiCache's `ReplicationGroup` gains `arn` and `region` fields (and its query handler threads `region` through), and RDS sources its resource tags from the existing `ResourceGroupsTaggingService`. Those are the only touches to existing request paths.

### Making a service discoverable

Implement `core/resource/ResourceProvider`:

```java
public interface ResourceProvider {
    List<ExplorerResource> getResources();
    Set<SupportedResourceType> getSupportedResourceTypes();
}
```

`ResourceExplorer2Service` pulls in every implementation through CDI. `services/lambda/LambdaService` is the shortest example.

### Suggested review approach

1. `core/resource/` — the three-type contract.
2. `services/resourceexplorer2/ResourceExplorer2Service` — index/view lifecycle, aggregation, pagination.
3. `services/resourceexplorer2/query/` — `QueryParser` and `ResourceFilter` implement the filter grammar; `ParsedQuery` is the parsed form.
4. `services/resourceexplorer2/ResourceExplorer2Controller` — wire mapping.
5. One service integration; the other fifteen match it.

### Notes for reviewers

**Path collision with S3 Vectors.** Both are REST-JSON services rooted at `/`, and both declare `/CreateIndex`, `/GetIndex`, `/ListIndexes`, and `/DeleteIndex`. JAX-RS can't route by path. `ResourceExplorer2PathRewriteFilter` disambiguates on the SigV4 credential scope — the signal `AwsQueryController` already routes query services by, via the same `@PreMatching` rewrite that `SqsQueueUrlRouterFilter` and `S3VirtualHostFilter` use. It's the only non-local routing here. The filter comments the failure mode if its path set drifts from `S3VectorsController`.

**No index; resources are gathered per request.** `paginateResources()` calls every provider's `getResources()` on each `Search` / `ListResources`. Providers stay stateless and always match live service state, and an emulator never holds enough resources for the cost to matter. The constraint this puts on a provider: `getResources()` has to be cheap and has to tolerate a resource that's mid-creation, so it skips null ARNs and treats a null tag map as empty.

**Where floci differs from AWS on purpose:**
- An index returns `CREATING` on the create call and is `ACTIVE` right after. Floci is synchronous, so there's no provisioning window to fake.
- A `NextToken` pointing past a result set that shrank returns an empty page instead of an error, which is how AWS handles a replayed token.
- The per-region default view is stored on its own, not inferred from a name, so `DisassociateDefaultView` sticks across a restart.

**Tags only appear when a view's `IncludedProperties` lists `tags`**, same as AWS. Without it, tagged resources come back with no tag data.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Wire protocol verified against AWS Java SDK v2 `2.44.14` (`software.amazon.awssdk:resourceexplorer2`) in `compatibility-tests/sdk-test-java/ResourceExplorer2Test`, which drives the operations through the generated `ResourceExplorer2Client` against a running floci.

## Checklist

- [x] `./mvnw test` passes locally - ran it, struggling to get lambda & Neptune tests working with Colima on MacOS.
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
