### PR TITLE
feat(cloudformation): Parse secrets in ContainerDefinitions

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -46,6 +46,7 @@ import io.github.hectorvent.floci.services.ecs.model.LaunchType;
 import io.github.hectorvent.floci.services.ecs.model.NetworkConfiguration;
 import io.github.hectorvent.floci.services.ecs.model.NetworkMode;
 import io.github.hectorvent.floci.services.ecs.model.PortMapping;
+import io.github.hectorvent.floci.services.ecs.model.Secret;
 import io.github.hectorvent.floci.services.ecs.model.TaskDefinition;
 import io.github.hectorvent.floci.services.elbv2.ElbV2Service;
 import io.github.hectorvent.floci.services.elbv2.model.Action;
@@ -3354,6 +3355,7 @@ public class CloudFormationResourceProvisioner {
             }
             def.setPortMappings(parseCfnPortMappings(item.path("PortMappings")));
             def.setEnvironment(parseCfnEnvironment(item.path("Environment")));
+            def.setSecrets(parseCfnSecrets(item.path("Secrets")));
             if (item.path("Command").isArray()) {
                 List<String> cmd = new ArrayList<>();
                 item.path("Command").forEach(c -> cmd.add(c.asText()));
@@ -3390,6 +3392,17 @@ public class CloudFormationResourceProvisioner {
         }
         for (JsonNode item : node) {
             result.add(new KeyValuePair(item.path("Name").asText(), item.path("Value").asText()));
+        }
+        return result;
+    }
+
+    private List<Secret> parseCfnSecrets(JsonNode node) {
+        List<Secret> result = new ArrayList<>();
+        if (node == null || !node.isArray()) {
+            return result;
+        }
+        for (JsonNode item : node) {
+            result.add(new Secret(item.path("Name").asText(), item.path("ValueFrom").asText()));
         }
         return result;
     }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -5642,6 +5642,81 @@ class CloudFormationIntegrationTest {
     }
 
     @Test
+    void createStack_ecsTaskDefWithSecrets_resolvesRefToSecretArnInValueFrom() {
+        String template = """
+            {
+              "Resources": {
+                "DbPassword": {
+                  "Type": "AWS::SecretsManager::Secret",
+                  "Properties": {
+                    "Name": "cfn-ecs-secret",
+                    "SecretString": "password"
+                  }
+                },
+                "TaskDef": {
+                  "Type": "AWS::ECS::TaskDefinition",
+                  "Properties": {
+                    "Family": "cfn-ecs-secrets-taskdef",
+                    "ContainerDefinitions": [
+                      {
+                        "Name": "web",
+                        "Image": "nginx:latest",
+                        "Essential": true,
+                        "Secrets": [
+                          { "Name": "DB_PASSWORD", "ValueFrom": { "Ref": "DbPassword" } }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              },
+              "Outputs": {
+                "SecretArn": { "Value": { "Ref": "DbPassword" } }
+              }
+            }
+            """;
+
+        String stackName = "cfn-ecs-secrets-stack";
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        String describeXml = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"))
+            .extract().asString();
+
+        // Ref on AWS::SecretsManager::Secret resolves to the secret's ARN (confirmed independently
+        // via the stack Output above). The same ARN, not the literal {"Ref": "DbPassword"} JSON,
+        // must end up in the registered task definition's Secrets[].ValueFrom.
+        String secretArn = outputValue(describeXml, "SecretArn");
+        given()
+            .header("X-Amz-Target", ECS_TARGET_PREFIX + "DescribeTaskDefinition")
+            .contentType(ECS_CONTENT_TYPE)
+            .body("{\"taskDefinition\": \"cfn-ecs-secrets-taskdef\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("taskDefinition.containerDefinitions[0].secrets[0].name", equalTo("DB_PASSWORD"))
+            .body("taskDefinition.containerDefinitions[0].secrets[0].valueFrom", equalTo(secretArn));
+    }
+
+    @Test
     void updateStack_ecsService_registersNewTaskDefRevisionAndUpdatesDesiredCount() {
         String stackName = "cfn-ecs-update-stack";
         String template = """


### PR DESCRIPTION
## Summary
Floci allows registering task definitions with secrets, but does parse secrets from JSON in CloudFormation. With these changes it parses the `Secrets` property on `AWS::ECS::TaskDefinition` in CloudFormation templates, mapping each entry's `Name`/`ValueFrom` into the ECS `Secret` model. These secrets are already resolved into container env vars at task-start time by the existing `EcsContainerManager.resolveSecretValue`, so this closes the last gap between CFN-provisioned task definitions and directly-registered ones.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Matches `AWS::ECS::TaskDefinition`'s `ContainerDefinition.Secrets` property (list of `{Name, ValueFrom}`), consistent with the direct ECS `RegisterTaskDefinition` API's `secrets` field. `ValueFrom` accepts a Secrets Manager secret ARN or an SSM parameter name/ARN, both already supported by `EcsContainerManager.resolveSecretValue`.

## Checklist

- [x] `./mvnw test` passes locally (CloudFormation suite including new test)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)