### PR TITLE
feat(cloudformation): provision AWS::EC2::VPCEndpoint

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -331,6 +331,8 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::EC2::Subnet" -> provisionSubnet(resource, properties, engine, region);
                 case "AWS::EC2::SecurityGroup" -> provisionSecurityGroup(resource, properties, engine, region, stackName);
                 case "AWS::EC2::InternetGateway" -> provisionInternetGateway(resource, region);
+                case "AWS::EC2::VPCEndpoint" ->
+                        provisionVpcEndpoint(resource, properties, engine, region);
                 case "AWS::EC2::RouteTable" -> provisionRouteTable(resource, properties, engine, region);
                 case "AWS::EC2::SubnetRouteTableAssociation" ->
                         provisionSubnetRouteTableAssociation(resource, properties, engine, region);
@@ -454,6 +456,7 @@ public class CloudFormationResourceProvisioner {
             case "AWS::ElasticLoadBalancingV2::ListenerRule" -> elbV2Service.deleteRule(region, physicalId);
             case "AWS::KinesisFirehose::DeliveryStream" -> firehoseService.deleteDeliveryStream(physicalId);
             case "AWS::EC2::SecurityGroup" -> ec2Service.deleteSecurityGroup(region, physicalId);
+            case "AWS::EC2::VPCEndpoint" -> ec2Service.deleteVpcEndpoints(region, List.of(physicalId));
             case "AWS::EC2::Instance" -> ec2Service.terminateInstances(region, List.of(physicalId));
             case "AWS::RDS::DBInstance" -> rdsService.deleteDbInstance(physicalId);
             case "AWS::RDS::DBCluster" -> rdsService.deleteDbCluster(physicalId);
@@ -588,6 +591,34 @@ public class CloudFormationResourceProvisioner {
         if (sg.getVpcId() != null) {
             r.getAttributes().put("VpcId", sg.getVpcId());
         }
+    }
+
+    private void provisionVpcEndpoint(StackResource r, JsonNode props,
+                                      CloudFormationTemplateEngine engine, String region) {
+        String vpcId = resolveOptional(props, "VpcId", engine);
+        String serviceName = resolveOptional(props, "ServiceName", engine);
+        String endpointType = resolveOptional(props, "VpcEndpointType", engine);
+        var endpoint = ec2Service.createVpcEndpoint(region, vpcId, serviceName,
+                endpointType != null ? endpointType : "Gateway",
+                resolveIdList(props, "RouteTableIds", engine),
+                resolveIdList(props, "SubnetIds", engine),
+                resolveIdList(props, "SecurityGroupIds", engine),
+                props != null && props.path("PrivateDnsEnabled").asBoolean(false),
+                List.of());
+        r.setPhysicalId(endpoint.getVpcEndpointId());
+        r.getAttributes().put("Id", endpoint.getVpcEndpointId());
+    }
+
+    /** Resolve an array property of Ref/GetAtt entries into plain id strings. */
+    private List<String> resolveIdList(JsonNode props, String field, CloudFormationTemplateEngine engine) {
+        List<String> ids = new ArrayList<>();
+        if (props != null && props.has(field) && props.get(field).isArray()) {
+            for (JsonNode entry : props.get(field)) {
+                String id = engine.resolve(entry);
+                if (id != null && !id.isBlank()) ids.add(id);
+            }
+        }
+        return ids;
     }
 
     private void provisionInternetGateway(StackResource r, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -339,8 +339,6 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::EC2::Subnet" -> provisionSubnet(resource, properties, engine, region);
                 case "AWS::EC2::SecurityGroup" -> provisionSecurityGroup(resource, properties, engine, region, stackName);
                 case "AWS::EC2::InternetGateway" -> provisionInternetGateway(resource, region);
-                case "AWS::EC2::VPCEndpoint" ->
-                        provisionVpcEndpoint(resource, properties, engine, region);
                 case "AWS::EC2::RouteTable" -> provisionRouteTable(resource, properties, engine, region);
                 case "AWS::EC2::SubnetRouteTableAssociation" ->
                         provisionSubnetRouteTableAssociation(resource, properties, engine, region);
@@ -480,7 +478,6 @@ public class CloudFormationResourceProvisioner {
             case "AWS::ElasticLoadBalancingV2::ListenerRule" -> elbV2Service.deleteRule(region, physicalId);
             case "AWS::KinesisFirehose::DeliveryStream" -> firehoseService.deleteDeliveryStream(physicalId);
             case "AWS::EC2::SecurityGroup" -> ec2Service.deleteSecurityGroup(region, physicalId);
-            case "AWS::EC2::VPCEndpoint" -> ec2Service.deleteVpcEndpoints(region, List.of(physicalId));
             case "AWS::EC2::Instance" -> ec2Service.terminateInstances(region, List.of(physicalId));
             case "AWS::RDS::DBInstance" -> rdsService.deleteDbInstance(physicalId);
             case "AWS::RDS::DBCluster" -> rdsService.deleteDbCluster(physicalId);
@@ -619,34 +616,6 @@ public class CloudFormationResourceProvisioner {
         if (sg.getVpcId() != null) {
             r.getAttributes().put("VpcId", sg.getVpcId());
         }
-    }
-
-    private void provisionVpcEndpoint(StackResource r, JsonNode props,
-                                      CloudFormationTemplateEngine engine, String region) {
-        String vpcId = resolveOptional(props, "VpcId", engine);
-        String serviceName = resolveOptional(props, "ServiceName", engine);
-        String endpointType = resolveOptional(props, "VpcEndpointType", engine);
-        var endpoint = ec2Service.createVpcEndpoint(region, vpcId, serviceName,
-                endpointType != null ? endpointType : "Gateway",
-                resolveIdList(props, "RouteTableIds", engine),
-                resolveIdList(props, "SubnetIds", engine),
-                resolveIdList(props, "SecurityGroupIds", engine),
-                props != null && props.path("PrivateDnsEnabled").asBoolean(false),
-                List.of());
-        r.setPhysicalId(endpoint.getVpcEndpointId());
-        r.getAttributes().put("Id", endpoint.getVpcEndpointId());
-    }
-
-    /** Resolve an array property of Ref/GetAtt entries into plain id strings. */
-    private List<String> resolveIdList(JsonNode props, String field, CloudFormationTemplateEngine engine) {
-        List<String> ids = new ArrayList<>();
-        if (props != null && props.has(field) && props.get(field).isArray()) {
-            for (JsonNode entry : props.get(field)) {
-                String id = engine.resolve(entry);
-                if (id != null && !id.isBlank()) ids.add(id);
-            }
-        }
-        return ids;
     }
 
     private void provisionInternetGateway(StackResource r, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2VpcEndpointCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2VpcEndpointCfnProvisioner.java
@@ -1,0 +1,90 @@
+package io.github.hectorvent.floci.services.cloudformation.provisioners;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * CloudFormation provisioning for {@code AWS::EC2::VPCEndpoint}.
+ *
+ * <p>Updates are handled as replacement: a new endpoint is created and the previous one is
+ * deleted, so re-deploys do not accumulate orphaned endpoints. {@code Ec2Service} has no
+ * modify operation, so mutable-property updates also replace; this matches how the other
+ * EC2 networking types behave here while still cleaning up the prior endpoint.
+ */
+@ApplicationScoped
+public class Ec2VpcEndpointCfnProvisioner implements CfnResourceProvisioner {
+
+    private final Ec2Service ec2Service;
+
+    @Inject
+    public Ec2VpcEndpointCfnProvisioner(Ec2Service ec2Service) {
+        this.ec2Service = ec2Service;
+    }
+
+    @Override
+    public Set<String> resourceTypes() {
+        return Set.of("AWS::EC2::VPCEndpoint");
+    }
+
+    @Override
+    public void provision(StackResource r, JsonNode props, ProvisionContext ctx) {
+        String vpcId = ctx.resolveOptional(props, "VpcId");
+        String serviceName = ctx.resolveOptional(props, "ServiceName");
+        String endpointType = ctx.resolveOptional(props, "VpcEndpointType");
+        // Resolve through the engine so Refs/parameters work, not just literal booleans. When the
+        // property is absent, pass null and let Ec2Service apply its own default (true for
+        // Interface endpoints, false otherwise), matching the AWS default.
+        String privateDns = ctx.resolveOptional(props, "PrivateDnsEnabled");
+        Boolean privateDnsEnabled = privateDns != null && !privateDns.isBlank()
+                ? Boolean.parseBoolean(privateDns)
+                : null;
+        String previousEndpointId = r.getPhysicalId();
+        var endpoint = ec2Service.createVpcEndpoint(ctx.region(), vpcId, serviceName,
+                endpointType != null ? endpointType : "Gateway",
+                resolveIdList(props, "RouteTableIds", ctx),
+                resolveIdList(props, "SubnetIds", ctx),
+                resolveIdList(props, "SecurityGroupIds", ctx),
+                privateDnsEnabled,
+                List.of());
+        r.setPhysicalId(endpoint.getVpcEndpointId());
+        r.getAttributes().put("Id", endpoint.getVpcEndpointId());
+        if (previousEndpointId != null && !previousEndpointId.equals(endpoint.getVpcEndpointId())) {
+            deleteReplacedEndpoint(previousEndpointId, ctx.region());
+        }
+    }
+
+    @Override
+    public void delete(String resourceType, String physicalId, String region) {
+        ec2Service.deleteVpcEndpoints(region, List.of(physicalId));
+    }
+
+    /** Resolve an array property of Ref/GetAtt entries into plain id strings. */
+    private List<String> resolveIdList(JsonNode props, String field, ProvisionContext ctx) {
+        List<String> ids = new ArrayList<>();
+        if (props != null && props.has(field) && props.get(field).isArray()) {
+            for (JsonNode entry : props.get(field)) {
+                String id = ctx.engine().resolve(entry);
+                if (id != null && !id.isBlank()) ids.add(id);
+            }
+        }
+        return ids;
+    }
+
+    private void deleteReplacedEndpoint(String endpointId, String region) {
+        try {
+            ec2Service.deleteVpcEndpoints(region, List.of(endpointId));
+        } catch (AwsException e) {
+            if (!"InvalidVpcEndpointId.NotFound".equals(e.getErrorCode()) && e.getHttpStatus() != 404) {
+                throw e;
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2VpcEndpointCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2VpcEndpointCfnProvisioner.java
@@ -7,6 +7,8 @@ import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -21,6 +23,10 @@ import java.util.Set;
  */
 @ApplicationScoped
 public class Ec2VpcEndpointCfnProvisioner implements CfnResourceProvisioner {
+
+    /** Same rendering DescribeVpcEndpoints uses, so the attribute reads as the API reports it. */
+    private static final DateTimeFormatter ISO_FMT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC);
 
     private final Ec2Service ec2Service;
 
@@ -56,6 +62,11 @@ public class Ec2VpcEndpointCfnProvisioner implements CfnResourceProvisioner {
                 List.of());
         r.setPhysicalId(endpoint.getVpcEndpointId());
         r.getAttributes().put("Id", endpoint.getVpcEndpointId());
+        // An unset attribute resolves to the literal "LogicalId.CreationTimestamp" rather than
+        // failing, so leaving it out hands the template a wrong value quietly.
+        if (endpoint.getCreationTimestamp() != null) {
+            r.getAttributes().put("CreationTimestamp", ISO_FMT.format(endpoint.getCreationTimestamp()));
+        }
         if (previousEndpointId != null && !previousEndpointId.equals(endpoint.getVpcEndpointId())) {
             deleteReplacedEndpoint(previousEndpointId, ctx.region());
         }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationVpcEndpointIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationVpcEndpointIntegrationTest.java
@@ -1,0 +1,100 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * End-to-end check that CloudFormation provisions AWS::EC2::VPCEndpoint for
+ * real (issue #1994): the endpoint lands in Ec2Service with its route-table
+ * association, and DeleteStack removes it. Metadata-only — Docker-free.
+ */
+@QuarkusTest
+class CloudFormationVpcEndpointIntegrationTest {
+
+    private static final String CFN_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/cloudformation/aws4_request";
+    private static final String EC2_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/ec2/aws4_request";
+
+    @Test
+    void createStackProvisionsGatewayEndpointAndDeleteRemovesIt() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String stackName = "cfn-vpce-stack-" + suffix;
+
+        String template = """
+                {
+                  "Resources": {
+                    "Vpc": {"Type": "AWS::EC2::VPC", "Properties": {"CidrBlock": "10.60.0.0/16"}},
+                    "Rt": {"Type": "AWS::EC2::RouteTable", "Properties": {"VpcId": {"Ref": "Vpc"}}},
+                    "S3Endpoint": {
+                      "Type": "AWS::EC2::VPCEndpoint",
+                      "Properties": {
+                        "VpcId": {"Ref": "Vpc"},
+                        "ServiceName": "com.amazonaws.us-east-1.s3",
+                        "VpcEndpointType": "Gateway",
+                        "RouteTableIds": [{"Ref": "Rt"}]
+                      }
+                    }
+                  },
+                  "Outputs": {
+                    "EndpointId": {"Value": {"Ref": "S3Endpoint"}}
+                  }
+                }
+                """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"))
+            .body(containsString("<OutputValue>vpce-"));
+
+        given()
+            .formParam("Action", "DescribeVpcEndpoints")
+            .header("Authorization", EC2_AUTH)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("com.amazonaws.us-east-1.s3"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DeleteStack")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .formParam("Action", "DescribeVpcEndpoints")
+            .header("Authorization", EC2_AUTH)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(not(containsString("com.amazonaws.us-east-1.s3")));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2VpcEndpointCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2VpcEndpointCfnProvisionerTest.java
@@ -1,0 +1,124 @@
+package io.github.hectorvent.floci.services.cloudformation.provisioners;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.services.cloudformation.CloudFormationTemplateEngine;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.model.VpcEndpoint;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** The VPC-endpoint CFN provisioner in isolation, mocking only Ec2Service. */
+class Ec2VpcEndpointCfnProvisionerTest {
+
+    private final Ec2Service ec2 = mock(Ec2Service.class);
+    private final Ec2VpcEndpointCfnProvisioner provisioner = new Ec2VpcEndpointCfnProvisioner(ec2);
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private ProvisionContext ctx() {
+        // Scalars resolve to their text; {"Ref": "X"} resolves to a fake physical id, which is
+        // enough to prove properties go through the engine instead of being read raw.
+        CloudFormationTemplateEngine engine = mock(CloudFormationTemplateEngine.class);
+        when(engine.resolve(any())).thenAnswer(inv -> {
+            JsonNode node = inv.getArgument(0);
+            if (node == null) {
+                return null;
+            }
+            if (node.isObject() && node.has("Ref")) {
+                String ref = node.get("Ref").asText();
+                // Models a template parameter carrying a boolean value.
+                return "EnableDns".equals(ref) ? "true" : "resolved-" + ref;
+            }
+            return node.asText();
+        });
+        return new ProvisionContext(engine, "us-east-1", "000000000000", "my-stack");
+    }
+
+    private StackResource resource() {
+        StackResource r = new StackResource();
+        r.setLogicalId("S3Endpoint");
+        r.setResourceType("AWS::EC2::VPCEndpoint");
+        r.setAttributes(new HashMap<>());
+        return r;
+    }
+
+    private VpcEndpoint endpoint(String id) {
+        VpcEndpoint e = new VpcEndpoint();
+        e.setVpcEndpointId(id);
+        return e;
+    }
+
+    @Test
+    void gatewayEndpointSetsPhysicalIdAndResolvesRefs() {
+        when(ec2.createVpcEndpoint(eq("us-east-1"), eq("resolved-Vpc"), eq("com.amazonaws.us-east-1.s3"),
+                eq("Gateway"), eq(List.of("resolved-Rt")), eq(List.of()), eq(List.of()), isNull(), anyList()))
+                .thenReturn(endpoint("vpce-123"));
+        StackResource r = resource();
+        ObjectNode props = mapper.createObjectNode()
+                .put("ServiceName", "com.amazonaws.us-east-1.s3");
+        props.set("VpcId", mapper.createObjectNode().put("Ref", "Vpc"));
+        props.putArray("RouteTableIds").add(mapper.createObjectNode().put("Ref", "Rt"));
+
+        provisioner.provision(r, props, ctx());
+
+        assertEquals("vpce-123", r.getPhysicalId());
+        assertEquals("vpce-123", r.getAttributes().get("Id"));
+    }
+
+    @Test
+    void privateDnsEnabledResolvesThroughEngine() {
+        when(ec2.createVpcEndpoint(anyString(), anyString(), anyString(), anyString(),
+                anyList(), anyList(), anyList(), eq(Boolean.TRUE), anyList()))
+                .thenReturn(endpoint("vpce-dns"));
+        StackResource r = resource();
+        ObjectNode props = mapper.createObjectNode()
+                .put("VpcId", "vpc-1")
+                .put("ServiceName", "com.amazonaws.us-east-1.ecr.api")
+                .put("VpcEndpointType", "Interface");
+        // A Ref, not a literal boolean: raw props.asBoolean(false) would silently yield false.
+        props.set("PrivateDnsEnabled", mapper.createObjectNode().put("Ref", "EnableDns"));
+
+        provisioner.provision(r, props, ctx());
+
+        assertEquals("vpce-dns", r.getPhysicalId());
+        verify(ec2).createVpcEndpoint(eq("us-east-1"), eq("vpc-1"), eq("com.amazonaws.us-east-1.ecr.api"),
+                eq("Interface"), anyList(), anyList(), anyList(), eq(Boolean.TRUE), anyList());
+    }
+
+    @Test
+    void updateReplacesAndDeletesPreviousEndpoint() {
+        when(ec2.createVpcEndpoint(anyString(), anyString(), anyString(), anyString(),
+                anyList(), anyList(), anyList(), any(), anyList()))
+                .thenReturn(endpoint("vpce-new"));
+        StackResource r = resource();
+        r.setPhysicalId("vpce-old");
+        ObjectNode props = mapper.createObjectNode()
+                .put("VpcId", "vpc-1")
+                .put("ServiceName", "com.amazonaws.us-east-1.s3");
+
+        provisioner.provision(r, props, ctx());
+
+        assertEquals("vpce-new", r.getPhysicalId());
+        verify(ec2).deleteVpcEndpoints("us-east-1", List.of("vpce-old"));
+    }
+
+    @Test
+    void deleteDelegatesToService() {
+        provisioner.delete("AWS::EC2::VPCEndpoint", "vpce-123", "us-east-1");
+        verify(ec2).deleteVpcEndpoints("us-east-1", List.of("vpce-123"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2VpcEndpointCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2VpcEndpointCfnProvisionerTest.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.ec2.model.VpcEndpoint;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 
@@ -24,6 +25,8 @@ import static org.mockito.Mockito.when;
 
 /** The VPC-endpoint CFN provisioner in isolation, mocking only Ec2Service. */
 class Ec2VpcEndpointCfnProvisionerTest {
+
+    private static final Instant CREATED_AT = Instant.parse("2026-08-13T10:15:30Z");
 
     private final Ec2Service ec2 = mock(Ec2Service.class);
     private final Ec2VpcEndpointCfnProvisioner provisioner = new Ec2VpcEndpointCfnProvisioner(ec2);
@@ -59,6 +62,7 @@ class Ec2VpcEndpointCfnProvisionerTest {
     private VpcEndpoint endpoint(String id) {
         VpcEndpoint e = new VpcEndpoint();
         e.setVpcEndpointId(id);
+        e.setCreationTimestamp(CREATED_AT);
         return e;
     }
 
@@ -77,6 +81,7 @@ class Ec2VpcEndpointCfnProvisionerTest {
 
         assertEquals("vpce-123", r.getPhysicalId());
         assertEquals("vpce-123", r.getAttributes().get("Id"));
+        assertEquals("2026-08-13T10:15:30.000Z", r.getAttributes().get("CreationTimestamp"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #1994. `Ec2Service` already models VPC endpoints fully; this adds the CFN case (VpcId, ServiceName, VpcEndpointType, RouteTableIds/SubnetIds/SecurityGroupIds reference lists, PrivateDnsEnabled) plus stack-delete removal, and a shared `resolveIdList` helper for Ref-array properties.

Context: supports running the [aws-bench](https://github.com/aws-bench/aws-bench) scenarios against Floci — five of eight scenario CDK apps declare VPC endpoints (series: lex00/floci#17).

## Tests

New `CloudFormationVpcEndpointIntegrationTest`: gateway endpoint with a route-table ref reaches CREATE_COMPLETE, appears in `DescribeVpcEndpoints`, and is gone after DeleteStack.