### PR TITLE
fix(s3): preserve literal question marks in copy source keys

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -1925,21 +1925,13 @@ public class S3Controller {
                                       String contentType, HttpHeaders httpHeaders) {
         // copySource format: /bucket/key or bucket/key, where key is URL-encoded
         String source = copySource.startsWith("/") ? copySource.substring(1) : copySource;
-        
-        // URL decode the entire source first, then split
-        String decodedSource;
-        try {
-            decodedSource = URLDecoder.decode(source, StandardCharsets.UTF_8);
-        } catch (IllegalArgumentException e) {
-            throw new AwsException("InvalidArgument", "Invalid copy source: " + copySource, 400);
-        }
-        int slashIndex = decodedSource.indexOf('/');
+
+        int slashIndex = source.indexOf('/');
         if (slashIndex <= 0) {
             throw new AwsException("InvalidArgument", "Invalid copy source: " + copySource, 400);
         }
-        String sourceBucket = decodedSource.substring(0, slashIndex);
-        String pathAfterBucket = decodedSource.substring(slashIndex + 1);
-        ParsedCopySource sourceObject = parseCopySourceObject(pathAfterBucket);
+        String sourceBucket = decodeCopySourceComponent(source.substring(0, slashIndex), copySource);
+        ParsedCopySource sourceObject = parseCopySourceObject(source.substring(slashIndex + 1), copySource);
         String copyContentEncoding = toPersistedContentEncoding(httpHeaders.getHeaderString("Content-Encoding"));
         String copyContentDisposition = httpHeaders.getHeaderString("Content-Disposition");
         String copyCacheControl = httpHeaders.getHeaderString("Cache-Control");
@@ -1993,20 +1985,12 @@ public class S3Controller {
         // copySource format: /bucket/key or bucket/key, where key is URL-encoded
         String source = copySource.startsWith("/") ? copySource.substring(1) : copySource;
 
-        // URL decode the entire source first, then split.
-        String decodedSource;
-        try {
-            decodedSource = URLDecoder.decode(source, StandardCharsets.UTF_8);
-        } catch (IllegalArgumentException e) {
-            throw new AwsException("InvalidArgument", "Invalid copy source: " + copySource, 400);
-        }
-        int slashIndex = decodedSource.indexOf('/');
+        int slashIndex = source.indexOf('/');
         if (slashIndex <= 0) {
             throw new AwsException("InvalidArgument", "Invalid copy source: " + copySource, 400);
         }
-        String sourceBucket = decodedSource.substring(0, slashIndex);
-        String pathAfterBucket = decodedSource.substring(slashIndex + 1);
-        ParsedCopySource sourceObject = parseCopySourceObject(pathAfterBucket);
+        String sourceBucket = decodeCopySourceComponent(source.substring(0, slashIndex), copySource);
+        ParsedCopySource sourceObject = parseCopySourceObject(source.substring(slashIndex + 1), copySource);
         String copySourceRange = httpHeaders.getHeaderString("x-amz-copy-source-range");
         String eTag = s3Service.uploadPartCopy(destBucket, destKey, uploadId, partNumber,
                 sourceBucket, sourceObject.objectKey(), sourceObject.versionId(), copySourceRange,
@@ -2893,42 +2877,66 @@ public class S3Controller {
     }
 
     /**
-     * Splits the {@code CopyObject}/{@code UploadPartCopy} copy-source remainder into S3 object key and
-     * optional source {@code versionId}.
+     * Splits the raw {@code CopyObject}/{@code UploadPartCopy} copy-source remainder into decoded S3 object
+     * key and optional source {@code versionId}.
      * <ul>
-     *   <li><b>Input:</b> decoded {@code x-amz-copy-source} with bucket already removed (substring after
+     *   <li><b>Input:</b> raw {@code x-amz-copy-source} with bucket already removed (substring after
      *   the {@code '/'} that follows the bucket). Both {@code handleCopyObject} and
      *   {@code handleUploadPartCopy} compute this as {@code pathAfterBucket}.</li>
-     *   <li><b>Key:</b> substring before the first {@code '?'} if any; keys may contain more {@code '/'}
-     *   segments.</li>
-     *   <li><b>{@code versionId}:</b> first {@code versionId} query pair, when present (raw value after
-     *   {@code '='}). Other query pairs are ignored.</li>
+     *   <li><b>Key:</b> the decoded full path unless a trailing query string contains {@code versionId=}.
+     *   Literal {@code '?'} characters in the key (encoded as {@code %3F} or raw) are preserved because the
+     *   split happens before decoding.</li>
+     *   <li><b>{@code versionId}:</b> first decoded {@code versionId} query pair, when present. Other query
+     *   pairs are ignored and do not cause the key to be truncated.</li>
      * </ul>
      *
-     * @param pathAfterBucket object key alone, or key with query (for example {@code dir/k.txt?versionId=uuid})
+     * @param pathAfterBucket    raw object key alone, or key with query (for example {@code dir/k.txt?versionId=uuid})
+     * @param originalCopySource original header value, used for error messages on malformed encoding
      * @return key without trailing query plus {@code versionId} value, or {@code null} version when absent
      */
-    private ParsedCopySource parseCopySourceObject(String pathAfterBucket) {
+    private ParsedCopySource parseCopySourceObject(String pathAfterBucket, String originalCopySource) {
         int queryStart = pathAfterBucket.indexOf('?');
         if (queryStart < 0) {
-            return new ParsedCopySource(pathAfterBucket, null);
+            return new ParsedCopySource(decodeCopySourceComponent(pathAfterBucket, originalCopySource), null);
         }
-        String objectKey = pathAfterBucket.substring(0, queryStart);
+
         String query = pathAfterBucket.substring(queryStart + 1);
+        String versionId = extractVersionId(query, originalCopySource);
+        if (versionId == null) {
+            return new ParsedCopySource(decodeCopySourceComponent(pathAfterBucket, originalCopySource), null);
+        }
+
+        String objectKey = decodeCopySourceComponent(pathAfterBucket.substring(0, queryStart), originalCopySource);
+        return new ParsedCopySource(objectKey, versionId);
+    }
+
+    private String extractVersionId(String query, String originalCopySource) {
+        if (!query.contains("versionId=")) {
+            return null;
+        }
+
         String versionId = null;
         for (String pair : query.split("&")) {
             int eq = pair.indexOf('=');
             if (eq <= 0) {
                 continue;
             }
-            String name = pair.substring(0, eq);
-            String value = pair.substring(eq + 1);
+            String name = decodeCopySourceComponent(pair.substring(0, eq), originalCopySource);
+            String value = decodeCopySourceComponent(pair.substring(eq + 1), originalCopySource);
             if ("versionId".equals(name)) {
                 versionId = value;
                 break;
             }
         }
-        return new ParsedCopySource(objectKey, versionId);
+        return versionId;
+    }
+
+    private String decodeCopySourceComponent(String value, String originalCopySource) {
+        try {
+            return URLDecoder.decode(value, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            throw new AwsException("InvalidArgument", "Invalid copy source: " + originalCopySource, 400);
+        }
     }
 
     private record ParsedCopySource(String objectKey, String versionId) {

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -480,6 +480,67 @@ class S3IntegrationTest {
     }
 
     @Test
+    @Order(120)
+    void copyObjectWithQuestionMarkInSourceKeySucceeds() {
+        String sourceBucket = "copy-question-source-bucket";
+        String destBucket = "copy-question-dest-bucket";
+        // The source key contains a literal '?'. Storing it requires a percent-encoded PUT path
+        // (with urlEncodingEnabled(false)) so the '?' is not treated as the query-string delimiter.
+        String rawSrcKey = "folder/file with question ?.txt";
+        String encodedSrcKey = "folder/file%20with%20question%20%3F.txt";
+
+        given().put("/" + sourceBucket).then().statusCode(200);
+        given().put("/" + destBucket).then().statusCode(200);
+
+        given()
+            .urlEncodingEnabled(false)
+            .contentType("text/plain")
+            .body("copy test")
+        .when()
+            .put("/" + sourceBucket + "/" + encodedSrcKey)
+        .then()
+            .statusCode(200);
+
+        // AWS-style copy source: the key is URL-encoded, so the literal '?' arrives as %3F.
+        given()
+            .header("x-amz-copy-source", "/" + sourceBucket + "/" + encodedSrcKey)
+        .when()
+            .put("/" + destBucket + "/copied/encoded.txt")
+        .then()
+            .statusCode(200)
+            .body(containsString("CopyObjectResult"));
+
+        // Lenient case: a raw literal '?' in the copy source (no versionId query) is kept in the key.
+        given()
+            .header("x-amz-copy-source", "/" + sourceBucket + "/" + rawSrcKey)
+        .when()
+            .put("/" + destBucket + "/copied/raw.txt")
+        .then()
+            .statusCode(200)
+            .body(containsString("CopyObjectResult"));
+
+        given()
+        .when()
+            .get("/" + destBucket + "/copied/encoded.txt")
+        .then()
+            .statusCode(200)
+            .body(equalTo("copy test"));
+
+        given()
+        .when()
+            .get("/" + destBucket + "/copied/raw.txt")
+        .then()
+            .statusCode(200)
+            .body(equalTo("copy test"));
+
+        given().urlEncodingEnabled(false).delete("/" + sourceBucket + "/" + encodedSrcKey);
+        given().delete("/" + destBucket + "/copied/encoded.txt");
+        given().delete("/" + destBucket + "/copied/raw.txt");
+        given().delete("/" + sourceBucket);
+        given().delete("/" + destBucket);
+    }
+
+    @Test
     @Order(24)
     void copyObjectWithMalformedEncodedSourceReturns400() {
         given()


### PR DESCRIPTION
## Summary
Fixes S3 `CopyObject` and `UploadPartCopy` when `x-amz-copy-source` references a source key that contains a literal question mark (`?`), sent either AWS-style URL-encoded (`%3F`) or raw.

Previously Floci returned `NoSuchKey` for a source object that existed and was resolvable via `HeadObject`, whenever the source key contained a `?`.

## Root cause
The copy-source parsing decoded the **entire** header value before splitting bucket, key, and query. A header like:

```
/bucket/folder/file%20with%20question%20%3F.txt
```

was decoded first into `bucket/folder/file with question ?.txt`, after which the parser treated the first `?` as the start of a query string and truncated the key to `folder/file with question `. The copy then looked up the wrong key and returned `NoSuchKey`. Raw `?` values behaved the same way.

## What changed
The parsing flow now:

- splits the raw `x-amz-copy-source` into bucket and path **before** URL decoding
- decodes bucket, object-key, and query components separately
- only interprets a trailing `?` section as metadata when it actually contains `versionId=`
- preserves literal question marks in the object key when no `versionId` query is present
- keeps existing copy-source version selection via `?versionId=...`

The same parsing is shared by `CopyObject` and `UploadPartCopy`, so the two stay aligned. Malformed percent-encoding still returns `400 InvalidArgument`.

## Tests
Adds `S3IntegrationTest#copyObjectWithQuestionMarkInSourceKeySucceeds`, covering:

- AWS-style encoded copy source: `folder/file%20with%20question%20%3F.txt`
- raw copy source: `folder/file with question ?.txt`

Both are verified through to the copied object's content. The source object is created via a percent-encoded PUT path (`urlEncodingEnabled(false)`) so the key is genuinely stored with a literal `?`.

## Validation
- `./mvnw test -Dtest=S3IntegrationTest#copyObjectWithQuestionMarkInSourceKeySucceeds` — passes
- `./mvnw test -Dtest=S3CopyObjectVersionedIntegrationTest,S3UploadPartCopyVersionedIntegrationTest` — `versionId` copy-source behavior unaffected (12 tests pass)

## Credit
Supersedes and closes #1713 — same root-cause analysis and fix approach, adapted to the current `parseCopySourceObject` structure on `main` (which #1713 conflicted with) and with the regression test corrected so it exercises a genuinely stored `?` key. Thanks to @Tomoya0k for the original diagnosis.

Closes #1713
