### PR TITLE
feat(firehose): implement S3 buffered delivery honoring BufferingHints

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DataLakeTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DataLakeTest.java
@@ -5,10 +5,14 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.athena.model.*;
 import software.amazon.awssdk.services.firehose.FirehoseClient;
+import software.amazon.awssdk.services.firehose.model.BufferingHints;
 import software.amazon.awssdk.services.firehose.model.PutRecordRequest;
 import software.amazon.awssdk.services.firehose.model.Record;
+import software.amazon.awssdk.services.firehose.model.S3DestinationConfiguration;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.glue.model.*;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -25,6 +29,7 @@ class DataLakeTest {
     private static AthenaClient athena;
     private static GlueClient glue;
     private static FirehoseClient firehose;
+    private static S3Client s3;
 
     private static final String DB_NAME = TestFixtures.uniqueName("test_db");
     private static final String TABLE_NAME = "orders";
@@ -35,6 +40,7 @@ class DataLakeTest {
         athena = TestFixtures.athenaClient();
         glue = TestFixtures.glueClient();
         firehose = TestFixtures.firehoseClient();
+        s3 = TestFixtures.s3Client();
     }
 
     @Test
@@ -66,9 +72,27 @@ class DataLakeTest {
                         .build())
                 .build());
 
-        // 3. Firehose Stream
+        // 3. Firehose Stream — explicit destination matching the Glue table
+        // location, with 1s buffering so ingested records land quickly
+        // (delivery follows BufferingHints; there is no per-record-count flush).
+        // The destination bucket must exist before delivery, as on real AWS.
+        try {
+            s3.createBucket(software.amazon.awssdk.services.s3.model.CreateBucketRequest.builder()
+                    .bucket("floci-firehose-results").build());
+        } catch (software.amazon.awssdk.services.s3.model.S3Exception e) {
+            System.err.println("Setup: createBucket floci-firehose-results: " + e.getMessage());
+        }
         firehose.createDeliveryStream(software.amazon.awssdk.services.firehose.model.CreateDeliveryStreamRequest.builder()
                 .deliveryStreamName(STREAM_NAME)
+                .s3DestinationConfiguration(S3DestinationConfiguration.builder()
+                        .roleARN("arn:aws:iam::000000000000:role/datalake-firehose-role")
+                        .bucketARN("arn:aws:s3:::floci-firehose-results")
+                        .prefix(STREAM_NAME + "/")
+                        .bufferingHints(BufferingHints.builder()
+                                .sizeInMBs(1)
+                                .intervalInSeconds(1)
+                                .build())
+                        .build())
                 .build());
     }
 
@@ -82,6 +106,16 @@ class DataLakeTest {
                     .deliveryStreamName(STREAM_NAME)
                     .record(Record.builder().data(SdkBytes.fromString(json, StandardCharsets.UTF_8)).build())
                     .build());
