### PR TITLE
fix(s3): handle DeleteBucketReplication instead of deleting the whole bucket

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -314,6 +314,12 @@ public class S3Controller {
                 s3Service.deleteBucketOwnershipControls(bucket);
                 return Response.noContent().build();
             }
+            if (hasQueryParam(uriInfo, "replication")) {
+                // Floci does not model bucket replication; DeleteBucketReplication is a
+                // no-op that always returns 204, matching real S3. Crucially it must be
+                // handled here so it does NOT fall through to deleting the whole bucket.
+                return Response.noContent().build();
+            }
             s3Service.deleteBucket(bucket);
             return Response.noContent().build();
         } catch (AwsException e) {

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ReplicationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ReplicationIntegrationTest.java
@@ -1,0 +1,86 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class S3ReplicationIntegrationTest {
+
+    private static final String BUCKET = "replication-int-test";
+
+    @Test
+    @Order(1)
+    void createBucket() {
+        given()
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+    }
+
+    /**
+     * Regression test for the bucket-destroying bug where {@code DELETE /{bucket}?replication}
+     * (DeleteBucketReplication) was not handled and fell through to the unqualified
+     * {@code DeleteBucket}, silently deleting the entire bucket. Real S3 removes only the
+     * replication configuration and returns 204.
+     */
+    @Test
+    @Order(2)
+    void deleteReplicationDoesNotDeleteBucket() {
+        given()
+        .when()
+            .delete("/" + BUCKET + "?replication")
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    @Order(3)
+    void bucketStillExistsAfterReplicationDelete() {
+        // A sub-resource-qualified DELETE must never remove the bucket itself.
+        given()
+        .when()
+            .get("/" + BUCKET + "?versioning")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(4)
+    void putVersioningAfterReplicationDeleteSucceeds() {
+        given()
+            .body("""
+                    <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                        <Status>Enabled</Status>
+                    </VersioningConfiguration>
+                    """)
+        .when()
+            .put("/" + BUCKET + "?versioning")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(5)
+    void unqualifiedDeleteStillRemovesBucket() {
+        given()
+        .when()
+            .delete("/" + BUCKET)
+        .then()
+            .statusCode(204);
+        // Bucket is gone now: a sub-resource GET should report NoSuchBucket.
+        given()
+        .when()
+            .get("/" + BUCKET + "?versioning")
+        .then()
+            .statusCode(404)
+            .body(containsString("NoSuchBucket"));
+    }
+}


### PR DESCRIPTION
## Summary

`DELETE /{bucket}?replication` (DeleteBucketReplication) fell through the sub-resource switch to the unqualified `DeleteBucket`, silently destroying the entire bucket while returning `204`. This handles `?replication` explicitly as a no-op `204`, matching real S3 — a sub-resource-qualified DELETE never deletes the bucket. Floci does not model replication.

Closes #1835

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

Incorrect behavior: `delete-bucket-replication` destroyed the bucket (`head-bucket` → 404). Real S3 removes only the replication config and returns 204; the bucket survives. Verified in Docker with AWS CLI 2.35.7 before and after the fix.

## Checklist

- [x] New integration test added (`S3ReplicationIntegrationTest`, 5 tests)
- [x] `S3ReplicationIntegrationTest` passes locally (5/5)
- [x] Commit messages follow Conventional Commits
