### PR TITLE
fix(rds): preserve configured database images

### DIFF
--- a/docs/configuration/advanced/application-yml.md
+++ b/docs/configuration/advanced/application-yml.md
@@ -165,9 +165,11 @@ floci:
       proxy-base-port: 7001
       proxy-max-port: 7099
       # endpoint-host: localhost              # Hostname clients use; enables published-port translation in Docker
-      default-postgres-image: "postgres:16-alpine"
-      default-mysql-image: "mysql:8.0"
-      default-mariadb-image: "mariadb:11"
+      # Omit image overrides to adapt Floci's built-in images to EngineVersion.
+      # Uncomment an override to pin that engine to an exact image.
+      # default-postgres-image: "registry.example.com/postgres:16-alpine"
+      # default-mysql-image: "registry.example.com/mysql:8.0"
+      # default-mariadb-image: "registry.example.com/mariadb:11"
 
     rds-data:
       enabled: true

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -877,6 +877,10 @@ public interface EmulatorConfig {
     }
 
     interface RdsServiceConfig {
+        String DEFAULT_POSTGRES_IMAGE = "postgres:16-alpine";
+        String DEFAULT_MYSQL_IMAGE = "mysql:8.0";
+        String DEFAULT_MARIADB_IMAGE = "mariadb:11";
+
         @WithDefault("true")
         boolean enabled();
 
@@ -892,14 +896,14 @@ public interface EmulatorConfig {
         @WithDefault("7099")
         int proxyMaxPort();
 
-        @WithDefault("postgres:16-alpine")
-        String defaultPostgresImage();
+        /** Empty when Floci should adapt its built-in image to the requested engine version. */
+        Optional<String> defaultPostgresImage();
 
-        @WithDefault("mysql:8.0")
-        String defaultMysqlImage();
+        /** Empty when Floci should adapt its built-in image to the requested engine version. */
+        Optional<String> defaultMysqlImage();
 
-        @WithDefault("mariadb:11")
-        String defaultMariadbImage();
+        /** Empty when Floci should adapt its built-in image to the requested engine version. */
+        Optional<String> defaultMariadbImage();
 
         /** Hostname advertised for RDS endpoints. Uses published Docker ports when configured. */
         Optional<String> endpointHost();

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -1101,12 +1101,17 @@ public class RdsService implements Resettable {
     }
 
     private String imageForEngine(DatabaseEngine engine, String engineVersion) {
-        String defaultImage = switch (engine) {
-            case POSTGRES -> config.services().rds().defaultPostgresImage();
-            case MYSQL -> config.services().rds().defaultMysqlImage();
-            case MARIADB -> config.services().rds().defaultMariadbImage();
+        return switch (engine) {
+            case POSTGRES -> config.services().rds().defaultPostgresImage()
+                    .orElseGet(() -> imageForRequestedVersion(
+                            EmulatorConfig.RdsServiceConfig.DEFAULT_POSTGRES_IMAGE, engineVersion));
+            case MYSQL -> config.services().rds().defaultMysqlImage()
+                    .orElseGet(() -> imageForRequestedVersion(
+                            EmulatorConfig.RdsServiceConfig.DEFAULT_MYSQL_IMAGE, engineVersion));
+            case MARIADB -> config.services().rds().defaultMariadbImage()
+                    .orElseGet(() -> imageForRequestedVersion(
+                            EmulatorConfig.RdsServiceConfig.DEFAULT_MARIADB_IMAGE, engineVersion));
         };
-        return imageForRequestedVersion(defaultImage, engineVersion);
     }
 
     private void validateInstanceParameterGroup(String paramGroupName, String engineParam, String engineVersion) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -269,9 +269,11 @@ floci:
       proxy-base-port: 7001
       proxy-max-port: 7099
       # endpoint-host: localhost                 # Hostname clients use; enables published-port translation in Docker
-      default-postgres-image: "postgres:16-alpine"
-      default-mysql-image: "mysql:8.0"
-      default-mariadb-image: "mariadb:11"
+      # Omit image overrides to adapt Floci's built-in images to EngineVersion.
+      # Uncomment an override to pin that engine to an exact image.
+      # default-postgres-image: "registry.example.com/postgres:16-alpine"
+      # default-mysql-image: "registry.example.com/mysql:8.0"
+      # default-mariadb-image: "registry.example.com/mariadb:11"
     rds-data:
       enabled: true
       transaction-ttl-seconds: 180

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -74,6 +74,7 @@ class RdsServiceTest {
     private Ec2Service ec2Service;
     private RegionResolver regionResolver;
     private EmulatorConfig config;
+    private EmulatorConfig.RdsServiceConfig rdsConfig;
 
     @BeforeEach
     void setUp() {
@@ -83,15 +84,15 @@ class RdsServiceTest {
         regionResolver = new RegionResolver("us-east-1", "123456789012");
         config = mock(EmulatorConfig.class);
         EmulatorConfig.ServicesConfig servicesConfig = mock(EmulatorConfig.ServicesConfig.class);
-        EmulatorConfig.RdsServiceConfig rdsConfig = mock(EmulatorConfig.RdsServiceConfig.class);
+        rdsConfig = mock(EmulatorConfig.RdsServiceConfig.class);
 
         when(config.services()).thenReturn(servicesConfig);
         when(servicesConfig.rds()).thenReturn(rdsConfig);
         when(rdsConfig.proxyBasePort()).thenReturn(7000);
         when(rdsConfig.proxyMaxPort()).thenReturn(7099);
-        when(rdsConfig.defaultPostgresImage()).thenReturn("postgres:16-alpine");
-        when(rdsConfig.defaultMysqlImage()).thenReturn("mysql:8.0");
-        when(rdsConfig.defaultMariadbImage()).thenReturn("mariadb:11");
+        when(rdsConfig.defaultPostgresImage()).thenReturn(Optional.empty());
+        when(rdsConfig.defaultMysqlImage()).thenReturn(Optional.empty());
+        when(rdsConfig.defaultMariadbImage()).thenReturn(Optional.empty());
 
         rdsService = newService(containerManager, proxyManager,
                 new InMemoryStorage<>(), new InMemoryStorage<>(),
@@ -163,6 +164,30 @@ class RdsServiceTest {
 
         verify(containerManager).start(eq("mydb"), any(), eq(DatabaseEngine.POSTGRES),
                 eq("postgres:18.1-alpine"), eq("admin"), eq("password"), eq("dbname"));
+    }
+
+    @Test
+    void configuredPostgresImageIsNotRewrittenForRequestedEngineVersion() {
+        when(rdsConfig.defaultPostgresImage()).thenReturn(Optional.of("postgres:16.14-alpine3.23"));
+
+        rdsService.createDbCluster("cluster1", "postgres", "16.3",
+                "admin", "password", "dbname", false, null);
+
+        verify(containerManager).start(eq("cluster1"), any(), eq(DatabaseEngine.POSTGRES),
+                eq("postgres:16.14-alpine3.23"), eq("admin"), eq("password"), eq("dbname"));
+    }
+
+    @Test
+    void explicitlyConfiguredDefaultPostgresImageIsNotRewritten() {
+        when(rdsConfig.defaultPostgresImage())
+                .thenReturn(Optional.of(EmulatorConfig.RdsServiceConfig.DEFAULT_POSTGRES_IMAGE));
+
+        rdsService.createDbCluster("cluster1", "postgres", "18.1",
+                "admin", "password", "dbname", false, null);
+
+        verify(containerManager).start(eq("cluster1"), any(), eq(DatabaseEngine.POSTGRES),
+                eq(EmulatorConfig.RdsServiceConfig.DEFAULT_POSTGRES_IMAGE),
+                eq("admin"), eq("password"), eq("dbname"));
     }
 
     @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -145,9 +145,6 @@ floci:
       mock: false
       proxy-base-port: 7001
       proxy-max-port: 7099
-      default-postgres-image: "postgres:16-alpine"
-      default-mysql-image: "mysql:8.0"
-      default-mariadb-image: "mariadb:11"
     rds-data:
       enabled: true
       transaction-ttl-seconds: 180


### PR DESCRIPTION
## Summary
- preserve explicitly configured RDS database image references instead of rewriting their tags from `EngineVersion`
- retain `EngineVersion` substitution for Floci's built-in RDS image defaults
- define built-in image defaults once in `EmulatorConfig.RdsServiceConfig` and document the configured-image behavior
- add a cluster creation regression test

Closes #1959

## Validation
- `JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home ./mvnw test -Dtest=RdsServiceTest,RdsQueryHandlerTest` (103 tests passed)