### PR TITLE
fix(ec2): retry Docker port collisions

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -1446,9 +1446,9 @@ public class CloudFormationResourceProvisioner {
         var instance = reservation.getInstances().get(0);
         r.setPhysicalId(instance.getInstanceId());
         r.getAttributes().put("InstanceId", instance.getInstanceId());
-        r.getAttributes().put(ROLLBACK_OWNED_ATTR, "true");
+        r.getAttributes().put(CfnRollback.ROLLBACK_OWNED_ATTR, "true");
         ec2Service.awaitContainerLaunch(instance);
-        r.getAttributes().remove(ROLLBACK_OWNED_ATTR);
+        r.getAttributes().remove(CfnRollback.ROLLBACK_OWNED_ATTR);
         if (instance.getPrivateIpAddress() != null) {
             r.getAttributes().put("PrivateIp", instance.getPrivateIpAddress());
         }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -1446,6 +1446,7 @@ public class CloudFormationResourceProvisioner {
         var instance = reservation.getInstances().get(0);
         r.setPhysicalId(instance.getInstanceId());
         r.getAttributes().put("InstanceId", instance.getInstanceId());
+        ec2Service.awaitContainerLaunch(instance);
         if (instance.getPrivateIpAddress() != null) {
             r.getAttributes().put("PrivateIp", instance.getPrivateIpAddress());
         }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -1446,7 +1446,9 @@ public class CloudFormationResourceProvisioner {
         var instance = reservation.getInstances().get(0);
         r.setPhysicalId(instance.getInstanceId());
         r.getAttributes().put("InstanceId", instance.getInstanceId());
+        r.getAttributes().put(ROLLBACK_OWNED_ATTR, "true");
         ec2Service.awaitContainerLaunch(instance);
+        r.getAttributes().remove(ROLLBACK_OWNED_ATTR);
         if (instance.getPrivateIpAddress() != null) {
             r.getAttributes().put("PrivateIp", instance.getPrivateIpAddress());
         }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -47,6 +48,8 @@ import java.util.regex.Pattern;
  * Manages Docker container lifecycle for EC2 instances.
  * Handles launch, stop, start, terminate, and reboot operations.
  * SSH key injection and UserData execution are performed asynchronously after launch.
+ * A running instance has a reachable container address, while best-effort link-local IMDS setup,
+ * SSH initialization, and UserData may still be completing in the launch worker.
  */
 @ApplicationScoped
 public class Ec2ContainerManager {
@@ -132,8 +135,6 @@ public class Ec2ContainerManager {
         instance.setState(InstanceState.pending());
 
         executor.submit(() -> {
-            int sshHostPort = 0;
-            String containerId = null;
             try {
                 String instanceId = instance.getInstanceId();
                 // IMDS endpoint that this container should use
@@ -143,11 +144,11 @@ public class Ec2ContainerManager {
                 if (started == null) {
                     return;
                 }
-                sshHostPort = started.sshHostPort();
-                containerId = started.containerId();
+                int sshHostPort = started.sshHostPort();
+                String containerId = started.containerId();
 
                 if (isLaunchCancelled(instance)) {
-                    failLaunch(instance, containerId, sshHostPort);
+                    failLaunch(instance);
                     return;
                 }
 
@@ -155,7 +156,7 @@ public class Ec2ContainerManager {
                 boolean running = false;
                 for (int i = 0; i < 30 && !running; i++) {
                     if (isLaunchCancelled(instance)) {
-                        failLaunch(instance, containerId, sshHostPort);
+                        failLaunch(instance);
                         return;
                     }
                     running = lifecycleManager.isContainerRunning(containerId);
@@ -166,12 +167,12 @@ public class Ec2ContainerManager {
 
                 if (!running) {
                     LOG.warnv("EC2 instance {0} container {1} did not reach running state", instanceId, containerId);
-                    failLaunch(instance, containerId, sshHostPort);
+                    failLaunch(instance);
                     return;
                 }
 
                 if (isLaunchCancelled(instance)) {
-                    failLaunch(instance, containerId, sshHostPort);
+                    failLaunch(instance);
                     return;
                 }
 
@@ -188,12 +189,12 @@ public class Ec2ContainerManager {
                 else {
                     LOG.warnv("EC2 instance {0} container {1} did not receive a usable bridge IP for IMDS",
                             instanceId, containerId);
-                    failLaunch(instance, containerId, sshHostPort);
+                    failLaunch(instance);
                     return;
                 }
 
                 if (!markRunning(instance)) {
-                    failLaunch(instance, containerId, sshHostPort);
+                    failLaunch(instance);
                     return;
                 }
 
@@ -237,10 +238,10 @@ public class Ec2ContainerManager {
 
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                failLaunch(instance, containerId, sshHostPort);
+                failLaunch(instance);
             } catch (Exception e) {
                 LOG.warnv("Failed to launch EC2 instance {0}: {1}", instance.getInstanceId(), e.getMessage());
-                failLaunch(instance, containerId, sshHostPort);
+                failLaunch(instance);
             }
         });
     }
@@ -262,6 +263,7 @@ public class Ec2ContainerManager {
             ContainerSpec spec = buildContainerSpec(containerName, image, region, serviceEndpoint, imdsEndpoint,
                     instanceId, sshHostPort);
             String containerId = null;
+            boolean recorded = false;
             try {
                 containerId = lifecycleManager.create(spec);
                 if (!recordCreatedContainer(instance, containerId, sshHostPort)) {
@@ -269,9 +271,14 @@ public class Ec2ContainerManager {
                     portAllocator.release(sshHostPort);
                     return null;
                 }
+                recorded = true;
                 lifecycleManager.startCreated(containerId, spec);
                 return new StartedContainer(containerId, sshHostPort);
             } catch (Exception e) {
+                boolean ownsCleanup = !recorded || clearRecordedContainer(instance, containerId, sshHostPort);
+                if (!ownsCleanup) {
+                    return null;
+                }
                 if (containerId != null) {
                     lifecycleManager.removeIfExists(containerId);
                 }
@@ -316,8 +323,27 @@ public class Ec2ContainerManager {
         return specBuilder.build();
     }
 
-    private void failLaunch(Instance instance, String containerId, int sshHostPort) {
-        instance.setState(InstanceState.terminated());
+    private void failLaunch(Instance instance) {
+        String containerId;
+        int sshHostPort;
+        String containerIp;
+        boolean alreadyCleaned;
+        synchronized (instance) {
+            alreadyCleaned = isLaunchCancelledState(instance)
+                    && instance.getDockerContainerId() == null
+                    && instance.getSshHostPort() <= 0
+                    && (instance.getContainerBridgeIp() == null || instance.getContainerBridgeIp().isBlank());
+            instance.setState(InstanceState.terminated());
+            containerId = instance.getDockerContainerId();
+            sshHostPort = instance.getSshHostPort();
+            containerIp = instance.getContainerBridgeIp();
+            instance.setDockerContainerId(null);
+            instance.setSshHostPort(0);
+            instance.setContainerBridgeIp(null);
+        }
+        if (alreadyCleaned) {
+            return;
+        }
         try {
             portForwardManager.unpublishAll(instance);
         } catch (Exception e) {
@@ -334,7 +360,6 @@ public class Ec2ContainerManager {
         if (sshHostPort > 0) {
             portAllocator.release(sshHostPort);
         }
-        String containerIp = instance.getContainerBridgeIp();
         if (containerIp != null && !containerIp.isBlank()) {
             try {
                 metadataServer.unregisterContainer(containerIp, instance);
@@ -355,18 +380,14 @@ public class Ec2ContainerManager {
      * running.</p>
      */
     boolean cancelLaunch(Instance instance) {
-        String containerId;
-        int sshHostPort;
         synchronized (instance) {
             String state = instance.getState() != null ? instance.getState().getName() : null;
             if ("running".equals(state)) {
                 return false;
             }
             instance.setState(InstanceState.terminated());
-            containerId = instance.getDockerContainerId();
-            sshHostPort = instance.getSshHostPort();
         }
-        failLaunch(instance, containerId, sshHostPort);
+        failLaunch(instance);
         return true;
     }
 
@@ -393,6 +414,18 @@ public class Ec2ContainerManager {
             }
             instance.setSshHostPort(sshHostPort);
             instance.setDockerContainerId(containerId);
+            return true;
+        }
+    }
+
+    private static boolean clearRecordedContainer(Instance instance, String containerId, int sshHostPort) {
+        synchronized (instance) {
+            if (!Objects.equals(containerId, instance.getDockerContainerId())
+                    || sshHostPort != instance.getSshHostPort()) {
+                return false;
+            }
+            instance.setDockerContainerId(null);
+            instance.setSshHostPort(0);
             return true;
         }
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
@@ -132,53 +132,18 @@ public class Ec2ContainerManager {
         instance.setState(InstanceState.pending());
 
         executor.submit(() -> {
+            int sshHostPort = 0;
+            String containerId = null;
             try {
                 String instanceId = instance.getInstanceId();
-                String containerName = ContainerStorageHelper.resourceName(config, "ec2", null, instanceId);
-
-                // Allocate SSH host port
-                int sshHostPort = portAllocator.allocate(
-                        config.services().ec2().sshPortRangeStart(),
-                        config.services().ec2().sshPortRangeEnd());
-                instance.setSshHostPort(sshHostPort);
-
                 // IMDS endpoint that this container should use
                 String flociHost = dockerHostResolver.resolve();
                 int imdsPort = config.services().ec2().imdsPort();
-                String imdsEndpoint = "http://" + flociHost + ":" + imdsPort;
-                String serviceEndpoint = "http://" + flociHost + ":4566";
-
-                // Build container spec — minimal images keep the historic tail
-                // command, while cloud-image AMI guests can boot their init.
-                ContainerBuilder.Builder specBuilder = containerBuilder.newContainer(image.dockerImage())
-                        .withName(containerName)
-                        .withEmbeddedDns()
-                        .withDockerNetwork(Optional.empty())
-                        .withEnv(localAwsEnvironment(region, serviceEndpoint, imdsEndpoint))
-                        .withEnv("AWS_EC2_INSTANCE_ID", instanceId)
-                        .withPortBinding(22, sshHostPort)
-                        .withHostDockerInternalOnLinux()
-                        .withLogRotation()
-                        // EC2 instances expose IMDS on 169.254.169.254. Floci
-                        // needs network administration privileges in the local
-                        // container to attach that link-local address.
-                        .withPrivileged(true)
-                        .withCmd(image.systemd() ? List.of("/sbin/init") : List.of("tail", "-f", "/dev/null"));
-                if (image.systemd()) {
-                    specBuilder
-                            .withCgroupnsMode("host")
-                            .withMount(new Mount().withType(MountType.TMPFS).withTarget("/run"))
-                            .withMount(new Mount().withType(MountType.TMPFS).withTarget("/run/lock"))
-                            .withBind("/sys/fs/cgroup", "/sys/fs/cgroup");
-                }
-                ContainerSpec spec = specBuilder.build();
-
-                // Create container without starting it
-                String containerId = lifecycleManager.create(spec);
+                StartedContainer started = createAndStartContainer(instance, image, region, flociHost, imdsPort);
+                sshHostPort = started.sshHostPort();
+                containerId = started.containerId();
+                instance.setSshHostPort(sshHostPort);
                 instance.setDockerContainerId(containerId);
-
-                // Start the container
-                lifecycleManager.startCreated(containerId, spec);
 
                 // Poll until Docker confirms the container is running
                 boolean running = false;
@@ -191,7 +156,7 @@ public class Ec2ContainerManager {
 
                 if (!running) {
                     LOG.warnv("EC2 instance {0} container {1} did not reach running state", instanceId, containerId);
-                    instance.setState(InstanceState.terminated());
+                    failLaunch(instance, containerId, sshHostPort);
                     return;
                 }
 
@@ -208,7 +173,7 @@ public class Ec2ContainerManager {
                 else {
                     LOG.warnv("EC2 instance {0} container {1} did not receive a usable bridge IP for IMDS",
                             instanceId, containerId);
-                    instance.setState(InstanceState.terminated());
+                    failLaunch(instance, containerId, sshHostPort);
                     return;
                 }
 
@@ -251,12 +216,104 @@ public class Ec2ContainerManager {
 
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                instance.setState(InstanceState.terminated());
+                failLaunch(instance, containerId, sshHostPort);
             } catch (Exception e) {
                 LOG.warnv("Failed to launch EC2 instance {0}: {1}", instance.getInstanceId(), e.getMessage());
-                instance.setState(InstanceState.terminated());
+                failLaunch(instance, containerId, sshHostPort);
             }
         });
+    }
+
+    private StartedContainer createAndStartContainer(Instance instance, ResolvedAmiImage image, String region,
+                                                     String flociHost, int imdsPort) {
+        String instanceId = instance.getInstanceId();
+        String containerName = ContainerStorageHelper.resourceName(config, "ec2", null, instanceId);
+        String imdsEndpoint = "http://" + flociHost + ":" + imdsPort;
+        String serviceEndpoint = "http://" + flociHost + ":4566";
+
+        while (true) {
+            int sshHostPort = portAllocator.allocate(
+                    config.services().ec2().sshPortRangeStart(),
+                    config.services().ec2().sshPortRangeEnd());
+            ContainerSpec spec = buildContainerSpec(containerName, image, region, serviceEndpoint, imdsEndpoint,
+                    instanceId, sshHostPort);
+            String containerId = null;
+            try {
+                containerId = lifecycleManager.create(spec);
+                lifecycleManager.startCreated(containerId, spec);
+                return new StartedContainer(containerId, sshHostPort);
+            } catch (Exception e) {
+                if (containerId != null) {
+                    lifecycleManager.removeIfExists(containerId);
+                }
+                if (isHostPortCollision(e)) {
+                    // Docker Desktop can own a published port without exposing it to a host-side
+                    // ServerSocket probe. Keep it unavailable for this process and try the next port.
+                    portAllocator.markReserved(sshHostPort);
+                    LOG.warnv("EC2 instance {0} could not use SSH host port {1}; trying another port",
+                            instanceId, String.valueOf(sshHostPort));
+                    continue;
+                }
+                portAllocator.release(sshHostPort);
+                throw e;
+            }
+        }
+    }
+
+    private ContainerSpec buildContainerSpec(String containerName, ResolvedAmiImage image, String region,
+                                             String serviceEndpoint, String imdsEndpoint, String instanceId,
+                                             int sshHostPort) {
+        // Minimal images keep the historic tail command, while cloud-image AMI guests can boot their init.
+        ContainerBuilder.Builder specBuilder = containerBuilder.newContainer(image.dockerImage())
+                .withName(containerName)
+                .withEmbeddedDns()
+                .withDockerNetwork(Optional.empty())
+                .withEnv(localAwsEnvironment(region, serviceEndpoint, imdsEndpoint))
+                .withEnv("AWS_EC2_INSTANCE_ID", instanceId)
+                .withPortBinding(22, sshHostPort)
+                .withHostDockerInternalOnLinux()
+                .withLogRotation()
+                // EC2 instances expose IMDS on 169.254.169.254. Floci needs network administration
+                // privileges in the local container to attach that link-local address.
+                .withPrivileged(true)
+                .withCmd(image.systemd() ? List.of("/sbin/init") : List.of("tail", "-f", "/dev/null"));
+        if (image.systemd()) {
+            specBuilder
+                    .withCgroupnsMode("host")
+                    .withMount(new Mount().withType(MountType.TMPFS).withTarget("/run"))
+                    .withMount(new Mount().withType(MountType.TMPFS).withTarget("/run/lock"))
+                    .withBind("/sys/fs/cgroup", "/sys/fs/cgroup");
+        }
+        return specBuilder.build();
+    }
+
+    private void failLaunch(Instance instance, String containerId, int sshHostPort) {
+        portForwardManager.unpublishAll(instance);
+        if (containerId != null) {
+            lifecycleManager.removeIfExists(containerId);
+        }
+        if (sshHostPort > 0) {
+            portAllocator.release(sshHostPort);
+        }
+        String containerIp = instance.getContainerBridgeIp();
+        if (containerIp != null && !containerIp.isBlank()) {
+            metadataServer.unregisterContainer(containerIp, instance);
+        }
+        instance.setState(InstanceState.terminated());
+    }
+
+    private static boolean isHostPortCollision(Exception exception) {
+        for (Throwable cause = exception; cause != null; cause = cause.getCause()) {
+            String message = cause.getMessage();
+            if (message != null && (message.toLowerCase(Locale.ROOT).contains("port is already allocated")
+                    || message.toLowerCase(Locale.ROOT).contains("address already in use"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private record StartedContainer(String containerId, int sshHostPort) {
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
@@ -347,6 +347,12 @@ public class Ec2ContainerManager {
     /**
      * Cancels a pending asynchronous launch. Returns {@code false} only when the instance reached
      * running state while the caller was waiting, in which case it must not be torn down as a timeout.
+     *
+     * <p>The terminal state is established atomically before cleanup. The launch worker checks that
+     * state between phases, and {@link #recordCreatedContainer(Instance, String, int)} rejects and
+     * removes a container whose blocking Docker create call returns after cancellation. A timed-out
+     * CloudFormation waiter therefore cannot leave a late worker able to transition the instance to
+     * running.</p>
      */
     boolean cancelLaunch(Instance instance) {
         String containerId;

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
@@ -140,14 +140,26 @@ public class Ec2ContainerManager {
                 String flociHost = dockerHostResolver.resolve();
                 int imdsPort = config.services().ec2().imdsPort();
                 StartedContainer started = createAndStartContainer(instance, image, region, flociHost, imdsPort);
+                if (started == null) {
+                    return;
+                }
                 sshHostPort = started.sshHostPort();
                 containerId = started.containerId();
                 instance.setSshHostPort(sshHostPort);
                 instance.setDockerContainerId(containerId);
 
+                if (isLaunchCancelled(instance)) {
+                    failLaunch(instance, containerId, sshHostPort);
+                    return;
+                }
+
                 // Poll until Docker confirms the container is running
                 boolean running = false;
                 for (int i = 0; i < 30 && !running; i++) {
+                    if (isLaunchCancelled(instance)) {
+                        failLaunch(instance, containerId, sshHostPort);
+                        return;
+                    }
                     running = lifecycleManager.isContainerRunning(containerId);
                     if (!running) {
                         Thread.sleep(500);
@@ -160,11 +172,16 @@ public class Ec2ContainerManager {
                     return;
                 }
 
+                if (isLaunchCancelled(instance)) {
+                    failLaunch(instance, containerId, sshHostPort);
+                    return;
+                }
+
                 // Discover the container's bridge IP for IMDS registration.
                 // Docker can report the container as running before network
                 // settings are populated; wait here so IMDS is registered
                 // before link-local metadata validation and UserData run.
-                String containerIp = waitForContainerBridgeIp(containerId, instanceId);
+                String containerIp = waitForContainerBridgeIp(containerId, instanceId, instance);
                 if (containerIp != null && !containerIp.isBlank()) {
                     instance.setContainerBridgeIp(containerIp);
                     exposeReachablePrivateAddress(instance, containerIp, config.services().ec2().awsFaithfulPrivateIp());
@@ -173,6 +190,11 @@ public class Ec2ContainerManager {
                 else {
                     LOG.warnv("EC2 instance {0} container {1} did not receive a usable bridge IP for IMDS",
                             instanceId, containerId);
+                    failLaunch(instance, containerId, sshHostPort);
+                    return;
+                }
+
+                if (!markRunning(instance)) {
                     failLaunch(instance, containerId, sshHostPort);
                     return;
                 }
@@ -186,7 +208,6 @@ public class Ec2ContainerManager {
                     instance.setPublicDnsName("localhost");
                 }
 
-                instance.setState(InstanceState.running());
                 LOG.infov("EC2 instance {0} running in container {1} (SSH host port {2})",
                         instanceId, containerId, String.valueOf(sshHostPort));
 
@@ -234,6 +255,9 @@ public class Ec2ContainerManager {
         String serviceEndpoint = "http://" + flociHost + ":4566";
 
         while (true) {
+            if (isLaunchCancelled(instance)) {
+                return null;
+            }
             int sshHostPort = portAllocator.allocate(
                     config.services().ec2().sshPortRangeStart(),
                     config.services().ec2().sshPortRangeEnd());
@@ -291,16 +315,66 @@ public class Ec2ContainerManager {
 
     private void failLaunch(Instance instance, String containerId, int sshHostPort) {
         instance.setState(InstanceState.terminated());
-        portForwardManager.unpublishAll(instance);
+        try {
+            portForwardManager.unpublishAll(instance);
+        } catch (Exception e) {
+            LOG.warnv("Error removing EC2 port forwards during failed launch of {0}: {1}",
+                    instance.getInstanceId(), e.getMessage());
+        }
         if (containerId != null) {
-            lifecycleManager.removeIfExists(containerId);
+            try {
+                lifecycleManager.removeIfExists(containerId);
+            } catch (Exception e) {
+                LOG.warnv("Error removing failed EC2 container {0}: {1}", containerId, e.getMessage());
+            }
         }
         if (sshHostPort > 0) {
             portAllocator.release(sshHostPort);
         }
         String containerIp = instance.getContainerBridgeIp();
         if (containerIp != null && !containerIp.isBlank()) {
-            metadataServer.unregisterContainer(containerIp, instance);
+            try {
+                metadataServer.unregisterContainer(containerIp, instance);
+            } catch (Exception e) {
+                LOG.warnv("Error unregistering failed EC2 instance {0}: {1}", instance.getInstanceId(), e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Cancels a pending asynchronous launch. Returns {@code false} only when the instance reached
+     * running state while the caller was waiting, in which case it must not be torn down as a timeout.
+     */
+    boolean cancelLaunch(Instance instance) {
+        String containerId;
+        int sshHostPort;
+        synchronized (instance) {
+            String state = instance.getState() != null ? instance.getState().getName() : null;
+            if ("running".equals(state)) {
+                return false;
+            }
+            instance.setState(InstanceState.terminated());
+            containerId = instance.getDockerContainerId();
+            sshHostPort = instance.getSshHostPort();
+        }
+        failLaunch(instance, containerId, sshHostPort);
+        return true;
+    }
+
+    private static boolean isLaunchCancelled(Instance instance) {
+        synchronized (instance) {
+            String state = instance.getState() != null ? instance.getState().getName() : null;
+            return "shutting-down".equals(state) || "terminated".equals(state);
+        }
+    }
+
+    private static boolean markRunning(Instance instance) {
+        synchronized (instance) {
+            if (isLaunchCancelled(instance)) {
+                return false;
+            }
+            instance.setState(InstanceState.running());
+            return true;
         }
     }
 
@@ -471,10 +545,15 @@ public class Ec2ContainerManager {
      * Sets terminatedAt for TTL pruning.
      */
     public void terminate(Instance instance) {
-        String containerId = instance.getDockerContainerId();
-        String containerIp = instance.getContainerBridgeIp();
-        int sshHostPort = instance.getSshHostPort();
-        instance.setState(InstanceState.shuttingDown());
+        String containerId;
+        String containerIp;
+        int sshHostPort;
+        synchronized (instance) {
+            containerId = instance.getDockerContainerId();
+            containerIp = instance.getContainerBridgeIp();
+            sshHostPort = instance.getSshHostPort();
+            instance.setState(InstanceState.shuttingDown());
+        }
         executor.submit(() -> {
             portForwardManager.unpublishAll(instance);
             if (containerId != null) {
@@ -892,7 +971,15 @@ public class Ec2ContainerManager {
     }
 
     private String waitForContainerBridgeIp(String containerId, String instanceId) throws InterruptedException {
+        return waitForContainerBridgeIp(containerId, instanceId, null);
+    }
+
+    private String waitForContainerBridgeIp(String containerId, String instanceId, Instance instance)
+            throws InterruptedException {
         for (int i = 0; i < containerBridgeIpAttempts; i++) {
+            if (instance != null && isLaunchCancelled(instance)) {
+                return null;
+            }
             String containerIp = getContainerBridgeIp(containerId);
             if (containerIp != null && !containerIp.isBlank()) {
                 return containerIp;

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
@@ -290,6 +290,7 @@ public class Ec2ContainerManager {
     }
 
     private void failLaunch(Instance instance, String containerId, int sshHostPort) {
+        instance.setState(InstanceState.terminated());
         portForwardManager.unpublishAll(instance);
         if (containerId != null) {
             lifecycleManager.removeIfExists(containerId);
@@ -301,7 +302,6 @@ public class Ec2ContainerManager {
         if (containerIp != null && !containerIp.isBlank()) {
             metadataServer.unregisterContainer(containerIp, instance);
         }
-        instance.setState(InstanceState.terminated());
     }
 
     private static boolean isHostPortCollision(Exception exception) {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
@@ -145,8 +145,6 @@ public class Ec2ContainerManager {
                 }
                 sshHostPort = started.sshHostPort();
                 containerId = started.containerId();
-                instance.setSshHostPort(sshHostPort);
-                instance.setDockerContainerId(containerId);
 
                 if (isLaunchCancelled(instance)) {
                     failLaunch(instance, containerId, sshHostPort);
@@ -266,6 +264,11 @@ public class Ec2ContainerManager {
             String containerId = null;
             try {
                 containerId = lifecycleManager.create(spec);
+                if (!recordCreatedContainer(instance, containerId, sshHostPort)) {
+                    lifecycleManager.removeIfExists(containerId);
+                    portAllocator.release(sshHostPort);
+                    return null;
+                }
                 lifecycleManager.startCreated(containerId, spec);
                 return new StartedContainer(containerId, sshHostPort);
             } catch (Exception e) {
@@ -363,19 +366,34 @@ public class Ec2ContainerManager {
 
     private static boolean isLaunchCancelled(Instance instance) {
         synchronized (instance) {
-            String state = instance.getState() != null ? instance.getState().getName() : null;
-            return "shutting-down".equals(state) || "terminated".equals(state);
+            return isLaunchCancelledState(instance);
         }
     }
 
     private static boolean markRunning(Instance instance) {
         synchronized (instance) {
-            if (isLaunchCancelled(instance)) {
+            if (isLaunchCancelledState(instance)) {
                 return false;
             }
             instance.setState(InstanceState.running());
             return true;
         }
+    }
+
+    private static boolean recordCreatedContainer(Instance instance, String containerId, int sshHostPort) {
+        synchronized (instance) {
+            if (isLaunchCancelledState(instance)) {
+                return false;
+            }
+            instance.setSshHostPort(sshHostPort);
+            instance.setDockerContainerId(containerId);
+            return true;
+        }
+    }
+
+    private static boolean isLaunchCancelledState(Instance instance) {
+        String state = instance.getState() != null ? instance.getState().getName() : null;
+        return "shutting-down".equals(state) || "terminated".equals(state);
     }
 
     private static boolean isHostPortCollision(Exception exception) {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
@@ -177,8 +177,6 @@ public class Ec2ContainerManager {
                     return;
                 }
 
-                configureLinkLocalMetadataEndpoint(containerId, instanceId, flociHost, imdsPort);
-
                 // Set public-facing addresses only for instances whose subnet
                 // opts in via MapPublicIpOnLaunch (#1984). Private-subnet
                 // instances have no public IP/DNS, matching real EC2. The value
@@ -191,6 +189,10 @@ public class Ec2ContainerManager {
                 instance.setState(InstanceState.running());
                 LOG.infov("EC2 instance {0} running in container {1} (SSH host port {2})",
                         instanceId, containerId, String.valueOf(sshHostPort));
+
+                // IMDS proxy setup is best effort and has its own bounded commands. The instance
+                // is already running once Docker has assigned its reachable network address.
+                configureLinkLocalMetadataEndpoint(containerId, instanceId, flociHost, imdsPort);
 
                 // Publish security-group TCP ingress ports on the host via socat sidecars.
                 if (appPorts != null && !appPorts.isEmpty()) {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -112,7 +112,9 @@ public class Ec2Service implements ContainerTeardown {
             Pattern.compile("^tgw-rtb-[0-9a-f]{8}([0-9a-f]{9})?$");
     private static final Pattern TRANSIT_GATEWAY_ATTACHMENT_ID_PATTERN =
             Pattern.compile("^tgw-attach-[0-9a-f]{8}([0-9a-f]{9})?$");
-    private static final Duration CONTAINER_LAUNCH_TIMEOUT = Duration.ofSeconds(60);
+    // A first launch may need to pull a large AMI-backed image. Keep a finite CloudFormation
+    // bound, but allow enough time for that legitimate cold-start path before cancellation.
+    private static final Duration CONTAINER_LAUNCH_TIMEOUT = Duration.ofMinutes(5);
     private static final long CONTAINER_LAUNCH_POLL_MILLIS = 50;
 
     private final String accountId;

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -2264,7 +2264,7 @@ public class Ec2Service implements ContainerTeardown {
             if ("terminated".equals(state)) {
                 throw launchFailure(instance, "its container terminated during launch");
             }
-            if (System.nanoTime() >= deadline) {
+            if (System.nanoTime() - deadline >= 0) {
                 if (containerManager.cancelLaunch(instance)) {
                     throw launchFailure(instance, "it did not reach running state before the launch timeout");
                 }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1,7 +1,6 @@
 package io.github.hectorvent.floci.services.ec2;
 
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -2240,15 +2239,14 @@ public class Ec2Service implements ContainerTeardown {
      * Docker launch has already failed. Mock-mode instances do not launch containers.
      *
      * @param instance the instance returned by {@link #runInstances}
-     * @throws AwsException if the container terminates during launch or does not start in time
+     * @throws AwsException if the container terminates during launch
      */
     public void awaitContainerLaunch(Instance instance) {
         if (config.services().ec2().mock()) {
             return;
         }
 
-        long deadline = System.nanoTime() + CONTAINER_LAUNCH_TIMEOUT.toNanos();
-        while (System.nanoTime() < deadline) {
+        while (true) {
             String state = instance.getState() != null ? instance.getState().getName() : null;
             if ("running".equals(state)) {
                 return;
@@ -2265,9 +2263,6 @@ public class Ec2Service implements ContainerTeardown {
                         + instance.getInstanceId() + " to launch", 500);
             }
         }
-
-        throw new AwsException("InstanceLaunchFailure", "EC2 instance " + instance.getInstanceId()
-                + " did not start its container within " + CONTAINER_LAUNCH_TIMEOUT.toSeconds() + " seconds", 500);
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.ec2;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -2239,21 +2240,28 @@ public class Ec2Service implements ContainerTeardown {
      * Docker launch has already failed. Mock-mode instances do not launch containers.
      *
      * @param instance the instance returned by {@link #runInstances}
-     * @throws AwsException if the container terminates during launch
+     * @throws AwsException if the container terminates or does not launch before the timeout
      */
     public void awaitContainerLaunch(Instance instance) {
+        awaitContainerLaunch(instance, CONTAINER_LAUNCH_TIMEOUT);
+    }
+
+    void awaitContainerLaunch(Instance instance, Duration timeout) {
         if (config.services().ec2().mock()) {
             return;
         }
 
+        long deadline = System.nanoTime() + timeout.toNanos();
         while (true) {
             String state = instance.getState() != null ? instance.getState().getName() : null;
             if ("running".equals(state)) {
                 return;
             }
             if ("terminated".equals(state)) {
-                throw new AwsException("InstanceLaunchFailure",
-                        "EC2 instance " + instance.getInstanceId() + " terminated during container launch", 500);
+                throw launchFailure(instance, "its container terminated during launch");
+            }
+            if (System.nanoTime() >= deadline) {
+                throw launchFailure(instance, "it did not reach running state before the launch timeout");
             }
             try {
                 Thread.sleep(CONTAINER_LAUNCH_POLL_MILLIS);
@@ -2263,6 +2271,11 @@ public class Ec2Service implements ContainerTeardown {
                         + instance.getInstanceId() + " to launch", 500);
             }
         }
+    }
+
+    private static AwsException launchFailure(Instance instance, String reason) {
+        return new AwsException("InternalError", "EC2 instance " + instance.getInstanceId() + " failed to launch because "
+                + reason, 500);
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -2238,6 +2238,8 @@ public class Ec2Service implements ContainerTeardown {
      * Waits for a container-backed EC2 instance to reach a terminal launch state.
      * CloudFormation uses this to avoid reporting a stack success when the asynchronous
      * Docker launch has already failed. Mock-mode instances do not launch containers.
+     * On timeout, cancellation marks the launch terminal and the container manager prevents any
+     * in-flight Docker phase from later publishing a running instance.
      *
      * @param instance the instance returned by {@link #runInstances}
      * @throws AwsException if the container terminates or does not launch before the timeout

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.ec2;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -111,6 +112,8 @@ public class Ec2Service implements ContainerTeardown {
             Pattern.compile("^tgw-rtb-[0-9a-f]{8}([0-9a-f]{9})?$");
     private static final Pattern TRANSIT_GATEWAY_ATTACHMENT_ID_PATTERN =
             Pattern.compile("^tgw-attach-[0-9a-f]{8}([0-9a-f]{9})?$");
+    private static final Duration CONTAINER_LAUNCH_TIMEOUT = Duration.ofSeconds(60);
+    private static final long CONTAINER_LAUNCH_POLL_MILLIS = 50;
 
     private final String accountId;
     private final EmulatorConfig config;
@@ -2229,6 +2232,42 @@ public class Ec2Service implements ContainerTeardown {
         }
 
         return reservation;
+    }
+
+    /**
+     * Waits for a container-backed EC2 instance to reach a terminal launch state.
+     * CloudFormation uses this to avoid reporting a stack success when the asynchronous
+     * Docker launch has already failed. Mock-mode instances do not launch containers.
+     *
+     * @param instance the instance returned by {@link #runInstances}
+     * @throws AwsException if the container terminates during launch or does not start in time
+     */
+    public void awaitContainerLaunch(Instance instance) {
+        if (config.services().ec2().mock()) {
+            return;
+        }
+
+        long deadline = System.nanoTime() + CONTAINER_LAUNCH_TIMEOUT.toNanos();
+        while (System.nanoTime() < deadline) {
+            String state = instance.getState() != null ? instance.getState().getName() : null;
+            if ("running".equals(state)) {
+                return;
+            }
+            if ("terminated".equals(state)) {
+                throw new AwsException("InstanceLaunchFailure",
+                        "EC2 instance " + instance.getInstanceId() + " terminated during container launch", 500);
+            }
+            try {
+                Thread.sleep(CONTAINER_LAUNCH_POLL_MILLIS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AwsException("InternalError", "Interrupted while waiting for EC2 instance "
+                        + instance.getInstanceId() + " to launch", 500);
+            }
+        }
+
+        throw new AwsException("InstanceLaunchFailure", "EC2 instance " + instance.getInstanceId()
+                + " did not start its container within " + CONTAINER_LAUNCH_TIMEOUT.toSeconds() + " seconds", 500);
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -2261,7 +2261,9 @@ public class Ec2Service implements ContainerTeardown {
                 throw launchFailure(instance, "its container terminated during launch");
             }
             if (System.nanoTime() >= deadline) {
-                throw launchFailure(instance, "it did not reach running state before the launch timeout");
+                if (containerManager.cancelLaunch(instance)) {
+                    throw launchFailure(instance, "it did not reach running state before the launch timeout");
+                }
             }
             try {
                 Thread.sleep(CONTAINER_LAUNCH_POLL_MILLIS);

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/Instance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/Instance.java
@@ -15,7 +15,7 @@ public class Instance {
 
     private String instanceId;
     private String imageId;
-    private InstanceState state;
+    private volatile InstanceState state;
     private String stateTransitionReason;
     private String instanceType;
     private Placement placement;

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationEc2ProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationEc2ProvisionerTest.java
@@ -1,0 +1,77 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.CloudFormationResourceRegistry;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.model.Instance;
+import io.github.hectorvent.floci.services.ec2.model.InstanceState;
+import io.github.hectorvent.floci.services.ec2.model.Reservation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CloudFormationEc2ProvisionerTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private Ec2Service ec2Service;
+    private CloudFormationResourceProvisioner provisioner;
+
+    @BeforeEach
+    void setUp() {
+        ec2Service = mock(Ec2Service.class);
+        provisioner = new CloudFormationResourceProvisioner(
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, mapper, null, null, null, null, null, null,
+                ec2Service, null, null, null, null, null, null, null,
+                new CloudFormationResourceRegistry(List.of()));
+    }
+
+    @Test
+    void terminatedContainerLaunchMarksEc2ResourceCreateFailed() throws Exception {
+        Instance instance = new Instance();
+        instance.setInstanceId("i-launch-failed");
+        instance.setState(InstanceState.terminated());
+        Reservation reservation = new Reservation();
+        reservation.getInstances().add(instance);
+        when(ec2Service.runInstances(anyString(), anyString(), anyString(), anyInt(), anyInt(), any(), anyList(),
+                any(), any(), anyList(), any(), any())).thenReturn(reservation);
+        doThrow(new AwsException("InstanceLaunchFailure", "EC2 instance i-launch-failed terminated during container launch", 500))
+                .when(ec2Service).awaitContainerLaunch(instance);
+
+        StackResource resource = provisioner.provision("Server", "AWS::EC2::Instance", properties(), engine(),
+                "us-east-1", "000000000000", "test-stack");
+
+        assertEquals("CREATE_FAILED", resource.getStatus());
+        assertEquals("i-launch-failed", resource.getPhysicalId());
+        assertTrue(resource.getStatusReason().contains("terminated during container launch"));
+        verify(ec2Service).awaitContainerLaunch(instance);
+    }
+
+    private JsonNode properties() throws Exception {
+        return mapper.readTree("""
+                {"ImageId":"ami-12345678","InstanceType":"t3.micro"}
+                """);
+    }
+
+    private CloudFormationTemplateEngine engine() {
+        return new CloudFormationTemplateEngine("000000000000", "us-east-1", "test-stack", "stack/id",
+                Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), mapper, (Function<String, String>) name -> null);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationEc2ProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationEc2ProvisionerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.CfnRollback;
 import io.github.hectorvent.floci.services.cloudformation.provisioners.CloudFormationResourceRegistry;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.ec2.model.Instance;
@@ -41,7 +42,7 @@ class CloudFormationEc2ProvisionerTest {
                 null, null, null, null, null, null, null, null, null, null,
                 null, null, null, null, null, null, mapper, null, null, null, null, null, null,
                 ec2Service, null, null, null, null, null, null, null,
-                new CloudFormationResourceRegistry(List.of()));
+                null, null, new CloudFormationResourceRegistry(List.of()));
     }
 
     @Test
@@ -53,7 +54,7 @@ class CloudFormationEc2ProvisionerTest {
         reservation.getInstances().add(instance);
         when(ec2Service.runInstances(anyString(), anyString(), anyString(), anyInt(), anyInt(), any(), anyList(),
                 any(), any(), anyList(), any(), any())).thenReturn(reservation);
-        doThrow(new AwsException("InstanceLaunchFailure", "EC2 instance i-launch-failed terminated during container launch", 500))
+        doThrow(new AwsException("InternalError", "EC2 instance i-launch-failed failed to launch because its container terminated during launch", 500))
                 .when(ec2Service).awaitContainerLaunch(instance);
 
         StackResource resource = provisioner.provision("Server", "AWS::EC2::Instance", properties(), engine(),
@@ -61,8 +62,31 @@ class CloudFormationEc2ProvisionerTest {
 
         assertEquals("CREATE_FAILED", resource.getStatus());
         assertEquals("i-launch-failed", resource.getPhysicalId());
-        assertEquals("true", resource.getAttributes().get(CloudFormationResourceProvisioner.ROLLBACK_OWNED_ATTR));
-        assertTrue(resource.getStatusReason().contains("terminated during container launch"));
+        assertEquals("true", resource.getAttributes().get(CfnRollback.ROLLBACK_OWNED_ATTR));
+        assertTrue(resource.getStatusReason().contains("container terminated during launch"));
+        verify(ec2Service).awaitContainerLaunch(instance);
+    }
+
+    @Test
+    void timedOutContainerLaunchMarksEc2ResourceCreateFailed() throws Exception {
+        Instance instance = new Instance();
+        instance.setInstanceId("i-launch-timed-out");
+        instance.setState(InstanceState.pending());
+        Reservation reservation = new Reservation();
+        reservation.getInstances().add(instance);
+        when(ec2Service.runInstances(anyString(), anyString(), anyString(), anyInt(), anyInt(), any(), anyList(),
+                any(), any(), anyList(), any(), any())).thenReturn(reservation);
+        doThrow(new AwsException("InternalError",
+                "EC2 instance i-launch-timed-out failed to launch because it did not reach running state before the launch timeout",
+                500)).when(ec2Service).awaitContainerLaunch(instance);
+
+        StackResource resource = provisioner.provision("Server", "AWS::EC2::Instance", properties(), engine(),
+                "us-east-1", "000000000000", "test-stack");
+
+        assertEquals("CREATE_FAILED", resource.getStatus());
+        assertEquals("i-launch-timed-out", resource.getPhysicalId());
+        assertEquals("true", resource.getAttributes().get(CfnRollback.ROLLBACK_OWNED_ATTR));
+        assertTrue(resource.getStatusReason().contains("launch timeout"));
         verify(ec2Service).awaitContainerLaunch(instance);
     }
 
@@ -80,7 +104,7 @@ class CloudFormationEc2ProvisionerTest {
                 "us-east-1", "000000000000", "test-stack");
 
         assertEquals("CREATE_COMPLETE", resource.getStatus());
-        assertNull(resource.getAttributes().get(CloudFormationResourceProvisioner.ROLLBACK_OWNED_ATTR));
+        assertNull(resource.getAttributes().get(CfnRollback.ROLLBACK_OWNED_ATTR));
         verify(ec2Service).awaitContainerLaunch(instance);
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationEc2ProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationEc2ProvisionerTest.java
@@ -53,7 +53,7 @@ class CloudFormationEc2ProvisionerTest {
         Reservation reservation = new Reservation();
         reservation.getInstances().add(instance);
         when(ec2Service.runInstances(anyString(), anyString(), anyString(), anyInt(), anyInt(), any(), anyList(),
-                any(), any(), anyList(), any(), any())).thenReturn(reservation);
+                any(), any(), anyList(), any(), any(), any())).thenReturn(reservation);
         doThrow(new AwsException("InternalError", "EC2 instance i-launch-failed failed to launch because its container terminated during launch", 500))
                 .when(ec2Service).awaitContainerLaunch(instance);
 
@@ -75,7 +75,7 @@ class CloudFormationEc2ProvisionerTest {
         Reservation reservation = new Reservation();
         reservation.getInstances().add(instance);
         when(ec2Service.runInstances(anyString(), anyString(), anyString(), anyInt(), anyInt(), any(), anyList(),
-                any(), any(), anyList(), any(), any())).thenReturn(reservation);
+                any(), any(), anyList(), any(), any(), any())).thenReturn(reservation);
         doThrow(new AwsException("InternalError",
                 "EC2 instance i-launch-timed-out failed to launch because it did not reach running state before the launch timeout",
                 500)).when(ec2Service).awaitContainerLaunch(instance);
@@ -98,7 +98,7 @@ class CloudFormationEc2ProvisionerTest {
         Reservation reservation = new Reservation();
         reservation.getInstances().add(instance);
         when(ec2Service.runInstances(anyString(), anyString(), anyString(), anyInt(), anyInt(), any(), anyList(),
-                any(), any(), anyList(), any(), any())).thenReturn(reservation);
+                any(), any(), anyList(), any(), any(), any())).thenReturn(reservation);
 
         StackResource resource = provisioner.provision("Server", "AWS::EC2::Instance", properties(), engine(),
                 "us-east-1", "000000000000", "test-stack");

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationEc2ProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationEc2ProvisionerTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -60,7 +61,26 @@ class CloudFormationEc2ProvisionerTest {
 
         assertEquals("CREATE_FAILED", resource.getStatus());
         assertEquals("i-launch-failed", resource.getPhysicalId());
+        assertEquals("true", resource.getAttributes().get(CloudFormationResourceProvisioner.ROLLBACK_OWNED_ATTR));
         assertTrue(resource.getStatusReason().contains("terminated during container launch"));
+        verify(ec2Service).awaitContainerLaunch(instance);
+    }
+
+    @Test
+    void successfulContainerLaunchDoesNotKeepRollbackOwnershipMarker() throws Exception {
+        Instance instance = new Instance();
+        instance.setInstanceId("i-launch-succeeded");
+        instance.setState(InstanceState.running());
+        Reservation reservation = new Reservation();
+        reservation.getInstances().add(instance);
+        when(ec2Service.runInstances(anyString(), anyString(), anyString(), anyInt(), anyInt(), any(), anyList(),
+                any(), any(), anyList(), any(), any())).thenReturn(reservation);
+
+        StackResource resource = provisioner.provision("Server", "AWS::EC2::Instance", properties(), engine(),
+                "us-east-1", "000000000000", "test-stack");
+
+        assertEquals("CREATE_COMPLETE", resource.getStatus());
+        assertNull(resource.getAttributes().get(CloudFormationResourceProvisioner.ROLLBACK_OWNED_ATTR));
         verify(ec2Service).awaitContainerLaunch(instance);
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
@@ -475,6 +475,31 @@ class Ec2ContainerManagerTest {
     }
 
     @Test
+    void cancelledLaunchRemovesContainerCreatedAfterCancellation() throws Exception {
+        LaunchHarness harness = launchHarness();
+        CountDownLatch createEntered = new CountDownLatch(1);
+        CountDownLatch allowCreate = new CountDownLatch(1);
+        when(harness.lifecycleManager.create(any(ContainerSpec.class))).thenAnswer(invocation -> {
+            createEntered.countDown();
+            assertTrue(allowCreate.await(2, TimeUnit.SECONDS));
+            return TEST_CONTAINER_ID;
+        });
+
+        Instance instance = instance("i-cancelled-during-create");
+        harness.manager.launch(instance, "ubuntu:24.04", null, "us-west-2");
+
+        assertTrue(createEntered.await(2, TimeUnit.SECONDS), "container creation should begin");
+        assertTrue(harness.manager.cancelLaunch(instance));
+        assertEquals("terminated", instance.getState().getName());
+
+        allowCreate.countDown();
+        verify(harness.lifecycleManager, timeout(2_000)).removeIfExists(TEST_CONTAINER_ID);
+        verify(harness.portAllocator, timeout(2_000)).release(2201);
+        verify(harness.lifecycleManager, never()).startCreated(eq(TEST_CONTAINER_ID), any(ContainerSpec.class));
+        assertEquals("terminated", instance.getState().getName());
+    }
+
+    @Test
     void launchMarksInstanceRunningBeforeUserDataCompletes() throws Exception {
         Ec2ContainerManager.containerBridgeIpAttempts = 2;
         Ec2ContainerManager.containerBridgeIpPollMillis = 1;

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
@@ -53,7 +53,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
@@ -394,6 +393,49 @@ class Ec2ContainerManagerTest {
     }
 
     @Test
+    void launchRetriesWithNextPortWhenDockerReportsHostPortCollision() throws Exception {
+        Ec2ContainerManager.containerBridgeIpAttempts = 1;
+        Ec2ContainerManager.containerBridgeIpPollMillis = 1;
+        LaunchHarness harness = launchHarness();
+        when(harness.portAllocator.allocate(anyInt(), anyInt())).thenReturn(2201, 2202);
+        when(harness.lifecycleManager.create(any(ContainerSpec.class)))
+                .thenReturn("container-conflict", TEST_CONTAINER_ID);
+        when(harness.lifecycleManager.startCreated(anyString(), any(ContainerSpec.class)))
+                .thenThrow(new RuntimeException("Bind for 0.0.0.0:2201 failed: port is already allocated"))
+                .thenReturn(null);
+
+        InspectContainerCmd inspect = mock(InspectContainerCmd.class);
+        InspectContainerResponse withIp = inspectResponse("172.18.0.12");
+        when(harness.dockerClient.inspectContainerCmd(TEST_CONTAINER_ID)).thenReturn(inspect);
+        when(inspect.exec()).thenReturn(withIp);
+        harness.stubSuccessfulExecs(new CountDownLatch(0), new CountDownLatch(0));
+
+        Instance instance = instance("i-port-collision");
+        harness.manager.launch(instance, "ubuntu:24.04", null, "us-west-2");
+
+        awaitUntil(() -> "running".equals(instance.getState().getName()), Duration.ofSeconds(2));
+        assertEquals(2202, instance.getSshHostPort());
+        verify(harness.lifecycleManager).removeIfExists("container-conflict");
+        verify(harness.portAllocator).markReserved(2201);
+        verify(harness.builder).withPortBinding(22, 2201);
+        verify(harness.builder).withPortBinding(22, 2202);
+    }
+
+    @Test
+    void launchReleasesPortAndCleansUpContainerAfterNonRetryableStartFailure() throws Exception {
+        LaunchHarness harness = launchHarness();
+        when(harness.lifecycleManager.startCreated(eq(TEST_CONTAINER_ID), any(ContainerSpec.class)))
+                .thenThrow(new RuntimeException("Docker daemon unavailable"));
+
+        Instance instance = instance("i-start-failure");
+        harness.manager.launch(instance, "ubuntu:24.04", null, "us-west-2");
+
+        awaitUntil(() -> "terminated".equals(instance.getState().getName()), Duration.ofSeconds(2));
+        verify(harness.lifecycleManager).removeIfExists(TEST_CONTAINER_ID);
+        verify(harness.portAllocator).release(2201);
+    }
+
+    @Test
     void launchMarksInstanceRunningBeforeUserDataCompletes() throws Exception {
         Ec2ContainerManager.containerBridgeIpAttempts = 2;
         Ec2ContainerManager.containerBridgeIpPollMillis = 1;
@@ -604,8 +646,8 @@ class Ec2ContainerManagerTest {
                 config,
                 metadataServer,
                 mock(Ec2PortForwardManager.class));
-        return new LaunchHarness(manager, dockerClient, metadataServer, logStreamer, builder,
-                new CopyOnWriteArrayList<>());
+        return new LaunchHarness(manager, lifecycleManager, dockerClient, metadataServer, logStreamer, builder,
+                portAllocator, new CopyOnWriteArrayList<>());
     }
 
     /**
@@ -649,10 +691,12 @@ class Ec2ContainerManagerTest {
     }
 
     private record LaunchHarness(Ec2ContainerManager manager,
+                                 ContainerLifecycleManager lifecycleManager,
                                  DockerClient dockerClient,
                                  Ec2MetadataServer metadataServer,
                                  ContainerLogStreamer logStreamer,
                                  ContainerBuilder.Builder builder,
+                                 PortAllocator portAllocator,
                                  List<String[]> executedCommands) {
         void stubSuccessfulExecs(CountDownLatch userDataStarted, CountDownLatch finishUserData) throws Exception {
             AtomicReference<String[]> currentCommand = new AtomicReference<>();

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
@@ -467,11 +467,11 @@ class Ec2ContainerManagerTest {
 
         assertTrue(startEntered.await(2, TimeUnit.SECONDS), "container startup should begin");
         assertTrue(harness.manager.cancelLaunch(instance));
-        allowStart.countDown();
-
-        awaitUntil(() -> "terminated".equals(instance.getState().getName()), Duration.ofSeconds(2));
         verify(harness.lifecycleManager).removeIfExists(TEST_CONTAINER_ID);
         verify(harness.portAllocator).release(2201);
+
+        allowStart.countDown();
+        awaitUntil(() -> "terminated".equals(instance.getState().getName()), Duration.ofSeconds(2));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
@@ -49,6 +49,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Answers.RETURNS_SELF;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
@@ -436,6 +437,21 @@ class Ec2ContainerManagerTest {
     }
 
     @Test
+    void launchTerminatesBeforeCleanupFailure() throws Exception {
+        LaunchHarness harness = launchHarness();
+        when(harness.lifecycleManager.startCreated(eq(TEST_CONTAINER_ID), any(ContainerSpec.class)))
+                .thenThrow(new RuntimeException("Docker daemon unavailable"));
+        doThrow(new RuntimeException("port-forward cleanup failed"))
+                .when(harness.portForwardManager).unpublishAll(any(Instance.class));
+
+        Instance instance = instance("i-cleanup-failure");
+        harness.manager.launch(instance, "ubuntu:24.04", null, "us-west-2");
+
+        awaitUntil(() -> "terminated".equals(instance.getState().getName()), Duration.ofSeconds(2));
+        verify(harness.portForwardManager).unpublishAll(instance);
+    }
+
+    @Test
     void launchMarksInstanceRunningBeforeUserDataCompletes() throws Exception {
         Ec2ContainerManager.containerBridgeIpAttempts = 2;
         Ec2ContainerManager.containerBridgeIpPollMillis = 1;
@@ -635,6 +651,7 @@ class Ec2ContainerManagerTest {
         DockerClient dockerClient = mock(DockerClient.class);
         Ec2MetadataServer metadataServer = mock(Ec2MetadataServer.class);
         ContainerLogStreamer logStreamer = mock(ContainerLogStreamer.class);
+        Ec2PortForwardManager portForwardManager = mock(Ec2PortForwardManager.class);
         Ec2ContainerManager manager = new Ec2ContainerManager(
                 containerBuilder,
                 lifecycleManager,
@@ -645,9 +662,9 @@ class Ec2ContainerManagerTest {
                 portAllocator,
                 config,
                 metadataServer,
-                mock(Ec2PortForwardManager.class));
+                portForwardManager);
         return new LaunchHarness(manager, lifecycleManager, dockerClient, metadataServer, logStreamer, builder,
-                portAllocator, new CopyOnWriteArrayList<>());
+                portAllocator, portForwardManager, new CopyOnWriteArrayList<>());
     }
 
     /**
@@ -697,6 +714,7 @@ class Ec2ContainerManagerTest {
                                  ContainerLogStreamer logStreamer,
                                  ContainerBuilder.Builder builder,
                                  PortAllocator portAllocator,
+                                 Ec2PortForwardManager portForwardManager,
                                  List<String[]> executedCommands) {
         void stubSuccessfulExecs(CountDownLatch userDataStarted, CountDownLatch finishUserData) throws Exception {
             AtomicReference<String[]> currentCommand = new AtomicReference<>();

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
@@ -452,6 +452,29 @@ class Ec2ContainerManagerTest {
     }
 
     @Test
+    void cancelledLaunchRemovesContainerThatStartsAfterCancellation() throws Exception {
+        LaunchHarness harness = launchHarness();
+        CountDownLatch startEntered = new CountDownLatch(1);
+        CountDownLatch allowStart = new CountDownLatch(1);
+        when(harness.lifecycleManager.startCreated(eq(TEST_CONTAINER_ID), any(ContainerSpec.class))).thenAnswer(invocation -> {
+            startEntered.countDown();
+            assertTrue(allowStart.await(2, TimeUnit.SECONDS));
+            return null;
+        });
+
+        Instance instance = instance("i-cancelled-launch");
+        harness.manager.launch(instance, "ubuntu:24.04", null, "us-west-2");
+
+        assertTrue(startEntered.await(2, TimeUnit.SECONDS), "container startup should begin");
+        assertTrue(harness.manager.cancelLaunch(instance));
+        allowStart.countDown();
+
+        awaitUntil(() -> "terminated".equals(instance.getState().getName()), Duration.ofSeconds(2));
+        verify(harness.lifecycleManager).removeIfExists(TEST_CONTAINER_ID);
+        verify(harness.portAllocator).release(2201);
+    }
+
+    @Test
     void launchMarksInstanceRunningBeforeUserDataCompletes() throws Exception {
         Ec2ContainerManager.containerBridgeIpAttempts = 2;
         Ec2ContainerManager.containerBridgeIpPollMillis = 1;

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
@@ -42,6 +42,7 @@ import java.util.function.BooleanSupplier;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -49,6 +50,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Answers.RETURNS_SELF;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -389,7 +391,9 @@ class Ec2ContainerManagerTest {
         harness.manager.launch(instance, "ubuntu:24.04", null, "us-west-2");
 
         awaitUntil(() -> "terminated".equals(instance.getState().getName()), Duration.ofSeconds(2));
-        assertEquals(TEST_CONTAINER_ID, instance.getDockerContainerId());
+        verify(harness.lifecycleManager, timeout(2_000)).removeIfExists(TEST_CONTAINER_ID);
+        verify(harness.portAllocator, timeout(2_000)).release(2201);
+        assertNull(instance.getDockerContainerId());
         verify(harness.metadataServer, never()).registerContainer(anyString(), anyString(), any());
     }
 
@@ -471,7 +475,7 @@ class Ec2ContainerManagerTest {
         verify(harness.portAllocator).release(2201);
 
         allowStart.countDown();
-        awaitUntil(() -> "terminated".equals(instance.getState().getName()), Duration.ofSeconds(2));
+        verify(harness.portAllocator, after(500).times(1)).release(2201);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -15,6 +15,7 @@ import io.github.hectorvent.floci.services.ec2.model.IpPermission;
 import io.github.hectorvent.floci.services.ec2.model.Ipv6Range;
 import io.github.hectorvent.floci.services.ec2.model.SecurityGroupRule;
 import io.github.hectorvent.floci.services.ec2.model.UserIdGroupPair;
+import io.github.hectorvent.floci.services.ec2.model.InstanceState;
 import io.github.hectorvent.floci.services.ec2.model.LaunchTemplate;
 import io.github.hectorvent.floci.services.ec2.model.ManagedPrefixList;
 import io.github.hectorvent.floci.services.ec2.model.SecurityGroupRule;
@@ -39,7 +40,6 @@ import io.github.hectorvent.floci.services.ec2.model.Vpc;
 import io.github.hectorvent.floci.services.ec2.model.VpcEndpoint;
 import io.github.hectorvent.floci.services.ec2.model.Volume;
 import io.github.hectorvent.floci.services.ec2.model.VolumeAttachment;
-import io.github.hectorvent.floci.services.ec2.model.InstanceState;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -78,6 +78,21 @@ class Ec2ServiceTest {
         service.terminateInstances("us-east-1", List.of(instanceId));
         assertFalse(service.isInstanceContainerRunning(instanceId));
         verifyNoInteractions(containerManager);
+    }
+
+    @Test
+    void awaitContainerLaunchReportsTerminatedContainer() {
+        Ec2Service service = new Ec2Service(mockConfig(false), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class), mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class),
+                new Ec2InstanceTypeCatalog(), new InMemoryStorageFactory());
+        Instance instance = new Instance();
+        instance.setInstanceId("i-terminated");
+        instance.setState(InstanceState.terminated());
+
+        AwsException error = assertThrows(AwsException.class, () -> service.awaitContainerLaunch(instance));
+
+        assertEquals("InstanceLaunchFailure", error.getErrorCode());
+        assertTrue(error.getMessage().contains("terminated during container launch"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -98,18 +98,21 @@ class Ec2ServiceTest {
 
     @Test
     void awaitContainerLaunchTimesOutWhileInstanceIsPending() {
-        Ec2Service service = new Ec2Service(mockConfig(false), mock(Ec2ContainerManager.class),
+        Ec2ContainerManager containerManager = mock(Ec2ContainerManager.class);
+        Ec2Service service = new Ec2Service(mockConfig(false), containerManager,
                 mock(Ec2PortForwardManager.class), mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class),
                 new Ec2InstanceTypeCatalog(), new InMemoryStorageFactory());
         Instance instance = new Instance();
         instance.setInstanceId("i-pending");
         instance.setState(InstanceState.pending());
+        when(containerManager.cancelLaunch(instance)).thenReturn(true);
 
         AwsException error = assertThrows(AwsException.class,
                 () -> service.awaitContainerLaunch(instance, Duration.ZERO));
 
         assertEquals("InternalError", error.getErrorCode());
         assertTrue(error.getMessage().contains("did not reach running state before the launch timeout"));
+        verify(containerManager).cancelLaunch(instance);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -42,6 +42,7 @@ import io.github.hectorvent.floci.services.ec2.model.Volume;
 import io.github.hectorvent.floci.services.ec2.model.VolumeAttachment;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -91,8 +92,24 @@ class Ec2ServiceTest {
 
         AwsException error = assertThrows(AwsException.class, () -> service.awaitContainerLaunch(instance));
 
-        assertEquals("InstanceLaunchFailure", error.getErrorCode());
-        assertTrue(error.getMessage().contains("terminated during container launch"));
+        assertEquals("InternalError", error.getErrorCode());
+        assertTrue(error.getMessage().contains("container terminated during launch"));
+    }
+
+    @Test
+    void awaitContainerLaunchTimesOutWhileInstanceIsPending() {
+        Ec2Service service = new Ec2Service(mockConfig(false), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class), mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class),
+                new Ec2InstanceTypeCatalog(), new InMemoryStorageFactory());
+        Instance instance = new Instance();
+        instance.setInstanceId("i-pending");
+        instance.setState(InstanceState.pending());
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.awaitContainerLaunch(instance, Duration.ZERO));
+
+        assertEquals("InternalError", error.getErrorCode());
+        assertTrue(error.getMessage().contains("did not reach running state before the launch timeout"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #1982

- Retry an EC2 backing-container launch with the next configured SSH host port when Docker reports that the selected host port is already allocated.
- Make failed-launch cleanup idempotent: atomically claim and clear the recorded container ID and SSH port before cleanup so a timeout racing the launch worker releases each resource only once.
- Publish instance state safely across the launch worker and CloudFormation waiter, and use wrap-safe `System.nanoTime()` deadline arithmetic.
- Wait for the actual container lifecycle during CloudFormation provisioning, recording the physical instance ID and rollback ownership before waiting. A terminated launch now marks the resource `CREATE_FAILED` and is cleaned up by stack rollback rather than allowing `CREATE_COMPLETE`.
- Mark the instance running once its container address is reachable; best-effort link-local IMDS setup, SSH initialization, and UserData may finish afterward and this contract is now documented.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## AWS Compatibility

Previously, a stale Docker-published SSH port could terminate the asynchronous launch after CloudFormation had already recorded success. The launch now retries explicit Docker host-port collisions, CloudFormation waits for the real terminal state, and concurrent cancellation cannot double-release an SSH port that another instance may have reallocated.

## Validation

- [ ] `./mvnw test` passes locally (full suite delegated to CI)
- [x] Added focused regression coverage for Docker port-collision retry, timeout cancellation, exactly-once cleanup, CloudFormation failure propagation, and rollback ownership lifecycle
- [x] Java 25 focused run: `./mvnw -q -Dtest=Ec2ContainerManagerTest,Ec2ServiceTest test`
  - 145 tests, 0 failures/errors
- [x] Commit messages follow Conventional Commits
