### PR TITLE
docs: fill supported action descriptions

### DIFF
--- a/docs/services/cognito.md
+++ b/docs/services/cognito.md
@@ -23,87 +23,87 @@ Standalone `TagResource` rejects reserved `floci:*` keys. `ListTagsForResource` 
 
 | Action | Description |
 |--------|-------------|
-| CreateUserPool | - |
-| DescribeUserPool | - |
-| ListUserPools | - |
-| UpdateUserPool | - |
-| DeleteUserPool | - |
+| CreateUserPool | Creates a local user pool, applying supported `floci:*` creation-time overrides from tags. |
+| DescribeUserPool | Returns the stored user pool configuration. |
+| ListUserPools | Lists local user pools visible in the request region. |
+| UpdateUserPool | Updates mutable user pool settings and persisted user-pool tags. |
+| DeleteUserPool | Deletes a local user pool and its related state. |
 
 ### User Pool Tags
 
 | Action | Description |
 |--------|-------------|
-| TagResource | - |
-| UntagResource | - |
-| ListTagsForResource | - |
+| TagResource | Adds user-visible tags to a user pool and rejects reserved `floci:*` tag keys. |
+| UntagResource | Removes tags from a user pool's persisted tag map. |
+| ListTagsForResource | Returns the persisted user-pool tags. |
 
 ### User Pool Clients
 
 | Action | Description |
 |--------|-------------|
-| CreateUserPoolClient | - |
-| DescribeUserPoolClient | - |
-| ListUserPoolClients | - |
-| DeleteUserPoolClient | - |
+| CreateUserPoolClient | Creates an app client for a user pool, including optional generated secret handling. |
+| DescribeUserPoolClient | Returns the stored app client configuration. |
+| ListUserPoolClients | Lists app clients for a user pool. |
+| DeleteUserPoolClient | Deletes an app client from a user pool. |
 
 ### Resource Servers
 
 | Action | Description |
 |--------|-------------|
-| CreateResourceServer | - |
-| DescribeResourceServer | - |
-| ListResourceServers | - |
-| DeleteResourceServer | - |
+| CreateResourceServer | Registers a resource server and scopes for a user pool. |
+| DescribeResourceServer | Returns a registered resource server. |
+| ListResourceServers | Lists resource servers for a user pool. |
+| DeleteResourceServer | Deletes a resource server from a user pool. |
 
 ### Admin User Management
 
 | Action | Description |
 |--------|-------------|
-| AdminCreateUser | - |
-| AdminGetUser | - |
-| AdminDeleteUser | - |
-| AdminSetUserPassword | - |
-| AdminUpdateUserAttributes | - |
+| AdminCreateUser | Creates or resends setup for a user in a user pool. |
+| AdminGetUser | Returns a user's stored attributes and status. |
+| AdminDeleteUser | Deletes a user from a user pool. |
+| AdminSetUserPassword | Sets a user's password and permanent-password status. |
+| AdminUpdateUserAttributes | Updates attributes for a user in a user pool. |
 
 ### User Operations
 
 | Action | Description |
 |--------|-------------|
-| SignUp | - |
-| ConfirmSignUp | - |
-| GetUser | - |
-| UpdateUserAttributes | - |
-| ChangePassword | - |
-| ForgotPassword | - |
-| ConfirmForgotPassword | - |
+| SignUp | Creates a self-service user for an app client. |
+| ConfirmSignUp | Confirms a pending self-service signup. |
+| GetUser | Returns attributes for the authenticated access-token user. |
+| UpdateUserAttributes | Updates attributes for the authenticated access-token user. |
+| ChangePassword | Changes the authenticated user's password. |
+| ForgotPassword | Starts the local forgot-password flow for a user. |
+| ConfirmForgotPassword | Completes the forgot-password flow by setting a replacement password. |
 
 ### Authentication
 
 | Action | Description |
 |--------|-------------|
-| InitiateAuth | - |
-| AdminInitiateAuth | - |
-| RespondToAuthChallenge | - |
+| InitiateAuth | Authenticates app-client users through supported user-password and SRP-style flows. |
+| AdminInitiateAuth | Starts an admin authentication flow for a user pool user. |
+| RespondToAuthChallenge | Responds to supported Cognito auth challenges. |
 
 ### User Listing
 
 | Action | Description |
 |--------|-------------|
-| ListUsers | - |
+| ListUsers | Lists users stored in a user pool. |
 
 ### Groups
 
 | Action | Description |
 |--------|-------------|
