### PR TITLE
feat(cognito): implement VerifyUserAttribute

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CognitoVerifyUserAttributeTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CognitoVerifyUserAttributeTest.java
@@ -1,0 +1,204 @@
+package com.floci.test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeType;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.AuthFlowType;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.CodeMismatchException;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.ExplicitAuthFlowsType;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.MessageActionType;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CognitoVerifyUserAttributeTest {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final HttpClient HTTP = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+    private static final Pattern SIX_DIGIT_CODE = Pattern.compile("\\b(\\d{6})\\b");
+    private static final String PASSWORD = "Verify1234!";
+
+    private static CognitoIdentityProviderClient cognito;
+
+    private String poolId;
+
+    @BeforeAll
+    static void setUpClient() {
+        cognito = TestFixtures.cognitoClient();
+    }
+
+    @AfterAll
+    static void closeClient() {
+        if (cognito != null) {
+            cognito.close();
+        }
+    }
+
+    @AfterEach
+    void deletePool() {
+        if (poolId != null) {
+            cognito.deleteUserPool(b -> b.userPoolId(poolId));
+            poolId = null;
+        }
+    }
+
+    @Test
+    void verifiesEmailAndPhoneNumberWithAwsSdk() throws Exception {
+        poolId = cognito.createUserPool(b -> b.poolName("verify-attribute-" + UUID.randomUUID()))
+                .userPool()
+                .id();
+        String clientId = cognito.createUserPoolClient(b -> b
+                        .userPoolId(poolId)
+                        .clientName("verify-attribute-client")
+                        .explicitAuthFlows(ExplicitAuthFlowsType.ALLOW_USER_PASSWORD_AUTH))
+                .userPoolClient()
+                .clientId();
+
+        String username = "verify-" + UUID.randomUUID();
+        String email = username + "@example.com";
+        String phoneNumber = "+1555" + ThreadLocalRandom.current().nextLong(1_000_000, 10_000_000);
+
+        cognito.adminCreateUser(b -> b
+                .userPoolId(poolId)
+                .username(username)
+                .messageAction(MessageActionType.SUPPRESS)
+                .userAttributes(
+                        AttributeType.builder().name("email").value(email).build(),
+                        AttributeType.builder().name("phone_number").value(phoneNumber).build()));
+        cognito.adminSetUserPassword(b -> b
+                .userPoolId(poolId)
+                .username(username)
+                .password(PASSWORD)
+                .permanent(true));
+
+        String accessToken = cognito.initiateAuth(b -> b
+                        .clientId(clientId)
+                        .authFlow(AuthFlowType.USER_PASSWORD_AUTH)
+                        .authParameters(Map.of("USERNAME", username, "PASSWORD", PASSWORD)))
+                .authenticationResult()
+                .accessToken();
+
+        clearInspectionEndpoint("/_aws/ses");
+        clearInspectionEndpoint("/_aws/sns");
+
+        var emailDelivery = cognito.getUserAttributeVerificationCode(b -> b
+                        .accessToken(accessToken)
+                        .attributeName("email"))
+                .codeDeliveryDetails();
+        assertThat(emailDelivery.attributeName()).isEqualTo("email");
+        assertThat(emailDelivery.deliveryMediumAsString()).isEqualTo("EMAIL");
+        String emailCode = fetchLatestSesVerificationCode(email);
+
+        var phoneDelivery = cognito.getUserAttributeVerificationCode(b -> b
+                        .accessToken(accessToken)
+                        .attributeName("phone_number"))
+                .codeDeliveryDetails();
+        assertThat(phoneDelivery.attributeName()).isEqualTo("phone_number");
+        assertThat(phoneDelivery.deliveryMediumAsString()).isEqualTo("SMS");
+        String phoneCode = fetchLatestSnsVerificationCode(phoneNumber);
+
+        assertThatThrownBy(() -> cognito.verifyUserAttribute(b -> b
+                .accessToken(accessToken)
+                .attributeName("email")
+                .code(differentCode(emailCode))))
+                .isInstanceOf(CodeMismatchException.class);
+        assertThat(userAttribute(username, "email_verified")).isNull();
+
+        cognito.verifyUserAttribute(b -> b
+                .accessToken(accessToken)
+                .attributeName("email")
+                .code(emailCode));
+        cognito.verifyUserAttribute(b -> b
+                .accessToken(accessToken)
+                .attributeName("phone_number")
+                .code(phoneCode));
+
+        assertThat(userAttribute(username, "email_verified")).isEqualTo("true");
+        assertThat(userAttribute(username, "phone_number_verified")).isEqualTo("true");
+
+        assertThatThrownBy(() -> cognito.verifyUserAttribute(b -> b
+                .accessToken(accessToken)
+                .attributeName("email")
+                .code(emailCode)))
+                .isInstanceOf(CodeMismatchException.class);
+    }
+
+    private String userAttribute(String username, String attributeName) {
+        return cognito.adminGetUser(b -> b.userPoolId(poolId).username(username))
+                .userAttributes()
+                .stream()
+                .filter(attribute -> attributeName.equals(attribute.name()))
+                .map(AttributeType::value)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static void clearInspectionEndpoint(String path) throws Exception {
+        HttpResponse<String> response = HTTP.send(
+                HttpRequest.newBuilder()
+                        .uri(TestFixtures.endpoint().resolve(path))
+                        .DELETE()
+                        .timeout(Duration.ofSeconds(10))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    private static String fetchLatestSesVerificationCode(String recipient) throws Exception {
+        URI uri = TestFixtures.endpoint()
+                .resolve("/_aws/ses?email=" + URLEncoder.encode(recipient, StandardCharsets.UTF_8));
+        JsonNode messages = getInspectionMessages(uri);
+        return extractVerificationCode(messages.get(0).path("Body").path("text_part").asText());
+    }
+
+    private static String fetchLatestSnsVerificationCode(String phoneNumber) throws Exception {
+        URI uri = TestFixtures.endpoint()
+                .resolve("/_aws/sns?phone=" + URLEncoder.encode(phoneNumber, StandardCharsets.UTF_8));
+        JsonNode messages = getInspectionMessages(uri);
+        return extractVerificationCode(messages.get(0).path("Message").asText());
+    }
+
+    private static JsonNode getInspectionMessages(URI uri) throws Exception {
+        HttpResponse<String> response = HTTP.send(
+                HttpRequest.newBuilder()
+                        .uri(uri)
+                        .GET()
+                        .timeout(Duration.ofSeconds(10))
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isEqualTo(200);
+        JsonNode messages = JSON.readTree(response.body()).path("messages");
+        assertThat(messages.isArray() && !messages.isEmpty()).isTrue();
+        return messages;
+    }
+
+    private static String extractVerificationCode(String message) {
+        Matcher matcher = SIX_DIGIT_CODE.matcher(message);
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    private static String differentCode(String code) {
+        return "000000".equals(code) ? "000001" : "000000";
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CognitoVerifyUserAttributeTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CognitoVerifyUserAttributeTest.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityPr
 import software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeType;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.AuthFlowType;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.CodeMismatchException;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.ExpiredCodeException;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.ExplicitAuthFlowsType;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.MessageActionType;
 
@@ -107,6 +108,7 @@ class CognitoVerifyUserAttributeTest {
                 .codeDeliveryDetails();
         assertThat(emailDelivery.attributeName()).isEqualTo("email");
         assertThat(emailDelivery.deliveryMediumAsString()).isEqualTo("EMAIL");
+        assertThat(emailDelivery.destination()).isEqualTo("v***@e***");
         String emailCode = fetchLatestSesVerificationCode(email);
 
         var phoneDelivery = cognito.getUserAttributeVerificationCode(b -> b
@@ -115,6 +117,7 @@ class CognitoVerifyUserAttributeTest {
                 .codeDeliveryDetails();
         assertThat(phoneDelivery.attributeName()).isEqualTo("phone_number");
         assertThat(phoneDelivery.deliveryMediumAsString()).isEqualTo("SMS");
+        assertThat(phoneDelivery.destination()).isEqualTo(maskedPhoneNumber(phoneNumber));
         String phoneCode = fetchLatestSnsVerificationCode(phoneNumber);
 
         assertThatThrownBy(() -> cognito.verifyUserAttribute(b -> b
@@ -140,7 +143,34 @@ class CognitoVerifyUserAttributeTest {
                 .accessToken(accessToken)
                 .attributeName("email")
                 .code(emailCode)))
-                .isInstanceOf(CodeMismatchException.class);
+                .isInstanceOfSatisfying(ExpiredCodeException.class,
+                        exception -> assertThat(exception.awsErrorDetails().errorMessage())
+                                .isEqualTo("Invalid code provided, please request a code again."));
+
+        clearInspectionEndpoint("/_aws/ses");
+        clearInspectionEndpoint("/_aws/sns");
+
+        cognito.getUserAttributeVerificationCode(b -> b
+                .accessToken(accessToken)
+                .attributeName("email"));
+        String repeatedEmailCode = fetchLatestSesVerificationCode(email);
+
+        cognito.getUserAttributeVerificationCode(b -> b
+                .accessToken(accessToken)
+                .attributeName("phone_number"));
+        String repeatedPhoneCode = fetchLatestSnsVerificationCode(phoneNumber);
+
+        cognito.verifyUserAttribute(b -> b
+                .accessToken(accessToken)
+                .attributeName("email")
+                .code(repeatedEmailCode));
+        cognito.verifyUserAttribute(b -> b
+                .accessToken(accessToken)
+                .attributeName("phone_number")
+                .code(repeatedPhoneCode));
+
+        assertThat(userAttribute(username, "email_verified")).isEqualTo("true");
+        assertThat(userAttribute(username, "phone_number_verified")).isEqualTo("true");
     }
 
     private String userAttribute(String username, String attributeName) {
@@ -200,5 +230,10 @@ class CognitoVerifyUserAttributeTest {
 
     private static String differentCode(String code) {
         return "000000".equals(code) ? "000001" : "000000";
+    }
+
+    private static String maskedPhoneNumber(String phoneNumber) {
+        return "+" + "*".repeat(phoneNumber.length() - 5)
+                + phoneNumber.substring(phoneNumber.length() - 4);
     }
 }

--- a/docs/services/cognito.md
+++ b/docs/services/cognito.md
@@ -74,6 +74,7 @@ Standalone `TagResource` rejects reserved `floci:*` keys. `ListTagsForResource` 
 | ConfirmSignUp | Confirms a pending self-service signup. |
 | GetUser | Returns attributes for the authenticated access-token user. |
 | GetUserAttributeVerificationCode | Issues a verification code for the authenticated user's email or phone_number attribute. |
+| VerifyUserAttribute | Verifies an email or phone_number attribute with its issued verification code. |
 | UpdateUserAttributes | Updates attributes for the authenticated access-token user. |
 | ChangePassword | Changes the authenticated user's password. |
 | ForgotPassword | Starts the local forgot-password flow for a user. |

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -82,6 +82,7 @@ public class CognitoJsonHandler {
             case "ConfirmForgotPassword" -> handleConfirmForgotPassword(request);
             case "GetUser" -> handleGetUser(request);
             case "GetUserAttributeVerificationCode" -> handleGetUserAttributeVerificationCode(request);
+            case "VerifyUserAttribute" -> handleVerifyUserAttribute(request);
             case "UpdateUserAttributes" -> handleUpdateUserAttributes(request);
             case "DeleteUserAttributes" -> handleDeleteUserAttributes(request);
             case "GlobalSignOut" -> handleGlobalSignOut(request);
@@ -641,6 +642,15 @@ public class CognitoJsonHandler {
         delivery.put("DeliveryMedium", (String) deliveryDetails.get("DeliveryMedium"));
         delivery.put("Destination", (String) deliveryDetails.get("Destination"));
         return Response.ok(response).build();
+    }
+
+    private Response handleVerifyUserAttribute(JsonNode request) {
+        service.verifyUserAttribute(
+                request.path("AccessToken").asText(),
+                request.path("AttributeName").asText(),
+                request.path("Code").asText()
+        );
+        return Response.ok(objectMapper.createObjectNode()).build();
     }
 
     private Response handleUpdateUserAttributes(JsonNode request) {

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -1616,6 +1616,46 @@ public class CognitoService {
         return response;
     }
 
+    public void verifyUserAttribute(String accessToken, String attributeName, String code) {
+        String username = extractUsernameFromToken(accessToken);
+        String poolId = extractPoolIdFromToken(accessToken);
+        String jti = extractJtiFromToken(accessToken);
+
+        if (username == null || poolId == null || jti == null) {
+            throw new AwsException("NotAuthorizedException", "Invalid access token", 400);
+        }
+
+        validateTokenNotRevoked(jti, poolId, "access");
+        validateOriginJtiNotRevoked(accessToken, poolId);
+        Long iat = extractIatFromToken(accessToken);
+        validateUserNotGloballySignedOut(username, poolId, "access", iat != null ? iat : 0L);
+
+        if (!"email".equals(attributeName) && !"phone_number".equals(attributeName)) {
+            throw new AwsException("InvalidParameterException",
+                    "Only email and phone_number attributes can be verified", 400);
+        }
+
+        CognitoUser user = adminGetUser(poolId, username);
+        if (blankToNull(user.getAttributes().get(attributeName)) == null) {
+            throw new AwsException("InvalidParameterException",
+                    "User has no " + attributeName + " attribute set", 400);
+        }
+
+        VerificationCode.Purpose purpose = "email".equals(attributeName)
+                ? VerificationCode.Purpose.EMAIL_ATTRIBUTE_VERIFICATION
+                : VerificationCode.Purpose.PHONE_ATTRIBUTE_VERIFICATION;
+        ensureVerificationWiring();
+        try {
+            verificationCodeService.consume(poolId, user.getUsername(), purpose, code);
+        } catch (VerificationCodeException e) {
+            throw mapVerificationCodeException(e);
+        }
+
+        user.getAttributes().put(attributeName + "_verified", "true");
+        user.setLastModifiedDate(System.currentTimeMillis() / 1000L);
+        userStore.put(userKey(poolId, user.getUsername()), user);
+    }
+
     public void updateUserAttributes(String accessToken, Map<String, String> attributes) {
         String username = extractUsernameFromToken(accessToken);
         String poolId = extractPoolIdFromToken(accessToken);

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -1622,7 +1622,7 @@ public class CognitoService {
         String jti = extractJtiFromToken(accessToken);
 
         if (username == null || poolId == null || jti == null) {
-            throw new AwsException("NotAuthorizedException", "Invalid access token", 400);
+            throw new AwsException("NotAuthorizedException", "Invalid Access Token", 400);
         }
 
         validateTokenNotRevoked(jti, poolId, "access");
@@ -1632,13 +1632,14 @@ public class CognitoService {
 
         if (!"email".equals(attributeName) && !"phone_number".equals(attributeName)) {
             throw new AwsException("InvalidParameterException",
-                    "Only email and phone_number attributes can be verified", 400);
+                    "Invalid attribute name. Only phone_number and email can be verified.", 400);
         }
 
         CognitoUser user = adminGetUser(poolId, username);
         if (blankToNull(user.getAttributes().get(attributeName)) == null) {
             throw new AwsException("InvalidParameterException",
-                    "User has no " + attributeName + " attribute set", 400);
+                    "Unable to verify attribute: " + attributeName + " no value set to verify",
+                    400);
         }
 
         VerificationCode.Purpose purpose = "email".equals(attributeName)

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/verification/VerificationCodeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/verification/VerificationCodeService.java
@@ -86,8 +86,9 @@ public final class VerificationCodeService {
     }
 
     /**
-     * Validate a code. On success, marks it consumed and removes it. On any
-     * failure, throws {@link VerificationCodeException} with the specific
+     * Validate a code. On success, marks it consumed and retains the tombstone
+     * until it expires or a new code replaces it. On any failure, throws
+     * {@link VerificationCodeException} with the specific
      * {@link VerificationCodeException.Kind}.
      *
      * <p>Note: not thread-safe under concurrent {@code consume()} of the same
@@ -101,13 +102,13 @@ public final class VerificationCodeService {
         VerificationCode vc = store.get(key).orElseThrow(() -> new VerificationCodeException(
             VerificationCodeException.Kind.NOT_FOUND,
             "Invalid verification code provided, please try again"));
-        if (vc.isConsumed()) {
-            throw new VerificationCodeException(
-                VerificationCodeException.Kind.NOT_FOUND,
-                "Invalid verification code provided, please try again");
-        }
         if (vc.isExpired(clock.instant())) {
             store.delete(key);
+            throw new VerificationCodeException(
+                VerificationCodeException.Kind.EXPIRED,
+                "Invalid code provided, please request a code again");
+        }
+        if (vc.isConsumed()) {
             throw new VerificationCodeException(
                 VerificationCodeException.Kind.EXPIRED,
                 "Invalid code provided, please request a code again");
@@ -136,7 +137,7 @@ public final class VerificationCodeService {
         }
 
         vc.markConsumed();
-        store.delete(key);
+        store.put(key, vc);
     }
 
     /** Remove any active code for the (pool, user, purpose). Idempotent. */

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoAttributeVerificationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoAttributeVerificationIntegrationTest.java
@@ -20,7 +20,6 @@ import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 @QuarkusTest
@@ -111,8 +110,7 @@ class CognitoAttributeVerificationIntegrationTest {
                 .statusCode(200)
                 .body("CodeDeliveryDetails.AttributeName", equalTo("email"))
                 .body("CodeDeliveryDetails.DeliveryMedium", equalTo("EMAIL"))
-                .body("CodeDeliveryDetails.Destination", containsString("*"))
-                .body("CodeDeliveryDetails.Destination", containsString("@"));
+                .body("CodeDeliveryDetails.Destination", equalTo("v***@e***"));
 
         emailVerificationCode = fetchLatestSesVerificationCode(USERNAME);
     }
@@ -163,7 +161,8 @@ class CognitoAttributeVerificationIntegrationTest {
                 """.formatted(accessToken, emailVerificationCode))
                 .then()
                 .statusCode(400)
-                .body("__type", equalTo("CodeMismatchException"));
+                .body("__type", equalTo("ExpiredCodeException"))
+                .body("message", equalTo("Invalid code provided, please request a code again."));
     }
 
     @Test
@@ -177,7 +176,8 @@ class CognitoAttributeVerificationIntegrationTest {
                 """)
                 .then()
                 .statusCode(400)
-                .body("__type", equalTo("NotAuthorizedException"));
+                .body("__type", equalTo("NotAuthorizedException"))
+                .body("message", equalTo("Invalid Access Token"));
     }
 
     @Test
@@ -191,7 +191,9 @@ class CognitoAttributeVerificationIntegrationTest {
                 """.formatted(accessToken))
                 .then()
                 .statusCode(400)
-                .body("__type", equalTo("InvalidParameterException"));
+                .body("__type", equalTo("InvalidParameterException"))
+                .body("message", equalTo(
+                        "Invalid attribute name. Only phone_number and email can be verified."));
     }
 
     @Test
@@ -205,7 +207,8 @@ class CognitoAttributeVerificationIntegrationTest {
                 """.formatted(accessToken))
                 .then()
                 .statusCode(400)
-                .body("__type", equalTo("InvalidParameterException"));
+                .body("__type", equalTo("InvalidParameterException"))
+                .body("message", equalTo("User does not have a valid registered phone number"));
     }
 
     @Test
@@ -273,7 +276,7 @@ class CognitoAttributeVerificationIntegrationTest {
                 .statusCode(200)
                 .body("CodeDeliveryDetails.AttributeName", equalTo("phone_number"))
                 .body("CodeDeliveryDetails.DeliveryMedium", equalTo("SMS"))
-                .body("CodeDeliveryDetails.Destination", containsString("*"));
+                .body("CodeDeliveryDetails.Destination", equalTo("+*******4567"));
         String phoneCode = fetchLatestSnsVerificationCode(phoneNumber);
 
         cognitoAction("VerifyUserAttribute", """
@@ -312,7 +315,26 @@ class CognitoAttributeVerificationIntegrationTest {
                 """.formatted(accessToken))
                 .then()
                 .statusCode(400)
-                .body("__type", equalTo("InvalidParameterException"));
+                .body("__type", equalTo("InvalidParameterException"))
+                .body("message", equalTo(
+                        "Invalid attribute name. Only phone_number and email can be verified."));
+    }
+
+    @Test
+    @Order(11)
+    void rejectsVerificationForAttributeWithoutValue() {
+        cognitoAction("VerifyUserAttribute", """
+                {
+                  "AccessToken": "%s",
+                  "AttributeName": "phone_number",
+                  "Code": "123456"
+                }
+                """.formatted(accessToken))
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("InvalidParameterException"))
+                .body("message", equalTo(
+                        "Unable to verify attribute: phone_number no value set to verify"));
     }
 
     private static void clearInspectionEndpoint(String path) {

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoAttributeVerificationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoAttributeVerificationIntegrationTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.cognito;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -10,21 +11,31 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static io.github.hectorvent.floci.services.cognito.CognitoRestAssuredUtils.cognitoAction;
 import static io.github.hectorvent.floci.services.cognito.CognitoRestAssuredUtils.cognitoJson;
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 @QuarkusTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class CognitoAttributeVerificationIntegrationTest {
 
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final Pattern SIX_DIGIT_CODE = Pattern.compile("\\b(\\d{6})\\b");
     private static final String USERNAME = "verify+" + UUID.randomUUID() + "@example.com";
     private static final String PASSWORD = "Verify1234!";
 
     private static String poolId;
     private static String clientId;
     private static String accessToken;
+    private static String emailVerificationCode;
 
     @BeforeAll
     static void configureRestAssured() {
@@ -87,7 +98,9 @@ class CognitoAttributeVerificationIntegrationTest {
 
     @Test
     @Order(2)
-    void issuesEmailVerificationCode() {
+    void issuesEmailVerificationCode() throws Exception {
+        clearInspectionEndpoint("/_aws/ses");
+
         cognitoAction("GetUserAttributeVerificationCode", """
                 {
                   "AccessToken": "%s",
@@ -98,11 +111,63 @@ class CognitoAttributeVerificationIntegrationTest {
                 .statusCode(200)
                 .body("CodeDeliveryDetails.AttributeName", equalTo("email"))
                 .body("CodeDeliveryDetails.DeliveryMedium", equalTo("EMAIL"))
-                .body("CodeDeliveryDetails.Destination", equalTo("v***@e***"));
+                .body("CodeDeliveryDetails.Destination", containsString("*"))
+                .body("CodeDeliveryDetails.Destination", containsString("@"));
+
+        emailVerificationCode = fetchLatestSesVerificationCode(USERNAME);
     }
 
     @Test
     @Order(3)
+    void rejectsWrongVerificationCodeWithoutUpdatingAttribute() throws Exception {
+        cognitoAction("VerifyUserAttribute", """
+                {
+                  "AccessToken": "%s",
+                  "AttributeName": "email",
+                  "Code": "%s"
+                }
+                """.formatted(accessToken, differentCode(emailVerificationCode)))
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("CodeMismatchException"));
+
+        assertNull(userAttribute(USERNAME, "email_verified"));
+    }
+
+    @Test
+    @Order(4)
+    void verifiesEmailAttribute() throws Exception {
+        cognitoAction("VerifyUserAttribute", """
+                {
+                  "AccessToken": "%s",
+                  "AttributeName": "email",
+                  "Code": "%s"
+                }
+                """.formatted(accessToken, emailVerificationCode))
+                .then()
+                .statusCode(200)
+                .body(equalTo("{}"));
+
+        assertEquals("true", userAttribute(USERNAME, "email_verified"));
+    }
+
+    @Test
+    @Order(5)
+    void rejectsConsumedVerificationCode() {
+        cognitoAction("VerifyUserAttribute", """
+                {
+                  "AccessToken": "%s",
+                  "AttributeName": "email",
+                  "Code": "%s"
+                }
+                """.formatted(accessToken, emailVerificationCode))
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("CodeMismatchException"));
+    }
+
+    @Test
+    @Order(6)
     void rejectsInvalidAccessToken() {
         cognitoAction("GetUserAttributeVerificationCode", """
                 {
@@ -112,12 +177,11 @@ class CognitoAttributeVerificationIntegrationTest {
                 """)
                 .then()
                 .statusCode(400)
-                .body("__type", equalTo("NotAuthorizedException"))
-                .body("message", equalTo("Invalid Access Token"));
+                .body("__type", equalTo("NotAuthorizedException"));
     }
 
     @Test
-    @Order(4)
+    @Order(7)
     void rejectsUnverifiableAttribute() {
         cognitoAction("GetUserAttributeVerificationCode", """
                 {
@@ -127,12 +191,11 @@ class CognitoAttributeVerificationIntegrationTest {
                 """.formatted(accessToken))
                 .then()
                 .statusCode(400)
-                .body("__type", equalTo("InvalidParameterException"))
-                .body("message", equalTo("Invalid attribute name. Only phone_number and email can be verified."));
+                .body("__type", equalTo("InvalidParameterException"));
     }
 
     @Test
-    @Order(5)
+    @Order(8)
     void rejectsAttributeWithoutValue() {
         cognitoAction("GetUserAttributeVerificationCode", """
                 {
@@ -142,24 +205,24 @@ class CognitoAttributeVerificationIntegrationTest {
                 """.formatted(accessToken))
                 .then()
                 .statusCode(400)
-                .body("__type", equalTo("InvalidParameterException"))
-                .body("message", equalTo("User does not have a valid registered phone number"));
+                .body("__type", equalTo("InvalidParameterException"));
     }
 
     @Test
-    @Order(6)
+    @Order(9)
     void emailAndPhoneCodesAreIndependent() throws Exception {
         String username = "verify-both+" + UUID.randomUUID() + "@example.com";
+        String phoneNumber = "+15551234567";
         cognitoAction("AdminCreateUser", """
                 {
                   "UserPoolId": "%s",
                   "Username": "%s",
                   "UserAttributes": [
                     { "Name": "email", "Value": "%s" },
-                    { "Name": "phone_number", "Value": "+15551234567" }
+                    { "Name": "phone_number", "Value": "%s" }
                   ]
                 }
-                """.formatted(poolId, username, username))
+                """.formatted(poolId, username, username, phoneNumber))
                 .then()
                 .statusCode(200);
 
@@ -186,8 +249,9 @@ class CognitoAttributeVerificationIntegrationTest {
                 """.formatted(clientId, username, PASSWORD));
         String token = auth.path("AuthenticationResult").path("AccessToken").asText();
 
-        // Back-to-back requests for different attributes must not trip the shared
-        // rate limit or overwrite each other: each attribute has its own code slot.
+        clearInspectionEndpoint("/_aws/ses");
+        clearInspectionEndpoint("/_aws/sns");
+
         cognitoAction("GetUserAttributeVerificationCode", """
                 {
                   "AccessToken": "%s",
@@ -197,6 +261,7 @@ class CognitoAttributeVerificationIntegrationTest {
                 .then()
                 .statusCode(200)
                 .body("CodeDeliveryDetails.DeliveryMedium", equalTo("EMAIL"));
+        String emailCode = fetchLatestSesVerificationCode(username);
 
         cognitoAction("GetUserAttributeVerificationCode", """
                 {
@@ -208,57 +273,103 @@ class CognitoAttributeVerificationIntegrationTest {
                 .statusCode(200)
                 .body("CodeDeliveryDetails.AttributeName", equalTo("phone_number"))
                 .body("CodeDeliveryDetails.DeliveryMedium", equalTo("SMS"))
-                .body("CodeDeliveryDetails.Destination", equalTo("+*******4567"));
+                .body("CodeDeliveryDetails.Destination", containsString("*"));
+        String phoneCode = fetchLatestSnsVerificationCode(phoneNumber);
+
+        cognitoAction("VerifyUserAttribute", """
+                {
+                  "AccessToken": "%s",
+                  "AttributeName": "phone_number",
+                  "Code": "%s"
+                }
+                """.formatted(token, phoneCode))
+                .then()
+                .statusCode(200);
+
+        cognitoAction("VerifyUserAttribute", """
+                {
+                  "AccessToken": "%s",
+                  "AttributeName": "email",
+                  "Code": "%s"
+                }
+                """.formatted(token, emailCode))
+                .then()
+                .statusCode(200);
+
+        assertEquals("true", userAttribute(username, "email_verified"));
+        assertEquals("true", userAttribute(username, "phone_number_verified"));
     }
 
     @Test
-    @Order(7)
-    void allowsFreshCodeForAlreadyVerifiedAttribute() throws Exception {
-        String username = "verify-already+" + UUID.randomUUID() + "@example.com";
-        cognitoAction("AdminCreateUser", """
-                {
-                  "UserPoolId": "%s",
-                  "Username": "%s",
-                  "UserAttributes": [
-                    { "Name": "email", "Value": "%s" },
-                    { "Name": "email_verified", "Value": "true" }
-                  ]
-                }
-                """.formatted(poolId, username, username))
-                .then()
-                .statusCode(200);
-
-        cognitoAction("AdminSetUserPassword", """
-                {
-                  "UserPoolId": "%s",
-                  "Username": "%s",
-                  "Password": "%s",
-                  "Permanent": true
-                }
-                """.formatted(poolId, username, PASSWORD))
-                .then()
-                .statusCode(200);
-
-        JsonNode auth = cognitoJson("InitiateAuth", """
-                {
-                  "ClientId": "%s",
-                  "AuthFlow": "USER_PASSWORD_AUTH",
-                  "AuthParameters": {
-                    "USERNAME": "%s",
-                    "PASSWORD": "%s"
-                  }
-                }
-                """.formatted(clientId, username, PASSWORD));
-        String token = auth.path("AuthenticationResult").path("AccessToken").asText();
-
-        cognitoAction("GetUserAttributeVerificationCode", """
+    @Order(10)
+    void rejectsUnverifiableAttributeDuringVerification() {
+        cognitoAction("VerifyUserAttribute", """
                 {
                   "AccessToken": "%s",
-                  "AttributeName": "email"
+                  "AttributeName": "given_name",
+                  "Code": "123456"
                 }
-                """.formatted(token))
+                """.formatted(accessToken))
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("InvalidParameterException"));
+    }
+
+    private static void clearInspectionEndpoint(String path) {
+        given()
+                .delete(path)
+                .then()
+                .statusCode(200);
+    }
+
+    private static String fetchLatestSesVerificationCode(String recipient) throws Exception {
+        String response = given()
+                .queryParam("email", recipient)
+                .get("/_aws/ses")
                 .then()
                 .statusCode(200)
-                .body("CodeDeliveryDetails.AttributeName", equalTo("email"));
+                .extract()
+                .asString();
+        JsonNode messages = JSON.readTree(response).path("messages");
+        assertTrue(messages.isArray() && !messages.isEmpty());
+        return extractVerificationCode(messages.get(0).path("Body").path("text_part").asText());
+    }
+
+    private static String fetchLatestSnsVerificationCode(String phoneNumber) throws Exception {
+        String response = given()
+                .queryParam("phone", phoneNumber)
+                .get("/_aws/sns")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+        JsonNode messages = JSON.readTree(response).path("messages");
+        assertTrue(messages.isArray() && !messages.isEmpty());
+        return extractVerificationCode(messages.get(0).path("Message").asText());
+    }
+
+    private static String extractVerificationCode(String message) {
+        Matcher matcher = SIX_DIGIT_CODE.matcher(message);
+        assertTrue(matcher.find());
+        return matcher.group(1);
+    }
+
+    private static String differentCode(String code) {
+        return "000000".equals(code) ? "000001" : "000000";
+    }
+
+    private static String userAttribute(String username, String attributeName) throws Exception {
+        JsonNode user = cognitoJson("AdminGetUser", """
+                {
+                  "UserPoolId": "%s",
+                  "Username": "%s"
+                }
+                """.formatted(poolId, username));
+        for (JsonNode attribute : user.path("UserAttributes")) {
+            if (attributeName.equals(attribute.path("Name").asText())) {
+                return attribute.path("Value").asText();
+            }
+        }
+        return null;
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/verification/VerificationCodeServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/verification/VerificationCodeServiceTest.java
@@ -51,6 +51,32 @@ class VerificationCodeServiceTest {
     }
 
     @Test
+    void consume_consumedCode_throwsExpired() {
+        String code = service.issue("pool", "alice",
+            VerificationCode.Purpose.SIGNUP_CONFIRMATION, Duration.ofHours(24));
+        service.consume("pool", "alice",
+            VerificationCode.Purpose.SIGNUP_CONFIRMATION, code);
+
+        VerificationCodeException ex = assertThrows(VerificationCodeException.class,
+            () -> service.consume("pool", "alice",
+                VerificationCode.Purpose.SIGNUP_CONFIRMATION, code));
+
+        assertEquals(VerificationCodeException.Kind.EXPIRED, ex.getKind());
+    }
+
+    @Test
+    void issue_afterConsumedCode_succeedsImmediately() {
+        String code = service.issue("pool", "alice",
+            VerificationCode.Purpose.SIGNUP_CONFIRMATION, Duration.ofHours(24));
+        service.consume("pool", "alice",
+            VerificationCode.Purpose.SIGNUP_CONFIRMATION, code);
+
+        assertDoesNotThrow(() ->
+            service.issue("pool", "alice",
+                VerificationCode.Purpose.SIGNUP_CONFIRMATION, Duration.ofHours(24)));
+    }
+
+    @Test
     void consume_wrongCode_throwsMismatch() {
         service.issue("pool", "alice",
             VerificationCode.Purpose.SIGNUP_CONFIRMATION, Duration.ofHours(24));


### PR DESCRIPTION
## Summary

Closes #2017
Closes #2022
Depends on #1898.

- add `VerifyUserAttribute` JSON 1.1 dispatch
- validate and consume email and phone verification codes
- persist `email_verified` and `phone_number_verified`
- align errors, delivery-destination masking, and consumed-code behavior with real Cognito
- allow a fresh verification round for an unchanged attribute that is already verified
- require an access token carrying the `aws.cognito.signin.user.admin` scope, matching AWS's documented authorization contract for this operation
- scope the consumed-code tombstone to attribute verification only, leaving `ConfirmSignUp`/`ConfirmForgotPassword` reused-code behavior unchanged
- add integration, unit, and AWS SDK compatibility coverage

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Validated against a real Cognito user pool in `eu-central-1`:

- only `email` and `phone_number` can be verified
- an unchanged, already verified email or phone number can receive a fresh code and be verified again successfully
- reusing a successfully consumed code returns `ExpiredCodeException: Invalid code provided, please request a code again.`
- a wrong active code returns `CodeMismatchException: Invalid verification code provided, please try again.`
- invalid attributes return `InvalidParameterException: Invalid attribute name. Only phone_number and email can be verified.`
- invalid access tokens return `NotAuthorizedException: Invalid Access Token`
- observed destinations are masked as `z***@b***` for email and `+********8920` for phone

The self-sign-up sequence was also validated: email-only sign-up verifies email during `ConfirmSignUp`; email plus phone uses SMS for sign-up confirmation, then email can be verified separately through `GetUserAttributeVerificationCode` and `VerifyUserAttribute`.

Per AWS's `VerifyUserAttribute` reference, the access token must carry the `aws.cognito.signin.user.admin` scope. An ID token, or an access token whose scope list explicitly omits it, is now rejected with `NotAuthorizedException`.

`ConfirmSignUp` and `ConfirmForgotPassword` keep their original reused-code behavior (`CodeMismatchException`) unaffected by the consumed-code tombstone added here, since that reuse case was never validated against real Cognito for those two operations.

## Known follow-ups / out of scope

- #2021 - implement pending-value and verified-state semantics when `email` or `phone_number` changes

This PR remains focused on validating a code for the currently stored attribute and setting its verified flag. It does not change user confirmation status, authentication-flow eligibility, or attribute-update/pending-value behavior.

## Checklist

- [x] targeted verification-code and attribute-verification test classes pass locally
- [x] full local suite passed: 7,868 tests, 0 failures, 0 errors, 8 skipped (prior to the authorization-scope and tombstone-scoping commits below)
- [x] AWS SDK compatibility test for `VerifyUserAttribute` passes locally
- [x] real Cognito compatibility comparison in `eu-central-1`
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] downstream Amplify integration test
- [ ] full suite re-run after the authorization-scope and tombstone-scoping commits below

Rebased onto current `main` (2026-09-14). `main`'s Cognito access-token verification was substantially hardened in the meantime (a shared `verifyAccessToken()` now does real signature/issuer/client checks and enforces `token_use`, and access tokens carry `aws.cognito.signin.user.admin` by default); `VerifyUserAttribute` was updated to use that same shared path instead of the ad-hoc token parsing it originally had, so it now behaves consistently with `getUser`, `updateUserAttributes`, and the other self-service operations.

Two commits were pushed directly to this branch by a maintainer to close out review findings: requiring the access-token scope on `VerifyUserAttribute` (adapted, in the rebase above, to use the same shared token-verification path as its sibling operations), and scoping the consumed-code tombstone to attribute verification only.

