### PR TITLE
fix(lambda): register EventSourceMapping nested types for native-image reflection

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/model/EventSourceMapping.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/model/EventSourceMapping.java
@@ -104,6 +104,8 @@ public class EventSourceMapping {
         this.destinationConfig = destinationConfig;
     }
 
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class DestinationConfig {
         private OnFailure onFailure;
 
@@ -119,6 +121,8 @@ public class EventSourceMapping {
         }
     }
 
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class OnFailure {
         private String destination;
 


### PR DESCRIPTION
## Summary

`main` is currently red: `PersistedModelReflectionTest.persistedTypesAreRegisteredForReflection` fails on pristine `main` because `EventSourceMapping.DestinationConfig` and its nested `OnFailure` (added in #1629) are reachable from Lambda's persisted event-source-mapping storage but were never registered for reflection. `@RegisterForReflection` on the enclosing `EventSourceMapping` class does **not** cover nested static classes, so each needs its own.

This annotates both nested classes directly, matching the existing convention (`IotPolicy.PolicyVersion`, `LambdaUrlConfig.Cors`).

```java
@RegisterForReflection
public static class DestinationConfig { ... }

@RegisterForReflection
public static class OnFailure { ... }
```

Because CI tests every PR merged with `main`, this red is inherited by **all** open PRs. Merging this unblocks them.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No wire-protocol change. This is a native-image correctness fix: without it, a Lambda event source mapping that has a `DestinationConfig.OnFailure` fails to deserialize from persisted storage on restart in native mode (JVM mode is unaffected, which is why it slipped in). Behavior is otherwise unchanged.

## Checklist

- [x] `./mvnw test` passes locally (`PersistedModelReflectionTest` now green; it was the failing guard)
- [x] No new test needed — `PersistedModelReflectionTest` is itself the classpath-scan guard for this bug class (added in #1781) and now covers these types
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
