### PR TITLE
fix(ec2): reject duplicate key pair names in ImportKeyPair

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1572,6 +1572,11 @@ public class Ec2Service {
 
     public KeyPair importKeyPair(String region, String keyName, String publicKeyMaterial) {
         ensureDefaultResources(region);
+        boolean exists = keyPairs.scan(k -> true).stream()
+                .anyMatch(k -> k.getRegion().equals(region) && k.getKeyName().equals(keyName));
+        if (exists) {
+            throw new AwsException("InvalidKeyPair.Duplicate", "The keypair '" + keyName + "' already exists", 400);
+        }
         String keyPairId = "key-" + randomHex(17);
         KeyPair kp = new KeyPair();
         kp.setKeyPairId(keyPairId);

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -896,6 +896,21 @@ class Ec2IntegrationTest {
     }
 
     @Test
+    @Order(41)
+    void importKeyPairRejectsDuplicateKeyName() {
+        given()
+            .formParam("Action", "ImportKeyPair")
+            .formParam("KeyName", "imported-key")
+            .formParam("PublicKeyMaterial", "c3NoLXJzYSBBQUFBQjNOemFDMXljMkVBQUFBREFRQUJBQUFCQVFD")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidKeyPair.Duplicate"));
+    }
+
+    @Test
     @Order(42)
     void createLaunchTemplateRejectsMalformedUserData() {
         given()

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -266,6 +266,38 @@ class Ec2ServiceTest {
     }
 
     @Test
+    void importKeyPairRejectsDuplicateKeyName() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+
+        service.importKeyPair("us-east-1", "duplicate-key", "c3NoLXJzYSBBQUFB");
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.importKeyPair("us-east-1", "duplicate-key", "c3NoLXJzYSBBQUFB"));
+        assertEquals("InvalidKeyPair.Duplicate", error.getErrorCode());
+        assertEquals(400, error.getHttpStatus());
+
+        // same name in another region is allowed
+        service.importKeyPair("us-west-2", "duplicate-key", "c3NoLXJzYSBBQUFB");
+    }
+
+    @Test
+    void importKeyPairRejectsNameAlreadyUsedByCreateKeyPair() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+
+        service.createKeyPair("us-east-1", "shared-key-name");
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.importKeyPair("us-east-1", "shared-key-name", "c3NoLXJzYSBBQUFB"));
+        assertEquals("InvalidKeyPair.Duplicate", error.getErrorCode());
+    }
+
+    @Test
     void registerImageReusingSnapshotDoesNotOverwriteSnapshotMetadata() {
         Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
                 mock(Ec2PortForwardManager.class),


### PR DESCRIPTION
## Summary

Closes #1845

`ImportKeyPair` accepted any `KeyName` even when a key pair with the same name already existed in the region. Each call returned a new `KeyPairId`, so `DescribeKeyPairs` could list multiple entries with the same name — e.g. after repeated `terraform apply` runs, since the Terraform AWS provider's `aws_key_pair` resource (with `public_key`) calls `ImportKeyPair`, not `CreateKeyPair`.

Real AWS rejects this with `InvalidKeyPair.Duplicate` (HTTP 400).

Note: `CreateKeyPair` on `main` already performs this duplicate check — the released `latest` image the issue was reported against predates it. The remaining gap was `ImportKeyPair`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: importing a key pair with an already-used `KeyName` in the same region succeeded and created a second key pair with the same name. Real EC2 returns `InvalidKeyPair.Duplicate` ("The keypair '<name>' already exists") with HTTP 400 — same error `CreateKeyPair` already emulates on `main`. Same name in a different region remains allowed, matching AWS's region-scoped namespace.

Reproduction (before this change):

```bash
aws --endpoint-url=http://localhost:4566 ec2 import-key-pair --key-name terrakey --public-key-material fileb://terrakey.pub
aws --endpoint-url=http://localhost:4566 ec2 import-key-pair --key-name terrakey --public-key-material fileb://terrakey.pub  # succeeded, now returns InvalidKeyPair.Duplicate
```

## Checklist

- [x] `./mvnw test` passes locally (`Ec2ServiceTest` + `Ec2IntegrationTest`: 160 tests, 0 failures)
- [x] New or updated integration test added (duplicate `ImportKeyPair` → HTTP 400 `InvalidKeyPair.Duplicate` over the EC2 query protocol, plus unit tests for region scoping and cross-`CreateKeyPair` collisions)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)