### PR TITLE
fix(lambda): register EventSourceMapping nested config classes for reflection

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/model/EventSourceMapping.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/model/EventSourceMapping.java
@@ -104,6 +104,7 @@ public class EventSourceMapping {
         this.destinationConfig = destinationConfig;
     }
 
+    @RegisterForReflection
     public static class DestinationConfig {
         private OnFailure onFailure;
 
@@ -119,6 +120,7 @@ public class EventSourceMapping {
         }
     }
 
+    @RegisterForReflection
     public static class OnFailure {
         private String destination;
 


### PR DESCRIPTION
## Summary
`EventSourceMapping.DestinationConfig` and `EventSourceMapping.OnFailure` (added in #1629) are reachable from persisted `EventSourceMapping` storage, but only the outer `EventSourceMapping` class carried `@RegisterForReflection` — which registers just that class, not its nested types. Without registering the nested classes, a native-image build fails to deserialize persisted event-source-mapping state on restart.

`PersistedModelReflectionTest` (which runs in the full `Build and Test` job) flags exactly these two types, so `main` is currently red on that check. This annotates each nested class directly, matching the convention other nested persisted model classes use (e.g. the athena models).

## Type
- [x] Bug fix

## AWS Compatibility
No wire-protocol change; this only adds native-image reflection metadata so persisted event-source-mapping state (including its `DestinationConfig`/`OnFailure`) round-trips across a restart.

## Checklist
- [x] Verified with `PersistedModelReflectionTest` (fails on current main with these two violations; passes with the fix — negative-controlled)
- [x] Built + tested offline (maven:3.9-eclipse-temurin-25)