### PR TITLE
docs(cloudwatch): document Logs Insights subset and missing Logs actions

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -252,7 +252,8 @@ See [Initialization Hooks](./initialization-hooks.md) for lifecycle phases and s
 | Variable | Default | Description |
 |---|---|---|
 | `FLOCI_SERVICES_CLOUDWATCHLOGS_ENABLED` | `true` | Enable the CloudWatch Logs service |
-| `FLOCI_SERVICES_CLOUDWATCHLOGS_MAX_EVENTS_PER_QUERY` | `10000` | Maximum log events returned by a single `FilterLogEvents` call |
+| `FLOCI_SERVICES_CLOUDWATCHLOGS_MAX_EVENTS_PER_QUERY` | `10000` | Maximum log events returned by a single `FilterLogEvents` or `GetLogEvents` call, and the upper bound for a Logs Insights `limit` |
+| `FLOCI_SERVICES_CLOUDWATCHLOGS_QUERY_COMPLETION_DELAY_MS` | `0` | Artificial Logs Insights query delay. With `0` a query completes immediately; a positive value emulates the asynchronous `Running` → `Complete` lifecycle |
 
 ### CloudWatch Metrics
 

--- a/docs/services/cloudwatch.md
+++ b/docs/services/cloudwatch.md
@@ -27,13 +27,68 @@ Floci supports both CloudWatch Logs and CloudWatch Metrics.
 | `TagLogGroup` | Tag a log group |
 | `UntagLogGroup` | Remove tags |
 | `ListTagsLogGroup` | List tags |
