### PR TITLE
fix(eks): validate subnet IDs exist before creating a cluster

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/RegionResolver.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/RegionResolver.java
@@ -72,6 +72,24 @@ public class RegionResolver {
     }
 
     /**
+     * Returns the region for the current request when called from a request context,
+     * or the configured default region otherwise (async workers, startup, tests).
+     */
+    public String getRegion() {
+        if (requestContextInstance != null) {
+            try {
+                String region = requestContextInstance.get().getRegion();
+                if (region != null) {
+                    return region;
+                }
+            } catch (ContextNotActiveException ignored) {
+                // outside request scope — fall through to default
+            }
+        }
+        return defaultRegion;
+    }
+
+    /**
      * Returns the account ID for the current request when called from a request context,
      * or the configured default account ID otherwise (async workers, startup, tests).
      */

--- a/src/main/java/io/github/hectorvent/floci/services/eks/EksService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eks/EksService.java
@@ -100,7 +100,7 @@ public class EksService implements TagHandler {
                     "Cluster already exists: " + name, 409);
         }
 
-        String region = config.defaultRegion();
+        String region = regionResolver.getRegion();
         validateSubnets(region, request.getResourcesVpcConfig());
         String accountId = regionResolver.getAccountId();
         String arn = AwsArnUtils.Arn.of("eks", region, accountId, "cluster/" + name).toString();

--- a/src/main/java/io/github/hectorvent/floci/services/eks/EksService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eks/EksService.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.core.common.TagHandler;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.eks.model.CertificateAuthority;
 import io.github.hectorvent.floci.services.eks.model.Cluster;
 import io.github.hectorvent.floci.services.eks.model.ClusterStatus;
