### PR TITLE
feat(ec2): complete VPC Query lifecycle support

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2Tests.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2Tests.java
@@ -3,6 +3,7 @@ package com.floci.test;
 import org.junit.jupiter.api.*;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.*;
+import software.amazon.awssdk.services.ec2.model.Tag;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -29,6 +30,140 @@ class Ec2Tests {
     static void setup() {
         ec2 = TestFixtures.ec2Client();
         keyName = "sdk-test-key";
+    }
+
+    @Test
+    @Order(0)
+    @DisplayName("DescribeVpcPeeringConnections - empty when none exist")
+    void describeVpcPeeringConnectionsEmpty() {
+        DescribeVpcPeeringConnectionsResponse response = ec2.describeVpcPeeringConnections();
+
+        assertThat(response.vpcPeeringConnections()).isEmpty();
+        assertThat(ec2.describeVpcPeeringConnections(DescribeVpcPeeringConnectionsRequest.builder()
+                .filters(Filter.builder().name("status-code").values("active").build())
+                .build()).vpcPeeringConnections()).isEmpty();
+        DescribeVpcPeeringConnectionsResponse paged = ec2.describeVpcPeeringConnections(
+                DescribeVpcPeeringConnectionsRequest.builder().maxResults(5).build());
+        assertThat(paged.vpcPeeringConnections()).isEmpty();
+        assertThat(paged.nextToken()).isNull();
+
+        assertThatThrownBy(() -> ec2.describeVpcPeeringConnections(
+                DescribeVpcPeeringConnectionsRequest.builder()
+                        .vpcPeeringConnectionIds("pcx-0123456789abcdef0")
+                        .build()))
+                .isInstanceOfSatisfying(Ec2Exception.class, error -> {
+                    assertThat(error.statusCode()).isEqualTo(400);
+                    assertThat(error.awsErrorDetails().errorCode())
+                            .isEqualTo("InvalidVpcPeeringConnectionID.NotFound");
+                    assertThat(error.awsErrorDetails().errorMessage())
+                            .isEqualTo("The vpcPeeringConnection ID 'pcx-0123456789abcdef0' does not exist");
+                    assertThat(error.requestId()).isNotBlank();
+                });
+    }
+
+    @Test
+    @Order(0)
+    @DisplayName("DescribeTransitGatewayVpcAttachments - empty when none exist")
+    void describeTransitGatewayVpcAttachmentsEmpty() {
+        DescribeTransitGatewayVpcAttachmentsResponse response =
+                ec2.describeTransitGatewayVpcAttachments();
+
+        assertThat(response.transitGatewayVpcAttachments()).isEmpty();
+        assertThat(ec2.describeTransitGatewayVpcAttachments(
+                DescribeTransitGatewayVpcAttachmentsRequest.builder()
+                        .filters(Filter.builder().name("state").values("available").build())
+                        .build()).transitGatewayVpcAttachments()).isEmpty();
+        DescribeTransitGatewayVpcAttachmentsResponse paged =
+                ec2.describeTransitGatewayVpcAttachments(
+                        DescribeTransitGatewayVpcAttachmentsRequest.builder().maxResults(5).build());
+        assertThat(paged.transitGatewayVpcAttachments()).isEmpty();
+        assertThat(paged.nextToken()).isNull();
+
+        assertThatThrownBy(() -> ec2.describeTransitGatewayVpcAttachments(
+                DescribeTransitGatewayVpcAttachmentsRequest.builder()
+                        .transitGatewayAttachmentIds("tgw-attach-0123456789abcdef0")
+                        .build()))
+                .isInstanceOfSatisfying(Ec2Exception.class, error -> {
+                    assertThat(error.statusCode()).isEqualTo(400);
+                    assertThat(error.awsErrorDetails().errorCode())
+                            .isEqualTo("InvalidTransitGatewayAttachmentID.NotFound");
+                    assertThat(error.awsErrorDetails().errorMessage())
+                            .isEqualTo("Transit Gateway Attachment "
+                                    + "tgw-attach-0123456789abcdef0 was not found.");
+                    assertThat(error.requestId()).isNotBlank();
+                });
+
+        for (String filterName : List.of("tag:Owner", "tag-key")) {
+            assertThatThrownBy(() -> ec2.describeTransitGatewayVpcAttachments(
+                    DescribeTransitGatewayVpcAttachmentsRequest.builder()
+                            .filters(Filter.builder().name(filterName).values("TeamA").build())
+                            .build()))
+                    .isInstanceOfSatisfying(Ec2Exception.class, error -> {
+                        assertThat(error.statusCode()).isEqualTo(400);
+                        assertThat(error.awsErrorDetails().errorCode()).isEqualTo("InvalidParameterValue");
+                        assertThat(error.awsErrorDetails().errorMessage())
+                                .isEqualTo("The filter '" + filterName + "' is invalid");
+                        assertThat(error.requestId()).isNotBlank();
+                    });
+        }
+    }
+
+    @Test
+    @Order(0)
+    @DisplayName("DescribeVpnGateways - empty when none exist")
+    void describeVpnGatewaysEmpty() {
+        assertThat(ec2.describeVpnGateways().vpnGateways()).isEmpty();
+        assertThat(ec2.describeVpnGateways(DescribeVpnGatewaysRequest.builder()
+                .filters(Filter.builder()
+                        .name("attachment.vpc-id")
+                        .values("vpc-0123456789abcdef0")
+                        .build())
+                .build()).vpnGateways()).isEmpty();
+
+        assertThatThrownBy(() -> ec2.describeVpnGateways(DescribeVpnGatewaysRequest.builder()
+                .vpnGatewayIds("vgw-0123456789abcdef0")
+                .build()))
+                .isInstanceOfSatisfying(Ec2Exception.class, error -> {
+                    assertThat(error.statusCode()).isEqualTo(400);
+                    assertThat(error.awsErrorDetails().errorCode())
+                            .isEqualTo("InvalidVpnGatewayID.NotFound");
+                    assertThat(error.awsErrorDetails().errorMessage())
+                            .isEqualTo("The vpnGateway ID 'vgw-0123456789abcdef0' does not exist");
+                    assertThat(error.requestId()).isNotBlank();
+                });
+    }
+
+    @Test
+    @Order(0)
+    @DisplayName("DescribeEgressOnlyInternetGateways - empty when none exist")
+    void describeEgressOnlyInternetGatewaysEmpty() {
+        assertThat(ec2.describeEgressOnlyInternetGateways().egressOnlyInternetGateways()).isEmpty();
+        assertThat(ec2.describeEgressOnlyInternetGateways(
+                DescribeEgressOnlyInternetGatewaysRequest.builder()
+                        .filters(Filter.builder()
+                                .name("tag:Owner")
+                                .values("TeamA")
+                                .build())
+                        .build()).egressOnlyInternetGateways()).isEmpty();
+        DescribeEgressOnlyInternetGatewaysResponse paged =
+                ec2.describeEgressOnlyInternetGateways(
+                        DescribeEgressOnlyInternetGatewaysRequest.builder().maxResults(5).build());
+        assertThat(paged.egressOnlyInternetGateways()).isEmpty();
+        assertThat(paged.nextToken()).isNull();
+
+        assertThatThrownBy(() -> ec2.describeEgressOnlyInternetGateways(
+                DescribeEgressOnlyInternetGatewaysRequest.builder()
+                        .egressOnlyInternetGatewayIds("eigw-0123456789abcdef0")
+                        .build()))
+                .isInstanceOfSatisfying(Ec2Exception.class, error -> {
+                    assertThat(error.statusCode()).isEqualTo(400);
+                    assertThat(error.awsErrorDetails().errorCode())
+                            .isEqualTo("InvalidEgressOnlyInternetGatewayId.NotFound");
+                    assertThat(error.awsErrorDetails().errorMessage())
+                            .isEqualTo("The egress-only internet gateway ID "
+                                    + "'eigw-0123456789abcdef0' does not exist");
+                    assertThat(error.requestId()).isNotBlank();
+                });
     }
 
     @AfterAll
@@ -251,12 +386,74 @@ class Ec2Tests {
                 .vpcId(vpcId)
                 .cidrBlock("10.0.1.0/24")
                 .availabilityZone("us-east-1a")
+                .tagSpecifications(
+                        TagSpecification.builder()
+                                .resourceType(ResourceType.SUBNET)
+                                .tags(Tag.builder().key("example.io:managed-by").value("sdk-test").build())
+                                .build(),
+                        TagSpecification.builder()
+                                .resourceType(ResourceType.SUBNET)
+                                .tags(
+                                        Tag.builder().key("Name").value("sdk-test-subnet").build(),
+                                        Tag.builder().key("omitted-value").build(),
+                                        Tag.builder().key("explicit-empty-value").value("").build())
+                                .build())
                 .build());
         subnetId = resp.subnet().subnetId();
 
         assertThat(subnetId).isNotNull().startsWith("subnet-");
         assertThat(resp.subnet().vpcId()).isEqualTo(vpcId);
         assertThat(resp.subnet().cidrBlock()).isEqualTo("10.0.1.0/24");
+        assertThat(resp.subnet().tags()).extracting(Tag::key, Tag::value)
+                .containsExactlyInAnyOrder(
+                        tuple("example.io:managed-by", "sdk-test"),
+                        tuple("Name", "sdk-test-subnet"),
+                        tuple("omitted-value", ""),
+                        tuple("explicit-empty-value", ""));
+    }
+
+    @Test
+    @Order(11)
+    @DisplayName("CreateSubnet - reject unsupported tag resource type")
+    void createSubnetRejectsUnsupportedTagResourceType() {
+        assertCreateSubnetTagSpecificationRejected(
+                "10.0.2.0/24",
+                TagSpecification.builder()
+                        .resourceType(ResourceType.VPC)
+                        .tags(Tag.builder().key("Name").value("invalid").build())
+                        .build(),
+                "Tag specification resource type 'vpc'");
+    }
+
+    @Test
+    @Order(11)
+    @DisplayName("CreateSubnet - reject tag specification without resource type")
+    void createSubnetRejectsMissingTagResourceType() {
+        assertCreateSubnetTagSpecificationRejected(
+                "10.0.3.0/24",
+                TagSpecification.builder()
+                        .tags(Tag.builder().key("Name").value("invalid").build())
+                        .build(),
+                "Tag specification resource type ''");
+    }
+
+    private void assertCreateSubnetTagSpecificationRejected(
+            String cidrBlock, TagSpecification tagSpecification, String expectedMessage) {
+        assertThatThrownBy(() -> ec2.createSubnet(CreateSubnetRequest.builder()
+                .vpcId(vpcId)
+                .cidrBlock(cidrBlock)
+                .tagSpecifications(tagSpecification)
+                .build()))
+                .isInstanceOfSatisfying(Ec2Exception.class, error -> {
+                    assertThat(error.statusCode()).isEqualTo(400);
+                    assertThat(error.awsErrorDetails().errorCode()).isEqualTo("InvalidParameterValue");
+                    assertThat(error.awsErrorDetails().errorMessage()).contains(expectedMessage);
+                    assertThat(error.requestId()).isNotBlank();
+                });
+        assertThat(ec2.describeSubnets(DescribeSubnetsRequest.builder()
+                        .filters(Filter.builder().name("vpc-id").values(vpcId).build())
+                        .build()).subnets())
+                .noneMatch(subnet -> cidrBlock.equals(subnet.cidrBlock()));
     }
 
     @Test
@@ -268,6 +465,21 @@ class Ec2Tests {
 
         assertThat(resp.subnets()).hasSize(1);
         assertThat(resp.subnets().get(0).subnetId()).isEqualTo(subnetId);
+        assertThat(resp.subnets().get(0).tags()).extracting(Tag::key, Tag::value)
+                .containsExactlyInAnyOrder(
+                        tuple("example.io:managed-by", "sdk-test"),
+                        tuple("Name", "sdk-test-subnet"),
+                        tuple("omitted-value", ""),
+                        tuple("explicit-empty-value", ""));
+        assertThat(ec2.describeTags(DescribeTagsRequest.builder()
+                        .filters(Filter.builder().name("resource-id").values(subnetId).build())
+                        .build()).tags())
+                .extracting(TagDescription::key, TagDescription::value)
+                .containsExactlyInAnyOrder(
+                        tuple("example.io:managed-by", "sdk-test"),
+                        tuple("Name", "sdk-test-subnet"),
+                        tuple("omitted-value", ""),
+                        tuple("explicit-empty-value", ""));
     }
 
     @Test