-| CreateGroup | - |
-| GetGroup | - |
-| UpdateGroup | - |
-| ListGroups | - |
-| ListUsersInGroup | - |
-| DeleteGroup | - |
-| AdminAddUserToGroup | - |
-| AdminRemoveUserFromGroup | - |
-| AdminListGroupsForUser | - |
+| CreateGroup | Creates a group in a user pool. |
+| GetGroup | Returns a user-pool group. |
+| UpdateGroup | Updates a user-pool group's stored settings. |
+| ListGroups | Lists groups in a user pool. |
+| ListUsersInGroup | Lists users assigned to a group. |
+| DeleteGroup | Deletes a group from a user pool. |
+| AdminAddUserToGroup | Adds a user to a group. |
+| AdminRemoveUserFromGroup | Removes a user from a group. |
+| AdminListGroupsForUser | Lists the groups assigned to a user. |
 
 ## Well-Known And OAuth Endpoints
 

--- a/docs/services/ec2.md
+++ b/docs/services/ec2.md
@@ -159,165 +159,165 @@ Floci seeds the following resources on first use in each region so Terraform, th
 
 | Action | Description |
 |--------|-------------|
-| RunInstances | - |
-| DescribeInstances | - |
-| TerminateInstances | - |
-| StartInstances | - |
-| StopInstances | - |
-| RebootInstances | - |
-| DescribeInstanceStatus | - |
-| DescribeInstanceAttribute | - |
-| ModifyInstanceAttribute | - |
+| RunInstances | Creates one or more local EC2 instances, starting Docker-backed runtime when not in mock mode. |
+| DescribeInstances | Lists or returns stored EC2 instances. |
+| TerminateInstances | Terminates instances and updates their stored lifecycle state. |
+| StartInstances | Starts stopped instances and their local runtime when applicable. |
+| StopInstances | Stops running instances and updates their stored lifecycle state. |
+| RebootInstances | Reboots instances through the local EC2 service model. |
+| DescribeInstanceStatus | Returns status records for stored instances. |
+| DescribeInstanceAttribute | Returns a supported attribute for an instance. |
+| ModifyInstanceAttribute | Updates supported mutable attributes for an instance. |
 
 ### VPCs
 
 | Action | Description |
 |--------|-------------|
-| CreateVpc | - |
-| DescribeVpcs | - |
-| DeleteVpc | - |
-| ModifyVpcAttribute | - |
-| DescribeVpcAttribute | - |
-| DescribeVpcEndpointServices | - |
-| CreateVpcEndpoint | - |
-| DescribeVpcEndpoints | - |
-| DeleteVpcEndpoints | - |
-| CreateDefaultVpc | - |
-| AssociateVpcCidrBlock | - |
-| DisassociateVpcCidrBlock | - |
+| CreateVpc | Creates a VPC with the requested CIDR block. |
+| DescribeVpcs | Lists or returns stored VPCs. |
+| DeleteVpc | Deletes a VPC from the local EC2 store. |
+| ModifyVpcAttribute | Updates supported VPC attributes. |
+| DescribeVpcAttribute | Returns a supported VPC attribute. |
+| DescribeVpcEndpointServices | Returns an empty local VPC endpoint service catalog. |
+| CreateVpcEndpoint | Creates a VPC endpoint record. |
+| DescribeVpcEndpoints | Lists or returns stored VPC endpoints. |
+| DeleteVpcEndpoints | Deletes VPC endpoint records. |
+| CreateDefaultVpc | Creates or returns the default VPC for the region. |
+| AssociateVpcCidrBlock | Adds a secondary CIDR block association to a VPC. |
+| DisassociateVpcCidrBlock | Removes a secondary CIDR block association from a VPC. |
 
 ### Subnets
 
 | Action | Description |
 |--------|-------------|
-| CreateSubnet | - |
-| DescribeSubnets | - |
-| DeleteSubnet | - |
-| ModifySubnetAttribute | - |
+| CreateSubnet | Creates a subnet in a VPC. |
+| DescribeSubnets | Lists or returns stored subnets. |
+| DeleteSubnet | Deletes a subnet from the local EC2 store. |
+| ModifySubnetAttribute | Updates supported subnet attributes. |
 
 ### Security Groups
 
 | Action | Description |
 |--------|-------------|
-| CreateSecurityGroup | - |
-| DescribeSecurityGroups | - |
-| DeleteSecurityGroup | - |
-| AuthorizeSecurityGroupIngress | - |
-| AuthorizeSecurityGroupEgress | - |
-| RevokeSecurityGroupIngress | - |
-| RevokeSecurityGroupEgress | - |
-| DescribeSecurityGroupRules | - |
-| ModifySecurityGroupRules | - |
-| UpdateSecurityGroupRuleDescriptionsIngress | - |
-| UpdateSecurityGroupRuleDescriptionsEgress | - |
+| CreateSecurityGroup | Creates a security group in a VPC. |
+| DescribeSecurityGroups | Lists or returns stored security groups. |
+| DeleteSecurityGroup | Deletes a security group from the local EC2 store. |
+| AuthorizeSecurityGroupIngress | Adds inbound permissions to a security group. |
+| AuthorizeSecurityGroupEgress | Adds outbound permissions to a security group. |
+| RevokeSecurityGroupIngress | Removes inbound permissions from a security group. |
+| RevokeSecurityGroupEgress | Removes outbound permissions from a security group. |
+| DescribeSecurityGroupRules | Lists stored security group rules. |
+| ModifySecurityGroupRules | Updates supported fields on security group rules. |
+| UpdateSecurityGroupRuleDescriptionsIngress | Updates descriptions on matching inbound security group rules. |
+| UpdateSecurityGroupRuleDescriptionsEgress | Updates descriptions on matching outbound security group rules. |
 
 ### Key Pairs
 
 | Action | Description |
 |--------|-------------|
