### PR TITLE
fix(cognito): reject unconfirmed users in SRP auth

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoAuthFlowHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoAuthFlowHandler.java
@@ -328,6 +328,9 @@ final class CognitoAuthFlowHandler {
         if ("RESET_REQUIRED".equals(user.getUserStatus())) {
             throw new AwsException("PasswordResetRequiredException", "Password reset required", 400);
         }
+        if ("UNCONFIRMED".equals(user.getUserStatus())) {
+            throw new AwsException("UserNotConfirmedException", "User is not confirmed", 400);
+        }
         if (user.getSrpVerifier() == null) {
             throw new AwsException("NotAuthorizedException", "User does not support SRP auth", 400);
         }
@@ -385,6 +388,9 @@ final class CognitoAuthFlowHandler {
         if (!user.isEnabled()) throw new AwsException("UserNotConfirmedException", "User is disabled", 400);
         if ("RESET_REQUIRED".equals(user.getUserStatus())) {
             throw new AwsException("PasswordResetRequiredException", "Password reset required", 400);
+        }
+        if ("UNCONFIRMED".equals(user.getUserStatus())) {
+            throw new AwsException("UserNotConfirmedException", "User is not confirmed", 400);
         }
         if (user.getSrpVerifier() == null) {
             throw new AwsException("NotAuthorizedException", "User does not support SRP auth", 400);

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
@@ -1314,6 +1314,46 @@ class CognitoServiceTest {
     }
 
     @Test
+    void initiateAuthWithUserSrpAuthRejectsUnconfirmedUser() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
+        UserPoolClient client = service.createUserPoolClient(pool.getId(), "c", false, false, List.of(), List.of());
+        service.signUp(client.getClientId(), "bob", "Password123!", Map.of("email", "bob@example.com"));
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                service.initiateAuth(client.getClientId(), "USER_SRP_AUTH",
+                        Map.of("USERNAME", "bob", "SRP_A", "ABCDEF1234567890")));
+
+        assertEquals("UserNotConfirmedException", ex.getErrorCode());
+    }
+
+    @Test
+    void respondToAuthChallengeWithUserSrpAuthRejectsNewlyUnconfirmedUser() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
+        String password = "Password123!";
+        service.adminCreateUser(pool.getId(), "bob", Map.of("email", "bob@example.com"), null);
+        service.adminSetUserPassword(pool.getId(), "bob", password, true);
+        UserPoolClient client = service.createUserPoolClient(pool.getId(), "c", false, false, List.of(), List.of());
+
+        Map<String, Object> initResult = service.initiateAuth(client.getClientId(), "USER_SRP_AUTH",
+                Map.of("USERNAME", "bob", "SRP_A", "ABCDEF1234567890"));
+        String session = (String) initResult.get("Session");
+        // Simulate the user becoming unconfirmed after the SRP session is created.
+        CognitoUser user = service.adminGetUser(pool.getId(), "bob");
+        user.setUserStatus("UNCONFIRMED");
+        userStore.put(pool.getId() + "::" + user.getUsername(), user);
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                service.respondToAuthChallenge(client.getClientId(), "PASSWORD_VERIFIER", session,
+                        Map.of(
+                                "USERNAME", "bob",
+                                "PASSWORD_CLAIM_SIGNATURE", "invalid-sig",
+                                "TIMESTAMP", "Wed Apr 8 12:00:00 UTC 2026"
+                        )));
+
+        assertEquals("UserNotConfirmedException", ex.getErrorCode());
+    }
+
+    @Test
     void respondToAuthChallengeWithInvalidSrpSignatureRejects() {
         UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
         String password = "Password123!";


### PR DESCRIPTION
## Summary

Closes #2020.

- Reject UNCONFIRMED users before USER_SRP_AUTH creates a PASSWORD_VERIFIER session.
- Recheck the user state before PASSWORD_VERIFIER validates proof or issues tokens.
- Add regression coverage for both SRP stages.

## Type of change

- [x] Bug fix (fix:)
- [ ] New feature (feat:)
- [ ] Breaking change (feat!: or fix!:)
- [ ] Docs / chore

## AWS Compatibility

Floci previously allowed UNCONFIRMED users to continue through the SRP flow and receive tokens after a valid verifier response. Both SRP stages now return UserNotConfirmedException, matching USER_PASSWORD_AUTH.

## Checklist

- [ ] ./mvnw test passes locally (not run; focused suite below)
- [ ] New or updated integration test added
- [x] Focused regression coverage added
- [x] Commit messages follow Conventional Commits

Focused verification (JDK 25):

`./mvnw -q -Dtest=CognitoServiceTest test`