### PR TITLE
fix(tls): add host.docker.internal to self-signed cert SANs

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/config/TlsConfigSource.java
+++ b/src/main/java/io/github/hectorvent/floci/config/TlsConfigSource.java
@@ -49,6 +49,11 @@ public class TlsConfigSource implements ConfigSource {
     private static final String TLS_DIR = "tls";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
+    // host.docker.internal: how Lambda containers reach Floci when it runs on the host (not in a container).
+    private static final List<String> DEFAULT_SAN_HOSTNAMES = List.of(
+            "localhost", "127.0.0.1", "0.0.0.0", "*.localhost",
+            "localhost.floci.io", "*.localhost.floci.io", "host.docker.internal");
+
     private final Map<String, String> properties = new HashMap<>();
 
     public TlsConfigSource() {
@@ -77,8 +82,7 @@ public class TlsConfigSource implements ConfigSource {
                 // Extract current hostname configuration
                 List<String> customHostnames = extractCustomHostnames();
                 List<String> currentHostnames = new ArrayList<>();
-                currentHostnames.addAll(List.of("localhost", "127.0.0.1", "0.0.0.0", "*.localhost",
-                        "localhost.floci.io", "*.localhost.floci.io"));
+                currentHostnames.addAll(DEFAULT_SAN_HOSTNAMES);
                 currentHostnames.addAll(customHostnames);
                 
                 // Regenerate when the hostname config changed, or when the existing certificate
@@ -170,8 +174,7 @@ public class TlsConfigSource implements ConfigSource {
             // Extract custom hostnames and combine with defaults
             List<String> customHostnames = extractCustomHostnames();
             List<String> allSans = new ArrayList<>();
-            allSans.addAll(List.of("localhost", "127.0.0.1", "0.0.0.0", "*.localhost",
-                    "localhost.floci.io", "*.localhost.floci.io"));
+            allSans.addAll(DEFAULT_SAN_HOSTNAMES);
             allSans.addAll(customHostnames);
 
             CertificateGenerator gen = new CertificateGenerator();

--- a/src/test/java/io/github/hectorvent/floci/config/TlsCertificateHostnameTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/TlsCertificateHostnameTest.java
@@ -229,7 +229,7 @@ class TlsCertificateHostnameTest {
         List<String> sans = extractSansFromCertificate(cert);
         
         Set<String> expectedSans = Set.of("localhost", "127.0.0.1", "0.0.0.0", "*.localhost",
-                "localhost.floci.io", "*.localhost.floci.io");
+                "localhost.floci.io", "*.localhost.floci.io", "host.docker.internal");
         Set<String> actualSans = new HashSet<>(sans);
         
         assertEquals(expectedSans, actualSans,
@@ -252,7 +252,7 @@ class TlsCertificateHostnameTest {
         List<String> sans = extractSansFromCertificate(cert);
         
         Set<String> expectedSans = Set.of("localhost", "127.0.0.1", "0.0.0.0", "*.localhost",
-                "localhost.floci.io", "*.localhost.floci.io");
+                "localhost.floci.io", "*.localhost.floci.io", "host.docker.internal");
         Set<String> actualSans = new HashSet<>(sans);
         
         assertEquals(expectedSans, actualSans,

--- a/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceCertificateGenerationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceCertificateGenerationTest.java
@@ -158,9 +158,12 @@ class TlsConfigSourceCertificateGenerationTest {
         assertTrue(sans.contains("0.0.0.0"), 
             "Certificate SANs should include default '0.0.0.0'");
         
+        assertTrue(sans.contains("host.docker.internal"),
+            "Certificate SANs should include default 'host.docker.internal'");
+
         // Should not contain any custom hostnames
-        assertEquals(6, sans.size(), 
-            "Certificate SANs should contain exactly 6 default entries (localhost, 127.0.0.1, 0.0.0.0, *.localhost, localhost.floci.io, *.localhost.floci.io)");
+        assertEquals(7, sans.size(),
+            "Certificate SANs should contain exactly 7 default entries (localhost, 127.0.0.1, 0.0.0.0, *.localhost, localhost.floci.io, *.localhost.floci.io, host.docker.internal)");
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceMetadataPersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceMetadataPersistenceTest.java
@@ -83,6 +83,8 @@ class TlsConfigSourceMetadataPersistenceTest {
             "Metadata should contain 'localhost.floci.io'");
         assertTrue(metadata.getHostnames().contains("*.localhost.floci.io"),
             "Metadata should contain '*.localhost.floci.io'");
+        assertTrue(metadata.getHostnames().contains("host.docker.internal"),
+            "Metadata should contain 'host.docker.internal'");
     }
 
     /**


### PR DESCRIPTION
## Summary #1532 

add host.docker.internal to self-signed cert SANs

Lambda containers reach Floci via host.docker.internal when Floci
runs on the host instead of in a container, but the cert never
included it as a SAN, failing TLS verification.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
