### PR TITLE
fix(elbv2): move persisted-listener restore out of @PostConstruct

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
@@ -22,6 +22,7 @@ import io.github.hectorvent.floci.services.neptune.container.NeptuneContainerMan
 import io.github.hectorvent.floci.services.neptune.proxy.NeptuneProxyManager;
 import io.github.hectorvent.floci.services.pipes.PipesService;
 import io.github.hectorvent.floci.services.appsync.graphql.SchemaCreationWorker;
+import io.github.hectorvent.floci.services.elbv2.ElbV2Service;
 import io.github.hectorvent.floci.services.rds.RdsService;
 import io.github.hectorvent.floci.services.memorydb.container.MemoryDbContainerManager;
 import io.github.hectorvent.floci.services.memorydb.proxy.MemoryDbProxyManager;
@@ -75,6 +76,7 @@ public class EmulatorLifecycle {
     private final NeptuneProxyManager neptuneProxyManager;
     private final RabbitMqManager rabbitMqManager;
     private final RdsService rdsService;
+    private final ElbV2Service elbV2Service;
     private final InitializationHooksRunner initializationHooksRunner;
     private final SqsEventSourcePoller sqsPoller;
     private final KinesisEventSourcePoller kinesisPoller;
@@ -103,6 +105,7 @@ public class EmulatorLifecycle {
                              NeptuneProxyManager neptuneProxyManager,
                              RabbitMqManager rabbitMqManager,
                              RdsService rdsService,
+                             ElbV2Service elbV2Service,
                              InitializationHooksRunner initializationHooksRunner,
                              SqsEventSourcePoller sqsPoller,
                              KinesisEventSourcePoller kinesisPoller,
@@ -130,6 +133,7 @@ public class EmulatorLifecycle {
         this.neptuneProxyManager = neptuneProxyManager;
         this.rabbitMqManager = rabbitMqManager;
         this.rdsService = rdsService;
+        this.elbV2Service = elbV2Service;
         this.initializationHooksRunner = initializationHooksRunner;
         this.sqsPoller = sqsPoller;
         this.kinesisPoller = kinesisPoller;
@@ -173,6 +177,9 @@ public class EmulatorLifecycle {
         dynamodbStreamsPoller.startPersistedPollers();
         pipesService.startPersistedPollers();
         rdsService.restorePersistedRuntime();
+        if (config.services().elbv2().enabled()) {
+            elbV2Service.restorePersistedRuntime();
+        }
 
         if (config.services().ec2().enabled() && !config.services().ec2().mock()) {
             ec2MetadataServer.start().exceptionally(ex -> {

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
@@ -101,6 +101,13 @@ public class ElbV2Service {
         }
     }
 
+    /**
+     * Rebuilds the in-memory indexes from the storage-backed maps. Pure and in-process on purpose:
+     * nothing reachable from {@link #initializeStorage()} may call an injected collaborator, because
+     * {@link ElbV2DataPlane} calls back into this service and CDI has not registered the instance in
+     * the ApplicationScoped context yet — re-entering bean creation instead (issue #1913). Runtime
+     * side effects belong in {@link #restorePersistedRuntime()}.
+     */
     private void rebuildIndexes()
     {
         lbToListeners.clear();
@@ -123,7 +130,20 @@ public class ElbV2Service {
             for (TargetGroup targetGroup : regionEntry.getValue().values()) {
                 tgToLbs.computeIfAbsent(targetGroup.getTargetGroupArn(), k -> ConcurrentHashMap.newKeySet())
                         .addAll(targetGroup.getLoadBalancerArns());
-                if (healthChecker != null) {
+            }
+        }
+    }
+
+    /**
+     * Brings the data plane and health checks back up for state restored from disk. Invoked from
+     * {@code EmulatorLifecycle} once the bean is fully constructed, alongside the other services that
+     * restore persisted runtime after {@code storageFactory.loadAll()}.
+     */
+    public void restorePersistedRuntime()
+    {
+        if (healthChecker != null) {
+            for (Map<String, TargetGroup> regionTargetGroups : targetGroups.values()) {
+                for (TargetGroup targetGroup : regionTargetGroups.values()) {
                     healthChecker.startMonitoring(targetGroup);
                     if (!targetGroup.getTargets().isEmpty()) {
                         healthChecker.addTargets(targetGroup.getTargetGroupArn(), targetGroup.getTargets(), targetGroup);
@@ -131,10 +151,10 @@ public class ElbV2Service {
                 }
             }
         }
-        for (Map.Entry<String, Map<String, Listener>> regionEntry : listeners.entrySet()) {
-            String region = regionEntry.getKey();
-            for (Listener listener : regionEntry.getValue().values()) {
-                if (dataPlane != null) {
+        if (dataPlane != null) {
+            for (Map.Entry<String, Map<String, Listener>> regionEntry : listeners.entrySet()) {
+                String region = regionEntry.getKey();
+                for (Listener listener : regionEntry.getValue().values()) {
                     dataPlane.startListener(listener, region, getListenerRules(region, listener.getListenerArn()));
                 }
             }

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
@@ -57,6 +57,7 @@ class EmulatorLifecycleTest {
     @Mock private EmulatorConfig.StorageConfig storageConfig;
     @Mock private EmulatorConfig.ServicesConfig servicesConfig;
     @Mock private EmulatorConfig.Ec2ServiceConfig ec2ServiceConfig;
+    @Mock private EmulatorConfig.ElbV2ServiceConfig elbv2ServiceConfig;
     @Mock private ElastiCacheContainerManager elastiCacheContainerManager;
     @Mock private ElastiCacheMemcachedContainerManager elastiCacheMemcachedContainerManager;
     @Mock private ElastiCacheProxyManager elastiCacheProxyManager;
@@ -69,6 +70,7 @@ class EmulatorLifecycleTest {
     @Mock private NeptuneProxyManager neptuneProxyManager;
     @Mock private io.github.hectorvent.floci.services.amazonmq.container.RabbitMqManager rabbitMqManager;
     @Mock private RdsService rdsService;
+    @Mock private io.github.hectorvent.floci.services.elbv2.ElbV2Service elbV2Service;
     @Mock private InitializationHooksRunner initializationHooksRunner;
     @Mock private SqsEventSourcePoller sqsPoller;
     @Mock private KinesisEventSourcePoller kinesisPoller;
@@ -90,6 +92,8 @@ class EmulatorLifecycleTest {
         Mockito.lenient().when(config.services()).thenReturn(servicesConfig);
         Mockito.lenient().when(servicesConfig.ec2()).thenReturn(ec2ServiceConfig);
         Mockito.lenient().when(ec2ServiceConfig.enabled()).thenReturn(false);
+        Mockito.lenient().when(servicesConfig.elbv2()).thenReturn(elbv2ServiceConfig);
+        Mockito.lenient().when(elbv2ServiceConfig.enabled()).thenReturn(false);
         Mockito.lenient().when(config.tls()).thenReturn(tlsConfig);
         Mockito.lenient().when(tlsConfig.enabled()).thenReturn(false);
 
@@ -99,7 +103,7 @@ class EmulatorLifecycleTest {
                 elastiCacheProxyManager, rdsContainerManager, rdsProxyManager,
                 memoryDbContainerManager, memoryDbProxyManager,
                 docDbContainerManager, neptuneContainerManager, neptuneProxyManager,
-                rabbitMqManager, rdsService,
+                rabbitMqManager, rdsService, elbV2Service,
                 initializationHooksRunner, sqsPoller, kinesisPoller, dynamodbStreamsPoller,
                 pipesService, ec2MetadataServer, ecrRegistryManager, flociUiManager, initLifecycleState,
                 schemaCreationWorker, containerTeardowns, persistentPathValidator);

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
@@ -134,6 +134,36 @@ class EmulatorLifecycleTest {
     }
 
     @Test
+    @DisplayName("Should restore ELBv2 persisted runtime after loading storage when elbv2 is enabled")
+    void shouldRestoreElbV2PersistedRuntimeAfterStorageLoad() {
+        // The restore has to happen after the bean is constructed, not from @PostConstruct, or
+        // ElbV2DataPlane's callback re-enters bean creation (#1913). Pin the ordering so the call
+        // cannot be dropped or moved back into construction unnoticed.
+        stubStorageConfig();
+        when(elbv2ServiceConfig.enabled()).thenReturn(true);
+        when(initializationHooksRunner.hasHooks(InitializationHook.START)).thenReturn(false);
+        when(initializationHooksRunner.hasHooks(InitializationHook.READY)).thenReturn(false);
+
+        emulatorLifecycle.onStart(Mockito.mock(StartupEvent.class));
+
+        var inOrder = Mockito.inOrder(storageFactory, elbV2Service);
+        inOrder.verify(storageFactory).loadAll();
+        inOrder.verify(elbV2Service).restorePersistedRuntime();
+    }
+
+    @Test
+    @DisplayName("Should not restore ELBv2 persisted runtime when elbv2 is disabled")
+    void shouldNotRestoreElbV2PersistedRuntimeWhenDisabled() {
+        stubStorageConfig();
+        when(initializationHooksRunner.hasHooks(InitializationHook.START)).thenReturn(false);
+        when(initializationHooksRunner.hasHooks(InitializationHook.READY)).thenReturn(false);
+
+        emulatorLifecycle.onStart(Mockito.mock(StartupEvent.class));
+
+        Mockito.verify(elbV2Service, Mockito.never()).restorePersistedRuntime();
+    }
+
+    @Test
     @DisplayName("Should validate the persistent path after BOOT hooks and before loading storage")
     void shouldValidatePersistentPathBeforeStorageLoad() {
         stubStorageConfig();

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2ServiceTest.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -179,6 +180,9 @@ class ElbV2ServiceTest {
         assertTrue(reloadedRules.stream().anyMatch(candidate -> "10".equals(candidate.getPriority())));
         assertEquals("test", reloaded.describeTags(List.of(lbArn)).get(lbArn).get("env"));
         assertThrows(AwsException.class, () -> reloaded.deleteTargetGroup(REGION, tgArn));
+
+        // Data-plane and health-check startup is deliberately not part of construction (#1913).
+        reloaded.restorePersistedRuntime();
         verify(reloadedHealthChecker).startMonitoring(any(TargetGroup.class));
         ArgumentCaptor<List<TargetDescription>> targetsCaptor = ArgumentCaptor.captor();
         verify(reloadedHealthChecker).addTargets(eq(tgArn), targetsCaptor.capture(), any(TargetGroup.class));
@@ -193,7 +197,41 @@ class ElbV2ServiceTest {
     }
 
     @Test
-    void initializeStorageStartsPersistedListenersWithoutTargetGroups() {
+    void initializeStorageDoesNotTouchCollaborators() {
+        // #1913: ElbV2DataPlane.binding() calls back into this service, and during @PostConstruct the
+        // ApplicationScoped context has no instance yet — so CDI re-enters bean creation and recurses
+        // until the stack (or, before the storage dedupe in #1931, the heap) is gone. Nothing reachable
+        // from initializeStorage() may call an injected collaborator. A mock cannot reproduce the
+        // recursion, since it never calls back, so assert the absence of the interaction instead.
+        SharedStorageFactory storageFactory = new SharedStorageFactory();
+        ElbV2Service first = serviceWithStorage(storageFactory, mock(ElbV2DataPlane.class), mock(ElbV2HealthChecker.class));
+        String lbArn = first.createLoadBalancer(
+                REGION, "recursion-lb", "internal", "application", "ipv4",
+                ALB_SUBNETS, List.of("sg-a"), Map.of()).getLoadBalancerArn();
+        String tgArn = first.createTargetGroup(
+                REGION, "recursion-tg", "HTTP", "HTTP1", 8080, "vpc-a", "instance",
+                "HTTP", "traffic-port", true, "/health", 15, 5, 3, 2, "200",
+                "ipv4", Map.of()).getTargetGroupArn();
+        String listenerArn = first.createListener(
+                REGION, lbArn, "HTTP", 9090, null, List.of(),
+                List.of(forwardAction(tgArn)), List.of(), Map.of()).getListenerArn();
+
+        ElbV2DataPlane reloadedDataPlane = mock(ElbV2DataPlane.class);
+        ElbV2HealthChecker reloadedHealthChecker = mock(ElbV2HealthChecker.class);
+        ElbV2Service reloaded = serviceWithStorage(storageFactory, reloadedDataPlane, reloadedHealthChecker);
+
+        verifyNoInteractions(reloadedDataPlane, reloadedHealthChecker);
+
+        reloaded.restorePersistedRuntime();
+
+        ArgumentCaptor<Listener> listenerCaptor = ArgumentCaptor.captor();
+        verify(reloadedDataPlane).startListener(listenerCaptor.capture(), eq(REGION), anyList());
+        assertEquals(listenerArn, listenerCaptor.getValue().getListenerArn());
+        verify(reloadedHealthChecker).startMonitoring(any(TargetGroup.class));
+    }
+
+    @Test
+    void restorePersistedRuntimeStartsPersistedListenersWithoutTargetGroups() {
         SharedStorageFactory storageFactory = new SharedStorageFactory();
         ElbV2Service first = serviceWithStorage(storageFactory, mock(ElbV2DataPlane.class), mock(ElbV2HealthChecker.class));
         String lbArn = first.createLoadBalancer(
@@ -204,7 +242,8 @@ class ElbV2ServiceTest {
                 List.of(), List.of(), Map.of()).getListenerArn();
 
         ElbV2DataPlane reloadedDataPlane = mock(ElbV2DataPlane.class);
-        serviceWithStorage(storageFactory, reloadedDataPlane, mock(ElbV2HealthChecker.class));
+        ElbV2Service reloaded = serviceWithStorage(storageFactory, reloadedDataPlane, mock(ElbV2HealthChecker.class));
+        reloaded.restorePersistedRuntime();
 
         ArgumentCaptor<Listener> listenerCaptor = ArgumentCaptor.captor();
         verify(reloadedDataPlane).startListener(listenerCaptor.capture(), eq(REGION), anyList());


### PR DESCRIPTION
## Summary

Closes #1913.

`ElbV2Service` called back into itself through its own CDI client proxy while it was still being constructed, recursing until the process died. `rebuildIndexes()`, reached from the `@PostConstruct` `initializeStorage()`, called `dataPlane.startListener(...)` for every restored listener; `ElbV2DataPlane.binding()` then called `elbV2Service.getLoadBalancer(...)`, and since Arc had not yet registered the instance in the ApplicationScoped context, the proxy started another bean creation:

```
ElbV2Service_Bean.create()
 └ ElbV2Service.initializeStorage()          ← @PostConstruct
    └ rebuildIndexes()
       └ dataPlane.startListener(...)        ← per RESTORED listener
          └ ElbV2DataPlane.binding()
             └ elbV2Service.getLoadBalancer()   ← back in via the proxy
                └ no instance in context yet → ElbV2Service_Bean.create()   ← recursion
```

Only reproducible after a restart with persistent storage: on a fresh boot the listener map is empty, so `rebuildIndexes()` never reaches `startListener` and the callback never happens.

`rebuildIndexes()` now only builds the in-memory indexes. Starting the data plane and the health checks moved to `restorePersistedRuntime()`, invoked from `EmulatorLifecycle` after `storageFactory.loadAll()` alongside the four services that already restore persisted runtime there (`sqsPoller`, `kinesisPoller`, `pipesService`, `rdsService`).

Two things worth flagging for reviewers:

**The blast radius was wider than the issue title.** The bean is created lazily on first use, so after a restart *every* ELBv2 operation failed, not just `DeleteStack` — `DescribeLoadBalancers` and `DescribeTargetGroups` both returned 500.

**The symptom changed with #1931.** The storage dedupe removed the per-level allocation, so current `main` raises `StackOverflowError` where 1.5.32 exhausted the heap and was OOM-killed. Anyone bisecting from the issue's original description on `main` will not see an OOM.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behaviour, not a wire-format change. After a restart with persisted ELBv2 state, `DeleteStack` hung in `DELETE_IN_PROGRESS` and the emulator was killed by its memory limit; every ELBv2 API returned 500. Reproduced with the AWS CLI using the script in the issue.

Measured on the issue's own repro (CloudFormation stack with VPC, subnets, security group, ALB, target group, listener; persistent storage; restart; `delete-stack`):

| | before | after |
|---|---|---|
| ELBv2 APIs after restart | 500 `StackOverflowError` | load balancer and target group returned |
| `delete-stack` | stuck `DELETE_IN_PROGRESS` | stack deleted, 0 LBs and 0 TGs left |
| memory during delete | climbing to the 2GiB limit | flat at ~229MB, CPU idle |
| `elbv2-*.json` loads in the log | 3400 | 1 per file |

## Checklist

- [x] `./mvnw test` passes locally — full suite, 7943 tests, 0 failures
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

New `ElbV2ServiceTest.initializeStorageDoesNotTouchCollaborators` asserts that construction performs no interaction with `ElbV2DataPlane` or `ElbV2HealthChecker`, then that `restorePersistedRuntime()` starts the persisted listener. Two existing tests asserted the old behaviour and were updated to call `restorePersistedRuntime()` first; one is renamed accordingly.

Worth knowing why this shipped: `ElbV2ServiceTest` already simulated a restart, but mocks `ElbV2DataPlane` — the exact collaborator whose real implementation calls back into the service. A mock never calls back, so the recursion could not form in-tree. That is why the new test asserts the *absence* of collaborator interaction during construction rather than its presence afterwards.
