### PR TITLE
feat(ses): honor ConfigurationSetName on CreateEmailIdentity (v2)

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesEmailIdentityConfigurationSetTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesEmailIdentityConfigurationSetTest.java
@@ -104,4 +104,19 @@ class SesEmailIdentityConfigurationSetTest {
                         .build()))
                 .isInstanceOf(NotFoundException.class);
     }
+
+    @Test
+    @Order(4)
+    void createEmailIdentity_withConfigurationSet_readsBack() {
+        String id = "sdk-cs-oncreate-" + TestFixtures.uniqueName() + "@example.com";
+        sesV2.createEmailIdentity(CreateEmailIdentityRequest.builder()
+                .emailIdentity(id).configurationSetName(configSet).build());
+        try {
+            assertThat(sesV2.getEmailIdentity(GetEmailIdentityRequest.builder()
+                    .emailIdentity(id).build()).configurationSetName())
+                    .isEqualTo(configSet);
+        } finally {
+            sesV2.deleteEmailIdentity(DeleteEmailIdentityRequest.builder().emailIdentity(id).build());
+        }
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -117,6 +117,12 @@ public class SesController {
                         "Email identity " + emailIdentity + " already exist.", 400);
             }
 
+            // Parse Tags up front. parseTagsArray is pure (it only reads the node), so validating the
+            // shape before creating the identity keeps the call atomic — a malformed Tags value fails
+            // without leaving a half-created identity behind, matching AWS and the ConfigurationSetName
+            // pre-check below.
+            List<Tag> parsedTags = parseTagsArray(request.path("Tags"));
+
             // Verified against AWS: a non-existent ConfigurationSetName fails the whole call
             // (NotFoundException) without creating the identity, so validate it before creating.
             // Only the empty string means "no default configuration set" (consistent with the
@@ -135,7 +141,6 @@ public class SesController {
                 sesService.setEmailIdentityConfigurationSet(emailIdentity, configurationSetName, region);
             }
 
-            List<Tag> parsedTags = parseTagsArray(request.path("Tags"));
             if (parsedTags != null) {
                 sesService.setIdentityTags(emailIdentity, region, parsedTags);
             }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -93,15 +93,38 @@ public class SesController {
             if (emailIdentity == null || emailIdentity.isBlank()) {
                 throw new AwsException("BadRequestException", "EmailIdentity is required.", 400);
             }
+            // ConfigurationSetName is a String; AWS rejects a non-string with a 400 (empty body).
+            // Don't coerce via asText (which would turn 123 into "123").
+            JsonNode configSetNode = request.path("ConfigurationSetName");
+            String configurationSetName = null;
+            if (!configSetNode.isMissingNode() && !configSetNode.isNull()) {
+                if (!configSetNode.isTextual()) {
+                    throw new AwsException("SerializationException", null, 400);
+                }
+                configurationSetName = configSetNode.textValue();
+            }
 
             if (sesService.getIdentityVerificationAttributes(emailIdentity, region) != null) {
                 throw new AwsException("AlreadyExistsException",
                         "Email identity " + emailIdentity + " already exist.", 400);
             }
 
+            // Verified against AWS: a non-existent ConfigurationSetName fails the whole call
+            // (NotFoundException) without creating the identity, so validate it before creating.
+            // (AWS stores a blank name verbatim; Floci treats blank as "no default configuration set"
+            // to avoid persisting a default that no configuration set can satisfy.)
+            boolean hasConfigSet = configurationSetName != null && !configurationSetName.isBlank();
+            if (hasConfigSet) {
+                sesService.getConfigurationSet(configurationSetName, region);
+            }
+
             Identity identity = emailIdentity.contains("@")
                     ? sesService.verifyEmailIdentity(emailIdentity, region)
                     : sesService.verifyDomainIdentity(emailIdentity, region);
+
+            if (hasConfigSet) {
+                sesService.setEmailIdentityConfigurationSet(emailIdentity, configurationSetName, region);
+            }
 
             List<Tag> parsedTags = parseTagsArray(request.path("Tags"));
             if (parsedTags != null) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -89,7 +89,14 @@ public class SesController {
         String region = regionResolver.resolveRegion(headers);
         try {
             JsonNode request = objectMapper.readTree(body);
-            String emailIdentity = request.path("EmailIdentity").asText(null);
+            JsonNode emailIdentityNode = request.path("EmailIdentity");
+            if (!emailIdentityNode.isMissingNode() && !emailIdentityNode.isNull()
+                    && !emailIdentityNode.isTextual()) {
+                // A non-string EmailIdentity is rejected rather than coerced (asText would turn 123
+                // into "123"), the same as ConfigurationSetName below.
+                throw new AwsException("SerializationException", null, 400);
+            }
+            String emailIdentity = emailIdentityNode.asText(null);
             if (emailIdentity == null || emailIdentity.isBlank()) {
                 throw new AwsException("BadRequestException", "EmailIdentity is required.", 400);
             }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -93,8 +93,9 @@ public class SesController {
             if (emailIdentity == null || emailIdentity.isBlank()) {
                 throw new AwsException("BadRequestException", "EmailIdentity is required.", 400);
             }
-            // ConfigurationSetName is a String; AWS rejects a non-string with a 400 (empty body).
-            // Don't coerce via asText (which would turn 123 into "123").
+            // ConfigurationSetName must be a String; AWS rejects a non-string, so reject it here too
+            // rather than coercing via asText (which would turn 123 into "123"). Floci surfaces this
+            // as a 400 SerializationException, rendered as a JSON error body by AwsExceptionMapper.
             JsonNode configSetNode = request.path("ConfigurationSetName");
             String configurationSetName = null;
             if (!configSetNode.isMissingNode() && !configSetNode.isNull()) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -111,9 +111,10 @@ public class SesController {
 
             // Verified against AWS: a non-existent ConfigurationSetName fails the whole call
             // (NotFoundException) without creating the identity, so validate it before creating.
-            // (AWS stores a blank name verbatim; Floci treats blank as "no default configuration set"
-            // to avoid persisting a default that no configuration set can satisfy.)
-            boolean hasConfigSet = configurationSetName != null && !configurationSetName.isBlank();
+            // Only the empty string means "no default configuration set" (consistent with the
+            // PutEmailIdentityConfigurationSetAttributes path); a whitespace-only name flows through
+            // name validation and is rejected as invalid input, rather than being silently ignored.
+            boolean hasConfigSet = configurationSetName != null && !configurationSetName.isEmpty();
             if (hasConfigSet) {
                 sesService.getConfigurationSet(configurationSetName, region);
             }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesEmailIdentityConfigurationSetV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesEmailIdentityConfigurationSetV2IntegrationTest.java
@@ -349,15 +349,31 @@ class SesEmailIdentityConfigurationSetV2IntegrationTest {
 
     @Test
     @Order(14)
-    void createEmailIdentity_withBlankConfigurationSet_createsWithoutDefault() {
-        // AWS stores a blank name verbatim; Floci treats blank as no default configuration set.
-        String id = "cs-attr-blankcs@floci.test";
+    void createEmailIdentity_withEmptyConfigurationSet_createsWithoutDefault() {
+        // Only the empty string means "no default configuration set" (consistent with the
+        // PutEmailIdentityConfigurationSetAttributes path); AWS stores it verbatim.
+        String id = "cs-attr-emptycs@floci.test";
         given().contentType("application/json").header("Authorization", SES_AUTH)
                 .body("{\"EmailIdentity\":\"" + id + "\",\"ConfigurationSetName\":\"\"}")
         .when().post("/v2/email/identities").then().statusCode(200);
         given().header("Authorization", SES_AUTH)
         .when().get("/v2/email/identities/" + id).then().statusCode(200)
                 .body("$", org.hamcrest.Matchers.not(org.hamcrest.Matchers.hasKey("ConfigurationSetName")));
+    }
+
+    @Test
+    @Order(15)
+    void createEmailIdentity_withWhitespaceConfigurationSet_returns400AndDoesNotCreate() {
+        // A whitespace-only name is not "absent": it flows through name validation and is rejected
+        // as invalid input (the same 400 the Put path yields), rather than being silently ignored.
+        String id = "cs-attr-wscs@floci.test";
+        given().contentType("application/json").header("Authorization", SES_AUTH)
+                .body("{\"EmailIdentity\":\"" + id + "\",\"ConfigurationSetName\":\"   \"}")
+        .when().post("/v2/email/identities").then().statusCode(400)
+                .body("__type", equalTo("BadRequestException"))
+                .body("message", equalTo("ConfigurationSetName is required."));
+        given().header("Authorization", SES_AUTH)
+        .when().get("/v2/email/identities/" + id).then().statusCode(404);
     }
 
     private void drainQueue() {

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesEmailIdentityConfigurationSetV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesEmailIdentityConfigurationSetV2IntegrationTest.java
@@ -301,6 +301,65 @@ class SesEmailIdentityConfigurationSetV2IntegrationTest {
                 .body("message", equalTo("Configuration set <" + cs + "> does not exist."));
     }
 
+    @Test
+    @Order(11)
+    void createEmailIdentity_withConfigurationSet_surfacesInGet() {
+        String cs = "cs-attr-oncreate-cs";
+        String id = "cs-attr-oncreate@floci.test";
+        given().contentType("application/json").header("Authorization", SES_AUTH)
+                .body("{\"ConfigurationSetName\":\"" + cs + "\"}")
+        .when().post("/v2/email/configuration-sets").then().statusCode(200);
+
+        // CreateEmailIdentity accepts a ConfigurationSetName and sets it as the identity default.
+        given().contentType("application/json").header("Authorization", SES_AUTH)
+                .body("{\"EmailIdentity\":\"" + id + "\",\"ConfigurationSetName\":\"" + cs + "\"}")
+        .when().post("/v2/email/identities").then().statusCode(200);
+
+        given().header("Authorization", SES_AUTH)
+        .when().get("/v2/email/identities/" + id)
+        .then().statusCode(200).body("ConfigurationSetName", equalTo(cs));
+    }
+
+    @Test
+    @Order(12)
+    void createEmailIdentity_withMissingConfigurationSet_returns404AndDoesNotCreate() {
+        String id = "cs-attr-oncreate-missing@floci.test";
+        given().contentType("application/json").header("Authorization", SES_AUTH)
+                .body("{\"EmailIdentity\":\"" + id + "\",\"ConfigurationSetName\":\"cs-attr-ghost-oncreate\"}")
+        .when().post("/v2/email/identities").then().statusCode(404)
+                .body("__type", equalTo("NotFoundException"))
+                .body("message", equalTo("Configuration set <cs-attr-ghost-oncreate> does not exist."));
+
+        // The identity must not have been created (AWS is atomic on the config-set validation).
+        given().header("Authorization", SES_AUTH)
+        .when().get("/v2/email/identities/" + id).then().statusCode(404);
+    }
+
+    @Test
+    @Order(13)
+    void createEmailIdentity_withNonStringConfigurationSet_returns400() {
+        // ConfigurationSetName is a string; a non-string must be rejected, not coerced.
+        given().contentType("application/json").header("Authorization", SES_AUTH)
+                .body("{\"EmailIdentity\":\"cs-attr-badtype@floci.test\",\"ConfigurationSetName\":123}")
+        .when().post("/v2/email/identities").then().statusCode(400)
+                .body("__type", equalTo("SerializationException"));
+        given().header("Authorization", SES_AUTH)
+        .when().get("/v2/email/identities/cs-attr-badtype@floci.test").then().statusCode(404);
+    }
+
+    @Test
+    @Order(14)
+    void createEmailIdentity_withBlankConfigurationSet_createsWithoutDefault() {
+        // AWS stores a blank name verbatim; Floci treats blank as no default configuration set.
+        String id = "cs-attr-blankcs@floci.test";
+        given().contentType("application/json").header("Authorization", SES_AUTH)
+                .body("{\"EmailIdentity\":\"" + id + "\",\"ConfigurationSetName\":\"\"}")
+        .when().post("/v2/email/identities").then().statusCode(200);
+        given().header("Authorization", SES_AUTH)
+        .when().get("/v2/email/identities/" + id).then().statusCode(200)
+                .body("$", org.hamcrest.Matchers.not(org.hamcrest.Matchers.hasKey("ConfigurationSetName")));
+    }
+
     private void drainQueue() {
         for (int i = 0; i < 5; i++) {
             Response r = given().contentType(JSON_10).header("Authorization", SQS_AUTH)

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesEmailIdentityConfigurationSetV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesEmailIdentityConfigurationSetV2IntegrationTest.java
@@ -350,8 +350,10 @@ class SesEmailIdentityConfigurationSetV2IntegrationTest {
     @Test
     @Order(14)
     void createEmailIdentity_withEmptyConfigurationSet_createsWithoutDefault() {
-        // Only the empty string means "no default configuration set" (consistent with the
-        // PutEmailIdentityConfigurationSetAttributes path); AWS stores it verbatim.
+        // Floci treats an empty-string ConfigurationSetName as "no default configuration set"
+        // (consistent with the PutEmailIdentityConfigurationSetAttributes path). This is a deliberate
+        // deviation from AWS, which stores "" verbatim and echoes it back; Floci keeps the two paths
+        // aligned instead.
         String id = "cs-attr-emptycs@floci.test";
         given().contentType("application/json").header("Authorization", SES_AUTH)
                 .body("{\"EmailIdentity\":\"" + id + "\",\"ConfigurationSetName\":\"\"}")

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesEmailIdentityConfigurationSetV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesEmailIdentityConfigurationSetV2IntegrationTest.java
@@ -378,6 +378,19 @@ class SesEmailIdentityConfigurationSetV2IntegrationTest {
         .when().get("/v2/email/identities/" + id).then().statusCode(404);
     }
 
+    @Test
+    @Order(16)
+    void createEmailIdentity_withNonStringEmailIdentity_returns400() {
+        // EmailIdentity is a string; a non-string must be rejected (not coerced into "123"), the same
+        // as a non-string ConfigurationSetName.
+        given().contentType("application/json").header("Authorization", SES_AUTH)
+                .body("{\"EmailIdentity\":123}")
+        .when().post("/v2/email/identities").then().statusCode(400)
+                .body("__type", equalTo("SerializationException"));
+        given().header("Authorization", SES_AUTH)
+        .when().get("/v2/email/identities/123").then().statusCode(404);
+    }
+
     private void drainQueue() {
         for (int i = 0; i < 5; i++) {
             Response r = given().contentType(JSON_10).header("Authorization", SQS_AUTH)

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesEmailIdentityConfigurationSetV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesEmailIdentityConfigurationSetV2IntegrationTest.java
@@ -336,6 +336,21 @@ class SesEmailIdentityConfigurationSetV2IntegrationTest {
     }
 
     @Test
+    @Order(17)
+    void createEmailIdentity_withNonArrayTags_returns400AndDoesNotCreate() {
+        String id = "cs-attr-oncreate-badtags@floci.test";
+        given().contentType("application/json").header("Authorization", SES_AUTH)
+                .body("{\"EmailIdentity\":\"" + id + "\",\"Tags\":\"oops\"}")
+        .when().post("/v2/email/identities").then().statusCode(400)
+                .body("__type", equalTo("BadRequestException"))
+                .body("message", equalTo("Tags must be an array."));
+
+        // Tags is validated before the identity is persisted, so nothing is created.
+        given().header("Authorization", SES_AUTH)
+        .when().get("/v2/email/identities/" + id).then().statusCode(404);
+    }
+
+    @Test
     @Order(13)
     void createEmailIdentity_withNonStringConfigurationSet_returns400() {
         // ConfigurationSetName is a string; a non-string must be rejected, not coerced.


### PR DESCRIPTION
## Summary

Follow-up to #1698. `CreateEmailIdentity` (SES v2) now honors the optional `ConfigurationSetName` input, setting it as the identity's default configuration set — the same association `PutEmailIdentityConfigurationSetAttributes` (added in #1698) manages and `GetEmailIdentity` surfaces. Previously the field was accepted by the model but ignored, so a default set could only be attached in a second call.

The configuration set is validated **before** the identity is created, so a non-existent one fails the whole call without leaving a half-created identity.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against real AWS (SES v2, boto3, us-east-1):

- `CreateEmailIdentity` with a valid `ConfigurationSetName` sets the identity's default, and `GetEmailIdentity` returns that `ConfigurationSetName`.
- `CreateEmailIdentity` with a non-existent `ConfigurationSetName` fails with `NotFoundException` / `Configuration set <name> does not exist.` **and does not create the identity** (the validation is atomic — checked before creation).
- A non-string `ConfigurationSetName` is rejected with a 400 (`SerializationException`).

## Checklist

- [x] `./mvnw test` passes locally (SES suite + SDK compatibility test)
- [x] New or updated integration test added (v2 integration and an SDK compatibility test)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