@@ -377,9 +589,11 @@ class Ec2Tests {
                 DescribeInternetGatewaysRequest.builder()
                         .internetGatewayIds(igwId).build());
 
-        boolean attached = resp.internetGateways().get(0).attachments().stream()
-                .anyMatch(a -> vpcId.equals(a.vpcId()));
-        assertThat(attached).isTrue();
+        assertThat(resp.internetGateways().get(0).attachments())
+                .anySatisfy(attachment -> {
+                    assertThat(attachment.vpcId()).isEqualTo(vpcId);
+                    assertThat(attachment.stateAsString()).isEqualTo("attached");
+                });
     }
 
     @Test

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2Tests.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2Tests.java
@@ -42,6 +42,9 @@ class Ec2Tests {
         assertThat(ec2.describeVpcPeeringConnections(DescribeVpcPeeringConnectionsRequest.builder()
                 .filters(Filter.builder().name("status-code").values("active").build())
                 .build()).vpcPeeringConnections()).isEmpty();
+        assertThat(ec2.describeVpcPeeringConnections(DescribeVpcPeeringConnectionsRequest.builder()
+                .filters(Filter.builder().name("tag-value").values("TeamA").build())
+                .build()).vpcPeeringConnections()).isEmpty();
         DescribeVpcPeeringConnectionsResponse paged = ec2.describeVpcPeeringConnections(
                 DescribeVpcPeeringConnectionsRequest.builder().maxResults(5).build());
         assertThat(paged.vpcPeeringConnections()).isEmpty();
@@ -119,6 +122,9 @@ class Ec2Tests {
                         .values("vpc-0123456789abcdef0")
                         .build())
                 .build()).vpnGateways()).isEmpty();
