### PR TITLE
fix(s3): derive S3 host suffix matching from DNS config

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/dns/EmbeddedDnsServer.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/dns/EmbeddedDnsServer.java
@@ -66,7 +66,7 @@ public class EmbeddedDnsServer {
     // NOT cover "*.X" (e.g. "localhost.floci.io" does NOT resolve bare "*.floci.io").
     //   localhost.localstack.cloud → localhost.localstack.cloud, *.localhost.localstack.cloud
     //   localhost.floci.io         → localhost.floci.io, *.localhost.floci.io
-    static final List<String> BUILTIN_SUFFIXES = List.of(DEFAULT_SUFFIX, LOCALSTACK_SUFFIX);
+    public static final List<String> BUILTIN_SUFFIXES = List.of(DEFAULT_SUFFIX, LOCALSTACK_SUFFIX);
 
     private volatile String serverIp;
     private final SequencedSet<String> suffixes = new LinkedHashSet<>();

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
@@ -51,9 +51,10 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
     /**
      * Builds the service-host suffix set from the DNS source of truth rather than
      * re-hardcoding it: {@code {"localhost"}} plus the {@link EmbeddedDnsServer} builtins
-     * plus any configured extra suffixes.
+     * plus any configured extra suffixes. Package-private so tests reuse the same
+     * derivation instead of duplicating the builtin list.
      */
-    private static Set<String> buildServiceHostSuffixes(Optional<List<String>> extraSuffixes) {
+    static Set<String> buildServiceHostSuffixes(Optional<List<String>> extraSuffixes) {
         Set<String> suffixes = new HashSet<>();
         suffixes.add("localhost");
         EmbeddedDnsServer.BUILTIN_SUFFIXES.forEach(s -> suffixes.add(s.toLowerCase()));

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
@@ -12,6 +12,10 @@ import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.ext.Provider;
 
 import java.net.URI;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 @Provider
 @PreMatching
@@ -20,16 +24,41 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
 
     private final String baseHostname;
 
+    /**
+     * Hostname suffixes for which a bare {@code s3.<suffix>} Host header is Floci's own
+     * S3 service endpoint (bucketless) rather than a bucket literally named {@code s3}.
+     * Derived from the same source of truth the embedded DNS server uses: the always-on
+     * builtins ({@code localhost.floci.io}, {@code localhost.localstack.cloud}) plus any
+     * configured {@code floci.dns.extra-suffixes}, alongside plain {@code localhost}.
+     * Stored lowercase for case-insensitive matching.
+     */
+    private final Set<String> serviceHostSuffixes;
+
     @Inject
     public S3VirtualHostFilter(EmulatorConfig config, ContainerDetector containerDetector) {
         this.baseHostname = config.hostname()
                 .orElseGet(() -> containerDetector.isRunningInContainer()
                         ? EmbeddedDnsServer.DEFAULT_SUFFIX
                         : extractHostnameFromUrl(config.baseUrl()));
+        this.serviceHostSuffixes = buildServiceHostSuffixes(config.dns().extraSuffixes());
     }
 
     S3VirtualHostFilter() {
         this.baseHostname = "localhost";
+        this.serviceHostSuffixes = buildServiceHostSuffixes(Optional.empty());
+    }
+
+    /**
+     * Builds the service-host suffix set from the DNS source of truth rather than
+     * re-hardcoding it: {@code {"localhost"}} plus the {@link EmbeddedDnsServer} builtins
+     * plus any configured extra suffixes.
+     */
+    private static Set<String> buildServiceHostSuffixes(Optional<List<String>> extraSuffixes) {
+        Set<String> suffixes = new HashSet<>();
+        suffixes.add("localhost");
+        EmbeddedDnsServer.BUILTIN_SUFFIXES.forEach(s -> suffixes.add(s.toLowerCase()));
+        extraSuffixes.ifPresent(list -> list.forEach(s -> suffixes.add(s.toLowerCase())));
+        return Set.copyOf(suffixes);
     }
 
     @Override
@@ -58,7 +87,7 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
             return;
         }
 
-        String bucket = extractBucket(host, baseHostname);
+        String bucket = extractBucket(host, baseHostname, serviceHostSuffixes);
         if (bucket == null) return;
 
         String path = uri.getRawPath();
@@ -118,7 +147,7 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
      *
      * Returns null if the host does not match a virtual-hosted pattern.
      */
-    static String extractBucket(String host, String baseHostname) {
+    static String extractBucket(String host, String baseHostname, Set<String> serviceHostSuffixes) {
         if (host == null) {
             return null;
         }
@@ -140,7 +169,7 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
         String firstLabel = hostname.substring(0, firstDot);
         String remainder  = hostname.substring(firstDot + 1);
 
-        if (isS3ServiceEndpointHost(firstLabel, remainder, baseHostname)) {
+        if (isS3ServiceEndpointHost(firstLabel, remainder, baseHostname, serviceHostSuffixes)) {
             return null;
         }
 
@@ -155,20 +184,45 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
             return firstLabel;
         }
 
+        // Configured Floci DNS suffixes (builtins + floci.dns.extra-suffixes): route
+        // bucket.<suffix>, bucket.s3.<suffix> and bucket.s3.<region>.<suffix> the same
+        // way the always-on wildcard-DNS builtins resolve.
+        if (matchesConfiguredSuffixHost(remainder, serviceHostSuffixes)) {
+            return firstLabel;
+        }
+
         return null;
     }
 
-    private static boolean isS3ServiceEndpointHost(String firstLabel, String remainder, String baseHostname) {
+    /**
+     * Matches the virtual-hosted bucket forms for a configured DNS suffix {@code S}
+     * (a builtin or a {@code floci.dns.extra-suffix}): {@code bucket.S},
+     * {@code bucket.s3.S}, and the region-qualified {@code bucket.s3.<region>.S}.
+     * Plain {@code localhost} is skipped here — it keeps its dedicated
+     * {@link #matchesEndpointHost} handling via {@link #isAwsS3Domain}.
+     */
+    private static boolean matchesConfiguredSuffixHost(String remainder, Set<String> serviceHostSuffixes) {
+        String lower = remainder.toLowerCase();
+        for (String suffix : serviceHostSuffixes) {
+            if ("localhost".equals(suffix)) {
+                continue;
+            }
+            if (lower.equals(suffix) || (lower.startsWith("s3.") && lower.endsWith("." + suffix))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static boolean isS3ServiceEndpointHost(String firstLabel, String remainder, String baseHostname,
+                                           Set<String> serviceHostSuffixes) {
         if (!"s3".equalsIgnoreCase(firstLabel)) {
             return false;
         }
         if (baseHostname != null && matchesEndpointHost(remainder, baseHostname)) {
             return true;
         }
-        String lowerRemainder = remainder.toLowerCase();
-        return "localhost".equals(lowerRemainder)
-                || "localhost.localstack.cloud".equals(lowerRemainder)
-                || "localhost.floci.io".equals(lowerRemainder);
+        return serviceHostSuffixes.contains(remainder.toLowerCase());
     }
 
     /**
@@ -223,7 +277,13 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
         return true;
     }
 
-    /** Returns true for *.s3.amazonaws.com and other well-known S3 domains. */
+    /**
+     * Returns true for well-known AWS S3 domains and the always-on {@code localhost}
+     * endpoint. The Floci wildcard-DNS builtins ({@code localhost.floci.io},
+     * {@code localhost.localstack.cloud}) and any configured {@code floci.dns.extra-suffixes}
+     * are handled by {@link #matchesConfiguredSuffixHost} instead, so they stay derived
+     * from the DNS source of truth rather than hardcoded here.
+     */
     private static boolean isAwsS3Domain(String remainder) {
         if ("s3.amazonaws.com".equals(remainder)) {
             return true;
@@ -238,14 +298,6 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
         // Also accept the region-qualified s3.<region>.localhost form (e.g. bucket.s3.us-east-1.localhost).
         if (matchesEndpointHost(remainder, "localhost")) {
             return true;
-        }
-        // LocalStack public wildcard DNS: bucket.s3.localhost.localstack.cloud and bucket.localhost.localstack.cloud
-        if (remainder.endsWith(".localstack.cloud")) {
-            return remainder.startsWith("s3.") || "localhost.localstack.cloud".equals(remainder);
-        }
-        // Floci public wildcard DNS: bucket.s3.localhost.floci.io and bucket.localhost.floci.io → 127.0.0.1
-        if (remainder.endsWith(".localhost.floci.io") || "localhost.floci.io".equals(remainder)) {
-            return remainder.startsWith("s3.") || "localhost.floci.io".equals(remainder);
         }
         // S3 website endpoints: bucket.s3-website-<region>.amazonaws.com, bucket.s3-website-<region>.localhost, etc.
         if (remainder.startsWith("s3-website")) {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
@@ -28,9 +28,9 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
      * Hostname suffixes for which a bare {@code s3.<suffix>} Host header is Floci's own
      * S3 service endpoint (bucketless) rather than a bucket literally named {@code s3}.
      * Derived from the same source of truth the embedded DNS server uses: the always-on
-     * builtins ({@code localhost.floci.io}, {@code localhost.localstack.cloud}) plus any
-     * configured {@code floci.dns.extra-suffixes}, alongside plain {@code localhost}.
-     * Stored lowercase for case-insensitive matching.
+     * builtins ({@code localhost.floci.io}, {@code localhost.localstack.cloud}) plus the
+     * configured {@code floci.hostname} and any {@code floci.dns.extra-suffixes},
+     * alongside plain {@code localhost}. Stored lowercase for case-insensitive matching.
      */
     private final Set<String> serviceHostSuffixes;
 
@@ -40,24 +40,27 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
                 .orElseGet(() -> containerDetector.isRunningInContainer()
                         ? EmbeddedDnsServer.DEFAULT_SUFFIX
                         : extractHostnameFromUrl(config.baseUrl()));
-        this.serviceHostSuffixes = buildServiceHostSuffixes(config.dns().extraSuffixes());
+        this.serviceHostSuffixes = buildServiceHostSuffixes(config.hostname(), config.dns().extraSuffixes());
     }
 
     S3VirtualHostFilter() {
         this.baseHostname = "localhost";
-        this.serviceHostSuffixes = buildServiceHostSuffixes(Optional.empty());
+        this.serviceHostSuffixes = buildServiceHostSuffixes(Optional.empty(), Optional.empty());
     }
 
     /**
      * Builds the service-host suffix set from the DNS source of truth rather than
      * re-hardcoding it: {@code {"localhost"}} plus the {@link EmbeddedDnsServer} builtins
-     * plus any configured extra suffixes. Package-private so tests reuse the same
-     * derivation instead of duplicating the builtin list.
+     * plus the configured hostname and any extra suffixes. The three configured inputs
+     * mirror what {@code EmbeddedDnsServer} makes resolvable, so a host that reaches Floci
+     * by wildcard DNS is routed by the same rules it resolved under. Package-private so
+     * tests reuse the same derivation instead of duplicating the builtin list.
      */
-    static Set<String> buildServiceHostSuffixes(Optional<List<String>> extraSuffixes) {
+    static Set<String> buildServiceHostSuffixes(Optional<String> hostname, Optional<List<String>> extraSuffixes) {
         Set<String> suffixes = new HashSet<>();
         suffixes.add("localhost");
         EmbeddedDnsServer.BUILTIN_SUFFIXES.forEach(s -> suffixes.add(s.toLowerCase()));
+        hostname.ifPresent(h -> suffixes.add(h.toLowerCase()));
         extraSuffixes.ifPresent(list -> list.forEach(s -> suffixes.add(s.toLowerCase())));
         return Set.copyOf(suffixes);
     }
@@ -197,7 +200,7 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
 
     /**
      * Matches the virtual-hosted bucket forms for a configured DNS suffix {@code S}
-     * (a builtin or a {@code floci.dns.extra-suffix}): {@code bucket.S},
+     * (a builtin, {@code floci.hostname}, or a {@code floci.dns.extra-suffix}): {@code bucket.S},
      * {@code bucket.s3.S}, and the region-qualified {@code bucket.s3.<region>.S}.
      * Plain {@code localhost} is skipped here — it keeps its dedicated
      * {@link #matchesEndpointHost} handling via {@link #isAwsS3Domain}.

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
@@ -29,7 +29,7 @@ class S3VirtualHostFilterTest {
      * hardcoding a copy of {@code EmbeddedDnsServer.BUILTIN_SUFFIXES}.
      */
     private static final Set<String> DEFAULT_SUFFIXES =
-            S3VirtualHostFilter.buildServiceHostSuffixes(Optional.empty());
+            S3VirtualHostFilter.buildServiceHostSuffixes(Optional.empty(), Optional.empty());
 
     // --- extractBucket with baseHostname ---
 
@@ -195,6 +195,41 @@ class S3VirtualHostFilterTest {
                 "my-bucket.s3.localhost.example.internal", "localhost", DEFAULT_SUFFIXES));
     }
 
+    // --- The configured hostname is a DNS suffix too, and routes the same forms ---
+
+    @Test
+    void routesVirtualHostedBucketsForConfiguredHostname() {
+        String hostname = "aws.mycorp.test";
+        Set<String> withHostname =
+                S3VirtualHostFilter.buildServiceHostSuffixes(Optional.of(hostname), Optional.empty());
+
+        // EmbeddedDnsServer makes *.<hostname> resolvable, so the derived set must carry it too,
+        // lowercased like the rest of the set because matching is case-insensitive
+        assertTrue(withHostname.contains(hostname));
+        assertTrue(S3VirtualHostFilter.buildServiceHostSuffixes(Optional.of("AWS.MyCorp.Test"), Optional.empty())
+                .contains(hostname));
+
+        // bucket.s3.<hostname> resolves via wildcard DNS, so it must route as a bucket rather
+        // than fall through to path-style with "s3" read as the bucket name
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket(
+                "my-bucket.s3." + hostname, hostname, withHostname));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket(
+                "my-bucket.s3." + hostname + ":4566", hostname, withHostname));
+
+        // The forms already covered by baseHostname matching keep working
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket(
+                "my-bucket." + hostname, hostname, withHostname));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket(
+                "my-bucket.s3.us-east-1." + hostname, hostname, withHostname));
+
+        // The bare s3.<hostname> service host stays bucketless
+        assertNull(S3VirtualHostFilter.extractBucket("s3." + hostname, hostname, withHostname));
+
+        // Without the hostname configured, bucket.s3.<hostname> does not route (no accidental match)
+        assertNull(S3VirtualHostFilter.extractBucket(
+                "my-bucket.s3." + hostname, "localhost", DEFAULT_SUFFIXES));
+    }
+
     // --- Hostname extraction from URL ---
 
     @ParameterizedTest
@@ -241,7 +276,7 @@ class S3VirtualHostFilterTest {
         // be recovered from the URI authority instead of falling through to path-style.
         URI uri = URI.create("https://my-bucket.s3.us-east-1.localhost:4566/key.txt");
         String host = S3VirtualHostFilter.resolveHost(null, uri);
-        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket(host, "localhost"));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket(host, "localhost", DEFAULT_SUFFIXES));
     }
 
     // --- HTTP/2 website request: the path rewrite must preserve the s3-website authority (#1954) ---

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
@@ -10,6 +10,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.net.URI;
 
+import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,9 +23,13 @@ import static org.mockito.Mockito.when;
 
 class S3VirtualHostFilterTest {
 
-    /** Always-on service-host suffix set with no configured extra suffixes. */
+    /**
+     * Always-on service-host suffix set with no configured extra suffixes. Derived from the
+     * production factory so it stays in sync if a builtin suffix is ever added, rather than
+     * hardcoding a copy of {@code EmbeddedDnsServer.BUILTIN_SUFFIXES}.
+     */
     private static final Set<String> DEFAULT_SUFFIXES =
-            Set.of("localhost", "localhost.floci.io", "localhost.localstack.cloud");
+            S3VirtualHostFilter.buildServiceHostSuffixes(Optional.empty());
 
     // --- extractBucket with baseHostname ---
 

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
@@ -10,13 +10,21 @@ import org.mockito.ArgumentCaptor;
 
 import java.net.URI;
 
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class S3VirtualHostFilterTest {
+
+    /** Always-on service-host suffix set with no configured extra suffixes. */
+    private static final Set<String> DEFAULT_SUFFIXES =
+            Set.of("localhost", "localhost.floci.io", "localhost.localstack.cloud");
 
     // --- extractBucket with baseHostname ---
 
@@ -62,7 +70,7 @@ class S3VirtualHostFilterTest {
             "my-bucket.s3.us-east-1.localhost.floci.io, localhost, my-bucket",
     })
     void extractsBucketFromVirtualHostedStyle(String host, String baseHostname, String expectedBucket) {
-        assertEquals(expectedBucket, S3VirtualHostFilter.extractBucket(host, baseHostname));
+        assertEquals(expectedBucket, S3VirtualHostFilter.extractBucket(host, baseHostname, DEFAULT_SUFFIXES));
     }
 
     // --- Path-style: service hostname alone — must NOT extract a bucket ---
@@ -94,7 +102,7 @@ class S3VirtualHostFilterTest {
             "my-bucket.emulator.local,  localhost",
     })
     void returnsNullForPathStyleOrMismatchedRemainder(String host, String baseHostname) {
-        assertNull(S3VirtualHostFilter.extractBucket(host, baseHostname));
+        assertNull(S3VirtualHostFilter.extractBucket(host, baseHostname, DEFAULT_SUFFIXES));
     }
 
     @ParameterizedTest
@@ -105,31 +113,81 @@ class S3VirtualHostFilterTest {
             "10.0.0.1:9000,    localhost",
     })
     void returnsNullForIpAddresses(String host, String baseHostname) {
-        assertNull(S3VirtualHostFilter.extractBucket(host, baseHostname));
+        assertNull(S3VirtualHostFilter.extractBucket(host, baseHostname, DEFAULT_SUFFIXES));
     }
 
     @ParameterizedTest
     @NullSource
     void returnsNullForNullHost(String host) {
-        assertNull(S3VirtualHostFilter.extractBucket(host, "localhost"));
+        assertNull(S3VirtualHostFilter.extractBucket(host, "localhost", DEFAULT_SUFFIXES));
     }
 
     @Test
     void returnsNullForNullBaseHostname() {
         // path-style bare hostname (no subdomain) — must return null
-        assertNull(S3VirtualHostFilter.extractBucket("localhost:4566", null));
+        assertNull(S3VirtualHostFilter.extractBucket("localhost:4566", null, DEFAULT_SUFFIXES));
         // well-known domains match regardless of baseHostname
-        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.localhost", null));
-        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.localhost:4566", null));
-        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.amazonaws.com", null));
-        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.localhost.localstack.cloud", null));
-        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.localhost.localstack.cloud", null));
-        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.localhost.floci.io", null));
-        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.us-east-1.localhost.floci.io", null));
-        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.localhost.floci.io", null));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.localhost", null, DEFAULT_SUFFIXES));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.localhost:4566", null, DEFAULT_SUFFIXES));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.amazonaws.com", null, DEFAULT_SUFFIXES));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.localhost.localstack.cloud", null, DEFAULT_SUFFIXES));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.localhost.localstack.cloud", null, DEFAULT_SUFFIXES));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.localhost.floci.io", null, DEFAULT_SUFFIXES));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.us-east-1.localhost.floci.io", null, DEFAULT_SUFFIXES));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.localhost.floci.io", null, DEFAULT_SUFFIXES));
         // Region-qualified vhost against localhost fallback works without baseHostname
