### PR TITLE
feat(appsync): Phase 6 — Query Execution + HTTP Endpoint

### DIFF
--- a/docs/services/appsync.md
+++ b/docs/services/appsync.md
@@ -133,7 +133,9 @@ Floci implements the AWS AppSync Management API, providing local emulation of Gr
 
 ## Schema Registry
 
-`StartSchemaCreation` validates the provided GraphQL SDL using [graphql-java](https://github.com/graphql-java/graphql-java). Invalid schemas are rejected with a `BadRequestException` (400) at registration time, preventing them from being caught later during query execution.
+`StartSchemaCreation` validates the provided GraphQL SDL using [graphql-java](https://github.com/graphql-java/graphql-java). Invalid schemas are rejected asynchronously (status `FAILED` with details after `PROCESSING`). Valid schemas are registered in an in-memory `SchemaRegistry` and persisted to the schema store.
+
+On emulator startup, after storage load and orphan recovery, Floci **rehydrates** SUCCESS SDLs from the schema store into `SchemaRegistry` so `POST /v1/apis/{apiId}/graphql` works across restarts (memory/persistent/hybrid/wal).
 
 The following **AWS scalar types** are pre-registered and available in any schema without requiring explicit `scalar` declarations:
 
@@ -173,6 +175,30 @@ The following **AppSync directives** are pre-defined and recognized in schemas:
 Unknown directives are rejected during schema registration.
 
 Schema extensions (`extend type Query { ... }`) are supported natively through graphql-java.
+
+## GraphQL execute (data-plane)
+
+| Surface | Path | Content-Types |
+|---|---|---|
+| HTTP GraphQL | `POST /v1/apis/{apiId}/graphql` | `application/json`, `application/graphql` (+ charset) |
+
+Execute is a **separate** data-plane endpoint from the management API. Request body is GraphQL-over-HTTP JSON: `{ "query", "variables?", "operationName?" }`.
+
+Responses are `application/json` with AWS AppSync wire shapes (`data` / `errors[]` with top-level `errorType` / `errorInfo`). Most GraphQL syntax and validation errors return **HTTP 200** with `errors[]`.
+
+| Case | HTTP | Notes |
+|---|---|---|
+| Query / introspection / validation / syntax (incl. blank `query`) | 200 | Nullable fields may be `null` until DataFetchers (Phase 8) |
+| HTTP subscription operation | 200 | `OperationNotSupported` (realtime WebSocket is a later phase) |
+| Empty body / `{}` / `[]` / unparseable JSON / bad Content-Type | 400 | `MalformedHttpRequestException` |
+| Missing `operationName` with multiple operations | 400 | `BadRequestException` — `Missing operation name.` |
+| Unknown `apiId` | 404 | `NotFoundException` |
+| API exists but no executable schema (incl. PROCESSING) | **502** | `GraphQLSchemaException` — `No schema definition exists.` + `x-amzn-errortype` |
+| Unexpected failure | 500 | `InternalFailure` |
+
+**Evidence for data-plane statuses** (empty/`[]`/`{}` → 400; missing schema → 502): AppSync team sample in [graphql/graphql-over-http#81](https://github.com/graphql/graphql-over-http/issues/81) (@robzhu). The management API Reference lists `GraphQLSchemaException` as HTTP 400 for “schema not valid” on management operations — a different surface than the GraphQL execute data plane.
+
+Auth on the execute endpoint, DataFetcher/resolver dispatch, data-source adapters, guardrails, and WebSocket subscriptions are later phases.
 
 ## Pagination
 
@@ -215,15 +241,14 @@ This matches AWS behavior where deleting an API removes its entire configuration
 
 ## Not Implemented
 
-These AWS AppSync operations are not yet implemented and are tracked in future phases:
+These AWS AppSync capabilities are not yet implemented and are tracked in future phases:
 
-- **Execution engine** (Phase 5): GraphQL query execution, resolver dispatch, VTL template evaluation
-- **Data source adapters** (Phase 7): DynamoDB, Lambda, HTTP, EventBridge, OpenSearch, RDS connectors
-- **Pipeline resolvers** (Phase 8): Function chaining with `$prev` and `$stash`
-- **Subscriptions** (Phase 9): WebSocket real-time subscriptions
-- **Caching** (Phase 10): API-level and per-resolver caching
-- **Authentication** (Phase 4): API key validation on the GraphQL endpoint
-- **Introspection** (Phase 6): `__schema` and `__type` queries
+- **Authentication on execute** (Phase 7): API key / IAM / Cognito validation on the GraphQL endpoint
+- **DataFetcher / resolver dispatch** (Phase 8): resolver mapping templates and field resolution with non-null values
+- **Data source adapters** (Phase 9): DynamoDB, Lambda, HTTP, EventBridge, OpenSearch, RDS connectors
+- **Guardrails** (Phase 10): query depth / complexity limits and related errors
+- **Realtime subscriptions** (Phase 11+): WebSocket real-time subscriptions
+- **Caching**: API-level and per-resolver caching
 - **Merged API source management**: `AssociateMergedGraphqlApi`, `AssociateSourceGraphqlApi`, `StartSchemaMerge`, `ListTypesByAssociation`
 - **Data source introspection**: `StartDataSourceIntrospection`, `GetDataSourceIntrospection`
 
@@ -286,6 +311,11 @@ aws appsync associate-api \
   --domain-name api.example.com \
   --api-id API_ID \
   --endpoint-url $AWS_ENDPOINT_URL
+
+# Execute a GraphQL query (data-plane; null fields OK until resolvers)
+curl -s -X POST "$AWS_ENDPOINT_URL/v1/apis/API_ID/graphql" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ hello }"}'
 
 # Create a channel namespace
 aws appsync create-channel-namespace \

--- a/src/main/java/io/github/hectorvent/floci/core/storage/AccountAwareStorageBackend.java
+++ b/src/main/java/io/github/hectorvent/floci/core/storage/AccountAwareStorageBackend.java
@@ -41,6 +41,14 @@ public class AccountAwareStorageBackend<V> implements StorageBackend<String, V> 
         this.defaultAccountId = defaultAccountId;
     }
 
+    /**
+     * In-memory account-aware store with no request context (uses {@code defaultAccountId}).
+     * Useful for unit tests and for callers that need an explicit {@link AccountAwareStorageBackend}.
+     */
+    public static <V> AccountAwareStorageBackend<V> inMemory(String defaultAccountId) {
+        return new AccountAwareStorageBackend<>(new InMemoryStorage<>(), null, defaultAccountId);
+    }
+
     @Override
     public void put(String key, V value) {
         delegate.put(prefixed(key), value);

--- a/src/main/java/io/github/hectorvent/floci/core/storage/StorageFactory.java
+++ b/src/main/java/io/github/hectorvent/floci/core/storage/StorageFactory.java
@@ -54,7 +54,7 @@ public class StorageFactory {
      * @param fileName      the JSON file name for persistent storage
      * @param typeReference Jackson type reference for deserialization
      */
-    public synchronized <V> StorageBackend<String, V> create(String serviceName, String fileName,
+    public synchronized <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
                                                  TypeReference<Map<String, V>> typeReference) {
         String mode = resolveMode(serviceName);
         long flushInterval = resolveFlushInterval(serviceName);
@@ -68,7 +68,7 @@ public class StorageFactory {
         if (existing != null) {
             LOG.debugv("Reusing existing {0} storage for service {1} (file: {2})", mode, serviceName, filePath);
             @SuppressWarnings("unchecked")
-            StorageBackend<String, V> typed = (StorageBackend<String, V>) existing;
+            AccountAwareStorageBackend<V> typed = (AccountAwareStorageBackend<V>) existing;
             return typed;
         }
 

--- a/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
@@ -175,6 +175,7 @@ public class EmulatorLifecycle {
         serviceRegistry.logEnabledServices();
         storageFactory.loadAll();
         schemaCreationWorker.recoverOrphans();
+        schemaCreationWorker.rehydrateSchemas();
 
         sqsPoller.startPersistedPollers();
         kinesisPoller.startPersistedPollers();

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -25,7 +25,7 @@ public class AppSyncService {
     private static final Logger LOG = Logger.getLogger(AppSyncService.class);
 
     private final StorageBackend<String, GraphqlApi> apiStore;
-    private final StorageBackend<String, String> schemaStore;
+    private final AccountAwareStorageBackend<String> schemaStore;
     private final AccountAwareStorageBackend<SchemaCreationStatus> schemaStatusStore;
     private final StorageBackend<String, DataSource> dataSourceStore;
     private final StorageBackend<String, Resolver> resolverStore;
@@ -47,7 +47,7 @@ public class AppSyncService {
                           SchemaRegistry schemaRegistry, SchemaCreationWorker schemaCreationWorker,
                           Instance<RequestContext> requestContextInstance, ObjectMapper objectMapper,
                           AccountAwareStorageBackend<SchemaCreationStatus> schemaStatusStore,
-                          StorageBackend<String, String> schemaStore) {
+                          AccountAwareStorageBackend<String> schemaStore) {
         this.apiStore = storageFactory.create("appsync", "appsync-apis.json", new TypeReference<>() {});
         this.schemaStore = schemaStore;
         this.schemaStatusStore = schemaStatusStore;

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncErrorFormatter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncErrorFormatter.java
@@ -1,0 +1,103 @@
+package io.github.hectorvent.floci.services.appsync.graphql;
+
+import graphql.ErrorType;
+import graphql.ExecutionResult;
+import graphql.GraphQLError;
+import graphql.ErrorClassification;
+import graphql.language.SourceLocation;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Maps graphql-java {@link ExecutionResult} errors to AWS AppSync wire shapes
+ * with top-level {@code errorType}/{@code errorInfo} (not extensions-only).
+ *
+ * @see <a href="https://docs.aws.amazon.com/appsync/latest/devguide/security-authz.html">AppSync DG error samples</a>
+ * @see <a href="https://github.com/graphql/graphql-over-http/issues/81">AppSync HTTP behavior (AppSync team / @robzhu)</a>
+ */
+@ApplicationScoped
+public class AppSyncErrorFormatter {
+
+    /**
+     * Messages from AppSync team sample:
+     * <a href="https://github.com/graphql/graphql-over-http/issues/81">graphql-over-http#81</a>
+     */
+    public static final String MSG_EMPTY_BODY = "Request body is empty.";
+    public static final String MSG_UNABLE_TO_PARSE = "Unable to parse GraphQL query.";
+    public static final String MSG_MISSING_OPERATION_NAME = "Missing operation name.";
+    public static final String MSG_NO_SCHEMA = "No schema definition exists.";
+
+    public Map<String, Object> format(ExecutionResult result) {
+        Map<String, Object> response = new LinkedHashMap<>();
+        if (result.isDataPresent()) {
+            response.put("data", result.getData());
+        }
+        List<GraphQLError> errors = result.getErrors();
+        if (errors != null && !errors.isEmpty()) {
+            List<Map<String, Object>> formatted = new ArrayList<>(errors.size());
+            for (GraphQLError error : errors) {
+                formatted.add(formatError(error));
+            }
+            response.put("errors", formatted);
+        }
+        return response;
+    }
+
+    public Map<String, Object> transportError(String errorType, String message) {
+        Map<String, Object> error = new LinkedHashMap<>();
+        error.put("errorType", errorType);
+        error.put("message", message);
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("errors", List.of(error));
+        return response;
+    }
+
+    private Map<String, Object> formatError(GraphQLError error) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("message", error.getMessage());
+        List<SourceLocation> locations = error.getLocations();
+        if (locations != null && !locations.isEmpty()) {
+            List<Map<String, Object>> locationMaps = new ArrayList<>(locations.size());
+            for (SourceLocation location : locations) {
+                Map<String, Object> loc = new LinkedHashMap<>();
+                loc.put("line", location.getLine());
+                loc.put("column", location.getColumn());
+                locationMaps.add(loc);
+            }
+            map.put("locations", locationMaps);
+        }
+        List<Object> path = error.getPath();
+        if (path != null && !path.isEmpty()) {
+            map.put("path", path);
+        }
+        map.put("errorType", toAppSyncErrorType(error.getErrorType()));
+        map.put("errorInfo", null);
+        return map;
+    }
+
+    static String toAppSyncErrorType(ErrorClassification classification) {
+        if (classification == ErrorType.InvalidSyntax) {
+            return "SyntaxError";
+        }
+        if (classification == ErrorType.ValidationError) {
+            return "ValidationError";
+        }
+        if (classification == ErrorType.OperationNotSupported) {
+            return "OperationNotSupported";
+        }
+        if (classification == ErrorType.DataFetchingException) {
+            return "DataFetchingException";
+        }
+        if (classification == null) {
+            return "Unknown";
+        }
+        if (classification instanceof ErrorType errorType) {
+            return errorType.name();
+        }
+        return classification.toString();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncErrorFormatter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncErrorFormatter.java
@@ -16,7 +16,7 @@ import java.util.Map;
  * Maps graphql-java {@link ExecutionResult} errors to AWS AppSync wire shapes
  * with top-level {@code errorType}/{@code errorInfo} (not extensions-only).
  *
- * @see <a href="https://docs.aws.amazon.com/appsync/latest/devguide/security-authz.html">AppSync DG error samples</a>
+ * @see <a href="https://docs.aws.amazon.com/appsync/latest/devguide/built-in-util-js.html">AppSync DG {@code $util.error} ({@code errorType}/{@code errorInfo})</a>
  * @see <a href="https://github.com/graphql/graphql-over-http/issues/81">AppSync HTTP behavior (AppSync team / @robzhu)</a>
  */
 @ApplicationScoped

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncExecutionController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncExecutionController.java
@@ -76,19 +76,15 @@ public class AppSyncExecutionController {
                 throw e;
             }
 
-            var schemaOpt = schemaRegistry.getSchema(apiId);
-            if (schemaOpt.isEmpty()) {
-                return Response.status(502)
-                        .header(HEADER_ERROR_TYPE, "GraphQLSchemaException")
-                        .type(MediaType.APPLICATION_JSON)
-                        .entity(errorFormatter.transportError("GraphQLSchemaException",
-                                AppSyncErrorFormatter.MSG_NO_SCHEMA))
-                        .build();
+            var graphQLOpt = schemaRegistry.getGraphQL(apiId);
+            if (graphQLOpt.isEmpty()) {
+                return graphqlError(502, "GraphQLSchemaException",
+                        AppSyncErrorFormatter.MSG_NO_SCHEMA);
             }
 
             try {
                 Map<String, Object> result = queryExecutor.execute(
-                        schemaOpt.get(), parsed.query(), parsed.variables(), parsed.operationName());
+                        graphQLOpt.get(), parsed.query(), parsed.variables(), parsed.operationName());
                 return Response.ok(result).type(MediaType.APPLICATION_JSON).build();
             } catch (AppSyncTransportException e) {
                 return graphqlError(e.getHttpStatus(), e.getErrorType(), e.getMessage());
@@ -171,13 +167,11 @@ public class AppSyncExecutionController {
     }
 
     private Response graphqlError(int status, String errorType, String message) {
-        Response.ResponseBuilder builder = Response.status(status)
+        return Response.status(status)
+                .header(HEADER_ERROR_TYPE, errorType)
                 .type(MediaType.APPLICATION_JSON)
-                .entity(errorFormatter.transportError(errorType, message));
-        if (status >= 500 || "GraphQLSchemaException".equals(errorType)) {
-            builder.header(HEADER_ERROR_TYPE, errorType);
-        }
-        return builder.build();
+                .entity(errorFormatter.transportError(errorType, message))
+                .build();
     }
 
     private record ParsedRequest(String query, Map<String, Object> variables, String operationName) {}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncExecutionController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncExecutionController.java
@@ -1,0 +1,184 @@
+package io.github.hectorvent.floci.services.appsync.graphql;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.appsync.AppSyncService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * AppSync GraphQL data-plane HTTP endpoint (separate from management {@code AppSyncController}).
+ * Accepts {@code application/graphql} and {@code application/json}.
+ */
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+public class AppSyncExecutionController {
+
+    private static final Logger LOG = Logger.getLogger(AppSyncExecutionController.class);
+    private static final String HEADER_ERROR_TYPE = "x-amzn-errortype";
+
+    private final AppSyncService appSyncService;
+    private final SchemaRegistry schemaRegistry;
+    private final QueryExecutor queryExecutor;
+    private final AppSyncErrorFormatter errorFormatter;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public AppSyncExecutionController(AppSyncService appSyncService,
+                                      SchemaRegistry schemaRegistry,
+                                      QueryExecutor queryExecutor,
+                                      AppSyncErrorFormatter errorFormatter,
+                                      ObjectMapper objectMapper) {
+        this.appSyncService = appSyncService;
+        this.schemaRegistry = schemaRegistry;
+        this.queryExecutor = queryExecutor;
+        this.errorFormatter = errorFormatter;
+        this.objectMapper = objectMapper;
+    }
+
+    @POST
+    @Path("/v1/apis/{apiId}/graphql")
+    public Response execute(@PathParam("apiId") String apiId,
+                            @Context HttpHeaders headers,
+                            String body) {
+        try {
+            if (!isAcceptedContentType(headers)) {
+                return graphqlError(400, "MalformedHttpRequestException",
+                        AppSyncErrorFormatter.MSG_UNABLE_TO_PARSE);
+            }
+
+            ParsedRequest parsed;
+            try {
+                parsed = parseBody(body);
+            } catch (AppSyncTransportException e) {
+                return graphqlError(e.getHttpStatus(), e.getErrorType(), e.getMessage());
+            }
+
+            try {
+                appSyncService.getGraphqlApi(apiId);
+            } catch (AwsException e) {
+                if (e.getHttpStatus() == 404) {
+                    return graphqlError(404, "NotFoundException", e.getMessage());
+                }
+                throw e;
+            }
+
+            var schemaOpt = schemaRegistry.getSchema(apiId);
+            if (schemaOpt.isEmpty()) {
+                return Response.status(502)
+                        .header(HEADER_ERROR_TYPE, "GraphQLSchemaException")
+                        .type(MediaType.APPLICATION_JSON)
+                        .entity(errorFormatter.transportError("GraphQLSchemaException",
+                                AppSyncErrorFormatter.MSG_NO_SCHEMA))
+                        .build();
+            }
+
+            try {
+                Map<String, Object> result = queryExecutor.execute(
+                        schemaOpt.get(), parsed.query(), parsed.variables(), parsed.operationName());
+                return Response.ok(result).type(MediaType.APPLICATION_JSON).build();
+            } catch (AppSyncTransportException e) {
+                return graphqlError(e.getHttpStatus(), e.getErrorType(), e.getMessage());
+            }
+        } catch (AwsException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            LOG.errorv(e, "Unexpected error executing GraphQL for API {0}", apiId);
+            return graphqlError(500, "InternalFailure",
+                    e.getMessage() != null ? e.getMessage() : "InternalFailure");
+        }
+    }
+
+    private boolean isAcceptedContentType(HttpHeaders headers) {
+        String contentType = headers.getHeaderString(HttpHeaders.CONTENT_TYPE);
+        if (contentType == null || contentType.isBlank()) {
+            return false;
+        }
+        String normalized = contentType.toLowerCase(Locale.ROOT).trim();
+        int semicolon = normalized.indexOf(';');
+        if (semicolon >= 0) {
+            normalized = normalized.substring(0, semicolon).trim();
+        }
+        return "application/json".equals(normalized) || "application/graphql".equals(normalized);
+    }
+
+    private ParsedRequest parseBody(String body) {
+        if (body == null || body.isBlank()) {
+            throw new AppSyncTransportException(400, "MalformedHttpRequestException",
+                    AppSyncErrorFormatter.MSG_EMPTY_BODY);
+        }
+
+        JsonNode root;
+        try {
+            root = objectMapper.readTree(body);
+        } catch (JsonProcessingException e) {
+            throw new AppSyncTransportException(400, "MalformedHttpRequestException",
+                    AppSyncErrorFormatter.MSG_UNABLE_TO_PARSE);
+        }
+
+        if (root == null || root.isNull() || root.isArray() || !root.isObject()) {
+            throw new AppSyncTransportException(400, "MalformedHttpRequestException",
+                    AppSyncErrorFormatter.MSG_UNABLE_TO_PARSE);
+        }
+        if (root.isEmpty()) {
+            throw new AppSyncTransportException(400, "MalformedHttpRequestException",
+                    AppSyncErrorFormatter.MSG_UNABLE_TO_PARSE);
+        }
+
+        JsonNode queryNode = root.get("query");
+        if (queryNode == null || !queryNode.isTextual()) {
+            throw new AppSyncTransportException(400, "MalformedHttpRequestException",
+                    AppSyncErrorFormatter.MSG_UNABLE_TO_PARSE);
+        }
+        // Blank queries are valid GraphQL-over-HTTP JSON and become SyntaxError (HTTP 200)
+        // via graphql-java — not MalformedHttpRequestException (400).
+        String query = queryNode.asText();
+
+        Map<String, Object> variables = null;
+        JsonNode variablesNode = root.get("variables");
+        if (variablesNode != null && !variablesNode.isNull()) {
+            if (!variablesNode.isObject()) {
+                throw new AppSyncTransportException(400, "MalformedHttpRequestException",
+                        AppSyncErrorFormatter.MSG_UNABLE_TO_PARSE);
+            }
+            variables = objectMapper.convertValue(variablesNode, Map.class);
+        }
+
+        String operationName = null;
+        JsonNode opNode = root.get("operationName");
+        if (opNode != null && !opNode.isNull()) {
+            if (!opNode.isTextual()) {
+                throw new AppSyncTransportException(400, "MalformedHttpRequestException",
+                        AppSyncErrorFormatter.MSG_UNABLE_TO_PARSE);
+            }
+            operationName = opNode.asText();
+        }
+
+        return new ParsedRequest(query, variables, operationName);
+    }
+
+    private Response graphqlError(int status, String errorType, String message) {
+        Response.ResponseBuilder builder = Response.status(status)
+                .type(MediaType.APPLICATION_JSON)
+                .entity(errorFormatter.transportError(errorType, message));
+        if (status >= 500 || "GraphQLSchemaException".equals(errorType)) {
+            builder.header(HEADER_ERROR_TYPE, errorType);
+        }
+        return builder.build();
+    }
+
+    private record ParsedRequest(String query, Map<String, Object> variables, String operationName) {}
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncExecutionController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncExecutionController.java
@@ -93,8 +93,7 @@ public class AppSyncExecutionController {
             throw e;
         } catch (RuntimeException e) {
             LOG.errorv(e, "Unexpected error executing GraphQL for API {0}", apiId);
-            return graphqlError(500, "InternalFailure",
-                    e.getMessage() != null ? e.getMessage() : "InternalFailure");
+            return graphqlError(500, "InternalFailure", "InternalFailure");
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncExecutionController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncExecutionController.java
@@ -73,7 +73,9 @@ public class AppSyncExecutionController {
                 if (e.getHttpStatus() == 404) {
                     return graphqlError(404, "NotFoundException", e.getMessage());
                 }
-                throw e;
+                // Stay on the data-plane errors envelope; never leak to AwsExceptionMapper (__type).
+                LOG.errorv(e, "Unexpected AwsException looking up API {0}", apiId);
+                return graphqlError(500, "InternalFailure", "InternalFailure");
             }
 
             var graphQLOpt = schemaRegistry.getGraphQL(apiId);
@@ -89,8 +91,6 @@ public class AppSyncExecutionController {
             } catch (AppSyncTransportException e) {
                 return graphqlError(e.getHttpStatus(), e.getErrorType(), e.getMessage());
             }
-        } catch (AwsException e) {
-            throw e;
         } catch (RuntimeException e) {
             LOG.errorv(e, "Unexpected error executing GraphQL for API {0}", apiId);
             return graphqlError(500, "InternalFailure", "InternalFailure");

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncTransportException.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncTransportException.java
@@ -1,0 +1,25 @@
+package io.github.hectorvent.floci.services.appsync.graphql;
+
+/**
+ * Transport-layer AppSync GraphQL HTTP error that must be returned as
+ * GraphQL {@code errors[]} body (not management {@code __type} via AwsExceptionMapper).
+ */
+public class AppSyncTransportException extends RuntimeException {
+
+    private final int httpStatus;
+    private final String errorType;
+
+    public AppSyncTransportException(int httpStatus, String errorType, String message) {
+        super(message);
+        this.httpStatus = httpStatus;
+        this.errorType = errorType;
+    }
+
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getErrorType() {
+        return errorType;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/QueryExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/QueryExecutor.java
@@ -1,0 +1,100 @@
+package io.github.hectorvent.floci.services.appsync.graphql;
+
+import graphql.ErrorType;
+import graphql.ExecutionInput;
+import graphql.ExecutionResult;
+import graphql.ExecutionResultImpl;
+import graphql.GraphQL;
+import graphql.GraphqlErrorBuilder;
+import graphql.execution.AsyncExecutionStrategy;
+import graphql.execution.AsyncSerialExecutionStrategy;
+import graphql.execution.SubscriptionExecutionStrategy;
+import graphql.language.Document;
+import graphql.language.OperationDefinition;
+import graphql.parser.InvalidSyntaxException;
+import graphql.parser.Parser;
+import graphql.schema.GraphQLSchema;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@ApplicationScoped
+public class QueryExecutor {
+
+    private final AppSyncErrorFormatter formatter;
+
+    @Inject
+    public QueryExecutor(AppSyncErrorFormatter formatter) {
+        this.formatter = formatter;
+    }
+
+    public Map<String, Object> execute(GraphQLSchema schema, String query,
+                                       Map<String, Object> variables, String operationName) {
+        List<OperationDefinition> operations = parseOperations(query);
+        if (operations.size() > 1 && (operationName == null || operationName.isBlank())) {
+            throw new AppSyncTransportException(400, "BadRequestException",
+                    AppSyncErrorFormatter.MSG_MISSING_OPERATION_NAME);
+        }
+
+        OperationDefinition selected = selectOperation(operations, operationName);
+        if (selected != null && selected.getOperation() == OperationDefinition.Operation.SUBSCRIPTION) {
+            ExecutionResult rejected = ExecutionResultImpl.newExecutionResult()
+                    .addError(GraphqlErrorBuilder.newError()
+                            .message("Subscriptions are not supported over HTTP")
+                            .errorType(ErrorType.OperationNotSupported)
+                            .build())
+                    .build();
+            return formatter.format(rejected);
+        }
+
+        GraphQL graphQL = GraphQL.newGraphQL(schema)
+                .queryExecutionStrategy(new AsyncExecutionStrategy())
+                .mutationExecutionStrategy(new AsyncSerialExecutionStrategy())
+                .subscriptionExecutionStrategy(new SubscriptionExecutionStrategy())
+                .build();
+
+        ExecutionInput.Builder inputBuilder = ExecutionInput.newExecutionInput().query(query);
+        if (variables != null) {
+            inputBuilder.variables(variables);
+        }
+        if (operationName != null && !operationName.isBlank()) {
+            inputBuilder.operationName(operationName);
+        }
+
+        ExecutionResult result = graphQL.execute(inputBuilder.build());
+        return formatter.format(result);
+    }
+
+    private List<OperationDefinition> parseOperations(String query) {
+        try {
+            Document document = Parser.parse(query);
+            List<OperationDefinition> ops = new ArrayList<>();
+            for (var definition : document.getDefinitions()) {
+                if (definition instanceof OperationDefinition operationDefinition) {
+                    ops.add(operationDefinition);
+                }
+            }
+            return ops;
+        } catch (InvalidSyntaxException e) {
+            return List.of();
+        }
+    }
+
+    private OperationDefinition selectOperation(List<OperationDefinition> operations, String operationName) {
+        if (operations.isEmpty()) {
+            return null;
+        }
+        if (operationName == null || operationName.isBlank()) {
+            return operations.get(0);
+        }
+        for (OperationDefinition op : operations) {
+            if (operationName.equals(op.getName())) {
+                return op;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/QueryExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/QueryExecutor.java
@@ -6,9 +6,6 @@ import graphql.ExecutionResult;
 import graphql.ExecutionResultImpl;
 import graphql.GraphQL;
 import graphql.GraphqlErrorBuilder;
-import graphql.execution.AsyncExecutionStrategy;
-import graphql.execution.AsyncSerialExecutionStrategy;
-import graphql.execution.SubscriptionExecutionStrategy;
 import graphql.language.Document;
 import graphql.language.OperationDefinition;
 import graphql.parser.InvalidSyntaxException;
@@ -33,6 +30,11 @@ public class QueryExecutor {
 
     public Map<String, Object> execute(GraphQLSchema schema, String query,
                                        Map<String, Object> variables, String operationName) {
+        return execute(SchemaRegistry.buildGraphQL(schema), query, variables, operationName);
+    }
+
+    public Map<String, Object> execute(GraphQL graphQL, String query,
+                                       Map<String, Object> variables, String operationName) {
         List<OperationDefinition> operations = parseOperations(query);
         if (operations.size() > 1 && (operationName == null || operationName.isBlank())) {
             throw new AppSyncTransportException(400, "BadRequestException",
@@ -49,12 +51,6 @@ public class QueryExecutor {
                     .build();
             return formatter.format(rejected);
         }
-
-        GraphQL graphQL = GraphQL.newGraphQL(schema)
-                .queryExecutionStrategy(new AsyncExecutionStrategy())
-                .mutationExecutionStrategy(new AsyncSerialExecutionStrategy())
-                .subscriptionExecutionStrategy(new SubscriptionExecutionStrategy())
-                .build();
 
         ExecutionInput.Builder inputBuilder = ExecutionInput.newExecutionInput().query(query);
         if (variables != null) {

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaCreationWorker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaCreationWorker.java
@@ -149,4 +149,30 @@ public class SchemaCreationWorker {
             LOG.infov("Recovered {0} orphan schema creation(s) on startup", recovered);
         }
     }
+
+    /**
+     * Rehydrates executable schemas from persisted SDL into {@link SchemaRegistry}
+     * after storage load / orphan recovery so GraphQL execute works across restarts.
+     * Parse failures are logged and skipped.
+     */
+    public void rehydrateSchemas() {
+        int loaded = 0;
+        int skipped = 0;
+        for (String apiId : schemaStore.keys()) {
+            Optional<String> sdl = schemaStore.get(apiId);
+            if (sdl.isEmpty() || sdl.get().isBlank()) {
+                continue;
+            }
+            try {
+                schemaRegistry.register(apiId, sdl.get());
+                loaded++;
+            } catch (RuntimeException e) {
+                skipped++;
+                LOG.warnv(e, "Skipping rehydrate of schema for API {0}: {1}", apiId, e.getMessage());
+            }
+        }
+        if (loaded > 0 || skipped > 0) {
+            LOG.infov("Rehydrated {0} schema(s) into registry ({1} skipped)", loaded, skipped);
+        }
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaCreationWorker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaCreationWorker.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
-import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.services.appsync.model.SchemaCreationStatus;
 import io.github.hectorvent.floci.services.appsync.model.SchemaCreationStatusType;
 import jakarta.annotation.PostConstruct;
@@ -15,7 +14,6 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -33,7 +31,7 @@ public class SchemaCreationWorker {
 
     private final SchemaRegistry schemaRegistry;
     private final AccountAwareStorageBackend<SchemaCreationStatus> schemaStatusStore;
-    private final StorageBackend<String, String> schemaStore;
+    private final AccountAwareStorageBackend<String> schemaStore;
     private final EmulatorConfig config;
     private final ObjectMapper objectMapper;
 
@@ -42,7 +40,7 @@ public class SchemaCreationWorker {
     @Inject
     public SchemaCreationWorker(SchemaRegistry schemaRegistry,
                                 AccountAwareStorageBackend<SchemaCreationStatus> schemaStatusStore,
-                                StorageBackend<String, String> schemaStore,
+                                AccountAwareStorageBackend<String> schemaStore,
                                 EmulatorConfig config,
                                 ObjectMapper objectMapper) {
         this.schemaRegistry = schemaRegistry;
@@ -88,7 +86,8 @@ public class SchemaCreationWorker {
     private void process(String apiId, String sdl, String accountId) {
         try {
             schemaRegistry.register(apiId, sdl);
-            schemaStore.put(apiId, sdl);
+            // Worker thread has no request context; write under the submitting account.
+            schemaStore.putForAccount(accountId, apiId, sdl);
             markStatus(accountId, apiId, SchemaCreationStatusType.SUCCESS, null);
             LOG.infov("Schema creation completed for API {0}", apiId);
         } catch (AwsException e) {
@@ -153,18 +152,20 @@ public class SchemaCreationWorker {
     /**
      * Rehydrates executable schemas from persisted SDL into {@link SchemaRegistry}
      * after storage load / orphan recovery so GraphQL execute works across restarts.
+     * Scans every account (startup has no request context); apiIds are globally unique.
      * Parse failures are logged and skipped.
      */
     public void rehydrateSchemas() {
         int loaded = 0;
         int skipped = 0;
-        for (String apiId : schemaStore.keys()) {
-            Optional<String> sdl = schemaStore.get(apiId);
-            if (sdl.isEmpty() || sdl.get().isBlank()) {
+        for (Map.Entry<String, String> entry : schemaStore.scanAllAccountsAsMap().entrySet()) {
+            String apiId = entry.getKey();
+            String sdl = entry.getValue();
+            if (sdl == null || sdl.isBlank()) {
                 continue;
             }
             try {
-                schemaRegistry.register(apiId, sdl.get());
+                schemaRegistry.register(apiId, sdl);
                 loaded++;
             } catch (RuntimeException e) {
                 skipped++;

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaRegistry.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaRegistry.java
@@ -1,5 +1,9 @@
 package io.github.hectorvent.floci.services.appsync.graphql;
 
+import graphql.GraphQL;
+import graphql.execution.AsyncExecutionStrategy;
+import graphql.execution.AsyncSerialExecutionStrategy;
+import graphql.execution.SubscriptionExecutionStrategy;
 import graphql.schema.GraphQLSchema;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -11,6 +15,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @ApplicationScoped
 public class SchemaRegistry {
     private final Map<String, GraphQLSchema> schemas = new ConcurrentHashMap<>();
+    private final Map<String, GraphQL> engines = new ConcurrentHashMap<>();
     private final AppSyncSchemaParser appSyncSchemaParser;
 
     @Inject
@@ -21,13 +26,27 @@ public class SchemaRegistry {
     public void register(String apiId, String sdl) {
         GraphQLSchema schema = appSyncSchemaParser.parse(sdl);
         schemas.put(apiId, schema);
+        engines.put(apiId, buildGraphQL(schema));
     }
 
     public Optional<GraphQLSchema> getSchema(String apiId) {
         return Optional.ofNullable(schemas.get(apiId));
     }
 
+    public Optional<GraphQL> getGraphQL(String apiId) {
+        return Optional.ofNullable(engines.get(apiId));
+    }
+
     public void remove(String apiId) {
         schemas.remove(apiId);
+        engines.remove(apiId);
+    }
+
+    static GraphQL buildGraphQL(GraphQLSchema schema) {
+        return GraphQL.newGraphQL(schema)
+                .queryExecutionStrategy(new AsyncExecutionStrategy())
+                .mutationExecutionStrategy(new AsyncSerialExecutionStrategy())
+                .subscriptionExecutionStrategy(new SubscriptionExecutionStrategy())
+                .build();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaStatusStoreProducer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaStatusStoreProducer.java
@@ -24,7 +24,7 @@ public class SchemaStatusStoreProducer {
 
     @Inject
     public SchemaStatusStoreProducer(StorageFactory storageFactory) {
-        this.store = (AccountAwareStorageBackend<SchemaCreationStatus>) storageFactory.create("appsync", "appsync-schema-status.json",
+        this.store = storageFactory.create("appsync", "appsync-schema-status.json",
                 new TypeReference<Map<String, SchemaCreationStatus>>() {});
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaStoreProducer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaStoreProducer.java
@@ -21,7 +21,7 @@ public class SchemaStoreProducer {
 
     @Inject
     public SchemaStoreProducer(StorageFactory storageFactory) {
-        this.store = (AccountAwareStorageBackend<String>) storageFactory.create("appsync", "appsync-schemas.json",
+        this.store = storageFactory.create("appsync", "appsync-schemas.json",
                 new TypeReference<Map<String, String>>() {});
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaStoreProducer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaStoreProducer.java
@@ -1,7 +1,7 @@
 package io.github.hectorvent.floci.services.appsync.graphql;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
@@ -10,24 +10,24 @@ import jakarta.inject.Inject;
 import java.util.Map;
 
 /**
- * Produces the shared {@link StorageBackend} used to store compiled SDL schemas.
+ * Produces the shared {@link AccountAwareStorageBackend} used to store compiled SDL schemas.
  * Shared between {@code AppSyncService} (reads via getIntrospectionSchema) and
- * {@code SchemaCreationWorker} (writes on successful compilation).
+ * {@code SchemaCreationWorker} (writes on successful compilation / rehydrates on boot).
  */
 @ApplicationScoped
 public class SchemaStoreProducer {
 
-    private final StorageBackend<String, String> store;
+    private final AccountAwareStorageBackend<String> store;
 
     @Inject
     public SchemaStoreProducer(StorageFactory storageFactory) {
-        this.store = storageFactory.create("appsync", "appsync-schemas.json",
+        this.store = (AccountAwareStorageBackend<String>) storageFactory.create("appsync", "appsync-schemas.json",
                 new TypeReference<Map<String, String>>() {});
     }
 
     @Produces
     @ApplicationScoped
-    public StorageBackend<String, String> produce() {
+    public AccountAwareStorageBackend<String> produce() {
         return store;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
@@ -9,7 +9,6 @@ import io.github.hectorvent.floci.core.common.dns.EmbeddedDnsServer;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ManagedContext;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
-import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.cloudformation.model.ChangeSet;
 import io.github.hectorvent.floci.services.cloudformation.model.Stack;
@@ -80,14 +79,10 @@ public class CloudFormationService {
         this.samTransformProcessor = new SamTransformProcessor(objectMapper);
         this.clock = clock;
         this.storageAccount = config.defaultAccountId();
-        this.stackBackend = asAccountAware(storageFactory.create(
-                "cloudformation", "cloudformation-stacks.json", new TypeReference<Map<String, Stack>>() {}));
-        this.exportBackend = asAccountAware(storageFactory.create(
-                "cloudformation", "cloudformation-exports.json", new TypeReference<Map<String, String>>() {}));
-    }
-
-    private static <V> AccountAwareStorageBackend<V> asAccountAware(StorageBackend<String, V> backend) {
-        return (AccountAwareStorageBackend<V>) backend;
+        this.stackBackend = storageFactory.create(
+                "cloudformation", "cloudformation-stacks.json", new TypeReference<Map<String, Stack>>() {});
+        this.exportBackend = storageFactory.create(
+                "cloudformation", "cloudformation-exports.json", new TypeReference<Map<String, String>>() {});
     }
 
     @PostConstruct

--- a/src/main/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineService.java
@@ -70,11 +70,11 @@ public class CodePipelineService {
     public CodePipelineService(StorageFactory storageFactory, ObjectMapper mapper,
                                CodeBuildService codeBuildService, CodeDeployService codeDeployService,
                                LambdaService lambdaService, S3Service s3Service) {
-        this.pipelineStore = (AccountAwareStorageBackend<CodePipelinePipeline>) storageFactory.create(
+        this.pipelineStore = storageFactory.create(
                 "codepipeline", "codepipeline-pipelines.json", new TypeReference<Map<String, CodePipelinePipeline>>() {});
-        this.executionStore = (AccountAwareStorageBackend<CodePipelineExecution>) storageFactory.create(
+        this.executionStore = storageFactory.create(
                 "codepipeline", "codepipeline-executions.json", new TypeReference<Map<String, CodePipelineExecution>>() {});
-        this.itemStore = (AccountAwareStorageBackend<CodePipelineStoredItem>) storageFactory.create(
+        this.itemStore = storageFactory.create(
                 "codepipeline", "codepipeline-items.json", new TypeReference<Map<String, CodePipelineStoredItem>>() {});
         this.mapper = mapper;
         this.codeBuildService = codeBuildService;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,7 +56,6 @@ quarkus:
       - --initialize-at-run-time=io.github.hectorvent.floci.services.cloudfront.CloudFrontService
       - --initialize-at-run-time=io.github.hectorvent.floci.services.emr.EmrService
       - --initialize-at-run-time=io.github.hectorvent.floci.services.elasticbeanstalk.ElasticBeanstalkService
-      # graphql-java IdGenerator holds a static Random; AppSync execute makes it reachable for native builds
       - --initialize-at-run-time=graphql.util.IdGenerator
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,6 +56,8 @@ quarkus:
       - --initialize-at-run-time=io.github.hectorvent.floci.services.cloudfront.CloudFrontService
       - --initialize-at-run-time=io.github.hectorvent.floci.services.emr.EmrService
       - --initialize-at-run-time=io.github.hectorvent.floci.services.elasticbeanstalk.ElasticBeanstalkService
+      # graphql-java IdGenerator holds a static Random; AppSync execute makes it reachable for native builds
+      - --initialize-at-run-time=graphql.util.IdGenerator
 
 
 floci:

--- a/src/test/java/io/github/hectorvent/floci/core/common/WebIdentityTokenVerifierTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/WebIdentityTokenVerifierTest.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.core.common;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.eks.EksOidcService;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -38,9 +39,9 @@ class WebIdentityTokenVerifierTest {
         verifier = new WebIdentityTokenVerifier(objectMapper);
         oidcService = new EksOidcService(new StorageFactory(null, null) {
             @Override
-            public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+            public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
                     TypeReference<Map<String, V>> typeReference) {
-                return new InMemoryStorage<>();
+                return AccountAwareStorageBackend.inMemory("000000000000");
             }
         }, objectMapper);
         oidcService.ensureKey(CLUSTER, ISSUER);

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
@@ -165,6 +165,21 @@ class EmulatorLifecycleTest {
     }
 
     @Test
+    @DisplayName("Should rehydrate AppSync schemas after orphan recovery on startup")
+    void shouldRehydrateAppSyncSchemasAfterOrphanRecovery() {
+        stubStorageConfig();
+        when(initializationHooksRunner.hasHooks(InitializationHook.START)).thenReturn(false);
+        when(initializationHooksRunner.hasHooks(InitializationHook.READY)).thenReturn(false);
+
+        emulatorLifecycle.onStart(Mockito.mock(StartupEvent.class));
+
+        var inOrder = Mockito.inOrder(storageFactory, schemaCreationWorker);
+        inOrder.verify(storageFactory).loadAll();
+        inOrder.verify(schemaCreationWorker).recoverOrphans();
+        inOrder.verify(schemaCreationWorker).rehydrateSchemas();
+    }
+
+    @Test
     @DisplayName("Should validate the persistent path after BOOT hooks and before loading storage")
     void shouldValidatePersistentPathBeforeStorageLoad() {
         stubStorageConfig();

--- a/src/test/java/io/github/hectorvent/floci/services/amazonmq/AmazonMqServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/amazonmq/AmazonMqServiceTest.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.amazonmq.container.RabbitMqManager;
 import io.github.hectorvent.floci.services.amazonmq.model.Broker;
@@ -26,7 +27,7 @@ class AmazonMqServiceTest {
     void setUp() {
         StorageFactory storageFactory = Mockito.mock(StorageFactory.class);
         when(storageFactory.create(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
-                .thenReturn(new InMemoryStorage<>());
+                .thenReturn(AccountAwareStorageBackend.inMemory("000000000000"));
 
         EmulatorConfig config = Mockito.mock(EmulatorConfig.class);
         var servicesConfig = Mockito.mock(EmulatorConfig.ServicesConfig.class);
@@ -173,7 +174,7 @@ class AmazonMqServiceTest {
     private AmazonMqService realModeServiceWithFailingManager() {
         StorageFactory storageFactory = Mockito.mock(StorageFactory.class);
         when(storageFactory.create(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
-                .thenReturn(new InMemoryStorage<>());
+                .thenReturn(AccountAwareStorageBackend.inMemory("000000000000"));
 
         EmulatorConfig config = Mockito.mock(EmulatorConfig.class);
         var servicesConfig = Mockito.mock(EmulatorConfig.ServicesConfig.class);

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncExecutionIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncExecutionIntegrationTest.java
@@ -107,6 +107,7 @@ class AppSyncExecutionIntegrationTest {
             .post("/v1/apis/" + apiId + "/graphql")
         .then()
             .statusCode(400)
+            .header("x-amzn-errortype", containsString("MalformedHttpRequestException"))
             .body("errors[0].errorType", equalTo("MalformedHttpRequestException"))
             .body("errors[0].message", equalTo(AppSyncErrorFormatter.MSG_EMPTY_BODY));
     }
@@ -162,7 +163,8 @@ class AppSyncExecutionIntegrationTest {
         .when()
             .post("/v1/apis/does-not-exist-xyz/graphql")
         .then()
-            .statusCode(404);
+            .statusCode(404)
+            .header("x-amzn-errortype", containsString("NotFoundException"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncExecutionIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncExecutionIntegrationTest.java
@@ -1,0 +1,369 @@
+package io.github.hectorvent.floci.services.appsync;
+
+import io.github.hectorvent.floci.services.appsync.graphql.AppSyncErrorFormatter;
+import io.github.hectorvent.floci.services.appsync.graphql.SchemaRegistry;
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class AppSyncExecutionIntegrationTest {
+
+    private static final String AUTH = "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/appsync/aws4_request";
+
+    @Inject
+    SchemaRegistry schemaRegistry;
+
+    private String apiId;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @BeforeEach
+    void createApiWithSchema() {
+        apiId = createApi("exec-" + UUID.randomUUID().toString().substring(0, 8));
+        startSchema(apiId, "type Query { hello: String }");
+        awaitSchemaSuccess(apiId);
+    }
+
+    @Test
+    void dualContentTypeJsonReturnsNullHello() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("{\"query\":\"{ hello }\"}")
+        .when()
+            .post("/v1/apis/" + apiId + "/graphql")
+        .then()
+            .statusCode(200)
+            .contentType(containsString("application/json"))
+            .body("data.hello", nullValue())
+            .body("errors", nullValue());
+    }
+
+    @Test
+    void dualContentTypeGraphqlReturnsNullHello() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/graphql")
+            .body("{\"query\":\"{ hello }\"}")
+        .when()
+            .post("/v1/apis/" + apiId + "/graphql")
+        .then()
+            .statusCode(200)
+            .body("data.hello", nullValue());
+    }
+
+    @Test
+    void missingContentTypeReturns400GraphqlErrors() {
+        given()
+            .header("Authorization", AUTH)
+            .body("{\"query\":\"{ hello }\"}")
+        .when()
+            .post("/v1/apis/" + apiId + "/graphql")
+        .then()
+            .statusCode(400)
+            .body("errors[0].errorType", equalTo("MalformedHttpRequestException"))
+            .body("__type", nullValue());
+    }
+
+    @Test
+    void unsupportedContentTypeReturns400GraphqlErrors() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("text/plain")
+            .body("{\"query\":\"{ hello }\"}")
+        .when()
+            .post("/v1/apis/" + apiId + "/graphql")
+        .then()
+            .statusCode(400)
+            .body("errors[0].errorType", equalTo("MalformedHttpRequestException"))
+            .body("__type", nullValue());
+    }
+
+    @Test
+    void emptyBodyReturns400MalformedWithEmptyMessage() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("")
+        .when()
+            .post("/v1/apis/" + apiId + "/graphql")
+        .then()
+            .statusCode(400)
+            .body("errors[0].errorType", equalTo("MalformedHttpRequestException"))
+            .body("errors[0].message", equalTo(AppSyncErrorFormatter.MSG_EMPTY_BODY));
+    }
+
+    @Test
+    void emptyObjectBodyReturns400UnableToParse() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("{}")
+        .when()
+            .post("/v1/apis/" + apiId + "/graphql")
+        .then()
+            .statusCode(400)
+            .body("errors[0].errorType", equalTo("MalformedHttpRequestException"))
+            .body("errors[0].message", equalTo(AppSyncErrorFormatter.MSG_UNABLE_TO_PARSE));
+    }
+
+    @Test
+    void arrayBodyReturns400UnableToParse() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("[{\"query\":\"{ hello }\"}]")
+        .when()
+            .post("/v1/apis/" + apiId + "/graphql")
+        .then()
+            .statusCode(400)
+            .body("errors[0].errorType", equalTo("MalformedHttpRequestException"))
+            .body("errors[0].message", equalTo(AppSyncErrorFormatter.MSG_UNABLE_TO_PARSE));
+    }
+
+    @Test
+    void unparseableBodyReturns400UnableToParse() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("meow")
+        .when()
+            .post("/v1/apis/" + apiId + "/graphql")
+        .then()
+            .statusCode(400)
+            .body("errors[0].errorType", equalTo("MalformedHttpRequestException"))
+            .body("errors[0].message", equalTo(AppSyncErrorFormatter.MSG_UNABLE_TO_PARSE));
+    }
+
+    @Test
+    void unknownApiIdReturns404() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("{\"query\":\"{ hello }\"}")
+        .when()
+            .post("/v1/apis/does-not-exist-xyz/graphql")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    void apiWithoutSchemaReturns502GraphQLSchemaException() {
+        String bareApiId = createApi("bare-" + UUID.randomUUID().toString().substring(0, 8));
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("{\"query\":\"{ hello }\"}")
+        .when()
+            .post("/v1/apis/" + bareApiId + "/graphql")
+        .then()
+            .statusCode(502)
+            .header("x-amzn-errortype", containsString("GraphQLSchemaException"))
+            .body("errors[0].errorType", equalTo("GraphQLSchemaException"))
+            .body("errors[0].message", equalTo(AppSyncErrorFormatter.MSG_NO_SCHEMA));
+    }
+
+    @Test
+    void validationErrorReturns200WithTopLevelErrorType() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("{\"query\":\"{ nope }\"}")
+        .when()
+            .post("/v1/apis/" + apiId + "/graphql")
+        .then()
+            .statusCode(200)
+            .body("errors[0].errorType", equalTo("ValidationError"))
+            .body("errors[0].extensions", nullValue());
+    }
+
+    @Test
+    void syntaxErrorReturns200WithSyntaxError() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("{\"query\":\"{ hello\"}")
+        .when()
+            .post("/v1/apis/" + apiId + "/graphql")
+        .then()
+            .statusCode(200)
+            .body("errors[0].errorType", equalTo("SyntaxError"));
+    }
+
+    @Test
+    void introspectionReturnsNonEmptyTypes() {
+        Map<String, Object> body = given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("{\"query\":\"{ __schema { types { name } } }\"}")
+        .when()
+            .post("/v1/apis/" + apiId + "/graphql")
+        .then()
+            .statusCode(200)
+            .extract().jsonPath().getMap("");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> data = (Map<String, Object>) body.get("data");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> schema = (Map<String, Object>) data.get("__schema");
+        @SuppressWarnings("unchecked")
+        List<?> types = (List<?>) schema.get("types");
+        assertThat(types, hasSize(greaterThan(0)));
+    }
+
+    @Test
+    void variablesAndOperationNameExecuteSelectedOp() {
+        String multiApi = createApi("multi-" + UUID.randomUUID().toString().substring(0, 8));
+        startSchema(multiApi, "type Query { hello(id: String): String }");
+        awaitSchemaSuccess(multiApi);
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {
+                  "query": "query GetHello($id: String) { hello(id: $id) } query Other { hello }",
+                  "variables": {"id": "x"},
+                  "operationName": "GetHello"
+                }
+                """)
+        .when()
+            .post("/v1/apis/" + multiApi + "/graphql")
+        .then()
+            .statusCode(200)
+            .body("data.hello", nullValue());
+    }
+
+    @Test
+    void httpSubscriptionReturns200OperationNotSupported() {
+        String subApi = createApi("sub-" + UUID.randomUUID().toString().substring(0, 8));
+        startSchema(subApi, """
+                type Query { hello: String }
+                type Subscription { onHello: String }
+                """);
+        awaitSchemaSuccess(subApi);
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("{\"query\":\"subscription { onHello }\"}")
+        .when()
+            .post("/v1/apis/" + subApi + "/graphql")
+        .then()
+            .statusCode(200)
+            .body("errors[0].errorType", equalTo("OperationNotSupported"));
+    }
+
+    @Test
+    void whitespaceOnlyQueryReturns200SyntaxError() {
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("{\"query\":\"   \"}")
+        .when()
+            .post("/v1/apis/" + apiId + "/graphql")
+        .then()
+            .statusCode(200)
+            .body("errors[0].errorType", equalTo("SyntaxError"));
+    }
+
+    @Test
+    void rehydrateFromSchemaStoreEnablesExecute() {
+        String hydrateApi = createApi("hydrate-" + UUID.randomUUID().toString().substring(0, 8));
+        startSchema(hydrateApi, "type Query { hello: String }");
+        awaitSchemaSuccess(hydrateApi);
+
+        schemaRegistry.remove(hydrateApi);
+        assertTrue(schemaRegistry.getSchema(hydrateApi).isEmpty());
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("{\"query\":\"{ hello }\"}")
+        .when()
+            .post("/v1/apis/" + hydrateApi + "/graphql")
+        .then()
+            .statusCode(502);
+
+        // invoke rehydrate via worker (package-visible through CDI bean)
+        rehydrateWorker().rehydrateSchemas();
+
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("{\"query\":\"{ hello }\"}")
+        .when()
+            .post("/v1/apis/" + hydrateApi + "/graphql")
+        .then()
+            .statusCode(200)
+            .body("data.hello", nullValue());
+    }
+
+    @Inject
+    io.github.hectorvent.floci.services.appsync.graphql.SchemaCreationWorker schemaCreationWorker;
+
+    private io.github.hectorvent.floci.services.appsync.graphql.SchemaCreationWorker rehydrateWorker() {
+        return schemaCreationWorker;
+    }
+
+    private static String createApi(String name) {
+        return given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("""
+                {"name": "%s", "authenticationType": "API_KEY"}
+                """.formatted(name))
+        .when()
+            .post("/v1/apis")
+        .then()
+            .statusCode(200)
+            .extract().path("graphqlApi.apiId");
+    }
+
+    private static void startSchema(String apiId, String definition) {
+        String escaped = definition.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n");
+        given()
+            .header("Authorization", AUTH)
+            .contentType("application/json")
+            .body("{\"definition\": \"" + escaped + "\"}")
+        .when()
+            .post("/v1/apis/" + apiId + "/schemacreation")
+        .then()
+            .statusCode(200)
+            .body("status", equalTo("PROCESSING"));
+    }
+
+    private static void awaitSchemaSuccess(String apiId) {
+        await().atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(25))
+                .until(() -> {
+                    String status = given()
+                        .header("Authorization", AUTH)
+                    .when()
+                        .get("/v1/apis/" + apiId + "/schemacreation")
+                    .then()
+                        .statusCode(200)
+                        .extract().path("status");
+                    return "SUCCESS".equals(status);
+                });
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncErrorFormatterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncErrorFormatterTest.java
@@ -1,0 +1,119 @@
+package io.github.hectorvent.floci.services.appsync.graphql;
+
+import graphql.ErrorType;
+import graphql.ExecutionResult;
+import graphql.ExecutionResultImpl;
+import graphql.GraphQLError;
+import graphql.GraphqlErrorBuilder;
+import graphql.language.SourceLocation;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AppSyncErrorFormatterTest {
+
+    private final AppSyncErrorFormatter formatter = new AppSyncErrorFormatter();
+
+    @Test
+    void invalidSyntaxMapsToTopLevelSyntaxError() {
+        GraphQLError syntaxError = GraphqlErrorBuilder.newError()
+                .message("Invalid syntax near '{'")
+                .errorType(ErrorType.InvalidSyntax)
+                .location(new SourceLocation(1, 1))
+                .build();
+        ExecutionResult result = ExecutionResultImpl.newExecutionResult()
+                .addError(syntaxError)
+                .build();
+
+        Map<String, Object> response = formatter.format(result);
+
+        assertFalse(response.containsKey("data"));
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> errors = (List<Map<String, Object>>) response.get("errors");
+        assertEquals(1, errors.size());
+        Map<String, Object> error = errors.get(0);
+        assertEquals("Invalid syntax near '{'", error.get("message"));
+        assertEquals("SyntaxError", error.get("errorType"));
+        assertTrue(error.containsKey("errorInfo"));
+        assertNull(error.get("errorInfo"));
+        assertFalse(error.containsKey("extensions"));
+    }
+
+    @Test
+    void validationErrorUsesTopLevelErrorTypeNotExtensionsOnly() {
+        GraphQLError validationError = GraphqlErrorBuilder.newError()
+                .message("Validation error of type FieldUndefined: Field 'nope' is undefined")
+                .errorType(ErrorType.ValidationError)
+                .location(new SourceLocation(1, 3))
+                .path(List.of("nope"))
+                .build();
+        ExecutionResult result = ExecutionResultImpl.newExecutionResult()
+                .data(null)
+                .addError(validationError)
+                .build();
+
+        Map<String, Object> response = formatter.format(result);
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> errors = (List<Map<String, Object>>) response.get("errors");
+        Map<String, Object> error = errors.get(0);
+        assertEquals("ValidationError", error.get("errorType"));
+        assertTrue(error.containsKey("errorInfo"));
+        assertNull(error.get("errorInfo"));
+        assertEquals(List.of("nope"), error.get("path"));
+        assertFalse(error.containsKey("extensions"),
+                "AppSync wire uses top-level errorType, not extensions-only classification");
+    }
+
+    @Test
+    void emptyBodyMessageMatchesAppSyncSample() {
+        Map<String, Object> response = formatter.transportError(
+                "MalformedHttpRequestException",
+                AppSyncErrorFormatter.MSG_EMPTY_BODY);
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> errors = (List<Map<String, Object>>) response.get("errors");
+        assertEquals(1, errors.size());
+        assertEquals("MalformedHttpRequestException", errors.get(0).get("errorType"));
+        assertEquals("Request body is empty.", errors.get(0).get("message"));
+    }
+
+    @Test
+    void unparseableBodyMessageMatchesAppSyncSample() {
+        Map<String, Object> forBraces = formatter.transportError(
+                "MalformedHttpRequestException",
+                AppSyncErrorFormatter.MSG_UNABLE_TO_PARSE);
+        Map<String, Object> forArray = formatter.transportError(
+                "MalformedHttpRequestException",
+                AppSyncErrorFormatter.MSG_UNABLE_TO_PARSE);
+
+        assertEquals("Unable to parse GraphQL query.",
+                ((List<?>) forBraces.get("errors")).isEmpty() ? null
+                        : ((Map<?, ?>) ((List<?>) forBraces.get("errors")).get(0)).get("message"));
+        assertEquals("Unable to parse GraphQL query.",
+                ((Map<?, ?>) ((List<?>) forArray.get("errors")).get(0)).get("message"));
+    }
+
+    @Test
+    void successfulDataIncludedWithoutErrors() {
+        Map<String, Object> data = new java.util.LinkedHashMap<>();
+        data.put("hello", null);
+        ExecutionResult result = ExecutionResultImpl.newExecutionResult()
+                .data(data)
+                .build();
+
+        Map<String, Object> response = formatter.format(result);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> responseData = (Map<String, Object>) response.get("data");
+        assertNull(responseData.get("hello"));
+        assertTrue(responseData.containsKey("hello"));
+        assertFalse(response.containsKey("errors"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncExecutionControllerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncExecutionControllerTest.java
@@ -1,0 +1,72 @@
+package io.github.hectorvent.floci.services.appsync.graphql;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import graphql.schema.GraphQLSchema;
+import io.github.hectorvent.floci.services.appsync.AppSyncService;
+import io.github.hectorvent.floci.services.appsync.model.GraphqlApi;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AppSyncExecutionControllerTest {
+
+    @Mock
+    AppSyncService appSyncService;
+    @Mock
+    SchemaRegistry schemaRegistry;
+    @Mock
+    QueryExecutor queryExecutor;
+
+    private AppSyncExecutionController controller;
+    private HttpHeaders jsonHeaders;
+
+    @BeforeEach
+    void setUp() {
+        controller = new AppSyncExecutionController(
+                appSyncService,
+                schemaRegistry,
+                queryExecutor,
+                new AppSyncErrorFormatter(),
+                new ObjectMapper());
+
+        jsonHeaders = mock(HttpHeaders.class);
+        when(jsonHeaders.getHeaderString(HttpHeaders.CONTENT_TYPE)).thenReturn("application/json");
+    }
+
+    @Test
+    void unexpectedExecutorFailureReturns500InternalFailure() {
+        when(appSyncService.getGraphqlApi("api-1")).thenReturn(new GraphqlApi());
+        when(schemaRegistry.getSchema("api-1")).thenReturn(Optional.of(mock(GraphQLSchema.class)));
+        when(queryExecutor.execute(any(GraphQLSchema.class), eq("{ hello }"), isNull(), isNull()))
+                .thenThrow(new RuntimeException("boom"));
+
+        Response response = controller.execute("api-1", jsonHeaders, "{\"query\":\"{ hello }\"}");
+
+        assertEquals(500, response.getStatus());
+        assertEquals("InternalFailure", response.getHeaderString("x-amzn-errortype"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getEntity();
+        assertNotNull(body.get("errors"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> error = ((List<Map<String, Object>>) body.get("errors")).get(0);
+        assertEquals("InternalFailure", error.get("errorType"));
+        assertEquals("boom", error.get("message"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncExecutionControllerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncExecutionControllerTest.java
@@ -68,7 +68,7 @@ class AppSyncExecutionControllerTest {
         @SuppressWarnings("unchecked")
         Map<String, Object> error = ((List<Map<String, Object>>) body.get("errors")).get(0);
         assertEquals("InternalFailure", error.get("errorType"));
-        assertEquals("boom", error.get("message"));
+        assertEquals("InternalFailure", error.get("message"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncExecutionControllerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncExecutionControllerTest.java
@@ -1,7 +1,8 @@
 package io.github.hectorvent.floci.services.appsync.graphql;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import graphql.schema.GraphQLSchema;
+import graphql.GraphQL;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.appsync.AppSyncService;
 import io.github.hectorvent.floci.services.appsync.model.GraphqlApi;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -53,8 +54,8 @@ class AppSyncExecutionControllerTest {
     @Test
     void unexpectedExecutorFailureReturns500InternalFailure() {
         when(appSyncService.getGraphqlApi("api-1")).thenReturn(new GraphqlApi());
-        when(schemaRegistry.getSchema("api-1")).thenReturn(Optional.of(mock(GraphQLSchema.class)));
-        when(queryExecutor.execute(any(GraphQLSchema.class), eq("{ hello }"), isNull(), isNull()))
+        when(schemaRegistry.getGraphQL("api-1")).thenReturn(Optional.of(mock(GraphQL.class)));
+        when(queryExecutor.execute(any(GraphQL.class), eq("{ hello }"), isNull(), isNull()))
                 .thenThrow(new RuntimeException("boom"));
 
         Response response = controller.execute("api-1", jsonHeaders, "{\"query\":\"{ hello }\"}");
@@ -68,5 +69,35 @@ class AppSyncExecutionControllerTest {
         Map<String, Object> error = ((List<Map<String, Object>>) body.get("errors")).get(0);
         assertEquals("InternalFailure", error.get("errorType"));
         assertEquals("boom", error.get("message"));
+    }
+
+    @Test
+    void emptyBodyReturns400WithErrorTypeHeader() {
+        Response response = controller.execute("api-1", jsonHeaders, "");
+
+        assertEquals(400, response.getStatus());
+        assertEquals("MalformedHttpRequestException", response.getHeaderString("x-amzn-errortype"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getEntity();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> error = ((List<Map<String, Object>>) body.get("errors")).get(0);
+        assertEquals("MalformedHttpRequestException", error.get("errorType"));
+        assertEquals(AppSyncErrorFormatter.MSG_EMPTY_BODY, error.get("message"));
+    }
+
+    @Test
+    void unknownApiReturns404WithErrorTypeHeader() {
+        when(appSyncService.getGraphqlApi("missing"))
+                .thenThrow(new AwsException("NotFoundException", "API not found", 404));
+
+        Response response = controller.execute("missing", jsonHeaders, "{\"query\":\"{ hello }\"}");
+
+        assertEquals(404, response.getStatus());
+        assertEquals("NotFoundException", response.getHeaderString("x-amzn-errortype"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getEntity();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> error = ((List<Map<String, Object>>) body.get("errors")).get(0);
+        assertEquals("NotFoundException", error.get("errorType"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncExecutionControllerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/AppSyncExecutionControllerTest.java
@@ -100,4 +100,22 @@ class AppSyncExecutionControllerTest {
         Map<String, Object> error = ((List<Map<String, Object>>) body.get("errors")).get(0);
         assertEquals("NotFoundException", error.get("errorType"));
     }
+
+    @Test
+    void non404AwsExceptionFromLookupReturnsDataPlaneInternalFailure() {
+        when(appSyncService.getGraphqlApi("api-1"))
+                .thenThrow(new AwsException("BadRequestException", "unexpected management error", 400));
+
+        Response response = controller.execute("api-1", jsonHeaders, "{\"query\":\"{ hello }\"}");
+
+        assertEquals(500, response.getStatus());
+        assertEquals("InternalFailure", response.getHeaderString("x-amzn-errortype"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getEntity();
+        assertNotNull(body.get("errors"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> error = ((List<Map<String, Object>>) body.get("errors")).get(0);
+        assertEquals("InternalFailure", error.get("errorType"));
+        assertEquals("InternalFailure", error.get("message"));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/QueryExecutorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/QueryExecutorTest.java
@@ -1,0 +1,115 @@
+package io.github.hectorvent.floci.services.appsync.graphql;
+
+import graphql.schema.GraphQLSchema;
+import io.github.hectorvent.floci.services.appsync.graphql.scalars.AppSyncScalarRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QueryExecutorTest {
+
+    private QueryExecutor executor;
+    private GraphQLSchema helloSchema;
+    private GraphQLSchema subscriptionSchema;
+    private GraphQLSchema multiOpSchema;
+
+    @BeforeEach
+    void setUp() {
+        AppSyncErrorFormatter formatter = new AppSyncErrorFormatter();
+        executor = new QueryExecutor(formatter);
+        AppSyncSchemaParser parser = new AppSyncSchemaParser(new AppSyncScalarRegistry());
+        helloSchema = parser.parse("type Query { hello: String }");
+        subscriptionSchema = parser.parse("""
+                type Query { hello: String }
+                type Subscription { onHello: String }
+                """);
+        multiOpSchema = parser.parse("""
+                type Query {
+                  hello: String
+                  bye: String
+                }
+                """);
+    }
+
+    @Test
+    void nullableFieldReturnsNullWithoutDataFetcher() {
+        Map<String, Object> response = executor.execute(helloSchema, "{ hello }", null, null);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> data = (Map<String, Object>) response.get("data");
+        assertTrue(data.containsKey("hello"));
+        assertNull(data.get("hello"));
+        assertTrue(!response.containsKey("errors") || ((List<?>) response.get("errors")).isEmpty());
+    }
+
+    @Test
+    void usesAsyncStrategiesAndSupportsSimpleQuery() {
+        Map<String, Object> response = executor.execute(helloSchema, "query Q { hello }", Map.of(), "Q");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> data = (Map<String, Object>) response.get("data");
+        assertNull(data.get("hello"));
+    }
+
+    @Test
+    void httpSubscriptionReturnsOperationNotSupported() {
+        Map<String, Object> response = executor.execute(
+                subscriptionSchema,
+                "subscription { onHello }",
+                null,
+                null);
+
+        assertTrue(response.containsKey("errors"));
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> errors = (List<Map<String, Object>>) response.get("errors");
+        assertEquals(1, errors.size());
+        assertEquals("OperationNotSupported", errors.get(0).get("errorType"));
+        Object data = response.get("data");
+        if (data != null) {
+            assertTrue(!(data instanceof org.reactivestreams.Publisher),
+                    "Must not return Publisher JSON for HTTP subscriptions");
+        }
+    }
+
+    @Test
+    void missingOperationNameWithMultipleOpsThrowsBadRequest() {
+        AppSyncTransportException ex = assertThrows(AppSyncTransportException.class, () ->
+                executor.execute(multiOpSchema, """
+                        query A { hello }
+                        query B { bye }
+                        """, null, null));
+
+        assertEquals(400, ex.getHttpStatus());
+        assertEquals("BadRequestException", ex.getErrorType());
+        assertEquals("Missing operation name.", ex.getMessage());
+    }
+
+    @Test
+    void operationNameSelectsAmongMultipleOps() {
+        Map<String, Object> response = executor.execute(multiOpSchema, """
+                query A { hello }
+                query B { bye }
+                """, null, "B");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> data = (Map<String, Object>) response.get("data");
+        assertTrue(data.containsKey("bye"));
+        assertNull(data.get("bye"));
+    }
+
+    @Test
+    void syntaxErrorFormattedAsSyntaxError() {
+        Map<String, Object> response = executor.execute(helloSchema, "{ hello", null, null);
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> errors = (List<Map<String, Object>>) response.get("errors");
+        assertEquals("SyntaxError", errors.get(0).get("errorType"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaCreationWorkerRehydrateTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaCreationWorkerRehydrateTest.java
@@ -49,6 +49,7 @@ class SchemaCreationWorkerRehydrateTest {
         worker.rehydrateSchemas();
 
         assertTrue(schemaRegistry.getSchema("api-1").isPresent());
+        assertTrue(schemaRegistry.getGraphQL("api-1").isPresent());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaCreationWorkerRehydrateTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaCreationWorkerRehydrateTest.java
@@ -1,0 +1,74 @@
+package io.github.hectorvent.floci.services.appsync.graphql;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.services.appsync.graphql.scalars.AppSyncScalarRegistry;
+import io.github.hectorvent.floci.services.appsync.model.SchemaCreationStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SchemaCreationWorkerRehydrateTest {
+
+    @Mock
+    AccountAwareStorageBackend<SchemaCreationStatus> schemaStatusStore;
+    @Mock
+    StorageBackend<String, String> schemaStore;
+    @Mock
+    EmulatorConfig config;
+
+    private SchemaRegistry schemaRegistry;
+    private SchemaCreationWorker worker;
+
+    @BeforeEach
+    void setUp() {
+        schemaRegistry = new SchemaRegistry(new AppSyncSchemaParser(new AppSyncScalarRegistry()));
+        worker = new SchemaCreationWorker(
+                schemaRegistry, schemaStatusStore, schemaStore, config, new ObjectMapper());
+    }
+
+    @Test
+    void rehydrateRegistersSdlFromSchemaStore() {
+        when(schemaStore.keys()).thenReturn(Set.of("api-1"));
+        when(schemaStore.get("api-1")).thenReturn(Optional.of("type Query { hello: String }"));
+
+        worker.rehydrateSchemas();
+
+        assertTrue(schemaRegistry.getSchema("api-1").isPresent());
+    }
+
+    @Test
+    void rehydrateSkipsUnparseableSdl() {
+        when(schemaStore.keys()).thenReturn(Set.of("bad-api"));
+        when(schemaStore.get("bad-api")).thenReturn(Optional.of("not valid sdl {{{"));
+
+        worker.rehydrateSchemas();
+
+        assertTrue(schemaRegistry.getSchema("bad-api").isEmpty());
+    }
+
+    @Test
+    void rehydrateSkipsBlankEntries() {
+        when(schemaStore.keys()).thenReturn(Set.of("empty"));
+        when(schemaStore.get("empty")).thenReturn(Optional.of("   "));
+
+        worker.rehydrateSchemas();
+
+        assertTrue(schemaRegistry.getSchema("empty").isEmpty());
+        verify(schemaStore, never()).put(anyString(), anyString());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaCreationWorkerRehydrateTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaCreationWorkerRehydrateTest.java
@@ -3,7 +3,6 @@ package io.github.hectorvent.floci.services.appsync.graphql;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
-import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.services.appsync.graphql.scalars.AppSyncScalarRegistry;
 import io.github.hectorvent.floci.services.appsync.model.SchemaCreationStatus;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,8 +11,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Optional;
-import java.util.Set;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -27,7 +26,7 @@ class SchemaCreationWorkerRehydrateTest {
     @Mock
     AccountAwareStorageBackend<SchemaCreationStatus> schemaStatusStore;
     @Mock
-    StorageBackend<String, String> schemaStore;
+    AccountAwareStorageBackend<String> schemaStore;
     @Mock
     EmulatorConfig config;
 
@@ -43,8 +42,8 @@ class SchemaCreationWorkerRehydrateTest {
 
     @Test
     void rehydrateRegistersSdlFromSchemaStore() {
-        when(schemaStore.keys()).thenReturn(Set.of("api-1"));
-        when(schemaStore.get("api-1")).thenReturn(Optional.of("type Query { hello: String }"));
+        when(schemaStore.scanAllAccountsAsMap())
+                .thenReturn(Map.of("api-1", "type Query { hello: String }"));
 
         worker.rehydrateSchemas();
 
@@ -53,9 +52,27 @@ class SchemaCreationWorkerRehydrateTest {
     }
 
     @Test
+    void rehydrateLoadsSchemasFromNonDefaultAccounts() {
+        // Startup has no request context; keys()/get() would only see the default account.
+        // scanAllAccountsAsMap must surface SDLs stored under other accounts.
+        Map<String, String> acrossAccounts = new LinkedHashMap<>();
+        acrossAccounts.put("default-api", "type Query { fromDefault: String }");
+        acrossAccounts.put("other-acct-api", "type Query { fromOther: String }");
+        when(schemaStore.scanAllAccountsAsMap()).thenReturn(acrossAccounts);
+
+        worker.rehydrateSchemas();
+
+        assertTrue(schemaRegistry.getSchema("default-api").isPresent());
+        assertTrue(schemaRegistry.getSchema("other-acct-api").isPresent());
+        assertTrue(schemaRegistry.getGraphQL("other-acct-api").isPresent());
+        verify(schemaStore, never()).keys();
+        verify(schemaStore, never()).get(anyString());
+    }
+
+    @Test
     void rehydrateSkipsUnparseableSdl() {
-        when(schemaStore.keys()).thenReturn(Set.of("bad-api"));
-        when(schemaStore.get("bad-api")).thenReturn(Optional.of("not valid sdl {{{"));
+        when(schemaStore.scanAllAccountsAsMap())
+                .thenReturn(Map.of("bad-api", "not valid sdl {{{"));
 
         worker.rehydrateSchemas();
 
@@ -64,8 +81,7 @@ class SchemaCreationWorkerRehydrateTest {
 
     @Test
     void rehydrateSkipsBlankEntries() {
-        when(schemaStore.keys()).thenReturn(Set.of("empty"));
-        when(schemaStore.get("empty")).thenReturn(Optional.of("   "));
+        when(schemaStore.scanAllAccountsAsMap()).thenReturn(Map.of("empty", "   "));
 
         worker.rehydrateSchemas();
 

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaRegistryTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaRegistryTest.java
@@ -1,0 +1,55 @@
+package io.github.hectorvent.floci.services.appsync.graphql;
+
+import graphql.GraphQL;
+import io.github.hectorvent.floci.services.appsync.graphql.scalars.AppSyncScalarRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SchemaRegistryTest {
+
+    private static final String SDL = "type Query { hello: String }";
+
+    private SchemaRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SchemaRegistry(new AppSyncSchemaParser(new AppSyncScalarRegistry()));
+    }
+
+    @Test
+    void getGraphQLReturnsSameInstanceAcrossCalls() {
+        registry.register("api-1", SDL);
+
+        GraphQL first = registry.getGraphQL("api-1").orElseThrow();
+        GraphQL second = registry.getGraphQL("api-1").orElseThrow();
+
+        assertSame(first, second);
+    }
+
+    @Test
+    void removeClearsCachedGraphQL() {
+        registry.register("api-1", SDL);
+        assertTrue(registry.getGraphQL("api-1").isPresent());
+
+        registry.remove("api-1");
+
+        assertTrue(registry.getGraphQL("api-1").isEmpty());
+        assertTrue(registry.getSchema("api-1").isEmpty());
+    }
+
+    @Test
+    void reregisterReplacesCachedGraphQL() {
+        registry.register("api-1", SDL);
+        GraphQL original = registry.getGraphQL("api-1").orElseThrow();
+
+        registry.register("api-1", "type Query { bye: String }");
+        GraphQL replaced = registry.getGraphQL("api-1").orElseThrow();
+
+        assertNotSame(original, replaced);
+        assertSame(replaced, registry.getGraphQL("api-1").orElseThrow());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/StackSetServiceDeleteFailureTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/StackSetServiceDeleteFailureTest.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.cloudformation;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.cloudformation.model.Stack;
 import io.github.hectorvent.floci.services.cloudformation.model.StackInstance;
@@ -100,10 +101,10 @@ class StackSetServiceDeleteFailureTest {
         }
 
         @Override
-        public <V> StorageBackend<String, V> create(String serviceName,
+        public <V> AccountAwareStorageBackend<V> create(String serviceName,
                                                      String fileName,
                                                      TypeReference<Map<String, V>> typeReference) {
-            return new InMemoryStorage<>();
+            return AccountAwareStorageBackend.inMemory("000000000000");
         }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontServiceTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.cloudfront;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.cloudfront.model.Distribution;
 import io.github.hectorvent.floci.services.cloudfront.model.StreamingDistribution;
@@ -20,7 +21,7 @@ class CloudFrontServiceTest {
     private CloudFrontService serviceWithDomainSuffix(String domainSuffix) {
         StorageFactory storageFactory = Mockito.mock(StorageFactory.class);
         when(storageFactory.create(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
-                .thenReturn(new InMemoryStorage<>());
+                .thenReturn(AccountAwareStorageBackend.inMemory("000000000000"));
 
         EmulatorConfig config = Mockito.mock(EmulatorConfig.class);
         var servicesConfig = Mockito.mock(EmulatorConfig.ServicesConfig.class);

--- a/src/test/java/io/github/hectorvent/floci/services/codebuild/CodeBuildServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/codebuild/CodeBuildServicePersistenceTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.codebuild.model.Build;
 import io.github.hectorvent.floci.services.codebuild.model.Project;
@@ -149,10 +150,10 @@ class CodeBuildServicePersistenceTest {
 
         @Override
         @SuppressWarnings("unchecked")
-        public <V> StorageBackend<String, V> create(String serviceName,
+        public <V> AccountAwareStorageBackend<V> create(String serviceName,
                                                     String fileName,
                                                     TypeReference<Map<String, V>> typeReference) {
-            return (StorageBackend<String, V>) stores.computeIfAbsent(fileName, ignored -> new InMemoryStorage<>());
+            return (AccountAwareStorageBackend<V>) stores.computeIfAbsent(fileName, ignored -> AccountAwareStorageBackend.inMemory("000000000000"));
         }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/codedeploy/CodeDeployServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/codedeploy/CodeDeployServicePersistenceTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.codedeploy.model.DeploymentGroup;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
@@ -112,10 +113,10 @@ class CodeDeployServicePersistenceTest {
 
         @Override
         @SuppressWarnings("unchecked")
-        public <V> StorageBackend<String, V> create(String serviceName,
+        public <V> AccountAwareStorageBackend<V> create(String serviceName,
                                                     String fileName,
                                                     TypeReference<Map<String, V>> typeReference) {
-            return (StorageBackend<String, V>) stores.computeIfAbsent(fileName, ignored -> new InMemoryStorage<>());
+            return (AccountAwareStorageBackend<V>) stores.computeIfAbsent(fileName, ignored -> AccountAwareStorageBackend.inMemory("000000000000"));
         }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/verification/VerificationCodeServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/verification/VerificationCodeServiceTest.java
@@ -1,6 +1,6 @@
 package io.github.hectorvent.floci.services.cognito.verification;
 
-import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,7 +30,7 @@ class VerificationCodeServiceTest {
     void setUp() {
         clock = new MutableClock(Instant.parse("2026-05-15T12:00:00Z"));
         StorageFactory storageFactory = mock(StorageFactory.class);
-        when(storageFactory.create(anyString(), anyString(), any())).thenAnswer(inv -> new InMemoryStorage<>());
+        when(storageFactory.create(anyString(), anyString(), any())).thenAnswer(inv -> AccountAwareStorageBackend.inMemory("000000000000"));
         service = new VerificationCodeService(storageFactory, clock);
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/configservice/AwsConfigServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/configservice/AwsConfigServicePersistenceTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.configservice.model.ConfigRule;
 import io.github.hectorvent.floci.services.configservice.model.ConfigRuleSource;
@@ -93,10 +94,10 @@ class AwsConfigServicePersistenceTest {
 
         @Override
         @SuppressWarnings("unchecked")
-        public <V> StorageBackend<String, V> create(String serviceName,
+        public <V> AccountAwareStorageBackend<V> create(String serviceName,
                                                     String fileName,
                                                     TypeReference<Map<String, V>> typeReference) {
-            return (StorageBackend<String, V>) stores.computeIfAbsent(fileName, ignored -> new InMemoryStorage<>());
+            return (AccountAwareStorageBackend<V>) stores.computeIfAbsent(fileName, ignored -> AccountAwareStorageBackend.inMemory("000000000000"));
         }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbServiceTest.java
@@ -2,7 +2,7 @@ package io.github.hectorvent.floci.services.docdb;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.RegionResolver;
-import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.docdb.container.DocDbContainerManager;
 import io.github.hectorvent.floci.services.docdb.model.DocDbCluster;
@@ -29,7 +29,7 @@ class DocDbServiceTest {
     void setUp() {
         StorageFactory storageFactory = Mockito.mock(StorageFactory.class);
         when(storageFactory.create(anyString(), anyString(), any()))
-                .thenAnswer(invocation -> new InMemoryStorage<>());
+                .thenAnswer(inv -> AccountAwareStorageBackend.inMemory("000000000000"));
 
         EmulatorConfig config = Mockito.mock(EmulatorConfig.class);
         var servicesConfig = Mockito.mock(EmulatorConfig.ServicesConfig.class);

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceConcurrencyTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceConcurrencyTest.java
@@ -5,6 +5,7 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ec2.portforward.Ec2PortForwardManager;
 import io.github.hectorvent.floci.services.ec2.model.IpPermission;
@@ -259,9 +260,9 @@ class Ec2ServiceConcurrencyTest {
         }
 
         @Override
-        public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+        public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
                                                     TypeReference<Map<String, V>> typeReference) {
-            return new InMemoryStorage<>();
+            return AccountAwareStorageBackend.inMemory("000000000000");
         }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -3,8 +3,7 @@ package io.github.hectorvent.floci.services.ec2;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
-import io.github.hectorvent.floci.core.storage.InMemoryStorage;
-import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ec2.portforward.Ec2PortForwardManager;
 import io.github.hectorvent.floci.services.ec2.model.BlockDeviceMapping;
@@ -396,7 +395,7 @@ class Ec2ServiceTest {
 
     @Test
     void describeSnapshotsDefaultsToOwnedSnapshots() {
-        InMemoryStorage<String, Snapshot> snapshotStore = new InMemoryStorage<>();
+        AccountAwareStorageBackend<Snapshot> snapshotStore = AccountAwareStorageBackend.inMemory("000000000000");
         Snapshot foreign = new Snapshot();
         foreign.setSnapshotId("snap-foreign");
         foreign.setOwnerId("111111111111");
@@ -834,26 +833,26 @@ class Ec2ServiceTest {
     }
 
     private static final class InMemoryStorageFactory extends StorageFactory {
-        private final Map<String, StorageBackend<String, ?>> overrides;
+        private final Map<String, AccountAwareStorageBackend<?>> overrides;
 
         private InMemoryStorageFactory() {
             this(Map.of());
         }
 
-        private InMemoryStorageFactory(Map<String, StorageBackend<String, ?>> overrides) {
+        private InMemoryStorageFactory(Map<String, AccountAwareStorageBackend<?>> overrides) {
             super(null, null);
             this.overrides = overrides;
         }
 
         @Override
         @SuppressWarnings("unchecked")
-        public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+        public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
                                                     TypeReference<Map<String, V>> typeReference) {
-            StorageBackend<String, ?> override = overrides.get(fileName);
+            AccountAwareStorageBackend<?> override = overrides.get(fileName);
             if (override != null) {
-                return (StorageBackend<String, V>) override;
+                return (AccountAwareStorageBackend<V>) override;
             }
-            return new InMemoryStorage<>();
+            return AccountAwareStorageBackend.inMemory("000000000000");
         }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/EcsServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/EcsServicePersistenceTest.java
@@ -5,6 +5,7 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ecs.container.EcsContainerManager;
 import io.github.hectorvent.floci.services.ecs.model.Attribute;
@@ -127,10 +128,10 @@ class EcsServicePersistenceTest {
 
         @Override
         @SuppressWarnings("unchecked")
-        public <V> StorageBackend<String, V> create(String serviceName,
+        public <V> AccountAwareStorageBackend<V> create(String serviceName,
                                                     String fileName,
                                                     TypeReference<Map<String, V>> typeReference) {
-            return (StorageBackend<String, V>) stores.computeIfAbsent(fileName, ignored -> new InMemoryStorage<>());
+            return (AccountAwareStorageBackend<V>) stores.computeIfAbsent(fileName, ignored -> AccountAwareStorageBackend.inMemory("000000000000"));
         }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/EcsServiceTeardownTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/EcsServiceTeardownTest.java
@@ -5,6 +5,7 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ecs.container.EcsContainerManager;
 import io.github.hectorvent.floci.services.ecs.container.EcsTaskHandle;
@@ -127,10 +128,10 @@ class EcsServiceTeardownTest {
 
         @Override
         @SuppressWarnings("unchecked")
-        public <V> StorageBackend<String, V> create(String serviceName,
+        public <V> AccountAwareStorageBackend<V> create(String serviceName,
                                                     String fileName,
                                                     TypeReference<Map<String, V>> typeReference) {
-            return (StorageBackend<String, V>) stores.computeIfAbsent(fileName, ignored -> new InMemoryStorage<>());
+            return (AccountAwareStorageBackend<V>) stores.computeIfAbsent(fileName, ignored -> AccountAwareStorageBackend.inMemory("000000000000"));
         }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/eks/EksOidcServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eks/EksOidcServiceTest.java
@@ -32,9 +32,9 @@ class EksOidcServiceTest {
     void setUp() {
         oidcService = new EksOidcService(new StorageFactory(null, null) {
             @Override
-            public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+            public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
                     TypeReference<Map<String, V>> typeReference) {
-                return new InMemoryStorage<>();
+                return AccountAwareStorageBackend.inMemory("000000000000");
             }
         }, new ObjectMapper());
     }
@@ -83,9 +83,9 @@ class EksOidcServiceTest {
         EksOidcService service = new EksOidcService(new StorageFactory(null, null) {
             @Override
             @SuppressWarnings("unchecked")
-            public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+            public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
                     TypeReference<Map<String, V>> typeReference) {
-                return (StorageBackend<String, V>) accountAware;
+                return (AccountAwareStorageBackend<V>) accountAware;
             }
         }, new ObjectMapper());
 

--- a/src/test/java/io/github/hectorvent/floci/services/eks/EksServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eks/EksServiceTest.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ec2.AmiImageResolver;
 import io.github.hectorvent.floci.services.ec2.Ec2ContainerManager;
@@ -51,9 +52,9 @@ class EksServiceTest {
     void setUp() {
         StorageFactory storageFactory = new StorageFactory(null, null) {
             @Override
-            public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+            public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
                     TypeReference<Map<String, V>> typeReference) {
-                return new InMemoryStorage<>();
+                return AccountAwareStorageBackend.inMemory("000000000000");
             }
         };
 
@@ -131,9 +132,9 @@ class EksServiceTest {
 
         StorageFactory storageFactory = new StorageFactory(null, null) {
             @Override
-            public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+            public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
                     TypeReference<Map<String, V>> typeReference) {
-                return new InMemoryStorage<>();
+                return AccountAwareStorageBackend.inMemory("000000000000");
             }
         };
 
@@ -287,9 +288,13 @@ class EksServiceTest {
     private StorageFactory fixedStorageFactory(StorageBackend<String, ?> backend) {
         return new StorageFactory(null, null) {
             @Override
-            public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+            public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
                     TypeReference<Map<String, V>> typeReference) {
-                return (StorageBackend<String, V>) backend;
+                if (backend instanceof AccountAwareStorageBackend<?> aware) {
+                    return (AccountAwareStorageBackend<V>) aware;
+                }
+                return new AccountAwareStorageBackend<>(
+                        (StorageBackend<String, V>) backend, null, "000000000000");
             }
         };
     }
@@ -309,9 +314,9 @@ class EksServiceTest {
     void createClusterWithNonExistentSubnetFails() {
         StorageFactory storageFactory = new StorageFactory(null, null) {
             @Override
-            public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+            public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
                     TypeReference<Map<String, V>> typeReference) {
-                return new InMemoryStorage<>();
+                return AccountAwareStorageBackend.inMemory("000000000000");
             }
         };
         RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
@@ -336,9 +341,9 @@ class EksServiceTest {
     void createClusterWithExistingSubnetSucceeds() {
         StorageFactory storageFactory = new StorageFactory(null, null) {
             @Override
-            public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+            public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
                     TypeReference<Map<String, V>> typeReference) {
-                return new InMemoryStorage<>();
+                return AccountAwareStorageBackend.inMemory("000000000000");
             }
         };
         RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
@@ -369,9 +374,9 @@ class EksServiceTest {
         // resolved Subnet, which carries the vpcId; it was simply discarded.
         StorageFactory storageFactory = new StorageFactory(null, null) {
             @Override
-            public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+            public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
                     TypeReference<Map<String, V>> typeReference) {
-                return new InMemoryStorage<>();
+                return AccountAwareStorageBackend.inMemory("000000000000");
             }
         };
         RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
@@ -398,9 +403,9 @@ class EksServiceTest {
         // the validation half.
         StorageFactory storageFactory = new StorageFactory(null, null) {
             @Override
-            public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+            public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
                     TypeReference<Map<String, V>> typeReference) {
-                return new InMemoryStorage<>();
+                return AccountAwareStorageBackend.inMemory("000000000000");
             }
         };
         RegionResolver regionResolver = new RegionResolver("eu-west-2", "000000000000");
@@ -437,9 +442,9 @@ class EksServiceTest {
         // behaviour.
         StorageFactory storageFactory = new StorageFactory(null, null) {
             @Override
-            public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+            public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
                     TypeReference<Map<String, V>> typeReference) {
-                return new InMemoryStorage<>();
+                return AccountAwareStorageBackend.inMemory("000000000000");
             }
         };
         Ec2Service ec2Service = realEc2Service();

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheMemcachedServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheMemcachedServiceTest.java
@@ -2,7 +2,7 @@ package io.github.hectorvent.floci.services.elasticache;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
-import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheContainerHandle;
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheMemcachedContainerManager;
@@ -38,7 +38,7 @@ class ElastiCacheMemcachedServiceTest {
         when(ecConfig.defaultMemcachedImage()).thenReturn("memcached:1.6");
         when(config.hostname()).thenReturn(Optional.of("localhost"));
 
-        when(storageFactory.create(anyString(), anyString(), any())).thenAnswer(inv -> new InMemoryStorage<>());
+        when(storageFactory.create(anyString(), anyString(), any())).thenAnswer(inv -> AccountAwareStorageBackend.inMemory("000000000000"));
         when(containerManager.start(anyString(), anyString()))
                 .thenReturn(new ElastiCacheContainerHandle("cid", "cluster", "localhost", 11211));
 
@@ -110,7 +110,7 @@ class ElastiCacheMemcachedServiceTest {
         when(ecConfig.defaultMemcachedImage()).thenReturn("memcached:1.6");
         when(config.hostname()).thenReturn(Optional.empty());
 
-        when(storageFactory.create(anyString(), anyString(), any())).thenAnswer(inv -> new InMemoryStorage<>());
+        when(storageFactory.create(anyString(), anyString(), any())).thenAnswer(inv -> AccountAwareStorageBackend.inMemory("000000000000"));
         when(containerManager.start(anyString(), anyString()))
                 .thenReturn(new ElastiCacheContainerHandle("cid", "cluster", "172.20.0.10", 11211));
 

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
@@ -2,7 +2,7 @@ package io.github.hectorvent.floci.services.elasticache;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
-import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheContainerHandle;
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheContainerManager;
@@ -53,7 +53,7 @@ class ElastiCacheServiceTest {
         when(ecConfig.defaultImage()).thenReturn("valkey/valkey:8");
         when(config.hostname()).thenReturn(java.util.Optional.of("localhost"));
 
-        when(storageFactory.create(anyString(), anyString(), any())).thenAnswer(inv -> new InMemoryStorage<>());
+        when(storageFactory.create(anyString(), anyString(), any())).thenAnswer(inv -> AccountAwareStorageBackend.inMemory("000000000000"));
         when(containerManager.start(anyString(), anyString()))
                 .thenReturn(new ElastiCacheContainerHandle("cid", "grp", "localhost", 6379));
         doNothing().when(proxyManager).startProxy(anyString(), any(), anyInt(), anyString(), anyInt(), any());

--- a/src/test/java/io/github/hectorvent/floci/services/elasticbeanstalk/ElasticBeanstalkServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticbeanstalk/ElasticBeanstalkServicePersistenceTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.elasticbeanstalk.model.BeanstalkApplication;
 import io.github.hectorvent.floci.services.elasticbeanstalk.model.BeanstalkApplicationVersion;
@@ -118,10 +119,10 @@ class ElasticBeanstalkServicePersistenceTest {
 
         @Override
         @SuppressWarnings("unchecked")
-        public <V> StorageBackend<String, V> create(String serviceName,
+        public <V> AccountAwareStorageBackend<V> create(String serviceName,
                                                     String fileName,
                                                     TypeReference<Map<String, V>> typeReference) {
-            return (StorageBackend<String, V>) stores.computeIfAbsent(fileName, ignored -> new InMemoryStorage<>());
+            return (AccountAwareStorageBackend<V>) stores.computeIfAbsent(fileName, ignored -> AccountAwareStorageBackend.inMemory("000000000000"));
         }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2ServiceTest.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.ec2.model.Subnet;
@@ -334,10 +335,10 @@ class ElbV2ServiceTest {
 
         @Override
         @SuppressWarnings("unchecked")
-        public <V> StorageBackend<String, V> create(String serviceName,
+        public <V> AccountAwareStorageBackend<V> create(String serviceName,
                                                      String fileName,
                                                      TypeReference<Map<String, V>> typeReference) {
-            return (StorageBackend<String, V>) stores.computeIfAbsent(fileName, ignored -> new InMemoryStorage<>());
+            return (AccountAwareStorageBackend<V>) stores.computeIfAbsent(fileName, ignored -> AccountAwareStorageBackend.inMemory("000000000000"));
         }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/firehose/FirehoseServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/firehose/FirehoseServiceTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.firehose;
 
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.firehose.model.DeliveryStreamDescription;
 import io.github.hectorvent.floci.services.firehose.model.DeliveryStreamDescription.S3Destination;
@@ -34,7 +35,7 @@ class FirehoseServiceTest {
     void setUp() {
         StorageFactory storageFactory = Mockito.mock(StorageFactory.class);
         when(storageFactory.create(anyString(), anyString(), any()))
-                .thenReturn(new InMemoryStorage<>());
+                .thenReturn(AccountAwareStorageBackend.inMemory("000000000000"));
         s3Service = Mockito.mock(S3Service.class);
         firehoseService = new FirehoseService(storageFactory, s3Service,
                 new RegionResolver("us-east-1", "000000000000"), new MutableClock());

--- a/src/test/java/io/github/hectorvent/floci/services/glue/GlueJsonHandlerEmptyListTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/GlueJsonHandlerEmptyListTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.glue.schemaregistry.GlueSchemaRegistryService;
 import io.github.hectorvent.floci.services.resourcegroupstagging.ResourceGroupsTaggingService;
@@ -83,10 +84,10 @@ class GlueJsonHandlerEmptyListTest {
         }
 
         @Override
-        public <V> StorageBackend<String, V> create(String serviceName,
+        public <V> AccountAwareStorageBackend<V> create(String serviceName,
                                                      String fileName,
                                                      TypeReference<Map<String, V>> typeReference) {
-            return new InMemoryStorage<>();
+            return AccountAwareStorageBackend.inMemory("000000000000");
         }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
@@ -5,6 +5,7 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.glue.model.Column;
 import io.github.hectorvent.floci.services.glue.model.Database;
@@ -1032,10 +1033,10 @@ class GlueServiceTest {
         }
 
         @Override
-        public <V> StorageBackend<String, V> create(String serviceName,
+        public <V> AccountAwareStorageBackend<V> create(String serviceName,
                                                      String fileName,
                                                      TypeReference<Map<String, V>> typeReference) {
-            return new InMemoryStorage<>();
+            return AccountAwareStorageBackend.inMemory("000000000000");
         }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/kinesisanalytics/KinesisAnalyticsV2JsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesisanalytics/KinesisAnalyticsV2JsonHandlerTest.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.kinesisanalytics.container.FlinkContainerManager;
 import jakarta.ws.rs.core.Response;
@@ -413,7 +414,7 @@ class KinesisAnalyticsV2JsonHandlerTest {
     private KinesisAnalyticsV2Service mockModeService() {
         StorageFactory storageFactory = Mockito.mock(StorageFactory.class);
         when(storageFactory.create(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
-                .thenReturn(new InMemoryStorage<>());
+                .thenReturn(AccountAwareStorageBackend.inMemory("000000000000"));
 
         EmulatorConfig config = Mockito.mock(EmulatorConfig.class);
         var servicesConfig = Mockito.mock(EmulatorConfig.ServicesConfig.class);

--- a/src/test/java/io/github/hectorvent/floci/services/kinesisanalytics/KinesisAnalyticsV2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesisanalytics/KinesisAnalyticsV2ServiceTest.java
@@ -3,7 +3,7 @@ package io.github.hectorvent.floci.services.kinesisanalytics;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
-import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.kinesisanalytics.container.FlinkContainerManager;
 import io.github.hectorvent.floci.services.kinesisanalytics.model.ApplicationStatus;
@@ -552,9 +552,10 @@ class KinesisAnalyticsV2ServiceTest {
         // intermediate state must still be persisted — not just the final RUNNING transition — since
         // pendingJars (a separate in-process-only cache) is already cleared by then; an emulator
         // restart before the next persist would otherwise leave the application permanently stuck.
-        InMemoryStorage<String, FlinkApplication> backing = Mockito.spy(new InMemoryStorage<>());
+        AccountAwareStorageBackend<FlinkApplication> store =
+                Mockito.spy(AccountAwareStorageBackend.inMemory("000000000000"));
         StorageFactory storageFactory = Mockito.mock(StorageFactory.class);
-        Mockito.doReturn(backing).when(storageFactory)
+        Mockito.doReturn(store).when(storageFactory)
                 .create(Mockito.anyString(), Mockito.anyString(), Mockito.any());
 
         EmulatorConfig config = Mockito.mock(EmulatorConfig.class);
@@ -580,7 +581,7 @@ class KinesisAnalyticsV2ServiceTest {
         realMode.createApplication("demo", "FLINK-1_18", ROLE, null, null, "bucket", "app.jar", null, 1);
         FlinkApplication app = realMode.describeApplication("demo");
         app.setApplicationStatus(ApplicationStatus.STARTING);
-        Mockito.clearInvocations(backing); // ignore createApplication's own put()
+        Mockito.clearInvocations(store); // ignore createApplication's own put()
 
         try {
             // @PostConstruct isn't wired by a plain `new` in this unit test; start the poller manually.
@@ -588,7 +589,8 @@ class KinesisAnalyticsV2ServiceTest {
             // The poller's first tick fires ~1s after scheduling; give it margin.
             Thread.sleep(1500);
 
-            Mockito.verify(backing, Mockito.atLeastOnce()).put(Mockito.eq("demo"), Mockito.any());
+            Mockito.verify(store, Mockito.atLeastOnce())
+                    .putForAccount(Mockito.eq("000000000000"), Mockito.eq("demo"), Mockito.any());
             assertEquals("job-1", realMode.describeApplication("demo").getFlinkJobId());
         } finally {
             realMode.shutdown();
@@ -609,7 +611,7 @@ class KinesisAnalyticsV2ServiceTest {
     private KinesisAnalyticsV2Service buildService(boolean mock, FlinkContainerManager manager) {
         StorageFactory storageFactory = Mockito.mock(StorageFactory.class);
         when(storageFactory.create(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
-                .thenReturn(new InMemoryStorage<>());
+                .thenReturn(AccountAwareStorageBackend.inMemory("000000000000"));
 
         EmulatorConfig config = Mockito.mock(EmulatorConfig.class);
         var servicesConfig = Mockito.mock(EmulatorConfig.ServicesConfig.class);

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServicePersistenceTest.java
@@ -109,13 +109,13 @@ class LambdaServicePersistenceTest {
 
         @Override
         @SuppressWarnings("unchecked")
-        public <V> StorageBackend<String, V> create(String serviceName,
+        public <V> AccountAwareStorageBackend<V> create(String serviceName,
                                                     String fileName,
                                                     TypeReference<Map<String, V>> typeReference) {
             // Wrap like the production factory does so the tests exercise the
             // account-prefixed key space, not a bare backend.
-            return (StorageBackend<String, V>) stores.computeIfAbsent(fileName,
-                    ignored -> new AccountAwareStorageBackend<V>(new InMemoryStorage<>(), null, ACCOUNT_ID));
+            return (AccountAwareStorageBackend<V>) stores.computeIfAbsent(fileName,
+                    ignored -> AccountAwareStorageBackend.inMemory(ACCOUNT_ID));
         }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambdamicrovms/LambdaMicrovmsServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambdamicrovms/LambdaMicrovmsServicePersistenceTest.java
@@ -165,12 +165,12 @@ class LambdaMicrovmsServicePersistenceTest {
 
         @Override
         @SuppressWarnings("unchecked")
-        public <V> StorageBackend<String, V> create(String serviceName,
+        public <V> AccountAwareStorageBackend<V> create(String serviceName,
                                                     String fileName,
                                                     TypeReference<Map<String, V>> typeReference) {
             // Wrap like the production factory does so the tests exercise the
             // account-prefixed key space, not a bare backend.
-            return (StorageBackend<String, V>) stores.computeIfAbsent(fileName, ignored -> {
+            return (AccountAwareStorageBackend<V>) stores.computeIfAbsent(fileName, ignored -> {
                 PersistentStorage<String, V> inner =
                         new PersistentStorage<>(directory.resolve(fileName), typeReference);
                 inner.load();

--- a/src/test/java/io/github/hectorvent/floci/services/memorydb/MemoryDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/memorydb/MemoryDbServiceTest.java
@@ -4,7 +4,7 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
-import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.elasticache.proxy.SigV4Validator;
 import io.github.hectorvent.floci.services.memorydb.container.MemoryDbContainerHandle;
@@ -71,7 +71,7 @@ class MemoryDbServiceTest {
                 AwsArnUtils.Arn.of(inv.getArgument(0), inv.getArgument(1),
                         "000000000000", inv.getArgument(2)).toString());
 
-        when(storageFactory.create(anyString(), anyString(), any())).thenAnswer(inv -> new InMemoryStorage<>());
+        when(storageFactory.create(anyString(), anyString(), any())).thenAnswer(inv -> AccountAwareStorageBackend.inMemory("000000000000"));
         when(containerManager.start(anyString(), anyString()))
                 .thenReturn(new MemoryDbContainerHandle("cid", "cluster", "localhost", 6379));
         doNothing().when(proxyManager).startProxy(anyString(), anyBoolean(), anyInt(), anyString(), anyInt(), any());

--- a/src/test/java/io/github/hectorvent/floci/services/msk/MskServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/msk/MskServiceTest.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.msk;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.msk.model.ClusterState;
 import io.github.hectorvent.floci.services.msk.model.MskCluster;
@@ -26,7 +27,7 @@ class MskServiceTest {
     void setUp() {
         storageFactory = Mockito.mock(StorageFactory.class);
         when(storageFactory.create(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
-                .thenReturn(new InMemoryStorage<>());
+                .thenReturn(AccountAwareStorageBackend.inMemory("000000000000"));
 
         config = Mockito.mock(EmulatorConfig.class);
         var servicesConfig = Mockito.mock(EmulatorConfig.ServicesConfig.class);

--- a/src/test/java/io/github/hectorvent/floci/services/mwaa/MwaaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/mwaa/MwaaServiceTest.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.docker.PortAllocator;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.mwaa.model.CreateEnvironmentRequest;
 import io.github.hectorvent.floci.services.mwaa.model.Environment;
@@ -45,9 +46,9 @@ class MwaaServiceTest {
     void setUp() {
         StorageFactory storageFactory = new StorageFactory(null, null) {
             @Override
-            public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+            public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
                     TypeReference<Map<String, V>> typeReference) {
-                return new InMemoryStorage<>();
+                return AccountAwareStorageBackend.inMemory("000000000000");
             }
         };
 
@@ -329,9 +330,9 @@ class MwaaServiceTest {
         void setUpRealMode() {
             StorageFactory storageFactory = new StorageFactory(null, null) {
                 @Override
-                public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+                public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
                         TypeReference<Map<String, V>> typeReference) {
-                    return new InMemoryStorage<>();
+                    return AccountAwareStorageBackend.inMemory("000000000000");
                 }
             };
 

--- a/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneServiceTest.java
@@ -3,7 +3,7 @@ package io.github.hectorvent.floci.services.neptune;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
-import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.neptune.container.NeptuneContainerHandle;
 import io.github.hectorvent.floci.services.neptune.container.NeptuneContainerManager;
@@ -57,7 +57,7 @@ class NeptuneServiceTest {
         when(config.hostname()).thenReturn(Optional.of("localhost"));
 
         when(storageFactory.create(anyString(), anyString(), any()))
-                .thenAnswer(inv -> new InMemoryStorage<>());
+                .thenAnswer(inv -> AccountAwareStorageBackend.inMemory("000000000000"));
         when(containerManager.start(anyString(), anyString(), any(NeptuneDbType.class)))
                 .thenReturn(new NeptuneContainerHandle("cid", "c", "localhost", 8182));
         doNothing().when(proxyManager).startProxy(anyString(), anyInt(), anyString(), anyInt());

--- a/src/test/java/io/github/hectorvent/floci/services/pipes/PipesServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/pipes/PipesServiceTest.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.pipes;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.pipes.model.DesiredState;
 import io.github.hectorvent.floci.services.pipes.model.Pipe;
@@ -26,7 +27,7 @@ class PipesServiceTest {
     void setUp() {
         StorageFactory storageFactory = Mockito.mock(StorageFactory.class);
         when(storageFactory.create(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
-                .thenReturn(new InMemoryStorage<>());
+                .thenReturn(AccountAwareStorageBackend.inMemory("000000000000"));
 
         RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
 

--- a/src/test/java/io/github/hectorvent/floci/services/resourcegroupstagging/ResourceGroupsTaggingServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/resourcegroupstagging/ResourceGroupsTaggingServicePersistenceTest.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.resourcegroupstagging;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.resourcegroupstagging.model.ResourceTagMapping;
 import org.junit.jupiter.api.Test;
@@ -80,10 +81,10 @@ class ResourceGroupsTaggingServicePersistenceTest {
 
         @Override
         @SuppressWarnings("unchecked")
-        public <V> StorageBackend<String, V> create(String serviceName,
+        public <V> AccountAwareStorageBackend<V> create(String serviceName,
                                                     String fileName,
                                                     TypeReference<Map<String, V>> typeReference) {
-            return (StorageBackend<String, V>) stores.computeIfAbsent(fileName, ignored -> new InMemoryStorage<>());
+            return (AccountAwareStorageBackend<V>) stores.computeIfAbsent(fileName, ignored -> AccountAwareStorageBackend.inMemory("000000000000"));
         }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ssm/SsmCommandServiceDirectExecutionTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssm/SsmCommandServiceDirectExecutionTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ssm.model.Command;
 import io.github.hectorvent.floci.services.ssm.model.CommandInvocation;
@@ -390,9 +391,9 @@ class SsmCommandServiceDirectExecutionTest {
         }
 
         @Override
-        public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+        public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
                                                     TypeReference<Map<String, V>> typeReference) {
-            return new InMemoryStorage<>();
+            return AccountAwareStorageBackend.inMemory("000000000000");
         }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/transcribe/TranscribeServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/transcribe/TranscribeServicePersistenceTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.transcribe.model.VocabularyInfo;
 import org.junit.jupiter.api.Test;
@@ -65,10 +66,10 @@ class TranscribeServicePersistenceTest {
 
         @Override
         @SuppressWarnings("unchecked")
-        public <V> StorageBackend<String, V> create(String serviceName,
+        public <V> AccountAwareStorageBackend<V> create(String serviceName,
                                                     String fileName,
                                                     TypeReference<Map<String, V>> typeReference) {
-            return (StorageBackend<String, V>) stores.computeIfAbsent(fileName, ignored -> new InMemoryStorage<>());
+            return (AccountAwareStorageBackend<V>) stores.computeIfAbsent(fileName, ignored -> AccountAwareStorageBackend.inMemory("000000000000"));
         }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/testing/RestAssuredJsonUtils.java
+++ b/src/test/java/io/github/hectorvent/floci/testing/RestAssuredJsonUtils.java
@@ -39,7 +39,8 @@ public class RestAssuredJsonUtils {
         RestAssured.config = RestAssured.config().encoderConfig(
                 EncoderConfig.encoderConfig()
                         .encodeContentTypeAs(CONTENT_TYPE_AWS_JSON_1_0, ContentType.JSON)
-                        .encodeContentTypeAs(CONTENT_TYPE_AWS_JSON_1_1, ContentType.JSON));
+                        .encodeContentTypeAs(CONTENT_TYPE_AWS_JSON_1_1, ContentType.JSON)
+                        .encodeContentTypeAs("application/graphql", ContentType.JSON));
 
         if (!RestAssured.filters().contains(AWS_CONTENT_TYPE_FILTER)) {
             RestAssured.filters(AWS_CONTENT_TYPE_FILTER);


### PR DESCRIPTION
## Summary

Implements Phase 6 of the AppSync implementation plan in #1173.

Adds the GraphQL data-plane HTTP endpoint `POST /v1/apis/{apiId}/graphql` with AppSync-compatible wire behavior (error mapping, dual Content-Type, schema readiness statuses). Smoke execution works without Phase 8 DataFetchers (nullable fields may return `null`; introspection and validation/syntax paths are covered).

Does **not** close #1173 (multi-phase plan). Auth, resolvers, adapters, guardrails, and realtime remain later phases.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## What is included

**New**
- `AppSyncExecutionController` — `POST /v1/apis/{apiId}/graphql`
- `QueryExecutor` — graphql-java execute + strategies
- `AppSyncErrorFormatter` — top-level `errorType` / `errorInfo`
- `AppSyncTransportException` — GraphQL `errors[]` transport envelope (not management `__type`)

**Modified**
- `SchemaCreationWorker.rehydrateSchemas()` + `EmulatorLifecycle` boot hook
- `docs/services/appsync.md` — execute surface + status matrix
- RestAssured helper for `application/graphql`

## AWS Compatibility

Wire locks validated against AppSync Developer Guide samples and AppSync team HTTP behavior documented in [graphql/graphql-over-http#81](https://github.com/graphql/graphql-over-http/issues/81) (@robzhu):

| Case | HTTP | Notes |
|------|------|-------|
| Syntax / validation / blank `query` | 200 | `SyntaxError` / `ValidationError` |
| Empty / `{}` / `[]` / bad Content-Type | 400 | `MalformedHttpRequestException` |
| Missing `operationName` (multi-ops) | 400 | `BadRequestException` |
| Unknown `apiId` | 404 | `NotFoundException` |
| API exists, no executable schema (incl. PROCESSING) | **502** | `GraphQLSchemaException` + `x-amzn-errortype` (data-plane; management “schema not valid” remains 400) |
| Unexpected failure | 500 | `InternalFailure` |
| HTTP subscription | 200 | `OperationNotSupported` until Phase 11 |

Accepts `application/json` and `application/graphql`.

## Test plan

- [x] `./mvnw test -Dtest=AppSyncErrorFormatterTest,QueryExecutorTest,AppSyncExecutionControllerTest,AppSyncExecutionIntegrationTest,SchemaCreationWorkerRehydrateTest,EmulatorLifecycleTest#shouldRehydrateAppSyncSchemasAfterOrphanRecovery`
- [x] Dual Content-Type smoke (`{ hello }` → null until Phase 8)
- [x] Error matrix (400/404/502/200/500) covered by tests
- [x] Schema rehydrate after boot enables execute
- [ ] Optional: existing management `AppSyncTest` regression (not required for Phase 6 execute scope)

## Checklist

- [x] Focused AppSync execute tests pass locally
- [x] New unit + integration tests added
- [x] Commit messages follow Conventional Commits
- [x] Docs updated for execute endpoint
- [x] No custom non-AWS endpoint shapes