### PR TITLE
fix(docker): fall back to Windows named pipe when docker-host is at its unix-socket default

### DIFF
--- a/docs/configuration/docker.md
+++ b/docs/configuration/docker.md
@@ -12,6 +12,8 @@ floci:
     docker-host: unix:///var/run/docker.sock
 ```
 
+**Running natively on Windows** (not inside WSL or a container): Windows has no equivalent of `/var/run/docker.sock`, so when `docker-host` is left at its default and `DOCKER_HOST` isn't set, Floci automatically falls back to Docker Desktop's named pipe (`npipe:////./pipe/docker_engine`) instead. An explicit `docker-host` or `DOCKER_HOST` always takes priority over this fallback.
+
 Environment variable: `FLOCI_DOCKER_DOCKER_HOST`
 
 When running Floci inside Docker Compose, mount the host socket:

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/DockerClientProducer.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/DockerClientProducer.java
@@ -20,6 +20,13 @@ public class DockerClientProducer {
 
     private static final Logger LOG = Logger.getLogger(DockerClientProducer.class);
 
+    /**
+     * Docker Desktop's well-known named pipe on native Windows. Unlike the unix-socket default,
+     * this isn't reachable by simply bind-mounting a path — Windows has no equivalent of
+     * {@code /var/run/docker.sock}, so a platform-specific fallback is required.
+     */
+    private static final String WINDOWS_DEFAULT_DOCKER_HOST = "npipe:////./pipe/docker_engine";
+
     private final EmulatorConfig config;
 
     @Inject
@@ -56,15 +63,23 @@ public class DockerClientProducer {
      * Priority:
      * 1. If {@code floci.docker.docker-host} is explicitly configured (non-default), use it.
      * 2. Otherwise fall back to the standard {@code DOCKER_HOST} env var (normalized).
-     * 3. Otherwise use the default unix socket.
+     * 3. Otherwise use the platform default: the unix socket on Linux/macOS, or Docker Desktop's
+     *    named pipe on native Windows — which has no {@code /var/run/docker.sock} equivalent, so
+     *    the unix-socket default is unreachable there unless a user overrides it manually.
      *
      * Both the configured value and the env var are normalized to ensure a valid URI scheme.
      */
-    static String resolveEffectiveDockerHost(String configuredHost, String dockerHostEnv) {
+    static String resolveEffectiveDockerHost(String configuredHost, String dockerHostEnv, boolean isWindows) {
         String normalizedEnvHost = normalizeDockerHost(dockerHostEnv);
-        if ("unix:///var/run/docker.sock".equals(configuredHost)
-                && normalizedEnvHost != null && !normalizedEnvHost.isBlank()) {
+        boolean atDefault = "unix:///var/run/docker.sock".equals(configuredHost);
+        if (atDefault && normalizedEnvHost != null && !normalizedEnvHost.isBlank()) {
             return normalizedEnvHost;
+        }
+        if (atDefault && isWindows) {
+            LOG.infov("Docker host is at its unix-socket default on Windows, which has no "
+                    + "/var/run/docker.sock equivalent; using named pipe ''{0}'' instead.",
+                    WINDOWS_DEFAULT_DOCKER_HOST);
+            return WINDOWS_DEFAULT_DOCKER_HOST;
         }
         return normalizeDockerHost(configuredHost);
     }
@@ -84,11 +99,15 @@ public class DockerClientProducer {
         }
     }
 
+    private static boolean isWindows() {
+        return System.getProperty("os.name", "").toLowerCase().contains("win");
+    }
+
     @Produces
     @ApplicationScoped
     public DockerClient dockerClient() {
         String dockerHost = resolveEffectiveDockerHost(
-                config.docker().dockerHost(), System.getenv("DOCKER_HOST"));
+                config.docker().dockerHost(), System.getenv("DOCKER_HOST"), isWindows());
         LOG.infov("Creating DockerClient for host: {0}", dockerHost);
 
         // createDefaultConfigBuilder() reads DOCKER_HOST directly from System.getenv() and passes

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/DockerClientProducerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/DockerClientProducerTest.java
@@ -131,7 +131,7 @@ class DockerClientProducerTest {
     @Test
     void resolveEffectiveDockerHost_dockerHostEnvBareHostPort_usesNormalizedEnv() {
         String result = DockerClientProducer.resolveEffectiveDockerHost(
-                "unix:///var/run/docker.sock", "10.37.124.101:2375");
+                "unix:///var/run/docker.sock", "10.37.124.101:2375", false);
         assertEquals("tcp://10.37.124.101:2375", result,
                 "Bare DOCKER_HOST env var should be normalized and used when config is at its default");
     }
@@ -143,7 +143,7 @@ class DockerClientProducerTest {
     @Test
     void resolveEffectiveDockerHost_dockerHostEnvTcpUri_usedDirectly() {
         String result = DockerClientProducer.resolveEffectiveDockerHost(
-                "unix:///var/run/docker.sock", "tcp://10.37.124.101:2375");
+                "unix:///var/run/docker.sock", "tcp://10.37.124.101:2375", false);
         assertEquals("tcp://10.37.124.101:2375", result,
                 "Valid tcp:// DOCKER_HOST env var should be used when config is at its default");
     }
@@ -155,30 +155,80 @@ class DockerClientProducerTest {
     @Test
     void resolveEffectiveDockerHost_explicitFlociConfig_takesPriorityOverEnv() {
         String result = DockerClientProducer.resolveEffectiveDockerHost(
-                "tcp://custom-daemon:2376", "10.37.124.101:2375");
+                "tcp://custom-daemon:2376", "10.37.124.101:2375", false);
         assertEquals("tcp://custom-daemon:2376", result,
                 "Explicit floci.docker.docker-host should take priority over DOCKER_HOST env var");
     }
 
     /**
-     * When DOCKER_HOST env var is null and floci.docker.docker-host is default, use the default.
+     * When DOCKER_HOST env var is null and floci.docker.docker-host is default on a non-Windows
+     * platform, use the unix-socket default (existing Linux/macOS behavior, unchanged).
      */
     @Test
-    void resolveEffectiveDockerHost_noEnvVar_usesDefault() {
+    void resolveEffectiveDockerHost_noEnvVar_nonWindows_usesUnixSocketDefault() {
         String result = DockerClientProducer.resolveEffectiveDockerHost(
-                "unix:///var/run/docker.sock", null);
+                "unix:///var/run/docker.sock", null, false);
         assertEquals("unix:///var/run/docker.sock", result,
-                "Default unix socket should be used when DOCKER_HOST env var is not set");
+                "Default unix socket should be used on non-Windows platforms when DOCKER_HOST is not set");
     }
 
     /**
-     * When DOCKER_HOST env var is blank and floci.docker.docker-host is default, use the default.
+     * When DOCKER_HOST env var is blank and floci.docker.docker-host is default on a non-Windows
+     * platform, use the unix-socket default (existing Linux/macOS behavior, unchanged).
      */
     @Test
-    void resolveEffectiveDockerHost_blankEnvVar_usesDefault() {
+    void resolveEffectiveDockerHost_blankEnvVar_nonWindows_usesUnixSocketDefault() {
         String result = DockerClientProducer.resolveEffectiveDockerHost(
-                "unix:///var/run/docker.sock", "");
+                "unix:///var/run/docker.sock", "", false);
         assertEquals("unix:///var/run/docker.sock", result,
-                "Default unix socket should be used when DOCKER_HOST env var is blank");
+                "Default unix socket should be used on non-Windows platforms when DOCKER_HOST is blank");
+    }
+
+    /**
+     * Bug: on native Windows, /var/run/docker.sock has no equivalent — Docker Desktop exposes
+     * its API via a named pipe instead. When floci.docker.docker-host is still at its unix-socket
+     * default and no DOCKER_HOST override is set, Windows must fall back to the named pipe rather
+     * than the unreachable unix-socket path (issue floci-io/floci#2006).
+     */
+    @Test
+    void resolveEffectiveDockerHost_noEnvVar_windows_usesNamedPipeDefault() {
+        String result = DockerClientProducer.resolveEffectiveDockerHost(
+                "unix:///var/run/docker.sock", null, true);
+        assertEquals("npipe:////./pipe/docker_engine", result,
+                "Windows should fall back to the named pipe when the unix-socket default is unreachable");
+    }
+
+    /**
+     * Same as above, but with a blank (rather than null) DOCKER_HOST env var.
+     */
+    @Test
+    void resolveEffectiveDockerHost_blankEnvVar_windows_usesNamedPipeDefault() {
+        String result = DockerClientProducer.resolveEffectiveDockerHost(
+                "unix:///var/run/docker.sock", "", true);
+        assertEquals("npipe:////./pipe/docker_engine", result,
+                "Windows should fall back to the named pipe when DOCKER_HOST is blank");
+    }
+
+    /**
+     * An explicit DOCKER_HOST env var still takes priority over the Windows named-pipe fallback.
+     */
+    @Test
+    void resolveEffectiveDockerHost_envVarSet_windows_usesEnvNotNamedPipe() {
+        String result = DockerClientProducer.resolveEffectiveDockerHost(
+                "unix:///var/run/docker.sock", "tcp://10.0.0.5:2375", true);
+        assertEquals("tcp://10.0.0.5:2375", result,
+                "An explicit DOCKER_HOST should take priority over the Windows named-pipe fallback");
+    }
+
+    /**
+     * An explicitly-configured (non-default) floci.docker.docker-host still takes priority over
+     * the Windows named-pipe fallback.
+     */
+    @Test
+    void resolveEffectiveDockerHost_explicitFlociConfig_windows_takesPriorityOverNamedPipe() {
+        String result = DockerClientProducer.resolveEffectiveDockerHost(
+                "tcp://custom-daemon:2376", null, true);
+        assertEquals("tcp://custom-daemon:2376", result,
+                "An explicitly-configured docker-host should take priority over the Windows named-pipe fallback");
     }
 }


