### PR TITLE
fix(firehose): return Kinesis source in stream description

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseJsonHandler.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.firehose;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.firehose.model.DeliveryStreamDescription.KinesisStreamSource;
 import io.github.hectorvent.floci.services.firehose.model.DeliveryStreamDescription.S3Destination;
 import io.github.hectorvent.floci.services.firehose.model.Record;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -56,7 +57,10 @@ public class FirehoseJsonHandler {
                 }
                 String deliveryStreamType = request.has("DeliveryStreamType")
                         ? request.get("DeliveryStreamType").asText() : null;
-                String arn = firehoseService.createDeliveryStream(name, s3, tags, deliveryStreamType);
+                KinesisStreamSource source = request.has("KinesisStreamSourceConfiguration")
+                        ? mapper.treeToValue(request.get("KinesisStreamSourceConfiguration"), KinesisStreamSource.class)
+                        : null;
+                String arn = firehoseService.createDeliveryStream(name, s3, tags, deliveryStreamType, source);
                 yield Response.ok(Map.of("DeliveryStreamARN", arn)).build();
             }
             case "UpdateDestination" -> {

--- a/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseService.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.firehose.model.DeliveryStreamDescription;
+import io.github.hectorvent.floci.services.firehose.model.DeliveryStreamDescription.KinesisStreamSource;
 import io.github.hectorvent.floci.services.firehose.model.DeliveryStreamDescription.S3Destination;
 import io.github.hectorvent.floci.services.firehose.model.Record;
 import io.github.hectorvent.floci.services.s3.S3Service;
@@ -50,6 +51,11 @@ public class FirehoseService {
 
     public String createDeliveryStream(String name, S3Destination s3Config, List<DeliveryStreamDescription.Tag> tags,
                                        String deliveryStreamType) {
+        return createDeliveryStream(name, s3Config, tags, deliveryStreamType, null);
+    }
+
+    public String createDeliveryStream(String name, S3Destination s3Config, List<DeliveryStreamDescription.Tag> tags,
+                                       String deliveryStreamType, KinesisStreamSource source) {
         if (name == null || name.isEmpty() || name.length() > 64 || !name.matches("[a-zA-Z0-9_.-]+")) {
             throw new AwsException("InvalidArgumentException",
                     "Delivery stream name must be between 1 and 64 characters and contain only letters, numbers, underscores, hyphens, or periods.", 400);
@@ -62,7 +68,7 @@ public class FirehoseService {
 
         validateBufferingHints(s3Config);
         String arn = AwsArnUtils.Arn.of("firehose", regionResolver.getDefaultRegion(), regionResolver.getAccountId(), "deliverystream/" + name).toString();
-        DeliveryStreamDescription description = new DeliveryStreamDescription(name, arn, s3Config);
+        DeliveryStreamDescription description = new DeliveryStreamDescription(name, arn, s3Config, source);
         description.setAccountId(regionResolver.getAccountId());
         description.setTags(tags);
         if (deliveryStreamType != null && !deliveryStreamType.isBlank()) {

--- a/src/main/java/io/github/hectorvent/floci/services/firehose/model/DeliveryStreamDescription.java
+++ b/src/main/java/io/github/hectorvent/floci/services/firehose/model/DeliveryStreamDescription.java
@@ -34,11 +34,18 @@ public class DeliveryStreamDescription {
     private Instant lastUpdateTimestamp;
     @JsonProperty("Destinations")
     private List<Destination> destinations;
+    @JsonProperty("Source")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Source source;
     @JsonProperty("Tags")
     private List<Tag> tags = new ArrayList<>();
 
     public DeliveryStreamDescription() {}
     public DeliveryStreamDescription(String name, String arn, S3Destination s3) {
+        this(name, arn, s3, null);
+    }
+
+    public DeliveryStreamDescription(String name, String arn, S3Destination s3, KinesisStreamSource kinesisStreamSource) {
         this.deliveryStreamName = name;
         this.deliveryStreamARN = arn;
         this.deliveryStreamStatus = DeliveryStreamStatus.ACTIVE;
@@ -47,6 +54,9 @@ public class DeliveryStreamDescription {
             s3.applyDefaults();
         }
         this.destinations = List.of(new Destination(s3));
+        if (kinesisStreamSource != null) {
+            this.source = new Source(kinesisStreamSource);
+        }
     }
 
     public String getDeliveryStreamName() { return deliveryStreamName; }
@@ -70,6 +80,54 @@ public class DeliveryStreamDescription {
     public void setLastUpdateTimestamp(Instant lastUpdateTimestamp) { this.lastUpdateTimestamp = lastUpdateTimestamp; }
     public List<Destination> getDestinations() { return destinations; }
     public void setDestinations(List<Destination> destinations) { this.destinations = destinations; }
+    public Source getSource() { return source; }
+    public void setSource(Source source) { this.source = source; }
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Source {
+        @JsonProperty("KinesisStreamSourceDescription")
+        private KinesisStreamSource kinesisStreamSourceDescription;
+
+        public Source() {}
+
+        public Source(KinesisStreamSource kinesisStreamSourceDescription) {
+            this.kinesisStreamSourceDescription = kinesisStreamSourceDescription;
+            if (kinesisStreamSourceDescription.getDeliveryStartTimestamp() == null) {
+                kinesisStreamSourceDescription.setDeliveryStartTimestamp(Instant.now());
+            }
+        }
+
+        public KinesisStreamSource getKinesisStreamSourceDescription() { return kinesisStreamSourceDescription; }
+        public void setKinesisStreamSourceDescription(KinesisStreamSource kinesisStreamSourceDescription) {
+            this.kinesisStreamSourceDescription = kinesisStreamSourceDescription;
+        }
+    }
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class KinesisStreamSource {
+        @JsonProperty("KinesisStreamARN")
+        private String kinesisStreamArn;
+        @JsonProperty("RoleARN")
+        private String roleArn;
+        @JsonProperty("DeliveryStartTimestamp")
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+        private Instant deliveryStartTimestamp;
+
+        public KinesisStreamSource() {}
+
+        public String getKinesisStreamArn() { return kinesisStreamArn; }
+        public void setKinesisStreamArn(String kinesisStreamArn) { this.kinesisStreamArn = kinesisStreamArn; }
+        public String getRoleArn() { return roleArn; }
+        public void setRoleArn(String roleArn) { this.roleArn = roleArn; }
+        public Instant getDeliveryStartTimestamp() { return deliveryStartTimestamp; }
+        public void setDeliveryStartTimestamp(Instant deliveryStartTimestamp) {
+            this.deliveryStartTimestamp = deliveryStartTimestamp;
+        }
+    }
 
     /** Convenience: returns the first S3 destination, or null if none. */
     public S3Destination s3Destination() {

--- a/src/test/java/io/github/hectorvent/floci/services/firehose/FirehoseIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/firehose/FirehoseIntegrationTest.java
@@ -16,6 +16,9 @@ import static org.hamcrest.Matchers.*;
 class FirehoseIntegrationTest {
 
     private static final String STREAM_NAME = "test-delivery-stream";
+    private static final String KINESIS_SOURCE_STREAM_NAME = "kinesis-source-delivery-stream";
+    private static final String KINESIS_STREAM_ARN = "arn:aws:kinesis:us-east-1:000000000000:stream/events";
+    private static final String SOURCE_ROLE_ARN = "arn:aws:iam::000000000000:role/firehose-role";
 
     @BeforeAll
     static void configureRestAssured() {
@@ -122,6 +125,41 @@ class FirehoseIntegrationTest {
         .then()
             .statusCode(400)
             .body("__type", equalTo("ResourceNotFoundException"));
+    }
+
+    @Test
+    @Order(16)
+    void describeDeliveryStreamReturnsKinesisSourceConfiguration() {
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "Firehose_20150804.CreateDeliveryStream")
+            .body("""
+                {
+                  "DeliveryStreamName": "%s",
+                  "DeliveryStreamType": "KinesisStreamAsSource",
+                  "KinesisStreamSourceConfiguration": {
+                    "KinesisStreamARN": "%s",
+                    "RoleARN": "%s"
+                  }
+                }
+                """.formatted(KINESIS_SOURCE_STREAM_NAME, KINESIS_STREAM_ARN, SOURCE_ROLE_ARN))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("X-Amz-Target", "Firehose_20150804.DescribeDeliveryStream")
+            .body("{ \"DeliveryStreamName\": \"" + KINESIS_SOURCE_STREAM_NAME + "\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DeliveryStreamDescription.DeliveryStreamType", equalTo("KinesisStreamAsSource"))
+            .body("DeliveryStreamDescription.Source.KinesisStreamSourceDescription.KinesisStreamARN", equalTo(KINESIS_STREAM_ARN))
+            .body("DeliveryStreamDescription.Source.KinesisStreamSourceDescription.RoleARN", equalTo(SOURCE_ROLE_ARN))
+            .body("DeliveryStreamDescription.Source.KinesisStreamSourceDescription.DeliveryStartTimestamp", notNullValue());
     }
 
     @Test
@@ -266,4 +304,3 @@ class FirehoseIntegrationTest {
             .body("__type", equalTo("InvalidArgumentException"));
     }
 }
-


### PR DESCRIPTION
## Summary
Closes #2016.

- Persist KinesisStreamSourceConfiguration when creating a KinesisStreamAsSource delivery stream.
- Return the source ARN, role ARN, and delivery-start timestamp from DescribeDeliveryStream.
- Add an end-to-end CreateDeliveryStream to DescribeDeliveryStream regression test.

## Type of change
- [x] Bug fix (fix:)
- [ ] New feature (feat:)
- [ ] Breaking change (feat! or fix!)
- [ ] Docs / chore

## AWS Compatibility
DescribeDeliveryStream previously dropped DeliveryStreamDescription.Source for KinesisStreamAsSource streams. The response now mirrors AWS KinesisStreamSourceDescription shape.

## Checklist
- [ ] ./mvnw test passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits

Focused verification: ./mvnw -q -Dtest=FirehoseIntegrationTest test (JDK 25).