### PR TITLE
fix(apigateway): resolve v2 API region across all regions for data-plane dispatch

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -232,17 +232,15 @@ public class ApiGatewayExecuteController {
                               String proxy, HttpHeaders headers, UriInfo uriInfo, byte[] body) {
         String region = regionResolver.resolveRegion(headers);
 
-        // Check if this is a v2 (HTTP API) or v1 (REST API)
-        boolean isV2 = false;
-        try {
-            apiGatewayV2Service.getApi(region, apiId);
-            isV2 = true;
-        } catch (AwsException ignored) {
-            // Not a v2 API — fall through to v1 handling
-        }
-
+        // Check if this is a v2 (HTTP API) or v1 (REST API). Unsigned data-plane
+        // requests (e.g. from a browser/frontend) carry no SigV4 Authorization header,
+        // so the region resolves to the default. Scan all regions for the API so a
+        // v2 API created in any region stays reachable — mirroring v1's
+        // resolveRestApiRegion behaviour.
+        String v2Region = apiGatewayV2Service.resolveApiRegion(region, apiId);
+        boolean isV2 = !v2Region.equals(region) || apiGatewayV2Service.apiExists(region, apiId);
         if (isV2) {
-            return dispatchV2(httpMethod, apiId, stageName, proxy, headers, uriInfo, body, region);
+            return dispatchV2(httpMethod, apiId, stageName, proxy, headers, uriInfo, body, v2Region);
         }
 
         // Resolve region for unsigned data-plane requests

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -1234,7 +1234,7 @@ public class ApiGatewayExecuteController {
 
         String requestId = UUID.randomUUID().toString();
         String eventJson = buildV2ProxyEvent(httpMethod, path, route.getRouteKey(),
-                apiId, stageName, headers, uriInfo, body, requestId);
+                apiId, region, stageName, headers, uriInfo, body, requestId);
 
         LOG.debugv("execute-api v2: {0} {1}/{2}{3} → Lambda {4}", httpMethod, apiId, stageName, path, functionName);
 
@@ -1795,7 +1795,7 @@ public class ApiGatewayExecuteController {
     }
 
     String buildV2ProxyEvent(String httpMethod, String path, String routeKey,
-                                     String apiId, String stageName,
+                                     String apiId, String region, String stageName,
                                      HttpHeaders headers, UriInfo uriInfo,
                                      byte[] body, String requestId) {
         ObjectNode event = objectMapper.createObjectNode();
@@ -1828,7 +1828,7 @@ public class ApiGatewayExecuteController {
         ObjectNode ctx = event.putObject("requestContext");
         ctx.put("accountId", regionResolver.getAccountId());
         ctx.put("apiId", apiId);
-        ctx.put("domainName", apiId + ".execute-api.us-east-1.amazonaws.com");
+        ctx.put("domainName", apiId + ".execute-api." + region + ".amazonaws.com");
         ctx.put("domainPrefix", apiId);
         ctx.put("requestId", requestId);
         ctx.put("routeKey", routeKey != null ? routeKey : "$default");

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
@@ -118,6 +118,43 @@ public class ApiGatewayV2Service {
                 .orElseThrow(() -> new AwsException("NotFoundException", "Invalid API id specified", 404));
     }
 
+    /**
+     * Returns {@code true} if a v2 API with the given id exists in {@code region}.
+     * Used by the data-plane dispatch to detect a v2 API that lives in the same
+     * region the request resolved to (where {@link #resolveApiRegion} would
+     * return the preferred region unchanged).
+     */
+    public boolean apiExists(String region, String apiId) {
+        return apiStore.get(apiKey(region, apiId)).isPresent();
+    }
+
+    /**
+     * Resolves the region an API lives in, tolerating unsigned data-plane
+     * requests that carry no SigV4 {@code Authorization} header (and therefore
+     * resolve to the configured default region).
+     *
+     * <p>If the API exists in {@code preferredRegion} that region is returned.
+     * Otherwise every stored API key is scanned for one ending in
+     * {@code "::" + apiId} and its region prefix is returned. This mirrors the
+     * v1 {@code ApiGatewayService#resolveRestApiRegion} behaviour so that
+     * frontend/browser invocations of the execute-api URL keep working
+     * regardless of which region the API was created in.
+     *
+     * @return the resolved region, or {@code preferredRegion} if the API is
+     *         not found in any region (the caller will then surface the
+     *         standard "Invalid API id specified" error)
+     */
+    public String resolveApiRegion(String preferredRegion, String apiId) {
+        if (apiStore.get(apiKey(preferredRegion, apiId)).isPresent()) {
+            return preferredRegion;
+        }
+        return apiStore.keys().stream()
+                .filter(k -> k.endsWith("::" + apiId))
+                .map(k -> k.substring(0, k.indexOf("::")))
+                .findFirst()
+                .orElse(preferredRegion);
+    }
+
     public List<Api> getApis(String region) {
         String prefix = region + "::";
         return apiStore.scan(k -> k.startsWith(prefix));

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2ProxyEventPathParametersTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2ProxyEventPathParametersTest.java
@@ -49,7 +49,7 @@ class BuildV2ProxyEventPathParametersTest {
     void greedyProxyRoutePopulatesPathParameters() throws Exception {
         String json = controller.buildV2ProxyEvent(
                 "POST", "/trpc/health", "ANY /{proxy+}",
-                "abc123", "$default", headers, uriInfo, null, "req-1");
+                "abc123", "us-east-1", "$default", headers, uriInfo, null, "req-1");
         JsonNode event = new ObjectMapper().readTree(json);
         assertTrue(event.has("pathParameters"), "pathParameters must be present");
         assertEquals("trpc/health", event.get("pathParameters").get("proxy").asText());
@@ -60,7 +60,7 @@ class BuildV2ProxyEventPathParametersTest {
         when(uriInfo.getRequestUri()).thenReturn(new URI("http://localhost:4566/api/stage/users/42"));
         String json = controller.buildV2ProxyEvent(
                 "GET", "/users/42", "GET /users/{id}",
-                "abc123", "$default", headers, uriInfo, null, "req-2");
+                "abc123", "us-east-1", "$default", headers, uriInfo, null, "req-2");
         JsonNode event = new ObjectMapper().readTree(json);
         assertTrue(event.has("pathParameters"), "pathParameters must be present");
         assertEquals("42", event.get("pathParameters").get("id").asText());
@@ -71,7 +71,7 @@ class BuildV2ProxyEventPathParametersTest {
         when(uriInfo.getRequestUri()).thenReturn(new URI("http://localhost:4566/api/stage/anything"));
         String json = controller.buildV2ProxyEvent(
                 "GET", "/anything", "$default",
-                "abc123", "$default", headers, uriInfo, null, "req-3");
+                "abc123", "us-east-1", "$default", headers, uriInfo, null, "req-3");
         JsonNode event = new ObjectMapper().readTree(json);
         assertFalse(event.has("pathParameters"), "pathParameters must be absent for $default route");
     }

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2CrossRegionDataPlaneReproTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2CrossRegionDataPlaneReproTest.java
@@ -28,9 +28,10 @@ import static org.hamcrest.Matchers.notNullValue;
  * the lookup in the default region fails with "Invalid API id specified"
  * (404) — exactly the error reported in the issue.
  *
- * <p>This test currently asserts the BUGGY behaviour so the failure is visible.
- * Once the region-resolution fallback is fixed, the unsigned request should
- * succeed (or at least not report "Invalid API id specified").
+ * <p>The unsigned data-plane request now resolves the API across all regions,
+ * so it reaches the v2 dispatch and is no longer rejected with
+ * "Invalid API id specified". The assertions below validate this fixed
+ * behaviour.
  */
 @QuarkusTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2CrossRegionDataPlaneReproTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2CrossRegionDataPlaneReproTest.java
@@ -1,0 +1,155 @@
+package io.github.hectorvent.floci.services.apigatewayv2;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Reproduces floci-io/floci#1902.
+ *
+ * <p>A user creates an API Gateway v2 (HTTP API) in a non-default region
+ * (e.g. {@code eu-west-1}, as produced by Terraform/CDK) and then tries to
+ * invoke it from a browser/frontend via the data-plane URL
+ * {@code /execute-api/{apiId}/$default/{path}} WITHOUT an {@code Authorization}
+ * header (unsigned request).
+ *
+ * <p>The data-plane dispatch resolves the region from the {@code Authorization}
+ * header and falls back to the configured default region ({@code us-east-1})
+ * when the header is absent. Because the API was created in {@code eu-west-1},
+ * the lookup in the default region fails with "Invalid API id specified"
+ * (404) — exactly the error reported in the issue.
+ *
+ * <p>This test currently asserts the BUGGY behaviour so the failure is visible.
+ * Once the region-resolution fallback is fixed, the unsigned request should
+ * succeed (or at least not report "Invalid API id specified").
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayV2CrossRegionDataPlaneReproTest {
+
+    private static final String REGION = "eu-west-1";
+    // SigV4-style Authorization carrying the region so the management API
+    // stores the API under eu-west-1 (mirrors what the AWS SDK/Terraform sends).
+    private static final String AUTH = "AWS4-HMAC-SHA256 "
+            + "Credential=AKID/20260717/" + REGION + "/apigateway/aws4_request, "
+            + "SignedHeaders=host;x-amz-target, Signature=deadbeef";
+
+    private static String apiId;
+    private static String integrationId;
+    private static String routeId;
+    private static String deploymentId;
+
+    @Test @Order(1)
+    void createApiInNonDefaultRegion() {
+        apiId = given()
+                .header("Authorization", AUTH)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"repro-http-api","protocolType":"HTTP"}
+                        """)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .body("apiId", notNullValue())
+                .body("apiEndpoint", containsString("execute-api." + REGION + ".amazonaws.com"))
+                .extract().path("apiId");
+    }
+
+    @Test @Order(2)
+    void createIntegration() {
+        integrationId = given()
+                .header("Authorization", AUTH)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"integrationType":"HTTP_PROXY","integrationUri":"https://example.com","payloadFormatVersion":"2.0"}
+                        """)
+                .when().post("/v2/apis/" + apiId + "/integrations")
+                .then()
+                .statusCode(201)
+                .extract().path("integrationId");
+    }
+
+    @Test @Order(3)
+    void createRoute() {
+        routeId = given()
+                .header("Authorization", AUTH)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"routeKey":"GET /events","target":"integrations/%s"}
+                        """.formatted(integrationId))
+                .when().post("/v2/apis/" + apiId + "/routes")
+                .then()
+                .statusCode(201)
+                .extract().path("routeId");
+    }
+
+    @Test @Order(4)
+    void createDeployment() {
+        deploymentId = given()
+                .header("Authorization", AUTH)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"description":"v1"}
+                        """)
+                .when().post("/v2/apis/" + apiId + "/deployments")
+                .then()
+                .statusCode(201)
+                .extract().path("deploymentId");
+    }
+
+    @Test @Order(5)
+    void createDefaultStage() {
+        given()
+                .header("Authorization", AUTH)
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"stageName":"$default","deploymentId":"%s","autoDeploy":false}
+                        """.formatted(deploymentId))
+                .when().post("/v2/apis/" + apiId + "/stages")
+                .then()
+                .statusCode(201)
+                .body("stageName", equalTo("$default"));
+    }
+
+    /**
+     * Reproduces the user's failing request: an UNSIGNED data-plane call
+     * (no Authorization header) to the execute-api URL. The frontend/browser
+     * makes exactly this kind of request.
+     *
+     * <p>Before the fix this returned 404 "Invalid API id specified" because the
+     * region fell back to the default (us-east-1) while the API lives in
+     * eu-west-1. After the fix the region is resolved across all stored APIs, so
+     * the request reaches the v2 dispatch and is no longer rejected with that
+     * error. The integration targets example.com, which may be unreachable in
+     * the test sandbox (yielding a 502), but the key assertion is that the
+     * region-resolution error is gone.
+     */
+    @Test @Order(6)
+    void unsignedDataPlaneRequestResolvesApiAcrossRegions() {
+        given()
+                .contentType(ContentType.JSON)
+                .when().get("/execute-api/" + apiId + "/$default/events")
+                .then()
+                .statusCode(not(equalTo(404)))
+                .body(not(containsString("Invalid API id specified")));
+    }
+
+    @Test @Order(99)
+    void cleanup() {
+        given()
+                .header("Authorization", AUTH)
+                .contentType(ContentType.JSON)
+                .when().delete("/v2/apis/" + apiId)
+                .then()
+                .statusCode(204);
+    }
+}


### PR DESCRIPTION


Unsigned data-plane requests (browser/frontend) carry no SigV4 Authorization header, so the region resolves to the default (us-east-1). The v2 dispatch detection previously called getApi(region, apiId) with the unresolved region, so a v2 API created in another region (e.g. eu-west-1) was never detected and fell through to v1 handling, failing with
'Invalid API id specified' (404).

Resolve the region first via ApiGatewayV2Service.resolveApiRegion (which scans all stored API keys), then check isV2 using the resolved region. Add ApiGatewayV2Service.apiExists(region, apiId) to detect a v2 API that lives in the same/default region.

Fixes floci-io/floci#1902

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
