### PR TITLE
test(athena): allow for floci-duck cold start when polling query state

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AthenaTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AthenaTest.java
@@ -67,19 +67,33 @@ class AthenaTest {
     @Order(3)
     @DisplayName("Get query results returns result set")
     void getQueryResults() {
-        // Poll until succeeded (mock mode completes immediately, real duck may take a moment)
+        // Poll until succeeded. Mock mode completes immediately; against real floci-duck the
+        // first query also pays for pulling the sidecar image and waiting for its health check,
+        // so allow enough headroom to cover a cold start. The loop exits as soon as the state
+        // flips, so a warm sidecar costs nothing extra.
         QueryExecutionState state = QueryExecutionState.RUNNING;
         int attempts = 0;
-        while (state == QueryExecutionState.RUNNING && attempts++ < 20) {
+        while (state == QueryExecutionState.RUNNING && attempts++ < 120) {
             GetQueryExecutionResponse exec = athena.getQueryExecution(
                     GetQueryExecutionRequest.builder().queryExecutionId(queryExecutionId).build());
-            state = exec.queryExecution().status().state();
+            QueryExecutionStatus status = exec.queryExecution().status();
+            state = status.state();
+            if (state == QueryExecutionState.FAILED) {
+                Assertions.fail("Query failed: " + status.stateChangeReason());
+            }
             if (state == QueryExecutionState.RUNNING) {
-                try { Thread.sleep(500); } catch (InterruptedException ignored) {}
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
             }
         }
 
-        assertThat(state).isEqualTo(QueryExecutionState.SUCCEEDED);
+        assertThat(state)
+                .as("query %s did not succeed within 60s", queryExecutionId)
+                .isEqualTo(QueryExecutionState.SUCCEEDED);
 
         GetQueryResultsResponse results = athena.getQueryResults(
                 GetQueryResultsRequest.builder()


### PR DESCRIPTION
## Summary

- `AthenaTest.getQueryResults` allowed 10s (20 attempts at 500ms) for a query to reach a terminal state. The first Athena query in a run starts the floci-duck sidecar, so that budget also has to cover pulling `floci/floci-duck:latest` and waiting for the health check. `FlociDuckManager.HEALTH_POLL_MAX_MS` alone permits 30s for health, so 10s could never cover a cold start.
- This makes the test a race that CI loses intermittently. In [run 29706871552](https://github.com/floci-io/floci/actions/runs/29706871552/job/88245678963) the image pulled in 4.1s, the sidecar reported healthy at +10.0s, and the query succeeded **372ms after the final poll had already given up**.
- Raise the budget to 60s, matching `StepFunctionsActivityTest.pollUntilDone`, which polls the same way for the same reason. The loop still exits on the first non-RUNNING state, so a warm sidecar returns as fast as before and only a genuine hang uses the full window.
- Make a timeout self-explaining. The failure above surfaced as a bare `expected: SUCCEEDED but was: RUNNING`, which gives no hint that the budget ran out rather than the query landing in a wrong state. Fail fast on `FAILED` with the `stateChangeReason` (as `DataLakeTest` already does), name the execution and budget in the timeout assertion, and restore the interrupt flag rather than swallowing it (as `CloudWatchLogsInsightsTest` already does).

No production code changes, and no CI config changes: the lazy cold-start path stays under test rather than being pre-warmed away.

## Timeline from the failing run

| Time | Event |
|------|-------|
| 23:02:43.809 | `StartQueryExecution`, begins pulling `floci/floci-duck:latest` |
| 23:02:47.953 | Image pulled (4.1s) |
| 23:02:48.256 | Container started, waiting for health check |
| 23:02:53.390 | Test's 20th and final poll, still RUNNING, assertion fails |
| 23:02:53.762 | floci-duck ready |
| 23:02:53.802 | Query succeeded |

## Test plan

- [x] `mvn test-compile` clean for `compatibility-tests/sdk-test-java`
- [x] Diagnosis confirmed against `AthenaService.startQueryExecution`: state is `RUNNING` synchronously, then `SUCCEEDED`/`FAILED` via `vertx.executeBlocking`, so the loop exits on either terminal state and the budget change is a tolerance fix, not a masked hang
- [x] Budget cross-checked against sibling pollers in the same suite (`StepFunctionsActivityTest` 60s, `DataLakeTest` 30s, `AppSyncTest` 10s)
- [ ] `native / sdk-test-java` green in CI