### PR TITLE
fix(s3): recognize virtual-hosted-style requests over HTTP/2

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -489,7 +489,7 @@ public class S3Controller {
             }
 
             // --- Website Hosting Redirection Logic ---
-            if (isWebsiteRequest(httpHeaders) && (uriInfo.getQueryParameters().isEmpty() || (uriInfo.getQueryParameters().size() == 1 && hasQueryParam(uriInfo, "list-type")))) {
+            if (isWebsiteRequest(httpHeaders, uriInfo) && (uriInfo.getQueryParameters().isEmpty() || (uriInfo.getQueryParameters().size() == 1 && hasQueryParam(uriInfo, "list-type")))) {
                 try {
                     WebsiteConfiguration webConfig = s3Service.getBucketWebsite(bucket);
                     if (webConfig.getIndexDocument() != null) {
@@ -806,7 +806,7 @@ public class S3Controller {
             return fullObjectResponse(bucket, key, versionId, obj, overrides, includeChecksum);
         } catch (AwsException e) {
             emitCloudTrailEvent("GetObject", bucket, key, 0L, 0L, e.getErrorCode(), e.getMessage());
-            if (isWebsiteErrorDocumentTrigger(e) && isWebsiteRequest(httpHeaders)) {
+            if (isWebsiteErrorDocumentTrigger(e) && isWebsiteRequest(httpHeaders, uriInfo)) {
                 try {
                     WebsiteConfiguration webConfig = s3Service.getBucketWebsite(bucket);
                     Response r = serveErrorDocument(bucket, webConfig, authorization, e.getHttpStatus());
@@ -2183,8 +2183,11 @@ public class S3Controller {
         }
     }
 
-    private static boolean isWebsiteRequest(HttpHeaders httpHeaders) {
-        String host = httpHeaders.getHeaderString("Host");
+    static boolean isWebsiteRequest(HttpHeaders httpHeaders, UriInfo uriInfo) {
+        // HTTP/2 (RFC 9113) carries no Host header, so fall back to the request URI authority —
+        // the same resolution S3VirtualHostFilter applies. Without this, a website bucket reached
+        // over HTTP/2 would be served as an API (XML) response instead of website HTML.
+        String host = S3VirtualHostFilter.resolveHost(httpHeaders.getHeaderString("Host"), uriInfo.getRequestUri());
         return host != null && host.contains("s3-website");
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
@@ -34,7 +34,13 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
 
     @Override
     public void filter(ContainerRequestContext requestContext) {
-        String host = requestContext.getHeaderString("Host");
+        URI uri = requestContext.getUriInfo().getRequestUri();
+
+        // HTTP/2 (RFC 9113) has no "Host" header — the authority travels in the
+        // ":authority" pseudo-header, surfaced here as the request URI authority.
+        // Falling back to it keeps virtual-hosted-style routing working when a
+        // browser negotiates HTTP/2 over HTTPS (where the Host header is absent).
+        String host = resolveHost(requestContext.getHeaderString("Host"), uri);
         if (host == null) return;
 
         // Do not hijack requests meant for other AWS services
@@ -55,7 +61,6 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
         String bucket = extractBucket(host, baseHostname);
         if (bucket == null) return;
 
-        URI uri = requestContext.getUriInfo().getRequestUri();
         String path = uri.getRawPath();
 
         // Do not rewrite S3 Control API paths — the account ID appears as a host label
@@ -72,6 +77,26 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
                 .build();
 
         requestContext.setRequestUri(newUri);
+    }
+
+    /**
+     * Resolves the effective request authority used for virtual-host detection.
+     *
+     * <p>HTTP/1.1 carries it in the {@code Host} header. HTTP/2 (RFC 9113) has no
+     * {@code Host} header — the authority is in the {@code :authority} pseudo-header,
+     * which the container exposes as the request URI authority. When the {@code Host}
+     * header is absent we fall back to the URI authority so virtual-hosted-style
+     * requests are recognized on both protocol versions.
+     *
+     * @param hostHeader the value of the {@code Host} header, or {@code null}
+     * @param requestUri the request URI, or {@code null}
+     * @return the effective authority ({@code host[:port]}), or {@code null} if neither is available
+     */
+    static String resolveHost(String hostHeader, URI requestUri) {
+        if (hostHeader != null) {
+            return hostHeader;
+        }
+        return requestUri != null ? requestUri.getAuthority() : null;
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ControllerWebsiteRequestTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ControllerWebsiteRequestTest.java
@@ -1,0 +1,56 @@
+package io.github.hectorvent.floci.services.s3;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.UriInfo;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class S3ControllerWebsiteRequestTest {
+
+    private static HttpHeaders headers(String hostHeader) {
+        HttpHeaders h = mock(HttpHeaders.class);
+        when(h.getHeaderString("Host")).thenReturn(hostHeader);
+        return h;
+    }
+
+    private static UriInfo uri(String requestUri) {
+        UriInfo u = mock(UriInfo.class);
+        when(u.getRequestUri()).thenReturn(URI.create(requestUri));
+        return u;
+    }
+
+    @Test
+    void detectsWebsiteFromHostHeaderOverHttp1() {
+        assertTrue(S3Controller.isWebsiteRequest(
+                headers("my-bucket.s3-website-us-east-1.amazonaws.com"),
+                uri("http://my-bucket.s3-website-us-east-1.amazonaws.com/index.html")));
+    }
+
+    @Test
+    void detectsWebsiteFromUriAuthorityWhenHostHeaderAbsentOverHttp2() {
+        // Regression for the HTTP/2 review finding: no Host header, authority carried by the URI.
+        assertTrue(S3Controller.isWebsiteRequest(
+                headers(null),
+                uri("https://my-bucket.s3-website-us-east-1.localhost:4566/index.html")));
+    }
+
+    @Test
+    void nonWebsiteHttp2RequestIsNotWebsite() {
+        assertFalse(S3Controller.isWebsiteRequest(
+                headers(null),
+                uri("https://my-bucket.s3.us-east-1.localhost:4566/key.txt")));
+    }
+
+    @Test
+    void nonWebsiteHostHeaderIsNotWebsite() {
+        assertFalse(S3Controller.isWebsiteRequest(
+                headers("my-bucket.s3.amazonaws.com"),
+                uri("http://my-bucket.s3.amazonaws.com/key.txt")));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
@@ -1,14 +1,20 @@
 package io.github.hectorvent.floci.services.s3;
 
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.UriInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullSource;
+import org.mockito.ArgumentCaptor;
 
 import java.net.URI;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class S3VirtualHostFilterTest {
 
@@ -168,5 +174,34 @@ class S3VirtualHostFilterTest {
         URI uri = URI.create("https://my-bucket.s3.us-east-1.localhost:4566/key.txt");
         String host = S3VirtualHostFilter.resolveHost(null, uri);
         assertEquals("my-bucket", S3VirtualHostFilter.extractBucket(host, "localhost"));
+    }
+
+    // --- HTTP/2 website request: the path rewrite must preserve the s3-website authority (#1954) ---
+
+    @Test
+    void http2WebsiteRequestRewritePreservesAuthorityForDownstreamDetection() {
+        // Over HTTP/2 a website request has no Host header. The filter rewrites the path to
+        // /bucket/key for the path-style S3 controller, but must keep the s3-website authority
+        // on the request URI. Otherwise S3Controller.isWebsiteRequest — which, with no Host
+        // header, reads the URI authority (S3VirtualHostFilter.resolveHost) — can no longer
+        // recognize the request and serves API XML instead of the index/error document.
+        URI requestUri = URI.create("https://my-bucket.s3-website-us-east-1.localhost:4566/index.html");
+
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(uriInfo.getRequestUri()).thenReturn(requestUri);
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(ctx.getHeaderString("Host")).thenReturn(null); // HTTP/2: no Host header
+
+        new S3VirtualHostFilter().filter(ctx);
+
+        ArgumentCaptor<URI> rewritten = ArgumentCaptor.forClass(URI.class);
+        verify(ctx).setRequestUri(rewritten.capture());
+        URI newUri = rewritten.getValue();
+
+        // Path rewritten to path-style for the S3 controller...
+        assertEquals("/my-bucket/index.html", newUri.getRawPath());
+        // ...but the s3-website authority survives, so downstream website detection still fires.
+        assertEquals("my-bucket.s3-website-us-east-1.localhost:4566", newUri.getAuthority());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullSource;
 
+import java.net.URI;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -136,5 +138,35 @@ class S3VirtualHostFilterTest {
     @Test
     void extractHostnameFromUrlReturnsNullForNull() {
         assertNull(S3VirtualHostFilter.extractHostnameFromUrl(null));
+    }
+
+    // --- Host resolution: HTTP/1.1 Host header vs HTTP/2 :authority fallback ---
+
+    @Test
+    void resolveHostPrefersHostHeaderOverUriAuthority() {
+        URI uri = URI.create("https://my-bucket.s3.us-east-1.localhost:4566/key.txt");
+        assertEquals("my-bucket.localhost:4566", S3VirtualHostFilter.resolveHost("my-bucket.localhost:4566", uri));
+    }
+
+    @Test
+    void resolveHostFallsBackToUriAuthorityWhenHostHeaderAbsent() {
+        // HTTP/2 request: no Host header, authority carried by the URI (:authority).
+        URI uri = URI.create("https://my-bucket.s3.us-east-1.localhost:4566/key.txt");
+        assertEquals("my-bucket.s3.us-east-1.localhost:4566", S3VirtualHostFilter.resolveHost(null, uri));
+    }
+
+    @Test
+    void resolveHostReturnsNullWhenNeitherAvailable() {
+        assertNull(S3VirtualHostFilter.resolveHost(null, null));
+        assertNull(S3VirtualHostFilter.resolveHost(null, URI.create("/relative/path")));
+    }
+
+    @Test
+    void http2VirtualHostedRequestResolvesBucketWithoutHostHeader() {
+        // Regression for #1866: over HTTP/2 the Host header is null, so the bucket must
+        // be recovered from the URI authority instead of falling through to path-style.
+        URI uri = URI.create("https://my-bucket.s3.us-east-1.localhost:4566/key.txt");
+        String host = S3VirtualHostFilter.resolveHost(null, uri);
+        assertEquals("my-bucket", S3VirtualHostFilter.extractBucket(host, "localhost"));
     }
 }


### PR DESCRIPTION
Browsers negotiate HTTP/2 via ALPN over HTTPS, and HTTP/2 (RFC 9113) has no Host header — the authority is carried in the :authority pseudo-header. S3VirtualHostFilter read only getHeaderString("Host"), which is null over HTTP/2, so virtual-hosted-style requests fell through to path-style handling: the bucket label in the authority was ignored and the first path segment was treated as the bucket instead.

Resolve the effective authority from the request URI (populated from :authority) when the Host header is absent, so bucket routing works on both HTTP/1.1 and HTTP/2.

Closes #1866

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