-| CreateKeyPair | - |
-| DescribeKeyPairs | - |
-| DeleteKeyPair | - |
-| ImportKeyPair | - |
+| CreateKeyPair | Creates and stores a local key pair. |
+| DescribeKeyPairs | Lists or returns stored key pairs. |
+| DeleteKeyPair | Deletes a key pair from the local EC2 store. |
+| ImportKeyPair | Imports a public key as a local key pair. |
 
 ### AMIs
 
 | Action | Description |
 |--------|-------------|
-| DescribeImages | - |
+| DescribeImages | Returns AMI metadata known to the local EC2 service. |
 
 ### Tags
 
 | Action | Description |
 |--------|-------------|
-| CreateTags | - |
-| DeleteTags | - |
-| DescribeTags | - |
+| CreateTags | Adds tags to supported EC2 resources. |
+| DeleteTags | Removes tags from supported EC2 resources. |
+| DescribeTags | Lists tags stored for EC2 resources. |
 
 ### Internet Gateways
 
 | Action | Description |
 |--------|-------------|
-| CreateInternetGateway | - |
-| DescribeInternetGateways | - |
-| DeleteInternetGateway | - |
-| AttachInternetGateway | - |
-| DetachInternetGateway | - |
+| CreateInternetGateway | Creates an internet gateway. |
+| DescribeInternetGateways | Lists or returns stored internet gateways. |
+| DeleteInternetGateway | Deletes an internet gateway. |
+| AttachInternetGateway | Attaches an internet gateway to a VPC. |
+| DetachInternetGateway | Detaches an internet gateway from a VPC. |
 
 ### Route Tables
 
 | Action | Description |
 |--------|-------------|
-| CreateRouteTable | - |
-| DescribeRouteTables | - |
-| DeleteRouteTable | - |
-| AssociateRouteTable | - |
-| DisassociateRouteTable | - |
-| CreateRoute | - |
-| DeleteRoute | - |
+| CreateRouteTable | Creates a route table in a VPC. |
+| DescribeRouteTables | Lists or returns stored route tables. |
+| DeleteRouteTable | Deletes a route table from the local EC2 store. |
+| AssociateRouteTable | Associates a route table with a subnet. |
+| DisassociateRouteTable | Removes a route table association. |
+| CreateRoute | Adds a route to a route table. |
+| DeleteRoute | Removes a route from a route table. |
 
 ### Network ACLs
 
 | Action | Description |
 |--------|-------------|
-| CreateNetworkAcl | - |
-| DescribeNetworkAcls | - |
-| DeleteNetworkAcl | - |
-| CreateNetworkAclEntry | - |
-| ReplaceNetworkAclEntry | - |
-| DeleteNetworkAclEntry | - |
-| ReplaceNetworkAclAssociation | - |
+| CreateNetworkAcl | Creates a network ACL in a VPC. |
+| DescribeNetworkAcls | Lists or returns stored network ACLs. |
+| DeleteNetworkAcl | Deletes a network ACL from the local EC2 store. |
+| CreateNetworkAclEntry | Adds an entry to a network ACL. |
+| ReplaceNetworkAclEntry | Replaces an entry in a network ACL. |
+| DeleteNetworkAclEntry | Removes an entry from a network ACL. |
+| ReplaceNetworkAclAssociation | Replaces the network ACL associated with a subnet. |
 
 ### Prefix Lists
 
 | Action | Description |
 |--------|-------------|
-| DescribePrefixLists | - |
+| DescribePrefixLists | Returns prefix lists known to the local EC2 service. |
 
 ### NAT Gateways
 
 | Action | Description |
 |--------|-------------|
-| CreateNatGateway | - |
-| DescribeNatGateways | - |
-| DeleteNatGateway | - |
+| CreateNatGateway | Creates a NAT gateway record. |
+| DescribeNatGateways | Lists or returns stored NAT gateways. |
+| DeleteNatGateway | Deletes a NAT gateway record. |
 
 ### Elastic IPs
 
 | Action | Description |
 |--------|-------------|
