### PR TITLE
fix(rds): restore Terraform RDS and RabbitMQ compatibility

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/amazonmq/AmazonMqController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/amazonmq/AmazonMqController.java
@@ -90,7 +90,6 @@ public class AmazonMqController {
         body.put("autoMinorVersionUpgrade", b.isAutoMinorVersionUpgrade());
         body.put("created", b.getCreated());
         body.put("brokerInstances", b.getBrokerInstances());
-        body.put("users", b.getUsers());
         body.put("tags", b.getTags());
         return body;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -144,7 +144,15 @@ public class RdsQueryHandler {
             filterId = extractRdsFilterValue(params, "db-instance-id");
         }
         try {
-            Collection<DbInstance> result = service.listDbInstances(filterId);
+            Collection<DbInstance> result;
+            if (filterId != null && !filterId.isBlank()) {
+                result = service.listDbInstances(filterId);
+            } else {
+                List<String> resourceIds = extractRdsFilterValues(params, "dbi-resource-id");
+                result = resourceIds.isEmpty()
+                        ? service.listDbInstances(null)
+                        : service.listDbInstancesByDbiResourceIds(resourceIds);
+            }
             // AWS parity: the DBInstanceIdentifier PARAMETER faults with
             // DBInstanceNotFound when no instance matches, while the
             // db-instance-id Filters form returns an empty list.
@@ -925,16 +933,35 @@ public class RdsQueryHandler {
      * Returns null if no matching filter is present.
      */
     private static String extractRdsFilterValue(MultivaluedMap<String, String> params, String filterName) {
+        List<String> values = extractRdsFilterValues(params, filterName);
+        return values.isEmpty() ? null : values.getFirst();
+    }
+
+    /**
+     * Extracts all values for a named RDS filter. Values within one filter use
+     * AWS OR semantics and are encoded as {@code Values.Value.N}.
+     */
+    private static List<String> extractRdsFilterValues(MultivaluedMap<String, String> params, String filterName) {
         for (int i = 1; ; i++) {
             String name = params.getFirst("Filters.Filter." + i + ".Name");
             if (name == null) {
                 break;
             }
             if (filterName.equals(name)) {
-                return params.getFirst("Filters.Filter." + i + ".Values.Value.1");
+                java.util.ArrayList<String> values = new java.util.ArrayList<>();
+                for (int valueIndex = 1; ; valueIndex++) {
+                    String value = params.getFirst("Filters.Filter." + i + ".Values.Value." + valueIndex);
+                    if (value == null) {
+                        break;
+                    }
+                    if (!value.isBlank()) {
+                        values.add(value);
+                    }
+                }
+                return List.copyOf(values);
             }
         }
-        return null;
+        return List.of();
     }
 
     private static List<String> memberList(MultivaluedMap<String, String> params, String baseName) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -545,6 +545,15 @@ public class RdsService implements Resettable {
         return instances.scan(k -> true);
     }
 
+    public Collection<DbInstance> listDbInstancesByDbiResourceIds(Collection<String> resourceIds) {
+        if (resourceIds == null || resourceIds.isEmpty()) {
+            return instances.scan(k -> true);
+        }
+        return instances.scan(k -> true).stream()
+                .filter(instance -> resourceIds.contains(instance.getDbiResourceId()))
+                .toList();
+    }
+
     public DbInstance modifyDbInstance(String id, String newPassword, Boolean iamEnabled,
                                        String dbSubnetGroupName) {
         return modifyDbInstance(id, newPassword, iamEnabled, dbSubnetGroupName, null);

--- a/src/test/java/io/github/hectorvent/floci/services/amazonmq/AmazonMqControllerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/amazonmq/AmazonMqControllerIntegrationTest.java
@@ -41,6 +41,9 @@ class AmazonMqControllerIntegrationTest {
             .body("engineType", equalTo("RABBITMQ"))
             .body("brokerState", equalTo("RUNNING"))
             .body("brokerInstances[0].endpoints[0]", startsWith("amqp://"))
+            // AWS does not expose RabbitMQ users from DescribeBroker. Returning
+            // them makes Terraform call the unsupported standalone User API.
+            .body("users", nullValue())
             // internal bookkeeping is persisted but must never leak into the API
             .body("containerId", nullValue())
             .body("accountId", nullValue())

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -109,6 +109,24 @@ class RdsQueryHandlerTest {
     }
 
     @Test
+    void describeDbInstances_filterByDbiResourceId() {
+        DbInstance instance = makeInstance("mydb");
+        instance.setDbiResourceId("db-RESOURCE123");
+        when(service.listDbInstancesByDbiResourceIds(List.of("db-RESOURCE123", "db-RESOURCE456")))
+                .thenReturn(List.of(instance));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("Filters.Filter.1.Name", "dbi-resource-id");
+        p.add("Filters.Filter.1.Values.Value.1", "db-RESOURCE123");
+        p.add("Filters.Filter.1.Values.Value.2", "db-RESOURCE456");
+        Response response = handler.handle("DescribeDBInstances", p);
+
+        verify(service).listDbInstancesByDbiResourceIds(List.of("db-RESOURCE123", "db-RESOURCE456"));
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<DBInstanceIdentifier>mydb</DBInstanceIdentifier>"));
+    }
+
+    @Test
     void describeDbInstances_directIdentifierTakesPriorityOverFilters() {
         when(service.listDbInstances(any())).thenReturn(List.of());
 

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -336,6 +336,21 @@ class RdsServiceTest {
     }
 
     @Test
+    void listDbInstancesByDbiResourceIdsUsesExactOrMatching() {
+        DbInstance instance = rdsService.createDbInstance("mydb", "postgres", "13",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false);
+
+        Collection<DbInstance> result = rdsService.listDbInstancesByDbiResourceIds(
+                List.of("db-missing", instance.getDbiResourceId()));
+
+        assertEquals(1, result.size());
+        assertEquals("mydb", result.iterator().next().getDbInstanceIdentifier());
+        assertTrue(rdsService.listDbInstancesByDbiResourceIds(
+                List.of(instance.getDbiResourceId().toLowerCase())).isEmpty());
+    }
+
+    @Test
     void modifyDbInstanceBlankPasswordDoesNotOverwriteExistingPassword() {
         rdsService.createDbInstance("mydb", "postgres", "13",
                 "admin", "original-password", "dbname", "db.t3.micro",


### PR DESCRIPTION
## Summary
- support the RDS DescribeDBInstances dbi-resource-id filter
- omit RabbitMQ users from DescribeBroker, matching AWS wire behavior
- preserve existing DBInstanceIdentifier and db-instance-id behavior
- add focused RDS unit tests and Amazon MQ integration coverage

## Why
A real Terraform acceptance flow against Floci 1.5.33 found two post-create refresh failures:

1. AWS provider 6.56 stores an RDS instance by DbiResourceId and refreshes it with Filters.Filter.1.Name=dbi-resource-id. Floci returned an empty DBInstances list after successful creation.
2. Floci returned RabbitMQ users from DescribeBroker. Terraform then called the standalone DescribeUser API, which correctly rejects RabbitMQ, so the broker refresh failed. AWS does not expose the RabbitMQ user list from DescribeBroker.

## Validation
- Amazon Corretto 25 ./mvnw -Dtest=RdsQueryHandlerTest,RdsServiceTest test: 104 tests passed
- Amazon Corretto 25 ./mvnw -Dtest=AmazonMqControllerIntegrationTest test: 5 tests passed