### PR TITLE
feat(apigatewayv2): support execute-api subdomain host for WebSocket APIs 

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/websocket/WebSocketHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/websocket/WebSocketHandler.java
@@ -75,7 +75,9 @@ public class WebSocketHandler {
      */
     void init(@Observes Router router) {
         router.route("/ws/*").handler(this::handleWebSocketUpgrade);
-        LOG.debug("Registered WebSocket handler on /ws/*");
+        // Also accept AWS-native connect URLs: {apiId}.execute-api.{region}.localhost:4566/{stage}
+        router.route().handler(this::handleSubdomainWebSocketUpgrade);
+        LOG.debug("Registered WebSocket handler on /ws/* and execute-api subdomains");
     }
 
     /**
@@ -102,6 +104,61 @@ public class WebSocketHandler {
         // Resolve region from the request Authorization header
         String region = resolveRegionFromVertxRequest(ctx);
 
+        startConnect(ctx, apiId, region, stageName);
+    }
+
+    /**
+     * Handle a WebSocket upgrade addressed to an AWS-native execute-api subdomain host
+     * ({@code {apiId}.execute-api.{region}.localhost:4566/{stage}}). Unlike the path form,
+     * the region is taken from the host — the $connect upgrade carries no SigV4 header to
+     * derive it from. Requests that are not WebSocket upgrades, or whose host is not an
+     * execute-api subdomain, are passed through untouched.
+     */
+    private void handleSubdomainWebSocketUpgrade(RoutingContext ctx) {
+        if (!isWebSocketUpgrade(ctx)) {
+            ctx.next();
+            return;
+        }
+        ExecuteApiHost parsed = parseExecuteApiHost(ctx.request().getHeader("Host"));
+        if (parsed == null) {
+            ctx.next();
+            return;
+        }
+
+        // Region comes from the host; fall back to the default when the host omits it.
+        String region = parsed.region() != null ? parsed.region() : regionResolver.getDefaultRegion();
+
+        // The stage is the first path segment: /{stage}[/...]
+        String stageName = firstPathSegment(ctx.request().path());
+        if (stageName == null) {
+            ctx.response().setStatusCode(403).end();
+            return;
+        }
+
+        startConnect(ctx, parsed.apiId(), region, stageName);
+    }
+
+    /** True when the request is a WebSocket upgrade (carries {@code Upgrade: websocket}). */
+    private static boolean isWebSocketUpgrade(RoutingContext ctx) {
+        return "websocket".equalsIgnoreCase(ctx.request().getHeader("Upgrade"));
+    }
+
+    /** Returns the first path segment (e.g. {@code /prod/x} → {@code prod}), or null if none. */
+    private static String firstPathSegment(String path) {
+        if (path == null) {
+            return null;
+        }
+        String p = path.startsWith("/") ? path.substring(1) : path;
+        int slash = p.indexOf('/');
+        String seg = slash >= 0 ? p.substring(0, slash) : p;
+        return seg.isEmpty() ? null : seg;
+    }
+
+    /**
+     * Validate the API/stage and run the $connect lifecycle for a resolved (apiId, region, stageName).
+     * Shared by the path-based ({@code /ws/{apiId}/{stage}}) and subdomain-based upgrade entry points.
+     */
+    private void startConnect(RoutingContext ctx, String apiId, String region, String stageName) {
         // Validate the API exists and is a WEBSOCKET protocol API
         Api api;
         try {
@@ -686,6 +743,69 @@ public class WebSocketHandler {
         // Use a simple JAX-RS HttpHeaders adapter to delegate to RegionResolver
         jakarta.ws.rs.core.HttpHeaders headers = new SimpleHttpHeaders(authHeader);
         return regionResolver.resolveRegion(headers);
+    }
+
+    private static final String EXECUTE_API_LABEL = "execute-api";
+
+    /**
+     * Parses an {@code execute-api} subdomain host into its API ID and region.
+     *
+     * <p>AWS addresses a WebSocket API as {@code {apiId}.execute-api.{region}.amazonaws.com}.
+     * The local equivalents are {@code {apiId}.execute-api.{region}.localhost:4566} (region present)
+     * and {@code {apiId}.execute-api.localhost:4566} (region omitted). The region is needed for the
+     * $connect upgrade because, unlike the Management API, it carries no SigV4 Authorization header
+     * to derive the region from.
+     *
+     * <p>Examples:
+     * <ul>
+     *   <li>{@code abc123.execute-api.ap-northeast-2.localhost:4566} → (abc123, ap-northeast-2)</li>
+     *   <li>{@code abc123.execute-api.us-east-1.amazonaws.com} → (abc123, us-east-1)</li>
+     *   <li>{@code abc123.execute-api.localhost:4566} → (abc123, null)</li>
+     *   <li>{@code localhost:4566}, {@code my-bucket.localhost:4566} → null</li>
+     * </ul>
+     *
+     * @return the parsed host, or {@code null} if the host is not an execute-api subdomain
+     */
+    static ExecuteApiHost parseExecuteApiHost(String host) {
+        if (host == null) {
+            return null;
+        }
+        String hostname = stripPort(host);
+
+        int firstDot = hostname.indexOf('.');
+        if (firstDot <= 0) {
+            return null;
+        }
+        String apiId = hostname.substring(0, firstDot);
+        String remainder = hostname.substring(firstDot + 1);
+
+        String prefix = EXECUTE_API_LABEL + ".";
+        if (!remainder.toLowerCase().startsWith(prefix)) {
+            return null;
+        }
+
+        // The label right after "execute-api." is the region — but only when more labels
+        // follow it (e.g. ".localhost" / ".amazonaws.com"). If nothing follows, region is absent.
+        String afterExecuteApi = remainder.substring(prefix.length());
+        int nextDot = afterExecuteApi.indexOf('.');
+        String region = nextDot > 0 ? afterExecuteApi.substring(0, nextDot) : null;
+
+        return new ExecuteApiHost(apiId, region);
+    }
+
+    private static String stripPort(String host) {
+        int colon = host.lastIndexOf(':');
+        if (colon > 0) {
+            String maybePort = host.substring(colon + 1);
+            if (!maybePort.isEmpty() && maybePort.chars().allMatch(Character::isDigit)) {
+                return host.substring(0, colon);
+            }
+        }
+        return host;
+    }
+
+    /** Parsed execute-api subdomain host. {@code region} is null when the host omits it. */
+    record ExecuteApiHost(String apiId, String region) {
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/websocket/WebSocketHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/websocket/WebSocketHandlerTest.java
@@ -1,0 +1,38 @@
+package io.github.hectorvent.floci.services.apigatewayv2.websocket;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit tests for {@link WebSocketHandler} host parsing utilities.
+ */
+class WebSocketHandlerTest {
+
+    @Test
+    void parsesApiIdAndRegionFromSubdomainHost() {
+        WebSocketHandler.ExecuteApiHost h =
+                WebSocketHandler.parseExecuteApiHost("abc123.execute-api.ap-northeast-2.localhost:4566");
+        assertNotNull(h);
+        assertEquals("abc123", h.apiId());
+        assertEquals("ap-northeast-2", h.region());
+    }
+
+    @Test
+    void regionIsNullWhenHostOmitsIt() {
+        WebSocketHandler.ExecuteApiHost h =
+                WebSocketHandler.parseExecuteApiHost("abc123.execute-api.localhost:4566");
+        assertNotNull(h);
+        assertEquals("abc123", h.apiId());
+        assertNull(h.region());
+    }
+
+    @Test
+    void returnsNullForNonExecuteApiHosts() {
+        assertNull(WebSocketHandler.parseExecuteApiHost("my-bucket.localhost:4566"));
+        assertNull(WebSocketHandler.parseExecuteApiHost("localhost:4566"));
+        assertNull(WebSocketHandler.parseExecuteApiHost(null));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/websocket/WebSocketSubdomainConnectIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/websocket/WebSocketSubdomainConnectIntegrationTest.java
@@ -16,10 +16,9 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
- * WebSocket $connect over the AWS-native execute-api subdomain host
+ * Integration test for WebSocket $connect over the AWS-native execute-api subdomain host
  * ({@code {apiId}.execute-api.{region}.host/{stage}}).
  *
  * <p>Unlike the {@code /ws/{apiId}/{stage}} path form, the subdomain form carries the region in the
@@ -27,43 +26,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * region. This lets an API created in a non-default region complete the handshake.
  */
 @QuarkusTest
-class WebSocketSubdomainConnectTest {
+class WebSocketSubdomainConnectIntegrationTest {
 
     @TestHTTPResource("/")
     URL baseUrl;
 
-    // ──────────────────────────── Host parser (unit) ────────────────────────────
-
-    @Test
-    void parsesApiIdAndRegionFromSubdomainHost() {
-        WebSocketHandler.ExecuteApiHost h =
-                WebSocketHandler.parseExecuteApiHost("abc123.execute-api.ap-northeast-2.localhost:4566");
-        assertNotNull(h);
-        assertEquals("abc123", h.apiId());
-        assertEquals("ap-northeast-2", h.region());
-    }
-
-    @Test
-    void regionIsNullWhenHostOmitsIt() {
-        WebSocketHandler.ExecuteApiHost h =
-                WebSocketHandler.parseExecuteApiHost("abc123.execute-api.localhost:4566");
-        assertNotNull(h);
-        assertEquals("abc123", h.apiId());
-        assertNull(h.region());
-    }
-
-    @Test
-    void returnsNullForNonExecuteApiHosts() {
-        assertNull(WebSocketHandler.parseExecuteApiHost("my-bucket.localhost:4566"));
-        assertNull(WebSocketHandler.parseExecuteApiHost("localhost:4566"));
-        assertNull(WebSocketHandler.parseExecuteApiHost(null));
-    }
-
-    // ──────────────────────── Subdomain $connect (integration) ────────────────────────
-
     @Test
     void subdomainUpgradeSucceedsForNonDefaultRegionApi() throws Exception {
-        // Default region is us-east-1; create the API in a different region.
         String region = "ap-northeast-2";
         String apiId = createWebSocketApiWithMockConnect(region);
 
@@ -73,11 +42,8 @@ class WebSocketSubdomainConnectTest {
                 "Subdomain WebSocket upgrade should complete (101) for an API in a non-default region");
     }
 
-    // ──────────────────────────── helpers ────────────────────────────
-
     /** Creates a WEBSOCKET API with a MOCK $connect route in the given region and returns its id. */
     private String createWebSocketApiWithMockConnect(String region) {
-        // The region is derived from the SigV4 credential scope in the Authorization header.
         String auth = "AWS4-HMAC-SHA256 Credential=test/20260714/" + region
                 + "/apigateway/aws4_request, SignedHeaders=host, Signature=deadbeef";
 
@@ -128,7 +94,7 @@ class WebSocketSubdomainConnectTest {
 
             BufferedReader in = new BufferedReader(
                     new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
-            String statusLine = in.readLine(); // e.g. "HTTP/1.1 101 Switching Protocols"
+            String statusLine = in.readLine();
             assertNotNull(statusLine, "Expected an HTTP status line from the upgrade response");
             return Integer.parseInt(statusLine.split(" ")[1]);
         }

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/websocket/WebSocketSubdomainConnectTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/websocket/WebSocketSubdomainConnectTest.java
@@ -1,0 +1,136 @@
+package io.github.hectorvent.floci.services.apigatewayv2.websocket;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * WebSocket $connect over the AWS-native execute-api subdomain host
+ * ({@code {apiId}.execute-api.{region}.host/{stage}}).
+ *
+ * <p>Unlike the {@code /ws/{apiId}/{stage}} path form, the subdomain form carries the region in the
+ * host, so a $connect upgrade — which has no SigV4 Authorization header — can still resolve the API's
+ * region. This lets an API created in a non-default region complete the handshake.
+ */
+@QuarkusTest
+class WebSocketSubdomainConnectTest {
+
+    @TestHTTPResource("/")
+    URL baseUrl;
+
+    // ──────────────────────────── Host parser (unit) ────────────────────────────
+
+    @Test
+    void parsesApiIdAndRegionFromSubdomainHost() {
+        WebSocketHandler.ExecuteApiHost h =
+                WebSocketHandler.parseExecuteApiHost("abc123.execute-api.ap-northeast-2.localhost:4566");
+        assertNotNull(h);
+        assertEquals("abc123", h.apiId());
+        assertEquals("ap-northeast-2", h.region());
+    }
+
+    @Test
+    void regionIsNullWhenHostOmitsIt() {
+        WebSocketHandler.ExecuteApiHost h =
+                WebSocketHandler.parseExecuteApiHost("abc123.execute-api.localhost:4566");
+        assertNotNull(h);
+        assertEquals("abc123", h.apiId());
+        assertNull(h.region());
+    }
+
+    @Test
+    void returnsNullForNonExecuteApiHosts() {
+        assertNull(WebSocketHandler.parseExecuteApiHost("my-bucket.localhost:4566"));
+        assertNull(WebSocketHandler.parseExecuteApiHost("localhost:4566"));
+        assertNull(WebSocketHandler.parseExecuteApiHost(null));
+    }
+
+    // ──────────────────────── Subdomain $connect (integration) ────────────────────────
+
+    @Test
+    void subdomainUpgradeSucceedsForNonDefaultRegionApi() throws Exception {
+        // Default region is us-east-1; create the API in a different region.
+        String region = "ap-northeast-2";
+        String apiId = createWebSocketApiWithMockConnect(region);
+
+        int status = upgradeStatusViaSubdomain(apiId, region, "prod");
+
+        assertEquals(101, status,
+                "Subdomain WebSocket upgrade should complete (101) for an API in a non-default region");
+    }
+
+    // ──────────────────────────── helpers ────────────────────────────
+
+    /** Creates a WEBSOCKET API with a MOCK $connect route in the given region and returns its id. */
+    private String createWebSocketApiWithMockConnect(String region) {
+        // The region is derived from the SigV4 credential scope in the Authorization header.
+        String auth = "AWS4-HMAC-SHA256 Credential=test/20260714/" + region
+                + "/apigateway/aws4_request, SignedHeaders=host, Signature=deadbeef";
+
+        String apiId = given().header("Authorization", auth).contentType(ContentType.JSON)
+                .body("{\"name\":\"ws-subdomain-test\",\"protocolType\":\"WEBSOCKET\","
+                        + "\"routeSelectionExpression\":\"$request.body.action\"}")
+                .when().post("/v2/apis")
+                .then().statusCode(201).body("apiId", notNullValue())
+                .extract().path("apiId");
+
+        String integrationId = given().header("Authorization", auth).contentType(ContentType.JSON)
+                .body("{\"integrationType\":\"MOCK\"}")
+                .when().post("/v2/apis/" + apiId + "/integrations")
+                .then().statusCode(201)
+                .extract().path("integrationId");
+
+        given().header("Authorization", auth).contentType(ContentType.JSON)
+                .body("{\"routeKey\":\"$connect\",\"target\":\"integrations/" + integrationId + "\"}")
+                .when().post("/v2/apis/" + apiId + "/routes")
+                .then().statusCode(201);
+
+        given().header("Authorization", auth).contentType(ContentType.JSON)
+                .body("{\"stageName\":\"prod\",\"autoDeploy\":true}")
+                .when().post("/v2/apis/" + apiId + "/stages")
+                .then().statusCode(201);
+
+        return apiId;
+    }
+
+    /**
+     * Sends a raw WebSocket upgrade with an execute-api subdomain Host header and returns the HTTP
+     * status code. A raw socket is used because {@code java.net.http} forbids setting the Host header.
+     */
+    private int upgradeStatusViaSubdomain(String apiId, String region, String stage) throws Exception {
+        String host = apiId + ".execute-api." + region + ".localhost:" + baseUrl.getPort();
+        String request = "GET /" + stage + " HTTP/1.1\r\n"
+                + "Host: " + host + "\r\n"
+                + "Connection: Upgrade\r\n"
+                + "Upgrade: websocket\r\n"
+                + "Sec-WebSocket-Version: 13\r\n"
+                + "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                + "\r\n";
+
+        try (Socket socket = new Socket(baseUrl.getHost(), baseUrl.getPort())) {
+            OutputStream out = socket.getOutputStream();
+            out.write(request.getBytes(StandardCharsets.UTF_8));
+            out.flush();
+
+            BufferedReader in = new BufferedReader(
+                    new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
+            String statusLine = in.readLine(); // e.g. "HTTP/1.1 101 Switching Protocols"
+            assertNotNull(statusLine, "Expected an HTTP status line from the upgrade response");
+            return Integer.parseInt(statusLine.split(" ")[1]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- WebSocket APIs created in a non-default region return 403 when accessed via subdomain
- The WebSocket handshake carries no Authorization header, so the region cannot be determined
- Added a handler that parses apiId and region from the AWS-native subdomain host (`{apiId}.execute-api.{region}.localhost`)
- Existing `/ws/{apiId}/{stage}` path form is unaffected

Closes #1871

## What changed

- Recognise execute-api subdomain hosts on WebSocket upgrade requests and parse apiId/region from the hostname
- Follows the same structure as the existing REST subdomain filters — check Host, pass through if no match, handle if matched
- Refactored so that the path form and subdomain form share common logic

## Tests

- Unit tests for host parsing
- Integration test: subdomain upgrade to a non-default region API returns 101

## Type of change

- [x] New feature (`feat:`)

## AWS Compatibility

WebSocket URL in real AWS: `wss://{apiId}.execute-api.{region}.amazonaws.com/{stage}`
- Region is embedded in the hostname, no Authorization header needed
- This change brings floci in line with this behavior

Tested:
- Subdomain host (`{apiId}.execute-api.ap-northeast-2.localhost`) → 101 Switching Protocols
- Region-omitted subdomain (`{apiId}.execute-api.localhost`) → falls back to default region
- Non-execute-api host (`my-bucket.localhost`) → passes through, not affected
- Existing `/ws/{apiId}/{stage}` path → unchanged behavior

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits