### PR TITLE
fix(rds): preserve aurora engine types in API responses

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -630,13 +630,13 @@ public class RdsQueryHandler {
 
     private String dbInstanceInnerXml(DbInstance i) {
         DbEndpoint ep = i.getEndpoint();
-        String engineStr = i.getEngine() != null ? i.getEngine().name() : "";
+        String engineStr = i.getEngine() != null ? i.getEngine().apiName() : "";
         String statusStr = i.getStatus() != null ? statusLabel(i.getStatus()) : "available";
 
         XmlBuilder xml = new XmlBuilder()
                 .elem("DBInstanceIdentifier", i.getDbInstanceIdentifier())
                 .elem("DBInstanceStatus", statusStr)
-                .elem("Engine", engineStr.toLowerCase())
+                .elem("Engine", engineStr)
                 .elem("EngineVersion", i.getEngineVersion())
                 .elem("MasterUsername", i.getMasterUsername());
         if (i.getDbName() != null && !i.getDbName().isBlank()) {
@@ -760,13 +760,13 @@ public class RdsQueryHandler {
     private String dbClusterInnerXml(DbCluster c) {
         DbEndpoint ep = c.getEndpoint();
         DbEndpoint readerEp = c.getReaderEndpoint();
-        String engineStr = c.getEngine() != null ? c.getEngine().name() : "";
+        String engineStr = c.getEngine() != null ? c.getEngine().apiName() : "";
         String statusStr = c.getStatus() != null ? statusLabel(c.getStatus()) : "available";
 
         XmlBuilder xml = new XmlBuilder()
                 .elem("DBClusterIdentifier", c.getDbClusterIdentifier())
                 .elem("Status", statusStr)
-                .elem("Engine", engineStr.toLowerCase())
+                .elem("Engine", engineStr)
                 .elem("EngineVersion", c.getEngineVersion())
                 .elem("MasterUsername", c.getMasterUsername());
         if (c.getDatabaseName() != null && !c.getDatabaseName().isBlank()) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -480,7 +480,7 @@ public class RdsService implements Resettable {
             return JSON.writeValueAsString(Map.of(
                     "username", instance.getMasterUsername(),
                     "password", instance.getMasterPassword(),
-                    "engine", instance.getEngine().name().toLowerCase(),
+                    "engine", instance.getEngine().apiName(),
                     "host", instance.getEndpoint().address(),
                     "port", instance.getEndpoint().port(),
                     "dbname", instance.getDbName() == null ? "" : instance.getDbName(),
@@ -981,8 +981,11 @@ public class RdsService implements Resettable {
             return DatabaseEngine.POSTGRES;
         }
         return switch (engineParam.toLowerCase()) {
-            case "postgres", "aurora-postgresql" -> DatabaseEngine.POSTGRES;
-            case "mysql", "aurora-mysql", "aurora" -> DatabaseEngine.MYSQL;
+            case "postgres" -> DatabaseEngine.POSTGRES;
+            case "aurora-postgresql" -> DatabaseEngine.AURORA_POSTGRESQL;
+            case "mysql" -> DatabaseEngine.MYSQL;
+            case "aurora-mysql" -> DatabaseEngine.AURORA_MYSQL;
+            case "aurora" -> DatabaseEngine.AURORA_MYSQL;
             case "mariadb" -> DatabaseEngine.MARIADB;
             default -> throw new AwsException("InvalidParameterValue", invalidParameterValueMessage(), 400);
         };
@@ -990,8 +993,8 @@ public class RdsService implements Resettable {
 
     private String imageForEngine(DatabaseEngine engine, String engineVersion) {
         String defaultImage = switch (engine) {
-            case POSTGRES -> config.services().rds().defaultPostgresImage();
-            case MYSQL -> config.services().rds().defaultMysqlImage();
+            case POSTGRES, AURORA_POSTGRESQL -> config.services().rds().defaultPostgresImage();
+            case MYSQL, AURORA_MYSQL -> config.services().rds().defaultMysqlImage();
             case MARIADB -> config.services().rds().defaultMariadbImage();
         };
         return imageForRequestedVersion(defaultImage, engineVersion);

--- a/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
@@ -168,8 +168,8 @@ public class RdsContainerManager {
 
     static String engineDefaultDataPath(DatabaseEngine engine, String image) {
         return switch (engine) {
-            case POSTGRES -> postgresDataPath(image);
-            case MYSQL, MARIADB -> "/var/lib/mysql";
+            case POSTGRES, AURORA_POSTGRESQL -> postgresDataPath(image);
+            case MYSQL, AURORA_MYSQL, MARIADB -> "/var/lib/mysql";
         };
     }
 
@@ -316,13 +316,13 @@ public class RdsContainerManager {
 
         List<String> envs = new ArrayList<>();
         switch (engine) {
-            case POSTGRES -> {
+            case POSTGRES, AURORA_POSTGRESQL -> {
                 envs.add("POSTGRES_USER=" + effectiveUser);
                 envs.add("POSTGRES_PASSWORD=" + masterPassword);
                 envs.add("POSTGRES_DB=" + effectiveDb);
                 envs.add("POSTGRES_HOST_AUTH_METHOD=md5");
             }
-            case MYSQL -> {
+            case MYSQL, AURORA_MYSQL -> {
                 envs.add("MYSQL_ROOT_PASSWORD=" + masterPassword);
                 if (!"root".equals(effectiveUser)) {
                     envs.add("MYSQL_USER=" + effectiveUser);
@@ -346,8 +346,8 @@ public class RdsContainerManager {
         // Configure MySQL to use mysql_native_password so the proxy can authenticate
         // without needing caching_sha2_password RSA key exchange
         return switch (engine) {
-            case MYSQL -> List.of("--default-authentication-plugin=mysql_native_password");
-            case POSTGRES, MARIADB -> List.of();
+            case MYSQL, AURORA_MYSQL -> List.of("--default-authentication-plugin=mysql_native_password");
+            case POSTGRES, AURORA_POSTGRESQL, MARIADB -> List.of();
         };
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DatabaseEngine.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DatabaseEngine.java
@@ -4,12 +4,16 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 
 @RegisterForReflection
 public enum DatabaseEngine {
-    POSTGRES, MYSQL, MARIADB;
+    POSTGRES, AURORA_POSTGRESQL, MYSQL, AURORA_MYSQL, MARIADB;
 
     public int defaultPort() {
         return switch (this) {
-            case POSTGRES -> 5432;
-            case MYSQL, MARIADB -> 3306;
+            case POSTGRES, AURORA_POSTGRESQL -> 5432;
+            case MYSQL, AURORA_MYSQL, MARIADB -> 3306;
         };
+    }
+
+    public String apiName() {
+        return this.name().toLowerCase().replace("_", "-");
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/RdsAuthProxy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/RdsAuthProxy.java
@@ -87,10 +87,10 @@ public class RdsAuthProxy {
             backend.setTcpNoDelay(true);
 
             switch (engine) {
-                case POSTGRES -> PostgresProtocolHandler.handleAuth(
+                case POSTGRES, AURORA_POSTGRESQL -> PostgresProtocolHandler.handleAuth(
                         client, backend, masterUsername, masterPassword, dbName,
                         iamEnabled, sigV4, passwordValidator::validate);
-                case MYSQL, MARIADB -> MySqlProtocolHandler.handleAuth(
+                case MYSQL, AURORA_MYSQL, MARIADB -> MySqlProtocolHandler.handleAuth(
                         client, backend, masterUsername, masterPassword,
                         iamEnabled, sigV4, passwordValidator::validate);
             }

--- a/src/main/java/io/github/hectorvent/floci/services/rdsdata/RdsDataConnectionFactory.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rdsdata/RdsDataConnectionFactory.java
@@ -25,9 +25,9 @@ class RdsDataConnectionFactory {
 
     static String buildUrl(DatabaseEngine engine, String host, int port, String database) {
         return switch (engine) {
-            case MYSQL, MARIADB -> "jdbc:mysql://" + host + ":" + port + "/" + database
+            case MYSQL, AURORA_MYSQL, MARIADB -> "jdbc:mysql://" + host + ":" + port + "/" + database
                     + "?useSSL=false&allowPublicKeyRetrieval=true";
-            case POSTGRES -> "jdbc:postgresql://" + host + ":" + port + "/" + database
+            case POSTGRES, AURORA_POSTGRESQL -> "jdbc:postgresql://" + host + ":" + port + "/" + database
                     + "?sslmode=disable";
         };
     }
@@ -35,8 +35,8 @@ class RdsDataConnectionFactory {
     private static String connectTimeout(DatabaseEngine engine) {
         // MySQL Connector/J expects milliseconds; the PostgreSQL driver expects seconds.
         return switch (engine) {
-            case MYSQL, MARIADB -> "5000";
-            case POSTGRES -> "5";
+            case MYSQL, AURORA_MYSQL, MARIADB -> "5000";
+            case POSTGRES, AURORA_POSTGRESQL -> "5";
         };
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -785,6 +785,32 @@ class RdsQueryHandlerTest {
         assertTrue(((String) response.getEntity()).contains("DBSubnetGroupNotFoundFault"));
     }
 
+    @Test
+    void describeDbInstances_returnsAuroraPostgresqlCorrectly() {
+        DbInstance instance = makeInstance("aurora-pg");
+        instance.setEngine(io.github.hectorvent.floci.services.rds.model.DatabaseEngine.AURORA_POSTGRESQL);
+        when(service.listDbInstances(null)).thenReturn(List.of(instance));
+
+        Response response = handler.handle("DescribeDBInstances", params());
+
+        assertEquals(200, response.getStatus());
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<Engine>aurora-postgresql</Engine>"), "Expected aurora-postgresql in response, got: " + body);
+    }
+
+    @Test
+    void describeDbClusters_returnsAuroraMysqlCorrectly() {
+        DbCluster cluster = makeCluster("aurora-mysql-cluster");
+        cluster.setEngine(io.github.hectorvent.floci.services.rds.model.DatabaseEngine.AURORA_MYSQL);
+        when(service.listDbClusters(null)).thenReturn(List.of(cluster));
+
+        Response response = handler.handle("DescribeDBClusters", params());
+
+        assertEquals(200, response.getStatus());
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<Engine>aurora-mysql</Engine>"), "Expected aurora-mysql in response, got: " + body);
+    }
+
     // ──────────────────────────── Helpers ────────────────────────────
 
     private static MultivaluedMap<String, String> params() {


### PR DESCRIPTION
## Summary
Fixes issue #1918 where RDS aurora engine types (aurora-postgresql, aurora-mysql) were incorrectly converted to base engine types (postgres, mysql), causing Terraform state drift.

## Problem
When a user specified `engine="aurora-postgresql"` or `engine="aurora-mysql"` when creating an RDS instance or cluster, Floci was internally converting these to the base `DatabaseEngine.POSTGRES` or `DatabaseEngine.MYSQL` enum values. When querying the resource via API, only the base engine name was returned, causing Terraform to detect a mismatch and attempt invalid engine modifications.

## Solution
- Extended `DatabaseEngine` enum to include `AURORA_POSTGRESQL` and `AURORA_MYSQL` as distinct values
- Added `apiName()` method to the enum to convert names to correct API format (e.g., `AURORA_POSTGRESQL` → `"aurora-postgresql"`)
- Updated `RdsService.resolveEngine()` to map input strings to correct enum values:
  - `"postgres"` → `POSTGRES`
  - `"aurora-postgresql"` → `AURORA_POSTGRESQL`  
  - `"mysql"` → `MYSQL`
  - `"aurora-mysql"` → `AURORA_MYSQL`
  - `"aurora"` → `AURORA_MYSQL` (AWS default)
- Updated `imageForEngine()` to use the same Docker container image for Aurora variants as their base engines
- Updated `RdsQueryHandler` to use `engine.apiName()` when serializing engine names in XML responses
- Updated `RdsService.managedMasterSecretString()` to use `engine.apiName()`
- Updated all switch statements in `RdsContainerManager`, `RdsAuthProxy`, and `RdsDataConnectionFactory` to properly handle new Aurora engine types

## Test Coverage
- Added test for aurora-postgresql engine returned correctly in DescribeDBInstances
- Added test for aurora-mysql engine returned correctly in DescribeDBClusters
- All 48 existing RDS query handler tests continue to pass

## Related Issues
Closes #1918