+| `TagResource` | Tag a log group by ARN |
+| `UntagResource` | Remove tags from a log group by ARN |
+| `ListTagsForResource` | List tags for a log group ARN |
+| `PutSubscriptionFilter` | Create or update a subscription filter (stored only, see note below) |
+| `DescribeSubscriptionFilters` | List subscription filters on a log group |
+| `DeleteSubscriptionFilter` | Delete a subscription filter |
+| `GetDataProtectionPolicy` | Return the resolved log group identifier (see note below) |
+| `StartQuery` | Start a Logs Insights query (see [Logs Insights](#logs-insights)) |
+| `GetQueryResults` | Get the status and results of a Logs Insights query |
+| `StopQuery` | Stop a query that has not completed yet |
+
+Two actions are currently simplified:
+
+- **`PutSubscriptionFilter`** stores the filter so that `DescribeSubscriptionFilters`
+  returns it, but log events are **not** forwarded to the destination ARN. Lambda,
+  Kinesis, and Firehose subscription destinations are not wired up.
+- **`GetDataProtectionPolicy`** does not model data-protection policies. It returns
+  HTTP 200 with the resolved `logGroupIdentifier` and no `policyDocument` — including for
+  a log group that does not exist, where real AWS returns `ResourceNotFoundException`.
+
+### Logs Insights {#logs-insights}
+
+`StartQuery` / `GetQueryResults` / `StopQuery` run a **subset** of the Logs Insights
+query language. Supported commands:
+
+| Command | Notes |
+|---|---|
+| `fields a, b, ...` | Projection. Defaults to `@timestamp, @message`. `display` is an alias |
+| `filter <field> = 'v'` | Equality. `!=` and `==` are also accepted; `where` is an alias |
+| `sort <field> [asc\|desc]` | `order` is an alias |
+| `dedup <field, ...>` | Keeps the first row per unique tuple, applied after sorting |
+| `limit N` | The effective cap is the smallest of this value, the `StartQuery` `limit` parameter, and `FLOCI_SERVICES_CLOUDWATCHLOGS_MAX_EVENTS_PER_QUERY` |
+
+Fields may be `@timestamp`, `@message`, `@ingestionTime`, `@ptr`, or a dotted path into
+a JSON log message (for example `level` or `params.job_id`). A `@ptr` column is always
+included in each result row, appended unless `fields` already names it.
+
+Unsupported syntax never fails the query, so it is worth knowing how each case degrades:
+
+| Input | Result |
+|---|---|
+| An unsupported command (`stats`, `parse`, ...) | Skipped with a warning in the server log. No aggregation happens |
+| A `filter` whose operator is not `=`, `!=` or `==` — for example `like /ERROR/` or `=~ /ERROR/` | The whole stage is dropped with a warning, so **every** row is returned |
+| A `filter` using `<`, `<=`, `>` or `>=` | The `=` is taken as the operator and the rest of the token becomes part of the field name, which then resolves to nothing — so the row never matches and you get **no** rows. No warning is logged |
+| A projected field that does not exist | Rendered as an empty string. No warning |
+| A `sort` direction other than `asc` / `desc` | Treated as ascending. No warning |
+
+In short, a query can come back either wider or narrower than intended without any error. When a
+result set looks wrong, check the server log for `Ignoring unsupported Logs Insights ...` — and
+note that the `>=` case above produces no log line at all.
+
+For simple substring matching, `FilterLogEvents` is the more predictable option today. Note that
+Floci matches `--filter-pattern` as a plain substring of the message; the real filter-pattern
+syntax (`?ERROR ?WARN`, `{ $.level = "ERROR" }`, and so on) is not parsed.
 
 ### Configuration
 
 | Variable | Default | Description |
 |---|---|---|
 | `FLOCI_SERVICES_CLOUDWATCHLOGS_ENABLED` | `true` | Enable or disable the CloudWatch Logs service |
-| `FLOCI_SERVICES_CLOUDWATCHLOGS_MAX_EVENTS_PER_QUERY` | `10000` | Maximum events returned per `FilterLogEvents` / `GetLogEvents` call |
+| `FLOCI_SERVICES_CLOUDWATCHLOGS_MAX_EVENTS_PER_QUERY` | `10000` | Maximum events returned per `FilterLogEvents` / `GetLogEvents` call, and the upper bound for a Logs Insights `limit` |
+| `FLOCI_SERVICES_CLOUDWATCHLOGS_QUERY_COMPLETION_DELAY_MS` | `0` | Artificial Logs Insights query delay. With `0` a query completes immediately. A positive value emulates the real asynchronous lifecycle (`Running` → `Complete` after the delay), which also makes `StopQuery` on a still-running query return `success=true` |
 
 ### Examples
 
@@ -65,6 +120,19 @@ aws logs get-log-events \
 aws logs filter-log-events \
   --log-group-name /app/backend \
   --filter-pattern "ERROR" \
+  --endpoint-url $AWS_ENDPOINT_URL
+
+# Run a Logs Insights query
+QUERY_ID=$(aws logs start-query \
+  --log-group-name /app/backend \
+  --start-time $(($(date +%s) - 3600)) \
+  --end-time $(date +%s) \
+  --query-string 'fields @timestamp, @message | sort @timestamp desc | limit 20' \
+  --query queryId --output text \
+  --endpoint-url $AWS_ENDPOINT_URL)
+
+aws logs get-query-results \
+  --query-id "$QUERY_ID" \
   --endpoint-url $AWS_ENDPOINT_URL
 
 # Set retention


### PR DESCRIPTION
## Summary

`docs/services/cloudwatch.md` documents 14 of the 24 actions that `CloudWatchLogsHandler`
dispatches. The handler is on the `deferred_handlers` allowlist in `tools/docs/services.yaml`
("multi-table doc"), so this table is maintained by hand rather than regenerated, and it has
drifted as actions were added.

The most visible gap is Logs Insights. `StartQuery` / `GetQueryResults` / `StopQuery` landed in
1.5.31 (#1448) but appear nowhere in the docs, so there is no documented way to find out which
parts of the query language work — and the implemented subset is deliberately narrow.

Docs only, touching `docs/services/cloudwatch.md` and
`docs/configuration/environment-variables.md`:

- **Adds the 10 missing actions** — `TagResource`, `UntagResource`, `ListTagsForResource`,
  `PutSubscriptionFilter`, `DescribeSubscriptionFilters`, `DeleteSubscriptionFilter`,
  `GetDataProtectionPolicy`, `StartQuery`, `GetQueryResults`, `StopQuery`
- **Adds a Logs Insights section** covering the supported commands (`fields`, `filter`, `sort`,
  `dedup`, `limit`, plus the `display` / `where` / `order` aliases), the field syntax including
  dotted paths into JSON messages and the always-included `@ptr` column, and a table of how each
  kind of unsupported input degrades — a dropped `filter` stage returns every row, a `>=` / `<=`
  comparison is mis-parsed into a field name and returns none, a missing projected field becomes an
  empty string, and an unrecognised `sort` direction falls back to ascending. Only the first two of
  those log a warning
- **Notes two simplifications** that are easy to trip over: `PutSubscriptionFilter`
  stores the filter for `DescribeSubscriptionFilters` but does not forward events to the
  destination ARN, and `GetDataProtectionPolicy` returns 200 with no `policyDocument`
- **Documents `FLOCI_SERVICES_CLOUDWATCHLOGS_QUERY_COMPLETION_DELAY_MS`** in both the service page
  and the central environment-variable list, and corrects the `MAX_EVENTS_PER_QUERY` description,
  which mentioned only `FilterLogEvents`. The `limit` row notes that the effective cap is the
  smallest of the query `limit`, the `StartQuery` `limit` parameter and this variable
- **Adds a `start-query` / `get-query-results` example**

Descriptions were taken from `CloudWatchLogsHandler`, `CloudWatchLogsService`,
`LogsInsightsQuery` and `EmulatorConfig` rather than from the AWS documentation, so they describe
what Floci does rather than what AWS does.

The silent-ignore behaviour itself is a separate question and is filed as #2042; this PR
only documents the current state.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No wire behaviour changed. The behaviour being documented was checked against
`floci/floci:1.5.34` with AWS CLI v2.32.1:

- The new `start-query` / `get-query-results` example returns the expected row, with `@ptr` appended
- With `FLOCI_SERVICES_CLOUDWATCHLOGS_QUERY_COMPLETION_DELAY_MS=4000`, a query reports `Running`
  immediately after `StartQuery` and `Complete` once the delay elapses. `StopQuery` on a separate,
  still-running query returned `success=true` (a stopped query stays `Cancelled`, so these were two
  different queries)
- On a log group with one `INFO` and two `ERROR` events: `filter @message like /ERROR/` returns all
  3 rows, `filter @message >= "x"` returns 0, and `stats count()` returns the 3 raw rows. The server
  log shows `Ignoring unsupported Logs Insights ...` for the first and third but not for the `>=`
  case

## Checklist

- [ ] `./mvnw test` passes locally — not run; this PR touches no code
- [ ] New or updated integration test added — n/a for docs
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
