### PR TITLE
fix(ec2): DescribeKeyPairs returns InvalidKeyPair.NotFound for missing names/ids

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1583,8 +1583,27 @@ public class Ec2Service implements ContainerTeardown {
 
     public List<KeyPair> describeKeyPairs(String region, List<String> keyNames, List<String> keyPairIds) {
         ensureDefaultResources(region);
-        return keyPairs.scan(k -> true).stream()
+        List<KeyPair> regionKeyPairs = keyPairs.scan(k -> true).stream()
                 .filter(k -> k.getRegion().equals(region))
+                .collect(Collectors.toList());
+
+        // A named/id lookup for a key pair that does not exist is an error in real
+        // AWS (InvalidKeyPair.NotFound), not an empty result — otherwise idempotent
+        // callers that treat exit 0 as "present" skip creating the key.
+        for (String keyName : keyNames) {
+            if (regionKeyPairs.stream().noneMatch(k -> keyName.equals(k.getKeyName()))) {
+                throw new AwsException("InvalidKeyPair.NotFound",
+                        "The key pair '" + keyName + "' does not exist", 400);
+            }
+        }
+        for (String keyPairId : keyPairIds) {
+            if (regionKeyPairs.stream().noneMatch(k -> keyPairId.equals(k.getKeyPairId()))) {
+                throw new AwsException("InvalidKeyPair.NotFound",
+                        "The key pair ID '" + keyPairId + "' does not exist", 400);
+            }
+        }
+
+        return regionKeyPairs.stream()
                 .filter(k -> keyNames.isEmpty() || keyNames.contains(k.getKeyName()))
                 .filter(k -> keyPairIds.isEmpty() || keyPairIds.contains(k.getKeyPairId()))
                 .collect(Collectors.toList());

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -880,6 +880,20 @@ class Ec2IntegrationTest {
     }
 
     @Test
+    @Order(41)
+    void describeKeyPairsRejectsMissingName() {
+        given()
+            .formParam("Action", "DescribeKeyPairs")
+            .formParam("KeyName.1", "does-not-exist")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidKeyPair.NotFound"));
+    }
+
+    @Test
     @Order(39)
     void importKeyPair() {
         given()

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -298,6 +298,50 @@ class Ec2ServiceTest {
     }
 
     @Test
+    void describeKeyPairsThrowsNotFoundForMissingName() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.describeKeyPairs("us-east-1", List.of("does-not-exist"), List.of()));
+        assertEquals("InvalidKeyPair.NotFound", error.getErrorCode());
+        assertEquals(400, error.getHttpStatus());
+    }
+
+    @Test
+    void describeKeyPairsThrowsNotFoundForMissingId() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.describeKeyPairs("us-east-1", List.of(), List.of("key-missing")));
+        assertEquals("InvalidKeyPair.NotFound", error.getErrorCode());
+    }
+
+    @Test
+    void describeKeyPairsReturnsRequestedKeyAndAllowsEmptyUnfilteredList() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+
+        // Unfiltered describe on an empty account is not an error.
+        assertTrue(service.describeKeyPairs("us-east-1", List.of(), List.of()).isEmpty());
+
+        service.createKeyPair("us-east-1", "present-key");
+        assertEquals(1, service.describeKeyPairs("us-east-1", List.of("present-key"), List.of()).size());
+
+        // A missing name is not masked by a present one in the same request.
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.describeKeyPairs("us-east-1", List.of("present-key", "absent-key"), List.of()));
+        assertEquals("InvalidKeyPair.NotFound", error.getErrorCode());
+    }
+
+    @Test
     void registerImageReusingSnapshotDoesNotOverwriteSnapshotMetadata() {
         Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
                 mock(Ec2PortForwardManager.class),


### PR DESCRIPTION
## Summary

Closes #1911

`DescribeKeyPairs` returned an empty list (HTTP 200 / CLI exit 0) when a requested `KeyName` or `KeyPairId` did not exist, instead of the documented `InvalidKeyPair.NotFound` fault. Idempotent callers that treat `describe-key-pairs --key-names X` exit 0 as "present" then skip `ImportKeyPair`/create and leave the account without the key.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: a name/id lookup for a key pair that doesn't exist returned `{"KeyPairs": []}` with HTTP 200. Real EC2 returns `InvalidKeyPair.NotFound` (HTTP 400) — `The key pair '<name>' does not exist` / `The key pair ID '<id>' does not exist`. An **unfiltered** `DescribeKeyPairs` (no names/ids) on an empty account still correctly returns an empty list. A missing name is not masked by a present one in the same request. Same fault family as the `InvalidKeyPair.Duplicate` guard added for `CreateKeyPair`/`ImportKeyPair` in #1848.

Verified against the AWS CLI:

```bash
aws ec2 describe-key-pairs --key-names does-not-exist
# InvalidKeyPair.NotFound, non-zero exit
```

## Checklist

- [x] `./mvnw test` passes locally (`Ec2ServiceTest` + `Ec2IntegrationTest`: 164 tests, 0 failures)
- [x] New or updated integration test added (`DescribeKeyPairs` with a missing name → HTTP 400 `InvalidKeyPair.NotFound` over the EC2 query protocol, plus unit tests for missing name, missing id, and mixed present/absent names)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)