### PR TITLE
fix(stepfunctions): update AslExecutorJsonMergeTest for new AslExecutor constructor

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorJsonMergeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorJsonMergeTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.stepfunctions;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler;
 import io.github.hectorvent.floci.services.dynamodb.DynamoDbJsonHandler;
 import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
@@ -49,7 +50,9 @@ class AslExecutorJsonMergeTest {
                 mock(EcsJsonHandler.class),
                 mapper,
                 new JsonataEvaluator(mapper),
-                mock(Instance.class));
+                mock(Instance.class),
+                mock(EmulatorConfig.class),
+                null);
     }
 
     @Test


### PR DESCRIPTION
## Summary
`main` currently fails to test-compile, which turns "Build and Test" (and the native build) red on every open PR.

#1503 ("feat(sfn): support http invoke step") added `EmulatorConfig` and `Vertx` parameters to the `AslExecutor` constructor and updated the other `AslExecutor*` tests, but `AslExecutorJsonMergeTest` (added by #1662) was missed. It still calls the old 13-arg constructor:

```
AslExecutorJsonMergeTest.java:[39,20] constructor AslExecutor cannot be applied to given types;
  required: (…) EmulatorConfig, Vertx
  found:    (…) Instance
```

## What changed
Pass `mock(EmulatorConfig.class)` and a `null` Vertx for the two trailing constructor arguments, matching the plain-unit-test convention already used by `AslExecutorPathIntrinsicsTest`. No production code changes.

## Validation
- `./mvnw test -Dtest=AslExecutorJsonMergeTest` — 7 tests pass (previously would not compile)