### PR TITLE
feat(iam): add GetAccountSummary support

### DIFF
--- a/docs/services/iam.md
+++ b/docs/services/iam.md
@@ -141,6 +141,12 @@
 |--------|-------------|
 | SimulatePrincipalPolicy | Evaluates requested actions and resources against the resolved principal's policies. |
 
+### Account
+
+| Action | Description |
+|--------|-------------|
+| GetAccountSummary | Returns entity counts (users, groups, roles, customer-managed policies, instance profiles) and IAM quota values. Resources Floci does not track (MFA devices, SAML/OIDC providers, server certificates) are reported as zero rather than omitted. |
+
 ## AWS Managed Policies
 
 Floci seeds a catalog of commonly-used AWS managed policies at startup. These are attachable immediately without any setup:

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
@@ -93,6 +93,7 @@ public class IamQueryHandler {
             case "DeletePolicy" -> handleDeletePolicy(params);
             case "ListPolicies" -> handleListPolicies(params);
             case "ListEntitiesForPolicy" -> handleListEntitiesForPolicy(params);
+            case "GetAccountSummary" -> handleGetAccountSummary(params);
             case "CreatePolicyVersion" -> handleCreatePolicyVersion(params);
             case "GetPolicyVersion" -> handleGetPolicyVersion(params);
             case "DeletePolicyVersion" -> handleDeletePolicyVersion(params);
@@ -495,6 +496,15 @@ public class IamQueryHandler {
         }
         xml.end("PolicyRoles").elem("IsTruncated", false);
         return Response.ok(AwsQueryResponse.envelope("ListEntitiesForPolicy", AwsNamespaces.IAM, xml.build())).build();
+    }
+
+    private Response handleGetAccountSummary(MultivaluedMap<String, String> params) {
+        var xml = new XmlBuilder().start("SummaryMap");
+        for (Map.Entry<String, Long> entry : iamService.getAccountSummary().entrySet()) {
+            xml.start("entry").elem("key", entry.getKey()).elem("value", entry.getValue()).end("entry");
+        }
+        xml.end("SummaryMap");
+        return Response.ok(AwsQueryResponse.envelope("GetAccountSummary", AwsNamespaces.IAM, xml.build())).build();
     }
 
     private Response handleCreatePolicyVersion(MultivaluedMap<String, String> params) {

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
@@ -554,6 +554,64 @@ public class IamService implements SessionAccountLookup {
         return result;
     }
 
+    /**
+     * Entity counts and quotas backing GetAccountSummary. Covers all 34 documented SummaryMap
+     * keys; quota values are cross-checked against AWS's published IAM service quotas
+     * (docs.aws.amazon.com/general/latest/gr/iam-service.html), though floci itself enforces
+     * only the 5-versions-per-policy cap in {@link #createPolicyVersion}. Resources floci does
+     * not track at all (MFA devices, SAML/OIDC providers, server certificates, account password -
+     * all stub-empty elsewhere in this handler) are reported as zero rather than omitted, so
+     * callers indexing into the full AWS field set don't hit a missing-key error.
+     */
+    public Map<String, Long> getAccountSummary() {
+        long localPolicyCount = 0;
+        long policyVersionsInUse = 0;
+        for (IamPolicy policy : policies.scan(k -> true)) {
+            if (policy.getArn().startsWith(AwsManagedPolicies.ARN_PREFIX)) {
+                continue;
+            }
+            localPolicyCount++;
+            policyVersionsInUse += policy.getVersions().size();
+        }
+
+        Map<String, Long> summary = new LinkedHashMap<>();
+        summary.put("Users", (long) listUsers(null).size());
+        summary.put("UsersQuota", 5000L);
+        summary.put("Groups", (long) listGroups(null).size());
+        summary.put("GroupsQuota", 300L);
+        summary.put("GroupsPerUserQuota", 10L);
+        summary.put("Roles", (long) listRoles(null).size());
+        summary.put("RolesQuota", 1000L);
+        summary.put("AssumeRolePolicySizeQuota", 2048L);
+        summary.put("Policies", localPolicyCount);
+        summary.put("PoliciesQuota", 1500L);
+        summary.put("PolicySizeQuota", 6144L);
+        summary.put("PolicyVersionsInUse", policyVersionsInUse);
+        summary.put("PolicyVersionsInUseQuota", 10000L);
+        summary.put("VersionsPerPolicyQuota", 5L);
+        summary.put("InstanceProfiles", (long) listInstanceProfiles(null).size());
+        summary.put("InstanceProfilesQuota", 1000L);
+        summary.put("AttachedPoliciesPerUserQuota", 10L);
+        summary.put("AttachedPoliciesPerGroupQuota", 10L);
+        summary.put("AttachedPoliciesPerRoleQuota", 10L);
+        summary.put("GroupPolicySizeQuota", 5120L);
+        summary.put("UserPolicySizeQuota", 2048L);
+        summary.put("RolePolicySizeQuota", 10240L);
+        summary.put("AccessKeysPerUserQuota", 2L);
+        summary.put("SigningCertificatesPerUserQuota", 2L);
+        summary.put("ServerCertificates", 0L);
+        summary.put("ServerCertificatesQuota", 20L);
+        summary.put("Providers", 0L);
+        summary.put("MFADevices", 0L);
+        summary.put("MFADevicesInUse", 0L);
+        summary.put("AccountMFAEnabled", 0L);
+        summary.put("AccountAccessKeysPresent", 0L);
+        summary.put("AccountSigningCertificatesPresent", 0L);
+        summary.put("AccountPasswordPresent", 0L);
+        summary.put("GlobalEndpointTokenVersion", 1L);
+        return summary;
+    }
+
     public PolicyVersion createPolicyVersion(String policyArn, String document, boolean setAsDefault) {
         rejectIfAwsManaged(policyArn);
         IamPolicy policy = getPolicy(policyArn);

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamGetAccountSummaryIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamGetAccountSummaryIntegrationTest.java
@@ -1,0 +1,119 @@
+package io.github.hectorvent.floci.services.iam;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Verifies the IAM GetAccountSummary query action returns entity counts (which change as
+ * resources are created) alongside static quota values. IAM state is shared across tests in
+ * this suite, so counts are asserted via before/after deltas rather than absolute values.
+ */
+@QuarkusTest
+class IamGetAccountSummaryIntegrationTest {
+
+    private static final String IAM_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260227/us-east-1/iam/aws4_request";
+
+    private long summaryValue(String key) {
+        return Long.parseLong(
+                given()
+                    .formParam("Action", "GetAccountSummary")
+                    .header("Authorization", IAM_AUTH)
+                .when()
+                    .post("/")
+                .then()
+                    .statusCode(200)
+                    .contentType("application/xml")
+                    .extract()
+                    .path("GetAccountSummaryResponse.GetAccountSummaryResult.SummaryMap.entry"
+                            + ".find { it.key == '" + key + "' }.value"));
+    }
+
+    @Test
+    void countsIncreaseAsEntitiesAreCreated() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String userName = "gas-user-" + suffix;
+        String policyName = "gas-policy-" + suffix;
+
+        long usersBefore = summaryValue("Users");
+        long policiesBefore = summaryValue("Policies");
+
+        given()
+            .formParam("Action", "CreateUser")
+            .formParam("UserName", userName)
+            .header("Authorization", IAM_AUTH)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .formParam("Action", "CreatePolicy")
+            .formParam("PolicyName", policyName)
+            .formParam("PolicyDocument",
+                    "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\","
+                    + "\"Action\":\"s3:GetObject\",\"Resource\":\"*\"}]}")
+            .header("Authorization", IAM_AUTH)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        assertSummaryValue("Users", usersBefore + 1);
+        assertSummaryValue("Policies", policiesBefore + 1);
+    }
+
+    private void assertSummaryValue(String key, long expected) {
+        given()
+            .formParam("Action", "GetAccountSummary")
+            .header("Authorization", IAM_AUTH)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("GetAccountSummaryResponse.GetAccountSummaryResult.SummaryMap.entry"
+                    + ".find { it.key == '" + key + "' }.value", equalTo(String.valueOf(expected)));
+    }
+
+    @Test
+    void reportsAllThirtyFourDocumentedFields() {
+        // docs.aws.amazon.com/IAM/latest/APIReference/API_GetAccountSummary.html lists exactly
+        // 34 valid SummaryMap keys - a caller indexing into any of them should never KeyError.
+        given()
+            .formParam("Action", "GetAccountSummary")
+            .header("Authorization", IAM_AUTH)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("GetAccountSummaryResponse.GetAccountSummaryResult.SummaryMap.entry.size()",
+                    equalTo(34));
+    }
+
+    @Test
+    void reportsStaticQuotaValues() {
+        given()
+            .formParam("Action", "GetAccountSummary")
+            .header("Authorization", IAM_AUTH)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            // VersionsPerPolicyQuota mirrors the 5-versions-per-policy cap enforced in
+            // IamService#createPolicyVersion - not just a display value.
+            .body("GetAccountSummaryResponse.GetAccountSummaryResult.SummaryMap.entry"
+                    + ".find { it.key == 'VersionsPerPolicyQuota' }.value", equalTo("5"))
+            .body("GetAccountSummaryResponse.GetAccountSummaryResult.SummaryMap.entry"
+                    + ".find { it.key == 'UsersQuota' }.value", equalTo("5000"))
+            .body("GetAccountSummaryResponse.GetAccountSummaryResult.SummaryMap.entry"
+                    + ".find { it.key == 'AssumeRolePolicySizeQuota' }.value", equalTo("2048"))
+            .body("GetAccountSummaryResponse.GetAccountSummaryResult.SummaryMap.entry"
+                    + ".find { it.key == 'AccountPasswordPresent' }.value", equalTo("0"))
+            .body("GetAccountSummaryResponse.GetAccountSummaryResult.SummaryMap.entry"
+                    + ".find { it.key == 'MFADevices' }.value", equalTo("0"));
+    }
+}


### PR DESCRIPTION
**Title: feat(iam): add GetAccountSummary support**

**Part of #1938** - this PR implements GetAccountSummary. The other requested action, ListEntitiesForPolicy, is implemented separately in #1808. #1938 should only close once both PRs have merged.

Adds the `GetAccountSummary` IAM query action - currently falls through to `UnsupportedOperation`. Returns all 34 documented `SummaryMap` fields:

**- Live counts:** `Users`, `Groups`, `Roles`, `Policies` (customer-managed only), `InstanceProfiles`, `PolicyVersionsInUse`
**- Quota values:** cross-checked against [[AWS's published IAM service quotas](https://docs.aws.amazon.com/general/latest/gr/iam-service.html)](https://docs.aws.amazon.com/general/latest/gr/iam-service.html) and independently verified against moto's ``implementation; every value matches both sources exactly
- Untracked resources (MFA devices, SAML/OIDC providers, server certificates, account passwords): report `0` rather than being omitted, so callers indexing into the full AWS field set don't hit a missing-key error, the same class of bug as the CloudFront `OriginGroups` issue elsewhere in this repo

**Testing:**
- New `IamGetAccountSummaryIntegrationTest`: verifies counts increase correctly via before/after deltas (IAM state persists across this test suite), static quota values, and a completeness check asserting exactly 34 fields
- Full IAM package: 181/181 passing, no regressions
- Manually verified end-to-end against the live dev server via AWS CLI:

<img width="1622" height="972" alt="image" src="https://github.com/user-attachments/assets/67f87a3c-d177-4745-b6f8-8ea5b3d3a7e3" />
