### PR TITLE
fix(cloudformation): preserve subnet public IP setting

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -587,7 +587,11 @@ public class CloudFormationResourceProvisioner {
         String vpcId = resolveOptional(props, "VpcId", engine);
         String cidr = resolveOptional(props, "CidrBlock", engine);
         String az = resolveOptional(props, "AvailabilityZone", engine);
+        String mapPublicIpOnLaunch = resolveOptional(props, "MapPublicIpOnLaunch", engine);
         var subnet = ec2Service.createSubnet(region, vpcId, cidr, az);
+        if (mapPublicIpOnLaunch != null) {
+            ec2Service.modifySubnetAttribute(region, subnet.getSubnetId(), "mapPublicIpOnLaunch", mapPublicIpOnLaunch);
+        }
         r.setPhysicalId(subnet.getSubnetId());
         r.getAttributes().put("SubnetId", subnet.getSubnetId());
         r.getAttributes().put("VpcId", subnet.getVpcId());

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationEc2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationEc2IntegrationTest.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -48,7 +49,8 @@ class CloudFormationEc2IntegrationTest {
                       "Properties": {
                         "VpcId": {"Ref": "Vpc"},
                         "CidrBlock": "10.0.1.0/24",
-                        "AvailabilityZone": "ap-southeast-2a"
+                        "AvailabilityZone": "ap-southeast-2a",
+                        "MapPublicIpOnLaunch": true
                       }
                     },
                     "Subnet2": {
@@ -107,6 +109,8 @@ class CloudFormationEc2IntegrationTest {
             .post("/")
         .then()
             .statusCode(200)
+            .body("DescribeSubnetsResponse.subnetSet.item.find { it.availabilityZone == 'ap-southeast-2a' }.mapPublicIpOnLaunch",
+                    equalTo("true"))
             .extract().asString();
 
         for (String subnetId : exportedSubnetIds) {


### PR DESCRIPTION
## Summary

Closes #2013.

- Resolve `AWS::EC2::Subnet.MapPublicIpOnLaunch` from the CloudFormation template.
- Apply the resolved value through the existing EC2 subnet-attribute mutation path after subnet creation.
- Extend the CFN-to-EC2 integration flow to verify `DescribeSubnets` returns `mapPublicIpOnLaunch=true` for the public subnet.

## Type of change

- [x] Bug fix (fix:)
- [ ] New feature (feat:)
- [ ] Breaking change (feat!: or fix!:)
- [ ] Docs / chore

## AWS Compatibility

CloudFormation-created subnets now preserve the explicit `MapPublicIpOnLaunch` template property. This matches the EC2 subnet attribute exposed by `DescribeSubnets`, allowing public-subnet topology checks to distinguish CFN public and private subnets without inferring it from route tables.

## Checklist

- [ ] ./mvnw test passes locally (not run; focused integration test below)
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits

Focused verification (JDK 25):

`./mvnw -q -Dtest=CloudFormationEc2IntegrationTest test`