### PR TITLE
feat(iam): seed Amazon Bedrock managed policies

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
@@ -152,9 +152,10 @@ final class AwsManagedPolicies {
 
         // Amazon Bedrock policies
         new ManagedPolicyDef("AmazonBedrockFullAccess", "/",
-                "Provides full access to Amazon Bedrock as well as limited access to related services."),
+                "Provides full access to Amazon Bedrock as well as limited access to related services "
+                + "that are required by it"),
         new ManagedPolicyDef("AmazonBedrockReadOnly", "/",
-                "Provides read-only access to Amazon Bedrock as well as limited access to related services."),
+                "Provides read only access to Amazon Bedrock"),
         new ManagedPolicyDef("AmazonBedrockAgentCoreMemoryBedrockModelInferenceExecutionRolePolicy", "/",
                 "Provides Bedrock Model inference permissions to Bedrock agent core memory."),
 

--- a/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
@@ -150,7 +150,11 @@ final class AwsManagedPolicies {
         new ManagedPolicyDef("AmazonDataZoneDomainExecutionRolePolicy", "/service-role/",
                 "Provides permissions for the Amazon DataZone domain execution role."),
 
-        // Amazon Bedrock execution role policy
+        // Amazon Bedrock policies
+        new ManagedPolicyDef("AmazonBedrockFullAccess", "/",
+                "Provides full access to Amazon Bedrock as well as limited access to related services."),
+        new ManagedPolicyDef("AmazonBedrockReadOnly", "/",
+                "Provides read-only access to Amazon Bedrock as well as limited access to related services."),
         new ManagedPolicyDef("AmazonBedrockAgentCoreMemoryBedrockModelInferenceExecutionRolePolicy", "/",
                 "Provides Bedrock Model inference permissions to Bedrock agent core memory."),
 

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
@@ -615,6 +615,10 @@ class IamServiceTest {
         IamPolicy bedrock = iamService.getPolicy("arn:aws:iam::aws:policy/AmazonBedrockFullAccess");
         assertEquals("AmazonBedrockFullAccess", bedrock.getPolicyName());
         assertEquals("/", bedrock.getPath());
+
+        IamPolicy bedrockReadOnly = iamService.getPolicy("arn:aws:iam::aws:policy/AmazonBedrockReadOnly");
+        assertEquals("AmazonBedrockReadOnly", bedrockReadOnly.getPolicyName());
+        assertEquals("/", bedrockReadOnly.getPath());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
@@ -611,6 +611,23 @@ class IamServiceTest {
                 "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole");
         assertEquals("AmazonRDSEnhancedMonitoringRole", rdsMonitoring.getPolicyName());
         assertEquals("/service-role/", rdsMonitoring.getPath());
+
+        IamPolicy bedrock = iamService.getPolicy("arn:aws:iam::aws:policy/AmazonBedrockFullAccess");
+        assertEquals("AmazonBedrockFullAccess", bedrock.getPolicyName());
+        assertEquals("/", bedrock.getPath());
+    }
+
+    @Test
+    void attachAmazonBedrockFullAccessToRole() {
+        // Regression: AmazonBedrockFullAccess was absent from the seed catalog, so
+        // AttachRolePolicy (the Terraform path — CloudFormation attaches inline and
+        // never calls it) 404'd with NoSuchEntity. Attaching it must now succeed.
+        iamService.createRole("BedrockRole", "/", "{}", null, 0, null);
+        iamService.attachRolePolicy("BedrockRole", "arn:aws:iam::aws:policy/AmazonBedrockFullAccess");
+
+        List<String> attached = iamService.listAttachedRolePolicies("BedrockRole", null).stream()
+                .map(IamPolicy::getArn).toList();
+        assertTrue(attached.contains("arn:aws:iam::aws:policy/AmazonBedrockFullAccess"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #2033.

Seeds `AmazonBedrockFullAccess` and `AmazonBedrockReadOnly` into the AWS-managed
policy catalog (`AwsManagedPolicies`), alongside the Bedrock AgentCore policy
already there.

**Why:** CloudFormation attaches managed policies inline on role creation, so a
CFN deploy never hits a missing catalog entry. Terraform and the raw IAM API call
`AttachRolePolicy`, which validates existence and `404`s (`NoSuchEntity`) for a
policy Floci hasn't seeded. These two Bedrock policies are common in agent/ML
roles.

**Tests:** `IamServiceTest.seedAwsManagedPolicies` asserts `AmazonBedrockFullAccess`
resolves; new `attachAmazonBedrockFullAccessToRole` covers the exact failing path
(create role → attach → assert attached). Both green.

Follows the single-policy-addition pattern of #1559 (RDS) and #1216 (EKS).