### PR TITLE
feat(dynamodb): global-table v2 replicas (UpdateTable ReplicaUpdates + Custom::DynamoDBReplica)

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbTest.java
@@ -7,9 +7,11 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.BatchGetItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.CreateReplicationGroupMemberAction;
 import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.CreateTableResponse;
 import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.DeleteReplicationGroupMemberAction;
 import software.amazon.awssdk.services.dynamodb.model.DeleteRequest;
 import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
@@ -29,6 +31,7 @@ import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.PutRequest;
 import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
 import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+import software.amazon.awssdk.services.dynamodb.model.ReplicationGroupUpdate;
 import software.amazon.awssdk.services.dynamodb.model.ReturnValue;
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
@@ -39,6 +42,7 @@ import software.amazon.awssdk.services.dynamodb.model.TimeToLiveStatus;
 import software.amazon.awssdk.services.dynamodb.model.UntagResourceRequest;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.UpdateReplicationGroupMemberAction;
 import software.amazon.awssdk.services.dynamodb.model.UpdateTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.UpdateTableResponse;
 import software.amazon.awssdk.services.dynamodb.model.WriteRequest;
@@ -250,6 +254,47 @@ class DynamoDbTest {
 
     @Test
     @Order(12)
+    void updateTableReplicaLifecycle() {
+        String replicaRegion = "us-west-2";
+
+        UpdateTableResponse added = ddb.updateTable(UpdateTableRequest.builder()
+                .tableName(TABLE_NAME)
+                .replicaUpdates(ReplicationGroupUpdate.builder()
+                        .create(CreateReplicationGroupMemberAction.builder().regionName(replicaRegion).build())
+                        .build())
+                .build());
+
+        assertThat(added.tableDescription().replicas())
+                .anyMatch(replica -> replicaRegion.equals(replica.regionName())
+                        && "ACTIVE".equals(replica.replicaStatusAsString()));
+        assertThat(ddb.describeTable(DescribeTableRequest.builder().tableName(TABLE_NAME).build())
+                .table().replicas())
+                .anyMatch(replica -> replicaRegion.equals(replica.regionName()));
+
+        UpdateTableResponse updated = ddb.updateTable(UpdateTableRequest.builder()
+                .tableName(TABLE_NAME)
+                .replicaUpdates(ReplicationGroupUpdate.builder()
+                        .update(UpdateReplicationGroupMemberAction.builder().regionName(replicaRegion).build())
+                        .build())
+                .build());
+
+        assertThat(updated.tableDescription().replicas())
+                .anyMatch(replica -> replicaRegion.equals(replica.regionName())
+                        && "ACTIVE".equals(replica.replicaStatusAsString()));
+
+        UpdateTableResponse removed = ddb.updateTable(UpdateTableRequest.builder()
+                .tableName(TABLE_NAME)
+                .replicaUpdates(ReplicationGroupUpdate.builder()
+                        .delete(DeleteReplicationGroupMemberAction.builder().regionName(replicaRegion).build())
+                        .build())
+                .build());
+
+        assertThat(removed.tableDescription().replicas())
+                .noneMatch(replica -> replicaRegion.equals(replica.regionName()));
+    }
+
+    @Test
+    @Order(13)
     void describeTimeToLive() {
         DescribeTimeToLiveResponse response = ddb.describeTimeToLive(
                 DescribeTimeToLiveRequest.builder().tableName(TABLE_NAME).build());
@@ -259,7 +304,7 @@ class DynamoDbTest {
     }
 
     @Test
-    @Order(13)
+    @Order(14)
     void tagResource() {
         Assumptions.assumeTrue(tableArn != null);
 
@@ -273,7 +318,7 @@ class DynamoDbTest {
     }
 
     @Test
-    @Order(14)
+    @Order(15)
     void listTagsOfResource() {
         Assumptions.assumeTrue(tableArn != null);
 
@@ -286,7 +331,7 @@ class DynamoDbTest {
     }
 
     @Test
-    @Order(15)
+    @Order(16)
     void untagResource() {
         Assumptions.assumeTrue(tableArn != null);
 
@@ -302,7 +347,7 @@ class DynamoDbTest {
     }
 
     @Test
-    @Order(16)
+    @Order(17)
     void batchWriteItemDelete() {
         ddb.batchWriteItem(BatchWriteItemRequest.builder()
                 .requestItems(Map.of(TABLE_NAME, List.of(
@@ -324,7 +369,7 @@ class DynamoDbTest {
     }
 
     @Test
-    @Order(17)
+    @Order(18)
     void deleteItem() {
         ddb.deleteItem(DeleteItemRequest.builder()
                 .tableName(TABLE_NAME)
@@ -336,7 +381,7 @@ class DynamoDbTest {
     }
 
     @Test
-    @Order(18)
+    @Order(19)
     void deleteTable() {
         ddb.deleteTable(DeleteTableRequest.builder().tableName(TABLE_NAME).build());
 

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -133,6 +133,9 @@ public class CloudFormationResourceProvisioner {
     private static final String LOG_GROUP_NAME_MODE_ATTR = "FlociLogGroupNameMode";
     private static final String SECRET_TARGET_MANAGED_KEYS_ATTR = "__FlociSecretTargetManagedKeys";
     private static final String SECRET_TARGET_OWNER_ATTR = "__FlociSecretTargetOwner";
+    private static final String DDB_REPLICA_TABLE_NAME_ATTR = "TableName";
+    private static final String DDB_REPLICA_REGION_ATTR = "__FlociDynamoDbReplicaRegion";
+    private static final String DDB_REPLICA_SKIP_DELETION_ATTR = "__FlociDynamoDbReplicaSkipDeletion";
     private static final List<String> SECRET_TARGET_CONNECTION_KEYS = List.of(
             "engine", "host", "port", "dbname", "dbInstanceIdentifier", "dbClusterIdentifier");
     private static final int LAMBDA_DEFAULT_TIMEOUT_SECONDS = 3;
@@ -4303,7 +4306,8 @@ public class CloudFormationResourceProvisioner {
      * Provisions a {@code Custom::DynamoDBReplica} — the custom resource the CDK legacy global-table
      * (dynamodb.Table.replicationRegions) emits per replica region. Its provider Lambda simply calls
      * DynamoDB UpdateTable with a ReplicaUpdates Create, so apply that directly rather than running
-     * the async CDK Provider framework. {@code Ref} (PhysicalResourceId) is the replica region.
+     * the async CDK Provider framework. {@code Ref} (PhysicalResourceId) follows CDK's
+     * {@code <tableName>-<region>} format.
      */
     private void provisionDynamoDbReplica(StackResource r, JsonNode props,
                                           CloudFormationTemplateEngine engine, String region) {
@@ -4317,7 +4321,12 @@ public class CloudFormationResourceProvisioner {
             throw new AwsException("ValidationError",
                     "Custom::DynamoDBReplica " + r.getLogicalId() + " is missing Region", 400);
         }
-        String priorRegion = r.getPhysicalId();
+        String priorTableName = r.getAttributes().get(DDB_REPLICA_TABLE_NAME_ATTR);
+        String priorRegion = r.getAttributes().get(DDB_REPLICA_REGION_ATTR);
+        if (priorRegion == null || priorRegion.isBlank()) {
+            priorRegion = replicaRegionFromPhysicalId(
+                    r.getPhysicalId(), priorTableName != null ? priorTableName : tableName);
+        }
         List<String> removeRegions = priorRegion != null
                 && !priorRegion.isBlank()
                 && !priorRegion.equals(replicaRegion)
@@ -4327,13 +4336,24 @@ public class CloudFormationResourceProvisioner {
         // cannot leave the new replica applied while the resource still points at the old region.
         dynamoDbService.applyReplicaUpdates(
                 tableName, List.of(replicaRegion), removeRegions, region);
-        r.setPhysicalId(replicaRegion);
-        r.getAttributes().put("TableName", tableName);
+        r.setPhysicalId(tableName + "-" + replicaRegion);
+        r.getAttributes().put(DDB_REPLICA_TABLE_NAME_ATTR, tableName);
+        r.getAttributes().put(DDB_REPLICA_REGION_ATTR, replicaRegion);
+        r.getAttributes().put(DDB_REPLICA_SKIP_DELETION_ATTR,
+                Boolean.toString(Boolean.TRUE.equals(
+                        parseBooleanOrNull(resolveOptional(props, "SkipReplicaDeletion", engine)))));
     }
 
     private void deleteDynamoDbReplicaSafe(StackResource r, String region) {
-        String tableName = r.getAttributes().get("TableName");
-        String replicaRegion = r.getPhysicalId();
+        if (Boolean.parseBoolean(r.getAttributes().get(DDB_REPLICA_SKIP_DELETION_ATTR))) {
+            LOG.debugv("Keeping replica for retained Custom::DynamoDBReplica {0}", r.getLogicalId());
+            return;
+        }
+        String tableName = r.getAttributes().get(DDB_REPLICA_TABLE_NAME_ATTR);
+        String replicaRegion = r.getAttributes().get(DDB_REPLICA_REGION_ATTR);
+        if (replicaRegion == null || replicaRegion.isBlank()) {
+            replicaRegion = replicaRegionFromPhysicalId(r.getPhysicalId(), tableName);
+        }
         if (tableName == null || tableName.isBlank() || replicaRegion == null || replicaRegion.isBlank()) {
             return;
         }
@@ -4343,6 +4363,16 @@ public class CloudFormationResourceProvisioner {
             LOG.debugv("Could not remove replica {0} from table {1}: {2}",
                     replicaRegion, tableName, e.getMessage());
         }
+    }
+
+    private static String replicaRegionFromPhysicalId(String physicalId, String tableName) {
+        if (physicalId == null || physicalId.isBlank()) {
+            return null;
+        }
+        String prefix = tableName + "-";
+        return tableName != null && !tableName.isBlank() && physicalId.startsWith(prefix)
+                ? physicalId.substring(prefix.length())
+                : physicalId;
     }
 
     // Reads the ResourceProperties stashed at the last create/update (CR_PROPERTIES_ATTR).

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -339,6 +339,7 @@ public class CloudFormationResourceProvisioner {
                         provisionCognitoUserPoolClient(resource, properties, engine, region, accountId, stackName);
                 case "AWS::CloudFormation::CustomResource" ->
                         provisionCustomResource(resource, properties, engine, region, accountId, stackName);
+                case "Custom::DynamoDBReplica" -> provisionDynamoDbReplica(resource, properties, engine, region);
                 case "AWS::ECS::Cluster" -> provisionEcsCluster(resource, properties, engine, region, stackName);
                 case "AWS::ECS::TaskDefinition" -> provisionEcsTaskDefinition(resource, properties, engine, region, stackName);
                 case "AWS::ECS::Service" -> provisionEcsService(resource, properties, engine, region, stackName);
@@ -415,6 +416,12 @@ public class CloudFormationResourceProvisioner {
      */
     public void delete(StackResource resource, String region) {
         String resourceType = resource.getResourceType();
+        // Custom::DynamoDBReplica is applied natively against the DynamoDB service (not via its
+        // provider Lambda), so remove the replica the same way rather than invoking the handler.
+        if ("Custom::DynamoDBReplica".equals(resourceType)) {
+            deleteDynamoDbReplicaSafe(resource, region);
+            return;
+        }
         boolean custom = "AWS::CloudFormation::CustomResource".equals(resourceType)
                 || (resourceType != null && resourceType.startsWith("Custom::"));
         if (custom) {
@@ -4289,6 +4296,52 @@ public class CloudFormationResourceProvisioner {
         } catch (Exception e) {
             // Best-effort, consistent with the rest of delete().
             LOG.debugv("Custom resource {0} Delete invocation failed: {1}", r.getLogicalId(), e.getMessage());
+        }
+    }
+
+    /**
+     * Provisions a {@code Custom::DynamoDBReplica} — the custom resource the CDK legacy global-table
+     * (dynamodb.Table.replicationRegions) emits per replica region. Its provider Lambda simply calls
+     * DynamoDB UpdateTable with a ReplicaUpdates Create, so apply that directly rather than running
+     * the async CDK Provider framework. {@code Ref} (PhysicalResourceId) is the replica region.
+     */
+    private void provisionDynamoDbReplica(StackResource r, JsonNode props,
+                                          CloudFormationTemplateEngine engine, String region) {
+        String tableName = resolveOptional(props, "TableName", engine);
+        String replicaRegion = resolveOptional(props, "Region", engine);
+        if (tableName == null || tableName.isBlank()) {
+            throw new AwsException("ValidationError",
+                    "Custom::DynamoDBReplica " + r.getLogicalId() + " is missing TableName", 400);
+        }
+        if (replicaRegion == null || replicaRegion.isBlank()) {
+            throw new AwsException("ValidationError",
+                    "Custom::DynamoDBReplica " + r.getLogicalId() + " is missing Region", 400);
+        }
+        String priorRegion = r.getPhysicalId();
+        List<String> removeRegions = priorRegion != null
+                && !priorRegion.isBlank()
+                && !priorRegion.equals(replicaRegion)
+                ? List.of(priorRegion)
+                : List.of();
+        // Validate and persist replacement as one operation so an old-replica removal failure
+        // cannot leave the new replica applied while the resource still points at the old region.
+        dynamoDbService.applyReplicaUpdates(
+                tableName, List.of(replicaRegion), removeRegions, region);
+        r.setPhysicalId(replicaRegion);
+        r.getAttributes().put("TableName", tableName);
+    }
+
+    private void deleteDynamoDbReplicaSafe(StackResource r, String region) {
+        String tableName = r.getAttributes().get("TableName");
+        String replicaRegion = r.getPhysicalId();
+        if (tableName == null || tableName.isBlank() || replicaRegion == null || replicaRegion.isBlank()) {
+            return;
+        }
+        try {
+            dynamoDbService.applyReplicaUpdates(tableName, List.of(), List.of(replicaRegion), region);
+        } catch (Exception e) {
+            LOG.debugv("Could not remove replica {0} from table {1}: {2}",
+                    replicaRegion, tableName, e.getMessage());
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -1138,6 +1138,32 @@ public class DynamoDbJsonHandler {
 
     private Response handleUpdateTable(JsonNode request, String region) {
         String tableName = request.path("TableName").asText();
+        JsonNode replicaUpdates = request.path("ReplicaUpdates");
+        List<String> addRegions = new ArrayList<>();
+        List<String> removeRegions = new ArrayList<>();
+        List<String> updateRegions = new ArrayList<>();
+        if (replicaUpdates.isArray()) {
+            for (JsonNode update : replicaUpdates) {
+                JsonNode create = update.path("Create");
+                if (create.isObject()) {
+                    String replicaRegion = create.path("RegionName").asText(null);
+                    validateReplicaRegion(replicaRegion);
+                    addRegions.add(replicaRegion);
+                }
+                JsonNode delete = update.path("Delete");
+                if (delete.isObject()) {
+                    String replicaRegion = delete.path("RegionName").asText(null);
+                    validateReplicaRegion(replicaRegion);
+                    removeRegions.add(replicaRegion);
+                }
+                JsonNode updateNode = update.path("Update");
+                if (updateNode.isObject()) {
+                    String replicaRegion = updateNode.path("RegionName").asText(null);
+                    validateReplicaRegion(replicaRegion);
+                    updateRegions.add(replicaRegion);
+                }
+            }
+        }
         Long readCapacity = null;
         Long writeCapacity = null;
         JsonNode pt = request.path("ProvisionedThroughput");
@@ -1246,9 +1272,19 @@ public class DynamoDbJsonHandler {
             }
         }
 
+        if (!addRegions.isEmpty() || !removeRegions.isEmpty() || !updateRegions.isEmpty()) {
+            table = dynamoDbService.applyReplicaUpdates(tableName, addRegions, removeRegions, updateRegions, region);
+        }
+
         ObjectNode response = objectMapper.createObjectNode();
         response.set("TableDescription", tableToNode(table));
         return Response.ok(response).build();
+    }
+
+    private static void validateReplicaRegion(String replicaRegion) {
+        if (replicaRegion == null || replicaRegion.isBlank()) {
+            throw new AwsException("ValidationException", "Replica RegionName must not be empty", 400);
+        }
     }
 
     private Response handleDescribeTimeToLive(JsonNode request, String region) {
@@ -1912,6 +1948,22 @@ public class DynamoDbJsonHandler {
         warmThroughput.put("ReadUnitsPerSecond", 0);
         warmThroughput.put("WriteUnitsPerSecond", 0);
         node.set("WarmThroughput", warmThroughput);
+
+        // Global-table replicas. In a single-process emulator every region is served by this same
+        // table, so a replica is metadata; AWS reports each as an ACTIVE Replica and marks the table
+        // a 2019.11.21 global table.
+        List<String> replicaRegions = table.getReplicaRegions();
+        if (replicaRegions != null && !replicaRegions.isEmpty()) {
+            ArrayNode replicas = objectMapper.createArrayNode();
+            for (String replicaRegion : replicaRegions) {
+                ObjectNode replica = objectMapper.createObjectNode();
+                replica.put("RegionName", replicaRegion);
+                replica.put("ReplicaStatus", "ACTIVE");
+                replicas.add(replica);
+            }
+            node.set("Replicas", replicas);
+            node.put("GlobalTableVersion", "2019.11.21");
+        }
 
         ArrayNode keySchemaArray = objectMapper.createArrayNode();
         for (var ks : table.getKeySchema()) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -1224,6 +1224,11 @@ public class DynamoDbJsonHandler {
             }
         }
 
+        if (!addRegions.isEmpty() || !removeRegions.isEmpty() || !updateRegions.isEmpty()) {
+            dynamoDbService.validateReplicaUpdates(
+                    tableName, addRegions, removeRegions, updateRegions, region);
+        }
+
         TableDefinition table = dynamoDbService.updateTable(tableName, readCapacity, writeCapacity,
                 gsiCreates, gsiDeletes, newAttrDefs, region);
 

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -1307,6 +1307,66 @@ public class DynamoDbService {
         return table;
     }
 
+    // --- Global-table replicas ---
+
+    /**
+     * Applies global-table replica changes (the {@code ReplicaUpdates} of UpdateTable, and the
+     * legacy {@code dynamodb.Table.replicationRegions} replica custom resource). This single-process
+     * emulator serves every region from the same table, so a replica is tracked as metadata and
+     * surfaced by DescribeTable as an ACTIVE Replica; no cross-region copy is performed. Regions are
+     * de-duplicated and adding an existing / removing an absent one is a no-op, keeping repeated
+     * applies idempotent.
+     */
+    public TableDefinition applyReplicaUpdates(String tableName, List<String> addRegions,
+                                               List<String> removeRegions, String region) {
+        return applyReplicaUpdates(tableName, addRegions, removeRegions, Collections.emptyList(), region);
+    }
+
+    public TableDefinition applyReplicaUpdates(String tableName, List<String> addRegions,
+                                               List<String> removeRegions, List<String> updateRegions, String region) {
+        validateReplicaRegions(addRegions);
+        validateReplicaRegions(removeRegions);
+        validateReplicaRegions(updateRegions);
+        String canonicalTableName = canonicalTableName(region, tableName);
+        String storageKey = regionKey(region, canonicalTableName);
+        TableDefinition table = tableStore.get(storageKey)
+                .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
+        List<String> replicas = new ArrayList<>(table.getReplicaRegions());
+        if (updateRegions != null) {
+            for (String replicaRegion : updateRegions) {
+                if (!replicas.contains(replicaRegion)) {
+                    throw new AwsException("ValidationException",
+                            "Replica " + replicaRegion + " does not exist", 400);
+                }
+            }
+        }
+        if (removeRegions != null) {
+            replicas.removeAll(removeRegions);
+        }
+        if (addRegions != null) {
+            for (String r : addRegions) {
+                if (r != null && !r.isBlank() && !replicas.contains(r)) {
+                    replicas.add(r);
+                }
+            }
+        }
+        table.setReplicaRegions(replicas);
+        tableStore.put(storageKey, table);
+        LOG.infov("Updated replicas for table {0} in region {1}: {2}", canonicalTableName, region, replicas);
+        return table;
+    }
+
+    private static void validateReplicaRegions(List<String> replicaRegions) {
+        if (replicaRegions == null) {
+            return;
+        }
+        for (String replicaRegion : replicaRegions) {
+            if (replicaRegion == null || replicaRegion.isBlank()) {
+                throw new AwsException("ValidationException", "Replica RegionName must not be empty", 400);
+            }
+        }
+    }
+
     // --- TTL ---
 
     public void updateTimeToLive(String tableName, String ttlAttributeName, boolean enabled, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -1318,8 +1318,9 @@ public class DynamoDbService {
      * legacy {@code dynamodb.Table.replicationRegions} replica custom resource). This single-process
      * emulator serves every region from the same table, so a replica is tracked as metadata and
      * surfaced by DescribeTable as an ACTIVE Replica; no cross-region copy is performed. Regions are
-     * de-duplicated and adding an existing / removing an absent one is a no-op, keeping repeated
-     * applies idempotent.
+     * de-duplicated and adding an existing / removing an absent one is a no-op, keeping
+     * CloudFormation re-applies and cleanup idempotent. Update remains strict because it represents
+     * a settings change and has no target when the replica is absent.
      */
     public TableDefinition applyReplicaUpdates(String tableName, List<String> addRegions,
                                                List<String> removeRegions, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -1324,22 +1324,9 @@ public class DynamoDbService {
 
     public TableDefinition applyReplicaUpdates(String tableName, List<String> addRegions,
                                                List<String> removeRegions, List<String> updateRegions, String region) {
-        validateReplicaRegions(addRegions);
-        validateReplicaRegions(removeRegions);
-        validateReplicaRegions(updateRegions);
-        String canonicalTableName = canonicalTableName(region, tableName);
-        String storageKey = regionKey(region, canonicalTableName);
-        TableDefinition table = tableStore.get(storageKey)
-                .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
+        TableDefinition table = validateReplicaUpdatesAndGetTable(
+                tableName, addRegions, removeRegions, updateRegions, region);
         List<String> replicas = new ArrayList<>(table.getReplicaRegions());
-        if (updateRegions != null) {
-            for (String replicaRegion : updateRegions) {
-                if (!replicas.contains(replicaRegion)) {
-                    throw new AwsException("ValidationException",
-                            "Replica " + replicaRegion + " does not exist", 400);
-                }
-            }
-        }
         if (removeRegions != null) {
             replicas.removeAll(removeRegions);
         }
@@ -1351,8 +1338,35 @@ public class DynamoDbService {
             }
         }
         table.setReplicaRegions(replicas);
-        tableStore.put(storageKey, table);
+        String canonicalTableName = canonicalTableName(region, tableName);
+        tableStore.put(regionKey(region, canonicalTableName), table);
         LOG.infov("Updated replicas for table {0} in region {1}: {2}", canonicalTableName, region, replicas);
+        return table;
+    }
+
+    public void validateReplicaUpdates(String tableName, List<String> addRegions,
+                                       List<String> removeRegions, List<String> updateRegions, String region) {
+        validateReplicaUpdatesAndGetTable(tableName, addRegions, removeRegions, updateRegions, region);
+    }
+
+    private TableDefinition validateReplicaUpdatesAndGetTable(
+            String tableName, List<String> addRegions, List<String> removeRegions,
+            List<String> updateRegions, String region) {
+        validateReplicaRegions(addRegions);
+        validateReplicaRegions(removeRegions);
+        validateReplicaRegions(updateRegions);
+        String canonicalTableName = canonicalTableName(region, tableName);
+        String storageKey = regionKey(region, canonicalTableName);
+        TableDefinition table = tableStore.get(storageKey)
+                .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
+        if (updateRegions != null) {
+            for (String replicaRegion : updateRegions) {
+                if (!table.getReplicaRegions().contains(replicaRegion)) {
+                    throw new AwsException("ValidationException",
+                            "Replica " + replicaRegion + " does not exist", 400);
+                }
+            }
+        }
         return table;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -52,6 +52,10 @@ import java.util.zip.GZIPOutputStream;
 @ApplicationScoped
 public class DynamoDbService {
 
+    private static final String LOCAL_REPLICA_UPDATE_ERROR =
+            "Cannot add, delete, or update the local region through ReplicaUpdates. "
+                    + "Use CreateTable, DeleteTable, or UpdateTable as required.";
+
     private static final Logger LOG = Logger.getLogger(DynamoDbService.class);
 
     private final StorageBackend<String, TableDefinition> tableStore;
@@ -1352,9 +1356,9 @@ public class DynamoDbService {
     private TableDefinition validateReplicaUpdatesAndGetTable(
             String tableName, List<String> addRegions, List<String> removeRegions,
             List<String> updateRegions, String region) {
-        validateReplicaRegions(addRegions);
-        validateReplicaRegions(removeRegions);
-        validateReplicaRegions(updateRegions);
+        validateReplicaRegions(addRegions, region);
+        validateReplicaRegions(removeRegions, region);
+        validateReplicaRegions(updateRegions, region);
         String canonicalTableName = canonicalTableName(region, tableName);
         String storageKey = regionKey(region, canonicalTableName);
         TableDefinition table = tableStore.get(storageKey)
@@ -1370,13 +1374,16 @@ public class DynamoDbService {
         return table;
     }
 
-    private static void validateReplicaRegions(List<String> replicaRegions) {
+    private static void validateReplicaRegions(List<String> replicaRegions, String localRegion) {
         if (replicaRegions == null) {
             return;
         }
         for (String replicaRegion : replicaRegions) {
             if (replicaRegion == null || replicaRegion.isBlank()) {
                 throw new AwsException("ValidationException", "Replica RegionName must not be empty", 400);
+            }
+            if (replicaRegion.equals(localRegion)) {
+                throw new AwsException("ValidationException", LOCAL_REPLICA_UPDATE_ERROR, 400);
             }
         }
     }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
@@ -47,6 +47,9 @@ public class TableDefinition {
     private String tableClass; // "STANDARD" or "STANDARD_INFREQUENT_ACCESS"
     private Integer onDemandMaxReadRequestUnits;
     private Integer onDemandMaxWriteRequestUnits;
+    // Replica regions for a global table (single-process emulator backs them all with this table's
+    // data; the list drives the DescribeTable Replicas/GlobalTableVersion projection).
+    private List<String> replicaRegions;
 
     public TableDefinition() {
         this.keySchema = new ArrayList<>();
@@ -56,6 +59,7 @@ public class TableDefinition {
         this.localSecondaryIndexes = new ArrayList<>();
         this.pointInTimeRecoveryRecoveryPeriodInDays = 35;
         this.kinesisStreamingDestinations = new ArrayList<>();
+        this.replicaRegions = new ArrayList<>();
     }
 
     public TableDefinition(String tableName,
@@ -83,6 +87,7 @@ public class TableDefinition {
         this.localSecondaryIndexes = new ArrayList<>();
         this.pointInTimeRecoveryRecoveryPeriodInDays = 35;
         this.kinesisStreamingDestinations = new ArrayList<>();
+        this.replicaRegions = new ArrayList<>();
     }
 
     public String getTableName() { return tableName; }
@@ -187,6 +192,13 @@ public class TableDefinition {
 
     public String getTableClass() { return tableClass; }
     public void setTableClass(String tableClass) { this.tableClass = tableClass; }
+
+    public List<String> getReplicaRegions() {
+        return replicaRegions != null ? replicaRegions : new ArrayList<>();
+    }
+    public void setReplicaRegions(List<String> replicaRegions) {
+        this.replicaRegions = replicaRegions != null ? replicaRegions : new ArrayList<>();
+    }
 
     public Integer getOnDemandMaxReadRequestUnits() { return onDemandMaxReadRequestUnits; }
     public void setOnDemandMaxReadRequestUnits(Integer v) { this.onDemandMaxReadRequestUnits = v; }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationDynamoDbReplicaIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationDynamoDbReplicaIntegrationTest.java
@@ -140,6 +140,32 @@ class CloudFormationDynamoDbReplicaIntegrationTest {
     }
 
     @Test
+    void updateTableRejectsMissingReplicaBeforeApplyingOtherChanges() {
+        String tableName = "gt-missing-replica-" + Long.toString(System.nanoTime(), 36);
+        createTable(tableName);
+
+        given()
+            .contentType(DDB_CONTENT_TYPE)
+            .header("Authorization", DDB_AUTH)
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateTable")
+            .body("{\"TableName\":\"" + tableName + "\","
+                    + "\"DeletionProtectionEnabled\":true,"
+                    + "\"StreamSpecification\":{\"StreamEnabled\":true,"
+                    + "\"StreamViewType\":\"NEW_IMAGE\"},"
+                    + "\"ReplicaUpdates\":[{\"Update\":{\"RegionName\":\"eu-west-1\"}}]}")
+        .when().post("/").then().statusCode(400)
+            .body("__type", containsString("ValidationException"));
+
+        String table = ddb("DescribeTable", "{\"TableName\":\"" + tableName + "\"}");
+        assertTrue(table.contains("\"DeletionProtectionEnabled\":false"),
+                "rejected update must not partially mutate the table: " + table);
+        assertFalse(table.contains("\"LatestStreamArn\""),
+                "rejected update must not enable a stream: " + table);
+        assertFalse(table.contains("\"Replicas\""),
+                "rejected update must not add the missing replica: " + table);
+    }
+
+    @Test
     void updateTableReplicaUpdateValidatesRegionAndKeepsReplica() {
         String tableName = "gt-update-replica-" + Long.toString(System.nanoTime(), 36);
         createTable(tableName);

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationDynamoDbReplicaIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationDynamoDbReplicaIntegrationTest.java
@@ -11,6 +11,7 @@ import java.time.Duration;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -131,6 +132,31 @@ class CloudFormationDynamoDbReplicaIntegrationTest {
                     + "\"ReplicaUpdates\":[{\"" + action + "\":{\"RegionName\":\"\"}}]}")
         .when().post("/").then().statusCode(400)
             .body("__type", containsString("ValidationException"));
+
+        String table = ddb("DescribeTable", "{\"TableName\":\"" + tableName + "\"}");
+        assertTrue(table.contains("\"DeletionProtectionEnabled\":false"),
+                "rejected update must not partially mutate the table: " + table);
+        assertFalse(table.contains("\"Replicas\""),
+                "rejected update must not add replicas: " + table);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Create", "Delete", "Update"})
+    void updateTableRejectsLocalRegionBeforeApplyingOtherChanges(String action) {
+        String tableName = "gt-local-region-" + Long.toString(System.nanoTime(), 36);
+        createTable(tableName);
+
+        given()
+            .contentType(DDB_CONTENT_TYPE)
+            .header("Authorization", DDB_AUTH)
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateTable")
+            .body("{\"TableName\":\"" + tableName + "\","
+                    + "\"DeletionProtectionEnabled\":true,"
+                    + "\"ReplicaUpdates\":[{\"" + action + "\":{\"RegionName\":\"us-east-1\"}}]}")
+        .when().post("/").then().statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body("message", equalTo("Cannot add, delete, or update the local region through ReplicaUpdates. "
+                    + "Use CreateTable, DeleteTable, or UpdateTable as required."));
 
         String table = ddb("DescribeTable", "{\"TableName\":\"" + tableName + "\"}");
         assertTrue(table.contains("\"DeletionProtectionEnabled\":false"),

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationDynamoDbReplicaIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationDynamoDbReplicaIntegrationTest.java
@@ -1,0 +1,287 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Duration;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Verifies global-table v2 replica support: the DynamoDB API path (UpdateTable ReplicaUpdates +
+ * DescribeTable Replicas/GlobalTableVersion) and the CloudFormation {@code Custom::DynamoDBReplica}
+ * resource the CDK legacy global-table pattern ({@code dynamodb.Table.replicationRegions}) emits.
+ *
+ * <p>This single-process emulator serves every region from the same table, so a replica is tracked
+ * as metadata and reported as an ACTIVE Replica, matching what real DynamoDB returns for a
+ * {@code 2019.11.21} global table — with no provider Lambda required. All resources are
+ * metadata-only (no container), so the test is Docker-free.
+ */
+@QuarkusTest
+class CloudFormationDynamoDbReplicaIntegrationTest {
+
+    private static final String CFN_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/cloudformation/aws4_request";
+    private static final String DDB_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/dynamodb/aws4_request";
+    private static final String DDB_CONTENT_TYPE = "application/x-amz-json-1.0";
+    private static final String REPLICA_REGION = "us-west-2";
+    private static final Duration STACK_DELETE_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration STACK_DELETE_POLL_INTERVAL = Duration.ofMillis(50);
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    private void createStack(String stackName, String template) {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when().post("/").then().statusCode(200);
+    }
+
+    private void assertStackStatus(String stackName, String status) {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when().post("/").then().statusCode(200)
+            .body(containsString("<StackStatus>" + status + "</StackStatus>"));
+    }
+
+    private void deleteStack(String stackName) {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DeleteStack")
+            .formParam("StackName", stackName)
+        .when().post("/").then().statusCode(200);
+    }
+
+    private String ddb(String target, String body) {
+        return given()
+            .contentType(DDB_CONTENT_TYPE)
+            .header("Authorization", DDB_AUTH)
+            .header("X-Amz-Target", "DynamoDB_20120810." + target)
+            .body(body)
+        .when().post("/").then().statusCode(200).extract().asString();
+    }
+
+    private void createTable(String tableName) {
+        ddb("CreateTable", "{\"TableName\":\"" + tableName + "\","
+                + "\"AttributeDefinitions\":[{\"AttributeName\":\"pk\",\"AttributeType\":\"S\"}],"
+                + "\"KeySchema\":[{\"AttributeName\":\"pk\",\"KeyType\":\"HASH\"}],"
+                + "\"BillingMode\":\"PAY_PER_REQUEST\"}");
+    }
+
+    @Test
+    void updateTableReplicaUpdatesAddAndRemoveReplica() {
+        String tableName = "gt-api-table-" + Long.toString(System.nanoTime(), 36);
+        createTable(tableName);
+
+        // Add a replica via UpdateTable ReplicaUpdates -> Create.
+        String added = ddb("UpdateTable", "{\"TableName\":\"" + tableName + "\","
+                + "\"ReplicaUpdates\":[{\"Create\":{\"RegionName\":\"" + REPLICA_REGION + "\"}}]}");
+        org.junit.jupiter.api.Assertions.assertTrue(added.contains("\"RegionName\":\"" + REPLICA_REGION + "\""),
+                "UpdateTable response should report the new replica");
+
+        // DescribeTable reports it as an ACTIVE replica on a 2019.11.21 global table.
+        String afterAdd = ddb("DescribeTable", "{\"TableName\":\"" + tableName + "\"}");
+        org.junit.jupiter.api.Assertions.assertTrue(
+                afterAdd.contains("\"RegionName\":\"" + REPLICA_REGION + "\"")
+                        && afterAdd.contains("\"ReplicaStatus\":\"ACTIVE\"")
+                        && afterAdd.contains("\"GlobalTableVersion\":\"2019.11.21\""),
+                "DescribeTable should show the ACTIVE replica + global-table version, was: " + afterAdd);
+
+        // Remove it via UpdateTable ReplicaUpdates -> Delete; DescribeTable no longer lists it.
+        ddb("UpdateTable", "{\"TableName\":\"" + tableName + "\","
+                + "\"ReplicaUpdates\":[{\"Delete\":{\"RegionName\":\"" + REPLICA_REGION + "\"}}]}");
+        String afterRemove = ddb("DescribeTable", "{\"TableName\":\"" + tableName + "\"}");
+        org.junit.jupiter.api.Assertions.assertFalse(afterRemove.contains(REPLICA_REGION),
+                "DescribeTable should no longer list the removed replica, was: " + afterRemove);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Create", "Delete", "Update"})
+    void updateTableRejectsBlankReplicaRegionBeforeApplyingOtherChanges(String action) {
+        String tableName = "gt-invalid-region-" + Long.toString(System.nanoTime(), 36);
+        createTable(tableName);
+
+        given()
+            .contentType(DDB_CONTENT_TYPE)
+            .header("Authorization", DDB_AUTH)
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateTable")
+            .body("{\"TableName\":\"" + tableName + "\","
+                    + "\"DeletionProtectionEnabled\":true,"
+                    + "\"ReplicaUpdates\":[{\"" + action + "\":{\"RegionName\":\"\"}}]}")
+        .when().post("/").then().statusCode(400)
+            .body("__type", containsString("ValidationException"));
+
+        String table = ddb("DescribeTable", "{\"TableName\":\"" + tableName + "\"}");
+        assertTrue(table.contains("\"DeletionProtectionEnabled\":false"),
+                "rejected update must not partially mutate the table: " + table);
+        assertFalse(table.contains("\"Replicas\""),
+                "rejected update must not add replicas: " + table);
+    }
+
+    @Test
+    void updateTableReplicaUpdateValidatesRegionAndKeepsReplica() {
+        String tableName = "gt-update-replica-" + Long.toString(System.nanoTime(), 36);
+        createTable(tableName);
+        ddb("UpdateTable", "{\"TableName\":\"" + tableName + "\","
+                + "\"ReplicaUpdates\":[{\"Create\":{\"RegionName\":\"us-west-2\"}}]}");
+
+        given()
+            .contentType(DDB_CONTENT_TYPE)
+            .header("Authorization", DDB_AUTH)
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateTable")
+            .body("{\"TableName\":\"" + tableName + "\","
+                    + "\"DeletionProtectionEnabled\":true,"
+                    + "\"ReplicaUpdates\":[{\"Update\":{\"RegionName\":\"us-west-2\"}}]}")
+        .when().post("/").then().statusCode(200)
+            .body("TableDescription.Replicas[0].RegionName", containsString("us-west-2"));
+
+        String table = ddb("DescribeTable", "{\"TableName\":\"" + tableName + "\"}");
+        assertTrue(table.contains("\"DeletionProtectionEnabled\":true"),
+                "valid update should apply the other UpdateTable change: " + table);
+        assertTrue(table.contains("\"RegionName\":\"us-west-2\""),
+                "valid update should keep the existing replica: " + table);
+    }
+
+    /** Mirrors the CDK legacy global-table synth: a table plus a Custom::DynamoDBReplica for a peer region. */
+    private static String tableAndReplicaTemplate(String tableName) {
+        return """
+                {
+                  "Resources": {
+                    "Table": {
+                      "Type": "AWS::DynamoDB::Table",
+                      "Properties": {
+                        "TableName": "%s",
+                        "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                        "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                        "BillingMode": "PAY_PER_REQUEST"
+                      }
+                    },
+                    "Replica": {
+                      "Type": "Custom::DynamoDBReplica",
+                      "DependsOn": "Table",
+                      "Properties": {
+                        "ServiceToken": "arn:aws:lambda:us-east-1:000000000000:function:replica-provider",
+                        "TableName": {"Ref": "Table"},
+                        "Region": "%s"
+                      }
+                    }
+                  }
+                }
+                """.formatted(tableName, REPLICA_REGION);
+    }
+
+    @Test
+    void dynamoDbReplicaCustomResourceAddsReplicaVisibleInDescribeTable() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String tableName = "gt-replica-table-" + suffix;
+        String stackName = "gt-replica-stack-" + suffix;
+
+        createStack(stackName, tableAndReplicaTemplate(tableName));
+        assertStackStatus(stackName, "CREATE_COMPLETE");
+
+        // DescribeTable (same JVM => same DynamoDbService store) reports the replica as an ACTIVE
+        // Replica and the table as a 2019.11.21 global table. Read from the stack region (us-east-1).
+        given()
+            .contentType(DDB_CONTENT_TYPE)
+            .header("Authorization", DDB_AUTH)
+            .header("X-Amz-Target", "DynamoDB_20120810.DescribeTable")
+            .body("{\"TableName\":\"" + tableName + "\"}")
+        .when().post("/").then().statusCode(200)
+            .body(containsString("\"RegionName\":\"" + REPLICA_REGION + "\""))
+            .body(containsString("\"ReplicaStatus\":\"ACTIVE\""))
+            .body(containsString("\"GlobalTableVersion\":\"2019.11.21\""));
+
+        deleteStack(stackName);
+    }
+
+    @Test
+    void deletingStackDetachesReplicaFromSurvivingTable() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String tableName = "gt-ext-table-" + suffix;
+        String stackName = "gt-ext-replica-stack-" + suffix;
+
+        // Table owned OUTSIDE the stack, so it survives DeleteStack — isolates the replica detach
+        // (deleteDynamoDbReplicaSafe) from a cascade table delete.
+        createTable(tableName);
+
+        String template = """
+                {
+                  "Resources": {
+                    "Replica": {
+                      "Type": "Custom::DynamoDBReplica",
+                      "Properties": {
+                        "ServiceToken": "arn:aws:lambda:us-east-1:000000000000:function:replica-provider",
+                        "TableName": "%s",
+                        "Region": "%s"
+                      }
+                    }
+                  }
+                }
+                """.formatted(tableName, REPLICA_REGION);
+
+        createStack(stackName, template);
+        assertStackStatus(stackName, "CREATE_COMPLETE");
+
+        // The replica is attached to the pre-existing table.
+        given()
+            .contentType(DDB_CONTENT_TYPE)
+            .header("Authorization", DDB_AUTH)
+            .header("X-Amz-Target", "DynamoDB_20120810.DescribeTable")
+            .body("{\"TableName\":\"" + tableName + "\"}")
+        .when().post("/").then().statusCode(200)
+            .body(containsString("\"RegionName\":\"" + REPLICA_REGION + "\""));
+
+        // Deleting the stack must detach the replica from the surviving table (async delete).
+        deleteStack(stackName);
+        awaitStackGone(stackName);
+
+        // The table still exists, but its replica is gone.
+        given()
+            .contentType(DDB_CONTENT_TYPE)
+            .header("Authorization", DDB_AUTH)
+            .header("X-Amz-Target", "DynamoDB_20120810.DescribeTable")
+            .body("{\"TableName\":\"" + tableName + "\"}")
+        .when().post("/").then().statusCode(200)
+            .body(containsString("\"TableName\":\"" + tableName + "\""))
+            .body(not(containsString(REPLICA_REGION)));
+    }
+
+    private void awaitStackGone(String stackName) {
+        await()
+            .atMost(STACK_DELETE_TIMEOUT)
+            .pollInterval(STACK_DELETE_POLL_INTERVAL)
+            .untilAsserted(() -> {
+                String body = given()
+                    .contentType("application/x-www-form-urlencoded")
+                    .header("Authorization", CFN_AUTH)
+                    .formParam("Action", "DescribeStacks")
+                    .formParam("StackName", stackName)
+                .when().post("/").then().extract().asString();
+                if (body.contains("<StackStatus>DELETE_FAILED</StackStatus>")) {
+                    fail("stack delete failed: " + body);
+                }
+                assertTrue(body.contains("does not exist"), "stack still exists: " + body);
+            });
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/DynamoDbReplicaCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/DynamoDbReplicaCfnProvisionerTest.java
@@ -1,0 +1,78 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.CloudFormationResourceRegistry;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class DynamoDbReplicaCfnProvisionerTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private DynamoDbService dynamoDbService;
+    private CloudFormationResourceProvisioner provisioner;
+
+    @BeforeEach
+    void setUp() {
+        dynamoDbService = mock(DynamoDbService.class);
+        provisioner = new CloudFormationResourceProvisioner(
+                null, null, null, dynamoDbService, null, null, null, null, null, null,
+                null, null, null, null, null, null, mapper, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null,
+                new CloudFormationResourceRegistry(List.of()));
+    }
+
+    @Test
+    void changingReplicaRegionFailsWithoutOverwritingPhysicalIdWhenOldRemovalFails() throws Exception {
+        Set<String> replicas = new HashSet<>(Set.of("us-west-2"));
+        when(dynamoDbService.applyReplicaUpdates(
+                eq("global-table"), anyList(), anyList(), eq("us-east-1")))
+                .thenAnswer(invocation -> {
+                    List<String> additions = invocation.getArgument(1);
+                    List<String> removals = invocation.getArgument(2);
+                    if (removals.contains("us-west-2")) {
+                        throw new AwsException("InternalError", "simulated removal failure", 500);
+                    }
+                    replicas.removeAll(removals);
+                    replicas.addAll(additions);
+                    return null;
+                });
+
+        StackResource resource = provisioner.provision(
+                "Replica", "Custom::DynamoDBReplica",
+                mapper.readTree("""
+                        {"TableName":"global-table","Region":"eu-west-1"}
+                        """),
+                engine(), "us-east-1", "000000000000", "my-stack", "us-west-2", Map.of());
+
+        assertEquals("CREATE_FAILED", resource.getStatus());
+        assertEquals("simulated removal failure", resource.getStatusReason());
+        assertEquals("us-west-2", resource.getPhysicalId());
+        assertEquals(Set.of("us-west-2"), replicas);
+        verify(dynamoDbService).applyReplicaUpdates(
+                "global-table", List.of("eu-west-1"), List.of("us-west-2"), "us-east-1");
+        verifyNoMoreInteractions(dynamoDbService);
+    }
+
+    private CloudFormationTemplateEngine engine() {
+        return new CloudFormationTemplateEngine("000000000000", "us-east-1", "my-stack",
+                "stack/id", Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), mapper,
+                (Function<String, String>) name -> null);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/DynamoDbReplicaCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/DynamoDbReplicaCfnProvisionerTest.java
@@ -34,7 +34,7 @@ class DynamoDbReplicaCfnProvisionerTest {
         provisioner = new CloudFormationResourceProvisioner(
                 null, null, null, dynamoDbService, null, null, null, null, null, null,
                 null, null, null, null, null, null, mapper, null, null, null, null, null,
-                null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null,
                 new CloudFormationResourceRegistry(List.of()));
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/DynamoDbReplicaCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/DynamoDbReplicaCfnProvisionerTest.java
@@ -59,14 +59,50 @@ class DynamoDbReplicaCfnProvisionerTest {
                 mapper.readTree("""
                         {"TableName":"global-table","Region":"eu-west-1"}
                         """),
-                engine(), "us-east-1", "000000000000", "my-stack", "us-west-2", Map.of());
+                engine(), "us-east-1", "000000000000", "my-stack", "global-table-us-west-2",
+                Map.of("TableName", "global-table", "__FlociDynamoDbReplicaRegion", "us-west-2"));
 
         assertEquals("CREATE_FAILED", resource.getStatus());
         assertEquals("simulated removal failure", resource.getStatusReason());
-        assertEquals("us-west-2", resource.getPhysicalId());
+        assertEquals("global-table-us-west-2", resource.getPhysicalId());
         assertEquals(Set.of("us-west-2"), replicas);
         verify(dynamoDbService).applyReplicaUpdates(
                 "global-table", List.of("eu-west-1"), List.of("us-west-2"), "us-east-1");
+        verifyNoMoreInteractions(dynamoDbService);
+    }
+
+    @Test
+    void usesCdkPhysicalIdAndPersistsReplicaDeleteProperties() throws Exception {
+        StackResource resource = provisioner.provision(
+                "Replica", "Custom::DynamoDBReplica",
+                mapper.readTree("""
+                        {"TableName":"global-table","Region":"us-west-2","SkipReplicaDeletion":false}
+                        """),
+                engine(), "us-east-1", "000000000000", "my-stack");
+
+        assertEquals("CREATE_COMPLETE", resource.getStatus());
+        assertEquals("global-table-us-west-2", resource.getPhysicalId());
+        assertEquals("global-table", resource.getAttributes().get("TableName"));
+        assertEquals("us-west-2", resource.getAttributes().get("__FlociDynamoDbReplicaRegion"));
+        assertEquals("false", resource.getAttributes().get("__FlociDynamoDbReplicaSkipDeletion"));
+        verify(dynamoDbService).applyReplicaUpdates(
+                "global-table", List.of("us-west-2"), List.of(), "us-east-1");
+        verifyNoMoreInteractions(dynamoDbService);
+    }
+
+    @Test
+    void deleteKeepsReplicaWhenSkipReplicaDeletionIsTrue() throws Exception {
+        StackResource resource = provisioner.provision(
+                "Replica", "Custom::DynamoDBReplica",
+                mapper.readTree("""
+                        {"TableName":"global-table","Region":"us-west-2","SkipReplicaDeletion":true}
+                        """),
+                engine(), "us-east-1", "000000000000", "my-stack");
+
+        provisioner.delete(resource, "us-east-1");
+
+        verify(dynamoDbService).applyReplicaUpdates(
+                "global-table", List.of("us-west-2"), List.of(), "us-east-1");
         verifyNoMoreInteractions(dynamoDbService);
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -132,6 +132,21 @@ class DynamoDbServiceTest {
     }
 
     @Test
+    void invalidReplicaUpdateLeavesExistingReplicasUnchanged() {
+        createUsersTable("us-east-1");
+        service.applyReplicaUpdates(
+                "Users", List.of("eu-west-1"), List.of(), List.of(), "us-east-1");
+
+        AwsException exception = assertThrows(AwsException.class, () ->
+                service.applyReplicaUpdates(
+                        "Users", List.of(), List.of(), List.of("ap-south-1"), "us-east-1"));
+
+        assertEquals("ValidationException", exception.getErrorCode());
+        assertEquals(List.of("eu-west-1"),
+                service.describeTable("Users", "us-east-1").getReplicaRegions());
+    }
+
+    @Test
     void deleteTable() {
         String region = "eu-west-1";
         createUsersTable(region);

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -121,6 +121,17 @@ class DynamoDbServiceTest {
     }
 
     @Test
+    void applyReplicaUpdatesRejectsBlankRegion() {
+        createUsersTable("us-east-1");
+
+        AwsException exception = assertThrows(AwsException.class,
+                () -> service.applyReplicaUpdates("Users", List.of(" "), List.of(), "us-east-1"));
+
+        assertEquals("ValidationException", exception.getErrorCode());
+        assertEquals(400, exception.getHttpStatus());
+    }
+
+    @Test
     void deleteTable() {
         String region = "eu-west-1";
         createUsersTable(region);

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -132,6 +132,22 @@ class DynamoDbServiceTest {
     }
 
     @Test
+    void repeatedReplicaCreateAndDeleteAreIdempotent() {
+        createUsersTable("us-east-1");
+
+        service.applyReplicaUpdates("Users", List.of("eu-west-1"), List.of(), "us-east-1");
+        service.applyReplicaUpdates("Users", List.of("eu-west-1"), List.of(), "us-east-1");
+
+        assertEquals(List.of("eu-west-1"),
+                service.describeTable("Users", "us-east-1").getReplicaRegions());
+
+        service.applyReplicaUpdates("Users", List.of(), List.of("eu-west-1"), "us-east-1");
+        service.applyReplicaUpdates("Users", List.of(), List.of("eu-west-1"), "us-east-1");
+
+        assertTrue(service.describeTable("Users", "us-east-1").getReplicaRegions().isEmpty());
+    }
+
+    @Test
     void invalidReplicaUpdateLeavesExistingReplicasUnchanged() {
         createUsersTable("us-east-1");
         service.applyReplicaUpdates(


### PR DESCRIPTION
## Summary

DynamoDB global tables (version 2019.11.21) were unsupported:
- `UpdateTable` ignored `ReplicaUpdates`.
- `DescribeTable` never reported `Replicas` or `GlobalTableVersion`.
- A CloudFormation `Custom::DynamoDBReplica` resource fell through to the generic custom-resource path and tried to invoke a provider Lambda the emulator does not run, so the replica never materialized.

This change:
- Applies `UpdateTable` `ReplicaUpdates` for `Create`, `Delete`, and `Update`.
- Reports each tracked replica region as an `ACTIVE` replica with `GlobalTableVersion` `2019.11.21`.
- Applies `Custom::DynamoDBReplica` directly against the DynamoDB store, and removes the replica when the owning stack is deleted.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## AWS Compatibility

This follows DynamoDB global tables v2 request/response shapes:
- `UpdateTableInput.ReplicaUpdates` is a list of `ReplicationGroupUpdate` values with `Create`, `Delete`, or `Update`.
- Each replica action validates `RegionName`.
- `Update` is accepted for an existing tracked replica as a metadata/settings update. Floci does not emulate per-replica KMS, throughput override, table class override, or replica GSI settings yet.
- `TableDescription` includes `Replicas` entries with `RegionName` and `ReplicaStatus`, plus `GlobalTableVersion`.

Documented emulator simplifications:
- Replicas are metadata in this single-process emulator; no cross-region data copy is performed.
- Replica status is reported as `ACTIVE` immediately.
- `DescribeTable` lists added replica regions; it does not also include the queried/primary region in `Replicas`.
- `CreateTable` does not accept a `Replicas` input member.

## Validation

- `mise exec java@25 -- ./mvnw test -q -Dtest=CloudFormationDynamoDbReplicaIntegrationTest,DynamoDbReplicaCfnProvisionerTest,DynamoDbServiceTest`
- `FLOCI_ENDPOINT=http://localhost:4571 mise exec java@25 -- ./mvnw -f compatibility-tests/sdk-test-java/pom.xml test -q -Dtest=DynamoDbTest`
- `git diff --check`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