-        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.us-east-1.localhost", null));
-        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.us-east-1.localhost:4566", null));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.us-east-1.localhost", null, DEFAULT_SUFFIXES));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket("my-bucket.s3.us-east-1.localhost:4566", null, DEFAULT_SUFFIXES));
+    }
+
+    // --- Service-host classification derives from the configured suffix set ---
+
+    @Test
+    void classifiesServiceHostFromDerivedSuffixSet() {
+        // Always-on builtins: bare s3.<builtin> is the service endpoint, not a bucket named "s3"
+        assertTrue(S3VirtualHostFilter.isS3ServiceEndpointHost("s3", "localhost", "localhost", DEFAULT_SUFFIXES));
+        assertTrue(S3VirtualHostFilter.isS3ServiceEndpointHost("s3", "localhost.localstack.cloud", "localhost", DEFAULT_SUFFIXES));
+        assertTrue(S3VirtualHostFilter.isS3ServiceEndpointHost("s3", "localhost.floci.io", "localhost", DEFAULT_SUFFIXES));
+
+        // A configured extra suffix is newly recognised as a service host...
+        Set<String> withExtra = Set.of(
+                "localhost", "localhost.floci.io", "localhost.localstack.cloud", "emulator.internal");
+        assertTrue(S3VirtualHostFilter.isS3ServiceEndpointHost("s3", "emulator.internal", "localhost", withExtra));
+        // ...but is not, with only the builtins configured (proves it comes from config, not a literal)
+        assertFalse(S3VirtualHostFilter.isS3ServiceEndpointHost("s3", "emulator.internal", "localhost", DEFAULT_SUFFIXES));
+
+        // The configured base hostname still wins regardless of the suffix set
+        assertTrue(S3VirtualHostFilter.isS3ServiceEndpointHost("s3", "floci.internal", "floci.internal", DEFAULT_SUFFIXES));
+
+        // Only the "s3" service label is a service host; any other first label is a bucket
+        assertFalse(S3VirtualHostFilter.isS3ServiceEndpointHost("my-bucket", "localhost", "localhost", DEFAULT_SUFFIXES));
+    }
+
+    // --- Virtual-hosted buckets route on a configured extra suffix (like the builtins) ---
+
+    @Test
+    void routesVirtualHostedBucketsForConfiguredExtraSuffix() {
+        Set<String> withExtra = Set.of(
+                "localhost", "localhost.floci.io", "localhost.localstack.cloud", "localhost.example.internal");
+
+        // All three virtual-hosted forms route to the bucket, exactly as the builtins do
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket(
+                "my-bucket.localhost.example.internal", "localhost", withExtra));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket(
+                "my-bucket.localhost.example.internal:4566", "localhost", withExtra));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket(
+                "my-bucket.s3.localhost.example.internal", "localhost", withExtra));
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket(
+                "my-bucket.s3.us-east-1.localhost.example.internal", "localhost", withExtra));
+
+        // The bare s3.<extra> service host stays bucketless
+        assertNull(S3VirtualHostFilter.extractBucket("s3.localhost.example.internal", "localhost", withExtra));
+
+        // Without the suffix configured, the same forms do NOT route (no accidental match)
+        assertNull(S3VirtualHostFilter.extractBucket(
+                "my-bucket.localhost.example.internal", "localhost", DEFAULT_SUFFIXES));
+        assertNull(S3VirtualHostFilter.extractBucket(
+                "my-bucket.s3.localhost.example.internal", "localhost", DEFAULT_SUFFIXES));
     }
 
     // --- Hostname extraction from URL ---


