### PR TITLE
fix(athena): report the result CSV object key as OutputLocation

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
@@ -73,7 +73,8 @@ public class AthenaService {
             resolvedContext.setCatalog(DEFAULT_CATALOG);
         }
 
-        // Ensure output location has a trailing slash so floci-duck writes into the prefix
+        // AWS reports the result CSV object itself as the OutputLocation, not a
+        // directory prefix — the same key is written and returned to the client.
         String outputLocation = resolveOutputLocation(resultConfiguration, id);
         ResultConfiguration resolvedResult = new ResultConfiguration(outputLocation);
 
@@ -93,7 +94,7 @@ public class AthenaService {
         vertx.executeBlocking(() -> {
             String setupDdl = buildGlueDdl(database);
             ensureOutputBucket(outputLocation);
-            duckClient.execute(query, setupDdl, outputLocation + "results.csv");
+            duckClient.execute(query, setupDdl, outputLocation);
             return null;
         }).onSuccess(v -> {
             execution.getStatus().setState(QueryExecutionState.SUCCEEDED);
@@ -279,7 +280,7 @@ public class AthenaService {
         String base = (rc != null && rc.getOutputLocation() != null && !rc.getOutputLocation().isBlank())
                 ? rc.getOutputLocation()
                 : "s3://" + DEFAULT_OUTPUT_BUCKET + "/results/";
-        return base.endsWith("/") ? base + queryId + "/" : base + "/" + queryId + "/";
+        return base.endsWith("/") ? base + queryId + ".csv" : base + "/" + queryId + ".csv";
     }
 
     private WorkGroupConfiguration normalizeWorkGroupConfiguration(CreateWorkGroupConfigurationRequest configuration) {

--- a/src/test/java/io/github/hectorvent/floci/services/athena/AthenaIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/athena/AthenaIntegrationTest.java
@@ -377,4 +377,35 @@ class AthenaIntegrationTest {
                 .body("TableMetadata.CreateTime", instanceOf(Number.class))
                 .body("TableMetadata.LastAccessTime", instanceOf(Number.class));
     }
+
+    @Test
+    @Order(13)
+    void outputLocationIsTheResultCsvObjectKey() {
+        String id = given()
+            .header("X-Amz-Target", "AmazonAthena.StartQueryExecution")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "QueryString": "SELECT 1",
+                  "ResultConfiguration": { "OutputLocation": "s3://athena-location-test/out/" }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("QueryExecutionId");
+
+        // AWS reports the result CSV object itself, not a directory prefix
+        given()
+            .header("X-Amz-Target", "AmazonAthena.GetQueryExecution")
+            .contentType(CONTENT_TYPE)
+            .body("{ \"QueryExecutionId\": \"" + id + "\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("QueryExecution.ResultConfiguration.OutputLocation",
+                    equalTo("s3://athena-location-test/out/" + id + ".csv"));
+    }
 }


### PR DESCRIPTION
## Summary

`GetQueryExecution` reported `OutputLocation` as a directory prefix (`<base>/<QueryExecutionId>/`) while the result CSV was written to `results.csv` inside it — so a client that GETs the reported location verbatim fails with `NoSuchKey`. Real Athena names result files `<QueryID>.csv` and saves them directly to the result location for API/CLI queries ([finding output files](https://docs.aws.amazon.com/athena/latest/ug/querying-finding-output-files.html)), so the reported location is the result object itself.

`resolveOutputLocation` now returns the `<base>/<QueryExecutionId>.csv` object key, and the result is written to exactly that key — report and write stay one value. `readResultsFromS3` needs no change: it lists by prefix, which matches the exact key, and keeps executions persisted with the old prefix form readable after an upgrade.

The new test fails without the fix (old code reports `…/<id>/`).

Closes #1752

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

`StartQueryExecution` with `OutputLocation: s3://bucket/out/` now reports `s3://bucket/out/<QueryExecutionId>.csv`, matching Athena's documented `<QueryID>.csv` result-file naming. The floci-duck write path receives the same kind of value it always did — one full object path. Verified via the wire-level integration test (the test profile runs Athena in mock mode, so the test pins the reported key shape; the write/read sides pass the identical string).

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
