### PR TITLE
fix(dynamodb): resolve nested document paths in ADD and DELETE update actions

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbNestedPathTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbNestedPathTest.java
@@ -1,0 +1,155 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for issue #1756: DynamoDB UpdateItem ADD and DELETE on a nested map path with ExpressionAttributeNames.
+ */
+@DisplayName("DynamoDB UpdateItem ADD/DELETE on nested map path (#1756)")
+class DynamoDbNestedPathTest {
+
+    private static DynamoDbClient ddb;
+    private static final String TABLE = "nested-path-repro-" + java.util.UUID.randomUUID().toString().substring(0, 8);
+
+    private static final String TOP_LEVEL = "functionInvocationSummaries";
+    private static final String ISA_KEY = "ISA_10136";
+
+    @BeforeAll
+    static void setup() {
+        ddb = TestFixtures.dynamoDbClient();
+
+        ddb.createTable(r -> r
+                .tableName(TABLE)
+                .keySchema(KeySchemaElement.builder().attributeName("pk").keyType(KeyType.HASH).build())
+                .attributeDefinitions(
+                        AttributeDefinition.builder()
+                                .attributeName("pk")
+                                .attributeType(ScalarAttributeType.S)
+                                .build())
+                .billingMode(BillingMode.PAY_PER_REQUEST)
+        );
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (ddb != null) {
+            try {
+                ddb.deleteTable(DeleteTableRequest.builder().tableName(TABLE).build());
+            } catch (Exception ignored) {
+            }
+            ddb.close();
+        }
+    }
+
+    @Test
+    @DisplayName("ADD on nested placeholder path increments nested counter")
+    void addOnNestedPlaceholderPath() {
+        String pk = "add";
+
+        ddb.updateItem(
+                UpdateItemRequest.builder()
+                        .tableName(TABLE)
+                        .key(Map.of("pk", AttributeValue.fromS(pk)))
+                        .updateExpression("SET #fis = if_not_exists(#fis, :empty)")
+                        .expressionAttributeNames(Map.of("#fis", TOP_LEVEL))
+                        .expressionAttributeValues(Map.of(":empty", AttributeValue.builder().m(Map.of()).build()))
+                        .build()
+        );
+
+        ddb.updateItem(
+                UpdateItemRequest.builder()
+                        .tableName(TABLE)
+                        .key(Map.of("pk", AttributeValue.fromS(pk)))
+                        .updateExpression("SET #fis.#isa = if_not_exists(#fis.#isa, :seed)")
+                        .expressionAttributeNames(Map.of("#fis", TOP_LEVEL, "#isa", ISA_KEY))
+                        .expressionAttributeValues(Map.of(
+                                ":seed", AttributeValue.builder().m(Map.of("eventsAvailable", AttributeValue.fromN("0"))).build()))
+                        .build()
+        );
+
+        ddb.updateItem(
+                UpdateItemRequest.builder()
+                        .tableName(TABLE)
+                        .key(Map.of("pk", AttributeValue.fromS(pk)))
+                        .updateExpression("ADD #fis.#isa.#ea :one")
+                        .expressionAttributeNames(Map.of(
+                                "#fis", TOP_LEVEL,
+                                "#isa", ISA_KEY,
+                                "#ea", "eventsAvailable"))
+                        .expressionAttributeValues(Map.of(":one", AttributeValue.fromN("1")))
+                        .build()
+        );
+
+        GetItemResponse resp = ddb.getItem(r -> r
+                .tableName(TABLE)
+                .key(Map.of("pk", AttributeValue.fromS(pk)))
+                .consistentRead(true)
+        );
+
+        String counter = resp.item().get(TOP_LEVEL).m().get(ISA_KEY).m().get("eventsAvailable").n();
+        assertThat(counter).isEqualTo("1");
+        assertThat(resp.item()).doesNotContainKey("#fis.#isa.#ea");
+    }
+
+    @Test
+    @DisplayName("DELETE on nested placeholder path removes elements from nested set")
+    void deleteOnNestedPlaceholderPath() {
+        String pk = "del";
+
+        AttributeValue isaMap = AttributeValue.builder()
+                .m(Map.of("tags", AttributeValue.builder().ss(List.of("a", "b", "c")).build()))
+                .build();
+        AttributeValue topLevelMap = AttributeValue.builder()
+                .m(Map.of(ISA_KEY, isaMap))
+                .build();
+
+        ddb.putItem(
+                PutItemRequest.builder()
+                        .tableName(TABLE)
+                        .item(Map.of("pk", AttributeValue.fromS(pk), TOP_LEVEL, topLevelMap))
+                        .build()
+        );
+
+        ddb.updateItem(
+                UpdateItemRequest.builder()
+                        .tableName(TABLE)
+                        .key(Map.of("pk", AttributeValue.fromS(pk)))
+                        .updateExpression("DELETE #fis.#isa.#tags :val")
+                        .expressionAttributeNames(Map.of(
+                                "#fis", TOP_LEVEL,
+                                "#isa", ISA_KEY,
+                                "#tags", "tags"))
+                        .expressionAttributeValues(Map.of(":val", AttributeValue.builder().ss(List.of("b")).build()))
+                        .build()
+        );
+
+        GetItemResponse resp = ddb.getItem(
+                r -> r
+                        .tableName(TABLE)
+                        .key(Map.of("pk", AttributeValue.fromS(pk)))
+                        .consistentRead(true)
+        );
+
+        List<String> tags = resp.item().get(TOP_LEVEL).m().get(ISA_KEY).m().get("tags").ss();
+        assertThat(tags).containsExactlyInAnyOrder("a", "c");
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -1710,15 +1710,15 @@ public class DynamoDbService {
             String[] parts = clause.split("\\s+", 3);
             if (parts.length < 2) break;
 
-            String attrName = resolveAttributeName(parts[0], exprAttrNames);
+            String attrPath = parts[0];
             String valuePlaceholder = parts[1].replaceAll(",.*", "").trim();
 
             if (valuePlaceholder.startsWith(":") && exprAttrValues != null) {
                 JsonNode addValue = exprAttrValues.get(valuePlaceholder);
                 if (addValue != null) {
-                    JsonNode existingValue = item.get(attrName);
+                    JsonNode existingValue = getValueAtPath(item, attrPath, exprAttrNames);
                     JsonNode newValue = applyAddOperation(existingValue, addValue);
-                    item.set(attrName, newValue);
+                    setValueAtPath(item, attrPath, newValue, exprAttrNames);
                 }
             }
 
@@ -1821,19 +1821,19 @@ public class DynamoDbService {
             String[] parts = clause.split("\\s+", 3);
             if (parts.length < 2) break;
 
-            String attrName = resolveAttributeName(parts[0], exprAttrNames);
+            String attrPath = parts[0];
             String valuePlaceholder = parts[1].replaceAll(",.*", "").trim();
 
             if (valuePlaceholder.startsWith(":") && exprAttrValues != null) {
                 JsonNode deleteValue = exprAttrValues.get(valuePlaceholder);
                 if (deleteValue != null) {
-                    JsonNode existingValue = item.get(attrName);
+                    JsonNode existingValue = getValueAtPath(item, attrPath, exprAttrNames);
                     if (existingValue != null) {
                         JsonNode newValue = applyDeleteOperation(existingValue, deleteValue);
                         if (newValue == null) {
-                            item.remove(attrName);
+                            removeValueAtPath(item, attrPath, exprAttrNames);
                         } else {
-                            item.set(attrName, newValue);
+                            setValueAtPath(item, attrPath, newValue, exprAttrNames);
                         }
                     }
                 }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -13,7 +13,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -2347,5 +2349,320 @@ class DynamoDbServiceTest {
 
         JsonNode stored = service.getItem("Users", item("userId", "u1"), "us-east-1");
         assertEquals("2", stored.get("counter").get("N").asText());
+    }
+
+    @Test
+    void addOnNestedPlaceholderPathIncrementsCounter() {
+        String region = "eu-west-1";
+        String tableName = "Users";
+
+        createUsersTable(region);
+
+        service.putItem(tableName, makeNestedCounterItem("u1", "5"), region);
+
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#s", "stats");
+        exprNames.put("#c", "counters");
+        exprNames.put("#v", "visits");
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":inc", attributeValue("N", "1"));
+
+        service.updateItem(
+                tableName,
+                userIdKey("u1"),
+                null,
+                "ADD #s.#c.#v :inc",
+                exprNames,
+                exprValues,
+                null,
+                region
+        );
+
+        JsonNode stored = service.getItem(tableName, userIdKey("u1"), region);
+
+        assertEquals(
+                "6", stored.get("stats").get("M").get("counters").get("M").get("visits").get("N").asText(),
+                "ADD on nested placeholder path should increment the nested counter"
+        );
+        assertFalse(
+                stored.has("#s.#c.#v"),
+                "no phantom top level attribute should be created"
+        );
+    }
+
+    @Test
+    void addOnNestedPlainDottedPathIncrementsCounter() {
+        String region = "eu-west-1";
+        String tableName = "Users";
+
+        createUsersTable(region);
+
+        service.putItem(tableName, makeNestedCounterItem("u2", "10"), region);
+
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":inc", attributeValue("N", "5"));
+
+        service.updateItem(
+                tableName,
+                userIdKey("u2"),
+                null,
+                "ADD stats.counters.visits :inc",
+                null,
+                exprValues,
+                null,
+                region
+        );
+
+        JsonNode stored = service.getItem(tableName, userIdKey("u2"), region);
+
+        assertEquals(
+                "15", stored.get("stats").get("M").get("counters").get("M").get("visits").get("N").asText(),
+                "ADD on plain path should increment the nested counter"
+        );
+    }
+
+    @Test
+    void addOnNestedPathCreatesMissingLeaf() {
+        String region = "eu-west-1";
+        String tableName = "Users";
+
+        createUsersTable(region);
+
+        ObjectNode seed = mapper.createObjectNode();
+        seed.set("userId", attributeValue("S", "u3"));
+
+        ObjectNode midMap = mapper.createObjectNode();
+        midMap.set("M", mapper.createObjectNode());
+
+        ObjectNode topInner = mapper.createObjectNode();
+        topInner.set("counters", midMap);
+
+        ObjectNode topMap = mapper.createObjectNode();
+        topMap.set("M", topInner);
+
+        seed.set("stats", topMap);
+        service.putItem(tableName, seed, region);
+
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":one", attributeValue("N", "1"));
+
+        service.updateItem(
+                tableName,
+                userIdKey("u3"),
+                null,
+                "ADD stats.counters.visits :one",
+                null,
+                exprValues,
+                null,
+                region
+        );
+
+        JsonNode stored = service.getItem(tableName, userIdKey("u3"), region);
+
+        assertEquals(
+                "1", stored.get("stats").get("M").get("counters").get("M").get("visits").get("N").asText(),
+                "ADD should create the missing leaf inside the nested map"
+        );
+    }
+
+    @Test
+    void addOnNestedPathAccumulatesAcrossCalls() {
+        String region = "eu-west-1";
+        String tableName = "Users";
+
+        createUsersTable(region);
+
+        service.putItem(tableName, makeNestedCounterItem("u4", "0"), region);
+
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#s", "stats");
+        exprNames.put("#c", "counters");
+        exprNames.put("#v", "visits");
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":one", attributeValue("N", "1"));
+
+        for (int i = 0; i < 3; i++) {
+            service.updateItem(
+                    tableName,
+                    userIdKey("u4"),
+                    null,
+                    "ADD #s.#c.#v :one",
+                    exprNames,
+                    exprValues,
+                    null,
+                    region
+            );
+        }
+
+        JsonNode stored = service.getItem(tableName, userIdKey("u4"), region);
+
+        assertEquals(
+                "3", stored.get("stats").get("M").get("counters").get("M").get("visits").get("N").asText(),
+                "repeated ADD on nested path should accumulate"
+        );
+    }
+
+    @Test
+    void deleteOnNestedPlaceholderPathRemovesFromStringSet() {
+        String region = "eu-west-1";
+        String tableName = "Users";
+
+        createUsersTable(region);
+
+        service.putItem(tableName, makeNestedSetItem("u5", "tags", "labels", SetType.STRING, "a", "b", "c"), region);
+
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#s", "stats");
+        exprNames.put("#t", "tags");
+        exprNames.put("#l", "labels");
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":val", stringSetAttributeValue("b"));
+
+        service.updateItem(
+                tableName,
+                userIdKey("u5"),
+                null,
+                "DELETE #s.#t.#l :val",
+                exprNames,
+                exprValues,
+                null,
+                region
+        );
+
+        JsonNode stored = service.getItem(tableName, userIdKey("u5"), region);
+        JsonNode labels = stored.get("stats").get("M").get("tags").get("M").get("labels").get("SS");
+
+        assertEquals(2, labels.size(), "DELETE should remove one element from the nested SS");
+
+        Set<String> remaining = new HashSet<>();
+        labels.forEach(n -> remaining.add(n.asText()));
+        assertTrue(remaining.contains("a"));
+        assertTrue(remaining.contains("c"));
+        assertFalse(remaining.contains("b"));
+    }
+
+    @Test
+    void deleteOnNestedPlainDottedPathRemovesFromNumberSet() {
+        String region = "eu-west-1";
+        String tableName = "Users";
+
+        createUsersTable(region);
+
+        service.putItem(tableName, makeNestedSetItem("u6", "scores", "marks", SetType.NUMBER, "1", "2", "3"), region);
+
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":val", numberSetAttributeValue("2"));
+
+        service.updateItem(
+                tableName,
+                userIdKey("u6"),
+                null,
+                "DELETE stats.scores.marks :val",
+                null,
+                exprValues,
+                null,
+                region
+        );
+
+        JsonNode stored = service.getItem(tableName, userIdKey("u6"), region);
+        JsonNode marks = stored.get("stats").get("M").get("scores").get("M").get("marks").get("NS");
+
+        assertEquals(2, marks.size(), "DELETE should remove one element from the nested NS");
+        java.util.Set<String> remaining = new java.util.HashSet<>();
+        marks.forEach(n -> remaining.add(n.asText()));
+        assertTrue(remaining.contains("1"));
+        assertTrue(remaining.contains("3"));
+        assertFalse(remaining.contains("2"));
+    }
+
+    @Test
+    void deleteOnNestedPathEmptiesSetAndRemovesAttribute() {
+        String region = "eu-west-1";
+        String tableName = "Users";
+
+        createUsersTable(region);
+
+        service.putItem(tableName, makeNestedSetItem("u7", "tags", "labels", SetType.STRING, "only"), region);
+
+        ObjectNode exprNames = mapper.createObjectNode();
+        exprNames.put("#s", "stats");
+        exprNames.put("#t", "tags");
+        exprNames.put("#l", "labels");
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":val", stringSetAttributeValue("only"));
+
+        service.updateItem(
+                tableName,
+                userIdKey("u7"),
+                null,
+                "DELETE #s.#t.#l :val",
+                exprNames,
+                exprValues,
+                null,
+                region
+        );
+
+        JsonNode stored = service.getItem(tableName, userIdKey("u7"), region);
+        JsonNode tagsMap = stored.get("stats").get("M").get("tags").get("M");
+
+        assertFalse(
+                tagsMap.has("labels"),
+                "DELETE that empties the nested set should remove the attribute from the nested map"
+        );
+    }
+
+    private ObjectNode makeNestedCounterItem(String id, String value) {
+        ObjectNode item = mapper.createObjectNode();
+        item.set("userId", attributeValue("S", id));
+
+        ObjectNode midInner = mapper.createObjectNode();
+
+        ObjectNode leafNode = attributeValue("N", value);
+        midInner.set("visits", leafNode);
+
+        ObjectNode midMap = mapper.createObjectNode();
+        midMap.set("M", midInner);
+
+        ObjectNode topInner = mapper.createObjectNode();
+        topInner.set("counters", midMap);
+
+        ObjectNode topMap = mapper.createObjectNode();
+        topMap.set("M", topInner);
+
+        item.set("stats", topMap);
+
+        return item;
+    }
+
+    enum SetType {
+        STRING,
+        NUMBER
+    }
+
+    private ObjectNode makeNestedSetItem(String id, String midLevel, String leaf,
+                                         SetType setType, String... values) {
+        ObjectNode item = mapper.createObjectNode();
+        item.set("userId", attributeValue("S", id));
+
+        ObjectNode setNode = switch (setType) {
+            case STRING -> stringSetAttributeValue(values);
+            case NUMBER -> numberSetAttributeValue(values);
+        };
+
+        ObjectNode midInner = mapper.createObjectNode();
+        midInner.set(leaf, setNode);
+
+        ObjectNode midMap = mapper.createObjectNode();
+        midMap.set("M", midInner);
+
+        ObjectNode topInner = mapper.createObjectNode();
+        topInner.set(midLevel, midMap);
+
+        ObjectNode topMap = mapper.createObjectNode();
+        topMap.set("M", topInner);
+
+        item.set("stats", topMap);
+
+        return item;
     }
 }


### PR DESCRIPTION
## Summary

Closes #1756

The issue was originally about the ADD operation, but the same bug affected the DELETE path.

Changes made:

- Fixed nested path resolution in ADD and DELETE update actions
- Added unit and compatibility tests

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Before the fix, `ADD #fis.#isa.#ea :one` on an item with `functionInvocationSummaries.ISA_10136.eventsAvailable = 0` produced a phantom top level attribute `"#fis.#isa.#ea": {"N":"1"}` and left the nested counter at "0". 
After the fix the counter increments to "1" and no phantom attribute appears. Also DELETE on a nested SS path now removes elements from the nested set instead of being a silent no-op.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