-| AllocateAddress | - |
-| DescribeAddresses | - |
-| DescribeAddressesAttribute | - |
-| AssociateAddress | - |
-| DisassociateAddress | - |
-| ReleaseAddress | - |
+| AllocateAddress | Allocates an Elastic IP address record. |
+| DescribeAddresses | Lists or returns stored Elastic IP address records. |
+| DescribeAddressesAttribute | Returns allocation ID and public IP attributes for Elastic IP addresses. |
+| AssociateAddress | Associates an Elastic IP address with a resource. |
+| DisassociateAddress | Removes an Elastic IP address association. |
+| ReleaseAddress | Releases an Elastic IP address record. |
 
 ### Availability Zones & Regions
 
 | Action | Description |
 |--------|-------------|
-| DescribeAvailabilityZones | - |
-| DescribeRegions | - |
-| DescribeAccountAttributes | - |
+| DescribeAvailabilityZones | Returns the configured local availability zones. |
+| DescribeRegions | Returns the regions known to the local EC2 service. |
+| DescribeAccountAttributes | Returns local account-level EC2 attributes. |
 
 ### Instance Types
 
 | Action | Description |
 |--------|-------------|
-| DescribeInstanceTypes | - |
-| DescribeInstanceTypeOfferings | - |
+| DescribeInstanceTypes | Returns instance type metadata known to the local EC2 service. |
+| DescribeInstanceTypeOfferings | Returns instance type offerings for the requested location filters. |
 
 ### Launch Templates
 
 | Action | Description |
 |--------|-------------|
-| CreateLaunchTemplate | - |
-| CreateLaunchTemplateVersion | - |
-| DescribeLaunchTemplates | - |
-| DescribeLaunchTemplateVersions | - |
-| ModifyLaunchTemplate | - |
-| DeleteLaunchTemplate | - |
+| CreateLaunchTemplate | Creates a launch template with an initial version. |
+| CreateLaunchTemplateVersion | Creates a new launch template version, optionally from a source version. |
+| DescribeLaunchTemplates | Lists or returns stored launch templates. |
+| DescribeLaunchTemplateVersions | Lists versions stored for a launch template. |
+| ModifyLaunchTemplate | Updates launch template metadata such as the default version. |
+| DeleteLaunchTemplate | Deletes a launch template and its versions. |
 
 Launch templates store versioned launch data. New template versions can be created from an existing source version, and `ModifyLaunchTemplate` updates the default version used by later launches.
 
@@ -325,21 +325,21 @@ Launch templates store versioned launch data. New template versions can be creat
 
 | Action | Description |
 |--------|-------------|
-| DescribeIamInstanceProfileAssociations | - |
+| DescribeIamInstanceProfileAssociations | Lists IAM instance profile associations known to the local EC2 service. |
 
 ### Network Interfaces
 
 | Action | Description |
 |--------|-------------|
-| DescribeNetworkInterfaces | - |
+| DescribeNetworkInterfaces | Lists network interfaces known to the local EC2 service. |
 
 ### Volumes
 
 | Action | Description |
 |--------|-------------|
-| CreateVolume | - |
-| DescribeVolumes | - |
-| DeleteVolume | - |
+| CreateVolume | Creates an EBS volume record. |
+| DescribeVolumes | Lists or returns stored EBS volume records. |
+| DeleteVolume | Deletes an EBS volume record. |
 
 ## Configuration
 

--- a/docs/services/elb.md
+++ b/docs/services/elb.md
@@ -10,73 +10,73 @@ Floci supports Application Load Balancers (ALB) and Network Load Balancers (NLB)
 
 | Action | Description |
 |--------|-------------|
-| CreateLoadBalancer | - |
-| DescribeLoadBalancers | - |
-| DeleteLoadBalancer | - |
-| ModifyLoadBalancerAttributes | - |
-| DescribeLoadBalancerAttributes | - |
-| DescribeCapacityReservation | - |
-| SetSecurityGroups | - |
-| SetSubnets | - |
-| SetIpAddressType | - |
+| CreateLoadBalancer | Creates an ALB or NLB in active state with persisted attributes and tags. |
+| DescribeLoadBalancers | Lists or returns stored load balancers. |
+| DeleteLoadBalancer | Deletes a load balancer and stops its listener sockets. |
+| ModifyLoadBalancerAttributes | Updates persisted load balancer attributes. |
+| DescribeLoadBalancerAttributes | Returns attributes stored for a load balancer. |
+| DescribeCapacityReservation | Returns the stored capacity reservation fields for a load balancer. |
+| SetSecurityGroups | Replaces the security groups associated with a load balancer. |
+| SetSubnets | Replaces the subnets associated with a load balancer. |
+| SetIpAddressType | Updates the IP address type stored for a load balancer. |
 
 ### Target Groups
 
 | Action | Description |
 |--------|-------------|
