### PR TITLE
ci: add reusable JVM and native image publishing

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -11,6 +11,11 @@ on:
         description: OCI image repository without a tag or digest
         required: true
         type: string
+      publish-native:
+        description: Also publish native and native compatibility images
+        required: false
+        type: boolean
+        default: false
     secrets:
       REGISTRY_USERNAME:
         description: Username for a registry other than GHCR
@@ -20,25 +25,37 @@ on:
         required: false
     outputs:
       source-sha:
-        description: Full source revision used for both images
+        description: Full source revision used for all images
         value: ${{ jobs.prepare.outputs.source-sha }}
+      image-ref:
+        description: Commit-tagged default JVM image reference
+        value: ${{ jobs.publish.outputs.jvm-ref }}
+      image-digest-ref:
+        description: Immutable default JVM image reference
+        value: ${{ jobs.publish.outputs.jvm-digest-ref }}
+      jvm-ref:
+        description: Commit-tagged JVM image reference
+        value: ${{ jobs.publish.outputs.jvm-ref }}
+      jvm-digest-ref:
+        description: Immutable JVM image reference
+        value: ${{ jobs.publish.outputs.jvm-digest-ref }}
       native-ref:
-        description: Commit-tagged native image reference
+        description: Commit-tagged native image reference when publish-native is true
         value: ${{ jobs.publish.outputs.native-ref }}
       native-digest-ref:
-        description: Immutable native image reference
+        description: Immutable native image reference when publish-native is true
         value: ${{ jobs.publish.outputs.native-digest-ref }}
       compat-ref:
-        description: Commit-tagged compatibility image reference
+        description: Commit-tagged native compatibility image reference when publish-native is true
         value: ${{ jobs.publish.outputs.compat-ref }}
       compat-digest-ref:
-        description: Immutable compatibility image reference
+        description: Immutable native compatibility image reference when publish-native is true
         value: ${{ jobs.publish.outputs.compat-digest-ref }}
 
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.repository }}-${{ inputs.source-ref }}-${{ inputs.image }}
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ inputs.source-ref }}-${{ inputs.image }}-${{ inputs.publish-native }}
   cancel-in-progress: false
 
 jobs:
@@ -128,6 +145,7 @@ jobs:
 
   build-native-amd64:
     name: Build native artifact (amd64)
+    if: inputs.publish-native
     needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -167,6 +185,7 @@ jobs:
 
   build-native-arm64:
     name: Build native artifact (arm64)
+    if: inputs.publish-native
     needs: prepare
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
@@ -205,16 +224,26 @@ jobs:
           retention-days: 1
 
   publish:
-    name: Publish native and compat images
+    name: Publish JVM image
     needs: [prepare, build-native-amd64, build-native-arm64]
