### PR TITLE
test(s3): cover shared edge host routing

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilterTest.java
@@ -72,6 +72,11 @@ class S3VirtualHostFilterTest {
             "s3.localhost.localstack.cloud:4566, localhost",
             "s3.localhost.floci.io,             localhost",
             "s3.localhost.floci.io:4566,        localhost",
+            // Shared edge hosts are endpoints, not buckets named localhost
+            "localhost.localstack.cloud,        localhost",
+            "localhost.localstack.cloud:4566,   localhost",
+            "localhost.floci.io,                localhost",
+            "localhost.floci.io:4566,           localhost",
             // K8s service hostname used as endpoint (path-style) — must NOT be rewritten
             "floci.default.svc.cluster.local,           localhost",
             "floci-service.namespace.svc.cluster.local, localhost",


### PR DESCRIPTION
## Summary

- cover LocalStack and Floci shared edge hostnames as path-style endpoints
- prevent the `localhost` label from being interpreted as an S3 bucket
- add explicit regression coverage for the routing concern raised in #1081

## Testing

- `./mvnw test -Dtest=S3VirtualHostFilterTest -Denforcer.skip=true` (57 tests passed)