-| CreateTargetGroup | - |
-| DescribeTargetGroups | - |
-| ModifyTargetGroup | - |
-| DeleteTargetGroup | - |
-| ModifyTargetGroupAttributes | - |
-| DescribeTargetGroupAttributes | - |
+| CreateTargetGroup | Creates a target group with protocol, port, health check, and target-type settings. |
+| DescribeTargetGroups | Lists or returns stored target groups. |
+| ModifyTargetGroup | Updates mutable target group settings. |
+| DeleteTargetGroup | Deletes an unused target group. |
+| ModifyTargetGroupAttributes | Updates persisted target group attributes. |
+| DescribeTargetGroupAttributes | Returns attributes stored for a target group. |
 
 ### Targets
 
 | Action | Description |
 |--------|-------------|
-| RegisterTargets | - |
-| DeregisterTargets | - |
-| DescribeTargetHealth | - |
+| RegisterTargets | Registers targets with a target group. |
+| DeregisterTargets | Removes targets from a target group. |
+| DescribeTargetHealth | Returns target health records maintained by Floci. |
 
 ### Listeners
 
 | Action | Description |
 |--------|-------------|
-| CreateListener | - |
-| DescribeListeners | - |
-| ModifyListener | - |
-| ModifyListenerAttributes | - |
-| DescribeListenerAttributes | - |
-| DeleteListener | - |
-| AddListenerCertificates | - |
-| RemoveListenerCertificates | - |
-| DescribeListenerCertificates | - |
+| CreateListener | Creates a listener and its immutable default rule. |
+| DescribeListeners | Lists or returns stored listeners. |
+| ModifyListener | Updates a listener's configuration and default actions. |
+| ModifyListenerAttributes | Updates persisted listener attributes. |
+| DescribeListenerAttributes | Returns attributes stored for a listener. |
+| DeleteListener | Deletes a listener and stops its socket. |
+| AddListenerCertificates | Adds certificates to a listener. |
+| RemoveListenerCertificates | Removes certificates from a listener. |
+| DescribeListenerCertificates | Lists certificates associated with a listener. |
 
 ### Rules
 
 | Action | Description |
 |--------|-------------|
-| CreateRule | - |
-| DescribeRules | - |
-| ModifyRule | - |
-| DeleteRule | - |
-| SetRulePriorities | - |
+| CreateRule | Creates a non-default listener rule with conditions, actions, and priority. |
+| DescribeRules | Lists or returns listener rules. |
+| ModifyRule | Updates a listener rule's conditions and actions. |
+| DeleteRule | Deletes a non-default listener rule. |
+| SetRulePriorities | Atomically updates rule priorities after validating uniqueness. |
 
 ### Tags
 
 | Action | Description |
 |--------|-------------|
-| AddTags | - |
-| RemoveTags | - |
-| DescribeTags | - |
+| AddTags | Adds tags to supported ELBv2 resources. |
+| RemoveTags | Removes tags from supported ELBv2 resources. |
+| DescribeTags | Returns tags for supported ELBv2 resources. |
 
 ### Metadata
 
 | Action | Description |
 |--------|-------------|
-| DescribeSSLPolicies | - |
-| DescribeAccountLimits | - |
+| DescribeSSLPolicies | Returns Floci's pre-seeded standard SSL policy list. |
+| DescribeAccountLimits | Returns standard default ELBv2 account limits. |
 
 ## Behavior Notes
 

--- a/docs/services/elb.md
+++ b/docs/services/elb.md
@@ -43,7 +43,7 @@ Floci supports Application Load Balancers (ALB) and Network Load Balancers (NLB)
 
 | Action | Description |
 |--------|-------------|
-| CreateListener | Creates a listener and its immutable default rule. |
+| CreateListener | Creates a listener and its non-deletable default rule. |
 | DescribeListeners | Lists or returns stored listeners. |
 | ModifyListener | Updates a listener's configuration and default actions. |
 | ModifyListenerAttributes | Updates persisted listener attributes. |

--- a/docs/services/glue.md
+++ b/docs/services/glue.md
@@ -13,36 +13,36 @@ Floci emulates the AWS Glue Data Catalog and Glue Schema Registry, allowing you 
 
 | Action | Description |
 |--------|-------------|
-| CreateDatabase | - |
-| GetDatabase | - |
-| GetDatabases | - |
-| DeleteDatabase | - |
+| CreateDatabase | Creates a database in the local Glue Data Catalog. |
+| GetDatabase | Returns a stored Data Catalog database. |
+| GetDatabases | Lists databases in the local Glue Data Catalog. |
+| DeleteDatabase | Deletes a database from the local Glue Data Catalog. |
 
 #### Tables
 
 | Action | Description |
 |--------|-------------|
