### PR TITLE
ci: use the snake_case input names first-interaction v3 expects

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -24,16 +24,16 @@ jobs:
       # single newline in a comment as a hard line break.
       - uses: actions/first-interaction@v3.1.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
 
-          issue-message: |
+          issue_message: |
             👋 Thanks for opening your first issue in Floci!
 
             A maintainer will triage this and add the right service label. If you included a minimal reproduction and the Floci version, that is everything we need — no action required from you right now.
 
             Come say hi in [Slack](https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw) if you want to talk it through with maintainers and other contributors. Questions about AWS behaviour, design tradeoffs, and rough proposals are all welcome there.
 
-          pr-message: |
+          pr_message: |
             🎉 Thanks for your first pull request to Floci!
 
             **Your CI checks need a maintainer to approve them before they run.** That is GitHub's standard gate on first-time contributors, not a problem with your PR — so if the checks look like they are doing nothing, that is why. Once a maintainer approves, CI and the compatibility suite start automatically. Nothing is needed from you in the meantime.


### PR DESCRIPTION
## Summary

The welcome workflow has failed on every run since it merged: **12 runs, 12 failures**. First-time contributors get a red check on their first PR and no welcome comment, which is the opposite of what it is for. Latest example: the run on #1979.

The step passes `repo-token`, `issue-message` and `pr-message`, which are the **v1** input names. `actions/first-interaction@v3.1.0` renamed them to `repo_token`, `issue_message` and `pr_message`, so GitHub drops all three as unknown inputs and the action fails on its first required lookup:

```
Unexpected input(s) 'repo-token', 'issue-message', 'pr-message',
  valid inputs are ['issue_message', 'pr_message', 'repo_token']
Error: Input required and not supplied: issue_message
```

`repo_token` looks supplied in the logs only because the action declares it with `default: ${{ github.token }}`. The two message inputs have no default, so the first `getInput(..., { required: true })` throws.

Verified against the action's own `action.yml` at the pinned tag:

```yaml
inputs:
  issue_message:
    description: Comment to post on an individual's first issue
  pr_message:
    description: Comment to post on an individual's first pull request
  repo_token:
    required: true
    default: ${{ github.token }}
```

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Not applicable, CI workflow only. No emulator code changes.

## Checklist

- [x] `./mvnw test` — not applicable, no source changes
- [x] New or updated integration test added — not applicable, see below
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

`pull_request_target` always runs the **base branch's** copy of a workflow, so this fix cannot be exercised from a PR: this PR's checks still use the broken version on `main`. The real verification is the next first-time contribution after merge, which should post the welcome comment and go green. Worth watching the following newcomer PR to confirm.
