### PR TITLE
fix(eventbridge): boolean/numeric pattern values are matched correctly

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -858,8 +859,7 @@ public class EventBridgeService {
             JsonNode expected = field.getValue();
             JsonNode actualField = actual.get(field.getKey());
             if (expected.isArray()) {
-                String actualStr = actualField != null ? actualField.asText(null) : null;
-                if (!matchesArrayField(expected, actualStr)) {
+                if (!matchesArrayField(expected, actualField)) {
                     return false;
                 }
             } else if (expected.isObject()) {
@@ -883,25 +883,23 @@ public class EventBridgeService {
     }
 
     private boolean matchesArrayField(JsonNode arrayNode, String value) {
+        JsonNode actual = value != null ? TextNode.valueOf(value) : null;
+        return matchesArrayField(arrayNode, actual);
+    }
+
+    private boolean matchesArrayField(JsonNode arrayNode, JsonNode actual) {
         for (JsonNode element : arrayNode) {
-            if (matchesSingleElement(element, value)) {
+            if (matchesSingleElement(element, actual)) {
                 return true;
             }
         }
         return false;
     }
 
-    private boolean matchesSingleElement(JsonNode element, String value) {
-        // Exact string match
-        if (element.isTextual()) {
-            return value != null && value.equals(element.asText());
-        }
-        // Null literal match
-        if (element.isNull()) {
-            return value == null;
-        }
+    private boolean matchesSingleElement(JsonNode element, JsonNode actual) {
         // Content filter object
         if (element.isObject()) {
+            String value = actual != null && actual.isTextual() ? actual.asText() : null;
             if (element.has("prefix")) {
                 return value != null && value.startsWith(element.get("prefix").asText());
             }
@@ -915,9 +913,9 @@ public class EventBridgeService {
                 JsonNode anythingBut = element.get("anything-but");
                 if (anythingBut.isArray()) {
                     for (JsonNode v : anythingBut) {
-                        if (v.isTextual() && v.asText().equals(value)) return false;
+                        if (matchesExactValue(v, actual)) return false;
                     }
-                    return value != null;
+                    return actual != null && !actual.isNull();
                 }
                 if (anythingBut.isObject() && anythingBut.has("prefix")) {
                     return value != null && !value.startsWith(anythingBut.get("prefix").asText());
@@ -925,8 +923,32 @@ public class EventBridgeService {
             }
             if (element.has("exists")) {
                 boolean shouldExist = element.get("exists").asBoolean();
-                return shouldExist ? (value != null) : (value == null);
+                boolean present = actual != null && !actual.isNull();
+                return shouldExist == present;
             }
+            return false;
+        }
+        // Exact literal match (string, null, boolean, number)
+        return matchesExactValue(element, actual);
+    }
+
+    private boolean matchesExactValue(JsonNode expected, JsonNode actual) {
+        if (expected.isNull()) {
+            return actual == null || actual.isNull();
+        }
+        if (actual == null) {
+            return false;
+        }
+        if (expected.isTextual()) {
+            return actual.isTextual() && expected.asText().equals(actual.asText());
+        }
+        if (expected.isBoolean()) {
+            return actual.isBoolean() && expected.booleanValue() == actual.booleanValue();
+        }
+        if (expected.isNumber()) {
+            // AWS exact numeric matching compares string representations:
+            // 300, 300.0 and 3.0e2 are NOT considered equal.
+            return actual.isNumber() && expected.asText().equals(actual.asText());
         }
         return false;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -913,7 +913,9 @@ public class EventBridgeService {
                 JsonNode anythingBut = element.get("anything-but");
                 if (anythingBut.isArray()) {
                     for (JsonNode v : anythingBut) {
-                        if (matchesExactValue(v, actual)) return false;
+                        if (matchesExactValue(v, actual)) {
+                            return false;
+                        }
                     }
                     return actual != null && !actual.isNull();
                 }
@@ -946,9 +948,9 @@ public class EventBridgeService {
             return actual.isBoolean() && expected.booleanValue() == actual.booleanValue();
         }
         if (expected.isNumber()) {
-            // AWS exact numeric matching compares string representations:
-            // 300, 300.0 and 3.0e2 are NOT considered equal.
-            return actual.isNumber() && expected.asText().equals(actual.asText());
+            // AWS normalizes numbers before comparing: 300, 300.0 and 3.0e2
+            // are all considered equal.
+            return actual.isNumber() && expected.decimalValue().compareTo(actual.decimalValue()) == 0;
         }
         return false;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -925,7 +925,7 @@ public class EventBridgeService {
             }
             if (element.has("exists")) {
                 boolean shouldExist = element.get("exists").asBoolean();
-                boolean present = actual != null && !actual.isNull();
+                boolean present = actual != null;
                 return shouldExist == present;
             }
             return false;
@@ -936,7 +936,7 @@ public class EventBridgeService {
 
     private boolean matchesExactValue(JsonNode expected, JsonNode actual) {
         if (expected.isNull()) {
-            return actual == null || actual.isNull();
+            return actual != null && actual.isNull();
         }
         if (actual == null) {
             return false;

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -911,6 +911,9 @@ public class EventBridgeService {
             }
             if (element.has("anything-but")) {
                 JsonNode anythingBut = element.get("anything-but");
+                if (anythingBut.isValueNode()) {
+                    return actual != null && !actual.isNull() && !matchesExactValue(anythingBut, actual);
+                }
                 if (anythingBut.isArray()) {
                     for (JsonNode v : anythingBut) {
                         if (matchesExactValue(v, actual)) {

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeTestEventPatternIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeTestEventPatternIntegrationTest.java
@@ -275,6 +275,115 @@ class EventBridgeTestEventPatternIntegrationTest {
     }
 
     @Test
+    void detailNullLiteralMatchesNullValue() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"field\\":[null]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"field\\":null}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(true));
+    }
+
+    @Test
+    void detailNullLiteralDoesNotMatchMissingField() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"field\\":[null]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"other\\":1}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(false));
+    }
+
+    @Test
+    void detailExistsTrueMatchesNullValue() {
+        // A key carrying the JSON literal null still exists in AWS.
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"field\\":[{\\"exists\\":true}]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"field\\":null}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(true));
+    }
+
+    @Test
+    void detailExistsFalseDoesNotMatchNullValue() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"field\\":[{\\"exists\\":false}]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"field\\":null}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(false));
+    }
+
+    @Test
+    void detailExistsFalseMatchesMissingField() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"field\\":[{\\"exists\\":false}]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"other\\":1}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(true));
+    }
+
+    @Test
+    void detailExistsTrueDoesNotMatchMissingField() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"field\\":[{\\"exists\\":true}]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"other\\":1}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(false));
+    }
+
+    @Test
     void detailAnythingButNumberValue() {
         given()
             .contentType(EVENT_BRIDGE_CONTENT_TYPE)

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeTestEventPatternIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeTestEventPatternIntegrationTest.java
@@ -220,9 +220,8 @@ class EventBridgeTestEventPatternIntegrationTest {
     }
 
     @Test
-    void detailNumberMatchIsByStringRepresentation() {
-        // AWS exact numeric matching compares string representations:
-        // 300 and 300.0 are NOT considered equal.
+    void detailNumberMatchIsByNumericValue() {
+        // AWS normalizes numbers before comparing: 300 and 300.0 are equal.
         given()
             .contentType(EVENT_BRIDGE_CONTENT_TYPE)
             .header("X-Amz-Target", TARGET)
@@ -236,7 +235,25 @@ class EventBridgeTestEventPatternIntegrationTest {
             .post("/")
         .then()
             .statusCode(200)
-            .body("Result", equalTo(false));
+            .body("Result", equalTo(true));
+    }
+
+    @Test
+    void detailNumberScientificNotationMatchesDecimal() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"count\\":[3.0e2]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"count\\":300.0}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(true));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeTestEventPatternIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeTestEventPatternIntegrationTest.java
@@ -92,6 +92,208 @@ class EventBridgeTestEventPatternIntegrationTest {
     }
 
     @Test
+    void detailBooleanLiteralMatch() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"enabled\\":[true]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"enabled\\":true}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(true));
+    }
+
+    @Test
+    void detailBooleanLiteralNoMatchOnDifferentValue() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"enabled\\":[true]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"enabled\\":false}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(false));
+    }
+
+    @Test
+    void detailStringPatternDoesNotMatchBooleanValue() {
+        // Pattern ["true"] must not match the JSON boolean true (type-strict, as in AWS)
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"enabled\\":[\\"true\\"]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"enabled\\":true}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(false));
+    }
+
+    @Test
+    void detailBooleanPatternDoesNotMatchStringValue() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"enabled\\":[true]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"enabled\\":\\"true\\"}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(false));
+    }
+
+    @Test
+    void detailNumberLiteralMatch() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"count\\":[5]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"count\\":5}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(true));
+    }
+
+    @Test
+    void detailStringPatternDoesNotMatchNumberValue() {
+        // Pattern ["5"] must not match the JSON number 5 (type-strict, as in AWS)
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"count\\":[\\"5\\"]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"count\\":5}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(false));
+    }
+
+    @Test
+    void detailNumberPatternDoesNotMatchStringValue() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"count\\":[5]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"count\\":\\"5\\"}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(false));
+    }
+
+    @Test
+    void detailNumberMatchIsByStringRepresentation() {
+        // AWS exact numeric matching compares string representations:
+        // 300 and 300.0 are NOT considered equal.
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"count\\":[300]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"count\\":300.0}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(false));
+    }
+
+    @Test
+    void detailExistsMatchesBooleanValue() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"enabled\\":[{\\"exists\\":true}]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"enabled\\":false}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(true));
+    }
+
+    @Test
+    void detailAnythingButNumberValue() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"count\\":[{\\"anything-but\\":[3]}]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"count\\":5}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(true));
+    }
+
+    @Test
+    void detailAnythingButNumberValueExcluded() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"count\\":[{\\"anything-but\\":[5]}]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"count\\":5}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(false));
+    }
+
+    @Test
     void prefixFilterMatch() {
         given()
             .contentType(EVENT_BRIDGE_CONTENT_TYPE)

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeTestEventPatternIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeTestEventPatternIntegrationTest.java
@@ -420,6 +420,96 @@ class EventBridgeTestEventPatternIntegrationTest {
     }
 
     @Test
+    void detailAnythingButScalarStringValue() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"state\\":[{\\"anything-but\\":\\"initializing\\"}]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"state\\":\\"running\\"}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(true));
+    }
+
+    @Test
+    void detailAnythingButScalarStringValueExcluded() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"state\\":[{\\"anything-but\\":\\"initializing\\"}]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"state\\":\\"initializing\\"}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(false));
+    }
+
+    @Test
+    void detailAnythingButScalarNumberValue() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"count\\":[{\\"anything-but\\":5}]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"count\\":3}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(true));
+    }
+
+    @Test
+    void detailAnythingButScalarNumberValueExcluded() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"count\\":[{\\"anything-but\\":5}]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"count\\":5}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(false));
+    }
+
+    @Test
+    void detailAnythingButScalarMissingFieldDoesNotMatch() {
+        given()
+            .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+            .header("X-Amz-Target", TARGET)
+            .body("""
+                {
+                    "EventPattern": "{\\"detail\\":{\\"state\\":[{\\"anything-but\\":\\"initializing\\"}]}}",
+                    "Event": "{\\"source\\":\\"com.myapp\\",\\"detail-type\\":\\"OrderPlaced\\",\\"detail\\":{\\"other\\":1}}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Result", equalTo(false));
+    }
+
+    @Test
     void prefixFilterMatch() {
         given()
             .contentType(EVENT_BRIDGE_CONTENT_TYPE)


### PR DESCRIPTION
## Summary
Fixes #1888

### Problem

EventBridge pattern matching inverted AWS's type semantics for boolean and numeric values in `detail`:

- `{"detail": {"enabled": ["true"]}}` (string pattern) wrongly **matched** the JSON boolean `true`
- `{"detail": {"enabled": [true]}}` (boolean pattern) could **never match** anything
- Same for numbers: `["5"]` matched the number `5`, while `[5]` matched nothing

Two defects in `EventBridgeService`:

1. `matchesDetailNode` collapsed the event's detail value to a `String` via `asText()` before comparison, destroying type information so `"true".equals("true")` succeeded for the string pattern.
2. `matchesSingleElement` had no `isBoolean()`/`isNumber()` branches, so non-textual pattern literals fell through to `return false`.

### Fix

- The detail-matching pipeline now passes the actual `JsonNode` end-to-end (`matchesArrayField(JsonNode pattern, JsonNode actual)`); envelope fields (source, detail-type, account, region, resources), which are inherently strings, delegate through a thin `TextNode`-wrapping overload.
- Exact matching is type-aware via a new `matchesExactValue`: strings match strings, booleans match booleans by value, numbers match numbers by normalized numeric value (verified against real AWS: `[3.0e2]` matches `300.0`).
- String operators (`prefix`, `suffix`, `equals-ignore-case`) now only apply when the event value is actually a string, matching AWS behavior.
- `exists` checks key presence regardless of value type; a key carrying the JSON literal `null` counts as **present** (`exists: true` matches it, `exists: false` does not). The pre-existing code treated null-valued keys as absent (`NullNode.asText(defaultValue)` returns the default, so the old stringified value was Java `null`).
- The `[null]` literal pattern requires the key to be present with a `null` value; a missing key does not match (verified against real AWS).
- `anything-but` reuses `matchesExactValue`, which also fixes a latent bug: numeric `anything-but: [5]` previously excluded nothing because only textual elements were checked.

Both `TestEventPattern` and real rule dispatch funnel through the same `matchesDetailNode`, so one fix covers both paths.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
