### PR TITLE
fix(lambda): discard warm container invalidated while in use

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/WarmPool.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/WarmPool.java
@@ -120,6 +120,13 @@ public class WarmPool implements ContainerTeardown {
         boolean ephemeral = config != null && config.services().lambda().ephemeral();
         ContainerHandle handle = null;
 
+        // Sample before the container leaves the pool, not after: from pollFirst() onwards the
+        // handle is checked out and invisible to a drain, and what follows — the isAlive() probe,
+        // or a cold start — is a Docker round-trip wide enough for a delete to land in. Reading
+        // the generation afterwards would stamp the handle with the post-drain value and let
+        // release() pool it, which is the very bug this guards against.
+        long generation = currentGeneration(fn.getFunctionName());
+
         if (!ephemeral) {
             ArrayDeque<ContainerHandle> queue = pool.computeIfAbsent(fn.getFunctionName(), k -> new ArrayDeque<>());
             // Skip pooled handles whose container died out-of-band — otherwise the
@@ -152,7 +159,7 @@ public class WarmPool implements ContainerTeardown {
         handle.setState(ContainerState.BUSY);
         // Stamp the generation this container is valid for; release() drops it if a drain has
         // bumped the function's generation in the meantime.
-        handle.setPoolGeneration(currentGeneration(fn.getFunctionName()));
+        handle.setPoolGeneration(generation);
         return handle;
     }
 
@@ -228,13 +235,17 @@ public class WarmPool implements ContainerTeardown {
      * Called on function delete or code update.
      */
     public void drainFunction(String functionName) {
-        // Bump first, and unconditionally: containers checked out right now are not in the queue,
-        // so this is the only thing that keeps them from being pooled again on release. It has to
-        // happen even when the queue is empty — that is precisely the case where every live
-        // container is checked out.
-        generations.merge(functionName, 1L, Long::sum);
-
+        // Detach the queue first, then bump — and bump unconditionally, before the empty-queue
+        // early return, since containers checked out right now are not in the queue and the
+        // generation is the only thing that keeps them from being pooled again on release.
+        //
+        // Order matters as much as unconditionality. Bumping first leaves a window where the
+        // generation has moved but the queue is still reachable, so an acquire sampling after the
+        // bump could still poll a pre-drain handle and stamp it valid. Detaching first means a
+        // concurrent acquire either finds a fresh empty deque (and cold-starts) or sampled its
+        // generation before the bump (and is discarded on release).
         ArrayDeque<ContainerHandle> queue = pool.remove(functionName);
+        generations.merge(functionName, 1L, Long::sum);
         if (queue == null) {
             return;
         }

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/WarmPool.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/WarmPool.java
@@ -42,6 +42,21 @@ public class WarmPool implements ContainerTeardown {
     private final EmulatorConfig config;
     private final int maxPoolSizePerFunction;
     private final ConcurrentHashMap<String, ArrayDeque<ContainerHandle>> pool = new ConcurrentHashMap<>();
+    /**
+     * Per-function generation counter, bumped by {@link #drainFunction(String)}.
+     *
+     * <p>{@code pool} only holds idle containers: {@link #acquire} polls a handle off the queue,
+     * so a container serving an invocation is referenced solely by the invoking thread and is
+     * invisible to a drain. Without the generation check, {@link #release} would hand that
+     * container back for a function that has since been deleted (and, on a redeploy, recreated)
+     * and the next invoke would run the old code and old baked environment. A function under an
+     * event-source poller nearly always has a container checked out, so the drain nearly always
+     * misses it; an idle redeploy drains cleanly, which is what makes this hard to notice.
+     *
+     * <p>Comparing generations rather than stopping busy containers during the drain lets the
+     * in-flight invocation finish normally — it just never gets pooled again.
+     */
+    private final ConcurrentHashMap<String, Long> generations = new ConcurrentHashMap<>();
     private final ScheduledExecutorService evictionScheduler = Executors.newSingleThreadScheduledExecutor(
             r -> { Thread t = new Thread(r, "warm-pool-evictor"); t.setDaemon(true); return t; });
 
@@ -135,7 +150,14 @@ public class WarmPool implements ContainerTeardown {
             LOG.debugv("Reusing warm container for function: {0}", fn.getFunctionName());
         }
         handle.setState(ContainerState.BUSY);
+        // Stamp the generation this container is valid for; release() drops it if a drain has
+        // bumped the function's generation in the meantime.
+        handle.setPoolGeneration(currentGeneration(fn.getFunctionName()));
         return handle;
+    }
+
+    private long currentGeneration(String functionName) {
+        return generations.getOrDefault(functionName, 0L);
     }
 
     /**
@@ -148,6 +170,16 @@ public class WarmPool implements ContainerTeardown {
         if (ephemeral || handle.isHotReload()) {
             LOG.debugv("{0}: stopping container {1} after invocation",
                     handle.isHotReload() ? "Hot-reload" : "Ephemeral", handle.getContainerId());
+            stopQuietly(handle);
+            return;
+        }
+
+        // The function's containers were invalidated while this one was checked out (delete,
+        // redeploy, or code update), so it must not go back into the pool — it would serve the
+        // pre-invalidation code and environment to the next invoke.
+        if (handle.getPoolGeneration() != currentGeneration(handle.getFunctionName())) {
+            LOG.debugv("Discarding container {0} for function {1}: invalidated while in use",
+                    handle.getContainerId(), handle.getFunctionName());
             stopQuietly(handle);
             return;
         }
@@ -196,6 +228,12 @@ public class WarmPool implements ContainerTeardown {
      * Called on function delete or code update.
      */
     public void drainFunction(String functionName) {
+        // Bump first, and unconditionally: containers checked out right now are not in the queue,
+        // so this is the only thing that keeps them from being pooled again on release. It has to
+        // happen even when the queue is empty — that is precisely the case where every live
+        // container is checked out.
+        generations.merge(functionName, 1L, Long::sum);
+
         ArrayDeque<ContainerHandle> queue = pool.remove(functionName);
         if (queue == null) {
             return;

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerHandle.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerHandle.java
@@ -18,6 +18,13 @@ public class ContainerHandle {
     private volatile ContainerState state;
     private volatile long lastUsedMs;
     private Closeable logStream;
+    /**
+     * The warm-pool generation this container was handed out under. {@code WarmPool} bumps a
+     * function's generation whenever its containers are invalidated (delete, redeploy, code
+     * update) and compares on release, so a container checked out across an invalidation is
+     * discarded instead of being pooled again for the new code.
+     */
+    private volatile long poolGeneration;
 
     public ContainerHandle(String containerId, String functionName,
                            RuntimeApiServer runtimeApiServer, ContainerState state) {
@@ -46,4 +53,6 @@ public class ContainerHandle {
     public void setState(ContainerState state) { this.state = state; }
     public Closeable getLogStream() { return logStream; }
     public void setLogStream(Closeable logStream) { this.logStream = logStream; }
+    public long getPoolGeneration() { return poolGeneration; }
+    public void setPoolGeneration(long poolGeneration) { this.poolGeneration = poolGeneration; }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/WarmPoolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/WarmPoolTest.java
@@ -223,6 +223,47 @@ class WarmPoolTest {
     }
 
     @Test
+    void release_afterDrainDuringAcquire_doesNotReturnCheckedOutContainerToPool() {
+        // The generation must be sampled before the container leaves the pool, not after. acquire
+        // polls the handle off the queue and only then probes isAlive() — a Docker daemon
+        // round-trip — or cold-starts a container, which is slower still. A drain landing in that
+        // window bumps the generation, finds an empty queue and stops nothing, and the handle then
+        // gets stamped with the POST-drain generation, so release pools it. Sampling after the
+        // poll narrows the reported bug from "always" to "whenever a delete lands during a Docker
+        // call", which a function under continuous ESM invocation reaches.
+        WarmPool pool = buildPool();
+        pool.init();
+
+        LambdaFunction fn = mock(LambdaFunction.class);
+        when(fn.getFunctionName()).thenReturn("acquire-race-fn");
+
+        ContainerHandle stale = new ContainerHandle("cid-stale", "acquire-race-fn", null, ContainerState.WARM);
+        ContainerHandle fresh = new ContainerHandle("cid-fresh", "acquire-race-fn", null, ContainerState.WARM);
+        when(containerLauncher.launch(any())).thenReturn(stale, fresh);
+
+        // Seed the pool, so the acquire under test takes the reuse path through isAlive().
+        pool.release(pool.acquire(fn));
+
+        // The function is deleted *inside* acquire: after pollFirst() has checked the handle out,
+        // while the liveness probe is still in flight.
+        when(containerLauncher.isAlive(any())).thenAnswer(invocation -> {
+            pool.drainFunction("acquire-race-fn");
+            return true;
+        });
+
+        ContainerHandle inFlight = pool.acquire(fn);
+        assertSame(stale, inFlight);
+
+        pool.release(inFlight);
+
+        // Stamped with the generation in force when acquire started, so release sees it as stale.
+        verify(containerLauncher).stop(stale);
+        assertNotSame(stale, pool.acquire(fn));
+
+        pool.shutdown();
+    }
+
+    @Test
     void release_withoutDrain_stillReusesContainerAcrossFunctions() {
         // Guard against over-correcting: a drain of one function must not invalidate another's
         // checked-out container.

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/WarmPoolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/WarmPoolTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -153,6 +154,94 @@ class WarmPoolTest {
 
         // containerLauncher.launch should only have been called once (cold start)
         verify(containerLauncher, times(1)).launch(any());
+
+        pool.shutdown();
+    }
+
+    @Test
+    void release_afterDrain_doesNotReturnCheckedOutContainerToPool() {
+        // drainFunction only stops containers sitting idle in the pool. A container checked out by
+        // an in-flight invocation has been polled off the queue, so the drain cannot see it, and
+        // release() then hands it back for a function that was deleted (and, on a redeploy,
+        // recreated) — the next invoke reuses it and runs the OLD code and OLD baked env.
+        // An ESM-driven function nearly always has one checked out, so the drain nearly always
+        // misses; an idle redeploy drains cleanly, which is why this is invisible without
+        // concurrent invocation.
+        WarmPool pool = buildPool();
+        pool.init();
+
+        LambdaFunction fn = mock(LambdaFunction.class);
+        when(fn.getFunctionName()).thenReturn("drain-race-fn");
+
+        ContainerHandle stale = new ContainerHandle("cid-stale", "drain-race-fn", null, ContainerState.WARM);
+        ContainerHandle fresh = new ContainerHandle("cid-fresh", "drain-race-fn", null, ContainerState.WARM);
+        when(containerLauncher.launch(any())).thenReturn(stale, fresh);
+        lenient().when(containerLauncher.isAlive(any())).thenReturn(true);
+
+        ContainerHandle inFlight = pool.acquire(fn);
+        assertSame(stale, inFlight);
+
+        // The function is deleted while that invocation is still running.
+        pool.drainFunction("drain-race-fn");
+
+        // The invocation finishes afterwards.
+        pool.release(inFlight);
+
+        // The drained container must be stopped rather than pooled...
+        verify(containerLauncher).stop(stale);
+        // ...so the next invoke cold-starts instead of serving stale code.
+        assertNotSame(stale, pool.acquire(fn));
+        verify(containerLauncher, times(2)).launch(any());
+
+        pool.shutdown();
+    }
+
+    @Test
+    void release_afterPushCodeUpdate_doesNotReturnCheckedOutContainerToPool() {
+        // Same blind spot on the code-update path: pushCodeUpdate drains the pool to force a fresh
+        // start on new code, but a container checked out mid-invocation is not in the pool, so
+        // without this it is pooled again and keeps serving the pre-update code.
+        WarmPool pool = buildPool();
+        pool.init();
+
+        LambdaFunction fn = mock(LambdaFunction.class);
+        when(fn.getFunctionName()).thenReturn("code-update-fn");
+
+        ContainerHandle stale = new ContainerHandle("cid-old-code", "code-update-fn", null, ContainerState.WARM);
+        ContainerHandle fresh = new ContainerHandle("cid-new-code", "code-update-fn", null, ContainerState.WARM);
+        when(containerLauncher.launch(any())).thenReturn(stale, fresh);
+        lenient().when(containerLauncher.isAlive(any())).thenReturn(true);
+
+        ContainerHandle inFlight = pool.acquire(fn);
+        pool.pushCodeUpdate(fn);
+        pool.release(inFlight);
+
+        verify(containerLauncher).stop(stale);
+        assertNotSame(stale, pool.acquire(fn));
+
+        pool.shutdown();
+    }
+
+    @Test
+    void release_withoutDrain_stillReusesContainerAcrossFunctions() {
+        // Guard against over-correcting: a drain of one function must not invalidate another's
+        // checked-out container.
+        WarmPool pool = buildPool();
+        pool.init();
+
+        LambdaFunction kept = mock(LambdaFunction.class);
+        when(kept.getFunctionName()).thenReturn("kept-fn");
+
+        ContainerHandle keptHandle = new ContainerHandle("cid-kept", "kept-fn", null, ContainerState.WARM);
+        when(containerLauncher.launch(any())).thenReturn(keptHandle);
+        when(containerLauncher.isAlive(any())).thenReturn(true);
+
+        ContainerHandle inFlight = pool.acquire(kept);
+        pool.drainFunction("some-other-fn");
+        pool.release(inFlight);
+
+        assertSame(keptHandle, pool.acquire(kept));
+        verify(containerLauncher, never()).stop(keptHandle);
 
         pool.shutdown();
     }


### PR DESCRIPTION
## Summary

`drainFunction` only stops containers sitting **idle** in the pool. `acquire` polls
a handle off the queue, so a container serving an invocation is referenced solely
by the invoking thread and a drain cannot see it — `release` then hands it back for
a function that was deleted and, on a redeploy, recreated. The next invoke reuses
it and runs the old code and old baked environment, durably:
`get-function-configuration` reports the new values while every invoke returns the
old ones.

A function under an event-source poller is invoked continuously, so it hits this on
essentially every redeploy. An idle redeploy drains cleanly, which is why it is
invisible without concurrent invocation.

Closes #1962

## Approach

`WarmPool` keeps a per-function generation counter:

- `acquire` samples the function's generation **before it touches the pool**, and
  stamps the handle it hands out with that value.
- `drainFunction` detaches the queue and then bumps the generation —
  unconditionally, before the empty-queue early return, since an absent queue is
  exactly the state where every live container is checked out.
- `release` discards and stops a handle whose stamp is stale instead of pooling it.

Both orderings carry weight; getting either backwards reopens the bug through a
narrower window:

- **Sample before checkout.** From `pollFirst()` onwards the handle is checked out
  and invisible to a drain, and what follows is a Docker round-trip — the
  `isAlive()` probe on the reuse path, a full container start on the cold path.
  Reading the generation after that stamps the handle with the post-drain value, so
  `release` pools it anyway.
- **Detach before bumping.** The mirror image: with the generation bumped but the
  queue still reachable, an `acquire` sampling after the bump can poll a pre-drain
  handle and stamp it valid.

Comparing generations rather than force-stopping busy containers during the drain
lets the in-flight invocation finish normally — it just never gets reused.

`pushCodeUpdate` delegates to `drainFunction`, so the reactive S3 hot-reload path
(#509) is fixed with it.

The generation entry per function name is retained deliberately: removing it would
reset the counter to zero and re-admit exactly the stale handles this prevents. It
is one `long` per function name ever drained.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior was: after a delete + recreate under concurrent invocation, the
function served pre-delete code and environment indefinitely. Observed on 1.5.33
against a function with four DynamoDB-stream event source mappings — 5+ invokes
over 10s, container up 54s, no self-correction; `docker rm -f` on the container
restored correct output immediately.

Real Lambda has no equivalent: a deleted function's execution environments do not
outlive it.

## Tests

Four new `WarmPoolTest` cases, each written **before** the code it covers and
confirmed failing without it:

- `release_afterDrain_doesNotReturnCheckedOutContainerToPool` — the reported bug
- `release_afterPushCodeUpdate_doesNotReturnCheckedOutContainerToPool` — the same
  blind spot on the code-update path
- `release_afterDrainDuringAcquire_doesNotReturnCheckedOutContainerToPool` — the
  drain lands *inside* `acquire`, driven from the `isAlive` stub. The other three
  drain strictly between `acquire` and `release`, so none of them reach the
  sampling window.
- `release_withoutDrain_stillReusesContainerAcrossFunctions` — guards against
  over-correcting: draining one function must not invalidate another's checked-out
  container. Passes before and after, so it is a real guard rather than a
  restatement of the fix.

Deliberately no Docker-backed integration test racing an invoke against a delete:
the timing that makes the bug appear is what would make such a test flaky in CI.
The unit tests pin the mechanism precisely instead.

`./mvnw test`: **7946 tests, 0 failures, 0 errors** (8 skipped), 586 classes, JDK 25,
single process. An earlier revision reported an `ElastiCacheIntegrationTest` failure
as pre-existing; that was contamination from a second suite running concurrently,
and it passes 14/14 here.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (unit tests — see Tests)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