### PR DESCRIPTION
Fixes #2006

Root cause traced via live reproduction: `docker-host` defaults to `unix:///var/run/docker.sock`, which doesn't exist on native Windows (Docker Desktop exposes its API via a named pipe instead). This hardcoded default silently overrides `docker-java`'s own correct OS-aware detection, so every Lambda-backed operation - including Lambda-invoked CloudFormation custom resources like CDK's `Custom::S3BucketNotifications` - failed at container-start time with `SocketException: Network is down`.

**Fix:** when `docker-host` is still at its unmodified default and no `DOCKER_HOST` override is present, fall back to Docker Desktop's named pipe on Windows. An explicit `docker-host` config or `DOCKER_HOST` env var always takes priority. Linux/macOS behavior is completely unchanged.

**Verification:**
- Reproduced the exact failure live: deployed a hand-built CDK-shaped stack (bucket + IAM role + Lambda + `Custom::S3BucketNotifications`) against a native-Windows floci instance - confirmed `CREATE_FAILED` before the fix, `CREATE_COMPLETE` after, reconfirmed on three independent runs
- 7 new/updated tests in `DockerClientProducerTest` (Windows vs. non-Windows, explicit overrides, env var priority) - 19/19 pass
- Full `docker`/`lambda`/`cloudformation` packages (716 tests) - 1 pre-existing unrelated failure (`ZipExtractorTest`, a Windows zip-path quirk, confirmed identical on unmodified `main`)
- Docs updated: `docs/configuration/docker.md`, `CHANGELOG.md`

<img width="1913" height="601" alt="image" src="https://github.com/user-attachments/assets/1f6cdc1a-b5e4-49d3-964e-808a728c095d" />
