### PR TITLE
feat(cloudcontrol): include EC2 resource tags

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlService.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.ec2.model.SecurityGroup;
 import io.github.hectorvent.floci.services.ec2.model.Subnet;
+import io.github.hectorvent.floci.services.ec2.model.Tag;
 import io.github.hectorvent.floci.services.ec2.model.Vpc;
 import io.github.hectorvent.floci.services.iam.IamService;
 import io.github.hectorvent.floci.services.iam.model.IamRole;
@@ -66,6 +67,7 @@ public class CloudControlService {
             properties.put("VpcId", vpc.getVpcId());
             properties.put("CidrBlock", vpc.getCidrBlock());
             properties.put("InstanceTenancy", vpc.getInstanceTenancy());
+            addTags(properties, vpc.getTags());
             resources.add(new ResourceDescription(vpc.getVpcId(), propertiesString(properties)));
         }
         return resources;
@@ -79,6 +81,7 @@ public class CloudControlService {
             properties.put("VpcId", subnet.getVpcId());
             properties.put("CidrBlock", subnet.getCidrBlock());
             properties.put("AvailabilityZone", subnet.getAvailabilityZone());
+            addTags(properties, subnet.getTags());
             resources.add(new ResourceDescription(subnet.getSubnetId(), propertiesString(properties)));
         }
         return resources;
@@ -92,6 +95,7 @@ public class CloudControlService {
             properties.put("GroupName", group.getGroupName());
             properties.put("GroupDescription", group.getDescription());
             properties.put("VpcId", group.getVpcId());
+            addTags(properties, group.getTags());
             resources.add(new ResourceDescription(group.getGroupId(), propertiesString(properties)));
         }
         return resources;