-| CreateTable | - |
-| GetTable | - |
-| GetTables | - |
-| DeleteTable | - |
+| CreateTable | Creates a table definition in the local Glue Data Catalog. |
+| GetTable | Returns a stored table definition and resolves schema references when possible. |
+| GetTables | Lists table definitions for a database. |
+| DeleteTable | Deletes a table definition from a database. |
 
 #### Partitions
 
 | Action | Description |
 |--------|-------------|
-| CreatePartition | - |
-| GetPartitions | - |
+| CreatePartition | Creates a partition for a Data Catalog table. |
+| GetPartitions | Lists partitions stored for a Data Catalog table. |
 
 #### User-defined Functions
 
 | Action | Description |
 |--------|-------------|
-| CreateUserDefinedFunction | - |
-| GetUserDefinedFunction | - |
-| GetUserDefinedFunctions | - |
-| UpdateUserDefinedFunction | - |
-| DeleteUserDefinedFunction | - |
+| CreateUserDefinedFunction | Creates a user-defined function in the Data Catalog. |
+| GetUserDefinedFunction | Returns a stored user-defined function. |
+| GetUserDefinedFunctions | Lists user-defined functions for a database. |
+| UpdateUserDefinedFunction | Updates a stored user-defined function. |
+| DeleteUserDefinedFunction | Deletes a user-defined function from a database. |
 
 ### Schema Registry
 
@@ -50,44 +50,44 @@ Floci emulates the AWS Glue Data Catalog and Glue Schema Registry, allowing you 
 
 | Action | Description |
 |--------|-------------|
-| CreateRegistry | - |
-| GetRegistry | - |
-| ListRegistries | - |
-| UpdateRegistry | - |
-| DeleteRegistry | - |
+| CreateRegistry | Creates a schema registry. |
+| GetRegistry | Returns a stored schema registry. |
+| ListRegistries | Lists schema registries. |
+| UpdateRegistry | Updates a schema registry's stored metadata. |
+| DeleteRegistry | Deletes a schema registry. |
 
 #### Schemas
 
 | Action | Description |
 |--------|-------------|
-| CreateSchema | - |
-| GetSchema | - |
-| ListSchemas | - |
-| UpdateSchema | - |
-| DeleteSchema | - |
+| CreateSchema | Creates a schema in a registry with the supplied data format and compatibility mode. |
+| GetSchema | Returns a stored schema. |
+| ListSchemas | Lists schemas in a registry. |
+| UpdateSchema | Updates schema metadata or compatibility settings. |
+| DeleteSchema | Deletes a schema from a registry. |
 
 #### Versions
 
 | Action | Description |
 |--------|-------------|
-| RegisterSchemaVersion | - |
-| GetSchemaByDefinition | - |
-| GetSchemaVersion | - |
-| ListSchemaVersions | - |
-| DeleteSchemaVersions | - |
-| GetSchemaVersionsDiff | - |
-| CheckSchemaVersionValidity | - |
+| RegisterSchemaVersion | Registers a new schema version definition. |
+| GetSchemaByDefinition | Finds a schema version that matches a supplied definition. |
+| GetSchemaVersion | Returns a stored schema version. |
+| ListSchemaVersions | Lists versions for a schema. |
+| DeleteSchemaVersions | Deletes schema versions from a schema. |
+| GetSchemaVersionsDiff | Returns the diff between two schema version numbers. |
+| CheckSchemaVersionValidity | Validates a schema definition for the supplied data format. |
 
 #### Metadata and Tags
 
 | Action | Description |
 |--------|-------------|
-| PutSchemaVersionMetadata | - |
-| RemoveSchemaVersionMetadata | - |
-| QuerySchemaVersionMetadata | - |
-| TagResource | - |
-| UntagResource | - |
-| GetTags | - |
+| PutSchemaVersionMetadata | Adds metadata to a schema version. |
+| RemoveSchemaVersionMetadata | Removes metadata from a schema version. |
+| QuerySchemaVersionMetadata | Returns metadata stored for matching schema versions. |
+| TagResource | Adds tags to a Glue schema registry resource. |
+| UntagResource | Removes tags from a Glue schema registry resource. |
+| GetTags | Returns tags stored for a Glue schema registry resource. |
 
 Supported schema formats are `AVRO`, `JSON`, and `PROTOBUF`. Compatibility modes are `NONE`, `DISABLED`, `BACKWARD`, `BACKWARD_ALL`, `FORWARD`, `FORWARD_ALL`, `FULL`, and `FULL_ALL`.
 

--- a/docs/services/iam.md
+++ b/docs/services/iam.md
@@ -8,133 +8,133 @@
 
 | Action | Description |
 |--------|-------------|
