### PR TITLE
fix(lambda): isolate warm containers by version

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -440,8 +440,8 @@ public class LambdaService {
         fn.setLastModified(System.currentTimeMillis());
         fn.setRevisionId(UUID.randomUUID().toString());
 
-        // Drain warm containers — they have stale code mounted
-        warmPool.drainFunction(functionName);
+        // Published versions are immutable; only $LATEST containers have stale code mounted.
+        warmPool.drainFunctionVersion(functionName, fn.getVersion());
 
         functionStore.save(region, fn);
         LOG.infov("Updated code for function: {0}", functionName);
@@ -561,8 +561,8 @@ public class LambdaService {
         fn.setLastModified(System.currentTimeMillis());
         fn.setRevisionId(UUID.randomUUID().toString());
 
-        // Drain warm containers so the next invocation picks up the new configuration
-        warmPool.drainFunction(functionName);
+        // Published versions are immutable; only $LATEST containers need the new configuration.
+        warmPool.drainFunctionVersion(fn.getFunctionName(), fn.getVersion());
 
         functionStore.save(region, fn);
         LOG.infov("Updated configuration for function: {0}", functionName);

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/WarmPool.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/WarmPool.java
@@ -23,7 +23,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Manages a pool of warm Lambda containers per function.
+ * Manages a pool of warm Lambda containers per function version.
  *
  * Two modes controlled by {@code emulator.services.lambda.ephemeral}:
  *  - {@code false} (default): containers are reused across invocations and evicted
@@ -106,7 +106,7 @@ public class WarmPool implements ContainerTeardown {
         ContainerHandle handle = null;
 
         if (!ephemeral) {
-            ArrayDeque<ContainerHandle> queue = pool.computeIfAbsent(fn.getFunctionName(), k -> new ArrayDeque<>());
+            ArrayDeque<ContainerHandle> queue = pool.computeIfAbsent(poolKey(fn), k -> new ArrayDeque<>());
             // Skip pooled handles whose container died out-of-band — otherwise the
             // caller would wait the full Lambda function timeout.
             while (true) {
@@ -154,7 +154,7 @@ public class WarmPool implements ContainerTeardown {
 
         handle.setState(ContainerState.WARM);
         handle.touchLastUsed();
-        ArrayDeque<ContainerHandle> queue = pool.computeIfAbsent(handle.getFunctionName(), k -> new ArrayDeque<>());
+        ArrayDeque<ContainerHandle> queue = pool.computeIfAbsent(poolKey(handle), k -> new ArrayDeque<>());
         boolean returned;
         synchronized (queue) {
             returned = queue.size() < maxPoolSizePerFunction;
@@ -192,19 +192,18 @@ public class WarmPool implements ContainerTeardown {
     }
 
     /**
-     * Stops and removes all warm containers for the given function.
+     * Stops and removes all warm containers for every version of the given function.
      * Called on function delete or code update.
      */
     public void drainFunction(String functionName) {
-        ArrayDeque<ContainerHandle> queue = pool.remove(functionName);
-        if (queue == null) {
-            return;
+        List<ContainerHandle> toStop = new ArrayList<>();
+        String prefix = functionName + "::";
+        for (String poolKey : new ArrayList<>(pool.keySet())) {
+            if (poolKey.startsWith(prefix)) {
+                toStop.addAll(removePool(poolKey));
+            }
         }
-        List<ContainerHandle> toStop;
-        synchronized (queue) {
-            toStop = new ArrayList<>(queue);
-            queue.clear();
-        }
+        if (toStop.isEmpty()) return;
         LOG.infov("Draining {0} container(s) for function: {1}", toStop.size(), functionName);
         stopInParallel(toStop);
     }
@@ -232,9 +231,11 @@ public class WarmPool implements ContainerTeardown {
     }
 
     private void drainAll() {
-        for (String functionName : new ArrayList<>(pool.keySet())) {
-            drainFunction(functionName);
+        List<ContainerHandle> toStop = new ArrayList<>();
+        for (String poolKey : new ArrayList<>(pool.keySet())) {
+            toStop.addAll(removePool(poolKey));
         }
+        stopInParallel(toStop);
     }
 
     private void evictIdleContainers() {
@@ -243,7 +244,7 @@ public class WarmPool implements ContainerTeardown {
         long now = System.currentTimeMillis();
 
         for (var entry : pool.entrySet()) {
-            String functionName = entry.getKey();
+            String poolKey = entry.getKey();
             ArrayDeque<ContainerHandle> queue = entry.getValue();
             List<ContainerHandle> toEvict = new ArrayList<>();
 
@@ -259,13 +260,37 @@ public class WarmPool implements ContainerTeardown {
             }
 
             // Re-check that the queue is still registered to avoid double-stop with drainFunction.
-            if (!toEvict.isEmpty() && pool.get(functionName) == queue) {
-                LOG.infov("Evicting {0} idle container(s) for function: {1}", toEvict.size(), functionName);
+            if (!toEvict.isEmpty() && pool.get(poolKey) == queue) {
+                LOG.infov("Evicting {0} idle container(s) for function: {1}", toEvict.size(), poolKey);
                 for (ContainerHandle handle : toEvict) {
                     stopQuietly(handle);
                 }
             }
         }
+    }
+
+    private List<ContainerHandle> removePool(String poolKey) {
+        ArrayDeque<ContainerHandle> queue = pool.remove(poolKey);
+        if (queue == null) {
+            return List.of();
+        }
+        synchronized (queue) {
+            List<ContainerHandle> handles = new ArrayList<>(queue);
+            queue.clear();
+            return handles;
+        }
+    }
+
+    private String poolKey(LambdaFunction fn) {
+        return poolKey(fn.getFunctionName(), fn.getVersion());
+    }
+
+    private String poolKey(ContainerHandle handle) {
+        return poolKey(handle.getFunctionName(), handle.getFunctionVersion());
+    }
+
+    private String poolKey(String functionName, String functionVersion) {
+        return functionName + "::" + (functionVersion == null ? "$LATEST" : functionVersion);
     }
 
     private void stopQuietly(ContainerHandle handle) {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/WarmPool.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/WarmPool.java
@@ -177,7 +177,7 @@ public class WarmPool implements ContainerTeardown {
     public void pushCodeUpdate(LambdaFunction fn) {
         LOG.infov("Reactive S3 Sync: invalidating warm pool for function {0} to pick up new code",
                 fn.getFunctionName());
-        drainFunction(fn.getFunctionName());
+        drainFunctionVersion(fn.getFunctionName(), fn.getVersion());
     }
 
     /**
@@ -193,7 +193,7 @@ public class WarmPool implements ContainerTeardown {
 
     /**
      * Stops and removes all warm containers for every version of the given function.
-     * Called on function delete or code update.
+     * Called when a function is deleted.
      */
     public void drainFunction(String functionName) {
         List<ContainerHandle> toStop = new ArrayList<>();
@@ -205,6 +205,19 @@ public class WarmPool implements ContainerTeardown {
         }
         if (toStop.isEmpty()) return;
         LOG.infov("Draining {0} container(s) for function: {1}", toStop.size(), functionName);
+        stopInParallel(toStop);
+    }
+
+    /**
+     * Stops and removes warm containers for one specified function version.
+     * Code and configuration updates use this to invalidate only the mutable
+     * {@code $LATEST} version without disrupting published versions.
+     */
+    public void drainFunctionVersion(String functionName, String functionVersion) {
+        List<ContainerHandle> toStop = removePool(poolKey(functionName, functionVersion));
+        if (toStop.isEmpty()) return;
+        LOG.infov("Draining {0} container(s) for function {1} version {2}",
+                toStop.size(), functionName, functionVersion == null ? "$LATEST" : functionVersion);
         stopInParallel(toStop);
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerHandle.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerHandle.java
@@ -12,6 +12,7 @@ public class ContainerHandle {
 
     private final String containerId;
     private final String functionName;
+    private final String functionVersion;
     private final RuntimeApiServer runtimeApiServer;
     private final long createdAt;
     private final boolean hotReload;
@@ -21,13 +22,19 @@ public class ContainerHandle {
 
     public ContainerHandle(String containerId, String functionName,
                            RuntimeApiServer runtimeApiServer, ContainerState state) {
-        this(containerId, functionName, runtimeApiServer, state, false);
+        this(containerId, functionName, "$LATEST", runtimeApiServer, state, false);
     }
 
     public ContainerHandle(String containerId, String functionName,
                            RuntimeApiServer runtimeApiServer, ContainerState state, boolean hotReload) {
+        this(containerId, functionName, "$LATEST", runtimeApiServer, state, hotReload);
+    }
+
+    public ContainerHandle(String containerId, String functionName, String functionVersion,
+                           RuntimeApiServer runtimeApiServer, ContainerState state, boolean hotReload) {
         this.containerId = containerId;
         this.functionName = functionName;
+        this.functionVersion = functionVersion == null ? "$LATEST" : functionVersion;
         this.runtimeApiServer = runtimeApiServer;
         this.state = state;
         this.hotReload = hotReload;
@@ -37,6 +44,7 @@ public class ContainerHandle {
 
     public String getContainerId() { return containerId; }
     public String getFunctionName() { return functionName; }
+    public String getFunctionVersion() { return functionVersion; }
     public boolean isHotReload() { return hotReload; }
     public RuntimeApiServer getRuntimeApiServer() { return runtimeApiServer; }
     public long getCreatedAt() { return createdAt; }

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -328,7 +328,8 @@ public class ContainerLauncher {
         // Now start the container with code in place
         lifecycleManager.startCreated(containerId, spec);
 
-        ContainerHandle handle = new ContainerHandle(containerId, fn.getFunctionName(), runtimeApiServer, ContainerState.WARM, fn.isHotReload());
+        ContainerHandle handle = new ContainerHandle(containerId, fn.getFunctionName(), fn.getVersion(),
+                runtimeApiServer, ContainerState.WARM, fn.isHotReload());
 
         // Attach log streaming
         Closeable logHandle = logStreamer.attach(

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
@@ -345,6 +345,24 @@ class LambdaServiceTest {
     }
 
     @Test
+    void functionUpdatesDrainOnlyLatestWarmContainers() {
+        WarmPool warmPool = mock(WarmPool.class);
+        LambdaService service = new LambdaService(
+                new LambdaFunctionStore(new InMemoryStorage<String, LambdaFunction>()),
+                warmPool,
+                new CodeStore(Path.of("target/test-data/lambda-code")),
+                new ZipExtractor(),
+                new RegionResolver(REGION, "000000000000"));
+        service.createFunction(REGION, baseRequest("update-fn"));
+
+        service.updateFunctionCode(REGION, "update-fn", Map.of());
+        service.updateFunctionConfiguration(REGION, "update-fn", Map.of());
+
+        verify(warmPool, times(2)).drainFunctionVersion("update-fn", "$LATEST");
+        verify(warmPool, never()).drainFunction(anyString());
+    }
+
+    @Test
     void rehydrateConcurrency_restoresReservedFromStore() {
         // Simulate a persisted state: functions already live in the store
         // with reserved values before the limiter is populated.

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/WarmPoolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/WarmPoolTest.java
@@ -158,6 +158,61 @@ class WarmPoolTest {
     }
 
     @Test
+    void acquireDoesNotReuseWarmContainerAcrossVersions() {
+        WarmPool pool = buildPool();
+        pool.init();
+
+        LambdaFunction latest = versionedFunction("versioned-fn", "$LATEST");
+        LambdaFunction versionOne = versionedFunction("versioned-fn", "1");
+        ContainerHandle latestHandle = new ContainerHandle("cid-latest", "versioned-fn", "$LATEST",
+                null, ContainerState.WARM, false);
+        ContainerHandle versionOneHandle = new ContainerHandle("cid-v1", "versioned-fn", "1",
+                null, ContainerState.WARM, false);
+        when(containerLauncher.launch(any())).thenReturn(latestHandle, versionOneHandle);
+
+        ContainerHandle acquiredLatest = pool.acquire(latest);
+        pool.release(acquiredLatest);
+
+        ContainerHandle acquiredVersionOne = pool.acquire(versionOne);
+
+        assertSame(versionOneHandle, acquiredVersionOne);
+        assertNotSame(latestHandle, acquiredVersionOne);
+        verify(containerLauncher, times(2)).launch(any());
+
+        pool.shutdown();
+    }
+
+    @Test
+    void drainFunctionDrainsWarmContainersForEveryVersion() {
+        WarmPool pool = buildPool();
+        pool.init();
+
+        LambdaFunction latest = versionedFunction("versioned-fn", "$LATEST");
+        LambdaFunction versionOne = versionedFunction("versioned-fn", "1");
+        ContainerHandle latestHandle = new ContainerHandle("cid-latest", "versioned-fn", "$LATEST",
+                null, ContainerState.WARM, false);
+        ContainerHandle versionOneHandle = new ContainerHandle("cid-v1", "versioned-fn", "1",
+                null, ContainerState.WARM, false);
+        when(containerLauncher.launch(any())).thenReturn(latestHandle, versionOneHandle);
+
+        pool.release(pool.acquire(latest));
+        pool.release(pool.acquire(versionOne));
+
+        pool.drainFunction("versioned-fn");
+
+        verify(containerLauncher).stop(latestHandle);
+        verify(containerLauncher).stop(versionOneHandle);
+        pool.shutdown();
+    }
+
+    private LambdaFunction versionedFunction(String name, String version) {
+        LambdaFunction function = new LambdaFunction();
+        function.setFunctionName(name);
+        function.setVersion(version);
+        return function;
+    }
+
+    @Test
     void acquire_discardsDeadPooledHandleAndColdStarts() {
         WarmPool pool = buildPool();
         pool.init();

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/WarmPoolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/WarmPoolTest.java
@@ -205,6 +205,32 @@ class WarmPoolTest {
         pool.shutdown();
     }
 
+    @Test
+    void pushCodeUpdatePreservesOtherWarmVersions() {
+        WarmPool pool = buildPool();
+        pool.init();
+
+        LambdaFunction latest = versionedFunction("versioned-fn", "$LATEST");
+        LambdaFunction versionOne = versionedFunction("versioned-fn", "1");
+        ContainerHandle latestHandle = new ContainerHandle("cid-latest", "versioned-fn", "$LATEST",
+                null, ContainerState.WARM, false);
+        ContainerHandle versionOneHandle = new ContainerHandle("cid-v1", "versioned-fn", "1",
+                null, ContainerState.WARM, false);
+        when(containerLauncher.launch(any())).thenReturn(latestHandle, versionOneHandle);
+        when(containerLauncher.isAlive(versionOneHandle)).thenReturn(true);
+
+        pool.release(pool.acquire(latest));
+        pool.release(pool.acquire(versionOne));
+
+        pool.pushCodeUpdate(latest);
+
+        verify(containerLauncher).stop(latestHandle);
+        verify(containerLauncher, never()).stop(versionOneHandle);
+        assertSame(versionOneHandle, pool.acquire(versionOne));
+        verify(containerLauncher, times(2)).launch(any());
+        pool.shutdown();
+    }
+
     private LambdaFunction versionedFunction(String name, String version) {
         LambdaFunction function = new LambdaFunction();
         function.setFunctionName(name);

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
@@ -177,10 +177,12 @@ class ContainerLauncherTest {
         fn.setRuntime("nodejs20.x");
         fn.setHandler("index.handler");
         fn.setCodeLocalPath(codePath.toString());
+        fn.setVersion("7");
 
-        launcher.launch(fn);
+        ContainerHandle handle = launcher.launch(fn);
 
         ContainerSpec spec = captureRealContainerSpec();
+        assertEquals("7", handle.getFunctionVersion());
         // Small code is copied directly into /var/task (the fast path), NOT bind-mounted...
         assertTrue(spec.binds().isEmpty(), "Function should NOT have bind mounts");
         // ...and NOT served from a named volume (that's reserved for large code).


### PR DESCRIPTION
## Summary

Closes #1988.

- Record the resolved Lambda version on each launched container.
- Key warm-container buckets by function name and version.
- Delete drains every version bucket, while code, configuration, and reactive S3 updates drain only the affected $LATEST bucket.

## Type of change

- [x] Bug fix (fix:)
- [ ] New feature (feat:)
- [ ] Breaking change (feat!: or fix!:)
- [ ] Docs / chore

## AWS Compatibility

Floci previously let a container warmed for f:$LATEST serve a qualified f:1 invocation. Qualified invocations now reuse only containers launched for the same resolved version. Published versions are immutable, so a $LATEST update preserves their warm containers while invalidating stale $LATEST containers. Version code snapshots remain independently covered by #2012.

## Checklist

- [ ] ./mvnw test passes locally (not run; focused suites below)
- [ ] New or updated integration test added
- [x] Focused regression coverage added
- [x] Commit messages follow Conventional Commits

Focused verification (JDK 25):

- `./mvnw -q -Dtest=WarmPoolTest,LambdaExecutorServiceTest,ContainerLauncherTest test`
- `./mvnw -q -Dtest=WarmPoolTest,LambdaServiceTest test`