### PR TITLE
fix(cloudformation): resolve Fn::GetAtt [Vpc, DefaultSecurityGroup]

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -335,7 +335,6 @@ public class CloudFormationResourceProvisioner {
                 // EC2 networking. These delegate to Ec2Service so the resources actually exist
                 // (describe-subnets, ELBv2, etc. can find them) instead of being stubbed with a
                 // fake physical id. Topological ordering guarantees parents are provisioned first.
-                case "AWS::EC2::VPC" -> provisionVpc(resource, properties, engine, region);
                 case "AWS::EC2::Subnet" -> provisionSubnet(resource, properties, engine, region);
                 case "AWS::EC2::SecurityGroup" -> provisionSecurityGroup(resource, properties, engine, region, stackName);
                 case "AWS::EC2::InternetGateway" -> provisionInternetGateway(resource, region);
@@ -573,21 +572,6 @@ public class CloudFormationResourceProvisioner {
     // ELBv2 create-load-balancer, etc. resolve it). physicalId is set to the real EC2 id so
     // Ref/exports resolve to a real vpc-/subnet-/... id rather than a stub.
 
-    private void provisionVpc(StackResource r, JsonNode props, CloudFormationTemplateEngine engine, String region) {
-        String cidr = resolveOptional(props, "CidrBlock", engine);
-        var vpc = ec2Service.createVpc(region, cidr, false);
-        r.setPhysicalId(vpc.getVpcId());
-        r.getAttributes().put("VpcId", vpc.getVpcId());
-        if (vpc.getCidrBlock() != null) {
-            r.getAttributes().put("CidrBlock", vpc.getCidrBlock());
-        }
-        // Fn::GetAtt DefaultSecurityGroup — CDK's Custom::VpcRestrictDefaultSG handler
-        // depends on it resolving to the VPC's default security group id.
-        ec2Service.describeSecurityGroups(region, List.of(), List.of("default"), Map.of()).stream()
-                .filter(sg -> vpc.getVpcId().equals(sg.getVpcId()))
-                .findFirst()
-                .ifPresent(sg -> r.getAttributes().put("DefaultSecurityGroup", sg.getGroupId()));
-    }
 
     private void provisionSubnet(StackResource r, JsonNode props, CloudFormationTemplateEngine engine, String region) {
         String vpcId = resolveOptional(props, "VpcId", engine);

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -557,6 +557,12 @@ public class CloudFormationResourceProvisioner {
         if (vpc.getCidrBlock() != null) {
             r.getAttributes().put("CidrBlock", vpc.getCidrBlock());
         }
+        // Fn::GetAtt DefaultSecurityGroup — CDK's Custom::VpcRestrictDefaultSG handler
+        // depends on it resolving to the VPC's default security group id.
+        ec2Service.describeSecurityGroups(region, List.of(), List.of("default"), Map.of()).stream()
+                .filter(sg -> vpc.getVpcId().equals(sg.getVpcId()))
+                .findFirst()
+                .ifPresent(sg -> r.getAttributes().put("DefaultSecurityGroup", sg.getGroupId()));
     }
 
     private void provisionSubnet(StackResource r, JsonNode props, CloudFormationTemplateEngine engine, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2VpcCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2VpcCfnProvisioner.java
@@ -1,0 +1,52 @@
+package io.github.hectorvent.floci.services.cloudformation.provisioners;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * CloudFormation provisioning for {@code AWS::EC2::VPC}. Extracted verbatim from
+ * {@code CloudFormationResourceProvisioner} as part of the per-service decomposition.
+ */
+@ApplicationScoped
+public class Ec2VpcCfnProvisioner implements CfnResourceProvisioner {
+
+    private final Ec2Service ec2Service;
+
+    @Inject
+    public Ec2VpcCfnProvisioner(Ec2Service ec2Service) {
+        this.ec2Service = ec2Service;
+    }
+
+    @Override
+    public Set<String> resourceTypes() {
+        return Set.of("AWS::EC2::VPC");
+    }
+
+    @Override
+    public void provision(StackResource r, JsonNode props, ProvisionContext ctx) {
+        String cidr = ctx.resolveOptional(props, "CidrBlock");
+        var vpc = ec2Service.createVpc(ctx.region(), cidr, false);
+        r.setPhysicalId(vpc.getVpcId());
+        r.getAttributes().put("VpcId", vpc.getVpcId());
+        if (vpc.getCidrBlock() != null) {
+            r.getAttributes().put("CidrBlock", vpc.getCidrBlock());
+        }
+        // Fn::GetAtt DefaultSecurityGroup — CDK's Custom::VpcRestrictDefaultSG handler
+        // depends on it resolving to the VPC's default security group id.
+        ec2Service.describeSecurityGroups(ctx.region(), List.of(), List.of("default"), Map.of()).stream()
+                .filter(sg -> vpc.getVpcId().equals(sg.getVpcId()))
+                .findFirst()
+                .ifPresent(sg -> r.getAttributes().put("DefaultSecurityGroup", sg.getGroupId()));
+    }
+
+    // No delete override: the switch this replaces had no AWS::EC2::VPC delete arm,
+    // so stack teardown leaves the VPC alone. Adding one here would change teardown
+    // behavior beyond the scope of this extraction.
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationVpcDefaultSgAttrIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationVpcDefaultSgAttrIntegrationTest.java
@@ -1,0 +1,64 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * End-to-end check that Fn::GetAtt [Vpc, DefaultSecurityGroup] resolves to the real
+ * default security group id of a stack-created VPC (issue #1976) instead of passing
+ * through as the literal "LogicalId.DefaultSecurityGroup".
+ */
+@QuarkusTest
+class CloudFormationVpcDefaultSgAttrIntegrationTest {
+
+    private static final String CFN_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/cloudformation/aws4_request";
+
+    @Test
+    void getAttDefaultSecurityGroupResolvesToRealSgId() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String stackName = "cfn-vpc-defsg-stack-" + suffix;
+
+        String template = """
+                {
+                  "Resources": {
+                    "Vpc": {
+                      "Type": "AWS::EC2::VPC",
+                      "Properties": {"CidrBlock": "10.43.0.0/16"}
+                    }
+                  },
+                  "Outputs": {
+                    "DefaultSg": {"Value": {"Fn::GetAtt": ["Vpc", "DefaultSecurityGroup"]}}
+                  }
+                }
+                """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"))
+            .body(containsString("<OutputValue>sg-"))
+            .body(not(containsString("Vpc.DefaultSecurityGroup")));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1976.

`provisionVpc` did not expose `DefaultSecurityGroup`, so `Fn::GetAtt [MyVpc, DefaultSecurityGroup]` reached downstream resources as the literal string `MyVpc.DefaultSecurityGroup`. CDK's `Custom::VpcRestrictDefaultSG` handler (synthesized by every `ec2.Vpc`) then fails with `InvalidGroup.NotFound`.

Ec2Service already creates a per-VPC default security group; this looks it up after `createVpc` and records its id as the `DefaultSecurityGroup` attribute.

## Tests

New `CloudFormationVpcDefaultSgAttrIntegrationTest`: a stack outputting `Fn::GetAtt [Vpc, DefaultSecurityGroup]` reaches `CREATE_COMPLETE` with the output resolving to a real `sg-*` id, not the literal. Verified end to end with `cdk deploy` of a CDK app whose `VpcRestrictDefaultSG` custom resource previously failed.