-| CreateUser | - |
-| GetUser | - |
-| DeleteUser | - |
-| ListUsers | - |
-| UpdateUser | - |
-| TagUser | - |
-| UntagUser | - |
-| ListUserTags | - |
+| CreateUser | Creates an IAM user in the local account. |
+| GetUser | Returns a stored IAM user. |
+| DeleteUser | Deletes an IAM user from the local IAM store. |
+| ListUsers | Lists IAM users in the local account. |
+| UpdateUser | Updates mutable IAM user fields. |
+| TagUser | Adds tags to an IAM user. |
+| UntagUser | Removes tags from an IAM user. |
+| ListUserTags | Lists tags stored for an IAM user. |
 
 ### Groups
 
 | Action | Description |
 |--------|-------------|
-| CreateGroup | - |
-| GetGroup | - |
-| DeleteGroup | - |
-| ListGroups | - |
-| AddUserToGroup | - |
-| RemoveUserFromGroup | - |
-| ListGroupsForUser | - |
+| CreateGroup | Creates an IAM group. |
+| GetGroup | Returns an IAM group and its users. |
+| DeleteGroup | Deletes an IAM group from the local IAM store. |
+| ListGroups | Lists IAM groups in the local account. |
+| AddUserToGroup | Adds a user to an IAM group. |
+| RemoveUserFromGroup | Removes a user from an IAM group. |
+| ListGroupsForUser | Lists groups that contain a user. |
 
 ### Roles
 
 | Action | Description |
 |--------|-------------|
-| CreateRole | - |
-| GetRole | - |
-| DeleteRole | - |
-| ListRoles | - |
-| UpdateRole | - |
-| UpdateAssumeRolePolicy | - |
-| TagRole | - |
-| UntagRole | - |
-| ListRoleTags | - |
+| CreateRole | Creates an IAM role with an assume-role policy. |
+| GetRole | Returns a stored IAM role. |
+| DeleteRole | Deletes an IAM role from the local IAM store. |
+| ListRoles | Lists IAM roles in the local account. |
+| UpdateRole | Updates mutable IAM role fields. |
+| UpdateAssumeRolePolicy | Replaces a role's assume-role policy document. |
+| TagRole | Adds tags to an IAM role. |
+| UntagRole | Removes tags from an IAM role. |
+| ListRoleTags | Lists tags stored for an IAM role. |
 
 ### Policies
 
 | Action | Description |
 |--------|-------------|
-| CreatePolicy | - |
-| GetPolicy | - |
-| DeletePolicy | - |
-| ListPolicies | - |
-| CreatePolicyVersion | - |
-| GetPolicyVersion | - |
-| DeletePolicyVersion | - |
-| ListPolicyVersions | - |
-| SetDefaultPolicyVersion | - |
-| TagPolicy | - |
-| UntagPolicy | - |
-| ListPolicyTags | - |
+| CreatePolicy | Creates a customer-managed IAM policy. |
+| GetPolicy | Returns metadata for a managed IAM policy. |
+| DeletePolicy | Deletes a managed IAM policy. |
+| ListPolicies | Lists managed IAM policies, including seeded AWS managed policies. |
+| CreatePolicyVersion | Creates a new version of a managed policy. |
+| GetPolicyVersion | Returns a managed policy version document. |
+| DeletePolicyVersion | Deletes a non-default managed policy version. |
+| ListPolicyVersions | Lists versions for a managed policy. |
+| SetDefaultPolicyVersion | Sets the default version for a managed policy. |
+| TagPolicy | Adds tags to a managed policy. |
+| UntagPolicy | Removes tags from a managed policy. |
+| ListPolicyTags | Lists tags stored for a managed policy. |
 
 ### Permission Boundaries
 
 | Action | Description |
 |--------|-------------|
-| PutUserPermissionsBoundary | - |
-| DeleteUserPermissionsBoundary | - |
-| PutRolePermissionsBoundary | - |
-| DeleteRolePermissionsBoundary | - |
+| PutUserPermissionsBoundary | Sets a managed policy as a user's permissions boundary. |
+| DeleteUserPermissionsBoundary | Removes a user's permissions boundary. |
+| PutRolePermissionsBoundary | Sets a managed policy as a role's permissions boundary. |
+| DeleteRolePermissionsBoundary | Removes a role's permissions boundary. |
 
 ### Policy Attachments
 
 | Action | Description |
 |--------|-------------|
-| AttachUserPolicy | - |
-| DetachUserPolicy | - |
-| ListAttachedUserPolicies | - |
-| AttachGroupPolicy | - |
-| DetachGroupPolicy | - |
-| ListAttachedGroupPolicies | - |
-| AttachRolePolicy | - |
-| DetachRolePolicy | - |
-| ListAttachedRolePolicies | - |
+| AttachUserPolicy | Attaches a managed policy to a user. |
+| DetachUserPolicy | Detaches a managed policy from a user. |
+| ListAttachedUserPolicies | Lists managed policies attached to a user. |
+| AttachGroupPolicy | Attaches a managed policy to a group. |
+| DetachGroupPolicy | Detaches a managed policy from a group. |
+| ListAttachedGroupPolicies | Lists managed policies attached to a group. |
+| AttachRolePolicy | Attaches a managed policy to a role. |
+| DetachRolePolicy | Detaches a managed policy from a role. |
+| ListAttachedRolePolicies | Lists managed policies attached to a role. |
 
 ### Inline Policies
 
 | Action | Description |
 |--------|-------------|
