### PR TITLE
feat(stepfunctions): support JSONata workflow variables (Assign)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -362,8 +362,8 @@ public class AslExecutor {
         if (jsonata) {
             JsonNode effectiveInput = input;
             if (stateDef.has("Arguments")) {
-                JsonNode statesVar = buildStatesVar(input, null, context, variables);
-                effectiveInput = jsonataEvaluator.resolveTemplate(stateDef.get("Arguments"), statesVar);
+                JsonNode statesVar = buildStatesVar(input, null, context);
+                effectiveInput = jsonataEvaluator.resolveTemplate(stateDef.get("Arguments"), statesVar, variables);
             }
             taskResult = invokeResource(effectiveResource, effectiveInput, sm, taskToken);
         } else {
@@ -1157,12 +1157,12 @@ public class AslExecutor {
     private StateResult executeChoiceState(JsonNode stateDef, JsonNode input, boolean jsonata, JsonNode context,
                                            ObjectNode variables) throws Exception {
         if (jsonata) {
-            JsonNode statesVar = buildStatesVar(input, null, context, variables);
+            JsonNode statesVar = buildStatesVar(input, null, context);
             JsonNode choices = stateDef.path("Choices");
             for (JsonNode choice : choices) {
                 String condition = choice.path("Condition").asText(null);
                 if (condition != null) {
-                    JsonNode result = jsonataEvaluator.evaluate(condition, statesVar);
+                    JsonNode result = jsonataEvaluator.evaluate(condition, statesVar, variables);
                     if (result.isBoolean() && result.asBoolean()) {
                         return new StateResult(input, choice.path("Next").asText());
                     }
@@ -1280,8 +1280,8 @@ public class AslExecutor {
             if (stateDef.has("Seconds")) {
                 JsonNode secondsNode = stateDef.get("Seconds");
                 if (secondsNode.isTextual() && JsonataEvaluator.isExpression(secondsNode.asText())) {
-                    JsonNode statesVar = buildStatesVar(input, null, context, variables);
-                    JsonNode result = jsonataEvaluator.evaluate(secondsNode.asText(), statesVar);
+                    JsonNode statesVar = buildStatesVar(input, null, context);
+                    JsonNode result = jsonataEvaluator.evaluate(secondsNode.asText(), statesVar, variables);
                     seconds = Math.min(result.asInt(), MAX_WAIT_SECONDS);
                 } else {
                     seconds = Math.min(secondsNode.asInt(), MAX_WAIT_SECONDS);
@@ -1316,12 +1316,12 @@ public class AslExecutor {
         String error = stateDef.path("Error").asText(null);
         String cause = stateDef.path("Cause").asText(null);
         if (jsonata) {
-            JsonNode statesVar = buildStatesVar(input, null, context, variables);
+            JsonNode statesVar = buildStatesVar(input, null, context);
             if (error != null && JsonataEvaluator.isExpression(error)) {
-                error = jsonataEvaluator.evaluate(error, statesVar).asText();
+                error = jsonataEvaluator.evaluate(error, statesVar, variables).asText();
             }
             if (cause != null && JsonataEvaluator.isExpression(cause)) {
-                cause = jsonataEvaluator.evaluate(cause, statesVar).asText();
+                cause = jsonataEvaluator.evaluate(cause, statesVar, variables).asText();
             }
         }
         throw new FailStateException(error, cause);
@@ -1461,8 +1461,8 @@ public class AslExecutor {
         if (jsonata && stateDef.has("Items")) {
             JsonNode itemsNode = stateDef.get("Items");
             if (itemsNode.isTextual() && JsonataEvaluator.isExpression(itemsNode.asText())) {
-                JsonNode statesVar = buildStatesVar(input, null, context, variables);
-                return new ResolvedMapItems(jsonataEvaluator.evaluate(itemsNode.asText(), statesVar),
+                JsonNode statesVar = buildStatesVar(input, null, context);
+                return new ResolvedMapItems(jsonataEvaluator.evaluate(itemsNode.asText(), statesVar, variables),
                         MapItemsSource.DEFAULT);
             }
             return new ResolvedMapItems(itemsNode, MapItemsSource.DEFAULT);
@@ -1497,8 +1497,8 @@ public class AslExecutor {
 
         JsonNode resolvedParameters;
         if (jsonata && itemReader.has("Arguments")) {
-            JsonNode statesVar = buildStatesVar(input, null, context, variables);
-            resolvedParameters = jsonataEvaluator.resolveTemplate(itemReader.get("Arguments"), statesVar);
+            JsonNode statesVar = buildStatesVar(input, null, context);
+            resolvedParameters = jsonataEvaluator.resolveTemplate(itemReader.get("Arguments"), statesVar, variables);
         } else {
             JsonNode parameters = itemReader.path("Parameters");
             resolvedParameters = resolveParameters(parameters, input, context);
@@ -1616,10 +1616,6 @@ public class AslExecutor {
     }
 
     private JsonNode buildStatesVar(JsonNode input, JsonNode result, JsonNode context) {
-        return buildStatesVar(input, result, context, null);
-    }
-
-    private JsonNode buildStatesVar(JsonNode input, JsonNode result, JsonNode context, JsonNode variables) {
         ObjectNode states = objectMapper.createObjectNode();
         states.set("input", input);
         if (result != null) {
@@ -1627,11 +1623,6 @@ public class AslExecutor {
         }
         if (context != null) {
             states.set("context", context);
-        }
-        // Carries execution-scoped variables into the evaluator, which binds each as a top-level
-        // $name reference (AWS's variable syntax). Kept out of user-visible $states fields.
-        if (variables != null) {
-            states.set("variables", variables);
         }
         return states;
     }
@@ -1674,24 +1665,35 @@ public class AslExecutor {
     /**
      * Apply the JSONata Assign and Output fields.
      *
-     * <p>Assign is evaluated first and updates the execution-scoped {@code variables}, so both this
-     * state's Output and all later states observe the newly assigned values — matching AWS ordering,
-     * where a state's Assign runs before its Output.
+     * <p>Every variable reference in a state — including the state's own Output — resolves against
+     * the values the variables held on state entry. Assign and Output are therefore both evaluated
+     * against the pre-assignment scope, and the new values are committed only afterwards, becoming
+     * visible to the <em>next</em> state. A state's Output never observes that same state's Assign.
+     *
+     * <p>This also makes assignments within one Assign block independent of each other: given
+     * {@code $x=3, $a=6} and {@code {"x": "{% $a %}", "nextX": "{% $x %}"}}, AWS ends with
+     * {@code $x=6, $nextX=3}.
      *
      * <p>Output, when present, is resolved as a template with $states bound; when absent, the result
      * is passed through directly (or input if result is null).
      */
     private JsonNode applyJsonataOutput(JsonNode stateDef, JsonNode input, JsonNode result, JsonNode context,
                                         ObjectNode variables) {
-        JsonNode statesVar = buildStatesVar(input, result, context, variables);
+        JsonNode statesVar = buildStatesVar(input, result, context);
 
+        JsonNode assigned = null;
         if (stateDef.has("Assign")) {
-            // Assignments in a single Assign block are evaluated against the pre-assignment scope,
-            // so intra-block references do not see each other (they resolve against statesVar here).
-            JsonNode assigned = jsonataEvaluator.resolveTemplate(stateDef.get("Assign"), statesVar);
+            assigned = jsonataEvaluator.resolveTemplate(stateDef.get("Assign"), statesVar, variables);
             if (assigned == null || !assigned.isObject()) {
                 throw new FailStateException("States.Runtime", "Assign must evaluate to an object");
             }
+        }
+
+        JsonNode output = stateDef.has("Output")
+                ? jsonataEvaluator.resolveTemplate(stateDef.get("Output"), statesVar, variables)
+                : (result != null ? result : input);
+
+        if (assigned != null) {
             Iterator<Map.Entry<String, JsonNode>> fields = assigned.fields();
             while (fields.hasNext()) {
                 Map.Entry<String, JsonNode> entry = fields.next();
@@ -1699,10 +1701,7 @@ public class AslExecutor {
             }
         }
 
-        if (!stateDef.has("Output")) {
-            return result != null ? result : input;
-        }
-        return jsonataEvaluator.resolveTemplate(stateDef.get("Output"), statesVar);
+        return output;
     }
 
     // ──────────────────────────── Path resolution ────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -243,8 +243,8 @@ public class AslExecutor {
                 // Update per-state context fields
                 updateStateContext(execContext, currentStateName);
 
+                boolean jsonata = isJsonata(stateDef, topLevelQueryLanguage);
                 try {
-                    boolean jsonata = isJsonata(stateDef, topLevelQueryLanguage);
                     StateResult stateResult = executeState(currentStateName, type, stateDef, currentInput,
                             history, eventId, sm, jsonata, topLevelQueryLanguage, execContext, variables);
                     addEvent(history, eventId, stateExitedEventType(type), eventId.get() - 1,
@@ -257,7 +257,7 @@ public class AslExecutor {
                         currentStateName = null;
                     }
                 } catch (FailStateException e) {
-                    StateResult caught = handleCatch(stateDef, currentInput, e);
+                    StateResult caught = handleCatch(stateDef, currentInput, e, jsonata, execContext, variables);
                     if (caught != null) {
                         addEvent(history, eventId, stateExitedEventType(type), eventId.get() - 1,
                                 Map.of("name", currentStateName, "output", caught.output().toString()));
@@ -1164,13 +1164,18 @@ public class AslExecutor {
                 if (condition != null) {
                     JsonNode result = jsonataEvaluator.evaluate(condition, statesVar, variables);
                     if (result.isBoolean() && result.asBoolean()) {
-                        return new StateResult(input, choice.path("Next").asText());
+                        // A matched rule carries its own Assign and Output; the state-level ones
+                        // belong to the Default path and do not run here.
+                        JsonNode output = applyJsonataAssignAndOutput(choice, statesVar, input, variables);
+                        return new StateResult(output, choice.path("Next").asText());
                     }
                 }
             }
             String defaultState = stateDef.path("Default").asText(null);
             if (defaultState != null) {
-                return new StateResult(input, defaultState);
+                // No rule matched: the state-level Assign and Output apply on the Default path.
+                JsonNode output = applyJsonataAssignAndOutput(stateDef, statesVar, input, variables);
+                return new StateResult(output, defaultState);
             }
             throw new FailStateException("States.NoChoiceMatched", "No choice rule matched and no default state");
         }
@@ -1298,6 +1303,10 @@ public class AslExecutor {
         // Timestamp and TimestampPath: wait until that time or now, whichever is sooner
         if (seconds > 0) {
             TimeUnit.SECONDS.sleep(seconds);
+        }
+        if (jsonata) {
+            JsonNode output = applyJsonataOutput(stateDef, input, null, context, variables);
+            return new StateResult(output, stateDef.path("Next").asText(null));
         }
         return new StateResult(input, stateDef.path("Next").asText(null));
     }
@@ -1589,7 +1598,7 @@ public class AslExecutor {
                 result = executeState(currentState, type, stateDef, currentInput, ignored, eventId, sm,
                         stateJsonata, topLevelQueryLanguage, context, variables);
             } catch (FailStateException e) {
-                StateResult caught = handleCatch(stateDef, currentInput, e);
+                StateResult caught = handleCatch(stateDef, currentInput, e, stateJsonata, context, variables);
                 if (caught == null) {
                     throw e;
                 }
@@ -1624,6 +1633,16 @@ public class AslExecutor {
         if (context != null) {
             states.set("context", context);
         }
+        return states;
+    }
+
+    /**
+     * $states inside a Catch block: errorOutput is bound in addition to input and context, and is the
+     * only place AWS makes it available.
+     */
+    private JsonNode buildCatchStatesVar(JsonNode input, JsonNode errorOutput, JsonNode context) {
+        ObjectNode states = (ObjectNode) buildStatesVar(input, null, context);
+        states.set("errorOutput", errorOutput);
         return states;
     }
 
@@ -1663,7 +1682,7 @@ public class AslExecutor {
     }
 
     /**
-     * Apply the JSONata Assign and Output fields.
+     * Apply the JSONata Assign and Output fields of a state.
      *
      * <p>Every variable reference in a state — including the state's own Output — resolves against
      * the values the variables held on state entry. Assign and Output are therefore both evaluated
@@ -1677,31 +1696,46 @@ public class AslExecutor {
      * <p>Output, when present, is resolved as a template with $states bound; when absent, the result
      * is passed through directly (or input if result is null).
      */
-    private JsonNode applyJsonataOutput(JsonNode stateDef, JsonNode input, JsonNode result, JsonNode context,
+    private JsonNode applyJsonataOutput(JsonNode holder, JsonNode input, JsonNode result, JsonNode context,
                                         ObjectNode variables) {
         JsonNode statesVar = buildStatesVar(input, result, context);
+        return applyJsonataAssignAndOutput(holder, statesVar, result != null ? result : input, variables);
+    }
 
-        JsonNode assigned = null;
-        if (stateDef.has("Assign")) {
-            assigned = jsonataEvaluator.resolveTemplate(stateDef.get("Assign"), statesVar, variables);
-            if (assigned == null || !assigned.isObject()) {
-                throw new FailStateException("States.Runtime", "Assign must evaluate to an object");
-            }
-        }
-
-        JsonNode output = stateDef.has("Output")
-                ? jsonataEvaluator.resolveTemplate(stateDef.get("Output"), statesVar, variables)
-                : (result != null ? result : input);
-
-        if (assigned != null) {
-            Iterator<Map.Entry<String, JsonNode>> fields = assigned.fields();
-            while (fields.hasNext()) {
-                Map.Entry<String, JsonNode> entry = fields.next();
-                variables.set(entry.getKey(), entry.getValue());
-            }
-        }
-
+    /**
+     * Apply the Assign and Output fields of anything that can carry them: a state, a Choice rule, or
+     * a Catch block. {@code fallbackOutput} is the value that becomes the output when Output is absent.
+     */
+    private JsonNode applyJsonataAssignAndOutput(JsonNode holder, JsonNode statesVar, JsonNode fallbackOutput,
+                                                 ObjectNode variables) {
+        JsonNode assigned = evaluateJsonataAssign(holder, statesVar, variables);
+        JsonNode output = holder.has("Output")
+                ? jsonataEvaluator.resolveTemplate(holder.get("Output"), statesVar, variables)
+                : fallbackOutput;
+        commitJsonataAssign(assigned, variables);
         return output;
+    }
+
+    private JsonNode evaluateJsonataAssign(JsonNode holder, JsonNode statesVar, ObjectNode variables) {
+        if (!holder.has("Assign")) {
+            return null;
+        }
+        JsonNode assigned = jsonataEvaluator.resolveTemplate(holder.get("Assign"), statesVar, variables);
+        if (assigned == null || !assigned.isObject()) {
+            throw new FailStateException("States.Runtime", "Assign must evaluate to an object");
+        }
+        return assigned;
+    }
+
+    private void commitJsonataAssign(JsonNode assigned, ObjectNode variables) {
+        if (assigned == null) {
+            return;
+        }
+        Iterator<Map.Entry<String, JsonNode>> fields = assigned.fields();
+        while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> entry = fields.next();
+            variables.set(entry.getKey(), entry.getValue());
+        }
     }
 
     // ──────────────────────────── Path resolution ────────────────────────────
@@ -2148,7 +2182,8 @@ public class AslExecutor {
                 Map.of("error", failError, "cause", failCause));
     }
 
-    private StateResult handleCatch(JsonNode stateDef, JsonNode input, FailStateException failure) throws Exception {
+    private StateResult handleCatch(JsonNode stateDef, JsonNode input, FailStateException failure,
+                                    boolean jsonata, JsonNode context, ObjectNode variables) throws Exception {
         JsonNode catchers = stateDef.path("Catch");
         if (!catchers.isArray()) {
             return null;
@@ -2166,6 +2201,14 @@ public class AslExecutor {
             ObjectNode errorOutput = objectMapper.createObjectNode();
             errorOutput.put("Error", error);
             errorOutput.put("Cause", cause);
+            if (jsonata) {
+                // The catch block's input is the error output, and a Catch's Assign writes into the
+                // scope the catching state lives in — so for a Parallel or Map it lands in the outer
+                // scope, not the branch scope that failed.
+                JsonNode statesVar = buildCatchStatesVar(input, errorOutput, context);
+                JsonNode output = applyJsonataAssignAndOutput(catcher, statesVar, errorOutput, variables);
+                return new StateResult(output, next);
+            }
             return new StateResult(mergeResult(catcher, input, errorOutput), next);
         }
         return null;

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -225,6 +225,9 @@ public class AslExecutor {
             String topLevelQueryLanguage = definition.path("QueryLanguage").asText("JSONPath");
             JsonNode currentInput = parseInput(exec.getInput());
             JsonNode execContext = buildContext(exec, sm);
+            // Execution-scoped JSONata variables (the Assign field). Mutated in place as states
+            // assign, so later states observe earlier assignments.
+            ObjectNode variables = objectMapper.createObjectNode();
 
             String currentStateName = startAt;
             while (currentStateName != null) {
@@ -243,7 +246,7 @@ public class AslExecutor {
                 try {
                     boolean jsonata = isJsonata(stateDef, topLevelQueryLanguage);
                     StateResult stateResult = executeState(currentStateName, type, stateDef, currentInput,
-                            history, eventId, sm, jsonata, topLevelQueryLanguage, execContext);
+                            history, eventId, sm, jsonata, topLevelQueryLanguage, execContext, variables);
                     addEvent(history, eventId, stateExitedEventType(type), eventId.get() - 1,
                             Map.of("name", currentStateName, "output", stateResult.output().toString()));
 
@@ -296,24 +299,26 @@ public class AslExecutor {
 
     private StateResult executeState(String name, String type, JsonNode stateDef, JsonNode input,
                                      List<HistoryEvent> history, AtomicLong eventId, StateMachine sm,
-                                     boolean jsonata, String topLevelQueryLanguage, JsonNode context) throws Exception {
+                                     boolean jsonata, String topLevelQueryLanguage, JsonNode context,
+                                     ObjectNode variables) throws Exception {
         return switch (type) {
-            case "Pass" -> executePassState(stateDef, input, jsonata, context);
-            case "Task" -> executeTaskState(name, stateDef, input, history, eventId, sm, jsonata, context);
-            case "Choice" -> executeChoiceState(stateDef, input, jsonata, context);
-            case "Wait" -> executeWaitState(stateDef, input, jsonata, context);
-            case "Succeed" -> executeSucceedState(stateDef, input, jsonata, context);
-            case "Fail" -> executeFail(stateDef, input, jsonata, context);
-            case "Parallel" -> executeParallelState(name, stateDef, input, sm, jsonata, topLevelQueryLanguage, context);
-            case "Map" -> executeMapState(name, stateDef, input, sm, jsonata, topLevelQueryLanguage, context);
+            case "Pass" -> executePassState(stateDef, input, jsonata, context, variables);
+            case "Task" -> executeTaskState(name, stateDef, input, history, eventId, sm, jsonata, context, variables);
+            case "Choice" -> executeChoiceState(stateDef, input, jsonata, context, variables);
+            case "Wait" -> executeWaitState(stateDef, input, jsonata, context, variables);
+            case "Succeed" -> executeSucceedState(stateDef, input, jsonata, context, variables);
+            case "Fail" -> executeFail(stateDef, input, jsonata, context, variables);
+            case "Parallel" -> executeParallelState(name, stateDef, input, sm, jsonata, topLevelQueryLanguage, context, variables);
+            case "Map" -> executeMapState(name, stateDef, input, sm, jsonata, topLevelQueryLanguage, context, variables);
             default -> new StateResult(input, stateDef.path("Next").asText(null));
         };
     }
 
-    private StateResult executePassState(JsonNode stateDef, JsonNode input, boolean jsonata, JsonNode context) throws Exception {
+    private StateResult executePassState(JsonNode stateDef, JsonNode input, boolean jsonata, JsonNode context,
+                                         ObjectNode variables) throws Exception {
         if (jsonata) {
             JsonNode result = stateDef.has("Result") ? stateDef.get("Result") : input;
-            JsonNode output = applyJsonataOutput(stateDef, input, result, context);
+            JsonNode output = applyJsonataOutput(stateDef, input, result, context, variables);
             return new StateResult(output, stateDef.path("Next").asText(null));
         }
 
@@ -336,7 +341,7 @@ public class AslExecutor {
 
     private StateResult executeTaskState(String stateName, JsonNode stateDef, JsonNode input,
                                          List<HistoryEvent> history, AtomicLong eventId, StateMachine sm,
-                                         boolean jsonata, JsonNode context) throws Exception {
+                                         boolean jsonata, JsonNode context, ObjectNode variables) throws Exception {
         String resource = stateDef.path("Resource").asText();
         boolean isWaitForToken = resource.endsWith(".waitForTaskToken");
         String effectiveResource = isWaitForToken
@@ -357,7 +362,7 @@ public class AslExecutor {
         if (jsonata) {
             JsonNode effectiveInput = input;
             if (stateDef.has("Arguments")) {
-                JsonNode statesVar = buildStatesVar(input, null, context);
+                JsonNode statesVar = buildStatesVar(input, null, context, variables);
                 effectiveInput = jsonataEvaluator.resolveTemplate(stateDef.get("Arguments"), statesVar);
             }
             taskResult = invokeResource(effectiveResource, effectiveInput, sm, taskToken);
@@ -374,7 +379,7 @@ public class AslExecutor {
         }
 
         if (jsonata) {
-            JsonNode output = applyJsonataOutput(stateDef, input, taskResult, context);
+            JsonNode output = applyJsonataOutput(stateDef, input, taskResult, context, variables);
             return new StateResult(output, stateDef.path("Next").asText(null));
         } else {
             // ResultSelector transforms the raw result before ResultPath merges it into the state input.
@@ -1149,9 +1154,10 @@ public class AslExecutor {
         };
     }
 
-    private StateResult executeChoiceState(JsonNode stateDef, JsonNode input, boolean jsonata, JsonNode context) throws Exception {
+    private StateResult executeChoiceState(JsonNode stateDef, JsonNode input, boolean jsonata, JsonNode context,
+                                           ObjectNode variables) throws Exception {
         if (jsonata) {
-            JsonNode statesVar = buildStatesVar(input, null, context);
+            JsonNode statesVar = buildStatesVar(input, null, context, variables);
             JsonNode choices = stateDef.path("Choices");
             for (JsonNode choice : choices) {
                 String condition = choice.path("Condition").asText(null);
@@ -1267,13 +1273,14 @@ public class AslExecutor {
         return false;
     }
 
-    private StateResult executeWaitState(JsonNode stateDef, JsonNode input, boolean jsonata, JsonNode context) throws InterruptedException {
+    private StateResult executeWaitState(JsonNode stateDef, JsonNode input, boolean jsonata, JsonNode context,
+                                         ObjectNode variables) throws InterruptedException {
         int seconds = 0;
         if (jsonata) {
             if (stateDef.has("Seconds")) {
                 JsonNode secondsNode = stateDef.get("Seconds");
                 if (secondsNode.isTextual() && JsonataEvaluator.isExpression(secondsNode.asText())) {
-                    JsonNode statesVar = buildStatesVar(input, null, context);
+                    JsonNode statesVar = buildStatesVar(input, null, context, variables);
                     JsonNode result = jsonataEvaluator.evaluate(secondsNode.asText(), statesVar);
                     seconds = Math.min(result.asInt(), MAX_WAIT_SECONDS);
                 } else {
@@ -1295,19 +1302,21 @@ public class AslExecutor {
         return new StateResult(input, stateDef.path("Next").asText(null));
     }
 
-    private StateResult executeSucceedState(JsonNode stateDef, JsonNode input, boolean jsonata, JsonNode context) {
+    private StateResult executeSucceedState(JsonNode stateDef, JsonNode input, boolean jsonata, JsonNode context,
+                                            ObjectNode variables) {
         if (jsonata) {
-            JsonNode output = applyJsonataOutput(stateDef, input, input, context);
+            JsonNode output = applyJsonataOutput(stateDef, input, input, context, variables);
             return new StateResult(output, null);
         }
         return new StateResult(applyOutputPath(stateDef, input, input), null);
     }
 
-    private StateResult executeFail(JsonNode stateDef, JsonNode input, boolean jsonata, JsonNode context) {
+    private StateResult executeFail(JsonNode stateDef, JsonNode input, boolean jsonata, JsonNode context,
+                                    ObjectNode variables) {
         String error = stateDef.path("Error").asText(null);
         String cause = stateDef.path("Cause").asText(null);
         if (jsonata) {
-            JsonNode statesVar = buildStatesVar(input, null, context);
+            JsonNode statesVar = buildStatesVar(input, null, context, variables);
             if (error != null && JsonataEvaluator.isExpression(error)) {
                 error = jsonataEvaluator.evaluate(error, statesVar).asText();
             }
@@ -1319,7 +1328,8 @@ public class AslExecutor {
     }
 
     private StateResult executeParallelState(String name, JsonNode stateDef, JsonNode input, StateMachine sm,
-                                              boolean jsonata, String topLevelQueryLanguage, JsonNode context) throws Exception {
+                                              boolean jsonata, String topLevelQueryLanguage, JsonNode context,
+                                              ObjectNode variables) throws Exception {
         JsonNode branches = stateDef.path("Branches");
         List<Future<JsonNode>> futures = new ArrayList<>();
 
@@ -1327,12 +1337,16 @@ public class AslExecutor {
             String startAt = branch.path("StartAt").asText();
             JsonNode branchStates = branch.path("States");
             JsonNode capturedInput = input;
+            // Each branch gets an isolated copy of the current variables: assignments inside a
+            // branch are scoped to that branch and do not leak back to the parent after the state.
+            ObjectNode branchVariables = variables.deepCopy();
 
             // Run each branch on its own worker thread under the execution's account: the request
             // scope is thread-bound, so without this a branch's Task integrations would resolve to
             // the default account rather than the execution's.
             futures.add(executor.submit(() -> callUnderExecutionAccount(sm,
-                    () -> executeBranch(startAt, branchStates, capturedInput, sm, topLevelQueryLanguage, context))));
+                    () -> executeBranch(startAt, branchStates, capturedInput, sm, topLevelQueryLanguage, context,
+                            branchVariables))));
         }
 
         int timeoutSeconds = stateDef.path("TimeoutSeconds").asInt(0);
@@ -1358,7 +1372,7 @@ public class AslExecutor {
         }
 
         if (jsonata) {
-            JsonNode output = applyJsonataOutput(stateDef, input, results, context);
+            JsonNode output = applyJsonataOutput(stateDef, input, results, context, variables);
             return new StateResult(output, stateDef.path("Next").asText(null));
         }
 
@@ -1372,7 +1386,8 @@ public class AslExecutor {
     }
 
     private StateResult executeMapState(String name, JsonNode stateDef, JsonNode input, StateMachine sm,
-                                         boolean jsonata, String topLevelQueryLanguage, JsonNode context) throws Exception {
+                                         boolean jsonata, String topLevelQueryLanguage, JsonNode context,
+                                         ObjectNode variables) throws Exception {
         if (stateDef.has("ItemReader")) {
             String mode = stateDef.path("ItemProcessor").path("ProcessorConfig").path("Mode").asText("INLINE");
             if (!"DISTRIBUTED".equals(mode)) {
@@ -1380,7 +1395,7 @@ public class AslExecutor {
                         "The ItemReader, ItemBatcher and ResultWriter fields are not supported for INLINE maps");
             }
         }
-        ResolvedMapItems resolvedItems = resolveMapItems(stateDef, input, jsonata, context);
+        ResolvedMapItems resolvedItems = resolveMapItems(stateDef, input, jsonata, context, variables);
         JsonNode items = resolvedItems.items();
 
         if (!items.isArray()) {
@@ -1420,12 +1435,15 @@ public class AslExecutor {
                 // $ in ItemSelector resolves against the Map state's effective input, not the item.
                 iterInput = resolveParameters(itemTransform, mapInput, iterContext);
             }
-            results.add(executeBranch(startAt, iteratorStates, iterInput, sm, topLevelQueryLanguage, iterContext));
+            // Each iteration gets an isolated copy of the current variables; assignments inside an
+            // iteration are scoped to that iteration and do not leak back to the parent scope.
+            results.add(executeBranch(startAt, iteratorStates, iterInput, sm, topLevelQueryLanguage, iterContext,
+                    variables.deepCopy()));
             index++;
         }
 
         if (jsonata) {
-            JsonNode output = applyJsonataOutput(stateDef, input, results, context);
+            JsonNode output = applyJsonataOutput(stateDef, input, results, context, variables);
             return new StateResult(output, stateDef.path("Next").asText(null));
         }
 
@@ -1439,11 +1457,11 @@ public class AslExecutor {
     }
 
     private ResolvedMapItems resolveMapItems(JsonNode stateDef, JsonNode input,
-                                             boolean jsonata, JsonNode context) throws Exception {
+                                             boolean jsonata, JsonNode context, ObjectNode variables) throws Exception {
         if (jsonata && stateDef.has("Items")) {
             JsonNode itemsNode = stateDef.get("Items");
             if (itemsNode.isTextual() && JsonataEvaluator.isExpression(itemsNode.asText())) {
-                JsonNode statesVar = buildStatesVar(input, null, context);
+                JsonNode statesVar = buildStatesVar(input, null, context, variables);
                 return new ResolvedMapItems(jsonataEvaluator.evaluate(itemsNode.asText(), statesVar),
                         MapItemsSource.DEFAULT);
             }
@@ -1451,7 +1469,7 @@ public class AslExecutor {
         }
 
         if (stateDef.has("ItemReader")) {
-            return resolveItemReaderItems(stateDef.get("ItemReader"), input, context, jsonata);
+            return resolveItemReaderItems(stateDef.get("ItemReader"), input, context, jsonata, variables);
         }
 
         JsonNode itemsPath = stateDef.path("ItemsPath");
@@ -1460,7 +1478,8 @@ public class AslExecutor {
     }
 
     private ResolvedMapItems resolveItemReaderItems(JsonNode itemReader, JsonNode input,
-                                                    JsonNode context, boolean jsonata) throws Exception {
+                                                    JsonNode context, boolean jsonata,
+                                                    ObjectNode variables) throws Exception {
         String resource = itemReader.path("Resource").asText(null);
         if ("arn:aws:states:::s3:listObjectsV2".equals(resource)) {
             throw new FailStateException("States.ItemReaderFailed",
@@ -1478,7 +1497,7 @@ public class AslExecutor {
 
         JsonNode resolvedParameters;
         if (jsonata && itemReader.has("Arguments")) {
-            JsonNode statesVar = buildStatesVar(input, null, context);
+            JsonNode statesVar = buildStatesVar(input, null, context, variables);
             resolvedParameters = jsonataEvaluator.resolveTemplate(itemReader.get("Arguments"), statesVar);
         } else {
             JsonNode parameters = itemReader.path("Parameters");
@@ -1552,7 +1571,7 @@ public class AslExecutor {
     }
 
     private JsonNode executeBranch(String startAt, JsonNode states, JsonNode input, StateMachine sm,
-                                    String topLevelQueryLanguage, JsonNode context) throws Exception {
+                                    String topLevelQueryLanguage, JsonNode context, ObjectNode variables) throws Exception {
         List<HistoryEvent> ignored = new ArrayList<>();
         AtomicLong eventId = new AtomicLong(0);
         JsonNode currentInput = input;
@@ -1568,7 +1587,7 @@ public class AslExecutor {
             StateResult result;
             try {
                 result = executeState(currentState, type, stateDef, currentInput, ignored, eventId, sm,
-                        stateJsonata, topLevelQueryLanguage, context);
+                        stateJsonata, topLevelQueryLanguage, context, variables);
             } catch (FailStateException e) {
                 StateResult caught = handleCatch(stateDef, currentInput, e);
                 if (caught == null) {
@@ -1597,6 +1616,10 @@ public class AslExecutor {
     }
 
     private JsonNode buildStatesVar(JsonNode input, JsonNode result, JsonNode context) {
+        return buildStatesVar(input, result, context, null);
+    }
+
+    private JsonNode buildStatesVar(JsonNode input, JsonNode result, JsonNode context, JsonNode variables) {
         ObjectNode states = objectMapper.createObjectNode();
         states.set("input", input);
         if (result != null) {
@@ -1604,6 +1627,11 @@ public class AslExecutor {
         }
         if (context != null) {
             states.set("context", context);
+        }
+        // Carries execution-scoped variables into the evaluator, which binds each as a top-level
+        // $name reference (AWS's variable syntax). Kept out of user-visible $states fields.
+        if (variables != null) {
+            states.set("variables", variables);
         }
         return states;
     }
@@ -1644,14 +1672,36 @@ public class AslExecutor {
     }
 
     /**
-     * Apply JSONata Output field. If Output is present, resolve it as a template with $states bound.
-     * If absent, use the result directly (or input if result is null).
+     * Apply the JSONata Assign and Output fields.
+     *
+     * <p>Assign is evaluated first and updates the execution-scoped {@code variables}, so both this
+     * state's Output and all later states observe the newly assigned values — matching AWS ordering,
+     * where a state's Assign runs before its Output.
+     *
+     * <p>Output, when present, is resolved as a template with $states bound; when absent, the result
+     * is passed through directly (or input if result is null).
      */
-    private JsonNode applyJsonataOutput(JsonNode stateDef, JsonNode input, JsonNode result, JsonNode context) {
+    private JsonNode applyJsonataOutput(JsonNode stateDef, JsonNode input, JsonNode result, JsonNode context,
+                                        ObjectNode variables) {
+        JsonNode statesVar = buildStatesVar(input, result, context, variables);
+
+        if (stateDef.has("Assign")) {
+            // Assignments in a single Assign block are evaluated against the pre-assignment scope,
+            // so intra-block references do not see each other (they resolve against statesVar here).
+            JsonNode assigned = jsonataEvaluator.resolveTemplate(stateDef.get("Assign"), statesVar);
+            if (assigned == null || !assigned.isObject()) {
+                throw new FailStateException("States.Runtime", "Assign must evaluate to an object");
+            }
+            Iterator<Map.Entry<String, JsonNode>> fields = assigned.fields();
+            while (fields.hasNext()) {
+                Map.Entry<String, JsonNode> entry = fields.next();
+                variables.set(entry.getKey(), entry.getValue());
+            }
+        }
+
         if (!stateDef.has("Output")) {
             return result != null ? result : input;
         }
-        JsonNode statesVar = buildStatesVar(input, result, context);
         return jsonataEvaluator.resolveTemplate(stateDef.get("Output"), statesVar);
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
@@ -63,15 +63,19 @@ public class JsonataEvaluator {
      * {@code [$states.result.Items.{"id": id}]}.
      */
     JsonNode evaluate(String expression, JsonNode statesVar) {
+        return evaluate(expression, statesVar, null);
+    }
+
+    JsonNode evaluate(String expression, JsonNode statesVar, JsonNode variables) {
         String expr = isExpression(expression) ? unwrap(expression) : expression;
         try {
             Jsonata jsonataExpr = jsonata(expr);
             Jsonata.Frame frame = jsonataExpr.createFrame();
             frame.bind("states", toObject(statesVar));
-            // Execution-scoped variables (the Assign field) are referenced as top-level $name in
-            // AWS's JSONata dialect, e.g. $CheckpointCount — bind each one accordingly.
-            JsonNode variables = statesVar.path("variables");
-            if (variables.isObject()) {
+            // Workflow variables (the Assign field) are referenced as top-level $name in AWS's
+            // JSONata dialect, e.g. $CheckpointCount. They are bound alongside $states, never
+            // inside it: AWS reserves $states for input/result/errorOutput/context only.
+            if (variables != null && variables.isObject()) {
                 Iterator<Map.Entry<String, JsonNode>> fields = variables.fields();
                 while (fields.hasNext()) {
                     Map.Entry<String, JsonNode> entry = fields.next();
@@ -93,13 +97,17 @@ public class JsonataEvaluator {
      * All other strings pass through unchanged.
      */
     JsonNode resolveTemplate(JsonNode template, JsonNode statesVar) {
+        return resolveTemplate(template, statesVar, null);
+    }
+
+    JsonNode resolveTemplate(JsonNode template, JsonNode statesVar, JsonNode variables) {
         if (template == null || template.isNull() || template.isMissingNode()) {
             return template;
         }
         if (template.isTextual()) {
             String text = template.asText();
             if (isExpression(text)) {
-                return evaluate(text, statesVar);
+                return evaluate(text, statesVar, variables);
             }
             return template;
         }
@@ -108,7 +116,7 @@ public class JsonataEvaluator {
             Iterator<Map.Entry<String, JsonNode>> fields = template.fields();
             while (fields.hasNext()) {
                 Map.Entry<String, JsonNode> entry = fields.next();
-                JsonNode value = resolveTemplate(entry.getValue(), statesVar);
+                JsonNode value = resolveTemplate(entry.getValue(), statesVar, variables);
                 // Per JSONata spec: undefined (null) values are omitted from object output,
                 // matching real AWS Step Functions behavior.
                 if (value != null && !value.isNull() && !value.isMissingNode()) {
@@ -121,7 +129,7 @@ public class JsonataEvaluator {
             ArrayNode resolved = objectMapper.createArrayNode();
             for (int i = 0; i < template.size(); i++) {
                 JsonNode element = template.get(i);
-                JsonNode value = resolveTemplate(element, statesVar);
+                JsonNode value = resolveTemplate(element, statesVar, variables);
                 // Per real AWS behavior: undefined array elements fail the execution.
                 // Unlike object fields (which are omitted), undefined in an array is a runtime error.
                 if (value == null || value.isNull() || value.isMissingNode()) {

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
@@ -71,10 +71,11 @@ public class JsonataEvaluator {
         try {
             Jsonata jsonataExpr = jsonata(expr);
             Jsonata.Frame frame = jsonataExpr.createFrame();
-            frame.bind("states", toObject(statesVar));
             // Workflow variables (the Assign field) are referenced as top-level $name in AWS's
             // JSONata dialect, e.g. $CheckpointCount. They are bound alongside $states, never
-            // inside it: AWS reserves $states for input/result/errorOutput/context only.
+            // inside it: AWS reserves $states for input/result/errorOutput/context only. $states is
+            // bound last so that reservation holds even if a definition assigns a variable named
+            // "states", which AWS rejects but Floci does not yet validate.
             if (variables != null && variables.isObject()) {
                 Iterator<Map.Entry<String, JsonNode>> fields = variables.fields();
                 while (fields.hasNext()) {
@@ -82,6 +83,7 @@ public class JsonataEvaluator {
                     frame.bind(entry.getKey(), toObject(entry.getValue()));
                 }
             }
+            frame.bind("states", toObject(statesVar));
             Object result = jsonataExpr.evaluate(null, frame);
             return toJsonNode(result);
         } catch (Exception e) {

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
@@ -68,6 +68,16 @@ public class JsonataEvaluator {
             Jsonata jsonataExpr = jsonata(expr);
             Jsonata.Frame frame = jsonataExpr.createFrame();
             frame.bind("states", toObject(statesVar));
+            // Execution-scoped variables (the Assign field) are referenced as top-level $name in
+            // AWS's JSONata dialect, e.g. $CheckpointCount — bind each one accordingly.
+            JsonNode variables = statesVar.path("variables");
+            if (variables.isObject()) {
+                Iterator<Map.Entry<String, JsonNode>> fields = variables.fields();
+                while (fields.hasNext()) {
+                    Map.Entry<String, JsonNode> entry = fields.next();
+                    frame.bind(entry.getKey(), toObject(entry.getValue()));
+                }
+            }
             Object result = jsonataExpr.evaluate(null, frame);
             return toJsonNode(result);
         } catch (Exception e) {

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
@@ -1194,6 +1194,146 @@ class StepFunctionsJsonataIntegrationTest {
     }
 
     @Test
+    void assignedVariablesSurviveBeyondNextStateOutput() throws Exception {
+        // Variables set via Assign persist across states even after a later state replaces the output.
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "AssignVariables",
+                    "States": {
+                        "AssignVariables": {
+                            "Type": "Pass",
+                            "Assign": {
+                                "CheckpointCount": "0",
+                                "ExecutionWaitTimeInSeconds": "3"
+                            },
+                            "Output": {
+                                "transient": 3
+                            },
+                            "Next": "UseAndReplaceOutput"
+                        },
+                        "UseAndReplaceOutput": {
+                            "Type": "Pass",
+                            "Output": {
+                                "fromAssignedVariable": "{% $ExecutionWaitTimeInSeconds %}",
+                                "fromPreviousOutput": "{% $states.input.transient %}"
+                            },
+                            "Next": "UseAssignedAgain"
+                        },
+                        "UseAssignedAgain": {
+                            "Type": "Pass",
+                            "Output": {
+                                "checkpoint": "{% $CheckpointCount %}",
+                                "fromAssignedVariable": "{% $ExecutionWaitTimeInSeconds %}",
+                                "previousTransientStillPresent": "{% $exists($states.input.transient) %}"
+                            },
+                            "End": true
+                        }
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-assign-vars-test", definition);
+        String execArn = startExecution(smArn, "{}");
+        String output = waitForExecution(execArn);
+
+        assertTrue(output.contains("\"checkpoint\":\"0\"") || output.contains("\"checkpoint\": \"0\""));
+        assertTrue(output.contains("\"fromAssignedVariable\":\"3\"") || output.contains("\"fromAssignedVariable\": \"3\""));
+        assertTrue(output.contains("\"previousTransientStillPresent\":false")
+                || output.contains("\"previousTransientStillPresent\": false"));
+    }
+
+    @Test
+    void assignedVariableVisibleToSameStateOutput() throws Exception {
+        // AWS evaluates a state's Assign before its Output, so the same state's Output sees the
+        // newly assigned variable.
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "AssignAndUse",
+                    "States": {
+                        "AssignAndUse": {
+                            "Type": "Pass",
+                            "Assign": {
+                                "Greeting": "{% 'hello ' & $states.input.name %}"
+                            },
+                            "Output": {
+                                "message": "{% $Greeting %}"
+                            },
+                            "End": true
+                        }
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-assign-same-state-test", definition);
+        String execArn = startExecution(smArn, "{\"name\": \"world\"}");
+        String output = waitForExecution(execArn);
+
+        assertTrue(output.contains("\"message\":\"hello world\"")
+                || output.contains("\"message\": \"hello world\""));
+    }
+
+    @Test
+    void variablesAssignedInsideMapDoNotLeakToParentScope() throws Exception {
+        // A variable is set in the parent scope, reassigned inside each Map iteration, and read
+        // again after the Map. The parent must still observe its own value: iteration assignments
+        // are scoped to the iteration.
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "SetScope",
+                    "States": {
+                        "SetScope": {
+                            "Type": "Pass",
+                            "Assign": {
+                                "Scope": "outer"
+                            },
+                            "Next": "MapState"
+                        },
+                        "MapState": {
+                            "Type": "Map",
+                            "Items": [1, 2],
+                            "ItemProcessor": {
+                                "ProcessorConfig": {
+                                    "Mode": "INLINE"
+                                },
+                                "StartAt": "Reassign",
+                                "States": {
+                                    "Reassign": {
+                                        "Type": "Pass",
+                                        "Assign": {
+                                            "Scope": "inner"
+                                        },
+                                        "Output": {
+                                            "seen": "{% $Scope %}"
+                                        },
+                                        "End": true
+                                    }
+                                }
+                            },
+                            "Next": "CheckScope"
+                        },
+                        "CheckScope": {
+                            "Type": "Pass",
+                            "Output": {
+                                "finalScope": "{% $Scope %}"
+                            },
+                            "End": true
+                        }
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-assign-map-scope-test", definition);
+        String execArn = startExecution(smArn, "{}");
+        String output = waitForExecution(execArn);
+
+        assertTrue(output.contains("\"finalScope\":\"outer\"")
+                || output.contains("\"finalScope\": \"outer\""));
+    }
+
+    @Test
     void mixedModeDefaultJsonPathWithPerStateJsonata() throws Exception {
         // Default JSONPath (no top-level QueryLanguage) with one state overriding to JSONata
         String definition = """

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.services.stepfunctions;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.response.Response;
@@ -14,6 +16,8 @@ class StepFunctionsJsonataIntegrationTest {
 
     private static final String SFN_CONTENT_TYPE = "application/x-amz-json-1.0";
     private static final String ROLE_ARN = "arn:aws:iam::000000000000:role/test-role";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeAll
     static void configureRestAssured() {
@@ -1244,21 +1248,42 @@ class StepFunctionsJsonataIntegrationTest {
     }
 
     @Test
-    void assignedVariableVisibleToSameStateOutput() throws Exception {
-        // AWS evaluates a state's Assign before its Output, so the same state's Output sees the
-        // newly assigned variable.
+    void assignedVariablesAreNotVisibleUntilTheNextState() throws Exception {
+        // Every variable reference in a state resolves against the values held on state entry, so a
+        // state's own Output never sees that state's Assign; the new values land in the next state.
+        // Assignments within one Assign block are likewise independent of each other. This mirrors
+        // the evaluation-order example in the AWS docs: starting from $x=3 and $a=6,
+        // {"x": "{% $a %}", "nextX": "{% $x %}"} ends with $x=6 and $nextX=3.
         String definition = """
                 {
                     "QueryLanguage": "JSONata",
-                    "StartAt": "AssignAndUse",
+                    "StartAt": "SeedVariables",
                     "States": {
-                        "AssignAndUse": {
+                        "SeedVariables": {
                             "Type": "Pass",
                             "Assign": {
-                                "Greeting": "{% 'hello ' & $states.input.name %}"
+                                "x": 3,
+                                "a": 6
+                            },
+                            "Next": "ReassignAndEmit"
+                        },
+                        "ReassignAndEmit": {
+                            "Type": "Pass",
+                            "Assign": {
+                                "x": "{% $a %}",
+                                "nextX": "{% $x %}"
                             },
                             "Output": {
-                                "message": "{% $Greeting %}"
+                                "xSeenByAssigningState": "{% $x %}"
+                            },
+                            "Next": "ObserveAfterAssign"
+                        },
+                        "ObserveAfterAssign": {
+                            "Type": "Pass",
+                            "Output": {
+                                "xSeenByAssigningState": "{% $states.input.xSeenByAssigningState %}",
+                                "xAfter": "{% $x %}",
+                                "nextXAfter": "{% $nextX %}"
                             },
                             "End": true
                         }
@@ -1266,28 +1291,32 @@ class StepFunctionsJsonataIntegrationTest {
                 }
                 """;
 
-        String smArn = createStateMachine("jsonata-assign-same-state-test", definition);
-        String execArn = startExecution(smArn, "{\"name\": \"world\"}");
-        String output = waitForExecution(execArn);
+        String smArn = createStateMachine("jsonata-assign-evaluation-order-test", definition);
+        String execArn = startExecution(smArn, "{}");
+        JsonNode output = objectMapper.readTree(waitForExecution(execArn));
 
-        assertTrue(output.contains("\"message\":\"hello world\"")
-                || output.contains("\"message\": \"hello world\""));
+        // The assigning state's own Output still sees the pre-assignment value of $x.
+        assertEquals(3, output.get("xSeenByAssigningState").asInt());
+        // The next state sees both new values: $x from $a, and $nextX from the old $x.
+        assertEquals(6, output.get("xAfter").asInt());
+        assertEquals(3, output.get("nextXAfter").asInt());
     }
 
     @Test
     void variablesAssignedInsideMapDoNotLeakToParentScope() throws Exception {
-        // A variable is set in the parent scope, reassigned inside each Map iteration, and read
-        // again after the Map. The parent must still observe its own value: iteration assignments
-        // are scoped to the iteration.
+        // Map iterations can read outer-scope variables but keep their own workflow-local scope:
+        // a variable assigned inside an iteration goes out of scope once the Map completes.
+        // The inner variable deliberately uses a name distinct from the outer one — AWS rejects an
+        // inner-scope assignment that reuses an outer-scope variable name.
         String definition = """
                 {
                     "QueryLanguage": "JSONata",
-                    "StartAt": "SetScope",
+                    "StartAt": "SetOuter",
                     "States": {
-                        "SetScope": {
+                        "SetOuter": {
                             "Type": "Pass",
                             "Assign": {
-                                "Scope": "outer"
+                                "outerVar": 42
                             },
                             "Next": "MapState"
                         },
@@ -1298,15 +1327,15 @@ class StepFunctionsJsonataIntegrationTest {
                                 "ProcessorConfig": {
                                     "Mode": "INLINE"
                                 },
-                                "StartAt": "Reassign",
+                                "StartAt": "AssignInner",
                                 "States": {
-                                    "Reassign": {
+                                    "AssignInner": {
                                         "Type": "Pass",
                                         "Assign": {
-                                            "Scope": "inner"
+                                            "innerVar": "{% $outerVar %}"
                                         },
                                         "Output": {
-                                            "seen": "{% $Scope %}"
+                                            "outerSeenFromIteration": "{% $outerVar %}"
                                         },
                                         "End": true
                                     }
@@ -1317,7 +1346,9 @@ class StepFunctionsJsonataIntegrationTest {
                         "CheckScope": {
                             "Type": "Pass",
                             "Output": {
-                                "finalScope": "{% $Scope %}"
+                                "iterations": "{% $states.input %}",
+                                "outerStillInScope": "{% $outerVar %}",
+                                "innerLeaked": "{% $exists($innerVar) %}"
                             },
                             "End": true
                         }
@@ -1327,10 +1358,14 @@ class StepFunctionsJsonataIntegrationTest {
 
         String smArn = createStateMachine("jsonata-assign-map-scope-test", definition);
         String execArn = startExecution(smArn, "{}");
-        String output = waitForExecution(execArn);
+        JsonNode output = objectMapper.readTree(waitForExecution(execArn));
 
-        assertTrue(output.contains("\"finalScope\":\"outer\"")
-                || output.contains("\"finalScope\": \"outer\""));
+        // Each iteration could read the outer variable.
+        assertEquals(42, output.get("iterations").get(0).get("outerSeenFromIteration").asInt());
+        assertEquals(42, output.get("iterations").get(1).get("outerSeenFromIteration").asInt());
+        // The outer variable survives the Map, and the iteration-local one does not escape it.
+        assertEquals(42, output.get("outerStillInScope").asInt());
+        assertFalse(output.get("innerLeaked").asBoolean());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
@@ -1369,6 +1369,132 @@ class StepFunctionsJsonataIntegrationTest {
     }
 
     @Test
+    void assignInMatchedChoiceRuleApplies() throws Exception {
+        // A Choice rule carries its own Assign, which applies when that rule matches. The state-level
+        // Assign belongs to the Default path and must not run when a rule matches.
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "ChoiceState",
+                    "States": {
+                        "ChoiceState": {
+                            "Type": "Choice",
+                            "Choices": [
+                                {
+                                    "Condition": "{% $states.input.condition %}",
+                                    "Next": "Report",
+                                    "Assign": {
+                                        "assignment": "Condition assignment"
+                                    }
+                                }
+                            ],
+                            "Default": "Report",
+                            "Assign": {
+                                "assignment": "Default Assignment"
+                            }
+                        },
+                        "Report": {
+                            "Type": "Pass",
+                            "Output": {
+                                "assignment": "{% $assignment %}"
+                            },
+                            "End": true
+                        }
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-assign-in-choice-test", definition);
+
+        JsonNode matched = objectMapper.readTree(
+                waitForExecution(startExecution(smArn, "{\"condition\": true}")));
+        assertEquals("Condition assignment", matched.get("assignment").asText());
+
+        JsonNode defaulted = objectMapper.readTree(
+                waitForExecution(startExecution(smArn, "{\"condition\": false}")));
+        assertEquals("Default Assignment", defaulted.get("assignment").asText());
+    }
+
+    @Test
+    void assignInWaitStateApplies() throws Exception {
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "WaitState",
+                    "States": {
+                        "WaitState": {
+                            "Type": "Wait",
+                            "Seconds": 0,
+                            "Assign": {
+                                "foo": "oof"
+                            },
+                            "Next": "Report"
+                        },
+                        "Report": {
+                            "Type": "Pass",
+                            "Output": {
+                                "foo": "{% $foo %}"
+                            },
+                            "End": true
+                        }
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-assign-in-wait-test", definition);
+        JsonNode output = objectMapper.readTree(waitForExecution(startExecution(smArn, "{}")));
+
+        assertEquals("oof", output.get("foo").asText());
+    }
+
+    @Test
+    void assignInCatchAppliesAndSeesErrorOutput() throws Exception {
+        // A Catch block supports Assign and Output, and $states.errorOutput is bound inside it.
+        // The Task fails while evaluating its Arguments, which is a catchable States.QueryEvaluationError.
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "Boom",
+                    "States": {
+                        "Boom": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::lambda:invoke",
+                            "Arguments": {
+                                "bad": "{% $number('not-a-number') %}"
+                            },
+                            "Catch": [
+                                {
+                                    "ErrorEquals": ["States.QueryEvaluationError"],
+                                    "Next": "Report",
+                                    "Assign": {
+                                        "caughtError": "{% $states.errorOutput.Error %}"
+                                    }
+                                }
+                            ],
+                            "End": true
+                        },
+                        "Report": {
+                            "Type": "Pass",
+                            "Output": {
+                                "caughtError": "{% $caughtError %}",
+                                "catchOutputError": "{% $states.input.Error %}"
+                            },
+                            "End": true
+                        }
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-assign-in-catch-test", definition);
+        JsonNode output = objectMapper.readTree(waitForExecution(startExecution(smArn, "{}")));
+
+        // The Catch's Assign ran, and it could read $states.errorOutput.
+        assertEquals("States.QueryEvaluationError", output.get("caughtError").asText());
+        // With no Output on the Catch, the error output becomes the state output.
+        assertEquals("States.QueryEvaluationError", output.get("catchOutputError").asText());
+    }
+
+    @Test
     void mixedModeDefaultJsonPathWithPerStateJsonata() throws Exception {
         // Default JSONPath (no top-level QueryLanguage) with one state overriding to JSONata
         String definition = """


### PR DESCRIPTION
## Summary

Adds support for **workflow variables** in JSONata Step Functions state machines (the `Assign` field), so values can be assigned once and reused across later states via top-level `$name` references.

Closes #1507. Supersedes the abandoned #1508 (re-implemented on current `main`; original author credited via `Co-authored-by`).

## Type of change

- [x] New feature (`feat:`)

## What changed

- **`AslExecutor`** — an execution-scoped `variables` object is threaded through every state executor (`Pass`/`Task`/`Choice`/`Wait`/`Succeed`/`Fail`/`Parallel`/`Map`, plus `executeBranch`, `resolveMapItems`, `resolveItemReaderItems`) and mutated in place, so assignments persist across states. `applyJsonataOutput` now evaluates the `Assign` field.
- **`JsonataEvaluator`** — binds each variable as a top-level `$name` reference, matching AWS's JSONata variable syntax.

## AWS parity notes

Behavior validated against the localstack ASL engine (`execute_state.py`), the authoritative reference for state-language semantics:

- **`Assign` is evaluated before `Output`** within a state, so the same state's `Output` (and all later states) observe the newly assigned variables. *(The original #1508 evaluated `Output` first — that ordering bug is fixed here and covered by a test.)*
- **Scope isolation** — Parallel branches and Map iterations each receive an isolated copy of the current variables; assignments inside them do not leak back to the parent scope.
- Assignments within a single `Assign` block are evaluated against the pre-assignment scope (they do not see each other).

## Scope / follow-ups (intentionally out of scope)

- `Assign` is implemented for **JSONata** states only. JSONPath-mode `Assign` is a follow-up.
- `assignedVariables` is not yet surfaced in `stateExited` history-event details. Execution output — what SDK/CLI callers observe — is fully correct.

## Tests

New integration tests in `StepFunctionsJsonataIntegrationTest`:

- `assignedVariablesSurviveBeyondNextStateOutput` — variables persist across states after output is replaced.
- `assignedVariableVisibleToSameStateOutput` — same-state `Output` sees this state's `Assign` (evaluation order).
- `variablesAssignedInsideMapDoNotLeakToParentScope` — Map iteration assignments are scoped to the iteration.

All 204 Step Functions tests pass (`./mvnw test -Dtest='StepFunctions*,AslExecutor*'`).

## Checklist

- [x] `./mvnw test` (Step Functions suite) passes locally
- [x] New integration tests added
- [x] Commit messages follow Conventional Commits
