### PR TITLE
fix(cloudformation): inline policy names are no longer global (can be reused in different stacks)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -95,6 +95,8 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -271,8 +273,9 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::IAM::Role" -> provisionIamRole(resource, properties, engine, accountId, stackName);
                 case "AWS::IAM::User" -> provisionIamUser(resource, properties, engine, stackName);
                 case "AWS::IAM::AccessKey" -> provisionIamAccessKey(resource, properties, engine);
-                case "AWS::IAM::Policy", "AWS::IAM::ManagedPolicy" ->
-                        provisionIamPolicy(resource, properties, engine, accountId, stackName);
+                case "AWS::IAM::Policy" -> provisionIamPolicy(resource, properties, engine, stackName);
+                case "AWS::IAM::ManagedPolicy" ->
+                        provisionIamManagedPolicy(resource, properties, engine, stackName);
                 case "AWS::IAM::InstanceProfile" -> provisionInstanceProfile(resource, properties, engine, accountId, stackName);
                 case "AWS::SSM::Parameter" -> provisionSsmParameter(resource, properties, engine, region, stackName);
                 case "AWS::KMS::Key" -> provisionKmsKey(resource, properties, engine, region, accountId);
@@ -400,6 +403,11 @@ public class CloudFormationResourceProvisioner {
                     LOG.debugv("Error deleting nodegroup {0}: {1}", resource.getPhysicalId(), e.getMessage());
                 }
             }
+            return;
+        }
+        if ("AWS::IAM::Policy".equals(resourceType)
+                && resource.getAttributes().containsKey("PolicyName")) {
+            deleteIamInlinePolicy(resource);
             return;
         }
         delete(resourceType, resource.getPhysicalId(), region);
