### PR TITLE
fix(s3): validate FULL_OBJECT checksum on CompleteMultipartUpload

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -1201,7 +1201,10 @@ public class S3Controller {
                 if (preconditionResponse != null) {
                     return preconditionResponse;
                 }
-                S3Object obj = s3Service.completeMultipartUpload(bucket, key, uploadId, partNumbers);
+                String checksumType = httpHeaders.getHeaderString("x-amz-checksum-type");
+                S3Checksum expectedChecksum = extractChecksumFromHeaders(httpHeaders);
+                S3Object obj = s3Service.completeMultipartUpload(bucket, key, uploadId, partNumbers,
+                        checksumType, expectedChecksum);
                 String baseUrl = uriInfo.getBaseUri().toString();
                 if (baseUrl.endsWith("/")) {
                     baseUrl = baseUrl.substring(0, baseUrl.length() - 1);

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -1463,7 +1463,8 @@ public class S3Service implements Resettable {
                 sseCustomerHeaders.algorithm(), sseCustomerHeaders.key(), sseCustomerHeaders.keyMd5());
     }
 
-    public S3Object completeMultipartUpload(String bucket, String key, String uploadId, List<Integer> partNumbers) {
+    public S3Object completeMultipartUpload(String bucket, String key, String uploadId, List<Integer> partNumbers,
+                                            String checksumType, S3Checksum expectedChecksum) {
         MultipartUpload upload = multipartUploads.get(uploadId);
         if (upload == null || !upload.getBucket().equals(bucket) || !upload.getKey().equals(key)) {
             throw new AwsException("NoSuchUpload",
@@ -1493,6 +1494,11 @@ public class S3Service implements Resettable {
             }
 
             byte[] allData = combined.toByteArray();
+
+            if ("FULL_OBJECT".equalsIgnoreCase(checksumType) && expectedChecksum != null
+                    && expectedChecksum.hasAnyValue()) {
+                validateFullObjectChecksum(allData, expectedChecksum);
+            }
 
             // Composite ETag: MD5 of concatenated part MD5s, suffixed with part count
             String compositeETag = "\"" + bytesToHex(md.digest()) + "-" + partNumbers.size() + "\"";
@@ -2396,6 +2402,25 @@ public class S3Service implements Resettable {
             throw new AwsException("InvalidRequest", "The checksum algorithm you specified is a valid AWS checksum algorithm, but is not currently supported by Floci (supported: CRC32, CRC32C, CRC64NVME, SHA1, SHA256).", 400);
         }
         throw new AwsException("InvalidArgument", "The checksum algorithm you specified is not supported.", 400);
+    }
+
+    private static void validateFullObjectChecksum(byte[] data, S3Checksum expected) {
+        if (expected.getChecksumSHA1() != null && !expected.getChecksumSHA1().equals(S3Checksum.sha1Base64(data))) {
+            throw new AwsException("BadDigest", "The SHA1 checksum you specified did not match the payload.", 400);
+        }
+        if (expected.getChecksumSHA256() != null && !expected.getChecksumSHA256().equals(S3Checksum.sha256Base64(data))) {
+            throw new AwsException("BadDigest", "The SHA256 checksum you specified did not match the payload.", 400);
+        }
+        if (expected.getChecksumCRC32() != null && !expected.getChecksumCRC32().equals(S3Checksum.crc32Base64(data))) {
+            throw new AwsException("BadDigest", "The CRC32 checksum you specified did not match the payload.", 400);
+        }
+        if (expected.getChecksumCRC32C() != null && !expected.getChecksumCRC32C().equals(S3Checksum.crc32cBase64(data))) {
+            throw new AwsException("BadDigest", "The CRC32C checksum you specified did not match the payload.", 400);
+        }
+        if (expected.getChecksumCRC64NVME() != null
+                && !expected.getChecksumCRC64NVME().equals(S3Checksum.crc64NvmeBase64(data))) {
+            throw new AwsException("BadDigest", "The CRC64NVME checksum you specified did not match the payload.", 400);
+        }
     }
 
     private static S3Checksum buildChecksum(byte[] data, List<Part> parts, boolean multipartUpload) {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -1495,8 +1495,9 @@ public class S3Service implements Resettable {
 
             byte[] allData = combined.toByteArray();
 
-            if ("FULL_OBJECT".equalsIgnoreCase(checksumType) && expectedChecksum != null
-                    && expectedChecksum.hasAnyValue()) {
+            boolean fullObjectChecksumRequested = "FULL_OBJECT".equalsIgnoreCase(checksumType)
+                    && expectedChecksum != null && expectedChecksum.hasAnyValue();
+            if (fullObjectChecksumRequested) {
                 validateFullObjectChecksum(allData, expectedChecksum);
             }
 
@@ -1507,6 +1508,9 @@ public class S3Service implements Resettable {
                     .map(num -> copyPart(upload.getParts().get(num)))
                     .toList();
             S3Checksum checksum = buildChecksum(allData, completedParts, true, upload.getChecksumAlgorithm());
+            if (fullObjectChecksumRequested) {
+                checksum.setChecksumType("FULL_OBJECT");
+            }
             S3Object object = storeObject(bucket, key, allData, upload.getContentType(), upload.getMetadata(),
                     checksum, completedParts,
                     new PutObjectOptions()
@@ -2405,11 +2409,11 @@ public class S3Service implements Resettable {
     }
 
     private static void validateFullObjectChecksum(byte[] data, S3Checksum expected) {
-        if (expected.getChecksumSHA1() != null && !expected.getChecksumSHA1().equals(S3Checksum.sha1Base64(data))) {
-            throw new AwsException("BadDigest", "The SHA1 checksum you specified did not match the payload.", 400);
-        }
-        if (expected.getChecksumSHA256() != null && !expected.getChecksumSHA256().equals(S3Checksum.sha256Base64(data))) {
-            throw new AwsException("BadDigest", "The SHA256 checksum you specified did not match the payload.", 400);
+        if (expected.getChecksumSHA1() != null || expected.getChecksumSHA256() != null) {
+            throw new AwsException("InvalidRequest",
+                    "The FULL_OBJECT checksum type is not supported with the SHA1 or SHA256 checksum algorithm. "
+                            + "Full object checksums are only supported with the CRC32, CRC32C, and CRC64NVME checksum algorithms.",
+                    400);
         }
         if (expected.getChecksumCRC32() != null && !expected.getChecksumCRC32().equals(S3Checksum.crc32Base64(data))) {
             throw new AwsException("BadDigest", "The CRC32 checksum you specified did not match the payload.", 400);

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.s3;
 
+import io.github.hectorvent.floci.services.s3.model.S3Checksum;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -559,6 +560,81 @@ class S3MultipartIntegrationTest {
 
     @Test
     @Order(20)
+    void completeMultipartUploadRejectsMismatchedFullObjectChecksum() {
+        String key = "checksum-mismatch-multipart.bin";
+        String newUploadId = given()
+            .header("x-amz-checksum-algorithm", "CRC32")
+        .when()
+            .post("/" + BUCKET + "/" + key + "?uploads")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath().getString("InitiateMultipartUploadResult.UploadId");
+
+        given()
+            .body("Part1Data-Hello")
+        .when()
+            .put("/" + BUCKET + "/" + key + "?uploadId=" + newUploadId + "&partNumber=1")
+        .then()
+            .statusCode(200);
+
+        String completeXml = """
+                <CompleteMultipartUpload>
+                    <Part><PartNumber>1</PartNumber><ETag>etag1</ETag></Part>
+                </CompleteMultipartUpload>""";
+
+        given()
+            .contentType("application/xml")
+            .header("x-amz-checksum-type", "FULL_OBJECT")
+            .header("x-amz-checksum-crc32", "AAAAAA==")
+            .body(completeXml)
+        .when()
+            .post("/" + BUCKET + "/" + key + "?uploadId=" + newUploadId)
+        .then()
+            .statusCode(400)
+            .body(containsString("BadDigest"));
+    }
+
+    @Test
+    @Order(21)
+    void completeMultipartUploadAcceptsMatchingFullObjectChecksum() {
+        String key = "checksum-match-multipart.bin";
+        String data = "Part1Data-Hello";
+        String correctCrc32 = S3Checksum.crc32Base64(data.getBytes(StandardCharsets.UTF_8));
+
+        String newUploadId = given()
+            .header("x-amz-checksum-algorithm", "CRC32")
+        .when()
+            .post("/" + BUCKET + "/" + key + "?uploads")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath().getString("InitiateMultipartUploadResult.UploadId");
+
+        given()
+            .body(data)
+        .when()
+            .put("/" + BUCKET + "/" + key + "?uploadId=" + newUploadId + "&partNumber=1")
+        .then()
+            .statusCode(200);
+
+        String completeXml = """
+                <CompleteMultipartUpload>
+                    <Part><PartNumber>1</PartNumber><ETag>etag1</ETag></Part>
+                </CompleteMultipartUpload>""";
+
+        given()
+            .contentType("application/xml")
+            .header("x-amz-checksum-type", "FULL_OBJECT")
+            .header("x-amz-checksum-crc32", correctCrc32)
+            .body(completeXml)
+        .when()
+            .post("/" + BUCKET + "/" + key + "?uploadId=" + newUploadId)
+        .then()
+            .statusCode(200)
+            .body(containsString("<CompleteMultipartUploadResult"));
+    }
+
+    @Test
+    @Order(22)
     void cleanUp() {
         given().when().delete("/" + BUCKET + "/" + KEY).then().statusCode(204);
         given().when().delete("/" + BUCKET + "/tagged-multipart.bin").then().statusCode(204);
@@ -566,6 +642,7 @@ class S3MultipartIntegrationTest {
         given().when().delete("/" + BUCKET + "/copy-dest.bin").then().statusCode(204);
         given().when().delete("/" + BUCKET + "/sse-c-multipart.bin").then().statusCode(204);
         given().when().delete("/" + BUCKET + "/sse-c-source-for-copy.bin").then().statusCode(204);
+        given().when().delete("/" + BUCKET + "/checksum-match-multipart.bin").then().statusCode(204);
         given().when().delete("/" + BUCKET).then().statusCode(204);
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
@@ -592,6 +592,13 @@ class S3MultipartIntegrationTest {
         .then()
             .statusCode(400)
             .body(containsString("BadDigest"));
+
+        // The checksum mismatch rejects completion before the upload is consumed, so abort it explicitly.
+        given()
+        .when()
+            .delete("/" + BUCKET + "/" + key + "?uploadId=" + newUploadId)
+        .then()
+            .statusCode(204);
     }
 
     @Test
@@ -635,6 +642,94 @@ class S3MultipartIntegrationTest {
 
     @Test
     @Order(22)
+    void completeMultipartUploadRejectsFullObjectShaChecksum() {
+        String key = "checksum-sha-full-object-multipart.bin";
+        String newUploadId = given()
+            .header("x-amz-checksum-algorithm", "SHA256")
+        .when()
+            .post("/" + BUCKET + "/" + key + "?uploads")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath().getString("InitiateMultipartUploadResult.UploadId");
+
+        given()
+            .body("Part1Data-Hello")
+        .when()
+            .put("/" + BUCKET + "/" + key + "?uploadId=" + newUploadId + "&partNumber=1")
+        .then()
+            .statusCode(200);
+
+        String completeXml = """
+                <CompleteMultipartUpload>
+                    <Part><PartNumber>1</PartNumber><ETag>etag1</ETag></Part>
+                </CompleteMultipartUpload>""";
+
+        given()
+            .contentType("application/xml")
+            .header("x-amz-checksum-type", "FULL_OBJECT")
+            .header("x-amz-checksum-sha256", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+            .body(completeXml)
+        .when()
+            .post("/" + BUCKET + "/" + key + "?uploadId=" + newUploadId)
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidRequest"));
+
+        given()
+        .when()
+            .delete("/" + BUCKET + "/" + key + "?uploadId=" + newUploadId)
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    @Order(23)
+    void completeMultipartUploadReportsFullObjectChecksumType() {
+        String key = "checksum-type-multipart.bin";
+        String data = "Part1Data-Hello";
+        String correctCrc32 = S3Checksum.crc32Base64(data.getBytes(StandardCharsets.UTF_8));
+
+        String newUploadId = given()
+            .header("x-amz-checksum-algorithm", "CRC32")
+        .when()
+            .post("/" + BUCKET + "/" + key + "?uploads")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath().getString("InitiateMultipartUploadResult.UploadId");
+
+        given()
+            .body(data)
+        .when()
+            .put("/" + BUCKET + "/" + key + "?uploadId=" + newUploadId + "&partNumber=1")
+        .then()
+            .statusCode(200);
+
+        String completeXml = """
+                <CompleteMultipartUpload>
+                    <Part><PartNumber>1</PartNumber><ETag>etag1</ETag></Part>
+                </CompleteMultipartUpload>""";
+
+        given()
+            .contentType("application/xml")
+            .header("x-amz-checksum-type", "FULL_OBJECT")
+            .header("x-amz-checksum-crc32", correctCrc32)
+            .body(completeXml)
+        .when()
+            .post("/" + BUCKET + "/" + key + "?uploadId=" + newUploadId)
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("x-amz-object-attributes", "Checksum")
+        .when()
+            .get("/" + BUCKET + "/" + key + "?attributes")
+        .then()
+            .statusCode(200)
+            .body(containsString("<ChecksumType>FULL_OBJECT</ChecksumType>"));
+    }
+
+    @Test
+    @Order(24)
     void cleanUp() {
         given().when().delete("/" + BUCKET + "/" + KEY).then().statusCode(204);
         given().when().delete("/" + BUCKET + "/tagged-multipart.bin").then().statusCode(204);
@@ -643,6 +738,7 @@ class S3MultipartIntegrationTest {
         given().when().delete("/" + BUCKET + "/sse-c-multipart.bin").then().statusCode(204);
         given().when().delete("/" + BUCKET + "/sse-c-source-for-copy.bin").then().statusCode(204);
         given().when().delete("/" + BUCKET + "/checksum-match-multipart.bin").then().statusCode(204);
+        given().when().delete("/" + BUCKET + "/checksum-type-multipart.bin").then().statusCode(204);
         given().when().delete("/" + BUCKET).then().statusCode(204);
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartServiceTest.java
@@ -79,7 +79,7 @@ class S3MultipartServiceTest {
         s3Service.uploadPart("test-bucket", "file.bin", upload.getUploadId(), 2, "part2".getBytes());
 
         S3Object result = s3Service.completeMultipartUpload("test-bucket", "file.bin",
-                upload.getUploadId(), List.of(1, 2));
+                upload.getUploadId(), List.of(1, 2), null, null);
 
         assertNotNull(result);
         assertEquals("text/plain", result.getContentType());
@@ -101,7 +101,7 @@ class S3MultipartServiceTest {
                 Map.of("token", "abc-123", "teamId", "42"));
         s3Service.uploadPart("test-bucket", "tagged.bin", upload.getUploadId(), 1, "part1".getBytes());
 
-        s3Service.completeMultipartUpload("test-bucket", "tagged.bin", upload.getUploadId(), List.of(1));
+        s3Service.completeMultipartUpload("test-bucket", "tagged.bin", upload.getUploadId(), List.of(1), null, null);
 
         Map<String, String> tags = s3Service.getObjectTagging("test-bucket", "tagged.bin");
         assertEquals(2, tags.size());
@@ -114,7 +114,7 @@ class S3MultipartServiceTest {
         MultipartUpload upload = s3Service.initiateMultipartUpload("test-bucket", "untagged.bin", null);
         s3Service.uploadPart("test-bucket", "untagged.bin", upload.getUploadId(), 1, "part1".getBytes());
 
-        s3Service.completeMultipartUpload("test-bucket", "untagged.bin", upload.getUploadId(), List.of(1));
+        s3Service.completeMultipartUpload("test-bucket", "untagged.bin", upload.getUploadId(), List.of(1), null, null);
 
         assertTrue(s3Service.getObjectTagging("test-bucket", "untagged.bin").isEmpty());
     }
@@ -126,7 +126,7 @@ class S3MultipartServiceTest {
 
         assertThrows(AwsException.class, () ->
                 s3Service.completeMultipartUpload("test-bucket", "file.bin",
-                        upload.getUploadId(), List.of(1, 2)));
+                        upload.getUploadId(), List.of(1, 2), null, null));
     }
 
     @Test
@@ -163,7 +163,7 @@ class S3MultipartServiceTest {
         s3Service.uploadPart("test-bucket", "versioned.bin", upload.getUploadId(), 1, "data".getBytes());
 
         S3Object result = s3Service.completeMultipartUpload("test-bucket", "versioned.bin",
-                upload.getUploadId(), List.of(1));
+                upload.getUploadId(), List.of(1), null, null);
 
         assertNotNull(result.getVersionId(), "Versioned bucket should produce a versionId");
     }
@@ -172,7 +172,7 @@ class S3MultipartServiceTest {
     void completeMultipartUploadCleansUp() {
         MultipartUpload upload = s3Service.initiateMultipartUpload("test-bucket", "file.bin", null);
         s3Service.uploadPart("test-bucket", "file.bin", upload.getUploadId(), 1, "data".getBytes());
-        s3Service.completeMultipartUpload("test-bucket", "file.bin", upload.getUploadId(), List.of(1));
+        s3Service.completeMultipartUpload("test-bucket", "file.bin", upload.getUploadId(), List.of(1), null, null);
 
         // Should no longer be in active uploads
         List<MultipartUpload> uploads = s3Service.listMultipartUploads("test-bucket");
@@ -184,7 +184,7 @@ class S3MultipartServiceTest {
         MultipartUpload upload = s3Service.initiateMultipartUpload("test-bucket", "parts.bin", "application/octet-stream");
         s3Service.uploadPart("test-bucket", "parts.bin", upload.getUploadId(), 1, "abc".getBytes(StandardCharsets.UTF_8));
         s3Service.uploadPart("test-bucket", "parts.bin", upload.getUploadId(), 2, "def".getBytes(StandardCharsets.UTF_8));
-        s3Service.completeMultipartUpload("test-bucket", "parts.bin", upload.getUploadId(), List.of(1, 2));
+        s3Service.completeMultipartUpload("test-bucket", "parts.bin", upload.getUploadId(), List.of(1, 2), null, null);
 
         GetObjectAttributesResult attributes = s3Service.getObjectAttributes("test-bucket", "parts.bin", null,
                 Set.of(ObjectAttributeName.OBJECT_PARTS, ObjectAttributeName.CHECKSUM),


### PR DESCRIPTION
### Summary

`CompleteMultipartUpload` silently ignored client-supplied `ChecksumType=FULL_OBJECT`
checksums (e.g. `ChecksumCRC32`), always returning HTTP 200 even when the
checksum didn't match the reassembled object. Real S3 rejects this with
`BadDigest`. This matters for anyone relying on Floci to catch multipart
integrity bugs locally before they hit production.

```python
# BEFORE the fix:
aws --endpoint-url http://localhost:4566 s3api complete-multipart-upload \
  --bucket test-bucket --key test-key --upload-id "$UPLOAD_ID" \
  --checksum-type FULL_OBJECT --checksum-crc32 "AAAAAA==" \
  --multipart-upload '{"Parts":[{"ETag":"...","PartNumber":1}]}'
# -> HTTP 200 (wrong: "AAAAAA==" does not match the uploaded content)

# AFTER the fix:
# -> HTTP 400 BadDigest: "The CRC32 checksum you specified did not match the payload."
```

Closes #1950

### Type of change

- [x] Bug fix (`fix:`)

### Root cause

`S3Controller.handleMultipartPost` never read the `x-amz-checksum-type` /
`x-amz-checksum-*` headers on the CompleteMultipartUpload path, and
`S3Service.completeMultipartUpload` had no checksum parameter at all — so
nothing was ever compared against the reassembled object.

### What changed

- `S3Controller`: extract `x-amz-checksum-type` and checksum headers (via the
  existing `extractChecksumFromHeaders` helper) and pass them through.
- `S3Service.completeMultipartUpload`: new `checksumType` / `expectedChecksum`
  params; validates the client's claimed checksum against the actual digest of
  the reassembled bytes before storing, throwing the same `BadDigest` error
  Floci already uses for PutObject/UploadPart checksum mismatches.
- Scoped to `ChecksumType=FULL_OBJECT` only. Floci's multipart completion
  always reports `ChecksumType=COMPOSITE`, but computes the value as a plain
  full-object hash rather than a true `crc32_combine`-style composite — so
  validating COMPOSITE-type requests against that simplified computation risks
  false-positive rejections. That's a separate, pre-existing gap, flagged as
  follow-up rather than folded into this fix.

### AWS Compatibility

Verified error code/message against AWS's documented behavior (S3
`CompleteMultipartUpload` with `ChecksumType=FULL_OBJECT` returns `BadDigest`
on mismatch) and against Floci's own existing convention for the same error on
PutObject/UploadPart (`S3Controller.validateChecksumHeaders`).

Full-object checksum support for multipart uploads is restricted to CRC-based algorithms (CRC64NVME, CRC32, CRC32C); SHA-1 and SHA-256 are composite-only, per the AWS S3 User Guide's "Full object and composite checksum types" table and "Using full object checksums for multipart upload" section (https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity-upload.html#Full-object-checksums), which states this restriction exists because only CRC algorithms can linearize part-level checksums into a full-object checksum.

### How it was tested

Rebased onto current `main` (post-#2151, which also touched multipart completion);
all figures below are from that rebased branch.

- Full suite (`./mvnw test`): **8540 run, 0 failures, 0 errors, 9 skipped**. BUILD SUCCESS.
- S3 subset (`-Dtest='S3*Test'`): 689 run, 0 failures, 0 errors.
- New tests in `S3MultipartIntegrationTest`:
  - `completeMultipartUploadRejectsMismatchedFullObjectChecksum` => wrong CRC32 => 400 BadDigest.
  - `completeMultipartUploadAcceptsMatchingFullObjectChecksum` => correct CRC32 => 200.
  - `completeMultipartUploadRejectsFullObjectShaChecksum` => SHA256 + FULL_OBJECT => 400 InvalidRequest.
  - `completeMultipartUploadReportsFullObjectChecksumType` => validated request reports
    `<ChecksumType>FULL_OBJECT</ChecksumType>` via GetObjectAttributes.
- `make docs-check` passes (no handler action registration changed).
- **Manually verified live** against `./mvnw quarkus:dev` using the AWS CLI, reproducing
  the issue's exact repro steps end-to-end:
  - `create-multipart-upload --checksum-type FULL_OBJECT --checksum-algorithm CRC32` => `upload-part` =>
    `complete-multipart-upload --checksum-crc32 "AAAAAA=="` (the issue's own wrong value) =>
    now returns `An error occurred (BadDigest) ... The CRC32 checksum you specified did not match the payload.`
    (previously silently returned 200).
  - Same upload completed with the correct CRC32 => 200, object stored, downloaded bytes
    verified byte-for-byte identical to the uploaded part.
  - A separate multipart upload completed with **no** checksum headers at all still
    succeeds (200), confirms the fix is additive and doesn't disturb existing callers.

### Rebase note

Rebased onto `main` to pick up #2151 (`fix(s3): Ensure tags are added on multipart s3 uploads`),
which touched the same three files. Resolution preserved both changes:

- `S3Service.completeMultipartUpload` now performs the FULL_OBJECT checksum validation
  **and** #2151's `.withTagging(upload.getTagging())` propagation.
- `S3MultipartIntegrationTest`: #2151's tagging tests keep `@Order(18)`/`@Order(19)`;
  this PR's four tests are renumbered to `@Order(20)`–`@Order(23)`, with `cleanUp` last.
- `S3MultipartServiceTest`: #2151's two new tests called the 4-arg
  `completeMultipartUpload`, which this PR widens to 6 args — both call sites updated to
  pass `null, null`, matching the existing call sites in that file.

### Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits
