### PR TITLE
fix(apigateway): collapse duplicate request headers to the last value in proxy events

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -706,14 +706,19 @@ public class ApiGatewayExecuteController {
         }
     }
 
-    private void putSingleValueHeaders(ObjectNode event, HttpHeaders headers) {
+    // Package-private for unit testing (see ApiGatewayExecuteControllerTest).
+    void putSingleValueHeaders(ObjectNode event, HttpHeaders headers) {
         ObjectNode headersNode = event.putObject("headers");
         headers.getRequestHeaders().forEach((name, values) -> {
-            if (!values.isEmpty()) headersNode.put(name, values.get(0));
+            // AWS collapses duplicate request headers to the LAST value in the single-value `headers`
+            // map (multiValueHeaders keeps every value). Taking the first value diverged from AWS.
+            if (!values.isEmpty()) {
+                headersNode.put(name, values.get(values.size() - 1));
+            }
         });
     }
 
-    private void putMultiValueHeaders(ObjectNode event, HttpHeaders headers) {
+    void putMultiValueHeaders(ObjectNode event, HttpHeaders headers) {
         ObjectNode mvHeaders = event.putObject("multiValueHeaders");
         headers.getRequestHeaders().forEach((name, values) -> {
             ArrayNode arr = mvHeaders.putArray(name);

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteControllerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteControllerTest.java
@@ -1,20 +1,32 @@
 package io.github.hectorvent.floci.services.apigateway;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-/**
- * Verifies {@link ApiGatewayExecuteController#extractV2PathParams(String, String)}
- * captures path parameters correctly for both greedy ({proxy+}) and non-greedy
- * ({proxy}) route templates, and that repeated invocations against the same
- * route key reuse the cached compiled Pattern (correctness check; the cache
- * itself is an internal implementation detail).
- */
+/** Unit coverage for API Gateway request-event construction and HTTP API v2 route matching. */
 class ApiGatewayExecuteControllerTest {
+
+    private static ApiGatewayExecuteController controller(ObjectMapper objectMapper) {
+        RegionResolver regionResolver = mock(RegionResolver.class);
+        when(regionResolver.getAccountId()).thenReturn("000000000000");
+        return new ApiGatewayExecuteController(
+                null, null, null,
+                regionResolver, objectMapper, null,
+                null, null, null, null);
+    }
 
     @Test
     void capturesGreedyProxyMultiSegment() {
@@ -75,5 +87,26 @@ class ApiGatewayExecuteControllerTest {
                     routeKey, "/payments/spei/" + i);
             assertEquals("spei/" + i, p.get("proxy"));
         }
+    }
+
+    @Test
+    void duplicateRequestHeaderUsesLastSingleValueAndPreservesAllMultiValues() {
+        MultivaluedMap<String, String> requestHeaders = new MultivaluedHashMap<>();
+        requestHeaders.add("X-Dup", "first");
+        requestHeaders.add("X-Dup", "second");
+        requestHeaders.add("X-Dup", "third");
+        HttpHeaders headers = mock(HttpHeaders.class);
+        when(headers.getRequestHeaders()).thenReturn(requestHeaders);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectNode event = objectMapper.createObjectNode();
+        ApiGatewayExecuteController controller = controller(objectMapper);
+        controller.putSingleValueHeaders(event, headers);
+        controller.putMultiValueHeaders(event, headers);
+
+        assertEquals("third", event.path("headers").path("X-Dup").asText());
+        assertEquals(
+                objectMapper.valueToTree(List.of("first", "second", "third")),
+                event.path("multiValueHeaders").path("X-Dup"));
     }
 }


### PR DESCRIPTION
## Summary

API Gateway REST proxy events previously collapsed duplicate request headers to the first value. This change uses the final value in the single-value `headers` map while preserving every value, in order, in `multiValueHeaders`.

## Type of change

- [x] Bug fix (non-breaking change)

## AWS compatibility

This matches the documented [API Gateway Lambda proxy integration input format](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format), where the example's duplicate header values are preserved in `multiValueHeaders` and the final value appears in `headers`.

The change is limited to REST proxy-event construction. It does not change request or response endpoints, and duplicate query-parameter behavior is outside this PR's scope.

## Tests

`ApiGatewayExecuteControllerTest` supplies three ordered values for one header and verifies that:

- `headers` contains the third and final value.
- `multiValueHeaders` contains all three values in their original order.

Local verification on the clean restack:

- `ApiGatewayExecuteControllerTest`: 9 tests passed.
- Broader execute-controller, REST API, and OpenAPI import set: 74 tests passed.
- `git diff --check`.
