### PR TITLE
feat(ec2): return an empty set for DescribeVpnGateways

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -111,6 +111,11 @@ public class Ec2QueryHandler {
                 case "DeleteInternetGateway" -> handleDeleteInternetGateway(params, region);
                 case "AttachInternetGateway" -> handleAttachInternetGateway(params, region);
                 case "DetachInternetGateway" -> handleDetachInternetGateway(params, region);
+                // VPN Gateways. There is no VPN gateway model; an empty set is
+                // AWS-accurate for an account without VPN gateways and unblocks the
+                // CDK VPC context provider, which always issues this describe.
+                case "DescribeVpnGateways" -> handleDescribeVpnGateways();
+
                 // Route Tables
                 case "CreateRouteTable" -> handleCreateRouteTable(params, region);
                 case "DescribeRouteTables" -> handleDescribeRouteTables(params, region);
@@ -1430,6 +1435,16 @@ public class Ec2QueryHandler {
                 .elem("requestId", UUID.randomUUID().toString())
                 .start("routeTable").raw(routeTableXml(rt)).end("routeTable")
                 .end("CreateRouteTableResponse");
+        return xmlResponse(xml.build());
+    }
+
+    private Response handleDescribeVpnGateways() {
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeVpnGatewaysResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .start("vpnGatewaySet")
+                .end("vpnGatewaySet")
+                .end("DescribeVpnGatewaysResponse");
         return xmlResponse(xml.build());
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -1,6 +1,8 @@
 package io.github.hectorvent.floci.services.ec2;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.everyItem;
@@ -1237,6 +1239,20 @@ class Ec2IntegrationTest {
             .post("/")
         .then()
             .statusCode(200);
+    }
+
+    @Test
+    @Order(52)
+    void describeVpnGatewaysReturnsEmptySet() {
+        given()
+            .formParam("Action", "DescribeVpnGateways")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<vpnGatewaySet"))
+            .body(not(containsString("UnsupportedOperation")));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -1251,7 +1251,7 @@ class Ec2IntegrationTest {
             .post("/")
         .then()
             .statusCode(200)
-            .body(containsString("<vpnGatewaySet"))
+            .body("DescribeVpnGatewaysResponse.vpnGatewaySet.item.size()", equalTo(0))
             .body(not(containsString("UnsupportedOperation")));
     }
 


### PR DESCRIPTION
## Summary

Fixes #1974.

`DescribeVpnGateways` returned `UnsupportedOperation`, which makes the CDK CLI's VPC context provider (`Vpc.fromLookup`) abort its lookup — DescribeVpcs / DescribeSubnets / DescribeRouteTables all succeed and the final DescribeVpnGateways kills it, so CDK falls back to dummy ids and synthesis fails.

Floci has no VPN gateway model, so this returns an empty `vpnGatewaySet`, which is AWS-accurate for an account without VPN gateways and unblocks the provider.

## Tests

`Ec2IntegrationTest.describeVpnGatewaysReturnsEmptySet` — the action returns 200 with an empty set instead of `UnsupportedOperation`. Full EC2 suite: 144 tests, 0 failures. Verified end to end: with this change `cdk deploy` VPC lookups complete against a local Floci.