### PR TITLE
feat(sagemaker): add SageMaker emulation with Docker-backed training

### DIFF
--- a/compatibility-tests/sdk-test-python/tests/test_sagemaker.py
+++ b/compatibility-tests/sdk-test-python/tests/test_sagemaker.py
@@ -1,0 +1,63 @@
+import time
+import uuid
+
+import boto3
+import pytest
+from botocore.config import Config
+
+
+def client(service):
+    return boto3.client(
+        service,
+        endpoint_url="http://localhost:4566",
+        region_name="us-east-1",
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        config=Config(retries={"max_attempts": 1}),
+    )
+
+
+def test_sagemaker_control_plane_and_training():
+    sm = client("sagemaker")
+    s3 = client("s3")
+    suffix = uuid.uuid4().hex[:8]
+    model = f"compat-sm-{suffix}"
+    cfg = f"compat-sm-cfg-{suffix}"
+    bucket = f"compat-sm-{suffix}"
+
+    sm.create_model(ModelName=model, PrimaryContainer={"Image": "public.ecr.aws/docker/library/busybox:stable"}, ExecutionRoleArn="arn:aws:iam::000000000000:role/r")
+    assert sm.describe_model(ModelName=model)["ModelName"] == model
+    sm.create_endpoint_config(EndpointConfigName=cfg, ProductionVariants=[{"VariantName": "AllTraffic", "ModelName": model, "InitialInstanceCount": 1, "InstanceType": "ml.t2.medium"}])
+    assert any(c["EndpointConfigName"] == cfg for c in sm.list_endpoint_configs()["EndpointConfigs"])
+
+    s3.create_bucket(Bucket=bucket)
+    s3.put_object(Bucket=bucket, Key="input/data.txt", Body=b"hello")
+    job = f"compat-train-{suffix}"
+    sm.create_training_job(
+        TrainingJobName=job,
+        AlgorithmSpecification={
+            "TrainingImage": "public.ecr.aws/docker/library/busybox:stable",
+            "ContainerEntrypoint": ["/bin/sh", "-c"],
+            "ContainerArguments": ["mkdir -p /opt/ml/model && echo ok > /opt/ml/model/model.txt"],
+        },
+        InputDataConfig=[{"ChannelName": "train", "DataSource": {"S3DataSource": {"S3Uri": f"s3://{bucket}/input"}}, "TrainingInputMode": "File"}],
+        OutputDataConfig={"S3OutputPath": f"s3://{bucket}/output"},
+        ResourceConfig={"InstanceType": "ml.m5.large", "InstanceCount": 1, "VolumeSizeInGB": 1},
+        StoppingCondition={"MaxRuntimeInSeconds": 60},
+    )
+    deadline = time.time() + 120
+    while time.time() < deadline:
+        desc = sm.describe_training_job(TrainingJobName=job)
+        if desc["TrainingJobStatus"] == "Completed":
+            artifact = desc["ModelArtifacts"]["S3ModelArtifacts"]
+            key = artifact.split(f"s3://{bucket}/", 1)[1]
+            assert s3.get_object(Bucket=bucket, Key=key)["Body"].read()
+            break
+        if desc["TrainingJobStatus"] == "Failed":
+            pytest.fail(desc.get("FailureReason", "training failed"))
+        time.sleep(1)
+    else:
+        pytest.fail("Timed out waiting for SageMaker training job")
+
+    sm.delete_endpoint_config(EndpointConfigName=cfg)
+    sm.delete_model(ModelName=model)

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -99,3 +99,5 @@ export AWS_SECRET_ACCESS_KEY=test
 ```
 
 `AWS_ENDPOINT_URL` is the standard env var recognised by the AWS CLI v2 and AWS SDKs v2+, so no `--endpoint-url` flag is needed on each command.
+
+- [SageMaker](sagemaker.md) - model, endpoint, runtime, and training emulation with Docker execution.

--- a/docs/services/sagemaker.md
+++ b/docs/services/sagemaker.md
@@ -1,0 +1,36 @@
+# Amazon SageMaker
+
+Floci emulates SageMaker control-plane APIs and runs real Docker containers for local training jobs and hosted endpoints. Containers use the SageMaker `/opt/ml` contract rather than mocks.
+
+## Supported operations
+
+| Area | Operations |
+| --- | --- |
+| Models | `CreateModel`, `DescribeModel`, `DeleteModel`, `ListModels` |
+| Endpoint configs | `CreateEndpointConfig`, `DescribeEndpointConfig`, `DeleteEndpointConfig`, `ListEndpointConfigs` |
+| Endpoints | `CreateEndpoint`, `DescribeEndpoint`, `UpdateEndpoint`, `DeleteEndpoint`, `ListEndpoints` |
+| Training | `CreateTrainingJob`, `DescribeTrainingJob`, `ListTrainingJobs`, `StopTrainingJob` |
+| Tags | `AddTags`, `ListTags`, `DeleteTags` |
+| Runtime | `POST /endpoints/{EndpointName}/invocations` |
+
+## Training contract
+
+`CreateTrainingJob` starts `AlgorithmSpecification.TrainingImage` with command `train` unless `ContainerEntrypoint`/`ContainerArguments` are supplied. Floci writes SageMaker config files under `/opt/ml/input/config`, downloads channel data from S3 into `/opt/ml/input/data/<channel>`, waits for container exit, and uploads `/opt/ml/model` as `model.tar.gz` under `OutputDataConfig.S3OutputPath/<TrainingJobName>/output/`.
+
+## Endpoint hosting
+
+`CreateEndpoint` starts the model image as a long-lived Docker container with command `serve`, port `8080`, `/ping` health checks, and `/invocations` runtime proxying. `ModelDataUrl` artifacts are downloaded from S3 and placed in `/opt/ml/model`.
+
+## Examples
+
+```python
+import boto3
+sm = boto3.client("sagemaker", endpoint_url="http://localhost:4566", region_name="us-east-1")
+sm.create_model(ModelName="m", PrimaryContainer={"Image":"my-image"}, ExecutionRoleArn="arn:aws:iam::000000000000:role/r")
+sm.create_endpoint_config(EndpointConfigName="cfg", ProductionVariants=[{"VariantName":"AllTraffic","ModelName":"m","InitialInstanceCount":1,"InstanceType":"ml.t2.medium"}])
+sm.create_endpoint(EndpointName="ep", EndpointConfigName="cfg")
+```
+
+```bash
+aws --endpoint-url=http://localhost:4566 sagemaker list-models
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
     - Elastic Beanstalk: services/elastic-beanstalk.md
     - CodeBuild: services/codebuild.md
     - AWS Batch: services/batch.md
