### PR TITLE
fix(neptune): throw a mappable capacity fault when the proxy-port range is exhausted

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneService.java
@@ -308,8 +308,11 @@ public class NeptuneService {
                 return port;
             }
         }
-        throw new AwsException("InsufficientNeptuneCapacity",
-                "No available proxy ports in range " + base + "-" + max, 503);
+        // Wire code the SDK maps to InsufficientStorageClusterCapacityFault (the only
+        // capacity fault CreateDBCluster declares); "InsufficientNeptuneCapacity" isn't a
+        // real Neptune code, so callers got an unmapped generic NeptuneException.
+        throw new AwsException("InsufficientStorageClusterCapacity",
+                "No available proxy ports in range " + base + "-" + max, 400);
     }
 
     private void releaseProxyPort(int port) {

--- a/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneServiceTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.neptune;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
@@ -32,6 +33,7 @@ class NeptuneServiceTest {
     private NeptuneService service;
     private NeptuneContainerManager containerManager;
     private NeptuneProxyManager proxyManager;
+    private EmulatorConfig.NeptuneServiceConfig neptuneConfig;
 
     @BeforeEach
     void setUp() {
@@ -42,7 +44,7 @@ class NeptuneServiceTest {
         RegionResolver regionResolver = mock(RegionResolver.class);
 
         EmulatorConfig.ServicesConfig servicesConfig = mock(EmulatorConfig.ServicesConfig.class);
-        EmulatorConfig.NeptuneServiceConfig neptuneConfig = mock(EmulatorConfig.NeptuneServiceConfig.class);
+        neptuneConfig = mock(EmulatorConfig.NeptuneServiceConfig.class);
         when(config.services()).thenReturn(servicesConfig);
         when(servicesConfig.neptune()).thenReturn(neptuneConfig);
         when(neptuneConfig.proxyBasePort()).thenReturn(18182);
@@ -139,5 +141,19 @@ class NeptuneServiceTest {
         NeptuneCluster recovered = service.createDbCluster("c2", "1.3.2.1", false);
         assertEquals(18182, recovered.getProxyPort(),
                 "Port from the failed create must be released so the next cluster reuses it");
+    }
+
+    @Test
+    void exhaustedProxyPortRangeThrowsMappableCapacityFault() {
+        // Shrink the range to one port so the second create exhausts it.
+        when(neptuneConfig.proxyMaxPort()).thenReturn(18182);
+        service.createDbCluster("c1", "1.3.2.1", false);
+
+        AwsException e = assertThrows(AwsException.class,
+                () -> service.createDbCluster("c2", "1.3.2.1", false));
+        // Real Neptune wire code (maps to InsufficientStorageClusterCapacityFault), not the
+        // fabricated "InsufficientNeptuneCapacity" the SDK couldn't map to a typed exception.
+        assertEquals("InsufficientStorageClusterCapacity", e.getErrorCode());
+        assertEquals(400, e.getHttpStatus());
     }
 }


### PR DESCRIPTION

allocateProxyPort threw AwsException("InsufficientNeptuneCapacity"), a code that does not exist in Neptune's API, so the SDK could not map it and callers got a generic NeptuneException. Use the wire code InsufficientStorageClusterCapacity (the InsufficientStorageClusterCapacityFault that CreateDBCluster declares), 400, so the SDK deserializes it to a typed exception.

## Summary
When the Neptune proxy-port range is exhausted, allocateProxyPort threw AwsException("InsufficientNeptuneCapacity", …, 503). That code does not exist in Neptune's API, so the AWS SDK can't map it to a typed exception — callers get a generic NeptuneException instead of a capacity fault.
This changes it to the wire code the SDK maps to InsufficientStorageClusterCapacityFault — the only capacity fault Neptune's CreateDBCluster declares — with HTTP 400.
Follow-up to the Neptune provisioning-rollback PR #1742 , where this was flagged in review as out-of-scope. The rollback made port exhaustion rarer but not impossible, so the wrong code could still surface.
## Type of change
- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore
## AWS Compatibility


Incorrect behavior: on proxy-port exhaustion the emulator returned error code InsufficientNeptuneCapacity (HTTP 503), which is not a Neptune error type. The AWS SDK v2 could not map it to a modeled exception, so CreateDBCluster callers saw a generic NeptuneException rather than a capacity fault.

After: returns InsufficientStorageClusterCapacity (HTTP 400), the wire code for InsufficientStorageClusterCapacityFault, which CreateDBCluster declares — so the SDK deserializes it to the modeled exception.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