@@ -1893,8 +1901,44 @@ public class CloudFormationResourceProvisioner {
     // ── IAM Policy ────────────────────────────────────────────────────────────
 
     private void provisionIamPolicy(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
-                                    String accountId, String stackName) {
+                                    String stackName) {
         String policyName = resolveOptional(props, "PolicyName", engine);
+        if (policyName == null || policyName.isBlank()) {
+            policyName = generatePhysicalName(stackName, r.getLogicalId(), 128, false);
+        }
+        String document = props != null && props.has("PolicyDocument")
+                ? props.get("PolicyDocument").toString()
+                : "{\"Version\":\"2012-10-17\",\"Statement\":[]}";
+
+        List<String> roles = resolveIamPolicyEntities(props, "Roles", engine, iamService::getRole);
+        List<String> users = resolveIamPolicyEntities(props, "Users", engine, iamService::getUser);
+        List<String> groups = resolveIamPolicyEntities(props, "Groups", engine, iamService::getGroup);
+
+        deleteRemovedIamInlinePolicies(r, "Roles", roles, policyName, "role", iamService::deleteRolePolicy);
+        deleteRemovedIamInlinePolicies(r, "Users", users, policyName, "user", iamService::deleteUserPolicy);
+        deleteRemovedIamInlinePolicies(r, "Groups", groups, policyName, "group", iamService::deleteGroupPolicy);
+
+        for (String roleName : roles) {
+            iamService.putRolePolicy(roleName, policyName, document);
+        }
+        for (String userName : users) {
+            iamService.putUserPolicy(userName, policyName, document);
+        }
+        for (String groupName : groups) {
+            iamService.putGroupPolicy(groupName, policyName, document);
+        }
+
+        r.setPhysicalId(policyName);
+        r.getAttributes().remove("Arn");
+        r.getAttributes().put("PolicyName", policyName);
+        r.getAttributes().put("Roles", String.join("|", roles));
+        r.getAttributes().put("Users", String.join("|", users));
+        r.getAttributes().put("Groups", String.join("|", groups));
+    }
+
+    private void provisionIamManagedPolicy(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
+                                           String stackName) {
+        String policyName = resolveOptional(props, "ManagedPolicyName", engine);
         if (policyName == null || policyName.isBlank()) {
             policyName = generatePhysicalName(stackName, r.getLogicalId(), 128, false);
         }
@@ -1906,20 +1950,15 @@ public class CloudFormationResourceProvisioner {
         r.setPhysicalId(policy.getArn());
         r.getAttributes().put("Arn", policy.getArn());
 
-        // Attach to roles if specified
         if (props != null && props.has("Roles")) {
             for (JsonNode role : props.get("Roles")) {
                 try {
                     iamService.attachRolePolicy(engine.resolve(role), policy.getArn());
-                } catch (Exception ignored) {
+                } catch (Exception e) {
+                    LOG.debugv("Could not attach managed policy {0} to role: {1}", policy.getArn(), e.getMessage());
                 }
             }
         }
-    }
-
-    private void provisionIamManagedPolicy(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
-                                           String accountId, String stackName) {
-        provisionIamPolicy(r, props, engine, accountId, stackName);
     }
 
     // ── IAM Instance Profile ──────────────────────────────────────────────────
@@ -3811,6 +3850,62 @@ public class CloudFormationResourceProvisioner {
             iamService.deleteRole(roleName);
         } catch (Exception e) {
             LOG.debugv("Could not delete role {0}: {1}", roleName, e.getMessage());
+        }
+    }
+
+    private void deleteIamInlinePolicy(StackResource resource) {
+        String policyName = resource.getAttributes().get("PolicyName");
+        deleteIamInlinePolicies(iamPolicyEntities(resource, "Roles"), policyName,
+                "role", iamService::deleteRolePolicy);
+        deleteIamInlinePolicies(iamPolicyEntities(resource, "Users"), policyName,
+                "user", iamService::deleteUserPolicy);
+        deleteIamInlinePolicies(iamPolicyEntities(resource, "Groups"), policyName,
+                "group", iamService::deleteGroupPolicy);
+    }
+
+    private List<String> resolveIamPolicyEntities(JsonNode props, String property,
+                                                  CloudFormationTemplateEngine engine,
+                                                  Consumer<String> validateEntity) {
+        if (props == null || !props.has(property)) {
+            return List.of();
+        }
+        List<String> entities = new ArrayList<>();
+        for (JsonNode entity : props.get(property)) {
+            String entityName = engine.resolve(entity);
+            validateEntity.accept(entityName);
+            entities.add(entityName);
+        }
+        return entities;
+    }
+
+    private void deleteRemovedIamInlinePolicies(StackResource resource, String attribute,
+                                                 List<String> currentEntities, String currentPolicyName,
+                                                 String entityType, BiConsumer<String, String> deletePolicy) {
+        String previousPolicyName = resource.getAttributes().get("PolicyName");
+        if (previousPolicyName == null) {
+            return;
+        }
+        List<String> removedEntities = iamPolicyEntities(resource, attribute).stream()
+                .filter(entity -> !previousPolicyName.equals(currentPolicyName) || !currentEntities.contains(entity))
+                .toList();
+        deleteIamInlinePolicies(removedEntities, previousPolicyName, entityType, deletePolicy);
+    }
+
+    private List<String> iamPolicyEntities(StackResource resource, String attribute) {
+        return Arrays.stream(resource.getAttributes().getOrDefault(attribute, "").split("\\|"))
+                .filter(entity -> !entity.isBlank())
+                .toList();
+    }
+
+    private void deleteIamInlinePolicies(Collection<String> entityNames, String policyName, String entityType,
+                                         BiConsumer<String, String> deletePolicy) {
+        for (String entityName : entityNames) {
+            try {
+                deletePolicy.accept(entityName, policyName);
+            } catch (Exception e) {
+                LOG.debugv("Could not delete inline policy {0} from {1} {2}: {3}",
+                        policyName, entityType, entityName, e.getMessage());
+            }
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
@@ -612,7 +612,7 @@ public class CloudFormationService {
             if (resource.getPhysicalId() != null && "CREATE_COMPLETE".equals(resource.getStatus())) {
                 addEvent(stack, resource.getLogicalId(), resource.getPhysicalId(),
                         resource.getResourceType(), "DELETE_IN_PROGRESS", null);
-                provisioner.delete(resource.getResourceType(), resource.getPhysicalId(), region);
+                provisioner.delete(resource, region);
                 resource.setStatus("DELETE_COMPLETE");
                 addEvent(stack, resource.getLogicalId(), resource.getPhysicalId(),
                         resource.getResourceType(), "DELETE_COMPLETE", null);

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -287,6 +287,16 @@ class CloudFormationIntegrationTest {
 
         given()
             .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-inline-policy-stack-a")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>UPDATE_COMPLETE</StackStatus>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
             .formParam("Action", "GetRolePolicy")
             .formParam("RoleName", "cfn-inline-policy-role-a")
             .formParam("PolicyName", policyName)
@@ -296,6 +306,19 @@ class CloudFormationIntegrationTest {
             .post("/")
         .then()
             .statusCode(404);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "GetRolePolicy")
+            .formParam("RoleName", "cfn-inline-policy-role-b")
+            .formParam("PolicyName", policyName)
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=test/20260227/us-east-1/iam/aws4_request")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<PolicyName>" + policyName + "</PolicyName>"));
 
         String invalidPolicyTemplate = """
             {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -17,6 +17,7 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
+import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import static io.restassured.RestAssured.given;
@@ -170,6 +171,181 @@ class CloudFormationIntegrationTest {
             .statusCode(200)
             .body(containsString("<StackName>test-stack</StackName>"))
             .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+    }
+
+    @Test
+    void createStacks_withSameIamInlinePolicyName() {
+        String policyName = "IamTaskRoleDefaultPolicy54CEC625";
+
+        for (String suffix : List.of("a", "b")) {
+            String stackName = "cfn-inline-policy-stack-" + suffix;
+            String roleName = "cfn-inline-policy-role-" + suffix;
+            String template = """
+                {
+                  "Resources": {
+                    "TaskRole": {
+                      "Type": "AWS::IAM::Role",
+                      "Properties": {
+                        "RoleName": "%s",
+                        "AssumeRolePolicyDocument": {
+                          "Version": "2012-10-17",
+                          "Statement": []
+                        }
+                      }
+                    },
+                    "TaskRoleDefaultPolicy": {
+                      "Type": "AWS::IAM::Policy",
+                      "Properties": {
+                        "PolicyName": "%s",
+                        "PolicyDocument": {
+                          "Version": "2012-10-17",
+                          "Statement": [{
+                            "Effect": "Allow",
+                            "Action": "logs:CreateLogStream",
+                            "Resource": "*"
+                          }]
+                        },
+                        "Roles": [{ "Ref": "TaskRole" }]
+                      }
+                    }
+                  }
+                }
+                """.formatted(roleName, policyName);
+
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "CreateStack")
+                .formParam("StackName", stackName)
+                .formParam("TemplateBody", template)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<StackId>"));
+
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "DescribeStacks")
+                .formParam("StackName", stackName)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "GetRolePolicy")
+                .formParam("RoleName", roleName)
+                .formParam("PolicyName", policyName)
+                .header("Authorization",
+                        "AWS4-HMAC-SHA256 Credential=test/20260227/us-east-1/iam/aws4_request")
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<PolicyName>" + policyName + "</PolicyName>"));
+        }
+
+        String movedPolicyTemplate = """
+            {
+              "Resources": {
+                "TaskRole": {
+                  "Type": "AWS::IAM::Role",
+                  "Properties": {
+                    "RoleName": "cfn-inline-policy-role-a",
+                    "AssumeRolePolicyDocument": {
+                      "Version": "2012-10-17",
+                      "Statement": []
+                    }
+                  }
+                },
+                "TaskRoleDefaultPolicy": {
+                  "Type": "AWS::IAM::Policy",
+                  "Properties": {
+                    "PolicyName": "%s",
+                    "PolicyDocument": {
+                      "Version": "2012-10-17",
+                      "Statement": []
+                    },
+                    "Roles": ["cfn-inline-policy-role-b"]
+                  }
+                }
+              }
+            }
+            """.formatted(policyName);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "UpdateStack")
+            .formParam("StackName", "cfn-inline-policy-stack-a")
+            .formParam("TemplateBody", movedPolicyTemplate)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "GetRolePolicy")
+            .formParam("RoleName", "cfn-inline-policy-role-a")
+            .formParam("PolicyName", policyName)
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=test/20260227/us-east-1/iam/aws4_request")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(404);
+
+        String invalidPolicyTemplate = """
+            {
+              "Resources": {
+                "TaskRoleDefaultPolicy": {
+                  "Type": "AWS::IAM::Policy",
+                  "Properties": {
+                    "PolicyName": "%s",
+                    "PolicyDocument": {
+                      "Version": "2012-10-17",
+                      "Statement": []
+                    },
+                    "Roles": ["cfn-inline-policy-role-a", "missing-inline-policy-role"]
+                  }
+                }
+              }
+            }
+            """.formatted(policyName);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-inline-policy-failing-stack")
+            .formParam("TemplateBody", invalidPolicyTemplate)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-inline-policy-failing-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>ROLLBACK_COMPLETE</StackStatus>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "GetRolePolicy")
+            .formParam("RoleName", "cfn-inline-policy-role-a")
+            .formParam("PolicyName", policyName)
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=test/20260227/us-east-1/iam/aws4_request")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(404);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsSqsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsSqsIntegrationTest.java
@@ -136,6 +136,58 @@ class StepFunctionsSqsIntegrationTest {
 
     @Test
     @Order(5)
+    void waitForTaskToken_preservesExecutionInputContextAfterCallback() throws Exception {
+        String definition = """
+                {
+                    "StartAt": "WaitTask",
+                    "States": {
+                        "WaitTask": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::sqs:sendMessage.waitForTaskToken",
+                            "Parameters": {
+                                "QueueUrl": "%s",
+                                "MessageBody": {"task_token.$": "$$.Task.Token"}
+                            },
+                            "Next": "ResolveDocs"
+                        },
+                        "ResolveDocs": {
+                            "Type": "Pass",
+                            "Parameters": {"document_pids.$": "$$.Execution.Input.document_pids"},
+                            "Next": "MapDocs"
+                        },
+                        "MapDocs": {
+                            "Type": "Map",
+                            "ItemsPath": "$.document_pids",
+                            "ItemSelector": {"document_pid.$": "$$.Map.Item.Value"},
+                            "ItemProcessor": {
+                                "ProcessorConfig": {"Mode": "INLINE"},
+                                "StartAt": "Echo",
+                                "States": {"Echo": {"Type": "Pass", "End": true}}
+                            },
+                            "End": true
+                        }
+                    }
+                }
+                """.formatted(callbackQueueUrl);
+
+        String smArn = createStateMachine("execution-input-context-" + System.currentTimeMillis(), definition);
+        String execArn = startExecution(smArn, "{\"document_pids\":[\"doc-a\",\"doc-b\",\"doc-c\"]}");
+
+        JsonNode message = receiveSingleMessage(callbackQueueUrl);
+        String taskToken = mapper.readTree(message.path("Body").asText()).path("task_token").asText();
+        assertFalse(taskToken.isBlank());
+
+        sendTaskSuccess(taskToken, "{}");
+        JsonNode output = mapper.readTree(waitForExecution(execArn));
+        assertEquals(mapper.readTree("""
+                [{"document_pid":"doc-a"},{"document_pid":"doc-b"},{"document_pid":"doc-c"}]
+                """), output);
+
+        deleteMessage(callbackQueueUrl, message.path("ReceiptHandle").asText());
+    }
+
+    @Test
+    @Order(6)
     void awsSdk_nonExistentQueue_fails_withSdkStyleErrorName() throws Exception {
         String definition = buildStateMachineDefinition("arn:aws:states:::aws-sdk:sqs:sendMessage", """
                 {
@@ -151,7 +203,7 @@ class StepFunctionsSqsIntegrationTest {
     }
 
     @Test
-    @Order(6)
+    @Order(7)
     void cleanup_deleteQueues() {
         deleteQueue(queueUrl);
         deleteQueue(callbackQueueUrl);


### PR DESCRIPTION
## Summary

Fixes CloudFormation AWS::IAM::Policy handling so inline policies can reuse the same name across stacks without collisions.
Also cleans up removed attachments during updates and validates all principals before applying policy changes.

Closes #1531

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

AWS::IAM::Policy was incorrectly persisted as a managed IAM policy, causing EntityAlreadyExists errors when separate stacks used the same inline-policy name.
The implementation now uses IAM inline-policy operations per role, user, and group.

Regression verified with CloudFormationIntegrationTest. Repository SDK compatibility tests use AWS SDK for Java 2.44.14; local AWS CLI version is 2.35.9.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