+    if: >-
+      ${{
+        always() &&
+        needs.prepare.result == 'success' &&
+        (!inputs.publish-native ||
+          (needs.build-native-amd64.result == 'success' &&
+           needs.build-native-arm64.result == 'success'))
+      }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
     outputs:
       compat-ref: ${{ steps.provenance.outputs.compat-ref }}
       compat-digest-ref: ${{ steps.provenance.outputs.compat-digest-ref }}
+      jvm-ref: ${{ steps.provenance.outputs.jvm-ref }}
+      jvm-digest-ref: ${{ steps.provenance.outputs.jvm-digest-ref }}
       native-ref: ${{ steps.provenance.outputs.native-ref }}
       native-digest-ref: ${{ steps.provenance.outputs.native-digest-ref }}
 
@@ -225,16 +254,19 @@ jobs:
           ref: ${{ needs.prepare.outputs.source-sha }}
 
       - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        if: inputs.publish-native
         with:
           name: floci-native-amd64-${{ needs.prepare.outputs.version }}
           path: native/amd64/
 
       - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        if: inputs.publish-native
         with:
           name: floci-native-arm64-${{ needs.prepare.outputs.version }}
           path: native/arm64/
 
       - name: Make native binaries executable
+        if: inputs.publish-native
         run: chmod +x native/amd64/*-runner native/arm64/*-runner
 
       - name: Set build metadata
@@ -262,8 +294,33 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_TOKEN }}
 
+      - name: Build and publish JVM image
+        id: jvm
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.metadata.outputs.source-date-epoch }}
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ needs.prepare.outputs.image }}:${{ needs.prepare.outputs.version }}
+          build-args: |
+            VERSION=${{ needs.prepare.outputs.version }}
+          labels: |
+            org.opencontainers.image.version=${{ needs.prepare.outputs.version }}
+            org.opencontainers.image.revision=${{ needs.prepare.outputs.source-sha }}
+            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            version=${{ needs.prepare.outputs.version }}
+            build-date=${{ steps.metadata.outputs.created }}
+            vcs-ref=${{ needs.prepare.outputs.source-sha }}
+          cache-from: type=gha,scope=floci-jvm
+          cache-to: type=gha,scope=floci-jvm,mode=max
+
       - name: Build and publish native image
         id: native
+        if: inputs.publish-native
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         env:
           SOURCE_DATE_EPOCH: ${{ steps.metadata.outputs.source-date-epoch }}
@@ -272,7 +329,7 @@ jobs:
           file: docker/Dockerfile.native-package
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ needs.prepare.outputs.image }}:${{ needs.prepare.outputs.version }}
+          tags: ${{ needs.prepare.outputs.image }}:${{ needs.prepare.outputs.version }}-native
           build-args: |
             VERSION=${{ needs.prepare.outputs.version }}
           labels: |
@@ -288,6 +345,7 @@ jobs:
 
       - name: Build and publish compat image
         id: compat
+        if: inputs.publish-native
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         env:
           SOURCE_DATE_EPOCH: ${{ steps.metadata.outputs.source-date-epoch }}
@@ -296,7 +354,7 @@ jobs:
           file: docker/Dockerfile.compat
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ needs.prepare.outputs.image }}:${{ needs.prepare.outputs.version }}-compat
+          tags: ${{ needs.prepare.outputs.image }}:${{ needs.prepare.outputs.version }}-native-compat
           build-args: |
             VERSION=${{ needs.prepare.outputs.version }}
             BASE_IMAGE=${{ needs.prepare.outputs.image }}@${{ steps.native.outputs.digest }}
@@ -317,7 +375,9 @@ jobs:
           COMPAT_DIGEST: ${{ steps.compat.outputs.digest }}
           CREATED: ${{ steps.metadata.outputs.created }}
           IMAGE: ${{ needs.prepare.outputs.image }}
+          JVM_DIGEST: ${{ steps.jvm.outputs.digest }}
           NATIVE_DIGEST: ${{ steps.native.outputs.digest }}
+          PUBLISH_NATIVE: ${{ inputs.publish-native }}
           REPOSITORY: ${{ github.repository }}
           REQUESTED_SOURCE_REF: ${{ inputs.source-ref }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
@@ -327,8 +387,10 @@ jobs:
           VERSION: ${{ needs.prepare.outputs.version }}
         shell: bash
         run: |
-          native_ref="$IMAGE:$VERSION"
-          compat_ref="$IMAGE:$VERSION-compat"
+          jvm_ref="$IMAGE:$VERSION"
+          jvm_digest_ref="$IMAGE@$JVM_DIGEST"
+          native_ref="$IMAGE:$VERSION-native"
+          compat_ref="$IMAGE:$VERSION-native-compat"
           native_digest_ref="$IMAGE@$NATIVE_DIGEST"
           compat_digest_ref="$IMAGE@$COMPAT_DIGEST"
           run_url="$SERVER_URL/$REPOSITORY/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT"
@@ -341,20 +403,35 @@ jobs:
             --arg runId "$RUN_ID" \
             --arg runAttempt "$RUN_ATTEMPT" \
             --arg runUrl "$run_url" \
-            --arg nativeRef "$native_ref" \
-            --arg nativeDigest "$NATIVE_DIGEST" \
-            --arg nativeDigestRef "$native_digest_ref" \
-            --arg compatRef "$compat_ref" \
-            --arg compatDigest "$COMPAT_DIGEST" \
-            --arg compatDigestRef "$compat_digest_ref" \
-            '{source: {sha: $sourceSha, requestedRef: $requestedSourceRef, repository: $repository}, workflow: {runId: $runId, attempt: $runAttempt, url: $runUrl}, created: $created, images: {native: {ref: $nativeRef, digest: $nativeDigest, digestRef: $nativeDigestRef, dockerfile: "docker/Dockerfile.native-package"}, compat: {ref: $compatRef, digest: $compatDigest, digestRef: $compatDigestRef, dockerfile: "docker/Dockerfile.compat", base: $nativeDigestRef}}, platforms: ["linux/amd64", "linux/arm64"]}' \
+            --arg jvmRef "$jvm_ref" \
+            --arg jvmDigest "$JVM_DIGEST" \
+            --arg jvmDigestRef "$jvm_digest_ref" \
+            '{source: {sha: $sourceSha, requestedRef: $requestedSourceRef, repository: $repository}, workflow: {runId: $runId, attempt: $runAttempt, url: $runUrl}, created: $created, images: {jvm: {ref: $jvmRef, digest: $jvmDigest, digestRef: $jvmDigestRef, dockerfile: "docker/Dockerfile"}}, platforms: ["linux/amd64", "linux/arm64"]}' \
             > floci-image-provenance.json
 
+          if [[ "$PUBLISH_NATIVE" == "true" ]]; then
+            jq \
+              --arg nativeRef "$native_ref" \
+              --arg nativeDigest "$NATIVE_DIGEST" \
+              --arg nativeDigestRef "$native_digest_ref" \
+              --arg compatRef "$compat_ref" \
+              --arg compatDigest "$COMPAT_DIGEST" \
+              --arg compatDigestRef "$compat_digest_ref" \
+              '.images.native = {ref: $nativeRef, digest: $nativeDigest, digestRef: $nativeDigestRef, dockerfile: "docker/Dockerfile.native-package"}
+               | .images.compat = {ref: $compatRef, digest: $compatDigest, digestRef: $compatDigestRef, dockerfile: "docker/Dockerfile.compat", base: $nativeDigestRef}' \
+              floci-image-provenance.json > floci-image-provenance.tmp
+            mv floci-image-provenance.tmp floci-image-provenance.json
+          fi
+
           {
-            echo "native-ref=$native_ref"
-            echo "native-digest-ref=$native_digest_ref"
-            echo "compat-ref=$compat_ref"
-            echo "compat-digest-ref=$compat_digest_ref"
+            echo "jvm-ref=$jvm_ref"
+            echo "jvm-digest-ref=$jvm_digest_ref"
+            if [[ "$PUBLISH_NATIVE" == "true" ]]; then
+              echo "native-ref=$native_ref"
+              echo "native-digest-ref=$native_digest_ref"
+              echo "compat-ref=$compat_ref"
+              echo "compat-digest-ref=$compat_digest_ref"
+            fi
           } >> "$GITHUB_OUTPUT"
 
           {
@@ -364,8 +441,11 @@ jobs:
             echo
             echo "| Image tag | Immutable digest reference |"
             echo "| --- | --- |"
-            echo "| \`$native_ref\` | \`$native_digest_ref\` |"
-            echo "| \`$compat_ref\` | \`$compat_digest_ref\` |"
+            echo "| \`$jvm_ref\` | \`$jvm_digest_ref\` |"
+            if [[ "$PUBLISH_NATIVE" == "true" ]]; then
+              echo "| \`$native_ref\` | \`$native_digest_ref\` |"
+              echo "| \`$compat_ref\` | \`$compat_digest_ref\` |"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,376 @@
+name: Build Floci Images
+
+on:
+  workflow_call:
+    inputs:
+      source-ref:
+        description: Floci branch, tag, or commit to publish
+        required: true
+        type: string
+      image:
+        description: OCI image repository without a tag or digest
+        required: true
+        type: string
+    secrets:
+      REGISTRY_USERNAME:
+        description: Username for a registry other than GHCR
+        required: false
+      REGISTRY_TOKEN:
+        description: Token for a registry other than GHCR
+        required: false
+    outputs:
+      source-sha:
+        description: Full source revision used for both images
+        value: ${{ jobs.prepare.outputs.source-sha }}
+      native-ref:
+        description: Commit-tagged native image reference
+        value: ${{ jobs.publish.outputs.native-ref }}
+      native-digest-ref:
+        description: Immutable native image reference
+        value: ${{ jobs.publish.outputs.native-digest-ref }}
+      compat-ref:
+        description: Commit-tagged compatibility image reference
+        value: ${{ jobs.publish.outputs.compat-ref }}
+      compat-digest-ref:
+        description: Immutable compatibility image reference
+        value: ${{ jobs.publish.outputs.compat-digest-ref }}
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ inputs.source-ref }}-${{ inputs.image }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Resolve source and image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      image: ${{ steps.image.outputs.image }}
+      registry: ${{ steps.image.outputs.registry }}
+      source-sha: ${{ steps.source.outputs.sha }}
+      version: ${{ steps.source.outputs.version }}
+
+    steps:
+      - name: Validate image repository
+        id: image
+        shell: bash
+        env:
+          IMAGE: ${{ inputs.image }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          owner="${REPOSITORY_OWNER,,}"
+          image="$IMAGE"
+
+          if [[ "$image" != */* ]]; then
+            echo "image must include a registry host and repository path." >&2
+            exit 1
+          fi
+
+          registry="${image%%/*}"
+          repository="${image#*/}"
+          registry_pattern='^([a-z0-9]([a-z0-9.-]*[a-z0-9])?)(:[0-9]{1,5})?$'
+          component='[a-z0-9]+([._-][a-z0-9]+)*'
+          repository_pattern="^${component}(/${component})*$"
+
+          if [[ "$registry" != "${registry,,}" || ! "$registry" =~ $registry_pattern ]]; then
+            echo "image registry must be a lowercase host with an optional port." >&2
+            exit 1
+          fi
+          if [[ "$registry" == *..* || "$registry" == *.-* || "$registry" == *-.* ]]; then
+            echo "image registry contains an invalid host separator." >&2
+            exit 1
+          fi
+          if [[ "$registry" == *:* ]]; then
+            port="${registry##*:}"
+            if (( 10#$port < 1 || 10#$port > 65535 )); then
+              echo "image registry port must be between 1 and 65535." >&2
+              exit 1
+            fi
+          fi
+          if [[ "$repository" != "${repository,,}" || ! "$repository" =~ $repository_pattern ]]; then
+            echo "image repository must be a lowercase path without a tag or digest." >&2
+            exit 1
+          fi
+          if [[ "$registry" == "ghcr.io" && "$repository" != "$owner/"* ]]; then
+            echo "GITHUB_TOKEN publication requires a GHCR repository under $owner/." >&2
+            exit 1
+          fi
+
+          echo "registry=$registry" >> "$GITHUB_OUTPUT"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+
+      - name: Validate external registry credentials
+        if: steps.image.outputs.registry != 'ghcr.io'
+        shell: bash
+        env:
+          REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+          REGISTRY_TOKEN: ${{ secrets.REGISTRY_TOKEN }}
+        run: |
+          if [[ -z "$REGISTRY_USERNAME" || -z "$REGISTRY_TOKEN" ]]; then
+            echo "External registries require REGISTRY_USERNAME and REGISTRY_TOKEN." >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.source-ref }}
+
+      - name: Resolve source revision
+        id: source
+        shell: bash
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "version=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+
+  build-native-amd64:
+    name: Build native artifact (amd64)
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.source-sha }}
+
+      - uses: graalvm/setup-graalvm@6f3fa030c4b8f77c1f554a860f593a654538fa38 # v1
+        with:
+          java-version: '25'
+          distribution: mandrel
+          cache: maven
+          github-token: ${{ github.token }}
+
+      - name: Set candidate version
+        env:
+          CANDIDATE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: mvn versions:set -DnewVersion="$CANDIDATE_VERSION" -DgenerateBackupPoms=false -q
+
+      - name: Build native executable
+        run: mvn clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-march=x86-64-v2"
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: floci-native-amd64-${{ needs.prepare.outputs.version }}
+          path: |
+            target/*-runner
+            target/*.properties
+            target/*.so
+          if-no-files-found: error
+          retention-days: 1
+
+  build-native-arm64:
+    name: Build native artifact (arm64)
+    needs: prepare
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 45
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.source-sha }}
+
+      - uses: graalvm/setup-graalvm@6f3fa030c4b8f77c1f554a860f593a654538fa38 # v1
+        with:
+          java-version: '25'
+          distribution: mandrel
+          cache: maven
+          github-token: ${{ github.token }}
+
+      - name: Set candidate version
+        env:
+          CANDIDATE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: mvn versions:set -DnewVersion="$CANDIDATE_VERSION" -DgenerateBackupPoms=false -q
+
+      - name: Build native executable
+        run: mvn clean package -Dnative -DskipTests -B
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: floci-native-arm64-${{ needs.prepare.outputs.version }}
+          path: |
+            target/*-runner
+            target/*.properties
+            target/*.so
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish native and compat images
+    needs: [prepare, build-native-amd64, build-native-arm64]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      compat-ref: ${{ steps.provenance.outputs.compat-ref }}
+      compat-digest-ref: ${{ steps.provenance.outputs.compat-digest-ref }}
+      native-ref: ${{ steps.provenance.outputs.native-ref }}
+      native-digest-ref: ${{ steps.provenance.outputs.native-digest-ref }}
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.source-sha }}
+
+      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          name: floci-native-amd64-${{ needs.prepare.outputs.version }}
+          path: native/amd64/
+
+      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          name: floci-native-arm64-${{ needs.prepare.outputs.version }}
+          path: native/arm64/
+
+      - name: Make native binaries executable
+        run: chmod +x native/amd64/*-runner native/arm64/*-runner
+
+      - name: Set build metadata
+        id: metadata
+        shell: bash
+        run: |
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+          echo "source-date-epoch=$(git log -1 --pretty=%ct)" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to GitHub Container Registry
+        if: needs.prepare.outputs.registry == 'ghcr.io'
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Log in to configured registry
+        if: needs.prepare.outputs.registry != 'ghcr.io'
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ needs.prepare.outputs.registry }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+
+      - name: Build and publish native image
+        id: native
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.metadata.outputs.source-date-epoch }}
+        with:
+          context: .
+          file: docker/Dockerfile.native-package
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ needs.prepare.outputs.image }}:${{ needs.prepare.outputs.version }}
+          build-args: |
+            VERSION=${{ needs.prepare.outputs.version }}
+          labels: |
+            org.opencontainers.image.version=${{ needs.prepare.outputs.version }}
+            org.opencontainers.image.revision=${{ needs.prepare.outputs.source-sha }}
+            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            version=${{ needs.prepare.outputs.version }}
+            build-date=${{ steps.metadata.outputs.created }}
+            vcs-ref=${{ needs.prepare.outputs.source-sha }}
+          cache-from: type=gha,scope=floci-native
+          cache-to: type=gha,scope=floci-native,mode=max
+
+      - name: Build and publish compat image
+        id: compat
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.metadata.outputs.source-date-epoch }}
+        with:
+          context: .
+          file: docker/Dockerfile.compat
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ needs.prepare.outputs.image }}:${{ needs.prepare.outputs.version }}-compat
+          build-args: |
+            VERSION=${{ needs.prepare.outputs.version }}
+            BASE_IMAGE=${{ needs.prepare.outputs.image }}@${{ steps.native.outputs.digest }}
+          labels: |
+            org.opencontainers.image.version=${{ needs.prepare.outputs.version }}
+            org.opencontainers.image.revision=${{ needs.prepare.outputs.source-sha }}
+            org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            version=${{ needs.prepare.outputs.version }}
+            build-date=${{ steps.metadata.outputs.created }}
+            vcs-ref=${{ needs.prepare.outputs.source-sha }}
+          cache-from: type=gha,scope=floci-compat
+          cache-to: type=gha,scope=floci-compat,mode=max
+
+      - name: Record image provenance
+        id: provenance
+        env:
+          COMPAT_DIGEST: ${{ steps.compat.outputs.digest }}
+          CREATED: ${{ steps.metadata.outputs.created }}
+          IMAGE: ${{ needs.prepare.outputs.image }}
+          NATIVE_DIGEST: ${{ steps.native.outputs.digest }}
+          REPOSITORY: ${{ github.repository }}
+          REQUESTED_SOURCE_REF: ${{ inputs.source-ref }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+          SOURCE_SHA: ${{ needs.prepare.outputs.source-sha }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        shell: bash
+        run: |
+          native_ref="$IMAGE:$VERSION"
+          compat_ref="$IMAGE:$VERSION-compat"
+          native_digest_ref="$IMAGE@$NATIVE_DIGEST"
+          compat_digest_ref="$IMAGE@$COMPAT_DIGEST"
+          run_url="$SERVER_URL/$REPOSITORY/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT"
+
+          jq -n \
+            --arg sourceSha "$SOURCE_SHA" \
+            --arg requestedSourceRef "$REQUESTED_SOURCE_REF" \
+            --arg created "$CREATED" \
+            --arg repository "$REPOSITORY" \
+            --arg runId "$RUN_ID" \
+            --arg runAttempt "$RUN_ATTEMPT" \
+            --arg runUrl "$run_url" \
+            --arg nativeRef "$native_ref" \
+            --arg nativeDigest "$NATIVE_DIGEST" \
+            --arg nativeDigestRef "$native_digest_ref" \
+            --arg compatRef "$compat_ref" \
+            --arg compatDigest "$COMPAT_DIGEST" \
+            --arg compatDigestRef "$compat_digest_ref" \
+            '{source: {sha: $sourceSha, requestedRef: $requestedSourceRef, repository: $repository}, workflow: {runId: $runId, attempt: $runAttempt, url: $runUrl}, created: $created, images: {native: {ref: $nativeRef, digest: $nativeDigest, digestRef: $nativeDigestRef, dockerfile: "docker/Dockerfile.native-package"}, compat: {ref: $compatRef, digest: $compatDigest, digestRef: $compatDigestRef, dockerfile: "docker/Dockerfile.compat", base: $nativeDigestRef}}, platforms: ["linux/amd64", "linux/arm64"]}' \
+            > floci-image-provenance.json
+
+          {
+            echo "native-ref=$native_ref"
+            echo "native-digest-ref=$native_digest_ref"
+            echo "compat-ref=$compat_ref"
+            echo "compat-digest-ref=$compat_digest_ref"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Floci images"
+            echo
+            echo "Source: \`$SOURCE_SHA\`"
+            echo
+            echo "| Image tag | Immutable digest reference |"
+            echo "| --- | --- |"
+            echo "| \`$native_ref\` | \`$native_digest_ref\` |"
+            echo "| \`$compat_ref\` | \`$compat_digest_ref\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: floci-image-provenance-${{ needs.prepare.outputs.version }}
+          path: floci-image-provenance.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -168,10 +168,10 @@ jobs:
       - name: Set candidate version
         env:
           CANDIDATE_VERSION: ${{ needs.prepare.outputs.version }}
-        run: mvn versions:set -DnewVersion="$CANDIDATE_VERSION" -DgenerateBackupPoms=false -q
+        run: ./mvnw versions:set -DnewVersion="$CANDIDATE_VERSION" -DgenerateBackupPoms=false -q
 
       - name: Build native executable
-        run: mvn clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-march=x86-64-v2"
+        run: ./mvnw clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-march=x86-64-v2"
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -208,10 +208,10 @@ jobs:
       - name: Set candidate version
         env:
           CANDIDATE_VERSION: ${{ needs.prepare.outputs.version }}
-        run: mvn versions:set -DnewVersion="$CANDIDATE_VERSION" -DgenerateBackupPoms=false -q
+        run: ./mvnw versions:set -DnewVersion="$CANDIDATE_VERSION" -DgenerateBackupPoms=false -q
 
       - name: Build native executable
-        run: mvn clean package -Dnative -DskipTests -B
+        run: ./mvnw clean package -Dnative -DskipTests -B
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -224,7 +224,7 @@ jobs:
           retention-days: 1
 
   publish:
-    name: Publish JVM image
+    name: Publish images
     needs: [prepare, build-native-amd64, build-native-arm64]
     if: >-
       ${{

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -27,6 +27,9 @@ on:
       source-sha:
         description: Full source revision used for all images
         value: ${{ jobs.prepare.outputs.source-sha }}
+      image-tag:
+        description: Timestamped source revision tag used for all images
+        value: ${{ jobs.prepare.outputs.image-tag }}
       image-ref:
         description: Commit-tagged default JVM image reference
         value: ${{ jobs.publish.outputs.jvm-ref }}
@@ -68,7 +71,8 @@ jobs:
       image: ${{ steps.image.outputs.image }}
       registry: ${{ steps.image.outputs.registry }}
       source-sha: ${{ steps.source.outputs.sha }}
-      version: ${{ steps.source.outputs.version }}
+      image-tag: ${{ steps.source.outputs.image-tag }}
+      product-version: ${{ steps.source.outputs.product-version }}
 
     steps:
       - name: Validate image repository
@@ -140,8 +144,19 @@ jobs:
         id: source
         shell: bash
         run: |
-          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          echo "version=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
+          source_sha="$(git rev-parse HEAD)"
+          source_short="${source_sha:0:8}"
+          timestamp="$(date -u +'%Y%m%d.%H%M%S')"
+          product_version="$(./mvnw -q -DforceStdout help:evaluate -Dexpression=project.version)"
+
+          if [[ -z "$product_version" ]]; then
+            echo "Could not resolve the Floci project version." >&2
+            exit 1
+          fi
+
+          echo "sha=$source_sha" >> "$GITHUB_OUTPUT"
+          echo "image-tag=$timestamp.$source_short" >> "$GITHUB_OUTPUT"
+          echo "product-version=$product_version" >> "$GITHUB_OUTPUT"
 
   build-native-amd64:
     name: Build native artifact (amd64)
@@ -165,17 +180,12 @@ jobs:
           cache: maven
           github-token: ${{ github.token }}
 
-      - name: Set candidate version
-        env:
-          CANDIDATE_VERSION: ${{ needs.prepare.outputs.version }}
-        run: ./mvnw versions:set -DnewVersion="$CANDIDATE_VERSION" -DgenerateBackupPoms=false -q
-
       - name: Build native executable
         run: ./mvnw clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-march=x86-64-v2"
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: floci-native-amd64-${{ needs.prepare.outputs.version }}
+          name: floci-native-amd64-${{ needs.prepare.outputs.image-tag }}
           path: |
             target/*-runner
             target/*.properties
@@ -205,17 +215,12 @@ jobs:
           cache: maven
           github-token: ${{ github.token }}
 
-      - name: Set candidate version
-        env:
-          CANDIDATE_VERSION: ${{ needs.prepare.outputs.version }}
-        run: ./mvnw versions:set -DnewVersion="$CANDIDATE_VERSION" -DgenerateBackupPoms=false -q
-
       - name: Build native executable
         run: ./mvnw clean package -Dnative -DskipTests -B
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: floci-native-arm64-${{ needs.prepare.outputs.version }}
+          name: floci-native-arm64-${{ needs.prepare.outputs.image-tag }}
           path: |
             target/*-runner
             target/*.properties
@@ -256,13 +261,13 @@ jobs:
       - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         if: inputs.publish-native
         with:
-          name: floci-native-amd64-${{ needs.prepare.outputs.version }}
+          name: floci-native-amd64-${{ needs.prepare.outputs.image-tag }}
           path: native/amd64/
 
       - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         if: inputs.publish-native
         with:
-          name: floci-native-arm64-${{ needs.prepare.outputs.version }}
+          name: floci-native-arm64-${{ needs.prepare.outputs.image-tag }}
           path: native/arm64/
 
       - name: Make native binaries executable
@@ -304,15 +309,16 @@ jobs:
           file: docker/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ needs.prepare.outputs.image }}:${{ needs.prepare.outputs.version }}
+          tags: ${{ needs.prepare.outputs.image }}:${{ needs.prepare.outputs.image-tag }}
           build-args: |
-            VERSION=${{ needs.prepare.outputs.version }}
+            VERSION=${{ needs.prepare.outputs.product-version }}
           labels: |
-            org.opencontainers.image.version=${{ needs.prepare.outputs.version }}
+            org.opencontainers.image.version=${{ needs.prepare.outputs.product-version }}
             org.opencontainers.image.revision=${{ needs.prepare.outputs.source-sha }}
+            org.opencontainers.image.vcs-ref=${{ needs.prepare.outputs.source-sha }}
             org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            version=${{ needs.prepare.outputs.version }}
+            version=${{ needs.prepare.outputs.product-version }}
             build-date=${{ steps.metadata.outputs.created }}
             vcs-ref=${{ needs.prepare.outputs.source-sha }}
           cache-from: type=gha,scope=floci-jvm
@@ -329,15 +335,16 @@ jobs:
           file: docker/Dockerfile.native-package
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ needs.prepare.outputs.image }}:${{ needs.prepare.outputs.version }}-native
+          tags: ${{ needs.prepare.outputs.image }}:${{ needs.prepare.outputs.image-tag }}-native
           build-args: |
-            VERSION=${{ needs.prepare.outputs.version }}
+            VERSION=${{ needs.prepare.outputs.product-version }}
           labels: |
-            org.opencontainers.image.version=${{ needs.prepare.outputs.version }}
+            org.opencontainers.image.version=${{ needs.prepare.outputs.product-version }}
             org.opencontainers.image.revision=${{ needs.prepare.outputs.source-sha }}
+            org.opencontainers.image.vcs-ref=${{ needs.prepare.outputs.source-sha }}
             org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            version=${{ needs.prepare.outputs.version }}
+            version=${{ needs.prepare.outputs.product-version }}
             build-date=${{ steps.metadata.outputs.created }}
             vcs-ref=${{ needs.prepare.outputs.source-sha }}
           cache-from: type=gha,scope=floci-native
@@ -354,16 +361,17 @@ jobs:
           file: docker/Dockerfile.compat
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ needs.prepare.outputs.image }}:${{ needs.prepare.outputs.version }}-native-compat
+          tags: ${{ needs.prepare.outputs.image }}:${{ needs.prepare.outputs.image-tag }}-native-compat
           build-args: |
-            VERSION=${{ needs.prepare.outputs.version }}
+            VERSION=${{ needs.prepare.outputs.product-version }}
             BASE_IMAGE=${{ needs.prepare.outputs.image }}@${{ steps.native.outputs.digest }}
           labels: |
-            org.opencontainers.image.version=${{ needs.prepare.outputs.version }}
+            org.opencontainers.image.version=${{ needs.prepare.outputs.product-version }}
             org.opencontainers.image.revision=${{ needs.prepare.outputs.source-sha }}
+            org.opencontainers.image.vcs-ref=${{ needs.prepare.outputs.source-sha }}
             org.opencontainers.image.created=${{ steps.metadata.outputs.created }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            version=${{ needs.prepare.outputs.version }}
+            version=${{ needs.prepare.outputs.product-version }}
             build-date=${{ steps.metadata.outputs.created }}
             vcs-ref=${{ needs.prepare.outputs.source-sha }}
           cache-from: type=gha,scope=floci-compat
@@ -375,8 +383,10 @@ jobs:
           COMPAT_DIGEST: ${{ steps.compat.outputs.digest }}
           CREATED: ${{ steps.metadata.outputs.created }}
           IMAGE: ${{ needs.prepare.outputs.image }}
+          IMAGE_TAG: ${{ needs.prepare.outputs.image-tag }}
           JVM_DIGEST: ${{ steps.jvm.outputs.digest }}
           NATIVE_DIGEST: ${{ steps.native.outputs.digest }}
+          PRODUCT_VERSION: ${{ needs.prepare.outputs.product-version }}
           PUBLISH_NATIVE: ${{ inputs.publish-native }}
           REPOSITORY: ${{ github.repository }}
           REQUESTED_SOURCE_REF: ${{ inputs.source-ref }}
@@ -384,13 +394,12 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           SERVER_URL: ${{ github.server_url }}
           SOURCE_SHA: ${{ needs.prepare.outputs.source-sha }}
-          VERSION: ${{ needs.prepare.outputs.version }}
         shell: bash
         run: |
-          jvm_ref="$IMAGE:$VERSION"
+          jvm_ref="$IMAGE:$IMAGE_TAG"
           jvm_digest_ref="$IMAGE@$JVM_DIGEST"
-          native_ref="$IMAGE:$VERSION-native"
-          compat_ref="$IMAGE:$VERSION-native-compat"
+          native_ref="$IMAGE:$IMAGE_TAG-native"
+          compat_ref="$IMAGE:$IMAGE_TAG-native-compat"
           native_digest_ref="$IMAGE@$NATIVE_DIGEST"
           compat_digest_ref="$IMAGE@$COMPAT_DIGEST"
           run_url="$SERVER_URL/$REPOSITORY/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT"
@@ -399,6 +408,8 @@ jobs:
             --arg sourceSha "$SOURCE_SHA" \
             --arg requestedSourceRef "$REQUESTED_SOURCE_REF" \
             --arg created "$CREATED" \
+            --arg imageTag "$IMAGE_TAG" \
+            --arg productVersion "$PRODUCT_VERSION" \
             --arg repository "$REPOSITORY" \
             --arg runId "$RUN_ID" \
             --arg runAttempt "$RUN_ATTEMPT" \
@@ -406,7 +417,7 @@ jobs:
             --arg jvmRef "$jvm_ref" \
             --arg jvmDigest "$JVM_DIGEST" \
             --arg jvmDigestRef "$jvm_digest_ref" \
-            '{source: {sha: $sourceSha, requestedRef: $requestedSourceRef, repository: $repository}, workflow: {runId: $runId, attempt: $runAttempt, url: $runUrl}, created: $created, images: {jvm: {ref: $jvmRef, digest: $jvmDigest, digestRef: $jvmDigestRef, dockerfile: "docker/Dockerfile"}}, platforms: ["linux/amd64", "linux/arm64"]}' \
+            '{source: {sha: $sourceSha, requestedRef: $requestedSourceRef, repository: $repository}, workflow: {runId: $runId, attempt: $runAttempt, url: $runUrl}, created: $created, imageTag: $imageTag, productVersion: $productVersion, images: {jvm: {ref: $jvmRef, digest: $jvmDigest, digestRef: $jvmDigestRef, dockerfile: "docker/Dockerfile"}}, platforms: ["linux/amd64", "linux/arm64"]}' \
             > floci-image-provenance.json
 
           if [[ "$PUBLISH_NATIVE" == "true" ]]; then
@@ -438,6 +449,7 @@ jobs:
             echo "## Floci images"
             echo
             echo "Source: \`$SOURCE_SHA\`"
+            echo "Product version: \`$PRODUCT_VERSION\`"
             echo
             echo "| Image tag | Immutable digest reference |"
             echo "| --- | --- |"
@@ -450,7 +462,7 @@ jobs:
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: floci-image-provenance-${{ needs.prepare.outputs.version }}
+          name: floci-image-provenance-${{ needs.prepare.outputs.image-tag }}
           path: floci-image-provenance.json
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       image:
-        description: OCI image repository without a tag or digest
+        description: OCI image repository including registry host (for example, ghcr.io/org/floci), without a tag or digest
         required: true
         type: string
       publish-native:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM eclipse-temurin:25-jdk AS build
+FROM eclipse-temurin:25-jdk-noble AS build
 WORKDIR /build
 
 RUN apt-get update && apt-get install -y maven && rm -rf /var/lib/apt/lists/*
@@ -11,7 +11,7 @@ COPY src/ src/
 RUN mvn clean package -DskipTests -q
 
 # Stage 2: Runtime
-FROM eclipse-temurin:25-jre-alpine
+FROM eclipse-temurin:25-jre-noble
 
 ARG VERSION=latest
 ENV FLOCI_VERSION=${VERSION}
@@ -26,16 +26,18 @@ ENV GOSU_VERSION=1.17
 ENV GOSU_AMD64_SHA256=bbc4136d03ab138b1ad66fa4fc051bafc6cc7ffae632b069a53657279a450de3
 ENV GOSU_ARM64_SHA256=c3805a85d17f4454c23d7059bcb97e1ec1af272b90126e79ed002342de08389b
 RUN set -eux; \
-    apk add --no-cache shadow ca-certificates python3 py3-pip; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates passwd python3 python3-pip wget; \
+    rm -rf /var/lib/apt/lists/*; \
     pip3 install --no-cache-dir --break-system-packages awscli boto3; \
-    mv /usr/bin/aws /usr/bin/aws.real; \
+    mv /usr/local/bin/aws /usr/bin/aws.real; \
     printf '#!/bin/sh\nexec /usr/bin/aws.real --endpoint-url=http://localhost:4566 "$@"\n' > /usr/bin/aws; \
     chmod +x /usr/bin/aws; \
-    useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci; \
-    arch="$(apk --print-arch)"; \
+    useradd -r -u 1001 -g root -d /app -s /usr/sbin/nologin floci; \
+    arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
-        x86_64) gosuArch='amd64'; gosuSha256="$GOSU_AMD64_SHA256" ;; \
-        aarch64) gosuArch='arm64'; gosuSha256="$GOSU_ARM64_SHA256" ;; \
+        amd64) gosuArch='amd64'; gosuSha256="$GOSU_AMD64_SHA256" ;; \
+        arm64) gosuArch='arm64'; gosuSha256="$GOSU_ARM64_SHA256" ;; \
         *) echo >&2 "unsupported arch: $arch"; exit 1 ;; \
     esac; \
     wget -q -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${gosuArch}"; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN set -eux; \
     mv /usr/local/bin/aws /usr/bin/aws.real; \
     printf '#!/bin/sh\nexec /usr/bin/aws.real --endpoint-url=http://localhost:4566 "$@"\n' > /usr/bin/aws; \
     chmod +x /usr/bin/aws; \
-    useradd -r -u 1001 -g root -d /app -s /usr/sbin/nologin floci; \
+    useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci; \
     arch="$(dpkg --print-architecture)"; \
     case "$arch" in \
         amd64) gosuArch='amd64'; gosuSha256="$GOSU_AMD64_SHA256" ;; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,8 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends ca-certificates passwd python3 python3-pip wget; \
     rm -rf /var/lib/apt/lists/*; \
     pip3 install --no-cache-dir --break-system-packages awscli boto3; \
-    mv /usr/local/bin/aws /usr/bin/aws.real; \
+    aws_bin="$(command -v aws)"; \
+    mv "$aws_bin" /usr/bin/aws.real; \
     printf '#!/bin/sh\nexec /usr/bin/aws.real --endpoint-url=http://localhost:4566 "$@"\n' > /usr/bin/aws; \
     chmod +x /usr/bin/aws; \
     useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci; \

--- a/docker/Dockerfile.compat
+++ b/docker/Dockerfile.compat
@@ -1,5 +1,6 @@
 ARG VERSION=latest
-FROM floci/floci:${VERSION}
+ARG BASE_IMAGE=floci/floci:${VERSION}
+FROM ${BASE_IMAGE}
 
 LABEL org.opencontainers.image.title="Floci (compat)" \
       org.opencontainers.image.description="Floci compatibility image with AWS CLI and boto3 pre-installed" \

--- a/docker/Dockerfile.compat
+++ b/docker/Dockerfile.compat
@@ -1,4 +1,7 @@
 ARG VERSION=latest
+# This must be the UBI-based image produced by Dockerfile.native-package.
+# Release and nightly tags use VERSION; reusable builds override BASE_IMAGE
+# with the digest-qualified native image they just published.
 ARG BASE_IMAGE=floci/floci:${VERSION}
 FROM ${BASE_IMAGE}
 

--- a/docs/configuration/docker-images.md
+++ b/docs/configuration/docker-images.md
@@ -58,6 +58,60 @@ image: floci/floci:nightly
 
 All images are published as multi-arch manifests supporting `linux/amd64` and `linux/arm64`. Docker selects the correct variant automatically.
 
+## Reusable Image Publishing
+
+The `Build Floci Images` reusable workflow publishes native and compat images
+for an exact branch, tag, or commit. A calling repository owns the trigger,
+destination registry, credentials, and package permissions; the shared workflow
+owns the native amd64 and arm64 builds, multi-architecture manifests, image
+labels, and provenance output.
+
+For example, a fork can keep this small manual caller on its default branch:
+
+```yaml title=".github/workflows/publish-images.yml"
+name: Publish Floci Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      source-ref:
+        description: Floci branch, tag, or commit to publish
+        required: true
+        type: string
+        default: main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    uses: floci-io/floci/.github/workflows/build-images.yml@main
+    with:
+      source-ref: ${{ inputs.source-ref }}
+      image: ghcr.io/${{ github.repository_owner }}/floci
+```
+
+Pin the reusable workflow to a trusted tag or full commit SHA when the caller
+requires a stable build contract. The caller's `GITHUB_TOKEN` publishes a GHCR
+image only below the caller's repository owner. Calls targeting another OCI
+registry must pass `REGISTRY_USERNAME` and `REGISTRY_TOKEN` through the reusable
+workflow's declared secrets.
+
+The workflow publishes commit-derived convenience tags:
+
+- `<commit-sha-12>` for the standard native image
+- `<commit-sha-12>-compat` for the compat image
+
+A rerun for the same commit can replace either tag. The workflow therefore
+returns digest-qualified native and compat references and uploads them in a
+provenance JSON artifact. Downstream tests should use a digest-qualified
+reference when they require an immutable image:
+
+```text
+ghcr.io/example/floci@sha256:...
+```
+
 ## What's in the Compat Image
 
 The compat image installs the following on top of the standard image:

--- a/docs/configuration/docker-images.md
+++ b/docs/configuration/docker-images.md
@@ -60,11 +60,12 @@ All images are published as multi-arch manifests supporting `linux/amd64` and `l
 
 ## Reusable Image Publishing
 
-The `Build Floci Images` reusable workflow publishes native and compat images
-for an exact branch, tag, or commit. A calling repository owns the trigger,
-destination registry, credentials, and package permissions; the shared workflow
-owns the native amd64 and arm64 builds, multi-architecture manifests, image
-labels, and provenance output.
+The `Build Floci Images` reusable workflow publishes a JVM image for an exact
+branch, tag, or commit by default. This matches the ordinary Maven package and
+the repository's local-development Docker image. A calling repository owns the
+trigger, destination registry, credentials, and package permissions; the shared
+workflow owns the multi-architecture manifest, image labels, and provenance
+output.
 
 For example, a fork can keep this small manual caller on its default branch:
 
@@ -98,15 +99,18 @@ image only below the caller's repository owner. Calls targeting another OCI
 registry must pass `REGISTRY_USERNAME` and `REGISTRY_TOKEN` through the reusable
 workflow's declared secrets.
 
-The workflow publishes commit-derived convenience tags:
+The default workflow publishes a commit-derived convenience tag:
 
-- `<commit-sha-12>` for the standard native image
-- `<commit-sha-12>-compat` for the compat image
+- `<commit-sha-12>` for the JVM image
 
-A rerun for the same commit can replace either tag. The workflow therefore
-returns digest-qualified native and compat references and uploads them in a
-provenance JSON artifact. Downstream tests should use a digest-qualified
-reference when they require an immutable image:
+Callers that also need native artifacts can pass `publish-native: true`. This
+adds `<commit-sha-12>-native` and `<commit-sha-12>-native-compat`; it does not
+change the unqualified JVM tag.
+
+A rerun for the same commit can replace a tag. The workflow therefore returns
+the digest-qualified JVM reference (plus native references when requested) and
+uploads them in a provenance JSON artifact. Downstream tests should use a
+digest-qualified reference when they require an immutable image:
 
 ```text
 ghcr.io/example/floci@sha256:...

--- a/docs/configuration/docker-images.md
+++ b/docs/configuration/docker-images.md
@@ -147,7 +147,10 @@ Override any of them at runtime via `docker run -e` or the Compose `environment`
 
 ## Local Development
 
-The project ships a `docker-compose.yml` at the repository root configured for local development. By default it uses `docker/Dockerfile` (a fast JVM build suited for iteration). Switch the `dockerfile` entry to test the native image locally:
+The project ships a `docker-compose.yml` at the repository root configured for local development.
+By default it uses `docker/Dockerfile`, a fast Ubuntu Noble/glibc JVM image suited for iteration
+with Java 25. The release and nightly images use the native Dockerfiles described above. Switch the
+`dockerfile` entry to test the native image locally:
 
 ```yaml title="docker-compose.yml"
 build:

--- a/docs/configuration/docker-images.md
+++ b/docs/configuration/docker-images.md
@@ -99,15 +99,16 @@ image only below the caller's repository owner. Calls targeting another OCI
 registry must pass `REGISTRY_USERNAME` and `REGISTRY_TOKEN` through the reusable
 workflow's declared secrets.
 
-The default workflow publishes a commit-derived convenience tag:
+The default workflow publishes a build-and-commit-derived convenience tag:
 
-- `<commit-sha-12>` for the JVM image
+- `<YYYYMMDD.HHMMSS>.<commit-sha-8>` for the JVM image
 
 Callers that also need native artifacts can pass `publish-native: true`. This
-adds `<commit-sha-12>-native` and `<commit-sha-12>-native-compat`; it does not
-change the unqualified JVM tag.
+adds `<YYYYMMDD.HHMMSS>.<commit-sha-8>-native` and
+`<YYYYMMDD.HHMMSS>.<commit-sha-8>-native-compat`; it does not change the
+unqualified JVM tag. Timestamps are generated in UTC.
 
-A rerun for the same commit can replace a tag. The workflow therefore returns
+Each workflow invocation produces a new timestamped tag. The workflow returns
 the digest-qualified JVM reference (plus native references when requested) and
 uploads them in a provenance JSON artifact. Downstream tests should use a
 digest-qualified reference when they require an immutable image:


### PR DESCRIPTION
## Summary

- Add a reusable GitHub Actions workflow that publishes Floci images for an
  exact branch, tag, or commit to a caller-selected OCI repository.
- Publish a multi-architecture JVM image by default, with native and native
  compatibility images available through an explicit `publish-native` input.
- Return digest-qualified image references and upload a provenance document so
  callers can consume immutable artifacts.
- Use an Ubuntu Noble Java 25 runtime for the JVM image so glibc-linked
  integrations work without changing the existing entrypoint or user model.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

The reusable workflow builds the same JVM package used by the repository's
ordinary Maven and local-development path. It publishes `linux/amd64` and
`linux/arm64` manifests and preserves the existing Floci entrypoint and runtime
configuration contract.

Callers own the trigger, destination registry, credentials, and package
permissions. The workflow resolves one exact source revision, applies that
revision consistently to every image, and reports immutable digest references
for downstream SDK and CLI compatibility tests.

The default JVM and opt-in native publication paths were both exercised from a
reusable-workflow caller.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added (not applicable: workflow, Docker, and docs only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Verification

Current rebased tree (`434dd27ee`):

- Workflow YAML parse
- `./mvnw -B -DskipTests package`
- `git diff --check upstream/main...HEAD`

Patch-set proof before the final upstream-only rebase:

- `make docs-check`
- `./mvnw -B test`
  - 7,937 tests, 0 failures, 0 errors, 8 skipped
  - log SHA-256:
    `a04e8673b1de032a940c28abbb13fc502eba89163dad365f72c00ef0f6b44c6a`
- Reusable workflow default JVM publication: successful
- Reusable workflow opt-in native and native-compat publication: successful

## Commit Stack

1. `7b20b8828` `ci: add reusable image publishing`
2. `5092308ff` `fix(docker): use glibc in JVM development image`
3. `ebd3623a9` `ci: publish JVM images by default`
4. `7c0b8beb9` `fix(ci): harden reusable image builds`
5. `434dd27ee` `docs(ci): clarify image registry input`