### PR TITLE
fix(rds): return DBSubnetGroupNotFoundFault for missing DescribeDBSub…

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -803,7 +803,10 @@ public class RdsService implements Resettable {
             groups.add(buildDefaultSubnetGroup(effectiveRegion(region)));
         }
         if (filterName != null && !filterName.isBlank()) {
-            subnetGroups.get(filterName).ifPresent(groups::add);
+            if (!"default".equalsIgnoreCase(filterName)) {
+                // Specific name: AWS DescribeDBSubnetGroups faults when absent (not empty 200).
+                groups.add(resolveDbSubnetGroupView(filterName, region));
+            }
             return groups;
         }
         groups.addAll(subnetGroups.scan(k -> true));

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -770,6 +770,21 @@ class RdsQueryHandlerTest {
         verify(service).listDbSubnetGroups(null, "us-west-2");
     }
 
+    @Test
+    void describeDbSubnetGroups_missingNameReturnsNotFoundFault() {
+        when(service.listDbSubnetGroups("does-not-exist", null))
+                .thenThrow(new AwsException("DBSubnetGroupNotFoundFault",
+                        "DB subnet group does-not-exist not found.", 404));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBSubnetGroupName", "does-not-exist");
+
+        Response response = handler.handle("DescribeDBSubnetGroups", p);
+
+        assertEquals(404, response.getStatus());
+        assertTrue(((String) response.getEntity()).contains("DBSubnetGroupNotFoundFault"));
+    }
+
     // ──────────────────────────── Helpers ────────────────────────────
 
     private static MultivaluedMap<String, String> params() {

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -293,7 +293,25 @@ class RdsServiceTest {
         assertEquals(1, rdsService.listDbSubnetGroups("sample-db-subnets").size());
 
         rdsService.deleteDbSubnetGroup("sample-db-subnets");
-        assertTrue(rdsService.listDbSubnetGroups("sample-db-subnets").isEmpty());
+        AwsException missing = assertThrows(AwsException.class,
+                () -> rdsService.listDbSubnetGroups("sample-db-subnets"));
+        assertEquals("DBSubnetGroupNotFoundFault", missing.getErrorCode());
+        assertEquals(404, missing.getHttpStatus());
+    }
+
+    @Test
+    void listDbSubnetGroupsFaultsForMissingName() {
+        AwsException missing = assertThrows(AwsException.class,
+                () -> rdsService.listDbSubnetGroups("does-not-exist"));
+        assertEquals("DBSubnetGroupNotFoundFault", missing.getErrorCode());
+        assertEquals(404, missing.getHttpStatus());
+    }
+
+    @Test
+    void listDbSubnetGroupsStillResolvesSyntheticDefault() {
+        Collection<DbSubnetGroup> groups = rdsService.listDbSubnetGroups("default");
+        assertEquals(1, groups.size());
+        assertEquals("default", groups.iterator().next().getDbSubnetGroupName());
     }
 
     @Test


### PR DESCRIPTION
# Title

fix(rds): return DBSubnetGroupNotFoundFault for missing DescribeDBSubnetGroups name

# Body

DescribeDBSubnetGroups with a missing DBSubnetGroupName returned HTTP 200 and an empty list; reuse resolveDbSubnetGroupView so AWS clients get a 404 fault instead.

Fixes #1728

## Summary

When `DBSubnetGroupName` is a specific non-`default` name that does not exist, `DescribeDBSubnetGroups` should raise `DBSubnetGroupNotFoundFault` (404). Floci previously returned HTTP 200 with an empty `DBSubnetGroups` list.

`listDbSubnetGroups` now reuses `resolveDbSubnetGroupView` for that path (same fault already used elsewhere). The synthetic `default` group is unchanged. Same empty-list-vs-fault pattern as #1740 for DescribeDBInstances / DescribeDBClusters.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect: `DescribeDBSubnetGroups` with a missing `DBSubnetGroupName` returned HTTP 200 and `DBSubnetGroups: []`.

Correct (AWS): `DBSubnetGroupNotFoundFault` (HTTP 404) when the named group does not exist. Unfiltered describe / `default` still list successfully.

Verified with `RdsServiceTest` / `RdsQueryHandlerTest` (including missing-name fault and synthetic default).

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