-| PutUserPolicy | - |
-| GetUserPolicy | - |
-| DeleteUserPolicy | - |
-| ListUserPolicies | - |
-| PutGroupPolicy | - |
-| GetGroupPolicy | - |
-| DeleteGroupPolicy | - |
-| ListGroupPolicies | - |
-| PutRolePolicy | - |
-| GetRolePolicy | - |
-| DeleteRolePolicy | - |
-| ListRolePolicies | - |
+| PutUserPolicy | Stores or replaces an inline policy on a user. |
+| GetUserPolicy | Returns an inline policy stored on a user. |
+| DeleteUserPolicy | Deletes an inline policy from a user. |
+| ListUserPolicies | Lists inline policy names stored on a user. |
+| PutGroupPolicy | Stores or replaces an inline policy on a group. |
+| GetGroupPolicy | Returns an inline policy stored on a group. |
+| DeleteGroupPolicy | Deletes an inline policy from a group. |
+| ListGroupPolicies | Lists inline policy names stored on a group. |
+| PutRolePolicy | Stores or replaces an inline policy on a role. |
+| GetRolePolicy | Returns an inline policy stored on a role. |
+| DeleteRolePolicy | Deletes an inline policy from a role. |
+| ListRolePolicies | Lists inline policy names stored on a role. |
 
 ### Instance Profiles
 
 | Action | Description |
 |--------|-------------|
-| CreateInstanceProfile | - |
-| GetInstanceProfile | - |
-| DeleteInstanceProfile | - |
-| ListInstanceProfiles | - |
-| AddRoleToInstanceProfile | - |
-| RemoveRoleFromInstanceProfile | - |
-| ListInstanceProfilesForRole | - |
+| CreateInstanceProfile | Creates an IAM instance profile. |
+| GetInstanceProfile | Returns an instance profile and its roles. |
+| DeleteInstanceProfile | Deletes an instance profile from the local IAM store. |
+| ListInstanceProfiles | Lists IAM instance profiles. |
+| AddRoleToInstanceProfile | Adds a role to an instance profile. |
+| RemoveRoleFromInstanceProfile | Removes a role from an instance profile. |
+| ListInstanceProfilesForRole | Lists instance profiles associated with a role. |
 
 ### Access Keys
 
 | Action | Description |
 |--------|-------------|
-| CreateAccessKey | - |
-| GetAccessKeyLastUsed | - |
-| ListAccessKeys | - |
-| UpdateAccessKey | - |
-| DeleteAccessKey | - |
+| CreateAccessKey | Creates access-key credentials for a user. |
+| GetAccessKeyLastUsed | Returns the stored last-used metadata for an access key. |
+| ListAccessKeys | Lists access keys for a user. |
+| UpdateAccessKey | Updates an access key's status. |
+| DeleteAccessKey | Deletes an access key from a user. |
 
 ### Login Profiles
 
 | Action | Description |
 |--------|-------------|
-| CreateLoginProfile | - |
-| DeleteLoginProfile | - |
-| UpdateLoginProfile | - |
+| CreateLoginProfile | Creates a password login profile for a user. |
+| DeleteLoginProfile | Deletes a user's login profile. |
+| UpdateLoginProfile | Updates a user's login profile password settings. |
 
 ### Policy Simulation
 
 | Action | Description |
 |--------|-------------|
-| SimulatePrincipalPolicy | - |
+| SimulatePrincipalPolicy | Evaluates requested actions and resources against the resolved principal's policies. |
 
 ## AWS Managed Policies
 


### PR DESCRIPTION
## Summary

Fill the `-` description placeholders in the "Supported Actions" tables for Cognito, EC2, ELBv2, Glue, and IAM. Each cell now describes Floci's local behavior for that action.

Scoped to these five services (the largest placeholder counts, 282 rows); other services' remaining placeholders are left for a follow-up. Only description cells are edited, no action names change, so the tables stay in sync with handler source.

## Type of change
- [x] Docs / chore

## AWS Compatibility

N/A, documentation only. No action coverage or wire-protocol change; descriptions reflect existing handler behavior.

## Checklist
- [x] `make docs-check` passes (regenerates with no diff; only description cells changed)
- [ ] `./mvnw test` not run, docs-only change
- [x] Commit messages follow Conventional Commits