### PR TITLE
fix(eks): register FargateProfileStatus for reflection

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/eks/model/FargateProfileStatus.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eks/model/FargateProfileStatus.java
@@ -1,5 +1,13 @@
 package io.github.hectorvent.floci.services.eks.model;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/** EKS Fargate profile lifecycle status (serialized as the enum name, e.g. "ACTIVE"). */
+@RegisterForReflection
 public enum FargateProfileStatus {
-  CREATING, ACTIVE, DELETING, CREATE_FAILED, DELETE_FAILED
+    CREATING,
+    ACTIVE,
+    DELETING,
+    CREATE_FAILED,
+    DELETE_FAILED
 }


### PR DESCRIPTION
## Summary

CI on `main` broke after #1523: `PersistedModelReflectionTest.persistedTypesAreRegisteredForReflection` fails because `FargateProfileStatus` is reachable from persisted storage (via `FargateProfile`) but was added without `@RegisterForReflection`, which breaks native-image persistence on restart.

Failing run: https://github.com/floci-io/floci/actions/runs/29390472539/job/87272623744

This adds the annotation, mirroring the sibling `NodegroupStatus` enum (every other class in `services/eks/model/` already carries it).

Enum values verified against botocore's EKS [service-2.json](https://github.com/boto/botocore/blob/develop/botocore/data/eks/2017-11-01/service-2.json): `CREATING | ACTIVE | DELETING | CREATE_FAILED | DELETE_FAILED` match exactly.

## Type of change

- [x] Bug fix (`fix:`)

## Checklist

- [x] `PersistedModelReflectionTest` passes locally
- [x] EKS suites pass locally (45 tests, all green)
- [x] Commit message follows Conventional Commits

No new test added: the existing `PersistedModelReflectionTest` guard is the regression test for this.