### PR TITLE
fix(cognito): prefer phone delivery for signup verification

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -2374,19 +2374,15 @@ public class CognitoService {
         List<String> autoVerifiedAttributes =
                 pool.getAutoVerifiedAttributes() != null ? pool.getAutoVerifiedAttributes()
                         : List.of();
-        for (String attribute : autoVerifiedAttributes) {
-            if ("email".equals(attribute)) {
-                String email = blankToNull(attributes.get("email"));
-                if (email != null) {
-                    return new DeliveryTarget("email", "EMAIL", maskEmail(email));
-                }
-            }
-            if ("phone_number".equals(attribute)) {
-                String phoneNumber = blankToNull(attributes.get("phone_number"));
-                if (phoneNumber != null) {
-                    return new DeliveryTarget("phone_number", "SMS", maskPhoneNumber(phoneNumber));
-                }
-            }
+
+        String phoneNumber = blankToNull(attributes.get("phone_number"));
+        if (autoVerifiedAttributes.contains("phone_number") && phoneNumber != null) {
+            return new DeliveryTarget("phone_number", "SMS", maskPhoneNumber(phoneNumber));
+        }
+
+        String email = blankToNull(attributes.get("email"));
+        if (autoVerifiedAttributes.contains("email") && email != null) {
+            return new DeliveryTarget("email", "EMAIL", maskEmail(email));
         }
 
         return null;

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
@@ -37,6 +37,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
 
 @QuarkusTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -291,6 +294,51 @@ class CognitoIntegrationTest {
                 .statusCode(400)
                 .body("__type", org.hamcrest.Matchers.equalTo("CodeMismatchException"))
                 .body("message", org.hamcrest.Matchers.equalTo("Invalid verification code provided, please try again."));
+    }
+
+    @Test
+    void signUpPrefersPhoneDeliveryWhenEmailAndPhoneAreAutoVerified() throws Exception {
+        Response poolResponse = cognitoAction("CreateUserPool", """
+                {
+                  "PoolName": "SignUpPhonePreferredPool",
+                  "AutoVerifiedAttributes": ["email", "phone_number"]
+                }
+                """);
+
+        poolResponse.then().statusCode(200);
+        String userPoolId = poolResponse.jsonPath().getString("UserPool.Id");
+
+        Response clientResponse = cognitoAction("CreateUserPoolClient", """
+                {
+                  "UserPoolId": "%s",
+                  "ClientName": "signup-phone-preferred-client"
+                }
+                """.formatted(userPoolId));
+
+        clientResponse.then().statusCode(200);
+        String clientId = clientResponse.jsonPath().getString("UserPoolClient.ClientId");
+
+        Response signUpResponse = cognitoAction("SignUp", """
+                {
+                  "ClientId": "%s",
+                  "Username": "phone-preferred-user",
+                  "Password": "Password123!",
+                  "UserAttributes": [
+                    { "Name": "email", "Value": "user@example.com" },
+                    { "Name": "phone_number", "Value": "+15551234567" }
+                  ]
+                }
+                """.formatted(clientId));
+
+        signUpResponse.then().statusCode(200);
+
+        assertEquals("phone_number",
+                signUpResponse.jsonPath().getString("CodeDeliveryDetails.AttributeName"));
+        assertEquals("SMS",
+                signUpResponse.jsonPath().getString("CodeDeliveryDetails.DeliveryMedium"));
+        String destination = signUpResponse.jsonPath().getString("CodeDeliveryDetails.Destination");
+        assertThat(destination, notNullValue());
+        assertThat(destination, containsString("4567"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Updates Cognito `SignUp` verification delivery-target selection to prefer phone/SMS when both `email` and `phone_number` are present and the user pool auto-verifies both attributes.

Previously, Floci selected the delivery target based on the order of `AutoVerifiedAttributes`. When `email` appeared before `phone_number`, `CodeDeliveryDetails` returned email delivery even though AWS prefers phone/SMS for the initial sign-up verification in this case.

Closes #1657

## Type of change

* [x] Bug fix (`fix:`)
* [ ] New feature (`feat:`)
* [ ] Breaking change (`feat!:` or `fix!:`)
* [ ] Docs / chore

## AWS Compatibility

Incorrect behavior:

For a user pool with `AutoVerifiedAttributes` containing both `email` and `phone_number`, signing up with both attributes could return `CodeDeliveryDetails` for email delivery depending on the configured attribute order.

Updated behavior:

`SignUp` now prefers `phone_number` / `SMS` delivery when both email and phone number are available and both are configured for auto-verification. Email remains the fallback when phone delivery is not applicable.

## Checklist

* [ ] `./mvnw test` passes locally
* [x] New or updated integration test added
* [x] Commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/)