### PR DESCRIPTION
## Summary

Follow-up to #1625. `S3VirtualHostFilter` hardcoded the wildcard-DNS suffixes (`localhost.floci.io`, `localhost.localstack.cloud`) in two places: the bare service-host check (`isS3ServiceEndpointHost`) and the virtual-hosted bucket fallback (`isAwsS3Domain`). Both now derive their suffix set from the embedded DNS source of truth (`EmbeddedDnsServer.BUILTIN_SUFFIXES`) plus any configured `floci.dns.extra-suffixes`, so a custom DNS suffix is recognised the same way the builtins are.

On #1625 you flagged deriving the service-host list from config as a follow-up ("fine now but worth deriving from config in a follow up"). This does that, and applies the same treatment to the virtual-host bucket path so `extra-suffixes` route buckets consistently, not just resolve in DNS.

## Type of change

- [x] Bug fix (`fix:`)

## What changed

- `buildServiceHostSuffixes()` computes `{localhost}` + `BUILTIN_SUFFIXES` + `extra-suffixes` once per instance; `isS3ServiceEndpointHost()` checks membership instead of string literals.
- `matchesConfiguredSuffixHost()` routes the virtual-hosted forms `bucket.<suffix>`, `bucket.s3.<suffix>` and `bucket.s3.<region>.<suffix>` for every configured suffix, replacing the hardcoded localstack/floci branches in `isAwsS3Domain`.
- `EmbeddedDnsServer.BUILTIN_SUFFIXES` widened to `public` so the filter reuses the canonical list instead of introducing a third copy.

## AWS Compatibility

No wire-format or SDK-visible change. One narrowing: the virtual-host match now requires the full builtin suffix (`.localhost.localstack.cloud`) rather than the bare parent domain (`.localstack.cloud`), so a non-LocalStack host like `bucket.s3.foo.localstack.cloud` no longer routes. This matches LocalStack's actual wildcard DNS (`*.localhost.localstack.cloud`); no existing test covered the broad form. Happy to keep the parent-domain match if you'd prefer it.

## Test plan

- [x] `S3VirtualHostFilterTest` (55 cases (added service-host classification from the derived set + virtual-host routing for a configured extra suffix, with negative cases)
- [x] `S3VirtualHostIntegrationTest`) 19, green
- [x] Full S3 suite `-Dtest='S3*Test'`: 651, green