### PR TITLE
feat(sqs): retain MessageGroupId on standard queue messages

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -479,8 +479,10 @@ public class SqsService implements Resettable {
             return message;
         }
 
-        // Standard queue
+        // Standard queue. MessageGroupId is retained for ReceiveMessage to
+        // return (fair queues); it has no effect on standard-queue delivery.
         Message message = new Message(body);
+        message.setMessageGroupId(messageGroupId);
         message.setAwsTraceHeader(awsTraceHeader);
         if (effectiveDelaySeconds > 0) {
             message.setVisibleAt(Instant.now().plusSeconds(effectiveDelaySeconds));

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
@@ -359,7 +359,7 @@ class SqsJsonProtocolTest {
     }
 
     @Test
-    @Order(7)
+    @Order(9)
     void sendMessageToStandardQueueRetainsMessageGroupId() {
         String groupQueueName = QUEUE_NAME + "-group";
         String groupQueueUrl = given()

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
@@ -360,6 +360,36 @@ class SqsJsonProtocolTest {
 
     @Test
     @Order(7)
+    void sendMessageToStandardQueueRetainsMessageGroupId() {
+        String groupQueueName = QUEUE_NAME + "-group";
+        String groupQueueUrl = given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+            .body("{\"QueueName\":\"" + groupQueueName + "\"}")
+        .when().post("/").then().statusCode(200)
+            .extract().jsonPath().getString("QueueUrl");
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.SendMessage")
+            .body("{\"QueueUrl\":\"" + groupQueueUrl + "\","
+                    + "\"MessageBody\":\"fair-queues message\","
+                    + "\"MessageGroupId\":\"tenant-1\"}")
+        .when().post("/").then().statusCode(200);
+
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+            .body("{\"QueueUrl\":\"" + groupQueueUrl + "\","
+                    + "\"MaxNumberOfMessages\":1,"
+                    + "\"VisibilityTimeout\":0,"
+                    + "\"MessageSystemAttributeNames\":[\"MessageGroupId\"]}")
+        .when().post("/").then().statusCode(200)
+            .body("Messages[0].Attributes.MessageGroupId", equalTo("tenant-1"));
+    }
+
+    @Test
+    @Order(7)
     void tagQueueWithJsonNullValueIsRejected() {
         String tagBody = "{\"QueueUrl\":\"" + queueUrl + "\","
                 + "\"Tags\":{\"NullTag\":null,\"RealTag\":\"value\"}}";


### PR DESCRIPTION
## Summary

Standard queues silently dropped `MessageGroupId` on SendMessage, so ReceiveMessage never returned it. Since the [July 2025 fair-queues launch](https://aws.amazon.com/about-aws/whats-new/2025/07/amazon-sns-standard-topics-sqs-fair-queues/), standard queues accept `MessageGroupId` ([SendMessage reference](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html)) and return it as a message system attribute ([ReceiveMessage reference](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html)).

The fix is one site: store the value in the standard-queue branch of `SqsService.sendMessage`. Both protocol handlers already parse it on send and return it on receive, so single and batch sends on both protocols are covered. Delivery is untouched — group locking only runs in the FIFO claim path, so same-group standard messages still deliver in parallel, matching AWS ("messages with the same MessageGroupId can be processed in parallel", per the SendMessage reference).

The new integration test fails without the service change.

Closes #1496

## Type of change

- [x] New feature (`feat:`)

## AWS Compatibility

Send with `MessageGroupId` to a standard queue, then `ReceiveMessage` with `MessageSystemAttributeNames=["MessageGroupId"]` returns the value. The response carries no `SequenceNumber` — that stays FIFO-only, matching AWS. Verified against the SendMessage API reference; wire shape exercised via the JSON-protocol integration test.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