@@ -127,6 +131,18 @@ public class CloudControlService {
         } catch (JsonProcessingException e) {
             throw new AwsException("InternalFailure",
                     "Failed to serialize CloudControl resource properties.", 500);
+        }
+    }
+
+    private void addTags(ObjectNode properties, List<Tag> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return;
+        }
+        var tagArray = properties.putArray("Tags");
+        for (Tag tag : tags) {
+            tagArray.addObject()
+                    .put("Key", tag.getKey())
+                    .put("Value", tag.getValue());
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlService.java
@@ -138,11 +138,17 @@ public class CloudControlService {
         if (tags == null || tags.isEmpty()) {
             return;
         }
+        List<Tag> validTags = tags.stream()
+                .filter(tag -> tag != null && tag.getKey() != null)
+                .toList();
+        if (validTags.isEmpty()) {
+            return;
+        }
         var tagArray = properties.putArray("Tags");
-        for (Tag tag : tags) {
+        for (Tag tag : validTags) {
             tagArray.addObject()
                     .put("Key", tag.getKey())
-                    .put("Value", tag.getValue());
+                    .put("Value", tag.getValue() == null ? "" : tag.getValue());
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlService.java
@@ -139,7 +139,7 @@ public class CloudControlService {
             return;
         }
         List<Tag> validTags = tags.stream()
-                .filter(tag -> tag != null && tag.getKey() != null)
+                .filter(tag -> tag != null && tag.getKey() != null && !tag.getKey().isBlank())
                 .toList();
         if (validTags.isEmpty()) {
             return;

--- a/src/test/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlIntegrationTest.java
@@ -38,6 +38,9 @@ class CloudControlIntegrationTest {
         String vpcId = given()
                 .formParam("Action", "CreateVpc")
                 .formParam("CidrBlock", "10.42.0.0/16")
+                .formParam("TagSpecification.1.ResourceType", "vpc")
+                .formParam("TagSpecification.1.Tag.1.Key", "Name")
+                .formParam("TagSpecification.1.Tag.1.Value", "cloudcontrol-vpc")
                 .header("Authorization", EC2_AUTH)
                 .when().post("/")
                 .then().statusCode(200)
@@ -47,6 +50,9 @@ class CloudControlIntegrationTest {
                 .formParam("Action", "CreateSubnet")
                 .formParam("VpcId", vpcId)
                 .formParam("CidrBlock", "10.42.1.0/24")
+                .formParam("TagSpecification.1.ResourceType", "subnet")
+                .formParam("TagSpecification.1.Tag.1.Key", "Name")
+                .formParam("TagSpecification.1.Tag.1.Value", "cloudcontrol-subnet")
                 .header("Authorization", EC2_AUTH)
                 .when().post("/")
                 .then().statusCode(200)
@@ -57,6 +63,9 @@ class CloudControlIntegrationTest {
                 .formParam("GroupName", "cloudcontrol-sg")
                 .formParam("GroupDescription", "cloudcontrol sg")
                 .formParam("VpcId", vpcId)
+                .formParam("TagSpecification.1.ResourceType", "security-group")
+                .formParam("TagSpecification.1.Tag.1.Key", "Name")
+                .formParam("TagSpecification.1.Tag.1.Value", "cloudcontrol-sg")
                 .header("Authorization", EC2_AUTH)
                 .when().post("/")
                 .then().statusCode(200)
@@ -78,9 +87,9 @@ class CloudControlIntegrationTest {
                 .then().statusCode(200);
 
         assertListed("AWS::S3::Bucket", bucket, "BucketName");
-        assertListed("AWS::EC2::VPC", vpcId, "CidrBlock");
-        assertListed("AWS::EC2::Subnet", subnetId, "VpcId");
-        assertListed("AWS::EC2::SecurityGroup", groupId, "GroupName");
+        assertListed("AWS::EC2::VPC", vpcId, "cloudcontrol-vpc");
+        assertListed("AWS::EC2::Subnet", subnetId, "cloudcontrol-subnet");
+        assertListed("AWS::EC2::SecurityGroup", groupId, "cloudcontrol-sg");
         assertListed("AWS::EC2::SecurityGroup", groupId, "GroupName", "application/x-amz-json-1.0");
         assertListed("AWS::IAM::User", "cloudcontrol-user", "UserName");
         assertListed("AWS::IAM::Role", "CloudControlRole", "RoleName");

--- a/src/test/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlIntegrationTest.java
@@ -1,5 +1,8 @@
 package io.github.hectorvent.floci.services.cloudcontrol;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.RestAssured;
 import io.restassured.parsing.Parser;
@@ -12,10 +15,14 @@ import static io.restassured.config.EncoderConfig.encoderConfig;
 import static io.restassured.config.RestAssuredConfig.config;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 class CloudControlIntegrationTest {
 
+    private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final String EC2_AUTH =
             "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/ec2/aws4_request";
     private static final String IAM_AUTH =
@@ -31,7 +38,7 @@ class CloudControlIntegrationTest {
     }
 
     @Test
-    void listResourcesReturnsCreatedS3Ec2AndIamResources() {
+    void listResourcesReturnsCreatedS3Ec2AndIamResources() throws JsonProcessingException {
         String bucket = "cloudcontrol-test-bucket";
         given().when().put("/" + bucket).then().statusCode(200);
 
@@ -87,9 +94,9 @@ class CloudControlIntegrationTest {
                 .then().statusCode(200);
 
         assertListed("AWS::S3::Bucket", bucket, "BucketName");
-        assertListed("AWS::EC2::VPC", vpcId, "cloudcontrol-vpc");
-        assertListed("AWS::EC2::Subnet", subnetId, "cloudcontrol-subnet");
-        assertListed("AWS::EC2::SecurityGroup", groupId, "cloudcontrol-sg");
+        assertListedWithTag("AWS::EC2::VPC", vpcId, "Name", "cloudcontrol-vpc");
+        assertListedWithTag("AWS::EC2::Subnet", subnetId, "Name", "cloudcontrol-subnet");
+        assertListedWithTag("AWS::EC2::SecurityGroup", groupId, "Name", "cloudcontrol-sg");
         assertListed("AWS::EC2::SecurityGroup", groupId, "GroupName", "application/x-amz-json-1.0");
         assertListed("AWS::IAM::User", "cloudcontrol-user", "UserName");
         assertListed("AWS::IAM::Role", "CloudControlRole", "RoleName");
@@ -100,7 +107,37 @@ class CloudControlIntegrationTest {
     }
 
     private void assertListed(String typeName, String identifier, String propertyName, String contentType) {
-        String body = given()
+        String body = listResources(typeName, contentType);
+
+        assertThat(body, containsString("\"TypeName\":\"" + typeName + "\""));
+        assertThat(body, containsString("\"Identifier\":\"" + identifier + "\""));
+        assertThat(body, containsString(propertyName));
+    }
+
+    private void assertListedWithTag(
+            String typeName, String identifier, String key, String value) throws JsonProcessingException {
+        JsonNode response = MAPPER.readTree(listResources(typeName, "application/x-amz-json-1.1"));
+        JsonNode description = null;
+        for (JsonNode candidate : response.path("ResourceDescriptions")) {
+            if (identifier.equals(candidate.path("Identifier").asText())) {
+                description = candidate;
+                break;
+            }
+        }
+
+        assertNotNull(description);
+        assertEquals(identifier, description.path("Identifier").asText());
+        JsonNode tags = MAPPER.readTree(description.path("Properties").asText()).path("Tags");
+        assertTrue(tags.isArray());
+        assertTrue(tags.valueStream().anyMatch(tag ->
+                key.equals(tag.path("Key").asText())
+                        && tag.path("Key").isTextual()
+                        && value.equals(tag.path("Value").asText())
+                        && tag.path("Value").isTextual()));
+    }
+
+    private String listResources(String typeName, String contentType) {
+        return given()
                 .config(config().encoderConfig(
                         encoderConfig().encodeContentTypeAs(contentType, TEXT)))
                 .contentType(contentType)
@@ -111,9 +148,5 @@ class CloudControlIntegrationTest {
                 .then()
                 .statusCode(200)
                 .extract().asString();
-
-        assertThat(body, containsString("\"TypeName\":\"" + typeName + "\""));
-        assertThat(body, containsString("\"Identifier\":\"" + identifier + "\""));
-        assertThat(body, containsString(propertyName));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlIntegrationTest.java
@@ -95,7 +95,9 @@ class CloudControlIntegrationTest {
 
         assertListed("AWS::S3::Bucket", bucket, "BucketName");
         assertListedWithTag("AWS::EC2::VPC", vpcId, "Name", "cloudcontrol-vpc");
+        assertListed("AWS::EC2::VPC", vpcId, "CidrBlock");
         assertListedWithTag("AWS::EC2::Subnet", subnetId, "Name", "cloudcontrol-subnet");
+        assertListed("AWS::EC2::Subnet", subnetId, "VpcId");
         assertListedWithTag("AWS::EC2::SecurityGroup", groupId, "Name", "cloudcontrol-sg");
         assertListed("AWS::EC2::SecurityGroup", groupId, "GroupName", "application/x-amz-json-1.0");
         assertListed("AWS::IAM::User", "cloudcontrol-user", "UserName");

--- a/src/test/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlServiceTest.java
@@ -1,0 +1,45 @@
+package io.github.hectorvent.floci.services.cloudcontrol;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.model.Tag;
+import io.github.hectorvent.floci.services.ec2.model.Vpc;
+import io.github.hectorvent.floci.services.iam.IamService;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CloudControlServiceTest {
+
+    @Test
+    void emitsOnlyAwsShapedTagsForMalformedPersistedData() throws Exception {
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        Vpc vpc = new Vpc();
+        vpc.setVpcId("vpc-test");
+        vpc.setTags(List.of(new Tag(null, "ignored"), new Tag("Name", null)));
+        when(ec2Service.describeVpcs("us-east-1", List.of(), Map.of())).thenReturn(List.of(vpc));
+        ObjectMapper mapper = new ObjectMapper();
+        CloudControlService service = new CloudControlService(
+                mock(S3Service.class), ec2Service, mock(IamService.class), mapper);
+
+        String properties = service.listResources("us-east-1", "AWS::EC2::VPC").getFirst().properties();
+        JsonNode tags = mapper.readTree(properties).path("Tags");
+
+        assertTrue(tags.isArray());
+        assertEquals(1, tags.size());
+        assertTrue(tags.get(0).path("Key").isTextual());
+        assertEquals("Name", tags.get(0).path("Key").asText());
+        assertTrue(tags.get(0).path("Value").isTextual());
+        assertEquals("", tags.get(0).path("Value").asText());
+        assertFalse(properties.contains("ignored"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlServiceTest.java
@@ -25,7 +25,11 @@ class CloudControlServiceTest {
         Ec2Service ec2Service = mock(Ec2Service.class);
         Vpc vpc = new Vpc();
         vpc.setVpcId("vpc-test");
-        vpc.setTags(List.of(new Tag(null, "ignored"), new Tag("Name", null)));
+        vpc.setTags(List.of(
+                new Tag(null, "ignored-null"),
+                new Tag("", "ignored-empty"),
+                new Tag("  ", "ignored-blank"),
+                new Tag("Name", null)));
         when(ec2Service.describeVpcs("us-east-1", List.of(), Map.of())).thenReturn(List.of(vpc));
         ObjectMapper mapper = new ObjectMapper();
         CloudControlService service = new CloudControlService(
@@ -40,6 +44,8 @@ class CloudControlServiceTest {
         assertEquals("Name", tags.get(0).path("Key").asText());
         assertTrue(tags.get(0).path("Value").isTextual());
         assertEquals("", tags.get(0).path("Value").asText());
-        assertFalse(properties.contains("ignored"));
+        assertFalse(properties.contains("ignored-null"));
+        assertFalse(properties.contains("ignored-empty"));
+        assertFalse(properties.contains("ignored-blank"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -1889,7 +1889,8 @@ class Ec2IntegrationTest {
             .post("/")
         .then()
             .statusCode(200)
-            .body("DescribeTagsResponse.tagSet.item.find { it.key == 'Name' }.value", equalTo("test-instance"));
+            .body("DescribeTagsResponse.tagSet.item.find { it.key == 'Name' && it.resourceId == '"
+                    + instanceId + "' }.value", equalTo("test-instance"));
     }
 
     @Test
@@ -1920,7 +1921,8 @@ class Ec2IntegrationTest {
             .post("/")
         .then()
             .statusCode(200)
-            .body("DescribeTagsResponse.tagSet.item.key", equalTo("Name"));
+            .body("DescribeTagsResponse.tagSet.item.size()", greaterThanOrEqualTo(1))
+            .body("DescribeTagsResponse.tagSet.item.findAll { it.key != 'Name' }.size()", equalTo(0));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Include persisted EC2 tags in the Cloud Control `Properties` returned for
  VPCs, subnets, and security groups.
- Preserve the existing response shape for untagged resources by omitting the
  `Tags` property when no tags are present.
- Make EC2 tag assertions identify the intended resource when multiple
  resources legitimately use the same tag key.
- Normalize malformed persisted tags so Cloud Control emits the AWS
  `Key`/`Value` string shape.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Cloud Control `ListResources` previously returned the core properties for
`AWS::EC2::VPC`, `AWS::EC2::Subnet`, and `AWS::EC2::SecurityGroup` resources
but omitted their persisted tags. The returned serialized `Properties` now
includes the AWS-shaped `Tags` array with `Key` and `Value` string entries.

The integration coverage creates tagged resources through the EC2 Query API
and verifies that each tag is exposed through Cloud Control's JSON 1.1
`ListResources` response.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Verification

Current rebased tree (`5d744db9a`):

- Focused Cloud Control integration proof
  - 2 tests, 0 failures, 0 errors, 0 skipped
- `git diff --check upstream/main...HEAD`

Additional patch-set proof before the final upstream-only rebase:

- `make docs-check`
- `./mvnw -B -Dtest='CloudControlIntegrationTest,Ec2IntegrationTest' test`
  - 144 tests, 0 failures, 0 errors, 0 skipped
- `./mvnw -B test`
  - 7,924 tests, 0 failures, 0 errors, 8 skipped
  - log SHA-256:
    `b77f4f36f33c3089bfef57676b43c48d95480125c2b5f5b3718c8aa60bba9c83`

## Commit Stack

1. `a3355fe73` `feat(cloudcontrol): include EC2 resource tags`
2. `216809f67` `test(ec2): isolate tag assertions`
3. `5d744db9a` `fix(cloudcontrol): emit AWS-shaped EC2 tags`