### PR TITLE
fix(lambda): carry the owning account into published version snapshots

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -928,6 +928,7 @@ public class LambdaService {
         functionName = fn.getFunctionName();
         int version = nextVersionNumber(region + "::" + functionName);
         LambdaFunction snapshot = new LambdaFunction();
+        snapshot.setAccountId(fn.getAccountId());
         snapshot.setFunctionName(fn.getFunctionName());
         snapshot.setVersion(String.valueOf(version));
         snapshot.setFunctionArn(fn.getFunctionArn().replace(":$LATEST", "") + ":" + version);

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
@@ -242,6 +242,21 @@ class LambdaServiceTest {
     }
 
     @Test
+    void publishVersionCarriesTheOwningAccount() {
+        service.createFunction(REGION, baseRequest("account-versioned-fn"));
+
+        LambdaFunction version = service.publishVersion(REGION, "account-versioned-fn", null);
+
+        // A version snapshot is built field by field, so anything reading accountId off it (the
+        // deployment-package key, execution-role session ownership) otherwise has to re-derive the
+        // account from the ARN or fall back to the default account.
+        assertEquals("000000000000", version.getAccountId());
+        assertEquals(
+                service.getFunction(REGION, "account-versioned-fn").getAccountId(),
+                version.getAccountId());
+    }
+
+    @Test
     void createFunctionWithSubdirectoryHandler() throws Exception {
         Map<String, Object> req = new java.util.HashMap<>(Map.of(
                 "FunctionName", "subdir-handler-fn",


### PR DESCRIPTION
## Summary

Closes #2040.

`publishVersion` builds its snapshot field by field and copies 20 fields, but never `accountId`. Every published version therefore carried a null owning account while `$LATEST` for the same function carried the real one.

The account was never lost, the version ARN already embeds it (`arn:aws:lambda:us-east-1:000000000000:function:fn:1`), it just was not on the model. This copies it alongside the other snapshot fields, so a version reports the same owning account as the function it was published from.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: a published version's owning account was absent from the model, so any consumer reading it had to re-derive the account from the function ARN or fall back to a default. `codeObjectKey` substitutes `000000000000` for a null account, which silently maps a version into the default account's prefix rather than the function's. That path is not reachable today (the one qualifier-accepting caller, `GetFunction`, resolves through `getFunction`, which strips the qualifier and returns the base function), so this is a latent mis-key rather than a live one. It becomes live as soon as any code path passes a version snapshot there.

Not observable through the CLI, since `accountId` is not surfaced in `GetFunctionConfiguration`. That is the reason for fixing it rather than leaving it: the field is invisibly absent, so each new consumer independently discovers the gap and adds its own fallback.

Worth noting a field copy does not fully remove the need for a fallback where the account is load-bearing. Version snapshots persist, so snapshots written before this change still deserialize with a null `accountId` after a restart.

## Checklist

- [x] `./mvnw test` passes locally (8065 tests, 0 failures, 9 skipped)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

`LambdaServiceTest.publishVersionCarriesTheOwningAccount` publishes a version and asserts it reports the same account as the base function. Verified it fails without the change: `expected: <000000000000> but was: <null>`.
