### PR TITLE
fix(ec2): apply cidr-block filter in DescribeSubnets

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -2674,6 +2674,7 @@ public class Ec2Service {
                 case "vpc-id" -> matchesValue(values, subnet.getVpcId());
                 case "state" -> matchesValue(values, subnet.getState());
                 case "availabilityZone", "availability-zone" -> matchesValue(values, subnet.getAvailabilityZone());
+                case "cidr-block", "cidrBlock", "cidr" -> matchesValue(values, subnet.getCidrBlock());
                 default -> true;
             };
         }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -684,7 +684,7 @@ class Ec2IntegrationTest {
     }
 
     @Test
-    @Order(21)
+    @Order(23)
     void describeSubnetsByCidrBlockFilter() {
         String isolatedVpcId = given()
             .formParam("Action", "CreateVpc")

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -685,6 +685,57 @@ class Ec2IntegrationTest {
 
     @Test
     @Order(21)
+    void describeSubnetsByCidrBlockFilter() {
+        String isolatedVpcId = given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.10.0.0/16")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+
+        String firstSubnetId = given()
+            .formParam("Action", "CreateSubnet")
+            .formParam("VpcId", isolatedVpcId)
+            .formParam("CidrBlock", "10.10.1.0/24")
+            .formParam("AvailabilityZone", "us-east-1a")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateSubnetResponse.subnet.subnetId");
+
+        given()
+            .formParam("Action", "CreateSubnet")
+            .formParam("VpcId", isolatedVpcId)
+            .formParam("CidrBlock", "10.10.2.0/24")
+            .formParam("AvailabilityZone", "us-east-1b")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .formParam("Action", "DescribeSubnets")
+            .formParam("Filter.1.Name", "vpc-id")
+            .formParam("Filter.1.Value.1", isolatedVpcId)
+            .formParam("Filter.2.Name", "cidr-block")
+            .formParam("Filter.2.Value.1", "10.10.1.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeSubnetsResponse.subnetSet.item.subnetId", equalTo(firstSubnetId))
+            .body("DescribeSubnetsResponse.subnetSet.item.cidrBlock", equalTo("10.10.1.0/24"));
+    }
+
+    @Test
+    @Order(21)
     void createSubnetHasAssignIpv6AddressOnCreation() {
         given()
             .formParam("Action", "DescribeSubnets")


### PR DESCRIPTION
# Title

fix(ec2): apply cidr-block filter in DescribeSubnets

# Body

DescribeSubnets ignored Name=cidr-block and returned all subnets in the VPC. Match AWS aliases cidr-block, cidrBlock, and cidr.

Fixes #1667
Fixes #1643

## Summary

Apply `cidr-block` / `cidrBlock` / `cidr` filters in `DescribeSubnets` matching. Unrecognized filters previously fell through to `default -> true`, so Floci returned every subnet in the VPC and broke describe-before-create idempotency (e.g. Ansible `ec2_vpc_subnet`, ALB/NAT subnet pairs).

#1643 was closed as completed without the fix landing on `main`; this PR addresses that regression and the open duplicate #1667.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect: `DescribeSubnets` with `Name=cidr-block,Values=…` ignored the filter and returned all subnets in the VPC (`availability-zone` already worked).

Correct (AWS): exact CIDR match; aliases `cidr-block`, `cidr`, and `cidrBlock` are accepted.

Verified with AWS CLI against local Floci (`AWS_ENDPOINT_URL=http://localhost:4566`) and `Ec2IntegrationTest#describeSubnetsByCidrBlockFilter`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
