### PR TITLE
chore: welcome first-time contributors and surface the Slack invite

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+# Adds links to the "New issue" chooser alongside the bug/feature templates.
+# Keeps the Slack invite visible before someone files, without adding boilerplate
+# to every issue body.
+blank_issues_enabled: true
+
+contact_links:
+  - name: 💬 Floci Community on Slack
+    url: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw
+    about: Ask a question, talk through AWS behaviour or a design tradeoff, or get help before filing.
+
+  - name: 🗣️ GitHub Discussions
+    url: https://github.com/orgs/floci-io/discussions
+    about: Longer-form proposals, ideas, and open-ended questions.
+
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/floci-io/floci/security/advisories/new
+    about: Please do not open a public issue for security problems — report them privately here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,3 +19,7 @@
 - [ ] `./mvnw test` passes locally
 - [ ] New or updated integration test added
 - [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+
+<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
+<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->
+

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,47 @@
+name: Welcome First-Time Contributors
+
+on:
+  issues:
+    types: [opened]
+  # pull_request_target so the token has write access on fork PRs, which is where
+  # first-time contributions come from. This workflow never checks out or executes
+  # PR code — it only posts a comment — so the elevated context is not exposed.
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  welcome:
+    name: Greet on first issue or PR
+    runs-on: ubuntu-latest
+
+    steps:
+      # Block scalars below are literal (|), not folded (>): folding joins Markdown
+      # bullets onto one line. One paragraph per line, because GitHub renders a
+      # single newline in a comment as a hard line break.
+      - uses: actions/first-interaction@v3.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          issue-message: |
+            👋 Thanks for opening your first issue in Floci!
+
+            A maintainer will triage this and add the right service label. If you included a minimal reproduction and the Floci version, that is everything we need — no action required from you right now.
+
+            Come say hi in [Slack](https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw) if you want to talk it through with maintainers and other contributors. Questions about AWS behaviour, design tradeoffs, and rough proposals are all welcome there.
+
+          pr-message: |
+            🎉 Thanks for your first pull request to Floci!
+
+            **Your CI checks need a maintainer to approve them before they run.** That is GitHub's standard gate on first-time contributors, not a problem with your PR — so if the checks look like they are doing nothing, that is why. Once a maintainer approves, CI and the compatibility suite start automatically. Nothing is needed from you in the meantime.
+
+            While you wait, a couple of things that make review faster:
+
+            - Link the issue this fixes with `Closes #N` in the description
+            - Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(s3): ...`, `fix(dynamodb): ...`)
+            - Behaviour changes come with a test — see [CONTRIBUTING.md](https://github.com/floci-io/floci/blob/main/CONTRIBUTING.md)
+
+            Come join us in [Slack](https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw) — it is the fastest way to reach maintainers if you get stuck, or want feedback on an approach before investing more time in it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thank you for your interest in contributing! Floci is a community-driven project and all contributions are welcome.
 
+**Join us on [Slack](https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw)** — it is the fastest way to reach maintainers. Ask about AWS behaviour, sanity-check an approach before you build it, or get unstuck on a PR.
+
 ## Ways to Contribute
 
 - **Bug reports** — open an issue with a minimal reproduction

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,6 +2,8 @@
 
 Floci is MIT licensed and welcomes contributions of all kinds.
 
+**Join us on [Slack](https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw)** — the fastest way to reach maintainers for questions, design tradeoffs, or feedback on an approach before you build it.
+
 ## Ways to Help 
 
 - **Bug reports** — open a [GitHub issue](https://github.com/floci-io/floci/issues/new?template=bug_report.md) with a minimal reproduction


### PR DESCRIPTION
## Summary

First-time contributors' PRs sit with no CI until a maintainer approves the workflow runs, and nothing on the PR explains the wait — #1789 and #1853 went 10–12 days before anyone noticed they had never been tested. The Slack invite was also reachable only from README line 785 of 834, and appeared in no contributor-facing template.

- `.github/workflows/welcome.yml` — `actions/first-interaction@v3.1.0` greets a contributor's first issue or PR. The PR message leads with *why* the checks have not started, so the gate reads as routine rather than as neglect.
- `.github/ISSUE_TEMPLATE/config.yml` — puts Slack, Discussions, and private security reporting on the new-issue chooser via `contact_links`, so the link appears *before* a template is picked and adds no boilerplate to issue bodies.
- Slack invite added to the PR template (as an HTML comment, so it is visible while writing but adds no rendered body noise) and to both `CONTRIBUTING.md` and `docs/contributing.md`.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

N/A — no emulator code, wire protocol, or service behaviour is touched. This changes repository metadata only.

## Checklist

- [ ] `./mvnw test` passes locally — not run; no Java changed
- [ ] New or updated integration test added — N/A, no testable code path
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Notes for review

**`pull_request_target` is the one line worth a careful look.** It is required for the token to have write access on fork PRs, which is where first-time contributions come from. It is safe here because the workflow only posts a comment — it never checks out or executes PR code. That reasoning is recorded in a comment in the workflow so a later change does not quietly add a checkout step.

`permissions:` is declared explicitly (`issues: write`, `pull-requests: write`) because this repo's default workflow permission is read-only; without it the action gets a 403.

**Validation.** Both YAML files parse, and the comment bodies were rendered to confirm the Markdown — that caught a folded-scalar (`>`) bug which had collapsed the bullet list onto a single line, and a second pass where GitHub's hard-line-break rendering would have broken paragraphs mid-sentence. Block scalars are now literal (`|`) with one paragraph per line. `first-interaction` only fires for a genuine first-time contributor, so end-to-end behaviour cannot be verified until this is on `main`.

**Scope.** This greets *future* first-timers only; the ~107 contributors already in flight will not receive a message.