@@ -51,11 +52,12 @@ public class EksService implements TagHandler {
     private final EmulatorConfig config;
     private final RegionResolver regionResolver;
     private final EksClusterManager clusterManager;
+    private final Ec2Service ec2Service;
     private final ScheduledExecutorService poller = Executors.newSingleThreadScheduledExecutor();
 
     @Inject
     public EksService(StorageFactory storageFactory, EmulatorConfig config,
-            RegionResolver regionResolver, EksClusterManager clusterManager) {
+            RegionResolver regionResolver, EksClusterManager clusterManager, Ec2Service ec2Service) {
         this.storage = storageFactory.create("eks", "eks-clusters.json",
                 new TypeReference<Map<String, Cluster>>() {
                 });
@@ -68,6 +70,7 @@ public class EksService implements TagHandler {
         this.config = config;
         this.regionResolver = regionResolver;
         this.clusterManager = clusterManager;
+        this.ec2Service = ec2Service;
     }
 
     @PostConstruct
@@ -98,6 +101,7 @@ public class EksService implements TagHandler {
         }
 
         String region = config.defaultRegion();
+        validateSubnets(region, request.getResourcesVpcConfig());
         String accountId = regionResolver.getAccountId();
         String arn = AwsArnUtils.Arn.of("eks", region, accountId, "cluster/" + name).toString();
 
@@ -378,6 +382,20 @@ public class EksService implements TagHandler {
                     "Invalid resource ARN: " + resourceArn, 400);
         }
         return resourceArn.substring(idx + 1);
+    }
+
+    private void validateSubnets(String region, ResourcesVpcConfig vpcConfig) {
+        if (vpcConfig == null || vpcConfig.getSubnetIds() == null) {
+            return;
+        }
+        for (String subnetId : vpcConfig.getSubnetIds()) {
+            try {
+                ec2Service.requireSubnet(region, subnetId);
+            } catch (AwsException e) {
+                throw new AwsException("InvalidParameterException",
+                        "Subnet ID '" + subnetId + "' does not exist", 400);
+            }
+        }
     }
 
     private ResourcesVpcConfig buildVpcConfigResponse(ResourcesVpcConfig request) {

--- a/src/main/java/io/github/hectorvent/floci/services/eks/EksService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eks/EksService.java
@@ -101,7 +101,7 @@ public class EksService implements TagHandler {
         }
 
         String region = regionResolver.getRegion();
-        validateSubnets(region, request.getResourcesVpcConfig());
+        String resolvedVpcId = validateSubnetsAndResolveVpcId(region, request.getResourcesVpcConfig());
         String accountId = regionResolver.getAccountId();
         String arn = AwsArnUtils.Arn.of("eks", region, accountId, "cluster/" + name).toString();
 
@@ -112,7 +112,7 @@ public class EksService implements TagHandler {
         cluster.setCreatedAt(Instant.now());
         cluster.setVersion(request.getVersion() != null ? request.getVersion() : "1.29");
         cluster.setRoleArn(request.getRoleArn());
-        cluster.setResourcesVpcConfig(buildVpcConfigResponse(request.getResourcesVpcConfig()));
+        cluster.setResourcesVpcConfig(buildVpcConfigResponse(request.getResourcesVpcConfig(), resolvedVpcId));
         cluster.setKubernetesNetworkConfig(buildNetworkConfig(request.getKubernetesNetworkConfig()));
         cluster.setStatus(ClusterStatus.CREATING);
         cluster.setTags(request.getTags() != null ? new HashMap<>(request.getTags()) : new HashMap<>());
@@ -384,26 +384,42 @@ public class EksService implements TagHandler {
         return resourceArn.substring(idx + 1);
     }
 
-    private void validateSubnets(String region, ResourcesVpcConfig vpcConfig) {
+    /**
+     * Validates every requested subnet and returns the VPC they belong to.
+     *
+     * CreateCluster carries no vpcId — real EKS derives it from the subnets, and
+     * #1942 reported resourcesVpcConfig.vpcId coming back blank because the
+     * Subnet that requireSubnet already resolves was discarded here.
+     *
+     * @return the vpcId of the requested subnets, or null when none were given
+     */
+    private String validateSubnetsAndResolveVpcId(String region, ResourcesVpcConfig vpcConfig) {
         if (vpcConfig == null || vpcConfig.getSubnetIds() == null) {
-            return;
+            return null;
         }
+        String vpcId = null;
         for (String subnetId : vpcConfig.getSubnetIds()) {
             try {
-                ec2Service.requireSubnet(region, subnetId);
+                vpcId = ec2Service.requireSubnet(region, subnetId).getVpcId();
             } catch (AwsException e) {
                 throw new AwsException("InvalidParameterException",
                         "Subnet ID '" + subnetId + "' does not exist", 400);
             }
         }
+        return vpcId;
     }
 
-    private ResourcesVpcConfig buildVpcConfigResponse(ResourcesVpcConfig request) {
+    private ResourcesVpcConfig buildVpcConfigResponse(ResourcesVpcConfig request, String resolvedVpcId) {
         ResourcesVpcConfig response = new ResourcesVpcConfig();
         if (request != null) {
             response.setSubnetIds(request.getSubnetIds() != null ? request.getSubnetIds() : List.of());
             response.setSecurityGroupIds(request.getSecurityGroupIds() != null ? request.getSecurityGroupIds() : List.of());
-            response.setVpcId(request.getVpcId() != null ? request.getVpcId() : "");
+            // A caller-supplied vpcId still wins; otherwise fall back to the one
+            // the subnets resolved to, and only then to empty.
+            String vpcId = request.getVpcId() != null && !request.getVpcId().isBlank()
+                    ? request.getVpcId()
+                    : (resolvedVpcId != null ? resolvedVpcId : "");
+            response.setVpcId(vpcId);
             response.setEndpointPublicAccess(
                     request.getEndpointPublicAccess() != null ? request.getEndpointPublicAccess() : Boolean.TRUE);
             response.setEndpointPrivateAccess(

--- a/src/test/java/io/github/hectorvent/floci/services/eks/EksServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eks/EksServiceTest.java
@@ -246,6 +246,37 @@ class EksServiceTest {
     }
 
     @Test
+    void createClusterValidatesSubnetsInRequestRegionNotDefaultRegion() {
+        // testConfig() always reports defaultRegion = "us-east-1". Here the
+        // *request's* region (via RegionResolver) is "eu-west-2", where the
+        // subnet actually exists. Validation must check eu-west-2, not fall
+        // back to the app's configured default region.
+        StorageFactory storageFactory = new StorageFactory(null, null) {
+            @Override
+            public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+                    TypeReference<Map<String, V>> typeReference) {
+                return new InMemoryStorage<>();
+            }
+        };
+        RegionResolver regionResolver = new RegionResolver("eu-west-2", "000000000000");
+        Ec2Service ec2Service = realEc2Service();
+        EksService service = new EksService(storageFactory, testConfig(), regionResolver, null, ec2Service);
+
+        ResourcesVpcConfig vpcConfig = new ResourcesVpcConfig();
+        vpcConfig.setSubnetIds(List.of("subnet-default-a"));
+
+        CreateClusterRequest req = new CreateClusterRequest();
+        req.setName("cross-region-cluster");
+        req.setRoleArn("arn:aws:iam::000000000000:role/eks-role");
+        req.setResourcesVpcConfig(vpcConfig);
+
+        Cluster cluster = service.createCluster(req);
+
+        assertEquals("cross-region-cluster", cluster.getName());
+        assertTrue(cluster.getArn().contains("eu-west-2"));
+    }
+
+    @Test
     void describeCluster() {
         CreateClusterRequest req = new CreateClusterRequest();
         req.setName("my-cluster");

--- a/src/test/java/io/github/hectorvent/floci/services/eks/EksServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eks/EksServiceTest.java
@@ -6,6 +6,12 @@ import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.ec2.AmiImageResolver;
+import io.github.hectorvent.floci.services.ec2.Ec2ContainerManager;
+import io.github.hectorvent.floci.services.ec2.Ec2ImageCatalog;
+import io.github.hectorvent.floci.services.ec2.Ec2InstanceTypeCatalog;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.portforward.Ec2PortForwardManager;
 import io.github.hectorvent.floci.services.eks.model.ClusterStatus;
 import io.github.hectorvent.floci.services.eks.model.CreateClusterRequest;
 import io.github.hectorvent.floci.services.eks.model.CreateFargateProfileRequest;
@@ -16,6 +22,7 @@ import io.github.hectorvent.floci.services.eks.model.Cluster;
 import io.github.hectorvent.floci.services.eks.model.Nodegroup;
 import io.github.hectorvent.floci.services.eks.model.NodegroupScalingConfig;
 import io.github.hectorvent.floci.services.eks.model.NodegroupStatus;
+import io.github.hectorvent.floci.services.eks.model.ResourcesVpcConfig;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,6 +35,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class EksServiceTest {
 
@@ -45,8 +54,9 @@ class EksServiceTest {
 
         EmulatorConfig config = testConfig();
         EksClusterManager clusterManager = null;
+        Ec2Service ec2Service = null;
         RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
-        eksService = new EksService(storageFactory, config, regionResolver, clusterManager);
+        eksService = new EksService(storageFactory, config, regionResolver, clusterManager, ec2Service);
     }
 
     private EmulatorConfig testConfig() {
@@ -104,6 +114,28 @@ class EksServiceTest {
         return null;
     }
 
+    private Ec2Service realEc2Service() {
+        EmulatorConfig ec2Config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.Ec2ServiceConfig ec2ServiceConfig = mock(EmulatorConfig.Ec2ServiceConfig.class);
+        when(ec2Config.defaultAccountId()).thenReturn("000000000000");
+        when(ec2Config.services()).thenReturn(services);
+        when(services.ec2()).thenReturn(ec2ServiceConfig);
+        when(ec2ServiceConfig.mock()).thenReturn(true);
+
+        StorageFactory storageFactory = new StorageFactory(null, null) {
+            @Override
+            public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+                    TypeReference<Map<String, V>> typeReference) {
+                return new InMemoryStorage<>();
+            }
+        };
+
+        return new Ec2Service(ec2Config, mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class), mock(AmiImageResolver.class),
+                mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(), storageFactory);
+    }
+
     private void createTestCluster(String name) {
         CreateClusterRequest clusterRequest = new CreateClusterRequest();
         clusterRequest.setName(name);
@@ -158,6 +190,59 @@ class EksServiceTest {
         eksService.createCluster(req);
 
         assertThrows(AwsException.class, () -> eksService.createCluster(req));
+    }
+
+    @Test
+    void createClusterWithNonExistentSubnetFails() {
+        StorageFactory storageFactory = new StorageFactory(null, null) {
+            @Override
+            public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+                    TypeReference<Map<String, V>> typeReference) {
+                return new InMemoryStorage<>();
+            }
+        };
+        RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
+        EksService service = new EksService(storageFactory, testConfig(), regionResolver, null, realEc2Service());
+
+        ResourcesVpcConfig vpcConfig = new ResourcesVpcConfig();
+        vpcConfig.setSubnetIds(List.of("subnet-1", "subnet-2"));
+
+        CreateClusterRequest req = new CreateClusterRequest();
+        req.setName("fake-subnet-cluster");
+        req.setRoleArn("arn:aws:iam::000000000000:role/eks-role");
+        req.setResourcesVpcConfig(vpcConfig);
+
+        AwsException ex = assertThrows(AwsException.class, () -> service.createCluster(req));
+        assertEquals("InvalidParameterException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+        assertTrue(service.listClusters().isEmpty());
+    }
+
+    @Test
+    void createClusterWithExistingSubnetSucceeds() {
+        StorageFactory storageFactory = new StorageFactory(null, null) {
+            @Override
+            public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+                    TypeReference<Map<String, V>> typeReference) {
+                return new InMemoryStorage<>();
+            }
+        };
+        RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
+        EksService service = new EksService(storageFactory, testConfig(), regionResolver, null, realEc2Service());
+
+        ResourcesVpcConfig vpcConfig = new ResourcesVpcConfig();
+        vpcConfig.setSubnetIds(List.of("subnet-default-a", "subnet-default-b"));
+
+        CreateClusterRequest req = new CreateClusterRequest();
+        req.setName("real-subnet-cluster");
+        req.setRoleArn("arn:aws:iam::000000000000:role/eks-role");
+        req.setResourcesVpcConfig(vpcConfig);
+
+        Cluster cluster = service.createCluster(req);
+
+        assertEquals("real-subnet-cluster", cluster.getName());
+        assertEquals(List.of("subnet-default-a", "subnet-default-b"),
+                cluster.getResourcesVpcConfig().getSubnetIds());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/eks/EksServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eks/EksServiceTest.java
@@ -246,11 +246,41 @@ class EksServiceTest {
     }
 
     @Test
-    void createClusterValidatesSubnetsInRequestRegionNotDefaultRegion() {
-        // testConfig() always reports defaultRegion = "us-east-1". Here the
-        // *request's* region (via RegionResolver) is "eu-west-2", where the
-        // subnet actually exists. Validation must check eu-west-2, not fall
-        // back to the app's configured default region.
+    void createClusterResolvesVpcIdFromTheSubnets() {
+        // The second half of #1942: resourcesVpcConfig.vpcId came back blank.
+        //
+        // CreateCluster does not carry a vpcId — real EKS derives it from the
+        // subnets, and so should this. requireSubnet already returns the
+        // resolved Subnet, which carries the vpcId; it was simply discarded.
+        StorageFactory storageFactory = new StorageFactory(null, null) {
+            @Override
+            public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+                    TypeReference<Map<String, V>> typeReference) {
+                return new InMemoryStorage<>();
+            }
+        };
+        RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
+        EksService service = new EksService(storageFactory, testConfig(), regionResolver, null,
+                realEc2Service());
+
+        ResourcesVpcConfig vpcConfig = new ResourcesVpcConfig();
+        vpcConfig.setSubnetIds(List.of("subnet-default-a", "subnet-default-b"));
+
+        CreateClusterRequest req = new CreateClusterRequest();
+        req.setName("vpc-id-cluster");
+        req.setRoleArn("arn:aws:iam::000000000000:role/eks-role");
+        req.setResourcesVpcConfig(vpcConfig);
+
+        Cluster cluster = service.createCluster(req);
+
+        assertEquals("vpc-default", cluster.getResourcesVpcConfig().getVpcId());
+    }
+
+    @Test
+    void createClusterBuildsArnFromRequestRegionNotDefaultRegion() {
+        // testConfig() always reports defaultRegion = "us-east-1"; the request's
+        // region is eu-west-2. This pins the ARN only — see the test below for
+        // the validation half.
         StorageFactory storageFactory = new StorageFactory(null, null) {
             @Override
             public <V> StorageBackend<String, V> create(String serviceName, String fileName,
@@ -259,8 +289,8 @@ class EksServiceTest {
             }
         };
         RegionResolver regionResolver = new RegionResolver("eu-west-2", "000000000000");
-        Ec2Service ec2Service = realEc2Service();
-        EksService service = new EksService(storageFactory, testConfig(), regionResolver, null, ec2Service);
+        EksService service = new EksService(storageFactory, testConfig(), regionResolver, null,
+                realEc2Service());
 
         ResourcesVpcConfig vpcConfig = new ResourcesVpcConfig();
         vpcConfig.setSubnetIds(List.of("subnet-default-a"));
@@ -274,6 +304,54 @@ class EksServiceTest {
 
         assertEquals("cross-region-cluster", cluster.getName());
         assertTrue(cluster.getArn().contains("eu-west-2"));
+    }
+
+    @Test
+    void createClusterValidatesSubnetsInRequestRegionNotDefaultRegion() {
+        // A subnet that exists in the DEFAULT region and nowhere else.
+        //
+        // The distinction matters: requireSubnet() calls ensureDefaultResources()
+        // on whatever region it is handed, which seeds subnet-default-a/b/c
+        // there on the spot. So a default subnet id resolves in EVERY region and
+        // cannot discriminate between "validated against the request region" and
+        // "validated against the configured default" — a test written with one
+        // passes with or without the fix.
+        //
+        // An explicitly created subnet is not seeded anywhere else, so asking
+        // for it from a different region is the only thing that pins the
+        // behaviour.
+        StorageFactory storageFactory = new StorageFactory(null, null) {
+            @Override
+            public <V> StorageBackend<String, V> create(String serviceName, String fileName,
+                    TypeReference<Map<String, V>> typeReference) {
+                return new InMemoryStorage<>();
+            }
+        };
+        Ec2Service ec2Service = realEc2Service();
+        ec2Service.ensureDefaultResources("us-east-1");
+        String usEastOnlySubnet = ec2Service
+                .createSubnet("us-east-1", "vpc-default", "172.31.200.0/24", "us-east-1a")
+                .getSubnetId();
+
+        // The request is for eu-west-2, where that subnet does not exist.
+        RegionResolver regionResolver = new RegionResolver("eu-west-2", "000000000000");
+        EksService service = new EksService(storageFactory, testConfig(), regionResolver, null,
+                ec2Service);
+
+        ResourcesVpcConfig vpcConfig = new ResourcesVpcConfig();
+        vpcConfig.setSubnetIds(List.of(usEastOnlySubnet));
+
+        CreateClusterRequest req = new CreateClusterRequest();
+        req.setName("wrong-region-subnet-cluster");
+        req.setRoleArn("arn:aws:iam::000000000000:role/eks-role");
+        req.setResourcesVpcConfig(vpcConfig);
+
+        // Resolving against config.defaultRegion() would find it in us-east-1
+        // and let the cluster through, which is the bug.
+        AwsException ex = assertThrows(AwsException.class, () -> service.createCluster(req));
+        assertEquals("InvalidParameterException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+        assertTrue(service.listClusters().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
Fixes #1942

## Problem

`CreateCluster` accepted any subnet ID in `resourcesVpcConfig.subnetIds`, including ones that don't exist, and returned a successful cluster with `vpcId` left blank. Real EKS validates subnets against EC2 at cluster-creation time and rejects the request with `InvalidParameterException` if any subnet isn't found.

## Fix

`EksService` now takes a dependency on `Ec2Service` and calls `Ec2Service.requireSubnet(region, subnetId)` for each subnet ID in `resourcesVpcConfig.subnetIds` before creating the cluster. Any missing subnet is surfaced as `InvalidParameterException` (400), matching EKS's real behavior. This mirrors the same validation pattern `RdsService` already uses for DB subnet groups.

Only `CreateCluster` is touched — `CreateNodeGroup`/`CreateFargateProfile` subnet handling is unchanged (out of scope for this fix).

## Region resolution (and an ARN fix that comes with it)

Review feedback caught that validating against `config.defaultRegion()` would reject valid subnets whenever a cluster was created in a non-default region. `createCluster` now resolves the region via `regionResolver.getRegion()` instead.

`RegionResolver` gains `getRegion()`, mirroring the existing `getAccountId()` — it reads the per-request region already set by `AccountContextFilter` and falls back to the configured default outside request scope.

**This intentionally changes one more thing:** the cluster ARN's region. `createCluster` previously built the ARN from `config.defaultRegion()` while `accountId` on the next line already came from the request-aware `regionResolver.getAccountId()`, so a `CreateCluster` against a non-default region produced an ARN with the wrong region. Both are now consistent. Slightly broader than "validate subnets", but a real bug and awkward to separate — the same call site has to resolve the region either way.

## Testing

- `createClusterWithNonExistentSubnetFails` — fake subnet IDs now throw `InvalidParameterException` / 400, and no cluster is persisted
- `createClusterWithExistingSubnetSucceeds` — real subnets (`subnet-default-a/b`) still work
- `createClusterValidatesSubnetsInRequestRegionNotDefaultRegion` — regression test for the region fix; fails against the pre-fix code
- Full `EksServiceTest` (26 tests) and `EksNodegroupIntegrationTest` (5 tests) pass — no regressions