### PR TITLE
feat(ec2): DescribeVpcEndpointServices returns the common interface services with AZs

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2Tests.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2Tests.java
@@ -697,13 +697,29 @@ class Ec2Tests {
 
     @Test
     @Order(49)
-    @DisplayName("DescribeVpcEndpointServices - returns empty list")
+    @DisplayName("DescribeVpcEndpointServices - lists the common services with AZs")
     void describeVpcEndpointServices() {
         DescribeVpcEndpointServicesResponse resp = ec2.describeVpcEndpointServices(
                 DescribeVpcEndpointServicesRequest.builder().build());
 
-        assertThat(resp.serviceNames()).isEmpty();
-        assertThat(resp.serviceDetails()).isEmpty();
+        assertThat(resp.serviceNames()).contains("com.amazonaws.us-east-1.s3");
+        assertThat(resp.serviceDetails()).isNotEmpty();
+
+        ServiceDetail s3 = resp.serviceDetails().stream()
+                .filter(d -> d.serviceName().equals("com.amazonaws.us-east-1.s3"))
+                .findFirst()
+                .orElseThrow();
+        // S3 is the one service offering both endpoint types.
+        assertThat(s3.serviceType().stream().map(ServiceTypeDetail::serviceTypeAsString).toList())
+                .containsExactlyInAnyOrder("Gateway", "Interface");
+        assertThat(s3.availabilityZones()).isNotEmpty();
+
+        ServiceDetail ecr = resp.serviceDetails().stream()
+                .filter(d -> d.serviceName().equals("com.amazonaws.us-east-1.ecr.api"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(ecr.serviceType().stream().map(ServiceTypeDetail::serviceTypeAsString).toList())
+                .containsExactly("Interface");
     }
 
     @Test

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -845,19 +845,24 @@ public class Ec2QueryHandler {
                 .elem("requestId", UUID.randomUUID().toString())
                 .start("serviceNameSet");
         List<String> fullNames = new ArrayList<>();
-        // S3 has both a Gateway and an Interface offering; keep it in the name set.
-        for (String name : INTERFACE_ENDPOINT_SERVICES) {
-            fullNames.add("com.amazonaws." + region + "." + name);
-        }
-        fullNames.add("com.amazonaws." + region + ".s3");
-        for (String full : fullNames) {
-            if (requested.isEmpty() || requested.contains(full)) {
-                xml.elem("item", full);
+        // An explicit ServiceName filter wins: the emulator supports any
+        // interface service in every AZ, so echo exactly what was asked. CDK's
+        // InterfaceVpcEndpoint queries a specific (often custom) service name
+        // and fails if the response omits it or lists no AZs.
+        if (!requested.isEmpty()) {
+            fullNames.addAll(requested);
+        } else {
+            // S3 has both a Gateway and an Interface offering; keep it in the set.
+            for (String name : INTERFACE_ENDPOINT_SERVICES) {
+                fullNames.add("com.amazonaws." + region + "." + name);
             }
+            fullNames.add("com.amazonaws." + region + ".s3");
+        }
+        for (String full : fullNames) {
+            xml.elem("item", full);
         }
         xml.end("serviceNameSet").start("serviceDetailSet");
         for (String full : fullNames) {
-            if (!requested.isEmpty() && !requested.contains(full)) continue;
             boolean s3 = full.endsWith(".s3");
             xml.start("item")
                     .elem("serviceName", full)

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -863,12 +863,18 @@ public class Ec2QueryHandler {
         }
         xml.end("serviceNameSet").start("serviceDetailSet");
         for (String full : fullNames) {
-            boolean s3 = full.endsWith(".s3");
+            // S3 is the one service with both offerings, and AWS reports both
+            // types on its single service detail. Everything else is Interface.
+            List<String> serviceTypes = full.endsWith(".s3")
+                    ? List.of("Gateway", "Interface")
+                    : List.of("Interface");
             xml.start("item")
                     .elem("serviceName", full)
-                    .start("serviceType").start("item")
-                        .elem("serviceType", s3 ? "Gateway" : "Interface")
-                    .end("item").end("serviceType")
+                    .start("serviceType");
+            for (String serviceType : serviceTypes) {
+                xml.start("item").elem("serviceType", serviceType).end("item");
+            }
+            xml.end("serviceType")
                     .start("availabilityZoneSet");
             for (String az : azNames) xml.elem("item", az);
             xml.end("availabilityZoneSet")

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -826,15 +826,53 @@ public class Ec2QueryHandler {
         return xmlResponse(xml.build());
     }
 
+    // The common AWS interface-endpoint services, as short names. Rendered as
+    // com.amazonaws.<region>.<name>. CDK's InterfaceVpcEndpoint (lookupSupportedAzs)
+    // calls DescribeVpcEndpointServices at synth time; an empty set aborts synth.
+    private static final List<String> INTERFACE_ENDPOINT_SERVICES = List.of(
+            "ec2", "ec2messages", "ssm", "ssmmessages", "logs", "monitoring", "sts",
+            "secretsmanager", "kms", "ecr.api", "ecr.dkr", "ecs", "ecs-agent", "ecs-telemetry",
+            "elasticloadbalancing", "sns", "sqs", "kinesis-streams", "kinesis-firehose",
+            "states", "events", "lambda", "glue", "athena", "iot.data", "execute-api");
+
     private Response handleDescribeVpcEndpointServices(MultivaluedMap<String, String> p, String region) {
+        List<String> requested = getList(p, "ServiceName");
+        List<String> azNames = service.describeAvailabilityZones(region).stream()
+                .map(z -> z.get("zoneName")).toList();
+
         XmlBuilder xml = new XmlBuilder()
                 .start("DescribeVpcEndpointServicesResponse", AwsNamespaces.EC2)
                 .elem("requestId", UUID.randomUUID().toString())
-                .start("serviceNameSet")
-                .end("serviceNameSet")
-                .start("serviceDetailSet")
-                .end("serviceDetailSet")
-                .end("DescribeVpcEndpointServicesResponse");
+                .start("serviceNameSet");
+        List<String> fullNames = new ArrayList<>();
+        // S3 has both a Gateway and an Interface offering; keep it in the name set.
+        for (String name : INTERFACE_ENDPOINT_SERVICES) {
+            fullNames.add("com.amazonaws." + region + "." + name);
+        }
+        fullNames.add("com.amazonaws." + region + ".s3");
+        for (String full : fullNames) {
+            if (requested.isEmpty() || requested.contains(full)) {
+                xml.elem("item", full);
+            }
+        }
+        xml.end("serviceNameSet").start("serviceDetailSet");
+        for (String full : fullNames) {
+            if (!requested.isEmpty() && !requested.contains(full)) continue;
+            boolean s3 = full.endsWith(".s3");
+            xml.start("item")
+                    .elem("serviceName", full)
+                    .start("serviceType").start("item")
+                        .elem("serviceType", s3 ? "Gateway" : "Interface")
+                    .end("item").end("serviceType")
+                    .start("availabilityZoneSet");
+            for (String az : azNames) xml.elem("item", az);
+            xml.end("availabilityZoneSet")
+                    .elem("owner", "amazon")
+                    .elem("acceptanceRequired", "false")
+                    .elem("managesVpcEndpoints", "false")
+                    .end("item");
+        }
+        xml.end("serviceDetailSet").end("DescribeVpcEndpointServicesResponse");
         return xmlResponse(xml.build());
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -1322,6 +1322,21 @@ class Ec2IntegrationTest {
 
     @Test
     @Order(52)
+    void describeVpcEndpointServicesEchoesAnExplicitServiceNameWithAzs() {
+        given()
+            .formParam("Action", "DescribeVpcEndpointServices")
+            .formParam("ServiceName.1", "com.amazonaws.us-east-1.custom-iot-data")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("custom-iot-data"))
+            .body(containsString("us-east-1a"));
+    }
+
+    @Test
+    @Order(52)
     void describeVpcEndpointServicesListsInterfaceServicesWithAzs() {
         given()
             .formParam("Action", "DescribeVpcEndpointServices")

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -1345,9 +1345,10 @@ class Ec2IntegrationTest {
             .post("/")
         .then()
             .statusCode(200)
-            .body(containsString("com.amazonaws.us-east-1.ecr.api"))
-            .body(containsString("com.amazonaws.us-east-1.s3"))
-            .body(containsString("<serviceType>Interface</serviceType>"))
+            .body(containsString(
+                "<serviceName>com.amazonaws.us-east-1.ecr.api</serviceName><serviceType><item><serviceType>Interface</serviceType>"))
+            .body(containsString(
+                "<serviceName>com.amazonaws.us-east-1.s3</serviceName><serviceType><item><serviceType>Gateway</serviceType>"))
             .body(containsString("us-east-1a"));
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -1347,8 +1347,12 @@ class Ec2IntegrationTest {
             .statusCode(200)
             .body(containsString(
                 "<serviceName>com.amazonaws.us-east-1.ecr.api</serviceName><serviceType><item><serviceType>Interface</serviceType>"))
+            // S3 carries both offerings, in that order.
             .body(containsString(
-                "<serviceName>com.amazonaws.us-east-1.s3</serviceName><serviceType><item><serviceType>Gateway</serviceType>"))
+                "<serviceName>com.amazonaws.us-east-1.s3</serviceName><serviceType>"
+                + "<item><serviceType>Gateway</serviceType></item>"
+                + "<item><serviceType>Interface</serviceType></item>"
+                + "</serviceType>"))
             .body(containsString("us-east-1a"));
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -1322,6 +1322,22 @@ class Ec2IntegrationTest {
 
     @Test
     @Order(52)
+    void describeVpcEndpointServicesListsInterfaceServicesWithAzs() {
+        given()
+            .formParam("Action", "DescribeVpcEndpointServices")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("com.amazonaws.us-east-1.ecr.api"))
+            .body(containsString("com.amazonaws.us-east-1.s3"))
+            .body(containsString("<serviceType>Interface</serviceType>"))
+            .body(containsString("us-east-1a"));
+    }
+
+    @Test
+    @Order(52)
     void describeInternetGateways() {
         given()
             .formParam("Action", "DescribeInternetGateways")


### PR DESCRIPTION
## Summary

Fixes #2004. `DescribeVpcEndpointServices` returned an empty set, which aborts CDK `InterfaceVpcEndpoint` synthesis (`lookupSupportedAzs: true` calls it at synth time to filter AZs). Now returns the standard `com.amazonaws.<region>.<service>` interface services plus `s3`, each with the region's AZs, serviceType (Interface/Gateway), and owner metadata; honors a `ServiceName` filter.

Context: supports running the [aws-bench](https://github.com/aws-bench/aws-bench) scenarios against Floci — this single gap blocked four of eight scenario CDK apps from synthesizing at all (streaming-and-iot, databases-and-storage, api-and-observability, troubleshooting-multiservice) — a bigger unlock than any one CFN type (series: lex00/floci#17).

## Tests

`Ec2IntegrationTest.describeVpcEndpointServicesListsInterfaceServicesWithAzs`: the action returns interface services (ecr.api, s3), a serviceType, and the region AZs. Full EC2 suite: 144 tests, 0 failures.