+    - SageMaker: services/sagemaker.md
     - CodeDeploy: services/codedeploy.md
     - CodePipeline: services/codepipeline.md
     - AWS Backup: services/backup.md

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -267,6 +267,7 @@ public interface EmulatorConfig {
         TaggingStorageConfig tagging();
         ElasticBeanstalkStorageConfig elasticbeanstalk();
         CloudTrailStorageConfig cloudtrail();
+        SageMakerStorageConfig sagemaker();
     }
 
     interface SsmStorageConfig {
@@ -475,6 +476,13 @@ public interface EmulatorConfig {
         long flushIntervalMs();
     }
 
+    interface SageMakerStorageConfig {
+        Optional<String> mode();
+
+        @WithDefault("5000")
+        long flushIntervalMs();
+    }
+
     interface CodeDeployStorageConfig {
         Optional<String> mode();
 
@@ -567,6 +575,7 @@ public interface EmulatorConfig {
         CloudFrontServiceConfig cloudfront();
         AppSyncServiceConfig appsync();
         BatchServiceConfig batch();
+        SageMakerServiceConfig sagemaker();
         LightsailServiceConfig lightsail();
         UiServiceConfig ui();
         S3VectorsServiceConfig s3vectors();
@@ -683,6 +692,13 @@ public interface EmulatorConfig {
 
         @WithDefault("immediate")
         String runnerMode();
+
+        Optional<String> dockerNetwork();
+    }
+
+    interface SageMakerServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
 
         Optional<String> dockerNetwork();
     }

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsJson11Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsJson11Controller.java
@@ -37,6 +37,7 @@ import io.github.hectorvent.floci.services.wafv2.WafV2Handler;
 import io.github.hectorvent.floci.services.kinesis.KinesisJsonHandler;
 import io.github.hectorvent.floci.services.kms.KmsJsonHandler;
 import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerJsonHandler;
+import io.github.hectorvent.floci.services.sagemaker.SageMakerJsonHandler;
 import io.github.hectorvent.floci.services.ssm.Ec2MessagesJsonHandler;
 import io.github.hectorvent.floci.services.ssm.SsmJsonHandler;
 import jakarta.inject.Inject;
@@ -99,6 +100,7 @@ public class AwsJson11Controller {
     private final CloudTrailJsonHandler cloudTrailJsonHandler;
     private final LightsailJsonHandler lightsailJsonHandler;
     private final CloudControlJsonHandler cloudControlJsonHandler;
+    private final SageMakerJsonHandler sageMakerJsonHandler;
 
     @Inject
     public AwsJson11Controller(ObjectMapper objectMapper, ResolvedServiceCatalog catalog,
@@ -132,7 +134,8 @@ public class AwsJson11Controller {
                                ConfigServiceJsonHandler configServiceJsonHandler,
                                CloudTrailJsonHandler cloudTrailJsonHandler,
                                LightsailJsonHandler lightsailJsonHandler,
-                               CloudControlJsonHandler cloudControlJsonHandler) {
+                               CloudControlJsonHandler cloudControlJsonHandler,
+                               SageMakerJsonHandler sageMakerJsonHandler) {
         this.objectMapper = objectMapper;
         this.strictBodyReader = objectMapper.reader().with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
         this.catalog = catalog;
@@ -171,6 +174,7 @@ public class AwsJson11Controller {
         this.cloudTrailJsonHandler = cloudTrailJsonHandler;
         this.lightsailJsonHandler = lightsailJsonHandler;
         this.cloudControlJsonHandler = cloudControlJsonHandler;
+        this.sageMakerJsonHandler = sageMakerJsonHandler;
     }
 
     @POST
@@ -240,6 +244,7 @@ public class AwsJson11Controller {
                 case "cloudtrail" -> cloudTrailJsonHandler.handle(action, request, region);
                 case "lightsail" -> lightsailJsonHandler.handle(action, request, region);
                 case "cloudcontrol" -> cloudControlJsonHandler.handle(action, request, region);
+                case "sagemaker" -> sageMakerJsonHandler.handle(action, request, region);
                 default -> null;
             };
             // catalog.matchTarget is protocol-agnostic: a JSON 1.0 target

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -20,6 +20,7 @@ import io.github.hectorvent.floci.services.ses.SesController;
 import io.github.hectorvent.floci.services.appsync.AppSyncController;
 import io.github.hectorvent.floci.services.rdsdata.RdsDataController;
 import io.github.hectorvent.floci.services.s3vectors.S3VectorsController;
+import io.github.hectorvent.floci.services.sagemaker.SageMakerRuntimeController;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -268,6 +269,12 @@ public class ResolvedServiceCatalog {
                         config.storage().services().batch().flushIntervalMs(), null, ServiceProtocol.REST_JSON,
                         protocols(ServiceProtocol.REST_JSON),
                         Set.of(), Set.of("batch"), Set.of(), Set.of(BatchController.class)),
+                descriptor("sagemaker", "sagemaker", config.services().sagemaker().enabled(), true,
+                        "sagemaker", storageMode(config.storage().services().sagemaker().mode(), config.storage().mode()),
+                        config.storage().services().sagemaker().flushIntervalMs(), null, ServiceProtocol.JSON,
+                        protocols(ServiceProtocol.JSON, ServiceProtocol.REST_JSON),
+                        Set.of("SageMaker."), Set.of("sagemaker", "runtime.sagemaker"), Set.of(),
+                        Set.of(SageMakerRuntimeController.class)),
                 descriptor("codedeploy", "codedeploy", config.services().codedeploy().enabled(), true,
                         "codedeploy", storageMode(config.storage().services().codedeploy().mode(), config.storage().mode()),
                         config.storage().services().codedeploy().flushIntervalMs(), null, ServiceProtocol.JSON,

--- a/src/main/java/io/github/hectorvent/floci/services/sagemaker/S3Uri.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sagemaker/S3Uri.java
@@ -1,0 +1,15 @@
+package io.github.hectorvent.floci.services.sagemaker;
+
+record S3Uri(String bucket, String key) {
+    static S3Uri parse(String uri) {
+        if (uri == null || !uri.startsWith("s3://")) {
+            throw new IllegalArgumentException("Expected s3:// URI");
+        }
+        String rest = uri.substring(5);
+        int slash = rest.indexOf('/');
+        if (slash < 0) {
+            return new S3Uri(rest, "");
+        }
+        return new S3Uri(rest.substring(0, slash), rest.substring(slash + 1));
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/sagemaker/SageMakerEndpointManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sagemaker/SageMakerEndpointManager.java
@@ -178,11 +178,14 @@ public class SageMakerEndpointManager implements ContainerTeardown {
         try (TarArchiveOutputStream tar = new TarArchiveOutputStream(out)) {
             if (key.endsWith(".tar.gz") || key.endsWith(".tgz")) {
                 try (TarArchiveInputStream in = new TarArchiveInputStream(new GzipCompressorInputStream(new ByteArrayInputStream(data)))) {
-                    TarArchiveEntry e;
-                    while ((e = in.getNextEntry()) != null) {
-                        if (!in.canReadEntryData(e) || e.isDirectory()) continue;
-                        addFile(tar, "opt/ml/model/" + e.getName(), in.readAllBytes());
-                    }
+TarArchiveEntry e;
+while ((e = in.getNextEntry()) != null) {
+    if (!in.canReadEntryData(e) || e.isDirectory()) continue;
+    String entryName = e.getName();
+    java.nio.file.Path normalized = java.nio.file.Path.of(entryName).normalize();
+    if (normalized.isAbsolute() || normalized.startsWith("..")) continue;
+    addFile(tar, "opt/ml/model/" + normalized.toString(), in.readAllBytes());
+}
                 }
             } else {
                 addFile(tar, "opt/ml/model/" + key.substring(key.lastIndexOf('/') + 1), data);

--- a/src/main/java/io/github/hectorvent/floci/services/sagemaker/SageMakerEndpointManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sagemaker/SageMakerEndpointManager.java
@@ -1,0 +1,243 @@
+package io.github.hectorvent.floci.services.sagemaker;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.ContainerTeardown;
+import io.github.hectorvent.floci.core.common.dns.EmbeddedDnsServer;
+import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
+import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
+import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
+import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.s3.model.S3Object;
+import io.github.hectorvent.floci.services.sagemaker.model.SageMakerEntities.EndpointResource;
+import io.github.hectorvent.floci.services.sagemaker.model.SageMakerEntities.ModelResource;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.jboss.logging.Logger;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.net.ConnectException;
+import java.net.URI;
+import java.net.http.HttpTimeoutException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@ApplicationScoped
+public class SageMakerEndpointManager implements ContainerTeardown {
+    private static final Logger LOG = Logger.getLogger(SageMakerEndpointManager.class);
+    private static final int PORT = 8080;
+    private static final int DEFAULT_FILE_MODE = 0644;
+    private static final int PING_LOG_FREQUENCY = 15;
+    private static final Duration PING_TIMEOUT = Duration.ofSeconds(120);
+
+    private final ContainerBuilder containerBuilder;
+    private final ContainerLifecycleManager lifecycleManager;
+    private final EmulatorConfig config;
+    private final ContainerDetector containerDetector;
+    private final S3Service s3Service;
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+    private final ConcurrentHashMap<String, String> containers = new ConcurrentHashMap<>();
+    private final HttpClient httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build();
+
+    @Inject
+    public SageMakerEndpointManager(ContainerBuilder containerBuilder, ContainerLifecycleManager lifecycleManager,
+                                    EmulatorConfig config, ContainerDetector containerDetector, S3Service s3Service) {
+        this.containerBuilder = containerBuilder;
+        this.lifecycleManager = lifecycleManager;
+        this.config = config;
+        this.containerDetector = containerDetector;
+        this.s3Service = s3Service;
+    }
+
+    public void startEndpointAsync(EndpointResource endpoint, SageMakerService service) {
+        executor.submit(() -> startEndpoint(endpoint, service));
+    }
+
+    private void startEndpoint(EndpointResource endpoint, SageMakerService service) {
+        String containerId = null;
+        try {
+            ModelResource model = service.modelForEndpoint(endpoint);
+            Map<String, Object> c = model.primaryContainer;
+            String image = string(c.get("Image"));
+            if (image == null) {
+                throw new IllegalArgumentException("PrimaryContainer.Image is required");
+            }
+            String name = ContainerStorageHelper.dockerName(config, "floci-sagemaker-endpoint-" + endpoint.endpointName);
+            lifecycleManager.removeIfExists(name);
+            ContainerBuilder.Builder builder = containerBuilder.newContainer(image)
+                    .withName(name)
+                    .withEnv(environment(endpoint.region, map(c.get("Environment"))))
+                    .withDockerNetwork(config.services().sagemaker().dockerNetwork())
+                    .withHostDockerInternalOnLinux()
+                    .withEmbeddedDns()
+                    .withPortBinding(PORT, 0)
+                    .withLogRotation();
+            applyEntrypoint(builder, c, "serve");
+            ContainerSpec spec = builder.build();
+            containerId = lifecycleManager.create(spec);
+            String modelDataUrl = string(c.get("ModelDataUrl"));
+            if (modelDataUrl != null && !modelDataUrl.isBlank()) {
+                copyModelData(containerId, modelDataUrl);
+            }
+            var info = lifecycleManager.startCreated(containerId, spec);
+            var ep = info.getEndpoint(PORT);
+            endpoint.containerId = containerId;
+            endpoint.invokeHost = ep.host();
+            endpoint.invokePort = ep.port();
+            containers.put(endpoint.endpointName, containerId);
+            waitForPing(endpoint.invokeHost, endpoint.invokePort);
+            endpoint.endpointStatus = "InService";
+            endpoint.failureReason = null;
+            service.updateEndpoint(endpoint);
+        } catch (Exception e) {
+            LOG.warnv("SageMaker endpoint {0} failed: {1}", endpoint.endpointName, e.getMessage());
+            if (containerId != null) {
+                lifecycleManager.stopAndRemove(containerId, null);
+            }
+            endpoint.endpointStatus = "Failed";
+            endpoint.failureReason = e.getMessage();
+            service.updateEndpoint(endpoint);
+        }
+    }
+
+    public void stopEndpoint(EndpointResource endpoint) {
+        String containerId = endpoint.containerId != null ? endpoint.containerId : containers.remove(endpoint.endpointName);
+        if (containerId != null) {
+            lifecycleManager.stopAndRemove(containerId, null);
+        }
+    }
+
+    @Override
+    public void stopManagedContainers() {
+        containers.forEach((name, id) -> lifecycleManager.stopAndRemove(id, null));
+        containers.clear();
+        executor.shutdownNow();
+    }
+
+    private List<String> environment(String region, Map<String, String> modelEnv) {
+        List<String> env = new ArrayList<>();
+        env.add("SAGEMAKER_BIND_TO_PORT=8080");
+        env.add("SAGEMAKER_REGION=" + region);
+        env.add("AWS_REGION=" + region);
+        env.add("AWS_DEFAULT_REGION=" + region);
+        env.add("AWS_ACCESS_KEY_ID=test");
+        env.add("AWS_SECRET_ACCESS_KEY=test");
+        env.add("AWS_SESSION_TOKEN=test");
+        String endpoint = "http://" + resolveEndpointHostname() + ":" + config.port();
+        env.add("AWS_ENDPOINT_URL=" + endpoint);
+        env.add("FLOCI_ENDPOINT=" + endpoint);
+        modelEnv.forEach((k, v) -> env.add(k + "=" + (v == null ? "" : v)));
+        return env;
+    }
+
+    private String resolveEndpointHostname() {
+        return containerDetector.isRunningInContainer() ? config.hostname().orElse(EmbeddedDnsServer.DEFAULT_SUFFIX) : "host.docker.internal";
+    }
+
+    static void applyEntrypoint(ContainerBuilder.Builder builder, Map<String, Object> container, String defaultCommand) {
+        Object entrypoint = container.get("ContainerEntrypoint");
+        Object arguments = container.get("ContainerArguments");
+        if (entrypoint instanceof List<?> list && !list.isEmpty()) {
+            builder.withEntrypoint(list.stream().map(String::valueOf).toList());
+            if (arguments instanceof List<?> args) {
+                builder.withCmd(args.stream().map(String::valueOf).toList());
+            }
+        } else if (arguments instanceof List<?> args && !args.isEmpty()) {
+            builder.withCmd(args.stream().map(String::valueOf).toList());
+        } else {
+            builder.withCmd(List.of(defaultCommand));
+        }
+    }
+
+    private void copyModelData(String containerId, String s3Uri) throws Exception {
+        S3Uri uri = S3Uri.parse(s3Uri);
+        S3Object object = s3Service.getObject(uri.bucket(), uri.key());
+        byte[] tarData = tarModelData(object.getData(), uri.key());
+        lifecycleManager.getDockerClient().copyArchiveToContainerCmd(containerId)
+                .withRemotePath("/")
+                .withTarInputStream(new ByteArrayInputStream(tarData))
+                .exec();
+    }
+
+    private byte[] tarModelData(byte[] data, String key) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (TarArchiveOutputStream tar = new TarArchiveOutputStream(out)) {
+            if (key.endsWith(".tar.gz") || key.endsWith(".tgz")) {
+                try (TarArchiveInputStream in = new TarArchiveInputStream(new GzipCompressorInputStream(new ByteArrayInputStream(data)))) {
+                    TarArchiveEntry e;
+                    while ((e = in.getNextEntry()) != null) {
+                        if (!in.canReadEntryData(e) || e.isDirectory()) continue;
+                        addFile(tar, "opt/ml/model/" + e.getName(), in.readAllBytes());
+                    }
+                }
+            } else {
+                addFile(tar, "opt/ml/model/" + key.substring(key.lastIndexOf('/') + 1), data);
+            }
+        }
+        return out.toByteArray();
+    }
+
+    static void addFile(TarArchiveOutputStream tar, String path, byte[] data) throws Exception {
+        TarArchiveEntry entry = new TarArchiveEntry(path);
+        entry.setSize(data.length);
+        entry.setMode(DEFAULT_FILE_MODE);
+        tar.putArchiveEntry(entry);
+        tar.write(data);
+        tar.closeArchiveEntry();
+    }
+
+    private void waitForPing(String host, int port) throws Exception {
+        long deadline = System.currentTimeMillis() + PING_TIMEOUT.toMillis();
+        URI uri = URI.create("http://" + host + ":" + port + "/ping");
+        int failures = 0;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                HttpRequest req = HttpRequest.newBuilder(uri).timeout(Duration.ofSeconds(2)).GET().build();
+                if (httpClient.send(req, HttpResponse.BodyHandlers.discarding()).statusCode() == 200) {
+                    return;
+                }
+                failures++;
+            } catch (ConnectException | HttpTimeoutException e) {
+                failures++;
+                if (failures % PING_LOG_FREQUENCY == 0) {
+                    LOG.warnv("Still waiting for SageMaker endpoint ping after {0} failures: {1}", failures, e.getMessage());
+                } else {
+                    LOG.debugv("Waiting for SageMaker endpoint ping: {0}", e.getMessage());
+                }
+            } catch (Exception e) {
+                failures++;
+                LOG.warnv("Waiting for SageMaker endpoint ping failed: {0}", e.getMessage());
+            }
+            Thread.sleep(1000);
+        }
+        throw new IllegalStateException("Container did not pass /ping health check");
+    }
+
+    @SuppressWarnings("unchecked")
+    static Map<String, String> map(Object value) {
+        if (value instanceof Map<?, ?> in) {
+            java.util.LinkedHashMap<String, String> out = new java.util.LinkedHashMap<>();
+            in.forEach((k, v) -> out.put(String.valueOf(k), v == null ? "" : String.valueOf(v)));
+            return out;
+        }
+        return Map.of();
+    }
+
+    static String string(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/sagemaker/SageMakerJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sagemaker/SageMakerJsonHandler.java
@@ -1,0 +1,43 @@
+package io.github.hectorvent.floci.services.sagemaker;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+
+@ApplicationScoped
+public class SageMakerJsonHandler {
+    private final SageMakerService service;
+
+    @Inject
+    public SageMakerJsonHandler(SageMakerService service) {
+        this.service = service;
+    }
+
+    public Response handle(String action, JsonNode request, String region) {
+        Object entity = switch (action) {
+            case "CreateModel" -> service.createModel(request, region);
+            case "DescribeModel" -> service.describeModel(request);
+            case "DeleteModel" -> service.deleteModel(request);
+            case "ListModels" -> service.listModels(request);
+            case "CreateEndpointConfig" -> service.createEndpointConfig(request, region);
+            case "DescribeEndpointConfig" -> service.describeEndpointConfig(request);
+            case "DeleteEndpointConfig" -> service.deleteEndpointConfig(request);
+            case "ListEndpointConfigs" -> service.listEndpointConfigs(request);
+            case "CreateEndpoint" -> service.createEndpoint(request, region);
+            case "DescribeEndpoint" -> service.describeEndpoint(request);
+            case "DeleteEndpoint" -> service.deleteEndpoint(request);
+            case "ListEndpoints" -> service.listEndpoints(request);
+            case "UpdateEndpoint" -> service.updateEndpoint(request);
+            case "CreateTrainingJob" -> service.createTrainingJob(request, region);
+            case "DescribeTrainingJob" -> service.describeTrainingJob(request);
+            case "ListTrainingJobs" -> service.listTrainingJobs(request);
+            case "StopTrainingJob" -> service.stopTrainingJob(request);
+            case "AddTags" -> service.addTags(request);
+            case "ListTags" -> service.listTags(request);
+            case "DeleteTags" -> service.deleteTags(request);
+            default -> throw SageMakerService.validation("Action " + action + " is not supported");
+        };
+        return Response.ok(entity).build();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/sagemaker/SageMakerRuntimeController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sagemaker/SageMakerRuntimeController.java
@@ -1,0 +1,81 @@
+package io.github.hectorvent.floci.services.sagemaker;
+
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.sagemaker.model.SageMakerEntities.EndpointResource;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Map;
+
+@Path("/endpoints")
+public class SageMakerRuntimeController {
+    private static final Logger LOG = Logger.getLogger(SageMakerRuntimeController.class);
+
+    private final SageMakerService service;
+    private final RegionResolver regionResolver;
+    private final HttpClient httpClient;
+
+    @Inject
+    public SageMakerRuntimeController(SageMakerService service, RegionResolver regionResolver) {
+        this.service = service;
+        this.regionResolver = regionResolver;
+        this.httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+    }
+
+    @POST
+    @Path("/{endpointName}/invocations")
+    @Consumes(MediaType.WILDCARD)
+    @Produces(MediaType.WILDCARD)
+    public Response invoke(@PathParam("endpointName") String endpointName,
+                           @HeaderParam("Content-Type") String contentType,
+                           @HeaderParam("Accept") String accept,
+                           @Context HttpHeaders headers,
+                           byte[] body) {
+        EndpointResource ep = service.endpoint(endpointName).orElse(null);
+        if (ep == null) {
+            return validation("Endpoint " + endpointName + " of account " + regionResolver.getAccountId() + " not found.");
+        }
+        if (!"InService".equals(ep.endpointStatus) || ep.invokeHost == null) {
+            return validation("Endpoint " + endpointName + " is not InService.");
+        }
+        try {
+            HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create("http://" + ep.invokeHost + ":" + ep.invokePort + "/invocations"))
+                    .timeout(Duration.ofSeconds(60))
+                    .POST(HttpRequest.BodyPublishers.ofByteArray(body == null ? new byte[0] : body));
+            if (contentType != null) {
+                builder.header("Content-Type", contentType);
+            }
+            if (accept != null) {
+                builder.header("Accept", accept);
+            }
+            HttpResponse<byte[]> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofByteArray());
+            // SageMaker Runtime maps model-container 5xx responses to ModelError (HTTP 424).
+            int status = response.statusCode() >= 500 ? 424 : response.statusCode();
+            Response.ResponseBuilder out = Response.status(status).entity(response.body());
+            response.headers().firstValue("Content-Type").ifPresent(out::type);
+            return out.build();
+        } catch (Exception e) {
+            LOG.warnv("SageMaker endpoint invocation failed for {0}: {1}", endpointName, e.getMessage());
+            return Response.status(424).entity(Map.of("__type", "ModelError", "message", e.getMessage())).build();
+        }
+    }
+
+    private Response validation(String message) {
+        return Response.status(400).entity(Map.of("__type", "ValidationError", "message", message)).build();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/sagemaker/SageMakerRuntimeController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sagemaker/SageMakerRuntimeController.java
@@ -71,7 +71,8 @@ public class SageMakerRuntimeController {
             return out.build();
         } catch (Exception e) {
             LOG.warnv("SageMaker endpoint invocation failed for {0}: {1}", endpointName, e.getMessage());
-            return Response.status(424).entity(Map.of("__type", "ModelError", "message", e.getMessage())).build();
+            return Response.status(424).type(MediaType.APPLICATION_JSON)
+                    .entity(Map.of("__type", "ModelError", "message", e.getMessage())).build();
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/sagemaker/SageMakerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sagemaker/SageMakerService.java
@@ -1,0 +1,539 @@
+package io.github.hectorvent.floci.services.sagemaker;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.sagemaker.model.SageMakerEntities.EndpointConfigResource;
+import io.github.hectorvent.floci.services.sagemaker.model.SageMakerEntities.EndpointResource;
+import io.github.hectorvent.floci.services.sagemaker.model.SageMakerEntities.ModelResource;
+import io.github.hectorvent.floci.services.sagemaker.model.SageMakerEntities.TrainingJobResource;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@ApplicationScoped
+public class SageMakerService {
+    static final int DEFAULT_LIMIT = 100;
+    private static final ObjectMapper STATIC_MAPPER = new ObjectMapper();
+
+    private final StorageBackend<String, ModelResource> modelStore;
+    private final StorageBackend<String, EndpointConfigResource> endpointConfigStore;
+    private final StorageBackend<String, EndpointResource> endpointStore;
+    private final StorageBackend<String, TrainingJobResource> trainingJobStore;
+    private final RegionResolver regionResolver;
+    private final ObjectMapper mapper;
+    private final SageMakerEndpointManager endpointManager;
+    private final SageMakerTrainingRunner trainingRunner;
+    private final Clock clock;
+
+    @Inject
+    public SageMakerService(StorageFactory storageFactory, RegionResolver regionResolver, ObjectMapper mapper,
+                            SageMakerEndpointManager endpointManager, SageMakerTrainingRunner trainingRunner) {
+        this(storageFactory.create("sagemaker", "sagemaker-models.json", new TypeReference<Map<String, ModelResource>>() {}),
+                storageFactory.create("sagemaker", "sagemaker-endpoint-configs.json", new TypeReference<Map<String, EndpointConfigResource>>() {}),
+                storageFactory.create("sagemaker", "sagemaker-endpoints.json", new TypeReference<Map<String, EndpointResource>>() {}),
+                storageFactory.create("sagemaker", "sagemaker-training-jobs.json", new TypeReference<Map<String, TrainingJobResource>>() {}),
+                regionResolver, mapper, endpointManager, trainingRunner, Clock.systemUTC());
+    }
+
+    SageMakerService(StorageBackend<String, ModelResource> modelStore,
+                     StorageBackend<String, EndpointConfigResource> endpointConfigStore,
+                     StorageBackend<String, EndpointResource> endpointStore,
+                     StorageBackend<String, TrainingJobResource> trainingJobStore,
+                     RegionResolver regionResolver,
+                     ObjectMapper mapper,
+                     SageMakerEndpointManager endpointManager,
+                     SageMakerTrainingRunner trainingRunner) {
+        this(modelStore, endpointConfigStore, endpointStore, trainingJobStore, regionResolver, mapper, endpointManager,
+                trainingRunner, Clock.systemUTC());
+    }
+
+    SageMakerService(StorageBackend<String, ModelResource> modelStore,
+                     StorageBackend<String, EndpointConfigResource> endpointConfigStore,
+                     StorageBackend<String, EndpointResource> endpointStore,
+                     StorageBackend<String, TrainingJobResource> trainingJobStore,
+                     RegionResolver regionResolver,
+                     ObjectMapper mapper,
+                     SageMakerEndpointManager endpointManager,
+                     SageMakerTrainingRunner trainingRunner,
+                     Clock clock) {
+        this.modelStore = modelStore;
+        this.endpointConfigStore = endpointConfigStore;
+        this.endpointStore = endpointStore;
+        this.trainingJobStore = trainingJobStore;
+        this.regionResolver = regionResolver;
+        this.mapper = mapper;
+        this.endpointManager = endpointManager;
+        this.trainingRunner = trainingRunner;
+        this.clock = clock;
+    }
+
+    public synchronized ObjectNode createModel(JsonNode request, String region) {
+        String name = required(request, "ModelName");
+        if (model(name).isPresent()) {
+            throw new AwsException("ValidationException", "Cannot create already existing model \"" + name + "\".", 400);
+        }
+        JsonNode primary = request.path("PrimaryContainer");
+        if (!primary.isObject() && !request.path("Containers").isArray()) {
+            throw validation("PrimaryContainer or Containers is required");
+        }
+        ModelResource model = new ModelResource();
+        model.modelName = name;
+        model.modelArn = arn(region, "model/" + name);
+        model.executionRoleArn = text(request, "ExecutionRoleArn");
+        model.creationTime = nowMillis();
+        model.region = region;
+        model.accountId = regionResolver.getAccountId();
+        model.primaryContainer = primary.isObject() ? map(primary) : map(request.path("Containers").get(0));
+        model.containers = listMap(request.path("Containers"));
+        model.tags = tagsFromList(request.path("Tags"));
+        modelStore.put(name, model);
+        ObjectNode out = mapper.createObjectNode();
+        out.put("ModelArn", model.modelArn);
+        return out;
+    }
+
+    public ObjectNode describeModel(JsonNode request) {
+        String name = required(request, "ModelName");
+        ModelResource m = model(name).orElseThrow(() -> validation("Could not find model \"" + name + "\"."));
+        ObjectNode out = mapper.createObjectNode();
+        out.put("ModelName", m.modelName);
+        out.put("ModelArn", m.modelArn);
+        out.set("PrimaryContainer", mapper.valueToTree(m.primaryContainer));
+        if (!m.containers.isEmpty()) {
+            out.set("Containers", mapper.valueToTree(m.containers));
+        }
+        if (m.executionRoleArn != null) {
+            out.put("ExecutionRoleArn", m.executionRoleArn);
+        }
+        out.put("CreationTime", epoch(m.creationTime));
+        return out;
+    }
+
+    public synchronized ObjectNode deleteModel(JsonNode request) {
+        String name = required(request, "ModelName");
+        model(name).orElseThrow(() -> validation("Could not find model \"" + name + "\"."));
+        modelStore.delete(name);
+        return mapper.createObjectNode();
+    }
+
+    public ObjectNode listModels(JsonNode request) {
+        List<ModelResource> models = modelStore.scan(k -> true).stream()
+                .sorted(Comparator.comparing(m -> m.modelName)).toList();
+        ArrayNode arr = mapper.createArrayNode();
+        page(models, request).forEach(m -> {
+            ObjectNode n = mapper.createObjectNode();
+            n.put("ModelName", m.modelName);
+            n.put("ModelArn", m.modelArn);
+            n.put("CreationTime", epoch(m.creationTime));
+            arr.add(n);
+        });
+        ObjectNode out = mapper.createObjectNode();
+        out.set("Models", arr);
+        return out;
+    }
+
+    public synchronized ObjectNode createEndpointConfig(JsonNode request, String region) {
+        String name = required(request, "EndpointConfigName");
+        if (endpointConfig(name).isPresent()) {
+            throw new AwsException("ValidationException", "Cannot create already existing endpoint configuration \"" + name + "\".", 400);
+        }
+        List<Map<String, Object>> variants = listMap(request.path("ProductionVariants"));
+        if (variants.isEmpty()) {
+            throw validation("ProductionVariants is required");
+        }
+        for (Map<String, Object> v : variants) {
+            String modelName = SageMakerEndpointManager.string(v.get("ModelName"));
+            if (modelName == null || modelName.isBlank()) {
+                throw validation("ProductionVariants.ModelName is required");
+            }
+            if (model(modelName).isEmpty()) {
+                throw validation("Could not find model \"" + modelName + "\".");
+            }
+        }
+        EndpointConfigResource cfg = new EndpointConfigResource();
+        cfg.endpointConfigName = name;
+        cfg.endpointConfigArn = arn(region, "endpoint-config/" + name);
+        cfg.productionVariants = variants;
+        cfg.creationTime = nowMillis();
+        cfg.region = region;
+        cfg.accountId = regionResolver.getAccountId();
+        cfg.tags = tagsFromList(request.path("Tags"));
+        endpointConfigStore.put(name, cfg);
+        ObjectNode out = mapper.createObjectNode();
+        out.put("EndpointConfigArn", cfg.endpointConfigArn);
+        return out;
+    }
+
+    public ObjectNode describeEndpointConfig(JsonNode request) {
+        String name = required(request, "EndpointConfigName");
+        EndpointConfigResource cfg = endpointConfig(name)
+                .orElseThrow(() -> validation("Could not find endpoint configuration \"" + name + "\"."));
+        ObjectNode out = mapper.createObjectNode();
+        out.put("EndpointConfigName", cfg.endpointConfigName);
+        out.put("EndpointConfigArn", cfg.endpointConfigArn);
+        out.set("ProductionVariants", mapper.valueToTree(cfg.productionVariants));
+        out.put("CreationTime", epoch(cfg.creationTime));
+        return out;
+    }
+
+    public synchronized ObjectNode deleteEndpointConfig(JsonNode request) {
+        String name = required(request, "EndpointConfigName");
+        endpointConfig(name).orElseThrow(() -> validation("Could not find endpoint configuration \"" + name + "\"."));
+        endpointConfigStore.delete(name);
+        return mapper.createObjectNode();
+    }
+
+    public ObjectNode listEndpointConfigs(JsonNode request) {
+        ArrayNode arr = mapper.createArrayNode();
+        endpointConfigStore.scan(k -> true).stream().sorted(Comparator.comparing(c -> c.endpointConfigName)).forEach(c -> {
+            ObjectNode n = mapper.createObjectNode();
+            n.put("EndpointConfigName", c.endpointConfigName);
+            n.put("EndpointConfigArn", c.endpointConfigArn);
+            n.put("CreationTime", epoch(c.creationTime));
+            arr.add(n);
+        });
+        ObjectNode out = mapper.createObjectNode();
+        out.set("EndpointConfigs", arr);
+        return out;
+    }
+
+    public synchronized ObjectNode createEndpoint(JsonNode request, String region) {
+        String name = required(request, "EndpointName");
+        if (endpoint(name).isPresent()) {
+            throw new AwsException("ValidationException", "Cannot create already existing endpoint \"" + name + "\".", 400);
+        }
+        String cfgName = required(request, "EndpointConfigName");
+        endpointConfig(cfgName).orElseThrow(() -> validation("Could not find endpoint configuration \"" + cfgName + "\"."));
+        EndpointResource ep = new EndpointResource();
+        ep.endpointName = name;
+        ep.endpointArn = arn(region, "endpoint/" + name);
+        ep.endpointConfigName = cfgName;
+        ep.endpointStatus = "Creating";
+        ep.creationTime = nowMillis();
+        ep.lastModifiedTime = ep.creationTime;
+        ep.region = region;
+        ep.accountId = regionResolver.getAccountId();
+        ep.tags = tagsFromList(request.path("Tags"));
+        endpointStore.put(name, ep);
+        endpointManager.startEndpointAsync(ep, this);
+        ObjectNode out = mapper.createObjectNode();
+        out.put("EndpointArn", ep.endpointArn);
+        return out;
+    }
+
+    public synchronized ObjectNode updateEndpoint(JsonNode request) {
+        String name = required(request, "EndpointName");
+        EndpointResource ep = endpoint(name).orElseThrow(() -> validation("Could not find endpoint \"" + name + "\"."));
+        String cfgName = required(request, "EndpointConfigName");
+        endpointConfig(cfgName).orElseThrow(() -> validation("Could not find endpoint configuration \"" + cfgName + "\"."));
+        if (ep.containerId != null) {
+            endpointManager.stopEndpoint(ep);
+        }
+        ep.endpointConfigName = cfgName;
+        ep.endpointStatus = "Creating";
+        ep.failureReason = null;
+        ep.lastModifiedTime = nowMillis();
+        endpointStore.put(name, ep);
+        endpointManager.startEndpointAsync(ep, this);
+        ObjectNode out = mapper.createObjectNode();
+        out.put("EndpointArn", ep.endpointArn);
+        return out;
+    }
+
+    public ObjectNode describeEndpoint(JsonNode request) {
+        String name = required(request, "EndpointName");
+        EndpointResource ep = endpoint(name).orElseThrow(() -> validation("Could not find endpoint \"" + name + "\"."));
+        ObjectNode out = mapper.createObjectNode();
+        out.put("EndpointName", ep.endpointName);
+        out.put("EndpointArn", ep.endpointArn);
+        out.put("EndpointConfigName", ep.endpointConfigName);
+        out.put("EndpointStatus", ep.endpointStatus);
+        if (ep.failureReason != null) {
+            out.put("FailureReason", ep.failureReason);
+        }
+        out.put("CreationTime", epoch(ep.creationTime));
+        out.put("LastModifiedTime", epoch(ep.lastModifiedTime));
+        return out;
+    }
+
+    public synchronized ObjectNode deleteEndpoint(JsonNode request) {
+        String name = required(request, "EndpointName");
+        EndpointResource ep = endpoint(name).orElseThrow(() -> validation("Could not find endpoint \"" + name + "\"."));
+        ep.endpointStatus = "Deleting";
+        endpointStore.put(name, ep);
+        endpointManager.stopEndpoint(ep);
+        endpointStore.delete(name);
+        return mapper.createObjectNode();
+    }
+
+    public ObjectNode listEndpoints(JsonNode request) {
+        ArrayNode arr = mapper.createArrayNode();
+        endpointStore.scan(k -> true).stream().sorted(Comparator.comparing(e -> e.endpointName)).forEach(e -> {
+            ObjectNode n = mapper.createObjectNode();
+            n.put("EndpointName", e.endpointName);
+            n.put("EndpointArn", e.endpointArn);
+            n.put("EndpointStatus", e.endpointStatus);
+            n.put("CreationTime", epoch(e.creationTime));
+            n.put("LastModifiedTime", epoch(e.lastModifiedTime));
+            arr.add(n);
+        });
+        ObjectNode out = mapper.createObjectNode();
+        out.set("Endpoints", arr);
+        return out;
+    }
+
+    public synchronized ObjectNode createTrainingJob(JsonNode request, String region) {
+        String name = required(request, "TrainingJobName");
+        if (trainingJob(name).isPresent()) {
+            throw new AwsException("ResourceInUse", "Training job already exists: " + name, 400);
+        }
+        if (!request.path("AlgorithmSpecification").isObject() || text(request.path("AlgorithmSpecification"), "TrainingImage") == null) {
+            throw validation("AlgorithmSpecification.TrainingImage is required");
+        }
+        if (!request.path("OutputDataConfig").isObject() || text(request.path("OutputDataConfig"), "S3OutputPath") == null) {
+            throw validation("OutputDataConfig.S3OutputPath is required");
+        }
+        TrainingJobResource job = new TrainingJobResource();
+        job.trainingJobName = name;
+        job.trainingJobArn = arn(region, "training-job/" + name);
+        job.trainingJobStatus = "InProgress";
+        job.secondaryStatus = "Starting";
+        job.creationTime = nowMillis();
+        job.region = region;
+        job.accountId = regionResolver.getAccountId();
+        job.algorithmSpecification = map(request.path("AlgorithmSpecification"));
+        job.inputDataConfig = listMap(request.path("InputDataConfig"));
+        job.outputDataConfig = map(request.path("OutputDataConfig"));
+        job.resourceConfig = map(request.path("ResourceConfig"));
+        job.stoppingCondition = map(request.path("StoppingCondition"));
+        job.hyperParameters = stringMap(request.path("HyperParameters"));
+        job.tags = tagsFromList(request.path("Tags"));
+        trainingJobStore.put(name, job);
+        trainingRunner.runAsync(job, this);
+        ObjectNode out = mapper.createObjectNode();
+        out.put("TrainingJobArn", job.trainingJobArn);
+        return out;
+    }
+
+    public ObjectNode describeTrainingJob(JsonNode request) {
+        String name = required(request, "TrainingJobName");
+        TrainingJobResource job = trainingJob(name).orElseThrow(() -> validation("Could not find training job \"" + name + "\"."));
+        ObjectNode out = mapper.valueToTree(Map.of(
+                "TrainingJobName", job.trainingJobName,
+                "TrainingJobArn", job.trainingJobArn,
+                "TrainingJobStatus", job.trainingJobStatus,
+                "SecondaryStatus", job.secondaryStatus == null ? "" : job.secondaryStatus,
+                "AlgorithmSpecification", job.algorithmSpecification,
+                "InputDataConfig", job.inputDataConfig,
+                "OutputDataConfig", job.outputDataConfig,
+                "ResourceConfig", job.resourceConfig,
+                "StoppingCondition", job.stoppingCondition,
+                "CreationTime", epoch(job.creationTime)
+        ));
+        if (job.trainingStartTime > 0) {
+            out.put("TrainingStartTime", epoch(job.trainingStartTime));
+        }
+        if (job.trainingEndTime > 0) {
+            out.put("TrainingEndTime", epoch(job.trainingEndTime));
+        }
+        if (job.failureReason != null) {
+            out.put("FailureReason", job.failureReason);
+        }
+        if (job.modelArtifactsS3ModelArtifacts != null) {
+            ObjectNode ma = mapper.createObjectNode();
+            ma.put("S3ModelArtifacts", job.modelArtifactsS3ModelArtifacts);
+            out.set("ModelArtifacts", ma);
+        }
+        return out;
+    }
+
+    public ObjectNode listTrainingJobs(JsonNode request) {
+        ArrayNode arr = mapper.createArrayNode();
+        trainingJobStore.scan(k -> true).stream().sorted(Comparator.comparing(j -> j.trainingJobName)).forEach(j -> {
+            ObjectNode n = mapper.createObjectNode();
+            n.put("TrainingJobName", j.trainingJobName);
+            n.put("TrainingJobArn", j.trainingJobArn);
+            n.put("TrainingJobStatus", j.trainingJobStatus);
+            n.put("CreationTime", epoch(j.creationTime));
+            arr.add(n);
+        });
+        ObjectNode out = mapper.createObjectNode();
+        out.set("TrainingJobSummaries", arr);
+        return out;
+    }
+
+    public synchronized ObjectNode stopTrainingJob(JsonNode request) {
+        String name = required(request, "TrainingJobName");
+        TrainingJobResource job = trainingJob(name).orElseThrow(() -> validation("Could not find training job \"" + name + "\"."));
+        trainingRunner.stop(job);
+        job.trainingJobStatus = "Stopped";
+        job.secondaryStatus = "Stopped";
+        job.trainingEndTime = nowMillis();
+        trainingJobStore.put(name, job);
+        return mapper.createObjectNode();
+    }
+
+    public synchronized ObjectNode addTags(JsonNode request) {
+        String arn = required(request, "ResourceArn");
+        Map<String, String> tags = tagsFromList(request.path("Tags"));
+        resourceTags(arn).putAll(tags);
+        persistByArn(arn);
+        ObjectNode out = mapper.createObjectNode();
+        out.set("Tags", tagsArray(resourceTags(arn)));
+        return out;
+    }
+
+    public ObjectNode listTags(JsonNode request) {
+        String arn = required(request, "ResourceArn");
+        ObjectNode out = mapper.createObjectNode();
+        out.set("Tags", tagsArray(resourceTags(arn)));
+        return out;
+    }
+
+    public synchronized ObjectNode deleteTags(JsonNode request) {
+        String arn = required(request, "ResourceArn");
+        Map<String, String> tags = resourceTags(arn);
+        request.path("TagKeys").forEach(k -> tags.remove(k.asText()));
+        persistByArn(arn);
+        return mapper.createObjectNode();
+    }
+
+    Optional<ModelResource> model(String name) {
+        return modelStore.get(name);
+    }
+
+    Optional<EndpointConfigResource> endpointConfig(String name) {
+        return endpointConfigStore.get(name);
+    }
+
+    Optional<EndpointResource> endpoint(String name) {
+        return endpointStore.get(name);
+    }
+
+    Optional<TrainingJobResource> trainingJob(String name) {
+        return trainingJobStore.get(name);
+    }
+
+    public ModelResource modelForEndpoint(EndpointResource ep) {
+        EndpointConfigResource cfg = endpointConfig(ep.endpointConfigName)
+                .orElseThrow(() -> validation("Could not find endpoint configuration \"" + ep.endpointConfigName + "\"."));
+        String modelName = String.valueOf(cfg.productionVariants.get(0).get("ModelName"));
+        return model(modelName).orElseThrow(() -> validation("Could not find model \"" + modelName + "\"."));
+    }
+
+    public synchronized void updateEndpoint(EndpointResource ep) {
+        ep.lastModifiedTime = nowMillis();
+        endpointStore.put(ep.endpointName, ep);
+    }
+
+    public synchronized void updateTrainingJob(TrainingJobResource job) {
+        trainingJobStore.put(job.trainingJobName, job);
+    }
+
+    private Map<String, String> resourceTags(String arn) {
+        String name = arn.substring(arn.lastIndexOf('/') + 1);
+        if (arn.contains(":model/")) return model(name).orElseThrow(() -> validation("Could not find model \"" + name + "\".")).tags;
+        if (arn.contains(":endpoint-config/")) return endpointConfig(name).orElseThrow(() -> validation("Could not find endpoint configuration \"" + name + "\".")).tags;
+        if (arn.contains(":endpoint/")) return endpoint(name).orElseThrow(() -> validation("Could not find endpoint \"" + name + "\".")).tags;
+        if (arn.contains(":training-job/")) return trainingJob(name).orElseThrow(() -> validation("Could not find training job \"" + name + "\".")).tags;
+        throw validation("ResourceArn is invalid");
+    }
+
+    private void persistByArn(String arn) {
+        String name = arn.substring(arn.lastIndexOf('/') + 1);
+        if (arn.contains(":model/")) model(name).ifPresent(v -> modelStore.put(name, v));
+        else if (arn.contains(":endpoint-config/")) endpointConfig(name).ifPresent(v -> endpointConfigStore.put(name, v));
+        else if (arn.contains(":endpoint/")) endpoint(name).ifPresent(v -> endpointStore.put(name, v));
+        else if (arn.contains(":training-job/")) trainingJob(name).ifPresent(v -> trainingJobStore.put(name, v));
+    }
+
+    private String arn(String region, String resource) {
+        return "arn:aws:sagemaker:" + region + ":" + regionResolver.getAccountId() + ":" + resource;
+    }
+
+    private long nowMillis() {
+        return clock.millis();
+    }
+
+    static double epoch(long millis) {
+        return millis / 1000.0;
+    }
+
+    static AwsException validation(String message) {
+        return new AwsException("ValidationException", message, 400);
+    }
+
+    static String required(JsonNode node, String field) {
+        String value = text(node, field);
+        if (value == null || value.isBlank()) {
+            throw validation(field + " is required");
+        }
+        return value;
+    }
+
+    static String text(JsonNode node, String field) {
+        JsonNode v = node.path(field);
+        return v.isMissingNode() || v.isNull() ? null : v.asText();
+    }
+
+    static Map<String, Object> map(JsonNode node) {
+        if (!node.isObject()) {
+            return new LinkedHashMap<>();
+        }
+        return STATIC_MAPPER.convertValue(node, new TypeReference<LinkedHashMap<String, Object>>() {});
+    }
+
+    static Map<String, String> stringMap(JsonNode node) {
+        Map<String, String> out = new LinkedHashMap<>();
+        if (node.isObject()) {
+            node.fields().forEachRemaining(e -> out.put(e.getKey(), e.getValue().asText()));
+        }
+        return out;
+    }
+
+    static List<Map<String, Object>> listMap(JsonNode node) {
+        List<Map<String, Object>> out = new ArrayList<>();
+        if (node.isArray()) {
+            node.forEach(n -> out.add(map(n)));
+        }
+        return out;
+    }
+
+    static Map<String, String> tagsFromList(JsonNode node) {
+        Map<String, String> out = new LinkedHashMap<>();
+        if (node.isArray()) {
+            node.forEach(t -> out.put(text(t, "Key"), text(t, "Value")));
+        }
+        return out;
+    }
+
+    private ArrayNode tagsArray(Map<String, String> tags) {
+        ArrayNode arr = mapper.createArrayNode();
+        tags.forEach((k, v) -> {
+            ObjectNode n = mapper.createObjectNode();
+            n.put("Key", k);
+            n.put("Value", v);
+            arr.add(n);
+        });
+        return arr;
+    }
+
+    private <T> List<T> page(List<T> values, JsonNode request) {
+        int max = request.path("MaxResults").asInt(DEFAULT_LIMIT);
+        return values.stream().limit(max).toList();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/sagemaker/SageMakerTrainingRunner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sagemaker/SageMakerTrainingRunner.java
@@ -1,0 +1,311 @@
+package io.github.hectorvent.floci.services.sagemaker;
+
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.core.command.LogContainerResultCallback;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.ContainerTeardown;
+import io.github.hectorvent.floci.core.common.dns.EmbeddedDnsServer;
+import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
+import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
+import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
+import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
+import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.s3.model.S3Object;
+import io.github.hectorvent.floci.services.sagemaker.model.SageMakerEntities.TrainingJobResource;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.jboss.logging.Logger;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@ApplicationScoped
+public class SageMakerTrainingRunner implements ContainerTeardown {
+    private static final Logger LOG = Logger.getLogger(SageMakerTrainingRunner.class);
+    private static final String LOG_GROUP = "/aws/sagemaker/TrainingJobs";
+
+    private final ContainerBuilder containerBuilder;
+    private final ContainerLifecycleManager lifecycleManager;
+    private final ContainerLogStreamer logStreamer;
+    private final EmulatorConfig config;
+    private final ContainerDetector containerDetector;
+    private final S3Service s3Service;
+    private final ObjectMapper mapper;
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+    private final ConcurrentHashMap<String, String> containers = new ConcurrentHashMap<>();
+
+    @Inject
+    public SageMakerTrainingRunner(ContainerBuilder containerBuilder, ContainerLifecycleManager lifecycleManager,
+                                   ContainerLogStreamer logStreamer, EmulatorConfig config,
+                                   ContainerDetector containerDetector, S3Service s3Service, ObjectMapper mapper) {
+        this.containerBuilder = containerBuilder;
+        this.lifecycleManager = lifecycleManager;
+        this.logStreamer = logStreamer;
+        this.config = config;
+        this.containerDetector = containerDetector;
+        this.s3Service = s3Service;
+        this.mapper = mapper;
+    }
+
+    public void runAsync(TrainingJobResource job, SageMakerService service) {
+        executor.submit(() -> run(job, service));
+    }
+
+    private void run(TrainingJobResource job, SageMakerService service) {
+        String containerId = null;
+        Closeable logs = null;
+        try {
+            String image = SageMakerEndpointManager.string(job.algorithmSpecification.get("TrainingImage"));
+            String name = ContainerStorageHelper.dockerName(config, "floci-sagemaker-training-" + job.trainingJobName);
+            lifecycleManager.removeIfExists(name);
+            ContainerBuilder.Builder builder = containerBuilder.newContainer(image)
+                    .withName(name)
+                    .withEnv(environment(job))
+                    .withDockerNetwork(config.services().sagemaker().dockerNetwork())
+                    .withHostDockerInternalOnLinux()
+                    .withEmbeddedDns()
+                    .withLogRotation();
+            SageMakerEndpointManager.applyEntrypoint(builder, job.algorithmSpecification, "train");
+            ContainerSpec spec = builder.build();
+            containerId = lifecycleManager.create(spec);
+            containers.put(job.trainingJobName, containerId);
+            job.containerId = containerId;
+            copyTrainingInput(containerId, job);
+            lifecycleManager.startCreated(containerId, spec);
+            job.trainingStartTime = System.currentTimeMillis();
+            job.secondaryStatus = "Training";
+            service.updateTrainingJob(job);
+            logs = logStreamer.attach(containerId, LOG_GROUP, job.trainingJobName + "/algo-1", job.region,
+                    "sagemaker:" + job.trainingJobName);
+            Integer exit = waitForExit(containerId, timeout(job));
+            if (exit == null) {
+                lifecycleManager.stopAndRemove(containerId, logs);
+                job.trainingJobStatus = "Failed";
+                job.secondaryStatus = "Failed";
+                job.failureReason = "Training job exceeded StoppingCondition.MaxRuntimeInSeconds";
+            } else if (exit == 0) {
+                job.modelArtifactsS3ModelArtifacts = uploadModelArtifacts(containerId, job);
+                lifecycleManager.stopAndRemove(containerId, logs);
+                job.trainingJobStatus = "Completed";
+                job.secondaryStatus = "Completed";
+            } else {
+                job.failureReason = readFailure(containerId, exit);
+                lifecycleManager.stopAndRemove(containerId, logs);
+                job.trainingJobStatus = "Failed";
+                job.secondaryStatus = "Failed";
+            }
+            containers.remove(job.trainingJobName);
+            job.trainingEndTime = System.currentTimeMillis();
+            service.updateTrainingJob(job);
+        } catch (Exception e) {
+            LOG.warnv("SageMaker training job {0} failed: {1}", job.trainingJobName, e.getMessage());
+            if (containerId != null) {
+                lifecycleManager.stopAndRemove(containerId, logs);
+            }
+            containers.remove(job.trainingJobName);
+            job.trainingJobStatus = "Failed";
+            job.secondaryStatus = "Failed";
+            job.failureReason = e.getMessage();
+            job.trainingEndTime = System.currentTimeMillis();
+            service.updateTrainingJob(job);
+        }
+    }
+
+    public void stop(TrainingJobResource job) {
+        String id = job.containerId != null ? job.containerId : containers.remove(job.trainingJobName);
+        if (id != null) {
+            lifecycleManager.stopAndRemove(id, null);
+        }
+    }
+
+    @Override
+    public void stopManagedContainers() {
+        containers.forEach((name, id) -> lifecycleManager.stopAndRemove(id, null));
+        containers.clear();
+        executor.shutdownNow();
+    }
+
+    private List<String> environment(TrainingJobResource job) {
+        List<String> env = new ArrayList<>();
+        env.add("TRAINING_JOB_NAME=" + job.trainingJobName);
+        env.add("TRAINING_JOB_ARN=" + job.trainingJobArn);
+        env.add("SAGEMAKER_REGION=" + job.region);
+        env.add("AWS_REGION=" + job.region);
+        env.add("AWS_DEFAULT_REGION=" + job.region);
+        env.add("AWS_ACCESS_KEY_ID=test");
+        env.add("AWS_SECRET_ACCESS_KEY=test");
+        env.add("AWS_SESSION_TOKEN=test");
+        String endpoint = "http://" + resolveEndpointHostname() + ":" + config.port();
+        env.add("AWS_ENDPOINT_URL=" + endpoint);
+        env.add("FLOCI_ENDPOINT=" + endpoint);
+        return env;
+    }
+
+    private String resolveEndpointHostname() {
+        return containerDetector.isRunningInContainer() ? config.hostname().orElse(EmbeddedDnsServer.DEFAULT_SUFFIX) : "host.docker.internal";
+    }
+
+    private void copyTrainingInput(String containerId, TrainingJobResource job) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (TarArchiveOutputStream tar = new TarArchiveOutputStream(out)) {
+            SageMakerEndpointManager.addFile(tar, "opt/ml/input/config/hyperparameters.json",
+                    mapper.writeValueAsBytes(job.hyperParameters));
+            SageMakerEndpointManager.addFile(tar, "opt/ml/input/config/resourceconfig.json",
+                    "{\"current_host\":\"algo-1\",\"hosts\":[\"algo-1\"]}".getBytes(StandardCharsets.UTF_8));
+            SageMakerEndpointManager.addFile(tar, "opt/ml/input/config/inputdataconfig.json",
+                    mapper.writeValueAsBytes(inputDataConfig(job.inputDataConfig)));
+            for (Map<String, Object> channel : job.inputDataConfig) {
+                copyChannelObjects(tar, channel);
+            }
+        }
+        lifecycleManager.getDockerClient().copyArchiveToContainerCmd(containerId)
+                .withRemotePath("/")
+                .withTarInputStream(new ByteArrayInputStream(out.toByteArray()))
+                .exec();
+    }
+
+    private Map<String, Object> inputDataConfig(List<Map<String, Object>> channels) {
+        Map<String, Object> out = new LinkedHashMap<>();
+        for (Map<String, Object> c : channels) {
+            Map<String, Object> value = new LinkedHashMap<>();
+            value.put("ContentType", c.getOrDefault("ContentType", "application/octet-stream"));
+            value.put("TrainingInputMode", c.getOrDefault("TrainingInputMode", "File"));
+            out.put(String.valueOf(c.get("ChannelName")), value);
+        }
+        return out;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void copyChannelObjects(TarArchiveOutputStream tar, Map<String, Object> channel) throws Exception {
+        String channelName = String.valueOf(channel.get("ChannelName"));
+        Object dataSource = channel.get("DataSource");
+        if (!(dataSource instanceof Map<?, ?> ds)) {
+            return;
+        }
+        Object s3 = ds.get("S3DataSource");
+        if (!(s3 instanceof Map<?, ?> s3ds)) {
+            return;
+        }
+        String s3Uri = String.valueOf(s3ds.get("S3Uri"));
+        S3Uri uri = S3Uri.parse(s3Uri);
+        List<S3Object> objects = uri.key().isBlank()
+                ? s3Service.listObjects(uri.bucket(), "", null, 1000)
+                : s3Service.listObjects(uri.bucket(), uri.key(), null, 1000);
+        for (S3Object object : objects) {
+            S3Object full = s3Service.getObject(uri.bucket(), object.getKey());
+            String base = object.getKey().substring(object.getKey().lastIndexOf('/') + 1);
+            if (!base.isBlank()) {
+                SageMakerEndpointManager.addFile(tar, "opt/ml/input/data/" + channelName + "/" + base, full.getData());
+            }
+        }
+    }
+
+    private Integer waitForExit(String containerId, Duration timeout) throws InterruptedException {
+        long deadline = timeout.isZero() ? Long.MAX_VALUE : System.currentTimeMillis() + timeout.toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            Integer exit = getExitCodeIfStopped(containerId);
+            if (exit != null) {
+                return exit;
+            }
+            Thread.sleep(500);
+        }
+        return null;
+    }
+
+    private Integer getExitCodeIfStopped(String containerId) {
+        try {
+            var inspect = lifecycleManager.getDockerClient().inspectContainerCmd(containerId).exec();
+            if (Boolean.TRUE.equals(inspect.getState().getRunning())) {
+                return null;
+            }
+            Long exit = inspect.getState().getExitCodeLong();
+            return exit == null ? 0 : exit.intValue();
+        } catch (NotFoundException e) {
+            return 1;
+        }
+    }
+
+    private Duration timeout(TrainingJobResource job) {
+        Object value = job.stoppingCondition.get("MaxRuntimeInSeconds");
+        if (value instanceof Number n) {
+            return Duration.ofSeconds(n.longValue());
+        }
+        return Duration.ZERO;
+    }
+
+    private String uploadModelArtifacts(String containerId, TrainingJobResource job) throws Exception {
+        byte[] data = modelTarGz(containerId);
+        S3Uri out = S3Uri.parse(String.valueOf(job.outputDataConfig.get("S3OutputPath")));
+        String prefix = out.key().isBlank() ? "" : (out.key().endsWith("/") ? out.key() : out.key() + "/");
+        String key = prefix + job.trainingJobName + "/output/model.tar.gz";
+        s3Service.putObject(out.bucket(), key, data, "application/x-tar", Map.of());
+        return "s3://" + out.bucket() + "/" + key;
+    }
+
+    private byte[] modelTarGz(String containerId) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (GzipCompressorOutputStream gz = new GzipCompressorOutputStream(out);
+             TarArchiveOutputStream tarOut = new TarArchiveOutputStream(gz);
+             InputStream dockerTar = lifecycleManager.getDockerClient().copyArchiveFromContainerCmd(containerId, "/opt/ml/model").exec();
+             TarArchiveInputStream tarIn = new TarArchiveInputStream(dockerTar)) {
+            TarArchiveEntry e;
+            String prefix = null;
+            while ((e = tarIn.getNextEntry()) != null) {
+                if (!tarIn.canReadEntryData(e) || e.isDirectory()) continue;
+                String name = e.getName();
+                if (prefix == null) {
+                    int slash = name.indexOf('/');
+                    prefix = slash >= 0 ? name.substring(0, slash + 1) : "";
+                }
+                if (!prefix.isBlank() && name.startsWith(prefix)) {
+                    name = name.substring(prefix.length());
+                }
+                if (!name.isBlank()) {
+                    SageMakerEndpointManager.addFile(tarOut, name, tarIn.readAllBytes());
+                }
+            }
+        }
+        return out.toByteArray();
+    }
+
+    private String readFailure(String containerId, int exitCode) {
+        StringBuilder sb = new StringBuilder();
+        try {
+            lifecycleManager.getDockerClient().logContainerCmd(containerId)
+                    .withStdErr(true).withTail(20)
+                    .exec(new LogContainerResultCallback() {
+                        @Override
+                        public void onNext(Frame item) {
+                            sb.append(new String(item.getPayload(), StandardCharsets.UTF_8));
+                        }
+                    }).awaitCompletion(Duration.ofSeconds(2).toMillis(), java.util.concurrent.TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            LOG.warnv("Interrupted while reading SageMaker training failure log for container {0}: {1}", containerId, e.getMessage());
+            Thread.currentThread().interrupt();
+            return "Container exited with code " + exitCode;
+        } catch (Exception e) {
+            LOG.warnv("Could not read SageMaker training failure log for container {0}: {1}", containerId, e.getMessage());
+        }
+        String detail = sb.toString().trim();
+        return detail.isBlank() ? "Container exited with code " + exitCode : detail;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/sagemaker/model/SageMakerEntities.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sagemaker/model/SageMakerEntities.java
@@ -1,0 +1,83 @@
+package io.github.hectorvent.floci.services.sagemaker.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@RegisterForReflection
+public final class SageMakerEntities {
+    private SageMakerEntities() {
+    }
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ModelResource {
+        public String modelName;
+        public String modelArn;
+        public Map<String, Object> primaryContainer = new LinkedHashMap<>();
+        public List<Map<String, Object>> containers = new ArrayList<>();
+        public String executionRoleArn;
+        public long creationTime;
+        public String region;
+        public String accountId;
+        public Map<String, String> tags = new LinkedHashMap<>();
+    }
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class EndpointConfigResource {
+        public String endpointConfigName;
+        public String endpointConfigArn;
+        public List<Map<String, Object>> productionVariants = new ArrayList<>();
+        public long creationTime;
+        public String region;
+        public String accountId;
+        public Map<String, String> tags = new LinkedHashMap<>();
+    }
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class EndpointResource {
+        public String endpointName;
+        public String endpointArn;
+        public String endpointConfigName;
+        public String endpointStatus;
+        public String failureReason;
+        public long creationTime;
+        public long lastModifiedTime;
+        public String region;
+        public String accountId;
+        public String containerId;
+        public String invokeHost;
+        public int invokePort;
+        public Map<String, String> tags = new LinkedHashMap<>();
+    }
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class TrainingJobResource {
+        public String trainingJobName;
+        public String trainingJobArn;
+        public String trainingJobStatus;
+        public String secondaryStatus;
+        public String failureReason;
+        public long creationTime;
+        public long trainingStartTime;
+        public long trainingEndTime;
+        public String region;
+        public String accountId;
+        public Map<String, Object> algorithmSpecification = new LinkedHashMap<>();
+        public List<Map<String, Object>> inputDataConfig = new ArrayList<>();
+        public Map<String, Object> outputDataConfig = new LinkedHashMap<>();
+        public Map<String, Object> resourceConfig = new LinkedHashMap<>();
+        public Map<String, Object> stoppingCondition = new LinkedHashMap<>();
+        public Map<String, String> hyperParameters = new LinkedHashMap<>();
+        public String modelArtifactsS3ModelArtifacts;
+        public String containerId;
+        public Map<String, String> tags = new LinkedHashMap<>();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -105,6 +105,8 @@ floci:
         flush-interval-ms: 5000
       opensearch:
         flush-interval-ms: 5000
+      sagemaker:
+        flush-interval-ms: 5000
       batch:
         flush-interval-ms: 5000
       lightsail:
@@ -378,6 +380,9 @@ floci:
       enabled: true
       mock: false
     codebuild:
+      enabled: true
+      # docker-network: floci-network
+    sagemaker:
       enabled: true
       # docker-network: floci-network
     batch:

--- a/src/test/java/io/github/hectorvent/floci/services/sagemaker/SageMakerDockerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sagemaker/SageMakerDockerIntegrationTest.java
@@ -1,0 +1,127 @@
+package io.github.hectorvent.floci.services.sagemaker;
+
+import com.github.dockerjava.api.DockerClient;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@QuarkusTest
+class SageMakerDockerIntegrationTest {
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/sagemaker/aws4_request";
+
+    @Inject DockerClient dockerClient;
+    @Inject S3Service s3Service;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @BeforeEach
+    void requireDocker() {
+        Assumptions.assumeTrue(isDockerAvailable(), "Docker daemon must be available for SageMaker Docker tests");
+    }
+
+    @Test
+    void trainingJobRunsRealContainerAndUploadsModelArtifacts() throws Exception {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String bucket = "sm-train-" + suffix;
+        s3Service.createBucket(bucket, "us-east-1");
+        s3Service.putObject(bucket, "input/data.txt", "hello".getBytes(StandardCharsets.UTF_8), "text/plain", Map.of());
+        String job = "sm-train-" + suffix;
+        post("SageMaker.CreateTrainingJob", """
+                {
+                  "TrainingJobName":"%s",
+                  "AlgorithmSpecification":{
+                    "TrainingImage":"public.ecr.aws/docker/library/busybox:stable",
+                    "ContainerEntrypoint":["/bin/sh","-c"],
+                    "ContainerArguments":["mkdir -p /opt/ml/model && cp /opt/ml/input/data/train/data.txt /opt/ml/model/model.txt"]
+                  },
+                  "InputDataConfig":[{"ChannelName":"train","DataSource":{"S3DataSource":{"S3Uri":"s3://%s/input"}},"ContentType":"text/plain","TrainingInputMode":"File"}],
+                  "OutputDataConfig":{"S3OutputPath":"s3://%s/output"},
+                  "ResourceConfig":{"InstanceType":"ml.m5.large","InstanceCount":1,"VolumeSizeInGB":1},
+                  "StoppingCondition":{"MaxRuntimeInSeconds":60}
+                }
+                """.formatted(job, bucket, bucket)).then().statusCode(200).body("TrainingJobArn", notNullValue());
+
+        waitForTraining(job, "Completed");
+        String artifact = post("SageMaker.DescribeTrainingJob", "{\"TrainingJobName\":\"%s\"}".formatted(job))
+                .then().statusCode(200).body("TrainingJobStatus", equalTo("Completed"))
+                .extract().path("ModelArtifacts.S3ModelArtifacts");
+        S3Uri uri = S3Uri.parse(artifact);
+        assertNotNull(s3Service.getObject(uri.bucket(), uri.key()).getData());
+    }
+
+    @Test
+    void endpointHostsRealContainerAndRuntimeProxiesInvocations() throws Exception {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String model = "sm-ep-model-" + suffix;
+        String cfg = "sm-ep-cfg-" + suffix;
+        String endpoint = "sm-endpoint-" + suffix;
+        String script = "cat > /server.py <<'PY'\nfrom http.server import BaseHTTPRequestHandler,HTTPServer\nclass H(BaseHTTPRequestHandler):\n def do_GET(self):\n  self.send_response(200 if self.path == '/ping' else 404); self.end_headers()\n def do_POST(self):\n  n=int(self.headers.get('content-length','0')); b=self.rfile.read(n); self.send_response(200); self.send_header('Content-Type','text/plain'); self.end_headers(); self.wfile.write(b.upper())\nHTTPServer(('0.0.0.0',8080),H).serve_forever()\nPY\npython /server.py";
+        post("SageMaker.CreateModel", """
+                {"ModelName":"%s","PrimaryContainer":{"Image":"public.ecr.aws/docker/library/python:3-alpine","ContainerEntrypoint":["/bin/sh","-c"],"ContainerArguments":[%s]}}
+                """.formatted(model, json(script))).then().statusCode(200);
+        post("SageMaker.CreateEndpointConfig", """
+                {"EndpointConfigName":"%s","ProductionVariants":[{"VariantName":"AllTraffic","ModelName":"%s","InitialInstanceCount":1,"InstanceType":"ml.t2.medium","InitialVariantWeight":1.0}]}
+                """.formatted(cfg, model)).then().statusCode(200);
+        post("SageMaker.CreateEndpoint", "{\"EndpointName\":\"%s\",\"EndpointConfigName\":\"%s\"}".formatted(endpoint, cfg))
+                .then().statusCode(200);
+        waitForEndpoint(endpoint, "InService");
+        given().header("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/runtime.sagemaker/aws4_request")
+                .contentType("text/plain").body("hello")
+                .when().post("/endpoints/%s/invocations".formatted(endpoint))
+                .then().statusCode(200).body(equalTo("HELLO"));
+        post("SageMaker.DeleteEndpoint", "{\"EndpointName\":\"%s\"}".formatted(endpoint)).then().statusCode(200);
+    }
+
+    private void waitForTraining(String job, String status) throws Exception {
+        long deadline = System.currentTimeMillis() + Duration.ofSeconds(120).toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            String current = post("SageMaker.DescribeTrainingJob", "{\"TrainingJobName\":\"%s\"}".formatted(job)).then().statusCode(200).extract().path("TrainingJobStatus");
+            if (status.equals(current)) return;
+            if ("Failed".equals(current)) throw new AssertionError("Training failed");
+            Thread.sleep(1000);
+        }
+        throw new AssertionError("Timed out waiting for training job");
+    }
+
+    private void waitForEndpoint(String endpoint, String status) throws Exception {
+        long deadline = System.currentTimeMillis() + Duration.ofSeconds(150).toMillis();
+        while (System.currentTimeMillis() < deadline) {
+            String current = post("SageMaker.DescribeEndpoint", "{\"EndpointName\":\"%s\"}".formatted(endpoint)).then().statusCode(200).extract().path("EndpointStatus");
+            if (status.equals(current)) return;
+            if ("Failed".equals(current)) throw new AssertionError("Endpoint failed");
+            Thread.sleep(1000);
+        }
+        throw new AssertionError("Timed out waiting for endpoint");
+    }
+
+    private io.restassured.response.Response post(String target, String body) {
+        return given().header("Authorization", AUTH).header("X-Amz-Target", target)
+                .contentType("application/x-amz-json-1.1").body(body).when().post("/");
+    }
+
+    private boolean isDockerAvailable() {
+        try { dockerClient.pingCmd().exec(); return true; } catch (Exception e) { return false; }
+    }
+
+    private String json(String value) {
+        return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n") + "\"";
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/sagemaker/SageMakerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sagemaker/SageMakerIntegrationTest.java
@@ -1,0 +1,67 @@
+package io.github.hectorvent.floci.services.sagemaker;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+
+@QuarkusTest
+class SageMakerIntegrationTest {
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/sagemaker/aws4_request";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void jsonControlPlaneModelEndpointConfigAndTags() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String model = "sm-model-" + suffix;
+        String arn = post("SageMaker.CreateModel", """
+                {"ModelName":"%s","PrimaryContainer":{"Image":"busybox:stable"},"Tags":[{"Key":"env","Value":"test"}]}
+                """.formatted(model))
+                .then().statusCode(200).body("ModelArn", notNullValue()).extract().path("ModelArn");
+
+        post("SageMaker.DescribeModel", "{\"ModelName\":\"%s\"}".formatted(model))
+                .then().statusCode(200).body("ModelName", equalTo(model)).body("PrimaryContainer.Image", equalTo("busybox:stable"));
+
+        String cfg = "sm-cfg-" + suffix;
+        post("SageMaker.CreateEndpointConfig", """
+                {"EndpointConfigName":"%s","ProductionVariants":[{"VariantName":"AllTraffic","ModelName":"%s","InitialInstanceCount":1,"InstanceType":"ml.t2.medium","InitialVariantWeight":1.0}]}
+                """.formatted(cfg, model))
+                .then().statusCode(200).body("EndpointConfigArn", notNullValue());
+        post("SageMaker.ListEndpointConfigs", "{}").then().statusCode(200)
+                .body("EndpointConfigs.find { it.EndpointConfigName == '%s' }.EndpointConfigName".formatted(cfg), equalTo(cfg));
+
+        post("SageMaker.AddTags", "{\"ResourceArn\":\"%s\",\"Tags\":[{\"Key\":\"owner\",\"Value\":\"sdk\"}]}".formatted(arn))
+                .then().statusCode(200).body("Tags", hasSize(2));
+        post("SageMaker.DeleteTags", "{\"ResourceArn\":\"%s\",\"TagKeys\":[\"env\"]}".formatted(arn))
+                .then().statusCode(200);
+        post("SageMaker.ListTags", "{\"ResourceArn\":\"%s\"}".formatted(arn))
+                .then().statusCode(200).body("Tags", hasSize(1)).body("Tags[0].Key", equalTo("owner"));
+
+        post("SageMaker.DeleteEndpointConfig", "{\"EndpointConfigName\":\"%s\"}".formatted(cfg)).then().statusCode(200);
+        post("SageMaker.DeleteModel", "{\"ModelName\":\"%s\"}".formatted(model)).then().statusCode(200);
+    }
+
+    @Test
+    void trainingJobValidationErrorsUseAwsJsonErrorShape() {
+        post("SageMaker.CreateTrainingJob", "{\"TrainingJobName\":\"bad\"}")
+                .then().statusCode(400).body("__type", equalTo("ValidationException"));
+    }
+
+    private io.restassured.response.Response post(String target, String body) {
+        return given().header("Authorization", AUTH)
+                .header("X-Amz-Target", target)
+                .contentType("application/x-amz-json-1.1")
+                .body(body)
+                .when().post("/");
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/sagemaker/SageMakerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sagemaker/SageMakerServiceTest.java
@@ -1,0 +1,87 @@
+package io.github.hectorvent.floci.services.sagemaker;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.sagemaker.model.SageMakerEntities.EndpointConfigResource;
+import io.github.hectorvent.floci.services.sagemaker.model.SageMakerEntities.EndpointResource;
+import io.github.hectorvent.floci.services.sagemaker.model.SageMakerEntities.ModelResource;
+import io.github.hectorvent.floci.services.sagemaker.model.SageMakerEntities.TrainingJobResource;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SageMakerServiceTest {
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void modelCrudAndDuplicateValidation() throws Exception {
+        SageMakerService service = service();
+        service.createModel(mapper.readTree("""
+                {"ModelName":"m1","PrimaryContainer":{"Image":"busybox:stable"},"ExecutionRoleArn":"arn:aws:iam::000000000000:role/r"}
+                """), "us-east-1");
+        assertEquals("m1", service.describeModel(mapper.readTree("{\"ModelName\":\"m1\"}")).path("ModelName").asText());
+        AwsException duplicate = assertThrows(AwsException.class, () -> service.createModel(mapper.readTree("""
+                {"ModelName":"m1","PrimaryContainer":{"Image":"busybox:stable"}}
+                """), "us-east-1"));
+        assertEquals("ValidationException", duplicate.getErrorCode());
+        service.deleteModel(mapper.readTree("{\"ModelName\":\"m1\"}"));
+        AwsException missing = assertThrows(AwsException.class,
+                () -> service.describeModel(mapper.readTree("{\"ModelName\":\"m1\"}")));
+        assertEquals("ValidationException", missing.getErrorCode());
+        AwsException deleteMissing = assertThrows(AwsException.class,
+                () -> service.deleteModel(mapper.readTree("{\"ModelName\":\"m1\"}")));
+        assertEquals("ValidationException", deleteMissing.getErrorCode());
+    }
+
+    @Test
+    void deleteEndpointConfigRequiresExistingConfig() throws Exception {
+        SageMakerService service = service();
+        AwsException missing = assertThrows(AwsException.class,
+                () -> service.deleteEndpointConfig(mapper.readTree("{\"EndpointConfigName\":\"missing\"}")));
+        assertEquals("ValidationException", missing.getErrorCode());
+    }
+
+    @Test
+    void endpointConfigRequiresExistingModel() throws Exception {
+        SageMakerService service = service();
+        AwsException missing = assertThrows(AwsException.class, () -> service.createEndpointConfig(mapper.readTree("""
+                {"EndpointConfigName":"cfg","ProductionVariants":[{"VariantName":"AllTraffic","ModelName":"missing","InitialInstanceCount":1,"InstanceType":"ml.t2.medium"}]}
+                """), "us-east-1"));
+        assertEquals("ValidationException", missing.getErrorCode());
+    }
+
+    @Test
+    void tagsRoundTrip() throws Exception {
+        SageMakerService service = service();
+        String arn = service.createModel(mapper.readTree("""
+                {"ModelName":"tagged","PrimaryContainer":{"Image":"busybox:stable"},"Tags":[{"Key":"a","Value":"b"}]}
+                """), "us-east-1").path("ModelArn").asText();
+        service.addTags(mapper.readTree("{\"ResourceArn\":\"" + arn + "\",\"Tags\":[{\"Key\":\"c\",\"Value\":\"d\"}]}"));
+        assertEquals(2, service.listTags(mapper.readTree("{\"ResourceArn\":\"" + arn + "\"}")).path("Tags").size());
+        service.deleteTags(mapper.readTree("{\"ResourceArn\":\"" + arn + "\",\"TagKeys\":[\"a\"]}"));
+        assertEquals("c", service.listTags(mapper.readTree("{\"ResourceArn\":\"" + arn + "\"}")).path("Tags").get(0).path("Key").asText());
+    }
+
+
+    @Test
+    void s3UriParsingCoversPrefixesAndValidation() {
+        S3Uri object = S3Uri.parse("s3://bucket/path/to/object");
+        assertEquals("bucket", object.bucket());
+        assertEquals("path/to/object", object.key());
+        S3Uri bucketOnly = S3Uri.parse("s3://bucket");
+        assertEquals("bucket", bucketOnly.bucket());
+        assertEquals("", bucketOnly.key());
+        assertThrows(IllegalArgumentException.class, () -> S3Uri.parse("http://bucket/key"));
+    }
+
+    private SageMakerService service() {
+        return new SageMakerService(new InMemoryStorage<String, ModelResource>(),
+                new InMemoryStorage<String, EndpointConfigResource>(),
+                new InMemoryStorage<String, EndpointResource>(),
+                new InMemoryStorage<String, TrainingJobResource>(),
+                new RegionResolver("us-east-1", "000000000000"), mapper, null, null);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -36,6 +36,8 @@ floci:
         flush-interval-ms: 60000
       opensearch:
         flush-interval-ms: 60000
+      sagemaker:
+        flush-interval-ms: 60000
       batch:
         flush-interval-ms: 60000
       lightsail:
@@ -230,6 +232,9 @@ floci:
       enabled: true
       mock: true
     codebuild:
+      enabled: true
+      # docker-network: floci-network
+    sagemaker:
       enabled: true
       # docker-network: floci-network
     batch:


### PR DESCRIPTION
Closes #1945

Implements the SageMaker control plane over the AWS JSON 1.1 protocol (`X-Amz-Target: SageMaker.*`) plus the SageMaker Runtime invocation path, backed by real Docker containers rather than mocks.

## Summary

- Models, endpoint configs, endpoints, training jobs, and tags with AWS-shaped validation errors (`ValidationException`/`ResourceInUse`), all scoped by region since the resource ARNs are regional.
- `CreateTrainingJob` runs the training image as a real Docker container using the `/opt/ml` contract: hyperparameters, `resourceconfig`, and `inputdataconfig` under `/opt/ml/input/config`, S3 channel data under `/opt/ml/input/data/<channel>` (preserving the relative path structure under the channel's S3 prefix, with a path-traversal guard), and `/opt/ml/model` uploaded back to S3 as `model.tar.gz`.
- `CreateEndpoint` hosts the model image as a long-lived container with the `serve` command, `/ping` health checks, and `ModelDataUrl` artifacts extracted into `/opt/ml/model`. A start still in flight when the endpoint is deleted or updated again discards its result instead of resurrecting a deleted endpoint or clobbering a newer one.
- `POST /endpoints/{name}/invocations` proxies to the container, resolves the calling region from the request's SigV4 credential scope, maps model 5xx responses to `ModelError` (HTTP 424), and returns `application/json` error envelopes.
- `StopTrainingJob` only transitions a job that is `InProgress`/`Stopping`; the async runner distinguishes an intentional stop from the container disappearing as a side effect of it, so a stopped job's terminal state is not overwritten with `Failed`.
- `ListModels`/`ListEndpointConfigs`/`ListEndpoints`/`ListTrainingJobs` validate `MaxResults` (1-100) and support `NextToken` pagination; `ListModels`/`ListTrainingJobs` additionally support `NameContains`, and `ListTrainingJobs` supports `StatusEquals`.
- Training container logs stream to CloudWatch Logs under `/aws/sagemaker/TrainingJobs`.
- Storage wired through `StorageFactory` with memory/persistent modes, config in `EmulatorConfig` and both `application.yml` files.
- Unit, integration, and Docker-gated integration tests (including regressions for the stop/delete races above) plus a boto3 compatibility test; service, action tables, and docs registered in the catalog.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified with boto3/botocore (the versions pinned in `compatibility-tests/sdk-test-python/requirements.txt`) via `tests/test_sagemaker.py`, which exercises the full control plane and a real training job end-to-end. The JSON 1.1 wire shapes (`X-Amz-Target: SageMaker.*`, `application/x-amz-json-1.1`, `__type` error envelopes) are additionally asserted at the HTTP level by `SageMakerIntegrationTest`. Cross-checked against the SageMaker API reference and the AWS SDK for Java v2 model for `CreateModel`, `CreateTrainingJob`, `ListModels`/`ListTrainingJobs` pagination and filters, and `StopTrainingJob`'s status-transition contract.

## Checklist

- [x] The full test suite passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
