### PR TITLE
fix(apigateway): preserve trailing slash in proxy event path

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -517,7 +517,10 @@ public class ApiGatewayExecuteController {
 
         ObjectNode node = objectMapper.createObjectNode();
         node.put("type", auth.getType());
-        node.put("methodArn", buildMethodArn(region, apiId, stageName, httpMethod, preservedPath));
+        // methodArn keeps the normalized path: it is matched against IAM-style policy resources,
+        // where a stray trailing slash would silently fail wildcards an authorizer already returns.
+        // No AWS behavior was found pinning it either way, so the conservative form wins.
+        node.put("methodArn", buildMethodArn(region, apiId, stageName, httpMethod, requestPath));
         if ("TOKEN".equals(auth.getType())) {
             String headerName = auth.getIdentitySource().replace("method.request.header.", "");
             node.put("authorizationToken", headers.getHeaderString(headerName));
@@ -625,7 +628,6 @@ public class ApiGatewayExecuteController {
         // Recover it from the raw request URI for the event path fields. Resource matching
         // and path-parameter extraction continue to use the normalized `path`.
         String requestPath = preserveTrailingSlash(path, uriInfo.getRequestUri().getRawPath());
-        boolean trailingSlash = !requestPath.equals(path);
 
         ObjectNode event = objectMapper.createObjectNode();
         event.put("resource", resourcePath);
@@ -637,9 +639,11 @@ public class ApiGatewayExecuteController {
         putQueryStringParameters(event, uriInfo);
         putMultiValueQueryStringParameters(event, uriInfo);
 
+        // pathParameters come from the matcher, which ran on the normalized path, so the greedy
+        // {proxy+} value has no trailing slash on real AWS even when event.path keeps one.
         ObjectNode pathParams = event.putObject("pathParameters");
         if (proxy != null && !proxy.isEmpty()) {
-            pathParams.put("proxy", trailingSlash ? proxy + "/" : proxy);
+            pathParams.put("proxy", proxy);
         }
         extractPathParams(resourcePath, path).forEach(pathParams::put);
 

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -615,9 +615,16 @@ public class ApiGatewayExecuteController {
                                    byte[] body, String requestId,
                                    String principalId, Map<String, Object> authorizerContext,
                                    String resolvedApiKey) {
+        // The JAX-RS {proxy} binding strips a trailing slash, but a trailing slash is
+        // significant in the delivered path (routers treat /x and /x/ as distinct routes).
+        // Recover it from the raw request URI for the event path fields. Resource matching
+        // and path-parameter extraction continue to use the normalized `path`.
+        String requestPath = preserveTrailingSlash(path, uriInfo.getRequestUri().getRawPath());
+        boolean trailingSlash = !requestPath.equals(path);
+
         ObjectNode event = objectMapper.createObjectNode();
         event.put("resource", resourcePath);
-        event.put("path", path);
+        event.put("path", requestPath);
         event.put("httpMethod", httpMethod);
 
         putSingleValueHeaders(event, headers);
@@ -626,7 +633,9 @@ public class ApiGatewayExecuteController {
         putMultiValueQueryStringParameters(event, uriInfo);
 
         ObjectNode pathParams = event.putObject("pathParameters");
-        if (proxy != null && !proxy.isEmpty()) pathParams.put("proxy", proxy);
+        if (proxy != null && !proxy.isEmpty()) {
+            pathParams.put("proxy", trailingSlash ? proxy + "/" : proxy);
+        }
         extractPathParams(resourcePath, path).forEach(pathParams::put);
 
         // stageVariables: populate from the Stage object (null if no variables configured)
@@ -652,7 +661,7 @@ public class ApiGatewayExecuteController {
         ctx.put("domainPrefix", apiId);
         ctx.put("extendedRequestId", requestId);
         ctx.put("httpMethod", httpMethod);
-        ctx.put("path", path);
+        ctx.put("path", requestPath);
         ctx.put("protocol", "HTTP/1.1");
         ctx.put("requestId", requestId);
         ctx.put("requestTime", requestTime);
@@ -1908,6 +1917,23 @@ public class ApiGatewayExecuteController {
     }
 
     // ──────────────────────────── Path matching ────────────────────────────
+
+    /**
+     * Re-appends a trailing slash that the JAX-RS {@code {proxy}} path-param binding strips.
+     * A trailing slash is significant in the proxy event path (many routers treat {@code /x}
+     * and {@code /x/} as distinct routes), so it is recovered from the raw request URI. The
+     * normalized path is still used for resource matching and path-parameter extraction, which
+     * mirrors AWS routing {@code /x/} to the {@code /x} resource while keeping the slash in the
+     * delivered event. Returns {@code normalizedPath} unchanged for the root path or when the
+     * raw request had no trailing slash.
+     */
+    static String preserveTrailingSlash(String normalizedPath, String rawRequestPath) {
+        if (!"/".equals(normalizedPath) && !normalizedPath.endsWith("/")
+                && rawRequestPath != null && rawRequestPath.endsWith("/")) {
+            return normalizedPath + "/";
+        }
+        return normalizedPath;
+    }
 
     /**
      * Finds all matching resources for {@code requestPath}, sorted by specificity.

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -510,15 +510,20 @@ public class ApiGatewayExecuteController {
                                      String httpMethod, String requestPath,
                                      String resourcePath, String resourceId, Stage stage, UriInfo uriInfo,
                                      String resolvedApiKey) {
+        // Recover the trailing slash the JAX-RS {proxy} binding strips, so the authorizer sees
+        // the same raw path the Lambda later receives from buildProxyEvent (AWS parity). Path
+        // matching and path-parameter extraction keep using the normalized requestPath.
+        String preservedPath = preserveTrailingSlash(requestPath, uriInfo.getRequestUri().getRawPath());
+
         ObjectNode node = objectMapper.createObjectNode();
         node.put("type", auth.getType());
-        node.put("methodArn", buildMethodArn(region, apiId, stageName, httpMethod, requestPath));
+        node.put("methodArn", buildMethodArn(region, apiId, stageName, httpMethod, preservedPath));
         if ("TOKEN".equals(auth.getType())) {
             String headerName = auth.getIdentitySource().replace("method.request.header.", "");
             node.put("authorizationToken", headers.getHeaderString(headerName));
         } else if ("REQUEST".equals(auth.getType())) {
             node.put("resource", resourcePath);
-            node.put("path", requestPath);
+            node.put("path", preservedPath);
             node.put("httpMethod", httpMethod);
             putSingleValueHeaders(node, headers);
             putMultiValueHeaders(node, headers);
@@ -545,7 +550,7 @@ public class ApiGatewayExecuteController {
             ctx.put("apiId", apiId);
             ctx.put("resourceId", resourceId != null ? resourceId : "");
             ctx.put("resourcePath", resourcePath);
-            ctx.put("path", requestPath);
+            ctx.put("path", preservedPath);
             ctx.put("httpMethod", httpMethod);
             ctx.put("stage", stageName);
             ctx.put("requestId", UUID.randomUUID().toString());

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayProxyMatchTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayProxyMatchTest.java
@@ -154,6 +154,33 @@ class ApiGatewayProxyMatchTest {
         assertSame(rootProxy, matched.get(2));
     }
 
+    // ──────────────────────────── trailing-slash preservation (#1557) ────────────────────────────
+
+    @Test
+    void preservesTrailingSlashFromRawRequestPath() {
+        assertEquals("/thing/", ApiGatewayExecuteController.preserveTrailingSlash(
+                "/thing", "/restapis/abc/prod/_user_request_/thing/"));
+        assertEquals("/a/b/", ApiGatewayExecuteController.preserveTrailingSlash(
+                "/a/b", "/restapis/abc/prod/_user_request_/a/b/"));
+    }
+
+    @Test
+    void leavesPathUnchangedWhenRawRequestHasNoTrailingSlash() {
+        assertEquals("/thing", ApiGatewayExecuteController.preserveTrailingSlash(
+                "/thing", "/restapis/abc/prod/_user_request_/thing"));
+    }
+
+    @Test
+    void doesNotDuplicateSlashOrAlterRootOrHandleNullRaw() {
+        // Root path is never turned into "//".
+        assertEquals("/", ApiGatewayExecuteController.preserveTrailingSlash(
+                "/", "/restapis/abc/prod/_user_request_/"));
+        // An already-normalized path that ends in "/" is not doubled.
+        assertEquals("/thing/", ApiGatewayExecuteController.preserveTrailingSlash("/thing/", "/x/thing/"));
+        // Null raw path is tolerated.
+        assertEquals("/thing", ApiGatewayExecuteController.preserveTrailingSlash("/thing", null));
+    }
+
     // ──────────────────────────── ELB_LISTENER_ARN ────────────────────────────
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayRequestAuthorizerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayRequestAuthorizerIntegrationTest.java
@@ -307,6 +307,35 @@ class ApiGatewayRequestAuthorizerIntegrationTest {
                 "multiValueQueryStringParameters must be null when no query string is present");
     }
 
+    @Test
+    @Order(11)
+    void requestAuthorizerReceivesRawPathWithTrailingSlash() throws Exception {
+        // The JAX-RS {proxy} binding strips a trailing slash, but the authorizer event must
+        // still carry the raw path so path-based access control gates the same value the Lambda
+        // later receives from buildProxyEvent (AWS parity). Path parameters keep coming from the
+        // normalized path, exactly as the AWS_PROXY event does.
+        String response = given()
+                .header("Authorization", "Bearer test")
+                .when().get("/execute-api/" + apiId + "/prod/items/42/")
+                .then()
+                .statusCode(200)
+                .extract().asString();
+
+        JsonNode payload = OBJECT_MAPPER.readTree(response);
+        String receivedEventStr = payload.path("authorizer").path("receivedEvent").asText(null);
+        assertNotNull(receivedEventStr);
+
+        JsonNode event = OBJECT_MAPPER.readTree(receivedEventStr);
+        assertEquals("/items/42/", event.path("path").asText(null),
+                "authorizer event path must preserve the trailing slash");
+        assertEquals("/items/42/", event.path("requestContext").path("path").asText(null),
+                "requestContext.path must preserve the trailing slash");
+        assertTrue(event.path("methodArn").asText("").endsWith("/items/42/"),
+                "methodArn must include the trailing slash");
+        assertEquals("42", event.path("pathParameters").path("id").asText(null),
+                "path parameters must still be extracted from the normalized path");
+    }
+
     // ──────────────────────────── TOKEN authorizer preservation ────────────────────────────
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayRequestAuthorizerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayRequestAuthorizerIntegrationTest.java
@@ -330,8 +330,8 @@ class ApiGatewayRequestAuthorizerIntegrationTest {
                 "authorizer event path must preserve the trailing slash");
         assertEquals("/items/42/", event.path("requestContext").path("path").asText(null),
                 "requestContext.path must preserve the trailing slash");
-        assertTrue(event.path("methodArn").asText("").endsWith("/items/42/"),
-                "methodArn must include the trailing slash");
+        assertTrue(event.path("methodArn").asText("").endsWith("/items/42"),
+                "methodArn keeps the normalized path, since it is matched against policy resources");
         assertEquals("42", event.path("pathParameters").path("id").asText(null),
                 "path parameters must still be extracted from the normalized path");
     }


### PR DESCRIPTION
## Problem

A REST API `AWS_PROXY` integration dropped a trailing slash from the request path in the Lambda proxy event. A request to `/thing/` produced `event.path = "/thing"` instead of `"/thing/"`. A trailing slash is significant to many backends (Go's `go-json-rest` and others treat `/thing` and `/thing/` as distinct routes), so a handler registered on `/thing/` never receives the request. Fixes #1557.

## Root cause

`ApiGatewayExecuteController` builds the request path from the JAX-RS `{proxy: .*}` path param, and that binding strips the trailing slash. Confirmed on `main`:

```
request /thing/  ->  proxy=[thing]   uriInfo.getRawPath()=[.../thing/]
request /a/b/    ->  proxy=[a/b]      uriInfo.getRawPath()=[.../a/b/]
```

So `path = "/" + proxy` lost the slash, and that value flowed into `event.path`, `requestContext.path`, and the `proxy` path parameter.

## Fix

Recover the trailing slash from the raw request URI (`uriInfo.getRequestUri().getRawPath()`), which retains it, and apply it to `path` and `requestContext.path` on both the Lambda proxy event and the REQUEST authorizer event. Resource matching and path-parameter extraction keep using the normalized path, mirroring AWS: `/thing/` still routes to the `/thing` resource, but the delivered event preserves the slash. The recovery is factored into a small pure `preserveTrailingSlash(normalizedPath, rawRequestPath)` helper.

`pathParameters.proxy` and `methodArn` deliberately stay normalized. Both carried the slash in an earlier revision of this PR; @hectorvent caught the proxy case in review and 38fcca2 dropped both. The greedy `{proxy+}` value comes from the matcher, which ran on the stripped path, and independent reports of the AWS behaviour confirm the asymmetry ([vendia/serverless-express#391](https://github.com/vendia/serverless-express/issues/391) traces a broken route to exactly it). `methodArn` gets matched against IAM-style policy resources, where a stray trailing slash would silently miss a wildcard an authorizer returns, so the conservative form is the safer default absent an authoritative capture.

## Verification

Live against `quarkus:dev`, `AWS_PROXY` integration, observing the built event path:

```
/thing   -> event.path /thing
/thing/  -> event.path /thing/     (was /thing)
/a/b/    -> event.path /a/b/        (was /a/b)
/a/b     -> event.path /a/b
```

Added `preserveTrailingSlash` unit tests to `ApiGatewayProxyMatchTest` (preservation, no-op without a trailing slash, root path untouched, no double slash, null-safe), plus authorizer-event coverage. Green locally on JDK 25: `ApiGatewayProxyMatchTest` (19), `ApiGatewayRequestAuthorizerIntegrationTest` (26), `ApiGatewayExecuteControllerTest` (9).

Diff is +85/-9 across 3 files.