+        assertThat(ec2.describeVpnGateways(DescribeVpnGatewaysRequest.builder()
+                .filters(Filter.builder().name("tag-value").values("TeamA").build())
+                .build()).vpnGateways()).isEmpty();
 
         assertThatThrownBy(() -> ec2.describeVpnGateways(DescribeVpnGatewaysRequest.builder()
                 .vpnGatewayIds("vgw-0123456789abcdef0")
@@ -144,6 +150,10 @@ class Ec2Tests {
                                 .name("tag:Owner")
                                 .values("TeamA")
                                 .build())
+                        .build()).egressOnlyInternetGateways()).isEmpty();
+        assertThat(ec2.describeEgressOnlyInternetGateways(
+                DescribeEgressOnlyInternetGatewaysRequest.builder()
+                        .filters(Filter.builder().name("tag-value").values("TeamA").build())
                         .build()).egressOnlyInternetGateways()).isEmpty();
         DescribeEgressOnlyInternetGatewaysResponse paged =
                 ec2.describeEgressOnlyInternetGateways(
@@ -592,7 +602,7 @@ class Ec2Tests {
         assertThat(resp.internetGateways().get(0).attachments())
                 .anySatisfy(attachment -> {
                     assertThat(attachment.vpcId()).isEqualTo(vpcId);
-                    assertThat(attachment.stateAsString()).isEqualTo("attached");
+                    assertThat(attachment.stateAsString()).isEqualTo("available");
                 });
     }
 

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2VpcDefaultResourceCleanupTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2VpcDefaultResourceCleanupTest.java
@@ -1,0 +1,50 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.CreateVpcRequest;
+import software.amazon.awssdk.services.ec2.model.DeleteVpcRequest;
+import software.amazon.awssdk.services.ec2.model.Filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Ec2VpcDefaultResourceCleanupTest {
+
+    @Test
+    void deleteVpcRemovesVpcOwnedDefaultResourcesAndSecurityGroupRules() {
+        try (Ec2Client ec2 = TestFixtures.ec2Client()) {
+            String vpcId = ec2.createVpc(CreateVpcRequest.builder()
+                            .cidrBlock("10.77.0.0/16")
+                            .build())
+                    .vpc().vpcId();
+            Filter vpcFilter = Filter.builder().name("vpc-id").values(vpcId).build();
+
+            var defaultGroup = ec2.describeSecurityGroups(request -> request.filters(vpcFilter))
+                    .securityGroups().stream()
+                    .filter(group -> "default".equals(group.groupName()))
+                    .findFirst().orElseThrow();
+            var mainRouteTable = ec2.describeRouteTables(request -> request.filters(vpcFilter))
+                    .routeTables().stream()
+                    .filter(table -> table.associations().stream().anyMatch(association -> association.main()))
+                    .findFirst().orElseThrow();
+            var defaultNetworkAcl = ec2.describeNetworkAcls(request -> request.filters(vpcFilter))
+                    .networkAcls().stream()
+                    .filter(acl -> acl.isDefault())
+                    .findFirst().orElseThrow();
+            Filter groupFilter = Filter.builder().name("group-id").values(defaultGroup.groupId()).build();
+            assertThat(ec2.describeSecurityGroupRules(request -> request.filters(groupFilter))
+                    .securityGroupRules()).isNotEmpty();
+
+            ec2.deleteVpc(DeleteVpcRequest.builder().vpcId(vpcId).build());
+
+            assertThat(ec2.describeSecurityGroups(request -> request.groupIds(defaultGroup.groupId()))
+                    .securityGroups()).isEmpty();
+            assertThat(ec2.describeRouteTables(request -> request.routeTableIds(mainRouteTable.routeTableId()))
+                    .routeTables()).isEmpty();
+            assertThat(ec2.describeNetworkAcls(request -> request.networkAclIds(defaultNetworkAcl.networkAclId()))
+                    .networkAcls()).isEmpty();
+            assertThat(ec2.describeSecurityGroupRules(request -> request.filters(groupFilter))
+                    .securityGroupRules()).isEmpty();
+        }
+    }
+}

--- a/docs/services/ec2.md
+++ b/docs/services/ec2.md
@@ -182,9 +182,19 @@ Floci seeds the following resources on first use in each region so Terraform, th
 | CreateVpcEndpoint | Creates a VPC endpoint record. |
 | DescribeVpcEndpoints | Lists or returns stored VPC endpoints. |
 | DeleteVpcEndpoints | Deletes VPC endpoint records. |
+| DescribeVpcPeeringConnections | Validates filters and returns empty discovery results; explicit IDs return not-found errors. |
+| DescribeTransitGatewayVpcAttachments | Validates filters and returns empty discovery results; explicit IDs return not-found errors. |
+| DescribeVpnGateways | Validates filters and returns empty discovery results; explicit IDs return not-found errors. |
+| DescribeEgressOnlyInternetGateways | Validates filters and returns empty discovery results; explicit IDs return not-found errors. |
 | CreateDefaultVpc | Creates or returns the default VPC for the region. |
 | AssociateVpcCidrBlock | Adds a secondary CIDR block association to a VPC. |
 | DisassociateVpcCidrBlock | Removes a secondary CIDR block association from a VPC. |
+
+The four describe-only network actions above provide discovery compatibility when no
+resources exist. VPC peering, transit gateway attachment, and egress-only gateway
+discovery validate their pagination parameters before returning an empty page. They do
+not model peering, transit gateway attachment, virtual private gateway, or egress-only
+internet gateway lifecycles.
 
 ### Subnets
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -70,6 +70,12 @@ public class Ec2QueryHandler {
                 case "DescribeFlowLogs" -> handleDescribeFlowLogs(params, region);
                 case "DeleteFlowLogs" -> handleDeleteFlowLogs(params, region);
                 case "DescribePrefixLists" -> handleDescribePrefixLists(params, region);
+                case "DescribeVpcPeeringConnections" -> handleDescribeVpcPeeringConnections(params, region);
+                case "DescribeTransitGatewayVpcAttachments" ->
+                        handleDescribeTransitGatewayVpcAttachments(params, region);
+                case "DescribeVpnGateways" -> handleDescribeVpnGateways(params, region);
+                case "DescribeEgressOnlyInternetGateways" ->
+                        handleDescribeEgressOnlyInternetGateways(params, region);
                 case "CreateDefaultVpc" -> handleCreateDefaultVpc(params, region);
                 case "AssociateVpcCidrBlock" -> handleAssociateVpcCidrBlock(params, region);
                 case "DisassociateVpcCidrBlock" -> handleDisassociateVpcCidrBlock(params, region);
@@ -339,6 +345,129 @@ public class Ec2QueryHandler {
         }
         return tags;
     }
+
+    private List<TagSpecificationMember> parseCreateSubnetTagSpecifications(MultivaluedMap<String, String> p) {
+        String prefix = "TagSpecification.";
+        SortedMap<Integer, SortedSet<Integer>> specificationTagIndexes = new TreeMap<>();
+        for (String parameter : p.keySet()) {
+            if (!parameter.startsWith(prefix)) {
+                continue;
+            }
+
+            String suffix = parameter.substring(prefix.length());
+            String[] segments = suffix.split("\\.", -1);
+            if (segments.length < 2) {
+                throw invalidCreateSubnetTagSpecificationParameter(parameter);
+            }
+
+            int specificationIndex = parseCreateSubnetTagMemberIndex(segments[0], false);
+            SortedSet<Integer> tagIndexes = specificationTagIndexes.computeIfAbsent(
+                    specificationIndex, ignored -> new TreeSet<>());
+
+            if (segments.length == 2 && "ResourceType".equals(segments[1])) {
+                continue;
+            }
+            if (segments.length != 4
+                    || !"Tag".equals(segments[1])
+                    || !("Key".equals(segments[3]) || "Value".equals(segments[3]))) {
+                throw invalidCreateSubnetTagSpecificationParameter(parameter);
+            }
+            tagIndexes.add(parseCreateSubnetTagMemberIndex(segments[2], true));
+        }
+
+        int expectedIndex = 1;
+        List<TagSpecificationMember> specifications = new ArrayList<>();
+        for (Map.Entry<Integer, SortedSet<Integer>> indexedSpecification : specificationTagIndexes.entrySet()) {
+            if (indexedSpecification.getKey() != expectedIndex++) {
+                throw invalidCreateSubnetTagSpecificationIndex(Integer.toString(indexedSpecification.getKey()));
+            }
+
+            String index = Integer.toString(indexedSpecification.getKey());
+            List<String> requestedTypes = p.get(prefix + index + ".ResourceType");
+            if (requestedTypes == null || requestedTypes.size() != 1) {
+                throw invalidCreateSubnetTagResourceType(null);
+            }
+            String requestedType = requestedTypes.getFirst();
+            if (!"subnet".equals(requestedType)) {
+                throw invalidCreateSubnetTagResourceType(requestedType);
+            }
+
+            List<Tag> tags = new ArrayList<>();
+            int expectedTagIndex = 1;
+            for (int tagIndex : indexedSpecification.getValue()) {
+                if (tagIndex != expectedTagIndex++) {
+                    throw invalidCreateSubnetTagIndex(index, Integer.toString(tagIndex));
+                }
+
+                String tagPrefix = prefix + index + ".Tag." + tagIndex;
+                List<String> keys = p.get(tagPrefix + ".Key");
+                if (keys == null || keys.size() != 1 || keys.getFirst() == null) {
+                    throw invalidCreateSubnetTagSpecificationParameter(tagPrefix + ".Key");
+                }
+                List<String> values = p.get(tagPrefix + ".Value");
+                if (values != null && values.size() != 1) {
+                    throw invalidCreateSubnetTagSpecificationParameter(tagPrefix + ".Value");
+                }
+                tags.add(new Tag(keys.getFirst(), values == null ? "" : values.getFirst()));
+            }
+            specifications.add(new TagSpecificationMember(tags));
+        }
+        return specifications;
+    }
+
+    private int parseCreateSubnetTagMemberIndex(String rawIndex, boolean tagIndex) {
+        int index;
+        try {
+            index = Integer.parseInt(rawIndex);
+        } catch (NumberFormatException e) {
+            if (tagIndex) {
+                throw invalidCreateSubnetTagIndex("", rawIndex);
+            }
+            throw invalidCreateSubnetTagSpecificationIndex(rawIndex);
+        }
+        if (index < 1 || !rawIndex.equals(Integer.toString(index))) {
+            if (tagIndex) {
+                throw invalidCreateSubnetTagIndex("", rawIndex);
+            }
+            throw invalidCreateSubnetTagSpecificationIndex(rawIndex);
+        }
+        return index;
+    }
+
+    private AwsException invalidCreateSubnetTagSpecificationIndex(String index) {
+        return new AwsException(
+                "InvalidParameterValue",
+                "Tag specification member index '" + index
+                        + "' is invalid. Member indexes must be contiguous positive integers starting at 1.",
+                400);
+    }
+
+    private AwsException invalidCreateSubnetTagResourceType(String requestedType) {
+        String value = requestedType == null ? "" : requestedType;
+        return new AwsException(
+                "InvalidParameterValue",
+                "Tag specification resource type '" + value
+                        + "' is not valid for this operation. The valid resource type is 'subnet'.",
+                400);
+    }
+
+    private AwsException invalidCreateSubnetTagIndex(String specificationIndex, String tagIndex) {
+        String specification = specificationIndex.isEmpty() ? "" : " in tag specification '" + specificationIndex + "'";
+        return new AwsException(
+                "InvalidParameterValue",
+                "Tag member index '" + tagIndex + "'" + specification
+                        + " is invalid. Member indexes must be contiguous positive integers starting at 1.",
+                400);
+    }
+
+    private AwsException invalidCreateSubnetTagSpecificationParameter(String parameter) {
+        return new AwsException(
+                "InvalidParameterValue",
+                "Tag specification parameter '" + parameter + "' has an invalid structure.",
+                400);
+    }
+
+    private record TagSpecificationMember(List<Tag> tags) {}
 
     private List<Tag> parseLaunchTemplateDataTagsForResource(MultivaluedMap<String, String> p, String resourceType) {
         List<Tag> tags = new ArrayList<>();
@@ -965,6 +1094,62 @@ public class Ec2QueryHandler {
         return xmlResponse(xml.build());
     }
 
+    private Response handleDescribeVpcPeeringConnections(MultivaluedMap<String, String> p, String region) {
+        validateEmptyDiscoveryPagination(p, 1000);
+        service.describeVpcPeeringConnectionIds(
+                region, getList(p, "VpcPeeringConnectionId"), getFilters(p));
+        return emptyDescribeResponse(
+                "DescribeVpcPeeringConnections", "vpcPeeringConnectionSet");
+    }
+
+    private Response handleDescribeTransitGatewayVpcAttachments(
+            MultivaluedMap<String, String> p, String region) {
+        validateEmptyDiscoveryPagination(p, 1000);
+        service.describeTransitGatewayVpcAttachmentIds(
+                region, getList(p, "TransitGatewayAttachmentIds"), getFilters(p));
+        return emptyDescribeResponse(
+                "DescribeTransitGatewayVpcAttachments", "transitGatewayVpcAttachments");
+    }
+
+    private Response handleDescribeVpnGateways(MultivaluedMap<String, String> p, String region) {
+        service.describeVpnGatewayIds(region, getList(p, "VpnGatewayId"), getFilters(p));
+        return emptyDescribeResponse("DescribeVpnGateways", "vpnGatewaySet");
+    }
+
+    private Response handleDescribeEgressOnlyInternetGateways(
+            MultivaluedMap<String, String> p, String region) {
+        validateEmptyDiscoveryPagination(p, 255);
+        service.describeEgressOnlyInternetGatewayIds(
+                region, getList(p, "EgressOnlyInternetGatewayId"), getFilters(p));
+        return emptyDescribeResponse(
+                "DescribeEgressOnlyInternetGateways", "egressOnlyInternetGatewaySet");
+    }
+
+    private void validateEmptyDiscoveryPagination(MultivaluedMap<String, String> p, int maximum) {
+        String rawMaxResults = p.getFirst("MaxResults");
+        if (rawMaxResults != null) {
+            int maxResults = parseIntParam(p, "MaxResults", 0);
+            if (maxResults < 5 || maxResults > maximum) {
+                throw new AwsException("InvalidMaxResults",
+                        "The specified value for MaxResults is not valid.", 400);
+            }
+        }
+        if (p.getFirst("NextToken") != null) {
+            throw new AwsException("InvalidParameterValue", "Invalid NextToken", 400);
+        }
+    }
+
+    private Response emptyDescribeResponse(String action, String resultSet) {
+        String response = action + "Response";
+        String xml = new XmlBuilder()
+                .start(response, AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .start(resultSet).end(resultSet)
+                .end(response)
+                .build();
+        return xmlResponse(xml);
+    }
+
     private Response handleDeleteVpcEndpoints(MultivaluedMap<String, String> p, String region) {
         List<String> endpointIds = getList(p, "VpcEndpointId");
         service.deleteVpcEndpoints(region, endpointIds);
@@ -1015,8 +1200,14 @@ public class Ec2QueryHandler {
         String vpcId = p.getFirst("VpcId");
         String cidrBlock = p.getFirst("CidrBlock");
         String az = p.getFirst("AvailabilityZone");
+        List<TagSpecificationMember> tagSpecifications = parseCreateSubnetTagSpecifications(p);
         Subnet subnet = service.createSubnet(region, vpcId, cidrBlock, az);
-        applyResourceTags(p, region, "subnet", subnet.getSubnetId());
+        List<Tag> subnetTags = tagSpecifications.stream()
+                .flatMap(specification -> specification.tags().stream())
+                .toList();
+        if (!subnetTags.isEmpty()) {
+            service.createTags(region, List.of(subnet.getSubnetId()), subnetTags);
+        }
         XmlBuilder xml = new XmlBuilder()
                 .start("CreateSubnetResponse", AwsNamespaces.EC2)
                 .elem("requestId", UUID.randomUUID().toString())

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -360,7 +360,7 @@ public class Ec2QueryHandler {
                 throw invalidCreateSubnetTagSpecificationParameter(parameter);
             }
 
-            int specificationIndex = parseCreateSubnetTagMemberIndex(segments[0], false);
+            int specificationIndex = parseCreateSubnetTagMemberIndex(segments[0], false, "");
             SortedSet<Integer> tagIndexes = specificationTagIndexes.computeIfAbsent(
                     specificationIndex, ignored -> new TreeSet<>());
 
@@ -372,7 +372,7 @@ public class Ec2QueryHandler {
                     || !("Key".equals(segments[3]) || "Value".equals(segments[3]))) {
                 throw invalidCreateSubnetTagSpecificationParameter(parameter);
             }
-            tagIndexes.add(parseCreateSubnetTagMemberIndex(segments[2], true));
+            tagIndexes.add(parseCreateSubnetTagMemberIndex(segments[2], true, segments[0]));
         }
 
         int expectedIndex = 1;
@@ -415,19 +415,20 @@ public class Ec2QueryHandler {
         return specifications;
     }
 
-    private int parseCreateSubnetTagMemberIndex(String rawIndex, boolean tagIndex) {
+    private int parseCreateSubnetTagMemberIndex(
+            String rawIndex, boolean tagIndex, String specificationIndex) {
         int index;
         try {
             index = Integer.parseInt(rawIndex);
         } catch (NumberFormatException e) {
             if (tagIndex) {
-                throw invalidCreateSubnetTagIndex("", rawIndex);
+                throw invalidCreateSubnetTagIndex(specificationIndex, rawIndex);
             }
             throw invalidCreateSubnetTagSpecificationIndex(rawIndex);
         }
         if (index < 1 || !rawIndex.equals(Integer.toString(index))) {
             if (tagIndex) {
-                throw invalidCreateSubnetTagIndex("", rawIndex);
+                throw invalidCreateSubnetTagIndex(specificationIndex, rawIndex);
             }
             throw invalidCreateSubnetTagSpecificationIndex(rawIndex);
         }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -384,8 +384,11 @@ public class Ec2QueryHandler {
 
             String index = Integer.toString(indexedSpecification.getKey());
             List<String> requestedTypes = p.get(prefix + index + ".ResourceType");
-            if (requestedTypes == null || requestedTypes.size() != 1) {
+            if (requestedTypes == null) {
                 throw invalidCreateSubnetTagResourceType(null);
+            }
+            if (requestedTypes.size() != 1) {
+                throw invalidCreateSubnetTagSpecificationParameter(prefix + index + ".ResourceType");
             }
             String requestedType = requestedTypes.getFirst();
             if (!"subnet".equals(requestedType)) {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -305,7 +305,7 @@ public class Ec2Service implements ContainerTeardown {
         igw.setInternetGatewayId(igwId);
         igw.setOwnerId(accountId);
         igw.setRegion(region);
-        igw.getAttachments().add(new InternetGatewayAttachment(vpcId, "available"));
+        igw.getAttachments().add(new InternetGatewayAttachment(vpcId, "attached"));
         internetGateways.put(key(region, igwId), igw);
 
         String rtId = createMainRouteTable(region, defaultVpc, "rtb-default", "rtbassoc-default");
@@ -1119,6 +1119,67 @@ public class Ec2Service implements ContainerTeardown {
                 .filter(v -> vpcIds.isEmpty() || vpcIds.contains(v.getVpcId()))
                 .filter(v -> matchesFilters(v, filters, region))
                 .collect(Collectors.toList());
+    }
+
+    public List<String> describeVpcPeeringConnectionIds(String region, List<String> connectionIds,
+                                                         Map<String, List<String>> filters) {
+        Set<String> supportedFilters = Set.of(
+                "accepter-vpc-info.cidr-block", "accepter-vpc-info.owner-id",
+                "accepter-vpc-info.vpc-id", "expiration-time",
+                "requester-vpc-info.cidr-block", "requester-vpc-info.owner-id",
+                "requester-vpc-info.vpc-id", "status-code", "status-message",
+                "tag-key", "vpc-peering-connection-id");
+        return emptyNetworkDiscovery(connectionIds, filters, supportedFilters,
+                "InvalidVpcPeeringConnectionID.NotFound",
+                "The vpcPeeringConnection ID '%s' does not exist");
+    }
+
+    public List<String> describeTransitGatewayVpcAttachmentIds(
+            String region, List<String> attachmentIds, Map<String, List<String>> filters) {
+        Set<String> supportedFilters = Set.of(
+                "state", "transit-gateway-attachment-id", "transit-gateway-id", "vpc-id");
+        return emptyNetworkDiscovery(attachmentIds, filters, supportedFilters,
+                "InvalidTransitGatewayAttachmentID.NotFound",
+                "Transit Gateway Attachment %s was not found.");
+    }
+
+    public List<String> describeVpnGatewayIds(
+            String region, List<String> gatewayIds, Map<String, List<String>> filters) {
+        Set<String> supportedFilters = Set.of(
+                "amazon-side-asn", "attachment.state", "attachment.vpc-id", "availability-zone",
+                "state", "tag-key", "type", "vpn-gateway-id");
+        return emptyNetworkDiscovery(gatewayIds, filters, supportedFilters,
+                "InvalidVpnGatewayID.NotFound",
+                "The vpnGateway ID '%s' does not exist");
+    }
+
+    public List<String> describeEgressOnlyInternetGatewayIds(
+            String region, List<String> gatewayIds, Map<String, List<String>> filters) {
+        Set<String> supportedFilters = Set.of(
+                "attachment.state", "attachment.vpc-id",
+                "egress-only-internet-gateway-id", "tag-key");
+        return emptyNetworkDiscovery(gatewayIds, filters, supportedFilters,
+                "InvalidEgressOnlyInternetGatewayId.NotFound",
+                "The egress-only internet gateway ID '%s' does not exist");
+    }
+
+    private List<String> emptyNetworkDiscovery(
+            List<String> resourceIds,
+            Map<String, List<String>> filters,
+            Set<String> supportedFilters,
+            String notFoundCode,
+            String notFoundMessage) {
+        filters.keySet().stream()
+                .filter(name -> !supportedFilters.contains(name)
+                        && !(supportedFilters.contains("tag-key") && name.startsWith("tag:")))
+                .findFirst()
+                .ifPresent(name -> {
+                    throw new AwsException("InvalidParameterValue", "The filter '" + name + "' is invalid", 400);
+                });
+        if (!resourceIds.isEmpty()) {
+            throw new AwsException(notFoundCode, notFoundMessage.formatted(resourceIds.getFirst()), 400);
+        }
+        return List.of();
     }
 
     public void deleteVpc(String region, String vpcId) {
@@ -2283,7 +2344,7 @@ public class Ec2Service implements ContainerTeardown {
         ensureDefaultResources(region);
         InternetGateway igw = getRequiredInternetGateway(region, igwId);
 
-        igw.getAttachments().add(new InternetGatewayAttachment(vpcId, "available"));
+        igw.getAttachments().add(new InternetGatewayAttachment(vpcId, "attached"));
         internetGateways.put(key(region, igwId), igw);
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1186,7 +1186,33 @@ public class Ec2Service implements ContainerTeardown {
         ensureDefaultResources(region);
         getRequiredVpc(region, vpcId);
 
+        deleteVpcDefaultResources(region, vpcId);
         vpcs.delete(key(region, vpcId));
+    }
+
+    private void deleteVpcDefaultResources(String region, String vpcId) {
+        securityGroups.scan(k -> true).stream()
+                .filter(group -> region.equals(group.getRegion()))
+                .filter(group -> vpcId.equals(group.getVpcId()))
+                .filter(group -> "default".equals(group.getGroupName()))
+                .forEach(group -> {
+                    securityGroupRules.scan(k -> k.startsWith(region + "::")).stream()
+                            .filter(rule -> group.getGroupId().equals(rule.getGroupId()))
+                            .forEach(rule -> securityGroupRules.delete(
+                                    key(region, rule.getSecurityGroupRuleId())));
+                    securityGroups.delete(key(region, group.getGroupId()));
+                });
+        routeTables.scan(k -> true).stream()
+                .filter(table -> region.equals(table.getRegion()))
+                .filter(table -> vpcId.equals(table.getVpcId()))
+                .filter(table -> table.getAssociations().stream()
+                        .anyMatch(association -> association.isMain()))
+                .forEach(table -> routeTables.delete(key(region, table.getRouteTableId())));
+        networkAcls.scan(k -> true).stream()
+                .filter(acl -> region.equals(acl.getRegion()))
+                .filter(acl -> vpcId.equals(acl.getVpcId()))
+                .filter(acl -> acl.isDefault())
+                .forEach(acl -> networkAcls.delete(key(region, acl.getNetworkAclId())));
     }
 
     public void modifyVpcAttribute(String region, String vpcId, String attribute, String value) {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -305,7 +305,7 @@ public class Ec2Service implements ContainerTeardown {
         igw.setInternetGatewayId(igwId);
         igw.setOwnerId(accountId);
         igw.setRegion(region);
-        igw.getAttachments().add(new InternetGatewayAttachment(vpcId, "attached"));
+        igw.getAttachments().add(new InternetGatewayAttachment(vpcId, "available"));
         internetGateways.put(key(region, igwId), igw);
 
         String rtId = createMainRouteTable(region, defaultVpc, "rtb-default", "rtbassoc-default");
@@ -1128,7 +1128,7 @@ public class Ec2Service implements ContainerTeardown {
                 "accepter-vpc-info.vpc-id", "expiration-time",
                 "requester-vpc-info.cidr-block", "requester-vpc-info.owner-id",
                 "requester-vpc-info.vpc-id", "status-code", "status-message",
-                "tag-key", "vpc-peering-connection-id");
+                "tag-key", "tag-value", "vpc-peering-connection-id");
         return emptyNetworkDiscovery(connectionIds, filters, supportedFilters,
                 "InvalidVpcPeeringConnectionID.NotFound",
                 "The vpcPeeringConnection ID '%s' does not exist");
@@ -1147,7 +1147,7 @@ public class Ec2Service implements ContainerTeardown {
             String region, List<String> gatewayIds, Map<String, List<String>> filters) {
         Set<String> supportedFilters = Set.of(
                 "amazon-side-asn", "attachment.state", "attachment.vpc-id", "availability-zone",
-                "state", "tag-key", "type", "vpn-gateway-id");
+                "state", "tag-key", "tag-value", "type", "vpn-gateway-id");
         return emptyNetworkDiscovery(gatewayIds, filters, supportedFilters,
                 "InvalidVpnGatewayID.NotFound",
                 "The vpnGateway ID '%s' does not exist");
@@ -1157,7 +1157,7 @@ public class Ec2Service implements ContainerTeardown {
             String region, List<String> gatewayIds, Map<String, List<String>> filters) {
         Set<String> supportedFilters = Set.of(
                 "attachment.state", "attachment.vpc-id",
-                "egress-only-internet-gateway-id", "tag-key");
+                "egress-only-internet-gateway-id", "tag-key", "tag-value");
         return emptyNetworkDiscovery(gatewayIds, filters, supportedFilters,
                 "InvalidEgressOnlyInternetGatewayId.NotFound",
                 "The egress-only internet gateway ID '%s' does not exist");
@@ -2370,7 +2370,7 @@ public class Ec2Service implements ContainerTeardown {
         ensureDefaultResources(region);
         InternetGateway igw = getRequiredInternetGateway(region, igwId);
 
-        igw.getAttachments().add(new InternetGatewayAttachment(vpcId, "attached"));
+        igw.getAttachments().add(new InternetGatewayAttachment(vpcId, "available"));
         internetGateways.put(key(region, igwId), igw);
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -83,6 +83,20 @@ public class Ec2Service implements ContainerTeardown {
     private static final Logger LOG = Logger.getLogger(Ec2Service.class);
     private static final DateTimeFormatter ISO_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
             .withZone(ZoneOffset.UTC);
+    private static final Set<String> VPC_PEERING_FILTERS = Set.of(
+            "accepter-vpc-info.cidr-block", "accepter-vpc-info.owner-id",
+            "accepter-vpc-info.vpc-id", "expiration-time",
+            "requester-vpc-info.cidr-block", "requester-vpc-info.owner-id",
+            "requester-vpc-info.vpc-id", "status-code", "status-message",
+            "tag-key", "tag-value", "vpc-peering-connection-id");
+    private static final Set<String> TRANSIT_GATEWAY_VPC_ATTACHMENT_FILTERS = Set.of(
+            "state", "transit-gateway-attachment-id", "transit-gateway-id", "vpc-id");
+    private static final Set<String> VPN_GATEWAY_FILTERS = Set.of(
+            "amazon-side-asn", "attachment.state", "attachment.vpc-id", "availability-zone",
+            "state", "tag-key", "tag-value", "type", "vpn-gateway-id");
+    private static final Set<String> EGRESS_ONLY_INTERNET_GATEWAY_FILTERS = Set.of(
+            "attachment.state", "attachment.vpc-id",
+            "egress-only-internet-gateway-id", "tag-key", "tag-value");
 
     private final String accountId;
     private final EmulatorConfig config;
@@ -1123,42 +1137,28 @@ public class Ec2Service implements ContainerTeardown {
 
     public List<String> describeVpcPeeringConnectionIds(String region, List<String> connectionIds,
                                                          Map<String, List<String>> filters) {
-        Set<String> supportedFilters = Set.of(
-                "accepter-vpc-info.cidr-block", "accepter-vpc-info.owner-id",
-                "accepter-vpc-info.vpc-id", "expiration-time",
-                "requester-vpc-info.cidr-block", "requester-vpc-info.owner-id",
-                "requester-vpc-info.vpc-id", "status-code", "status-message",
-                "tag-key", "tag-value", "vpc-peering-connection-id");
-        return emptyNetworkDiscovery(connectionIds, filters, supportedFilters,
+        return emptyNetworkDiscovery(connectionIds, filters, VPC_PEERING_FILTERS,
                 "InvalidVpcPeeringConnectionID.NotFound",
                 "The vpcPeeringConnection ID '%s' does not exist");
     }
 
     public List<String> describeTransitGatewayVpcAttachmentIds(
             String region, List<String> attachmentIds, Map<String, List<String>> filters) {
-        Set<String> supportedFilters = Set.of(
-                "state", "transit-gateway-attachment-id", "transit-gateway-id", "vpc-id");
-        return emptyNetworkDiscovery(attachmentIds, filters, supportedFilters,
+        return emptyNetworkDiscovery(attachmentIds, filters, TRANSIT_GATEWAY_VPC_ATTACHMENT_FILTERS,
                 "InvalidTransitGatewayAttachmentID.NotFound",
                 "Transit Gateway Attachment %s was not found.");
     }
 
     public List<String> describeVpnGatewayIds(
             String region, List<String> gatewayIds, Map<String, List<String>> filters) {
-        Set<String> supportedFilters = Set.of(
-                "amazon-side-asn", "attachment.state", "attachment.vpc-id", "availability-zone",
-                "state", "tag-key", "tag-value", "type", "vpn-gateway-id");
-        return emptyNetworkDiscovery(gatewayIds, filters, supportedFilters,
+        return emptyNetworkDiscovery(gatewayIds, filters, VPN_GATEWAY_FILTERS,
                 "InvalidVpnGatewayID.NotFound",
                 "The vpnGateway ID '%s' does not exist");
     }
 
     public List<String> describeEgressOnlyInternetGatewayIds(
             String region, List<String> gatewayIds, Map<String, List<String>> filters) {
-        Set<String> supportedFilters = Set.of(
-                "attachment.state", "attachment.vpc-id",
-                "egress-only-internet-gateway-id", "tag-key", "tag-value");
-        return emptyNetworkDiscovery(gatewayIds, filters, supportedFilters,
+        return emptyNetworkDiscovery(gatewayIds, filters, EGRESS_ONLY_INTERNET_GATEWAY_FILTERS,
                 "InvalidEgressOnlyInternetGatewayId.NotFound",
                 "The egress-only internet gateway ID '%s' does not exist");
     }
@@ -1191,28 +1191,36 @@ public class Ec2Service implements ContainerTeardown {
     }
 
     private void deleteVpcDefaultResources(String region, String vpcId) {
-        securityGroups.scan(k -> true).stream()
+        List<SecurityGroup> defaultGroups = securityGroups.scan(k -> k.startsWith(region + "::")).stream()
                 .filter(group -> region.equals(group.getRegion()))
                 .filter(group -> vpcId.equals(group.getVpcId()))
                 .filter(group -> "default".equals(group.getGroupName()))
-                .forEach(group -> {
-                    securityGroupRules.scan(k -> k.startsWith(region + "::")).stream()
+                .toList();
+        for (SecurityGroup group : defaultGroups) {
+            List<String> ruleIds = securityGroupRules.scan(k -> k.startsWith(region + "::")).stream()
                             .filter(rule -> group.getGroupId().equals(rule.getGroupId()))
-                            .forEach(rule -> securityGroupRules.delete(
-                                    key(region, rule.getSecurityGroupRuleId())));
-                    securityGroups.delete(key(region, group.getGroupId()));
-                });
-        routeTables.scan(k -> true).stream()
+                    .map(SecurityGroupRule::getSecurityGroupRuleId)
+                    .toList();
+            ruleIds.forEach(ruleId -> securityGroupRules.delete(key(region, ruleId)));
+            securityGroups.delete(key(region, group.getGroupId()));
+        }
+
+        List<String> mainRouteTableIds = routeTables.scan(k -> k.startsWith(region + "::")).stream()
                 .filter(table -> region.equals(table.getRegion()))
                 .filter(table -> vpcId.equals(table.getVpcId()))
                 .filter(table -> table.getAssociations().stream()
                         .anyMatch(association -> association.isMain()))
-                .forEach(table -> routeTables.delete(key(region, table.getRouteTableId())));
-        networkAcls.scan(k -> true).stream()
+                .map(RouteTable::getRouteTableId)
+                .toList();
+        mainRouteTableIds.forEach(routeTableId -> routeTables.delete(key(region, routeTableId)));
+
+        List<String> defaultNetworkAclIds = networkAcls.scan(k -> k.startsWith(region + "::")).stream()
                 .filter(acl -> region.equals(acl.getRegion()))
                 .filter(acl -> vpcId.equals(acl.getVpcId()))
                 .filter(acl -> acl.isDefault())
-                .forEach(acl -> networkAcls.delete(key(region, acl.getNetworkAclId())));
+                .map(NetworkAcl::getNetworkAclId)
+                .toList();
+        defaultNetworkAclIds.forEach(aclId -> networkAcls.delete(key(region, aclId)));
     }
 
     public void modifyVpcAttribute(String region, String vpcId, String attribute, String value) {

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -557,6 +557,209 @@ class Ec2IntegrationTest {
     }
 
     @Test
+    @Order(321)
+    void describeVpcPeeringConnectionsReturnsEmptySet() {
+        given()
+            .formParam("Action", "DescribeVpcPeeringConnections")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("DescribeVpcPeeringConnectionsResponse.vpcPeeringConnectionSet.item.size()", equalTo(0));
+
+        given()
+            .formParam("Action", "DescribeVpcPeeringConnections")
+            .formParam("Filter.1.Name", "status-code")
+            .formParam("Filter.1.Value.1", "active")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVpcPeeringConnectionsResponse.vpcPeeringConnectionSet.item.size()", equalTo(0));
+
+        given()
+            .formParam("Action", "DescribeVpcPeeringConnections")
+            .formParam("VpcPeeringConnectionId.1", "pcx-0123456789abcdef0")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidVpcPeeringConnectionID.NotFound"))
+            .body("Response.Errors.Error.Message",
+                    equalTo("The vpcPeeringConnection ID 'pcx-0123456789abcdef0' does not exist"));
+    }
+
+    @Test
+    @Order(322)
+    void describeTransitGatewayVpcAttachmentsReturnsEmptySet() {
+        given()
+            .formParam("Action", "DescribeTransitGatewayVpcAttachments")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("DescribeTransitGatewayVpcAttachmentsResponse.transitGatewayVpcAttachments.item.size()",
+                    equalTo(0));
+
+        given()
+            .formParam("Action", "DescribeTransitGatewayVpcAttachments")
+            .formParam("Filter.1.Name", "state")
+            .formParam("Filter.1.Value.1", "available")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeTransitGatewayVpcAttachmentsResponse.transitGatewayVpcAttachments.item.size()",
+                    equalTo(0));
+
+        given()
+            .formParam("Action", "DescribeTransitGatewayVpcAttachments")
+            .formParam("TransitGatewayAttachmentIds.1", "tgw-attach-0123456789abcdef0")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidTransitGatewayAttachmentID.NotFound"))
+            .body("Response.Errors.Error.Message",
+                     equalTo("Transit Gateway Attachment tgw-attach-0123456789abcdef0 was not found."));
+    }
+
+    @Test
+    @Order(323)
+    void describeVpnGatewaysReturnsEmptySetAndNotFoundError() {
+        given()
+            .formParam("Action", "DescribeVpnGateways")
+            .formParam("Filter.1.Name", "attachment.vpc-id")
+            .formParam("Filter.1.Value.1", vpcId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVpnGatewaysResponse.vpnGatewaySet.item.size()", equalTo(0));
+
+        given()
+            .formParam("Action", "DescribeVpnGateways")
+            .formParam("VpnGatewayId.1", "vgw-0123456789abcdef0")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidVpnGatewayID.NotFound"))
+            .body("Response.Errors.Error.Message",
+                    equalTo("The vpnGateway ID 'vgw-0123456789abcdef0' does not exist"));
+    }
+
+    @Test
+    @Order(324)
+    void describeEgressOnlyInternetGatewaysReturnsEmptySetAndNotFoundError() {
+        given()
+            .formParam("Action", "DescribeEgressOnlyInternetGateways")
+            .formParam("Filter.1.Name", "tag:Owner")
+            .formParam("Filter.1.Value.1", "TeamA")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeEgressOnlyInternetGatewaysResponse.egressOnlyInternetGatewaySet.item.size()",
+                    equalTo(0));
+
+        given()
+            .formParam("Action", "DescribeEgressOnlyInternetGateways")
+            .formParam("Filter.1.Name", "attachment.vpc-id")
+            .formParam("Filter.1.Value.1", vpcId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeEgressOnlyInternetGatewaysResponse.egressOnlyInternetGatewaySet.item.size()",
+                    equalTo(0));
+
+        given()
+            .formParam("Action", "DescribeEgressOnlyInternetGateways")
+            .formParam("Filter.1.Name", "unsupported")
+            .formParam("Filter.1.Value.1", "value")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidParameterValue"))
+            .body("Response.Errors.Error.Message",
+                    equalTo("The filter 'unsupported' is invalid"));
+
+        given()
+            .formParam("Action", "DescribeEgressOnlyInternetGateways")
+            .formParam("EgressOnlyInternetGatewayId.1", "eigw-0123456789abcdef0")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code",
+                    equalTo("InvalidEgressOnlyInternetGatewayId.NotFound"))
+            .body("Response.Errors.Error.Message",
+                    equalTo("The egress-only internet gateway ID "
+                            + "'eigw-0123456789abcdef0' does not exist"));
+    }
+
+    @Test
+    @Order(325)
+    void emptyNetworkDiscoveryValidatesPaginationBeforeReturningResults() {
+        for (var actionAndMaximum : java.util.Map.of(
+                "DescribeVpcPeeringConnections", 1000,
+                "DescribeTransitGatewayVpcAttachments", 1000,
+                "DescribeEgressOnlyInternetGateways", 255).entrySet()) {
+            String action = actionAndMaximum.getKey();
+            int maximum = actionAndMaximum.getValue();
+            for (String maxResults : List.of("5", Integer.toString(maximum))) {
+                given()
+                    .formParam("Action", action)
+                    .formParam("MaxResults", maxResults)
+                    .header("Authorization", AUTH_HEADER)
+                .when()
+                    .post("/")
+                .then()
+                    .statusCode(200)
+                    .body(not(containsString("<nextToken>")));
+            }
+
+            for (String maxResults : List.of("4", Integer.toString(maximum + 1), "not-a-number")) {
+                given()
+                    .formParam("Action", action)
+                    .formParam("MaxResults", maxResults)
+                    .header("Authorization", AUTH_HEADER)
+                .when()
+                    .post("/")
+                .then()
+                    .statusCode(400)
+                    .body("Response.Errors.Error.Code", equalTo("InvalidMaxResults"));
+            }
+
+            given()
+                .formParam("Action", action)
+                .formParam("NextToken", "arbitrary-token")
+                .header("Authorization", AUTH_HEADER)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(400)
+                .body("Response.Errors.Error.Code", equalTo("InvalidParameterValue"));
+        }
+    }
+
+    @Test
     @Order(12)
     void modifyVpcAttribute() {
         given()
@@ -1253,7 +1456,9 @@ class Ec2IntegrationTest {
             .body("DescribeInternetGatewaysResponse.internetGatewaySet.item.internetGatewayId",
                     equalTo(igwId))
             .body("DescribeInternetGatewaysResponse.internetGatewaySet.item.attachmentSet.item.vpcId",
-                    equalTo(vpcId));
+                    equalTo(vpcId))
+            .body("DescribeInternetGatewaysResponse.internetGatewaySet.item.attachmentSet.item.state",
+                    equalTo("attached"));
     }
 
     // =========================================================================
@@ -3081,9 +3286,20 @@ class Ec2IntegrationTest {
             .formParam("TagSpecification.1.ResourceType", "subnet")
             .formParam("TagSpecification.1.Tag.1.Key", "Name")
             .formParam("TagSpecification.1.Tag.1.Value", "tagged-subnet")
+            .formParam("TagSpecification.2.ResourceType", "subnet")
+            .formParam("TagSpecification.2.Tag.1.Key", "omitted-value")
+            .formParam("TagSpecification.2.Tag.2.Key", "explicit-empty-value")
+            .formParam("TagSpecification.2.Tag.2.Value", "")
             .header("Authorization", AUTH_HEADER)
         .when().post("/")
-        .then().statusCode(200)
+        .then()
+            .statusCode(200)
+            .body("CreateSubnetResponse.subnet.tagSet.item.find { it.key == 'Name' }.value",
+                    equalTo("tagged-subnet"))
+            .body("CreateSubnetResponse.subnet.tagSet.item.find { it.key == 'omitted-value' }.value",
+                    equalTo(""))
+            .body("CreateSubnetResponse.subnet.tagSet.item.find { it.key == 'explicit-empty-value' }.value",
+                    equalTo(""))
             .extract().path("CreateSubnetResponse.subnet.subnetId");
 
         given()
@@ -3093,8 +3309,120 @@ class Ec2IntegrationTest {
         .when().post("/")
         .then()
             .statusCode(200)
-            .body("DescribeSubnetsResponse.subnetSet.item.tagSet.item.key", equalTo("Name"))
-            .body("DescribeSubnetsResponse.subnetSet.item.tagSet.item.value", equalTo("tagged-subnet"));
+            .body("DescribeSubnetsResponse.subnetSet.item.tagSet.item.find { it.key == 'Name' }.value",
+                    equalTo("tagged-subnet"))
+            .body("DescribeSubnetsResponse.subnetSet.item.tagSet.item.find { it.key == 'omitted-value' }.value",
+                    equalTo(""))
+            .body("DescribeSubnetsResponse.subnetSet.item.tagSet.item.find { it.key == 'explicit-empty-value' }.value",
+                    equalTo(""));
+
+        given()
+            .formParam("Action", "DescribeTags")
+            .formParam("Filter.1.Name", "resource-id")
+            .formParam("Filter.1.Value.1", subnet)
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeTagsResponse.tagSet.item.find { it.key == 'Name' }.value",
+                    equalTo("tagged-subnet"))
+            .body("DescribeTagsResponse.tagSet.item.find { it.key == 'omitted-value' }.value",
+                    equalTo(""))
+            .body("DescribeTagsResponse.tagSet.item.find { it.key == 'explicit-empty-value' }.value",
+                    equalTo(""));
+    }
+
+    @Test
+    @Order(400)
+    void createSubnetRejectsEveryWrongTagSpecificationBeforeMutation() {
+        String vpc = newVpc("10.39.0.0/16");
+
+        given()
+            .formParam("Action", "CreateSubnet")
+            .formParam("VpcId", vpc)
+            .formParam("CidrBlock", "10.39.1.0/24")
+            .formParam("TagSpecification.1.ResourceType", "subnet")
+            .formParam("TagSpecification.1.Tag.1.Key", "Name")
+            .formParam("TagSpecification.1.Tag.1.Value", "valid")
+            .formParam("TagSpecification.2.ResourceType", "vpc")
+            .formParam("TagSpecification.2.Tag.1.Key", "Name")
+            .formParam("TagSpecification.2.Tag.1.Value", "invalid")
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidParameterValue"))
+            .body("Response.Errors.Error.Message", equalTo(
+                    "Tag specification resource type 'vpc' is not valid for this operation. "
+                            + "The valid resource type is 'subnet'."));
+
+        assertVpcHasNoSubnet(vpc);
+    }
+
+    @Test
+    @Order(401)
+    void createSubnetRejectsTagSpecificationWithoutResourceTypeBeforeMutation() {
+        String vpc = newVpc("10.40.0.0/16");
+
+        given()
+            .formParam("Action", "CreateSubnet")
+            .formParam("VpcId", vpc)
+            .formParam("CidrBlock", "10.40.1.0/24")
+            .formParam("TagSpecification.1.Tag.1.Key", "Name")
+            .formParam("TagSpecification.1.Tag.1.Value", "invalid")
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidParameterValue"));
+
+        assertVpcHasNoSubnet(vpc);
+    }
+
+    @Test
+    @Order(402)
+    void createSubnetRejectsSparseTagSpecificationBeforeMutation() {
+        assertCreateSubnetTagSpecificationIndexRejected("10.41.0.0/16", "10.41.1.0/24", "2");
+    }
+
+    @Test
+    @Order(403)
+    void createSubnetRejectsNonnumericTagSpecificationBeforeMutation() {
+        assertCreateSubnetTagSpecificationIndexRejected("10.42.0.0/16", "10.42.1.0/24", "member");
+    }
+
+    private void assertCreateSubnetTagSpecificationIndexRejected(
+            String vpcCidr, String subnetCidr, String specificationIndex) {
+        String vpc = newVpc(vpcCidr);
+
+        given()
+            .formParam("Action", "CreateSubnet")
+            .formParam("VpcId", vpc)
+            .formParam("CidrBlock", subnetCidr)
+            .formParam("TagSpecification." + specificationIndex + ".ResourceType", "subnet")
+            .formParam("TagSpecification." + specificationIndex + ".Tag.1.Key", "Name")
+            .formParam("TagSpecification." + specificationIndex + ".Tag.1.Value", "invalid")
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidParameterValue"))
+            .body("Response.Errors.Error.Message", containsString(
+                    "Tag specification member index '" + specificationIndex + "' is invalid"));
+
+        assertVpcHasNoSubnet(vpc);
+    }
+
+    private void assertVpcHasNoSubnet(String vpc) {
+        given()
+            .formParam("Action", "DescribeSubnets")
+            .formParam("Filter.1.Name", "vpc-id")
+            .formParam("Filter.1.Value.1", vpc)
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeSubnetsResponse.subnetSet.item.size()", equalTo(0));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -582,6 +582,17 @@ class Ec2IntegrationTest {
 
         given()
             .formParam("Action", "DescribeVpcPeeringConnections")
+            .formParam("Filter.1.Name", "tag-value")
+            .formParam("Filter.1.Value.1", "TeamA")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVpcPeeringConnectionsResponse.vpcPeeringConnectionSet.item.size()", equalTo(0));
+
+        given()
+            .formParam("Action", "DescribeVpcPeeringConnections")
             .formParam("VpcPeeringConnectionId.1", "pcx-0123456789abcdef0")
             .header("Authorization", AUTH_HEADER)
         .when()
@@ -648,6 +659,17 @@ class Ec2IntegrationTest {
 
         given()
             .formParam("Action", "DescribeVpnGateways")
+            .formParam("Filter.1.Name", "tag-value")
+            .formParam("Filter.1.Value.1", "TeamA")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVpnGatewaysResponse.vpnGatewaySet.item.size()", equalTo(0));
+
+        given()
+            .formParam("Action", "DescribeVpnGateways")
             .formParam("VpnGatewayId.1", "vgw-0123456789abcdef0")
             .header("Authorization", AUTH_HEADER)
         .when()
@@ -665,6 +687,18 @@ class Ec2IntegrationTest {
         given()
             .formParam("Action", "DescribeEgressOnlyInternetGateways")
             .formParam("Filter.1.Name", "tag:Owner")
+            .formParam("Filter.1.Value.1", "TeamA")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeEgressOnlyInternetGatewaysResponse.egressOnlyInternetGatewaySet.item.size()",
+                    equalTo(0));
+
+        given()
+            .formParam("Action", "DescribeEgressOnlyInternetGateways")
+            .formParam("Filter.1.Name", "tag-value")
             .formParam("Filter.1.Value.1", "TeamA")
             .header("Authorization", AUTH_HEADER)
         .when()
@@ -1458,7 +1492,7 @@ class Ec2IntegrationTest {
             .body("DescribeInternetGatewaysResponse.internetGatewaySet.item.attachmentSet.item.vpcId",
                     equalTo(vpcId))
             .body("DescribeInternetGatewaysResponse.internetGatewaySet.item.attachmentSet.item.state",
-                    equalTo("attached"));
+                    equalTo("available"));
     }
 
     // =========================================================================

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandlerTest.java
@@ -1,0 +1,207 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.ec2.model.Subnet;
+import io.github.hectorvent.floci.services.ec2.model.Tag;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import org.mockito.ArgumentCaptor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+class Ec2QueryHandlerTest {
+
+    @Test
+    void normalizesValuelessCreateSubnetTagsBeforeMutation() {
+        Ec2Service service = mock(Ec2Service.class);
+        Subnet subnet = new Subnet();
+        subnet.setSubnetId("subnet-test");
+        when(service.createSubnet("us-east-1", "vpc-test", "10.38.1.0/24", null))
+                .thenReturn(subnet);
+        MultivaluedMap<String, String> params = createSubnetParams("10.38.1.0/24");
+        params.putSingle("TagSpecification.1.ResourceType", "subnet");
+        params.putSingle("TagSpecification.1.Tag.1.Key", "omitted-value");
+        params.putSingle("TagSpecification.1.Tag.2.Key", "explicit-empty-value");
+        params.putSingle("TagSpecification.1.Tag.2.Value", "");
+        params.putSingle("TagSpecification.1.Tag.3.Key", "ordinary-value");
+        params.putSingle("TagSpecification.1.Tag.3.Value", "present");
+
+        Response response = handler(service).handle("CreateSubnet", params, "us-east-1");
+
+        assertEquals(200, response.getStatus());
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Tag>> tags = ArgumentCaptor.forClass(List.class);
+        verify(service).createTags(eq("us-east-1"), eq(List.of("subnet-test")), tags.capture());
+        assertEquals(List.of("", "", "present"),
+                tags.getValue().stream().map(Tag::getValue).toList());
+    }
+
+    @Test
+    void validatesEveryCreateSubnetTagSpecificationBeforeMutation() {
+        Ec2Service service = mock(Ec2Service.class);
+        MultivaluedMap<String, String> params = createSubnetParams("10.39.1.0/24");
+        params.putSingle("TagSpecification.1.ResourceType", "subnet");
+        params.putSingle("TagSpecification.1.Tag.1.Key", "Name");
+        params.putSingle("TagSpecification.1.Tag.1.Value", "valid");
+        params.putSingle("TagSpecification.2.ResourceType", "vpc");
+        params.putSingle("TagSpecification.2.Tag.1.Key", "Name");
+        params.putSingle("TagSpecification.2.Tag.1.Value", "invalid");
+
+        Response response = handler(service).handle("CreateSubnet", params, "us-east-1");
+
+        assertInvalidParameterValue(response, "resource type &apos;vpc&apos;");
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    void rejectsCreateSubnetTagSpecificationWithoutResourceTypeBeforeMutation() {
+        Ec2Service service = mock(Ec2Service.class);
+        MultivaluedMap<String, String> params = createSubnetParams("10.40.1.0/24");
+        params.putSingle("TagSpecification.1.Tag.1.Key", "Name");
+        params.putSingle("TagSpecification.1.Tag.1.Value", "invalid");
+
+        Response response = handler(service).handle("CreateSubnet", params, "us-east-1");
+
+        assertInvalidParameterValue(response, "resource type &apos;&apos;");
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    void rejectsSparseCreateSubnetTagSpecificationBeforeMutation() {
+        Ec2Service service = mock(Ec2Service.class);
+        MultivaluedMap<String, String> params = createSubnetParams("10.41.1.0/24");
+        params.putSingle("TagSpecification.2.ResourceType", "subnet");
+        params.putSingle("TagSpecification.2.Tag.1.Key", "Name");
+        params.putSingle("TagSpecification.2.Tag.1.Value", "invalid");
+
+        Response response = handler(service).handle("CreateSubnet", params, "us-east-1");
+
+        assertInvalidParameterValue(response, "member index &apos;2&apos;");
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    void rejectsNonnumericCreateSubnetTagSpecificationBeforeMutation() {
+        Ec2Service service = mock(Ec2Service.class);
+        MultivaluedMap<String, String> params = createSubnetParams("10.42.1.0/24");
+        params.putSingle("TagSpecification.member.ResourceType", "subnet");
+        params.putSingle("TagSpecification.member.Tag.1.Key", "Name");
+        params.putSingle("TagSpecification.member.Tag.1.Value", "invalid");
+
+        Response response = handler(service).handle("CreateSubnet", params, "us-east-1");
+
+        assertInvalidParameterValue(response, "member index &apos;member&apos;");
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    void rejectsDuplicateCreateSubnetTagSpecificationIndexBeforeMutation() {
+        Ec2Service service = mock(Ec2Service.class);
+        MultivaluedMap<String, String> params = createSubnetParams("10.43.1.0/24");
+        params.putSingle("TagSpecification.1.ResourceType", "subnet");
+        params.putSingle("TagSpecification.01.ResourceType", "subnet");
+
+        Response response = handler(service).handle("CreateSubnet", params, "us-east-1");
+
+        assertInvalidParameterValue(response, "member index &apos;01&apos;");
+        verifyNoInteractions(service);
+    }
+
+    @Test
+    void rejectsMalformedCreateSubnetTagSpecificationIndexBeforeMutation() {
+        Ec2Service service = mock(Ec2Service.class);
+        MultivaluedMap<String, String> params = createSubnetParams("10.44.1.0/24");
+        params.putSingle("TagSpecification.0.ResourceType", "subnet");
+
+        Response response = handler(service).handle("CreateSubnet", params, "us-east-1");
+
+        assertInvalidParameterValue(response, "member index &apos;0&apos;");
+        verifyNoInteractions(service);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("malformedNestedTagMembers")
+    void rejectsMalformedNestedCreateSubnetTagMembersBeforeMutation(
+            String description, Consumer<MultivaluedMap<String, String>> malformedParameters) {
+        Ec2Service service = mock(Ec2Service.class);
+        MultivaluedMap<String, String> params = createSubnetParams("10.45.1.0/24");
+        params.putSingle("TagSpecification.1.ResourceType", "subnet");
+        malformedParameters.accept(params);
+
+        Response response = handler(service).handle("CreateSubnet", params, "us-east-1");
+
+        assertInvalidParameterValue(response, "Tag");
+        verifyNoInteractions(service);
+    }
+
+    private static Stream<Arguments> malformedNestedTagMembers() {
+        return Stream.of(
+                malformed("sparse tag index", params -> putTag(params, "2", "Name", "invalid")),
+                malformed("nonnumeric tag index", params -> putTag(params, "member", "Name", "invalid")),
+                malformed("zero tag index", params -> putTag(params, "0", "Name", "invalid")),
+                malformed("noncanonical tag index", params -> putTag(params, "01", "Name", "invalid")),
+                malformed("value without key", params ->
+                        params.putSingle("TagSpecification.1.Tag.1.Value", "invalid")),
+                malformed("duplicate key", params -> {
+                    params.put("TagSpecification.1.Tag.1.Key", List.of("Name", "Other"));
+                    params.putSingle("TagSpecification.1.Tag.1.Value", "invalid");
+                }),
+                malformed("duplicate value", params -> {
+                    params.putSingle("TagSpecification.1.Tag.1.Key", "Name");
+                    params.put("TagSpecification.1.Tag.1.Value", List.of("one", "two"));
+                }),
+                malformed("unknown tag field", params ->
+                        params.putSingle("TagSpecification.1.Tag.1.Unknown", "invalid")),
+                malformed("malformed value structure", params ->
+                        params.putSingle("TagSpecification.1.Tag.1.Value.Member", "invalid")),
+                malformed("incomplete tag member", params ->
+                        params.putSingle("TagSpecification.1.Tag.1", "invalid")),
+                malformed("unknown specification field", params ->
+                        params.putSingle("TagSpecification.1.Unknown", "invalid")));
+    }
+
+    private static Arguments malformed(
+            String description, Consumer<MultivaluedMap<String, String>> malformedParameters) {
+        return Arguments.of(description, malformedParameters);
+    }
+
+    private static void putTag(
+            MultivaluedMap<String, String> params, String index, String key, String value) {
+        params.putSingle("TagSpecification.1.Tag." + index + ".Key", key);
+        params.putSingle("TagSpecification.1.Tag." + index + ".Value", value);
+    }
+
+    private Ec2QueryHandler handler(Ec2Service service) {
+        return new Ec2QueryHandler(
+                service, mock(EmulatorConfig.class), mock(FlowLogService.class));
+    }
+
+    private MultivaluedMap<String, String> createSubnetParams(String cidrBlock) {
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("VpcId", "vpc-test");
+        params.putSingle("CidrBlock", cidrBlock);
+        return params;
+    }
+
+    private void assertInvalidParameterValue(Response response, String messageFragment) {
+        assertEquals(400, response.getStatus());
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<Code>InvalidParameterValue</Code>"));
+        assertTrue(body.contains(messageFragment), body);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandlerTest.java
@@ -149,6 +149,21 @@ class Ec2QueryHandlerTest {
         verifyNoInteractions(service);
     }
 
+    @Test
+    void identifiesTagSpecificationForInvalidNestedMemberIndex() {
+        Ec2Service service = mock(Ec2Service.class);
+        MultivaluedMap<String, String> params = createSubnetParams("10.46.1.0/24");
+        params.putSingle("TagSpecification.1.ResourceType", "subnet");
+        putTag(params, "member", "Name", "invalid");
+
+        Response response = handler(service).handle("CreateSubnet", params, "us-east-1");
+
+        assertInvalidParameterValue(
+                response,
+                "Tag member index &apos;member&apos; in tag specification &apos;1&apos;");
+        verifyNoInteractions(service);
+    }
+
     private static Stream<Arguments> malformedNestedTagMembers() {
         return Stream.of(
                 malformed("sparse tag index", params -> putTag(params, "2", "Name", "invalid")),

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandlerTest.java
@@ -82,6 +82,20 @@ class Ec2QueryHandlerTest {
     }
 
     @Test
+    void rejectsDuplicateCreateSubnetTagSpecificationResourceTypeBeforeMutation() {
+        Ec2Service service = mock(Ec2Service.class);
+        MultivaluedMap<String, String> params = createSubnetParams("10.40.2.0/24");
+        params.put("TagSpecification.1.ResourceType", List.of("subnet", "vpc"));
+        params.putSingle("TagSpecification.1.Tag.1.Key", "Name");
+        params.putSingle("TagSpecification.1.Tag.1.Value", "invalid");
+
+        Response response = handler(service).handle("CreateSubnet", params, "us-east-1");
+
+        assertInvalidParameterValue(response, "TagSpecification.1.ResourceType");
+        verifyNoInteractions(service);
+    }
+
+    @Test
     void rejectsSparseCreateSubnetTagSpecificationBeforeMutation() {
         Ec2Service service = mock(Ec2Service.class);
         MultivaluedMap<String, String> params = createSubnetParams("10.41.1.0/24");

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServicePersistenceTest.java
@@ -91,6 +91,34 @@ class Ec2ServicePersistenceTest {
     }
 
     @Test
+    void deletedVpcDefaultResourcesRemainAbsentAfterRestart(@TempDir Path dir) {
+        Ec2Service first = newService(dir);
+        Vpc vpc = first.createVpc(REGION, "10.77.0.0/16", false);
+        SecurityGroup defaultGroup = first.describeSecurityGroups(REGION, List.of(), List.of(), Map.of()).stream()
+                .filter(group -> vpc.getVpcId().equals(group.getVpcId()) && "default".equals(group.getGroupName()))
+                .findFirst().orElseThrow();
+        String mainRouteTableId = first.describeRouteTables(REGION, List.of(), Map.of()).stream()
+                .filter(table -> vpc.getVpcId().equals(table.getVpcId()))
+                .filter(table -> table.getAssociations().stream().anyMatch(association -> association.isMain()))
+                .findFirst().orElseThrow().getRouteTableId();
+        String defaultNetworkAclId = first.describeNetworkAcls(REGION, List.of(), Map.of()).stream()
+                .filter(acl -> vpc.getVpcId().equals(acl.getVpcId()) && acl.isDefault())
+                .findFirst().orElseThrow().getNetworkAclId();
+
+        first.deleteVpc(REGION, vpc.getVpcId());
+        Ec2Service restarted = newService(dir);
+
+        assertTrue(restarted.describeVpcs(REGION, List.of(), Map.of()).stream()
+                .noneMatch(candidate -> vpc.getVpcId().equals(candidate.getVpcId())));
+        assertTrue(restarted.describeSecurityGroups(
+                REGION, List.of(defaultGroup.getGroupId()), List.of(), Map.of()).isEmpty());
+        assertTrue(restarted.describeSecurityGroupRules(
+                REGION, List.of(defaultGroup.getGroupId()), List.of()).isEmpty());
+        assertTrue(restarted.describeRouteTables(REGION, List.of(mainRouteTableId), Map.of()).isEmpty());
+        assertTrue(restarted.describeNetworkAcls(REGION, List.of(defaultNetworkAclId), Map.of()).isEmpty());
+    }
+
+    @Test
     void registeredImageAndSnapshotSurviveRestart(@TempDir Path dir) {
         Ec2Service first = newService(dir);
         Image image = first.registerImage(REGION, "persisted-image", "persisted image", "x86_64",

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServicePersistenceTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -50,6 +51,25 @@ import static org.mockito.Mockito.when;
 class Ec2ServicePersistenceTest {
 
     private static final String REGION = "us-east-1";
+
+    @Test
+    void emptyNetworkDiscoverySurvivesRestart(@TempDir Path dir) {
+        Ec2Service first = newService(dir);
+        assertTrue(first.describeVpcPeeringConnectionIds(REGION, List.of(), Map.of()).isEmpty());
+        assertTrue(first.describeTransitGatewayVpcAttachmentIds(REGION, List.of(), Map.of()).isEmpty());
+        assertTrue(first.describeVpnGatewayIds(REGION, List.of(), Map.of()).isEmpty());
+        assertTrue(first.describeEgressOnlyInternetGatewayIds(REGION, List.of(), Map.of()).isEmpty());
+
+        Ec2Service restarted = newService(dir);
+        assertTrue(restarted.describeVpcPeeringConnectionIds(
+                REGION, List.of(), Map.of("status-code", List.of("active"))).isEmpty());
+        assertTrue(restarted.describeTransitGatewayVpcAttachmentIds(
+                REGION, List.of(), Map.of("state", List.of("available"))).isEmpty());
+        assertTrue(restarted.describeVpnGatewayIds(
+                REGION, List.of(), Map.of("attachment.vpc-id", List.of("vpc-0123456789abcdef0"))).isEmpty());
+        assertTrue(restarted.describeEgressOnlyInternetGatewayIds(
+                REGION, List.of(), Map.of("tag:Owner", List.of("TeamA"))).isEmpty());
+    }
 
     @Test
     void vpcAndSubnetSurviveRestart(@TempDir Path dir) {

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -35,6 +35,64 @@ import static org.mockito.Mockito.when;
 class Ec2ServiceTest {
 
     @Test
+    void deleteVpcRemovesVpcOwnedDefaultResourcesAndRules() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+        String region = "us-east-1";
+        String vpcId = service.createVpc(region, "10.77.0.0/16", false).getVpcId();
+        SecurityGroup defaultGroup = service.describeSecurityGroups(region, List.of(), List.of(), Map.of()).stream()
+                .filter(group -> vpcId.equals(group.getVpcId()) && "default".equals(group.getGroupName()))
+                .findFirst().orElseThrow();
+        String mainRouteTableId = service.describeRouteTables(region, List.of(), Map.of()).stream()
+                .filter(table -> vpcId.equals(table.getVpcId()))
+                .filter(table -> table.getAssociations().stream().anyMatch(association -> association.isMain()))
+                .findFirst().orElseThrow().getRouteTableId();
+        String defaultNetworkAclId = service.describeNetworkAcls(region, List.of(), Map.of()).stream()
+                .filter(acl -> vpcId.equals(acl.getVpcId()) && acl.isDefault())
+                .findFirst().orElseThrow().getNetworkAclId();
+        assertFalse(service.describeSecurityGroupRules(region, List.of(defaultGroup.getGroupId()), List.of()).isEmpty());
+
+        service.deleteVpc(region, vpcId);
+
+        assertTrue(service.describeSecurityGroups(region, List.of(defaultGroup.getGroupId()), List.of(), Map.of()).isEmpty());
+        assertTrue(service.describeRouteTables(region, List.of(mainRouteTableId), Map.of()).isEmpty());
+        assertTrue(service.describeNetworkAcls(region, List.of(defaultNetworkAclId), Map.of()).isEmpty());
+        assertTrue(service.describeSecurityGroupRules(region, List.of(defaultGroup.getGroupId()), List.of()).isEmpty());
+    }
+
+    @Test
+    void deleteVpcDoesNotRemoveAnotherVpcDefaults() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+        String region = "us-east-1";
+        String deletedVpcId = service.createVpc(region, "10.78.0.0/16", false).getVpcId();
+        String preservedVpcId = service.createVpc(region, "10.79.0.0/16", false).getVpcId();
+        SecurityGroup preservedGroup = service.describeSecurityGroups(region, List.of(), List.of(), Map.of()).stream()
+                .filter(group -> preservedVpcId.equals(group.getVpcId()) && "default".equals(group.getGroupName()))
+                .findFirst().orElseThrow();
+        String preservedRouteTableId = service.describeRouteTables(region, List.of(), Map.of()).stream()
+                .filter(table -> preservedVpcId.equals(table.getVpcId()))
+                .filter(table -> table.getAssociations().stream().anyMatch(association -> association.isMain()))
+                .findFirst().orElseThrow().getRouteTableId();
+        String preservedNetworkAclId = service.describeNetworkAcls(region, List.of(), Map.of()).stream()
+                .filter(acl -> preservedVpcId.equals(acl.getVpcId()) && acl.isDefault())
+                .findFirst().orElseThrow().getNetworkAclId();
+
+        service.deleteVpc(region, deletedVpcId);
+
+        assertEquals(preservedGroup.getGroupId(), service.describeSecurityGroups(
+                region, List.of(preservedGroup.getGroupId()), List.of(), Map.of()).getFirst().getGroupId());
+        assertEquals(preservedRouteTableId,
+                service.describeRouteTables(region, List.of(preservedRouteTableId), Map.of()).getFirst().getRouteTableId());
+        assertEquals(preservedNetworkAclId,
+                service.describeNetworkAcls(region, List.of(preservedNetworkAclId), Map.of()).getFirst().getNetworkAclId());
+    }
+
+    @Test
     void describeVpcPeeringConnectionsReturnsEmptyWhenNoneExist() {
         Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
                 mock(Ec2PortForwardManager.class),

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -11,6 +11,7 @@ import io.github.hectorvent.floci.services.ec2.model.BlockDeviceMapping;
 import io.github.hectorvent.floci.services.ec2.model.EbsBlockDevice;
 import io.github.hectorvent.floci.services.ec2.model.GroupIdentifier;
 import io.github.hectorvent.floci.services.ec2.model.Instance;
+import io.github.hectorvent.floci.services.ec2.model.InternetGateway;
 import io.github.hectorvent.floci.services.ec2.model.LaunchTemplate;
 import io.github.hectorvent.floci.services.ec2.model.NetworkInterface;
 import io.github.hectorvent.floci.services.ec2.model.Reservation;
@@ -32,6 +33,125 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class Ec2ServiceTest {
+
+    @Test
+    void describeVpcPeeringConnectionsReturnsEmptyWhenNoneExist() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+
+        assertTrue(service.describeVpcPeeringConnectionIds("us-east-1", List.of(), Map.of()).isEmpty());
+        assertTrue(service.describeVpcPeeringConnectionIds(
+                "us-east-1", List.of(), Map.of("status-code", List.of("active"))).isEmpty());
+
+        AwsException error = assertThrows(AwsException.class, () -> service.describeVpcPeeringConnectionIds(
+                "us-east-1", List.of("pcx-0123456789abcdef0"), Map.of()));
+        assertEquals("InvalidVpcPeeringConnectionID.NotFound", error.getErrorCode());
+        assertEquals("The vpcPeeringConnection ID 'pcx-0123456789abcdef0' does not exist", error.getMessage());
+        assertEquals(400, error.getHttpStatus());
+
+        AwsException filterError = assertThrows(AwsException.class,
+                () -> service.describeVpcPeeringConnectionIds(
+                        "us-east-1", List.of(), Map.of("unsupported", List.of("value"))));
+        assertEquals("InvalidParameterValue", filterError.getErrorCode());
+        assertEquals("The filter 'unsupported' is invalid", filterError.getMessage());
+    }
+
+    @Test
+    void describeTransitGatewayVpcAttachmentsReturnsEmptyWhenNoneExist() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+
+        assertTrue(service.describeTransitGatewayVpcAttachmentIds(
+                "us-east-1", List.of(), Map.of()).isEmpty());
+        assertTrue(service.describeTransitGatewayVpcAttachmentIds(
+                "us-east-1", List.of(), Map.of("state", List.of("available"))).isEmpty());
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.describeTransitGatewayVpcAttachmentIds(
+                        "us-east-1", List.of("tgw-attach-0123456789abcdef0"), Map.of()));
+        assertEquals("InvalidTransitGatewayAttachmentID.NotFound", error.getErrorCode());
+        assertEquals("Transit Gateway Attachment tgw-attach-0123456789abcdef0 was not found.",
+                error.getMessage());
+        assertEquals(400, error.getHttpStatus());
+
+        AwsException filterError = assertThrows(AwsException.class,
+                () -> service.describeTransitGatewayVpcAttachmentIds(
+                        "us-east-1", List.of(), Map.of("subnet-id", List.of("subnet-123"))));
+        assertEquals("InvalidParameterValue", filterError.getErrorCode());
+        assertEquals("The filter 'subnet-id' is invalid", filterError.getMessage());
+
+        for (String filterName : List.of("tag:Owner", "tag-key")) {
+            AwsException tagFilterError = assertThrows(AwsException.class,
+                    () -> service.describeTransitGatewayVpcAttachmentIds(
+                            "us-east-1", List.of(), Map.of(filterName, List.of("TeamA"))));
+            assertEquals("InvalidParameterValue", tagFilterError.getErrorCode());
+            assertEquals("The filter '" + filterName + "' is invalid", tagFilterError.getMessage());
+            assertEquals(400, tagFilterError.getHttpStatus());
+        }
+    }
+
+    @Test
+    void describeVpnGatewaysReturnsEmptyWhenNoneExist() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+        Map<String, List<String>> vpcFilter =
+                Map.of("attachment.vpc-id", List.of("vpc-0123456789abcdef0"));
+
+        assertTrue(service.describeVpnGatewayIds("us-east-1", List.of(), vpcFilter).isEmpty());
+
+        AwsException vpnError = assertThrows(AwsException.class, () -> service.describeVpnGatewayIds(
+                "us-east-1", List.of("vgw-0123456789abcdef0"), Map.of()));
+        assertEquals("InvalidVpnGatewayID.NotFound", vpnError.getErrorCode());
+        assertEquals("The vpnGateway ID 'vgw-0123456789abcdef0' does not exist", vpnError.getMessage());
+        assertEquals(400, vpnError.getHttpStatus());
+
+        AwsException filterError = assertThrows(AwsException.class,
+                () -> service.describeVpnGatewayIds(
+                        "us-east-1", List.of(), Map.of("unsupported", List.of("value"))));
+        assertEquals("InvalidParameterValue", filterError.getErrorCode());
+        assertEquals("The filter 'unsupported' is invalid", filterError.getMessage());
+    }
+
+    @Test
+    void describeEgressOnlyInternetGatewaysReturnsEmptyWhenNoneExist() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+        Map<String, List<String>> supportedFilters = Map.of(
+                "attachment.state", List.of("attached"),
+                "attachment.vpc-id", List.of("vpc-0123456789abcdef0"),
+                "egress-only-internet-gateway-id", List.of("eigw-0123456789abcdef0"),
+                "tag:Owner", List.of("TeamA"),
+                "tag-key", List.of("Owner"));
+
+        for (Map.Entry<String, List<String>> filter : supportedFilters.entrySet()) {
+            assertTrue(service.describeEgressOnlyInternetGatewayIds(
+                    "us-east-1", List.of(), Map.of(filter.getKey(), filter.getValue())).isEmpty());
+        }
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.describeEgressOnlyInternetGatewayIds(
+                        "us-east-1", List.of("eigw-0123456789abcdef0"), Map.of()));
+        assertEquals("InvalidEgressOnlyInternetGatewayId.NotFound", error.getErrorCode());
+        assertEquals("The egress-only internet gateway ID 'eigw-0123456789abcdef0' does not exist",
+                error.getMessage());
+        assertEquals(400, error.getHttpStatus());
+
+        AwsException filterError = assertThrows(AwsException.class,
+                () -> service.describeEgressOnlyInternetGatewayIds(
+                        "us-east-1", List.of(),
+                        Map.of("unsupported", List.of("value"))));
+        assertEquals("InvalidParameterValue", filterError.getErrorCode());
+        assertEquals("The filter 'unsupported' is invalid", filterError.getMessage());
+        assertEquals(400, filterError.getHttpStatus());
+    }
 
     @Test
     void mockModeTreatsExistingNonTerminatedInstanceAsRunningContainer() {
@@ -181,6 +301,23 @@ class Ec2ServiceTest {
         assertEquals(2, types.getFirst().get("vcpu"));
         assertEquals(8192, types.getFirst().get("memoryMib"));
         assertEquals(List.of("arm64"), types.getFirst().get("supportedArchitectures"));
+    }
+
+    @Test
+    void attachedInternetGatewayRoundTripsAttachedState() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class), mock(AmiImageResolver.class),
+                mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(), new InMemoryStorageFactory());
+        String region = "us-east-1";
+        String vpcId = service.createVpc(region, "10.42.0.0/16", false).getVpcId();
+        InternetGateway gateway = service.createInternetGateway(region);
+
+        service.attachInternetGateway(region, gateway.getInternetGatewayId(), vpcId);
+
+        InternetGateway described = service.describeInternetGateways(
+                region, List.of(gateway.getInternetGatewayId()), Map.of()).getFirst();
+        assertEquals(vpcId, described.getAttachments().getFirst().getVpcId());
+        assertEquals("attached", described.getAttachments().getFirst().getState());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -100,8 +100,10 @@ class Ec2ServiceTest {
                 new InMemoryStorageFactory());
 
         assertTrue(service.describeVpcPeeringConnectionIds("us-east-1", List.of(), Map.of()).isEmpty());
-        assertTrue(service.describeVpcPeeringConnectionIds(
-                "us-east-1", List.of(), Map.of("status-code", List.of("active"))).isEmpty());
+        for (String filterName : List.of("status-code", "tag-value")) {
+            assertTrue(service.describeVpcPeeringConnectionIds(
+                    "us-east-1", List.of(), Map.of(filterName, List.of("value"))).isEmpty());
+        }
 
         AwsException error = assertThrows(AwsException.class, () -> service.describeVpcPeeringConnectionIds(
                 "us-east-1", List.of("pcx-0123456789abcdef0"), Map.of()));
@@ -158,10 +160,10 @@ class Ec2ServiceTest {
                 mock(Ec2PortForwardManager.class),
                 mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
                 new InMemoryStorageFactory());
-        Map<String, List<String>> vpcFilter =
-                Map.of("attachment.vpc-id", List.of("vpc-0123456789abcdef0"));
-
-        assertTrue(service.describeVpnGatewayIds("us-east-1", List.of(), vpcFilter).isEmpty());
+        for (String filterName : List.of("attachment.vpc-id", "tag-value")) {
+            assertTrue(service.describeVpnGatewayIds(
+                    "us-east-1", List.of(), Map.of(filterName, List.of("value"))).isEmpty());
+        }
 
         AwsException vpnError = assertThrows(AwsException.class, () -> service.describeVpnGatewayIds(
                 "us-east-1", List.of("vgw-0123456789abcdef0"), Map.of()));
@@ -187,7 +189,8 @@ class Ec2ServiceTest {
                 "attachment.vpc-id", List.of("vpc-0123456789abcdef0"),
                 "egress-only-internet-gateway-id", List.of("eigw-0123456789abcdef0"),
                 "tag:Owner", List.of("TeamA"),
-                "tag-key", List.of("Owner"));
+                "tag-key", List.of("Owner"),
+                "tag-value", List.of("TeamA"));
 
         for (Map.Entry<String, List<String>> filter : supportedFilters.entrySet()) {
             assertTrue(service.describeEgressOnlyInternetGatewayIds(
@@ -362,7 +365,7 @@ class Ec2ServiceTest {
     }
 
     @Test
-    void attachedInternetGatewayRoundTripsAttachedState() {
+    void attachedInternetGatewayRoundTripsAvailableState() {
         Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
                 mock(Ec2PortForwardManager.class), mock(AmiImageResolver.class),
                 mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(), new InMemoryStorageFactory());
@@ -375,7 +378,7 @@ class Ec2ServiceTest {
         InternetGateway described = service.describeInternetGateways(
                 region, List.of(gateway.getInternetGatewayId()), Map.of()).getFirst();
         assertEquals(vpcId, described.getAttachments().getFirst().getVpcId());
-        assertEquals("attached", described.getAttachments().getFirst().getState());
+        assertEquals("available", described.getAttachments().getFirst().getState());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Complete the EC2 Query handlers and response shapes for VPC attributes,
  CIDR associations, endpoint discovery, and related network discovery calls.
- Add AWS SDK coverage for the supported VPC lifecycle and document the
  implemented actions.
- Remove a deleted VPC's AWS-created default security group and rules, main
  route table, and default network ACL without cascading into unrelated VPCs.
- Preserve provider compatibility for empty filters, tag-only security group
  specifications, and the expected public-hostname response shape.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The EC2 Query endpoint now supports the VPC lifecycle and discovery calls used
by ordinary AWS SDK clients, including VPC attribute round trips, secondary
CIDR associations, VPC endpoint records, and empty discovery responses for
supported resource types that have no local lifecycle model.

Creating a VPC also creates AWS-owned default network resources. Deleting that
VPC now removes its default security group and persisted rules, main route
table, and default network ACL. The cleanup is scoped by VPC identity and does
not remove defaults belonging to another VPC.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Documentation updated
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Verification

Current rebased tree (`dacd4cad7`):

- `./mvnw -B -Dtest='Ec2IntegrationTest,Ec2QueryHandlerTest,Ec2ServicePersistenceTest,Ec2ServiceTest' test`
  - 195 tests, 0 failures, 0 errors, 0 skipped
- Terraform compatibility suite
  - 22 tests, 0 failures
- OpenTofu compatibility suite
  - 16 tests, 0 failures
- `git diff --check upstream/main...HEAD`

Additional patch-set proof before the final upstream-only rebase:

- `./mvnw -B -f compatibility-tests/sdk-test-java/pom.xml -DskipTests package`
  - 121 AWS SDK test sources compiled with target 17
- `./mvnw -B test`
  - 7,973 tests, 0 failures, 0 errors, 8 skipped
  - log SHA-256:
    `de0b9fc2a70fffa8d95d6eb2fcf32ceec41aa2862850b22fdccc2d47db00a610`

The compatibility project was compiled on the available JDK 25 host using its
configured Java 17 source/target settings; this is not a JDK 17 runtime claim.

## Commit Stack

1. `704439163` `feat(ec2): complete VPC Query compatibility`
2. `603be4ce9` `fix(ec2): clean up VPC default resources`
3. `dacd4cad7` `fix(ec2): preserve VPC provider compatibility`