### PR TITLE
test(cloudformation): pin the declared-false MapPublicIpOnLaunch case

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationEc2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationEc2IntegrationTest.java
@@ -204,6 +204,87 @@ class CloudFormationEc2IntegrationTest {
             .body(containsString("10.30.1.0/24"));
     }
 
+    /**
+     * Issue #2013: CloudFormation must apply MapPublicIpOnLaunch to a subnet. The declared
+     * true and the declared false both have to carry through — asserting only the public
+     * case passes equally well against an implementation that sets true unconditionally.
+     */
+    @Test
+    void subnetMapPublicIpOnLaunchCarriesThroughForBothValues() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String stackName = "cfn-subnetmap-" + suffix;
+
+        String template = """
+                {
+                  "Resources": {
+                    "Vpc": {"Type": "AWS::EC2::VPC", "Properties": {"CidrBlock": "10.90.0.0/16"}},
+                    "PublicSubnet": {
+                      "Type": "AWS::EC2::Subnet",
+                      "Properties": {"VpcId": {"Ref": "Vpc"}, "CidrBlock": "10.90.0.0/24", "MapPublicIpOnLaunch": true}
+                    },
+                    "PrivateSubnet": {
+                      "Type": "AWS::EC2::Subnet",
+                      "Properties": {"VpcId": {"Ref": "Vpc"}, "CidrBlock": "10.90.1.0/24", "MapPublicIpOnLaunch": false}
+                    }
+                  },
+                  "Outputs": {
+                    "PublicId": {"Value": {"Ref": "PublicSubnet"}},
+                    "PrivateId": {"Value": {"Ref": "PrivateSubnet"}}
+                  }
+                }
+                """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when().post("/").then().statusCode(200);
+
+        String describe = given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when().post("/").then().statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"))
+            .extract().asString();
+
+        String pubId = between(describe, "<OutputKey>PublicId</OutputKey>", "</member>");
+        pubId = between(pubId, "<OutputValue>", "</OutputValue>");
+
+        // The public subnet reports MapPublicIpOnLaunch true.
+        given()
+            .formParam("Action", "DescribeSubnets")
+            .formParam("SubnetId.1", pubId)
+            .header("Authorization", EC2_AUTH)
+        .when().post("/").then().statusCode(200)
+            .body(containsString("<mapPublicIpOnLaunch>true</mapPublicIpOnLaunch>"));
+
+        String privId = between(describe, "<OutputKey>PrivateId</OutputKey>", "</member>");
+        privId = between(privId, "<OutputValue>", "</OutputValue>");
+
+        // The declared false carries through — this is the case an
+        // unconditionally-true implementation would fail.
+        given()
+            .formParam("Action", "DescribeSubnets")
+            .formParam("SubnetId.1", privId)
+            .header("Authorization", EC2_AUTH)
+        .when().post("/").then().statusCode(200)
+            .body(containsString("<mapPublicIpOnLaunch>false</mapPublicIpOnLaunch>"));
+    }
+
+    private static String between(String haystack, String open, String close) {
+        int i = haystack.indexOf(open);
+        int j = i < 0 ? -1 : haystack.indexOf(close, i + open.length());
+        if (i < 0 || j < 0) {
+            throw new AssertionError(
+                    "could not find '" + open + "' ... '" + close + "' in:\n" + haystack);
+        }
+        return haystack.substring(i + open.length(), j);
+    }
+
     private static List<String> extractSubnetIds(String xml) {
         Matcher m = Pattern.compile("<OutputValue>(subnet-[0-9a-fA-F]+)</OutputValue>").matcher(xml);
         List<String> ids = new ArrayList<>();


### PR DESCRIPTION
## Summary

Fixes #2013. `provisionSubnet` called `createSubnet` (which has no MapPublicIpOnLaunch parameter) and never applied the template value, so every CFN-created subnet reported `false` — public/private topology was indistinguishable.

Now applies `MapPublicIpOnLaunch` after create via the same path as `ModifySubnetAttribute`.

Context: supports the [aws-bench](https://github.com/aws-bench/aws-bench) scenarios against Floci — the public-subnet-membership introspection task was unanswerable via the attribute (series: lex00/floci#17).

## Tests

New `CloudFormationSubnetMapPublicIpIntegrationTest`: a subnet declared `MapPublicIpOnLaunch: true` reports `true` via `DescribeSubnets`.