### PR TITLE
feat(apigateway): execute api subdomain routing

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteApiFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteApiFilter.java
@@ -1,8 +1,6 @@
 package io.github.hectorvent.floci.services.apigateway;
 
-import io.github.hectorvent.floci.core.common.RegionResolver;
 import jakarta.annotation.Priority;
-import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.PreMatching;
@@ -32,10 +30,6 @@ public class ApiGatewayExecuteApiFilter implements ContainerRequestFilter {
 
     private static final Logger LOG = Logger.getLogger(ApiGatewayExecuteApiFilter.class);
     private static final String EXECUTE_API_LABEL = "execute-api";
-
-    @Inject
-    public ApiGatewayExecuteApiFilter() {
-    }
 
     @Override
     public void filter(ContainerRequestContext requestContext) {

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteApiFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteApiFilter.java
@@ -1,0 +1,111 @@
+package io.github.hectorvent.floci.services.apigateway;
+
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.ext.Provider;
+import org.jboss.logging.Logger;
+
+import java.net.URI;
+
+/**
+ * Routes requests with an execute-api subdomain host to the API Gateway execute controller.
+ *
+ * <p>AWS SDKs address API Gateway APIs via
+ * {@code {apiId}.execute-api.{region}.amazonaws.com/{stage}/{path}}.
+ * This filter recognises the local equivalent
+ * ({@code {apiId}.execute-api.localhost:4566/{stage}/{path}}) and rewrites the path to
+ * {@code /execute-api/{apiId}/{stage}/{path}} so that {@link ApiGatewayExecuteController}
+ * can handle it.
+ *
+ * <p>Without this filter, requests like {@code POST /@connections/{connectionId}} are
+ * intercepted by the S3 controller, which interprets {@code @connections} as a bucket name.
+ */
+@Provider
+@PreMatching
+@Priority(10)
+public class ApiGatewayExecuteApiFilter implements ContainerRequestFilter {
+
+    private static final Logger LOG = Logger.getLogger(ApiGatewayExecuteApiFilter.class);
+    private static final String EXECUTE_API_LABEL = "execute-api";
+
+    @Inject
+    public ApiGatewayExecuteApiFilter() {
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        String host = requestContext.getHeaderString("Host");
+        if (host == null) {
+            return;
+        }
+
+        String apiId = extractApiId(host);
+        if (apiId == null) {
+            return;
+        }
+
+        URI uri = requestContext.getUriInfo().getRequestUri();
+        String path = uri.getRawPath();
+
+        String newPath = "/execute-api/" + apiId + (path.startsWith("/") ? path : "/" + path);
+
+        URI newUri = UriBuilder.fromUri(uri)
+                .replacePath(newPath)
+                .build();
+
+        LOG.debugv("Execute-api subdomain routing: {0}{1} -> {2}", host, path, newUri.getPath());
+        requestContext.setRequestUri(newUri);
+    }
+
+    /**
+     * Extracts the API ID from an execute-api subdomain host.
+     *
+     * <p>Examples:
+     * <ul>
+     *   <li>{@code abc123.execute-api.localhost:4566} → {@code abc123}</li>
+     *   <li>{@code abc123.execute-api.us-east-1.localhost:4566} → {@code abc123}</li>
+     *   <li>{@code abc123.execute-api.us-east-1.amazonaws.com} → {@code abc123}</li>
+     *   <li>{@code localhost:4566} → {@code null}</li>
+     *   <li>{@code my-bucket.localhost:4566} → {@code null}</li>
+     * </ul>
+     */
+    static String extractApiId(String host) {
+        if (host == null) {
+            return null;
+        }
+
+        String hostname = stripPort(host);
+
+        // Need {apiId}.execute-api.{something} — at least two dots
+        int firstDot = hostname.indexOf('.');
+        if (firstDot <= 0) {
+            return null;
+        }
+
+        String apiId = hostname.substring(0, firstDot);
+        String remainder = hostname.substring(firstDot + 1);
+
+        // remainder must start with "execute-api."
+        if (!remainder.toLowerCase().startsWith(EXECUTE_API_LABEL + ".")) {
+            return null;
+        }
+
+        return apiId;
+    }
+
+    private static String stripPort(String host) {
+        int colonIndex = host.lastIndexOf(':');
+        if (colonIndex > 0) {
+            String maybePart = host.substring(colonIndex + 1);
+            if (!maybePart.isEmpty() && maybePart.chars().allMatch(Character::isDigit)) {
+                return host.substring(0, colonIndex);
+            }
+        }
+        return host;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteApiFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteApiFilterTest.java
@@ -1,0 +1,56 @@
+package io.github.hectorvent.floci.services.apigateway;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link ApiGatewayExecuteApiFilter#extractApiId(String)}.
+ */
+class ApiGatewayExecuteApiFilterTest {
+
+    @Test
+    void extractsApiIdFromExecuteApiSubdomain() {
+        assertEquals("abc123", ApiGatewayExecuteApiFilter.extractApiId("abc123.execute-api.localhost:4566"));
+    }
+
+    @Test
+    void extractsApiIdWithoutPort() {
+        assertEquals("abc123", ApiGatewayExecuteApiFilter.extractApiId("abc123.execute-api.localhost"));
+    }
+
+    @Test
+    void extractsApiIdWithRegion() {
+        assertEquals("abc123", ApiGatewayExecuteApiFilter.extractApiId("abc123.execute-api.us-east-1.localhost:4566"));
+    }
+
+    @Test
+    void extractsApiIdFromAwsDomain() {
+        assertEquals("abc123", ApiGatewayExecuteApiFilter.extractApiId("abc123.execute-api.us-east-1.amazonaws.com"));
+    }
+
+    @Test
+    void returnsNullForPlainLocalhost() {
+        assertNull(ApiGatewayExecuteApiFilter.extractApiId("localhost:4566"));
+    }
+
+    @Test
+    void returnsNullForS3VirtualHost() {
+        assertNull(ApiGatewayExecuteApiFilter.extractApiId("my-bucket.localhost:4566"));
+    }
+
+    @Test
+    void returnsNullForS3ServiceHost() {
+        assertNull(ApiGatewayExecuteApiFilter.extractApiId("my-bucket.s3.localhost:4566"));
+    }
+
+    @Test
+    void returnsNullForNull() {
+        assertNull(ApiGatewayExecuteApiFilter.extractApiId(null));
+    }
+
+    @Test
+    void returnsNullForNoSubdomain() {
+        assertNull(ApiGatewayExecuteApiFilter.extractApiId("execute-api.localhost:4566"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteApiSubdomainIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteApiSubdomainIntegrationTest.java
@@ -1,0 +1,125 @@
+package io.github.hectorvent.floci.services.apigateway;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Verifies that execute-api subdomain routing works correctly.
+ *
+ * <p>When a request arrives with a Host header like
+ * {@code {apiId}.execute-api.localhost:{port}}, the filter rewrites the path to
+ * {@code /execute-api/{apiId}/{path}} so that {@link ApiGatewayExecuteController}
+ * handles it. This enables AWS SDK clients to use the standard execute-api
+ * endpoint URL format for features like the @connections Management API.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayExecuteApiSubdomainIntegrationTest {
+
+    private static String apiId;
+
+    @Test
+    @Order(1)
+    void createWebSocketApi() {
+        apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"execute-api-subdomain-test","protocolType":"WEBSOCKET","routeSelectionExpression":"$request.body.action"}
+                        """)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .body("apiId", notNullValue())
+                .extract().path("apiId");
+    }
+
+    @Test
+    @Order(2)
+    void createStage() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"stageName":"prod","autoDeploy":true}
+                        """)
+                .when().post("/v2/apis/" + apiId + "/stages")
+                .then()
+                .statusCode(201);
+    }
+
+    @Test
+    @Order(3)
+    void postToConnectionViaPathPrefix_returnsGoneException() {
+        given()
+                .contentType(ContentType.TEXT)
+                .body("hello")
+                .when().post("/execute-api/" + apiId + "/prod/@connections/fake-connection")
+                .then()
+                .statusCode(410)
+                .body("__type", equalTo("GoneException"));
+    }
+
+    @Test
+    @Order(4)
+    void postToConnectionViaSubdomain_returnsGoneException() {
+        given()
+                .header("Host", apiId + ".execute-api.localhost:" + io.restassured.RestAssured.port)
+                .contentType(ContentType.TEXT)
+                .body("hello")
+                .when().post("/prod/@connections/fake-connection")
+                .then()
+                .statusCode(410)
+                .body("__type", equalTo("GoneException"));
+    }
+
+    @Test
+    @Order(5)
+    void getConnectionViaSubdomain_returnsGoneException() {
+        given()
+                .header("Host", apiId + ".execute-api.localhost:" + io.restassured.RestAssured.port)
+                .when().get("/prod/@connections/fake-connection")
+                .then()
+                .statusCode(410)
+                .body("__type", equalTo("GoneException"));
+    }
+
+    @Test
+    @Order(6)
+    void deleteConnectionViaSubdomain_returnsGoneException() {
+        given()
+                .header("Host", apiId + ".execute-api.localhost:" + io.restassured.RestAssured.port)
+                .when().delete("/prod/@connections/fake-connection")
+                .then()
+                .statusCode(410)
+                .body("__type", equalTo("GoneException"));
+    }
+
+    @Test
+    @Order(7)
+    void subdomainWithRegion_routesCorrectly() {
+        given()
+                .header("Host", apiId + ".execute-api.us-east-1.localhost:" + io.restassured.RestAssured.port)
+                .contentType(ContentType.TEXT)
+                .body("hello")
+                .when().post("/prod/@connections/fake-connection")
+                .then()
+                .statusCode(410)
+                .body("__type", equalTo("GoneException"));
+    }
+
+    @Test
+    @Order(8)
+    void unknownSubdomain_doesNotRouteToApiGateway() {
+        given()
+                .header("Host", "my-bucket.localhost:" + io.restassured.RestAssured.port)
+                .when().get("/prod/@connections/fake-connection")
+                .then()
+                .statusCode(not(410));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteApiSubdomainIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteApiSubdomainIntegrationTest.java
@@ -120,6 +120,7 @@ class ApiGatewayExecuteApiSubdomainIntegrationTest {
                 .header("Host", "my-bucket.localhost:" + io.restassured.RestAssured.port)
                 .when().get("/prod/@connections/fake-connection")
                 .then()
-                .statusCode(not(410));
+                .statusCode(404)
+                .body(containsString("NoSuchBucket"));
     }
 }


### PR DESCRIPTION
## Summary

- API Gateway Management API (`/@connections`) was being routed to S3
- Added a path rewrite filter to recognise execute-api subdomains and route to API Gateway
- Verified WebSocket communication works with the AWS SDK's native subdomain-based endpoint URL in a separate project

Closes #1846

## What changed

- Added `ApiGatewayExecuteApiFilter`, extracts API ID from host patterns and rewrites the path to ApiGatewayExecuteController
- Follows the code style and structure of the existing `ApiGatewayCustomDomainFilter` and `S3VirtualHostFilter`
- Existing path prefix routing and custom domain routing are unaffected

## Tests

- 9 unit tests: `extractApiId` with various host patterns (subdomain, region-qualified, AWS domain, S3 host, null, etc.)
- 8 integration tests: create a WebSocket API, verify @connections routing via subdomain (POST/GET/DELETE), confirm path prefix still works, confirm unrelated subdomains are not affected
- Existing S3VirtualHostFilterTest (53) and ApiGatewayCustomDomainIntegrationTest (16) all pass

## Type of change

- [x] New feature (`feat:`)

## AWS Compatibility

Tested with `@connections` Management API (POST, GET, DELETE):
- Path prefix (`/execute-api/{apiId}/prod/@connections/connId`) returns 410 GoneException (unchanged)
- Subdomain (`{apiId}.execute-api.localhost/prod/@connections/connId`) returns 410 GoneException (new)
- Region-qualified subdomain (`{apiId}.execute-api.us-east-1.localhost`) routes correctly
- Non-execute-api subdomains (`my-bucket.localhost`) are not affected

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits
