### PR TITLE
fix(lambda): report resolved executed version

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -250,7 +250,7 @@ public class LambdaController {
         if (result.getLogResult() != null) {
             builder.header("X-Amz-Log-Result", result.getLogResult());
         }
-        builder.header("X-Amz-Executed-Version", "$LATEST");
+        builder.header("X-Amz-Executed-Version", result.getExecutedVersion());
         builder.header("X-Amz-Request-Id", result.getRequestId());
 
         if (result.getPayload() != null && result.getPayload().length > 0) {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -612,7 +612,9 @@ public class LambdaService {
         String name = ref.name();
         String qualifier = ref.qualifier();
         LambdaFunction fn = resolveInvokeTarget(region, name, qualifier);
-        return executorService.invoke(fn, payload, type);
+        InvokeResult result = executorService.invoke(fn, payload, type);
+        result.setExecutedVersion(fn.getVersion());
+        return result;
     }
 
     private LambdaFunction resolveInvokeTarget(String region, String name, String qualifier) {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/model/InvokeResult.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/model/InvokeResult.java
@@ -10,6 +10,7 @@ public class InvokeResult {
     private String functionError;
     private String logResult;
     private String requestId;
+    private String executedVersion;
 
     public InvokeResult() {
     }
@@ -60,5 +61,13 @@ public class InvokeResult {
 
     public void setRequestId(String requestId) {
         this.requestId = requestId;
+    }
+
+    public String getExecutedVersion() {
+        return executedVersion;
+    }
+
+    public void setExecutedVersion(String executedVersion) {
+        this.executedVersion = executedVersion;
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaVersionIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaVersionIntegrationTest.java
@@ -77,6 +77,18 @@ class LambdaVersionIntegrationTest {
 
     @Test
     @Order(4)
+    void invokePublishedVersionReturnsExecutedVersion() {
+        given()
+            .header("X-Amz-Invocation-Type", "DryRun")
+        .when()
+            .post(BASE_PATH + "/functions/" + FUNCTION_NAME + ":1/invocations")
+        .then()
+            .statusCode(204)
+            .header("X-Amz-Executed-Version", equalTo("1"));
+    }
+
+    @Test
+    @Order(5)
     void listVersionsByFunction() {
         given()
         .when()
@@ -90,7 +102,7 @@ class LambdaVersionIntegrationTest {
     }
 
     @Test
-    @Order(5)
+    @Order(6)
     void deleteFunctionDeletesAllVersions() {
         // Delete function
         given()


### PR DESCRIPTION
## Summary
Closes #1989.

- Carry the resolved Lambda target version through the invocation result.
- Emit that version in X-Amz-Executed-Version instead of always reporting $LATEST.
- Add a version-qualified DryRun regression test for the public HTTP endpoint.

## Type of change
- [x] Bug fix (fix:)
- [ ] New feature (feat:)
- [ ] Breaking change (feat! or fix!)
- [ ] Docs / chore

## AWS Compatibility
Version-qualified and alias-qualified invokes previously reported $LATEST even when another published version ran. The header now reports the resolved version, including aliases that route to a version.

## Checklist
- [x] ./mvnw test passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits

Focused verification: ./mvnw -q -Dtest=LambdaVersionIntegrationTest test and ./mvnw -q -Dtest=LambdaIntegrationTest test (JDK 25).