+        }
+
+        // Wait for the buffered records to be delivered (1s BufferingHints interval)
+        // before querying, so the table's S3 location is populated.
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline
+                && s3.listObjectsV2(ListObjectsV2Request.builder()
+                        .bucket("floci-firehose-results").prefix(STREAM_NAME + "/").build())
+                    .contents().isEmpty()) {
+            Thread.sleep(250);
         }
 
         // Athena Query

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/FirehoseS3DeliveryTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/FirehoseS3DeliveryTest.java
@@ -1,0 +1,179 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.firehose.FirehoseClient;
+import software.amazon.awssdk.services.firehose.model.*;
+import software.amazon.awssdk.services.firehose.model.Record;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Issue #1886 — PutRecord / PutRecordBatch must actually deliver buffered
+ * records to the S3 destination following BufferingHints (IntervalInSeconds /
+ * SizeInMBs), instead of silently accepting and dropping them.
+ */
+@DisplayName("Firehose S3 buffered delivery — issue #1886")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class FirehoseS3DeliveryTest {
+
+    private static FirehoseClient firehose;
+    private static S3Client s3;
+
+    private static final String SUFFIX = UUID.randomUUID().toString().substring(0, 8);
+    private static final String STREAM_NAME = "sdk-delivery-" + SUFFIX;
+    private static final String BUCKET = "floci-firehose-delivery-" + SUFFIX;
+    private static final String ROLE_ARN = "arn:aws:iam::000000000000:role/firehose-role";
+
+    private static String firstDeliveredKey;
+
+    @BeforeAll
+    static void setup() {
+        firehose = TestFixtures.firehoseClient();
+        s3 = TestFixtures.s3Client();
+        s3.createBucket(CreateBucketRequest.builder().bucket(BUCKET).build());
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (firehose != null) {
+            try {
+                firehose.deleteDeliveryStream(DeleteDeliveryStreamRequest.builder()
+                        .deliveryStreamName(STREAM_NAME).build());
+            } catch (Exception ignored) {}
+            firehose.close();
+        }
+        if (s3 != null) {
+            try {
+                for (S3Object object : listObjects("")) {
+                    s3.deleteObject(DeleteObjectRequest.builder().bucket(BUCKET).key(object.key()).build());
+                }
+                s3.deleteBucket(DeleteBucketRequest.builder().bucket(BUCKET).build());
+            } catch (Exception ignored) {}
+            s3.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("Create delivery stream with 1s/1MiB buffering hints")
+    void createDeliveryStream() {
+        firehose.createDeliveryStream(CreateDeliveryStreamRequest.builder()
+                .deliveryStreamName(STREAM_NAME)
+                .deliveryStreamType(DeliveryStreamType.DIRECT_PUT)
+                .s3DestinationConfiguration(S3DestinationConfiguration.builder()
+                        .roleARN(ROLE_ARN)
+                        .bucketARN("arn:aws:s3:::" + BUCKET)
+                        .prefix("events/")
+                        .bufferingHints(BufferingHints.builder()
+                                .sizeInMBs(1)
+                                .intervalInSeconds(1)
+                                .build())
+                        .build())
+                .build());
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("PutRecord delivers to the destination bucket within the buffering interval")
+    void putRecordIsDelivered() throws InterruptedException {
+        firehose.putRecord(PutRecordRequest.builder()
+                .deliveryStreamName(STREAM_NAME)
+                .record(Record.builder()
+                        .data(SdkBytes.fromUtf8String("{\"hello\":\"world\"}"))
+                        .build())
+                .build());
+
+        List<S3Object> objects = awaitObjects("events/", 1);
+        firstDeliveredKey = objects.get(0).key();
+        String body = s3.getObjectAsBytes(GetObjectRequest.builder()
+                        .bucket(BUCKET).key(firstDeliveredKey).build())
+                .asString(StandardCharsets.UTF_8);
+        assertThat(body).isEqualTo("{\"hello\":\"world\"}\n");
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("PutRecordBatch delivers all records")
+    void putRecordBatchIsDelivered() throws InterruptedException {
+        PutRecordBatchResponse response = firehose.putRecordBatch(PutRecordBatchRequest.builder()
+                .deliveryStreamName(STREAM_NAME)
+                .records(
+                        Record.builder().data(SdkBytes.fromUtf8String("{\"n\":1}")).build(),
+                        Record.builder().data(SdkBytes.fromUtf8String("{\"n\":2}")).build())
+                .build());
+        assertThat(response.failedPutCount()).isZero();
+
+        // S3 lists keys lexicographically, so identify the batch object by
+        // excluding the key already delivered in the previous test.
+        String batchKey = awaitObjects("events/", 2).stream()
+                .map(S3Object::key)
+                .filter(key -> !key.equals(firstDeliveredKey))
+                .findFirst().orElseThrow();
+        String body = s3.getObjectAsBytes(GetObjectRequest.builder()
+                        .bucket(BUCKET).key(batchKey).build())
+                .asString(StandardCharsets.UTF_8);
+        assertThat(body).isEqualTo("{\"n\":1}\n{\"n\":2}\n");
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("Out-of-range BufferingHints are rejected like AWS")
+    void outOfRangeBufferingHintsAreRejected() {
+        assertThatThrownBy(() -> firehose.createDeliveryStream(CreateDeliveryStreamRequest.builder()
+                .deliveryStreamName("sdk-bad-hints-" + SUFFIX)
+                .s3DestinationConfiguration(S3DestinationConfiguration.builder()
+                        .roleARN(ROLE_ARN)
+                        .bucketARN("arn:aws:s3:::" + BUCKET)
+                        .bufferingHints(BufferingHints.builder()
+                                .sizeInMBs(129)
+                                .intervalInSeconds(300)
+                                .build())
+                        .build())
+                .build()))
+                .isInstanceOf(FirehoseException.class)
+                .hasMessageContaining("sizeInMBs");
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("Duplicate CreateDeliveryStream returns ResourceInUseException")
+    void duplicateCreateIsRejected() {
+        assertThatThrownBy(() -> firehose.createDeliveryStream(CreateDeliveryStreamRequest.builder()
+                .deliveryStreamName(STREAM_NAME)
+                .s3DestinationConfiguration(S3DestinationConfiguration.builder()
+                        .roleARN(ROLE_ARN)
+                        .bucketARN("arn:aws:s3:::" + BUCKET)
+                        .build())
+                .build()))
+                .isInstanceOf(ResourceInUseException.class);
+    }
+
+    /** Polls the bucket until at least {@code count} objects exist under the prefix (10s cap). */
+    private static List<S3Object> awaitObjects(String prefix, int count) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 10_000;
+        List<S3Object> objects = listObjects(prefix);
+        while (objects.size() < count && System.currentTimeMillis() < deadline) {
+            Thread.sleep(250);
+            objects = listObjects(prefix);
+        }
+        assertThat(objects).hasSizeGreaterThanOrEqualTo(count);
+        return objects;
+    }
+
+    private static List<S3Object> listObjects(String prefix) {
+        return s3.listObjectsV2(ListObjectsV2Request.builder()
+                .bucket(BUCKET).prefix(prefix).build()).contents();
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/FirehoseS3DeliveryTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/FirehoseS3DeliveryTest.java
@@ -51,7 +51,9 @@ class FirehoseS3DeliveryTest {
             try {
                 firehose.deleteDeliveryStream(DeleteDeliveryStreamRequest.builder()
                         .deliveryStreamName(STREAM_NAME).build());
-            } catch (Exception ignored) {}
+            } catch (Exception e) {
+                System.err.println("Teardown: could not delete stream " + STREAM_NAME + ": " + e);
+            }
             firehose.close();
         }
         if (s3 != null) {
@@ -60,7 +62,9 @@ class FirehoseS3DeliveryTest {
                     s3.deleteObject(DeleteObjectRequest.builder().bucket(BUCKET).key(object.key()).build());
                 }
                 s3.deleteBucket(DeleteBucketRequest.builder().bucket(BUCKET).build());
-            } catch (Exception ignored) {}
+            } catch (Exception e) {
+                System.err.println("Teardown: could not empty/delete bucket " + BUCKET + ": " + e);
+            }
             s3.close();
         }
     }

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesEventPublishingTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesEventPublishingTest.java
@@ -56,6 +56,7 @@ import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
 
 import software.amazon.awssdk.services.firehose.FirehoseClient;
+import software.amazon.awssdk.services.firehose.model.BufferingHints;
 import software.amazon.awssdk.services.firehose.model.CreateDeliveryStreamRequest;
 import software.amazon.awssdk.services.firehose.model.DeleteDeliveryStreamRequest;
 import software.amazon.awssdk.services.firehose.model.S3DestinationConfiguration;
@@ -198,6 +199,13 @@ class SesEventPublishingTest {
                         .s3DestinationConfiguration(S3DestinationConfiguration.builder()
                                 .bucketARN("arn:aws:s3:::" + firehoseBucket)
                                 .roleARN("arn:aws:iam::000000000000:role/sdk-evt-fh-role")
+                                // 1s buffering so tests see delivery quickly, matching
+                                // AWS BufferingHints semantics (records are no longer
+                                // auto-flushed at a fixed record count).
+                                .bufferingHints(BufferingHints.builder()
+                                        .sizeInMBs(1)
+                                        .intervalInSeconds(1)
+                                        .build())
                                 .build())
                         .build())
                 .deliveryStreamARN();
@@ -477,8 +485,8 @@ class SesEventPublishingTest {
 
     @Test
     @Order(5)
-    @DisplayName("Firehose destination: 5 sends trigger auto-flush to S3 as NDJSON")
-    void firehoseDestination_fiveSends_triggerAutoFlushToS3() throws Exception {
+    @DisplayName("Firehose destination: 5 sends are delivered to S3 as NDJSON within the buffering interval")
+    void firehoseDestination_fiveSends_deliveredToS3() throws Exception {
         for (int i = 0; i < 5; i++) {
             ses.sendEmail(SendEmailRequest.builder()
                     .fromEmailAddress(identity)
@@ -497,12 +505,19 @@ class SesEventPublishingTest {
                     .build());
         }
 
-        ListObjectsV2Response listed = s3.listObjectsV2(ListObjectsV2Request.builder()
-                .bucket(firehoseBucket)
-                .prefix(firehoseStreamName + "/")
-                .build());
+        // Delivery follows the stream's 1s BufferingHints interval; poll briefly.
+        ListObjectsV2Response listed = null;
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            listed = s3.listObjectsV2(ListObjectsV2Request.builder()
+                    .bucket(firehoseBucket)
+                    .prefix(firehoseStreamName + "/")
+                    .build());
+            if (!listed.contents().isEmpty()) break;
+            Thread.sleep(250);
+        }
         assertThat(listed.contents())
-                .as("Firehose should have flushed exactly one S3 object after 5 records")
+                .as("Firehose should have delivered one S3 object with the 5 buffered records")
                 .hasSize(1);
 
         S3Object obj = listed.contents().get(0);

--- a/docs/services/firehose.md
+++ b/docs/services/firehose.md
@@ -24,9 +24,20 @@ Floci emulates Amazon Data Firehose for streaming data ingestion and delivery to
 
 ## How it works
 
-1. **Buffering**: Incoming records are buffered in memory.
-2. **Automatic Flush**: Floci automatically flushes the buffer to S3 after every 5 records for immediate local feedback.
-3. **Format**: Records are flushed as raw NDJSON (newline-delimited JSON) to the `floci-firehose-results` bucket.
+1. **Buffering**: Incoming records are buffered in memory per stream.
+2. **Delivery**: The buffer is flushed to the destination bucket following the stream's
+   `BufferingHints`, matching AWS semantics — as soon as `SizeInMBs` worth of data is
+   buffered, or once `IntervalInSeconds` has elapsed since the oldest buffered record,
+   whichever happens first. Defaults match AWS: 5 MiB / 300 seconds. Set
+   `"BufferingHints": {"SizeInMBs": 1, "IntervalInSeconds": 1}` on the destination
+   configuration for near-immediate local feedback. Hints are validated against the AWS
+   ranges (`SizeInMBs` 1–128, `IntervalInSeconds` 0–900).
+3. **Format**: Records are flushed as NDJSON (newline-delimited) to the bucket from the
+   destination's `BucketARN`, or to the `floci-firehose-results` fallback bucket when the
+   stream was created without an S3 destination.
+4. **Durability**: Buffers live in memory. A failed delivery is retried on the next
+   interval (up to 10 attempts, then the batch is dropped with an error log), and records
+   not yet delivered are lost when the emulator stops or the stream is deleted.
 
 ## Configuration
 

--- a/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseService.java
@@ -4,33 +4,54 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.RequestContext;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.firehose.model.DeliveryStreamDescription;
 import io.github.hectorvent.floci.services.firehose.model.DeliveryStreamDescription.S3Destination;
 import io.github.hectorvent.floci.services.firehose.model.Record;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ManagedContext;
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
-import java.nio.charset.StandardCharsets;
+import java.io.ByteArrayOutputStream;
+import java.time.Duration;
+import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 @ApplicationScoped
 public class FirehoseService {
 
     private static final Logger LOG = Logger.getLogger(FirehoseService.class);
     private static final String DEFAULT_BUCKET = "floci-firehose-results";
-    private static final int DEFAULT_FLUSH_COUNT = 5;
+    // How often the background flusher checks buffers against their stream's
+    // IntervalInSeconds. Delivery therefore lands within interval + 1s.
+    private static final long FLUSH_TICK_MILLIS = 1_000L;
+    // Bounds retries of a persistently failing destination so the in-memory
+    // buffer can't grow without limit; AWS likewise gives up eventually
+    // (retry window, then error output) rather than buffering forever.
+    private static final int MAX_DELIVERY_ATTEMPTS = 10;
 
     private final StorageBackend<String, DeliveryStreamDescription> streamStore;
-    private final Map<String, List<byte[]>> buffers = new ConcurrentHashMap<>();
+    // Keyed per account to mirror the account-prefixed streamStore, so
+    // same-named streams in different accounts don't share a buffer.
+    private final Map<BufferKey, StreamBuffer> buffers = new ConcurrentHashMap<>();
     private final S3Service s3Service;
     private final RegionResolver regionResolver;
+    private ScheduledExecutorService flushScheduler;
 
     @Inject
     public FirehoseService(StorageFactory storageFactory, S3Service s3Service, RegionResolver regionResolver) {
@@ -38,6 +59,23 @@ public class FirehoseService {
                 new TypeReference<Map<String, DeliveryStreamDescription>>() {});
         this.s3Service = s3Service;
         this.regionResolver = regionResolver;
+    }
+
+    void onStart(@Observes StartupEvent ev) {
+        flushScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "floci-firehose-flusher");
+            t.setDaemon(true);
+            return t;
+        });
+        flushScheduler.scheduleAtFixedRate(this::flushDueBuffers,
+                FLUSH_TICK_MILLIS, FLUSH_TICK_MILLIS, TimeUnit.MILLISECONDS);
+    }
+
+    void onStop(@Observes ShutdownEvent ev) {
+        if (flushScheduler != null) {
+            flushScheduler.shutdownNow();
+            flushScheduler = null;
+        }
     }
 
     public String createDeliveryStream(String name, S3Destination s3Config) {
@@ -50,6 +88,10 @@ public class FirehoseService {
 
     public String createDeliveryStream(String name, S3Destination s3Config, List<DeliveryStreamDescription.Tag> tags,
                                        String deliveryStreamType) {
+        if (streamStore.get(name).isPresent()) {
+            throw new AwsException("ResourceInUseException",
+                    "Firehose " + name + " under accountId " + regionResolver.getAccountId() + " already exists", 400);
+        }
         validateBufferingHints(s3Config);
         String arn = AwsArnUtils.Arn.of("firehose", regionResolver.getDefaultRegion(), regionResolver.getAccountId(), "deliverystream/" + name).toString();
         DeliveryStreamDescription description = new DeliveryStreamDescription(name, arn, s3Config);
@@ -59,7 +101,7 @@ public class FirehoseService {
             description.setDeliveryStreamType(deliveryStreamType);
         }
         streamStore.put(name, description);
-        buffers.put(name, Collections.synchronizedList(new ArrayList<>()));
+        buffers.put(bufferKey(name), new StreamBuffer());
         LOG.infov("Created Firehose delivery stream: {0}", name);
         return arn;
     }
@@ -124,6 +166,20 @@ public class FirehoseService {
                     "If you specify a value for SizeInMBs, you must also specify a value for IntervalInSeconds, and vice versa.",
                     400);
         }
+        // Ranges from the BufferingHints API reference: SizeInMBs 1-128, IntervalInSeconds 0-900.
+        requireRange(hints.getSizeInMBs(), 1, 128, "bufferingHints.sizeInMBs");
+        requireRange(hints.getIntervalInSeconds(), 0, 900, "bufferingHints.intervalInSeconds");
+    }
+
+    private static void requireRange(Integer value, int min, int max, String member) {
+        if (value == null || (value >= min && value <= max)) {
+            return;
+        }
+        throw new AwsException("ValidationException",
+                "1 validation error detected: Value '" + value + "' at '" + member
+                        + "' failed to satisfy constraint: Member must have value "
+                        + (value < min ? "greater than or equal to " + min : "less than or equal to " + max),
+                400);
     }
 
     private static void mergeDestination(S3Destination current, S3Destination update) {
@@ -199,7 +255,9 @@ public class FirehoseService {
     public void deleteDeliveryStream(String name) {
         describeDeliveryStream(name);
         streamStore.delete(name);
-        buffers.remove(name);
+        // Undelivered buffered data is dropped, matching AWS: deleting a
+        // delivery stream can lose data that hasn't reached the destination.
+        buffers.remove(bufferKey(name));
         LOG.infov("Deleted Firehose delivery stream: {0}", name);
     }
 
@@ -209,41 +267,119 @@ public class FirehoseService {
     }
 
     public void putRecord(String streamName, Record record) {
-        DeliveryStreamDescription stream = describeDeliveryStream(streamName);
-        buffers.computeIfAbsent(streamName, k -> Collections.synchronizedList(new ArrayList<>()))
-               .add(record.getData());
-
-        if (buffers.get(streamName).size() >= DEFAULT_FLUSH_COUNT) {
-            flush(streamName, stream);
-        }
+        putRecordBatch(streamName, List.of(record));
     }
 
     public void putRecordBatch(String streamName, List<Record> records) {
         DeliveryStreamDescription stream = describeDeliveryStream(streamName);
-        List<byte[]> buffer = buffers.computeIfAbsent(
-                streamName, k -> Collections.synchronizedList(new ArrayList<>()));
+        StreamBuffer buffer = buffers.computeIfAbsent(bufferKey(streamName), k -> new StreamBuffer());
         for (Record r : records) {
-            buffer.add(r.getData());
+            buffer.add(r.getData() == null ? new byte[0] : r.getData());
         }
-        if (buffer.size() >= DEFAULT_FLUSH_COUNT) {
-            flush(streamName, stream);
-        }
+        flushIfSizeReached(streamName, stream, buffer);
     }
 
     public void flush(String streamName) {
         streamStore.get(streamName).ifPresent(stream -> flush(streamName, stream));
     }
 
+    /** Size half of BufferingHints: deliver as soon as SizeInMBs worth of data is buffered. */
+    private void flushIfSizeReached(String streamName, DeliveryStreamDescription stream, StreamBuffer buffer) {
+        DeliveryStreamDescription.BufferingHints hints = bufferingHints(stream);
+        long thresholdBytes = hints.getSizeInMBs() * 1024L * 1024L;
+        if (buffer.byteCount() >= thresholdBytes) {
+            flush(streamName, stream);
+        }
+    }
+
+    /**
+     * Interval half of BufferingHints: runs on the background flusher thread every
+     * {@link #FLUSH_TICK_MILLIS} and delivers any buffer whose oldest record has
+     * been waiting at least the stream's IntervalInSeconds.
+     */
+    private void flushDueBuffers() {
+        for (Map.Entry<BufferKey, StreamBuffer> entry : buffers.entrySet()) {
+            try {
+                flushIfDue(entry.getKey(), entry.getValue());
+            } catch (RuntimeException e) {
+                LOG.errorv("Firehose flush tick failed for stream {0}: {1}",
+                        entry.getKey().streamName(), e.getMessage());
+            }
+        }
+    }
+
+    private void flushIfDue(BufferKey key, StreamBuffer buffer) {
+        Instant oldest = buffer.oldestRecordAt();
+        if (oldest == null) {
+            return;
+        }
+        DeliveryStreamDescription stream = streamForAccount(key);
+        if (stream == null) {
+            // Stream deleted outside the request path that owned the buffer: drop the
+            // orphaned buffer — conditionally, since the stream (and a fresh buffer)
+            // may have been re-created concurrently.
+            buffers.remove(key, buffer);
+            return;
+        }
+        int interval = bufferingHints(stream).getIntervalInSeconds();
+        if (Duration.between(oldest, Instant.now()).getSeconds() < interval) {
+            return;
+        }
+        // Only the actual delivery needs the synthetic request scope: the S3 write
+        // resolves buckets through account-aware storage, which reads the calling
+        // account from the active request context, and this thread has none.
+        runUnderAccount(key.accountId(), () -> flush(key.streamName(), stream));
+    }
+
+    /**
+     * Async-worker read of the stream store: outside a request scope the
+     * account-aware backend would fall back to the default account, so use the
+     * explicit per-account overload with the buffer's owning account.
+     */
+    private DeliveryStreamDescription streamForAccount(BufferKey key) {
+        if (streamStore instanceof AccountAwareStorageBackend<DeliveryStreamDescription> accountAware) {
+            return accountAware.getForAccount(key.accountId(), key.streamName()).orElse(null);
+        }
+        return streamStore.get(key.streamName()).orElse(null);
+    }
+
+    /**
+     * Activates a synthetic CDI request scope bound to {@code accountId} and runs
+     * {@code body} inside it (same pattern as {@code CurEmissionScheduler}): the
+     * account-aware storage backends used by the stream store and S3 read the
+     * calling account from the active request context. If a scope was already
+     * active, the previous account is restored afterwards so it isn't left
+     * behind on a reused thread.
+     */
+    private void runUnderAccount(String accountId, Runnable body) {
+        ManagedContext requestContext = Arc.container().requestContext();
+        boolean alreadyActive = requestContext.isActive();
+        if (!alreadyActive) {
+            requestContext.activate();
+        }
+        RequestContext ctx = Arc.container().instance(RequestContext.class).get();
+        String previousAccountId = alreadyActive ? ctx.getAccountId() : null;
+        try {
+            ctx.setAccountId(accountId);
+            body.run();
+        } finally {
+            if (!alreadyActive) {
+                requestContext.terminate();
+            } else {
+                ctx.setAccountId(previousAccountId);
+            }
+        }
+    }
+
     private void flush(String streamName, DeliveryStreamDescription stream) {
-        List<byte[]> buffer = buffers.get(streamName);
-        if (buffer == null || buffer.isEmpty()) {
+        StreamBuffer buffer = buffers.get(bufferKey(streamName));
+        if (buffer == null) {
             return;
         }
 
-        List<byte[]> toFlush;
-        synchronized (buffer) {
-            toFlush = new ArrayList<>(buffer);
-            buffer.clear();
+        List<byte[]> toFlush = buffer.drain();
+        if (toFlush.isEmpty()) {
+            return;
         }
 
         try {
@@ -253,20 +389,110 @@ public class FirehoseService {
 
             ensureBucket(bucket);
 
-            StringBuilder sb = new StringBuilder();
+            // Assemble the newline-delimited body on raw bytes: record data is an
+            // arbitrary binary blob, so a String round-trip would corrupt non-UTF-8
+            // payloads (and copy every byte twice for nothing).
+            ByteArrayOutputStream body = new ByteArrayOutputStream();
             for (byte[] data : toFlush) {
-                sb.append(new String(data, StandardCharsets.UTF_8));
-                if (!sb.isEmpty() && sb.charAt(sb.length() - 1) != '\n') {
-                    sb.append('\n');
+                body.write(data, 0, data.length);
+                if (data.length > 0 && data[data.length - 1] != '\n') {
+                    body.write('\n');
                 }
             }
 
-            byte[] body = sb.toString().getBytes(StandardCharsets.UTF_8);
-            s3Service.putObject(bucket, key, body, "application/x-ndjson", Map.of());
+            s3Service.putObject(bucket, key, body.toByteArray(), "application/x-ndjson", Map.of());
+            buffer.markDelivered();
             LOG.infov("Flushed {0} records from stream {1} to s3://{2}/{3}",
                     toFlush.size(), streamName, bucket, key);
         } catch (Exception e) {
-            LOG.errorv("Failed to flush Firehose stream {0}: {1}", streamName, e.getMessage());
+            // Put the drained records back (ahead of anything buffered meanwhile,
+            // preserving order) so the next interval tick retries instead of
+            // silently dropping them — up to MAX_DELIVERY_ATTEMPTS, after which the
+            // batch is dropped so a permanently failing destination can't grow the
+            // in-memory buffer without bound.
+            if (buffer.restoreForRetry(toFlush, MAX_DELIVERY_ATTEMPTS)) {
+                LOG.errorv("Failed to flush Firehose stream {0}, will retry: {1}", streamName, e.getMessage());
+            } else {
+                LOG.errorv("Failed to flush Firehose stream {0} after {1} attempts, dropping {2} records: {3}",
+                        streamName, MAX_DELIVERY_ATTEMPTS, toFlush.size(), e.getMessage());
+            }
+        }
+    }
+
+    private BufferKey bufferKey(String streamName) {
+        return new BufferKey(regionResolver.getAccountId(), streamName);
+    }
+
+    /** Effective hints for delivery decisions: the stream's own, or the AWS defaults (5 MiB / 300 s). */
+    private static DeliveryStreamDescription.BufferingHints bufferingHints(DeliveryStreamDescription stream) {
+        S3Destination s3 = stream.s3Destination();
+        if (s3 != null && s3.getBufferingHints() != null
+                && s3.getBufferingHints().getSizeInMBs() != null
+                && s3.getBufferingHints().getIntervalInSeconds() != null) {
+            return s3.getBufferingHints();
+        }
+        return DeliveryStreamDescription.BufferingHints.defaults();
+    }
+
+    /** Identifies one stream's buffer: the owning account plus the stream name. */
+    private record BufferKey(String accountId, String streamName) {}
+
+    /**
+     * In-memory delivery buffer for one stream: the pending record payloads plus
+     * the byte count (drives the SizeInMBs trigger) and the arrival time of the
+     * oldest pending record (drives the IntervalInSeconds trigger).
+     */
+    private static final class StreamBuffer {
+        private final List<byte[]> records = new ArrayList<>();
+        private long byteCount;
+        private Instant oldestRecordAt;
+        private int failedAttempts;
+
+        synchronized void add(byte[] data) {
+            if (records.isEmpty()) {
+                oldestRecordAt = Instant.now();
+            }
+            records.add(data);
+            byteCount += data.length;
+        }
+
+        synchronized List<byte[]> drain() {
+            List<byte[]> drained = new ArrayList<>(records);
+            records.clear();
+            byteCount = 0;
+            oldestRecordAt = null;
+            return drained;
+        }
+
+        synchronized void markDelivered() {
+            failedAttempts = 0;
+        }
+
+        /**
+         * Puts a failed batch back at the head of the buffer for a later retry.
+         * Returns false — and drops the batch — once maxAttempts deliveries of it
+         * have failed.
+         */
+        synchronized boolean restoreForRetry(List<byte[]> drained, int maxAttempts) {
+            if (++failedAttempts >= maxAttempts) {
+                failedAttempts = 0;
+                return false;
+            }
+            records.addAll(0, drained);
+            for (byte[] data : drained) {
+                byteCount += data.length;
+            }
+            // Pace retries by the stream's interval rather than retrying every tick.
+            oldestRecordAt = Instant.now();
+            return true;
+        }
+
+        synchronized long byteCount() {
+            return byteCount;
+        }
+
+        synchronized Instant oldestRecordAt() {
+            return oldestRecordAt;
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseService.java
@@ -377,7 +377,7 @@ public class FirehoseService {
             return;
         }
 
-        List<byte[]> toFlush = buffer.drain();
+        List<StreamBuffer.BufferedRecord> toFlush = buffer.drain();
         if (toFlush.isEmpty()) {
             return;
         }
@@ -393,28 +393,29 @@ public class FirehoseService {
             // arbitrary binary blob, so a String round-trip would corrupt non-UTF-8
             // payloads (and copy every byte twice for nothing).
             ByteArrayOutputStream body = new ByteArrayOutputStream();
-            for (byte[] data : toFlush) {
-                body.write(data, 0, data.length);
-                if (data.length > 0 && data[data.length - 1] != '\n') {
+            for (StreamBuffer.BufferedRecord record : toFlush) {
+                body.write(record.data, 0, record.data.length);
+                if (record.data.length > 0 && record.data[record.data.length - 1] != '\n') {
                     body.write('\n');
                 }
             }
 
             s3Service.putObject(bucket, key, body.toByteArray(), "application/x-ndjson", Map.of());
-            buffer.markDelivered();
             LOG.infov("Flushed {0} records from stream {1} to s3://{2}/{3}",
                     toFlush.size(), streamName, bucket, key);
         } catch (Exception e) {
             // Put the drained records back (ahead of anything buffered meanwhile,
             // preserving order) so the next interval tick retries instead of
-            // silently dropping them — up to MAX_DELIVERY_ATTEMPTS, after which the
-            // batch is dropped so a permanently failing destination can't grow the
-            // in-memory buffer without bound.
-            if (buffer.restoreForRetry(toFlush, MAX_DELIVERY_ATTEMPTS)) {
+            // silently dropping them. Each record carries its own attempt count and
+            // is dropped individually after MAX_DELIVERY_ATTEMPTS failed deliveries,
+            // so a permanently failing destination can't grow the buffer without
+            // bound, while records that arrived mid-failure keep their full budget.
+            int dropped = buffer.restoreForRetry(toFlush, MAX_DELIVERY_ATTEMPTS);
+            if (dropped == 0) {
                 LOG.errorv("Failed to flush Firehose stream {0}, will retry: {1}", streamName, e.getMessage());
             } else {
-                LOG.errorv("Failed to flush Firehose stream {0} after {1} attempts, dropping {2} records: {3}",
-                        streamName, MAX_DELIVERY_ATTEMPTS, toFlush.size(), e.getMessage());
+                LOG.errorv("Failed to flush Firehose stream {0}; dropped {1} records that exhausted {2} delivery attempts: {3}",
+                        streamName, dropped, MAX_DELIVERY_ATTEMPTS, e.getMessage());
             }
         }
     }
@@ -443,48 +444,62 @@ public class FirehoseService {
      * oldest pending record (drives the IntervalInSeconds trigger).
      */
     private static final class StreamBuffer {
-        private final List<byte[]> records = new ArrayList<>();
+
+        /** One pending payload plus how many failed deliveries it has been part of. */
+        static final class BufferedRecord {
+            final byte[] data;
+            int attempts;
+
+            BufferedRecord(byte[] data) {
+                this.data = data;
+            }
+        }
+
+        private final List<BufferedRecord> records = new ArrayList<>();
         private long byteCount;
         private Instant oldestRecordAt;
-        private int failedAttempts;
 
         synchronized void add(byte[] data) {
             if (records.isEmpty()) {
                 oldestRecordAt = Instant.now();
             }
-            records.add(data);
+            records.add(new BufferedRecord(data));
             byteCount += data.length;
         }
 
-        synchronized List<byte[]> drain() {
-            List<byte[]> drained = new ArrayList<>(records);
+        synchronized List<BufferedRecord> drain() {
+            List<BufferedRecord> drained = new ArrayList<>(records);
             records.clear();
             byteCount = 0;
             oldestRecordAt = null;
             return drained;
         }
 
-        synchronized void markDelivered() {
-            failedAttempts = 0;
-        }
-
         /**
-         * Puts a failed batch back at the head of the buffer for a later retry.
-         * Returns false — and drops the batch — once maxAttempts deliveries of it
-         * have failed.
+         * Puts a failed batch back at the head of the buffer (ahead of anything
+         * buffered meanwhile, preserving order) for a later retry. Each record
+         * tracks its own attempt count, so records that arrived between failures
+         * aren't charged for deliveries they weren't part of; a record is dropped
+         * only once it has personally been through maxAttempts failed deliveries.
+         * Returns the number of records dropped.
          */
-        synchronized boolean restoreForRetry(List<byte[]> drained, int maxAttempts) {
-            if (++failedAttempts >= maxAttempts) {
-                failedAttempts = 0;
-                return false;
+        synchronized int restoreForRetry(List<BufferedRecord> drained, int maxAttempts) {
+            List<BufferedRecord> retained = new ArrayList<>(drained.size());
+            int dropped = 0;
+            for (BufferedRecord record : drained) {
+                if (++record.attempts >= maxAttempts) {
+                    dropped++;
+                    continue;
+                }
+                retained.add(record);
+                byteCount += record.data.length;
             }
-            records.addAll(0, drained);
-            for (byte[] data : drained) {
-                byteCount += data.length;
+            records.addAll(0, retained);
+            if (!retained.isEmpty()) {
+                // Pace retries by the stream's interval rather than retrying every tick.
+                oldestRecordAt = Instant.now();
             }
-            // Pace retries by the stream's interval rather than retrying every tick.
-            oldestRecordAt = Instant.now();
-            return true;
+            return dropped;
         }
 
         synchronized long byteCount() {

--- a/src/test/java/io/github/hectorvent/floci/services/firehose/FirehoseS3DeliveryIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/firehose/FirehoseS3DeliveryIntegrationTest.java
@@ -1,0 +1,257 @@
+package io.github.hectorvent.floci.services.firehose;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Base64;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Delivery-plane coverage for the S3 destination: records put with
+ * PutRecord / PutRecordBatch must land in the destination bucket when either
+ * BufferingHints trigger fires — IntervalInSeconds elapsed since the oldest
+ * buffered record, or SizeInMBs worth of data buffered, whichever comes first.
+ */
+@QuarkusTest
+class FirehoseS3DeliveryIntegrationTest {
+
+    private static final String ROLE_ARN = "arn:aws:iam::000000000000:role/firehose-delivery-role";
+    private static final String JSON_CT = "application/x-amz-json-1.1";
+    private static final String TARGET_PREFIX = "Firehose_20150804.";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void putRecordIsDeliveredToS3WithinBufferingInterval() {
+        String bucket = "fh-delivery-interval-bucket";
+        String stream = "fh-delivery-interval-stream";
+        createBucket(bucket);
+        createStream(stream, bucket, "interval/", 1, 1);
+
+        putRecord(stream, "{\"hello\":\"world\"}");
+
+        String key = awaitFirstKey(bucket, "interval/");
+
+        given().when().get("/" + bucket + "/" + key)
+                .then().statusCode(200)
+                .body(equalTo("{\"hello\":\"world\"}\n"));
+    }
+
+    @Test
+    void putRecordBatchIsDeliveredAsOneObjectWithAllRecords() {
+        String bucket = "fh-delivery-batch-bucket";
+        String stream = "fh-delivery-batch-stream";
+        createBucket(bucket);
+        createStream(stream, bucket, "batch/", 1, 1);
+
+        given()
+            .contentType(JSON_CT)
+            .header("X-Amz-Target", TARGET_PREFIX + "PutRecordBatch")
+            .body("""
+                    {
+                      "DeliveryStreamName": "%s",
+                      "Records": [
+                        { "Data": "%s" },
+                        { "Data": "%s" },
+                        { "Data": "%s" }
+                      ]
+                    }
+                    """.formatted(stream, b64("{\"n\":1}"), b64("{\"n\":2}"), b64("{\"n\":3}")))
+        .when().post("/")
+        .then().statusCode(200)
+            .body("FailedPutCount", equalTo(0));
+
+        String key = awaitFirstKey(bucket, "batch/");
+
+        given().when().get("/" + bucket + "/" + key)
+                .then().statusCode(200)
+                .body(equalTo("{\"n\":1}\n{\"n\":2}\n{\"n\":3}\n"));
+    }
+
+    @Test
+    void reachingSizeThresholdFlushesWithoutWaitingForInterval() {
+        String bucket = "fh-delivery-size-bucket";
+        String stream = "fh-delivery-size-stream";
+        createBucket(bucket);
+        // Interval long enough (900s) that only the 1 MiB size trigger can
+        // explain a delivery inside the test's await window.
+        createStream(stream, bucket, "size/", 1, 900);
+
+        String halfMiB = "x".repeat(600 * 1024);
+        putRecord(stream, halfMiB);
+        putRecord(stream, halfMiB);
+
+        String key = awaitFirstKey(bucket, "size/");
+
+        given().when().get("/" + bucket + "/" + key)
+                .then().statusCode(200)
+                .header("Content-Length", String.valueOf(2 * (600 * 1024 + 1)));
+    }
+
+    @Test
+    void bufferedRecordsAreDroppedWhenStreamIsDeleted() throws InterruptedException {
+        String bucket = "fh-delivery-deleted-bucket";
+        String stream = "fh-delivery-deleted-stream";
+        createBucket(bucket);
+        // Interval comfortably larger than the put→delete gap so a slow CI
+        // machine can't let the flusher fire before the delete lands.
+        createStream(stream, bucket, "deleted/", 1, 3);
+
+        putRecord(stream, "{\"orphan\":true}");
+
+        given()
+            .contentType(JSON_CT)
+            .header("X-Amz-Target", TARGET_PREFIX + "DeleteDeliveryStream")
+            .body("{ \"DeliveryStreamName\": \"" + stream + "\" }")
+        .when().post("/")
+        .then().statusCode(200);
+
+        // Past the 3s interval (plus flusher tick) nothing may have been delivered.
+        Thread.sleep(5_000);
+        given().when().get("/" + bucket + "?prefix=deleted/")
+                .then().statusCode(200)
+                .body(not(containsString("<Contents>")));
+    }
+
+    @Test
+    void createRejectsDuplicateStreamName() {
+        String bucket = "fh-delivery-dup-bucket";
+        String stream = "fh-delivery-dup-stream";
+        createBucket(bucket);
+        createStream(stream, bucket, "dup/", 1, 300);
+
+        given()
+            .contentType(JSON_CT)
+            .header("X-Amz-Target", TARGET_PREFIX + "CreateDeliveryStream")
+            .body("""
+                    {
+                      "DeliveryStreamName": "%s",
+                      "ExtendedS3DestinationConfiguration": {
+                        "RoleARN": "%s",
+                        "BucketARN": "arn:aws:s3:::%s"
+                      }
+                    }
+                    """.formatted(stream, ROLE_ARN, bucket))
+        .when().post("/")
+        .then().statusCode(400)
+            .body("__type", equalTo("ResourceInUseException"));
+    }
+
+    @Test
+    void binaryRecordDataIsDeliveredByteIdentical() {
+        String bucket = "fh-delivery-binary-bucket";
+        String stream = "fh-delivery-binary-stream";
+        createBucket(bucket);
+        createStream(stream, bucket, "binary/", 1, 1);
+
+        // Not valid UTF-8: a String round-trip would mangle these bytes.
+        byte[] payload = {(byte) 0x89, 'P', 'N', 'G', 0x00, (byte) 0xFF, (byte) 0xFE, 0x01};
+        given()
+            .contentType(JSON_CT)
+            .header("X-Amz-Target", TARGET_PREFIX + "PutRecord")
+            .body("{ \"DeliveryStreamName\": \"%s\", \"Record\": { \"Data\": \"%s\" } }"
+                    .formatted(stream, Base64.getEncoder().encodeToString(payload)))
+        .when().post("/")
+        .then().statusCode(200);
+
+        String key = awaitFirstKey(bucket, "binary/");
+
+        byte[] delivered = given().when().get("/" + bucket + "/" + key)
+                .then().statusCode(200)
+                .extract().asByteArray();
+        byte[] expected = new byte[payload.length + 1];
+        System.arraycopy(payload, 0, expected, 0, payload.length);
+        expected[payload.length] = '\n';
+        org.junit.jupiter.api.Assertions.assertArrayEquals(expected, delivered);
+    }
+
+    @Test
+    void createRejectsOutOfRangeBufferingHints() {
+        rejectHints(0, 300, "sizeInMBs");
+        rejectHints(129, 300, "sizeInMBs");
+        rejectHints(5, -1, "intervalInSeconds");
+        rejectHints(5, 901, "intervalInSeconds");
+    }
+
+    private void rejectHints(int sizeInMBs, int intervalInSeconds, String expectedMember) {
+        given()
+            .contentType(JSON_CT)
+            .header("X-Amz-Target", TARGET_PREFIX + "CreateDeliveryStream")
+            .body("""
+                    {
+                      "DeliveryStreamName": "fh-invalid-hints-stream",
+                      "ExtendedS3DestinationConfiguration": {
+                        "RoleARN": "%s",
+                        "BucketARN": "arn:aws:s3:::fh-invalid-hints-bucket",
+                        "BufferingHints": { "SizeInMBs": %d, "IntervalInSeconds": %d }
+                      }
+                    }
+                    """.formatted(ROLE_ARN, sizeInMBs, intervalInSeconds))
+        .when().post("/")
+        .then().statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", containsString(expectedMember));
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────────
+
+    private static void createBucket(String bucket) {
+        given().when().put("/" + bucket).then().statusCode(200);
+    }
+
+    private static void createStream(String stream, String bucket, String prefix,
+                                     int sizeInMBs, int intervalInSeconds) {
+        given()
+            .contentType(JSON_CT)
+            .header("X-Amz-Target", TARGET_PREFIX + "CreateDeliveryStream")
+            .body("""
+                    {
+                      "DeliveryStreamName": "%s",
+                      "DeliveryStreamType": "DirectPut",
+                      "ExtendedS3DestinationConfiguration": {
+                        "RoleARN": "%s",
+                        "BucketARN": "arn:aws:s3:::%s",
+                        "Prefix": "%s",
+                        "BufferingHints": { "SizeInMBs": %d, "IntervalInSeconds": %d }
+                      }
+                    }
+                    """.formatted(stream, ROLE_ARN, bucket, prefix, sizeInMBs, intervalInSeconds))
+        .when().post("/")
+        .then().statusCode(200);
+    }
+
+    private static void putRecord(String stream, String data) {
+        given()
+            .contentType(JSON_CT)
+            .header("X-Amz-Target", TARGET_PREFIX + "PutRecord")
+            .body("{ \"DeliveryStreamName\": \"%s\", \"Record\": { \"Data\": \"%s\" } }"
+                    .formatted(stream, b64(data)))
+        .when().post("/")
+        .then().statusCode(200);
+    }
+
+    /** Polls the bucket listing until an object appears under the prefix and returns its key. */
+    private static String awaitFirstKey(String bucket, String prefix) {
+        return await().atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(200))
+                .until(() -> given().when().get("/" + bucket + "?prefix=" + prefix)
+                                .then().statusCode(200)
+                                .extract().xmlPath().getString("ListBucketResult.Contents[0].Key"),
+                        key -> key != null && !key.isEmpty());
+    }
+
+    private static String b64(String data) {
+        return Base64.getEncoder().encodeToString(data.getBytes());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesEventPublishingV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesEventPublishingV2IntegrationTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.services.cloudwatch.metrics.CloudWatchMetricsService;
 import io.github.hectorvent.floci.services.cloudwatch.metrics.CloudWatchMetricsService.MetricIdentity;
+import io.github.hectorvent.floci.services.firehose.FirehoseService;
 import io.github.hectorvent.floci.services.s3.S3Service;
 import io.github.hectorvent.floci.services.s3.model.S3Object;
 import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
@@ -79,6 +80,9 @@ class SesEventPublishingV2IntegrationTest {
 
     @Inject
     S3Service s3Service;
+
+    @Inject
+    FirehoseService firehoseService;
 
     @Inject
     CloudWatchMetricsService metricsService;
@@ -639,14 +643,19 @@ class SesEventPublishingV2IntegrationTest {
 
     @Test
     @Order(15)
-    void firehose_fiveSends_triggerAutoFlushAndWriteNdjsonToS3() throws Exception {
+    void firehose_fiveSends_flushWritesNdjsonToS3() throws Exception {
         for (int i = 0; i < 5; i++) {
             sendEmailToConfigSet(CS_FIREHOSE, "recipient" + i + "@example.com", "fh-evt-" + i);
         }
 
+        // The records sit in the stream buffer until the size/interval hints
+        // trigger delivery; force the flush so the assertion is deterministic
+        // (same mechanism the scheduled flusher uses).
+        firehoseService.flush(FIREHOSE_STREAM);
+
         List<S3Object> objects = s3Service.listObjects(FIREHOSE_BUCKET, FIREHOSE_STREAM + "/", null, 100);
         assertEquals(1, objects.size(),
-                "expected exactly one flushed S3 object after 5 putRecord calls (DEFAULT_FLUSH_COUNT)");
+                "expected exactly one flushed S3 object containing the 5 buffered records");
 
         S3Object obj = s3Service.getObject(FIREHOSE_BUCKET, objects.get(0).getKey());
         String body = new String(obj.getData(), StandardCharsets.UTF_8);
@@ -717,6 +726,9 @@ class SesEventPublishingV2IntegrationTest {
         for (int i = 0; i < 5; i++) {
             sendEmailToConfigSet(csDisabled, "recipient" + i + "@example.com", "fh-disabled-" + i);
         }
+
+        // Force a flush so an (incorrectly) buffered record would surface in S3.
+        firehoseService.flush(streamDisabled);
 
         List<S3Object> objects = s3Service.listObjects(FIREHOSE_BUCKET, streamDisabled + "/", null, 100);
         assertTrue(objects.isEmpty(),


### PR DESCRIPTION
PutRecord/PutRecordBatch buffered records but only flushed at a hard-coded 5-record count, so records below that threshold were never delivered to the S3 destination. Replace the count trigger with AWS semantics: flush when SizeInMBs of data is buffered or when IntervalInSeconds elapses since the oldest record, whichever comes first (defaults 5 MiB / 300 s). A 1s background flusher drives the interval side, running each delivery under the stream's account so account-prefixed storage resolves correctly.

Also aligned with AWS:
- BufferingHints range validation (SizeInMBs 1-128, IntervalInSeconds 0-900) -> ValidationException
- duplicate CreateDeliveryStream -> ResourceInUseException
- record data treated as raw bytes end to end (no UTF-8 round trip)
- failed deliveries retried per interval, bounded at 10 attempts

Fixes #1886

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
