### PR TITLE
fix(storage): dedupe backends by resolved file path

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/storage/StorageFactory.java
+++ b/src/main/java/io/github/hectorvent/floci/core/storage/StorageFactory.java
@@ -29,6 +29,8 @@ public class StorageFactory {
     private final EmulatorConfig config;
     private final ServiceConfigAccess serviceConfigAccess;
     private final List<StorageBackend<?, ?>> allBackends = new ArrayList<>();
+    // A file path identifies one logical store: callers sharing a path are expected to agree on
+    // its value type and storage mode. The first create() wins; repeat calls reuse that backend.
     private final Map<Path, StorageBackend<?, ?>> backendsByPath = new HashMap<>();
     private final List<HybridStorage<?, ?>> hybridBackends = new ArrayList<>();
     private final List<WalStorage<?, ?>> walBackends = new ArrayList<>();
@@ -101,21 +103,21 @@ public class StorageFactory {
     }
 
     /** Load all storage backends from disk. */
-    public void loadAll() {
+    public synchronized void loadAll() {
         for (StorageBackend<?, ?> backend : allBackends) {
             backend.load();
         }
     }
 
     /** Flush all storage backends to disk. */
-    public void flushAll() {
+    public synchronized void flushAll() {
         for (StorageBackend<?, ?> backend : allBackends) {
             backend.flush();
         }
     }
 
     /** Clear all storage backends. */
-    public void clearAll() {
+    public synchronized void clearAll() {
         for (StorageBackend<?, ?> backend : allBackends) {
             backend.clear();
         }
@@ -123,7 +125,7 @@ public class StorageFactory {
     }
 
     /** Shutdown all managed backends (stop schedulers, close connections). */
-    public void shutdownAll() {
+    public synchronized void shutdownAll() {
         for (HybridStorage<?, ?> hybrid : hybridBackends) {
             hybrid.shutdown();
         }

--- a/src/main/java/io/github/hectorvent/floci/core/storage/StorageFactory.java
+++ b/src/main/java/io/github/hectorvent/floci/core/storage/StorageFactory.java
@@ -11,6 +11,7 @@ import org.jboss.logging.Logger;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -28,6 +29,7 @@ public class StorageFactory {
     private final EmulatorConfig config;
     private final ServiceConfigAccess serviceConfigAccess;
     private final List<StorageBackend<?, ?>> allBackends = new ArrayList<>();
+    private final Map<Path, StorageBackend<?, ?>> backendsByPath = new HashMap<>();
     private final List<HybridStorage<?, ?>> hybridBackends = new ArrayList<>();
     private final List<WalStorage<?, ?>> walBackends = new ArrayList<>();
 
@@ -50,12 +52,23 @@ public class StorageFactory {
      * @param fileName      the JSON file name for persistent storage
      * @param typeReference Jackson type reference for deserialization
      */
-    public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+    public synchronized <V> StorageBackend<String, V> create(String serviceName, String fileName,
                                                  TypeReference<Map<String, V>> typeReference) {
         String mode = resolveMode(serviceName);
         long flushInterval = resolveFlushInterval(serviceName);
         Path basePath = Path.of(config.storage().persistentPath());
         Path filePath = basePath.resolve(fileName);
+
+        // Reuse an existing backend for the same file. Handing out a second backend bound to the
+        // same path creates a duplicate in-memory store; on shutdown the stale duplicate flushes
+        // after the active instance and clobbers persisted state (issue #1921).
+        StorageBackend<?, ?> existing = backendsByPath.get(filePath);
+        if (existing != null) {
+            LOG.debugv("Reusing existing {0} storage for service {1} (file: {2})", mode, serviceName, filePath);
+            @SuppressWarnings("unchecked")
+            StorageBackend<String, V> typed = (StorageBackend<String, V>) existing;
+            return typed;
+        }
 
         LOG.debugv("Creating {0} storage for service {1} (file: {2})", mode, serviceName, filePath);
 
@@ -83,6 +96,7 @@ public class StorageFactory {
         AccountAwareStorageBackend<V> backend = new AccountAwareStorageBackend<>(
                 inner, requestContextInstance, config.defaultAccountId());
         allBackends.add(backend);
+        backendsByPath.put(filePath, backend);
         return backend;
     }
 

--- a/src/test/java/io/github/hectorvent/floci/core/storage/StorageFactoryDuplicateBackendTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/storage/StorageFactoryDuplicateBackendTest.java
@@ -1,0 +1,75 @@
+package io.github.hectorvent.floci.core.storage;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Reproduces issue #1921: two components request the same storage file, the factory hands out
+ * two independent backends, and on graceful shutdown the stale duplicate flushes last and
+ * clobbers the persisted state written by the active instance.
+ */
+@QuarkusTest
+@TestProfile(StorageFactoryDuplicateBackendTest.PersistentProfile.class)
+class StorageFactoryDuplicateBackendTest {
+
+    private static final String STORAGE_PATH = "/tmp/floci-dedupe-backend-test";
+    private static final String FILE_NAME = "dynamodb-tables.json";
+
+    @Inject
+    StorageFactory storageFactory;
+
+    @BeforeEach
+    void cleanFile() throws IOException {
+        Files.deleteIfExists(Path.of(STORAGE_PATH, FILE_NAME));
+    }
+
+    @Test
+    void duplicateBackendsForSameFileDoNotClobberOnFlush() {
+        TypeReference<Map<String, String>> typeRef = new TypeReference<>() {};
+
+        // Active component (e.g. DynamoDbService) opens the tables file.
+        StorageBackend<String, String> active = storageFactory.create("dynamodb", FILE_NAME, typeRef);
+        // A second component (e.g. DynamoDbStreamService) opens the same file later.
+        storageFactory.create("dynamodb", FILE_NAME, typeRef);
+
+        // Active component writes tables; persistent mode write-throughs to disk.
+        for (int i = 0; i < 60; i++) {
+            active.put("table-" + i, "definition-" + i);
+        }
+
+        // Graceful shutdown flushes every registered backend. The stale duplicate must not
+        // overwrite the active instance's data.
+        storageFactory.flushAll();
+
+        // Read the persisted file back with an independent reader.
+        PersistentStorage<String, String> reader =
+                new PersistentStorage<>(Path.of(STORAGE_PATH, FILE_NAME), typeRef);
+        reader.load();
+
+        assertEquals(60, reader.keys().size(),
+                "persisted table definitions should survive flushAll despite the duplicate backend");
+    }
+
+    public static final class PersistentProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "floci.storage.mode", "memory",
+                    "floci.storage.services.dynamodb.mode", "persistent",
+                    "floci.storage.persistent-path", STORAGE_PATH
+            );
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/core/storage/StorageFactoryDuplicateBackendTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/storage/StorageFactoryDuplicateBackendTest.java
@@ -31,7 +31,11 @@ class StorageFactoryDuplicateBackendTest {
     StorageFactory storageFactory;
 
     @BeforeEach
-    void cleanFile() throws IOException {
+    void reset() throws IOException {
+        // StorageFactory is an application-scoped singleton, so a backend for this file may already
+        // exist and hold in-memory state from app startup. Clear all backends (wipes memory + disk),
+        // then remove the file so both create() calls below start from an empty store.
+        storageFactory.clearAll();
         Files.deleteIfExists(Path.of(STORAGE_PATH, FILE_NAME));
     }
 


### PR DESCRIPTION
## Problem

On graceful shutdown the emulator loses persisted DynamoDB table
definitions: `dynamodb-tables.json` retains only recently-created
tables while `dynamodb-items.json` stays intact. Closes #1921.

## Root cause

`StorageFactory.create()` builds a new backend per call and never
dedupes by file path. `DynamoDbService` and `DynamoDbStreamService`
both call `create("dynamodb", "dynamodb-tables.json", …)`, producing
two independent in-memory stores registered in `allBackends`. On
`flushAll()` they flush in registration order; the stale duplicate
flushes last and overwrites the active instance's data. `dynamodb-items.json`
is opened once, so it survives — matching the report.

## Fix

Cache backends by resolved file path in `create()` and return the
existing backend on repeat calls, so components sharing a file share
one store. `create()` is now `synchronized` since it reads-then-writes
shared factory state during startup.

Also synchronize `loadAll`/`flushAll`/`clearAll`/`shutdownAll` on the same
monitor as `create()`. `/state/reset` and `/state/nuke` call `clearAll()` on a
request thread; without this, a concurrent first-request that lazily creates a
service backend could mutate `allBackends` mid-iteration (CME). Pre-existing,
surfaced in review.

## Testing

- New `StorageFactoryDuplicateBackendTest` reproduces the clobber
  (fails before the fix: `expected: <60> but was: <0>`).
- The dedup test resets the application-scoped factory in setup so it isn't
  sensitive to startup state or test ordering.
- Storage suite (42) and DynamoDB tests (213) pass.
