### PR TITLE
feat(ci): publish Docker images to GitHub Container Registry

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,6 +19,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  packages: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -148,6 +149,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6.2.0
         with:
@@ -173,6 +181,8 @@ jobs:
             floci/floci:nightly-${{ needs.prepare.outputs.version }}
             public.ecr.aws/floci/floci:nightly
             public.ecr.aws/floci/floci:nightly-${{ needs.prepare.outputs.version }}
+            ghcr.io/floci-io/floci:nightly
+            ghcr.io/floci-io/floci:nightly-${{ needs.prepare.outputs.version }}
           labels: |
             org.opencontainers.image.version=nightly-${{ needs.prepare.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -197,6 +207,8 @@ jobs:
             floci/floci:nightly-${{ needs.prepare.outputs.version }}-compat
             public.ecr.aws/floci/floci:nightly-compat
             public.ecr.aws/floci/floci:nightly-${{ needs.prepare.outputs.version }}-compat
+            ghcr.io/floci-io/floci:nightly-compat
+            ghcr.io/floci-io/floci:nightly-${{ needs.prepare.outputs.version }}-compat
           build-args: |
             VERSION=nightly-${{ needs.prepare.outputs.version }}
           labels: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 # Per-tag concurrency. Back-to-back tag pushes (e.g. 1.5.3 and 1.6.0 landing
 # minutes apart) resolve to different ${{ github.ref }} values, so they run
@@ -126,6 +127,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push native multi-arch image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         env:
@@ -138,6 +146,8 @@ jobs:
           tags: |
             floci/floci:${{ steps.version.outputs.version }}
             floci/floci:latest
+            ghcr.io/floci-io/floci:${{ steps.version.outputs.version }}
+            ghcr.io/floci-io/floci:latest
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
           labels: |
@@ -162,6 +172,8 @@ jobs:
           tags: |
             floci/floci:${{ steps.version.outputs.version }}-compat
             floci/floci:latest-compat
+            ghcr.io/floci-io/floci:${{ steps.version.outputs.version }}-compat
+            ghcr.io/floci-io/floci:latest-compat
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
           labels: |

--- a/docs/configuration/docker-images.md
+++ b/docs/configuration/docker-images.md
@@ -1,6 +1,12 @@
 # Docker Images
 
-Floci publishes images to [Docker Hub (`floci/floci`)](https://hub.docker.com/r/floci/floci).
+Floci publishes images to multiple registries.
+
+| Registry | Image | Channels |
+|---|---|---|
+| [Docker Hub](https://hub.docker.com/r/floci/floci) | `floci/floci` | Release + nightly |
+| [GitHub Container Registry](https://github.com/floci-io/floci/pkgs/container/floci) | `ghcr.io/floci-io/floci` | Release + nightly |
+| [ECR Public Gallery](https://gallery.ecr.aws/floci/floci) | `public.ecr.aws/floci/floci` | Nightly |
 
 Every image tag combines two independent choices: **what's inside** (variant) and **how stable it is** (channel).
 


### PR DESCRIPTION
Why: ECR only contains nightly releases; DockerHub rate limits are low. GHCR is free, unlimited, and a natural fit for GitHub Actions workflows.

This adds ghcr.io/floci-io/floci as an additional push target alongside Docker Hub in both the release and nightly workflows, mirroring the same tags (release: {version}, latest, {version}-compat, latest-compat; nightly: nightly, nightly-{mmddyyyy}, nightly-compat, nightly-{mmddyyyy}-compat).

Authenticates with the built-in GITHUB_TOKEN via a workflow-level packages: write permission (consistent with the existing id-token: write grant in nightly.yml); no new secret is required, unlike the ECR Public integration which depends on an org-level AWS_ROLE_ARN and OIDC.

Also documents the registries Floci publishes to in docs/configuration/docker-images.md.

Note: the GHCR package will be created as private on first push and must be manually switched to public by a floci-io org owner.

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

N/A

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->

