### PR TITLE
feat(apigateway): support floci:override-id for v1 and v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **apigateway:** support the reserved `floci:override-id` tag on `CreateRestApi` (v1) and `CreateApi` (v2) to pin the generated API ID, unifying custom IDs with the tag KMS and Cognito already use. Override keys are stripped from the returned tags, validated (non-blank, no whitespace/control characters and no `/`, `?`, `#`) and rejected on `TagResource` with `BadRequestException`, which is what both services declare. The older API-Gateway-specific `_custom_id_` tag still works as a deprecated fallback and is now stripped too; `floci:override-id` wins when both are present ([#1593](https://github.com/floci-io/floci/pull/1593))
+- **apigateway:** support the reserved `floci:override-id` tag on `CreateRestApi` (v1) and `CreateApi` (v2) to pin the generated API ID, unifying custom IDs with the tag KMS and Cognito already use. Override keys are stripped from the returned tags, validated (non-blank, no whitespace/control characters and no `/`, `?`, `#`) and rejected on `TagResource` with `BadRequestException`, which is what both services declare. The older API-Gateway-specific `_custom_id_` tag still works as a deprecated fallback and is now stripped too; `floci:override-id` wins when both are present. Creating an API whose override ID already exists in the region is rejected with `ConflictException` (409) instead of overwriting the existing API ([#1593](https://github.com/floci-io/floci/pull/1593))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **apigateway:** support the reserved `floci:override-id` tag on `CreateRestApi` (v1) and `CreateApi` (v2) to pin the generated API ID, unifying custom IDs with the tag KMS and Cognito already use. Override keys are stripped from the returned tags, validated (non-blank, no whitespace/control characters and no `/`, `?`, `#`) and rejected on `TagResource` with `BadRequestException`, which is what both services declare. The older API-Gateway-specific `_custom_id_` tag still works as a deprecated fallback and is now stripped too; `floci:override-id` wins when both are present ([#1593](https://github.com/floci-io/floci/pull/1593))
+
+### Changed
+
+- **apigateway:** `_custom_id_` is no longer persisted in the tags returned for a REST API. It was previously echoed back as a normal tag.
+
 ## [1.5.34] - 2026-07-28
 
 ### Added

--- a/docs/services/api-gateway.md
+++ b/docs/services/api-gateway.md
@@ -2,6 +2,34 @@
 
 Floci supports both API Gateway v1 (REST APIs) and API Gateway v2 (HTTP APIs).
 
+## Custom API IDs
+
+API IDs are generated randomly, which means endpoint URLs change every time you recreate an API. To pin
+one, pass the reserved `floci:override-id` tag on creation and Floci uses its value as the API ID. This
+works for both v1 (`CreateRestApi`) and v2 (`CreateApi`), and matches the tag other services such as KMS
+and Cognito already use.
+
+```bash
+aws apigateway create-rest-api \
+  --name my-api \
+  --tags '{"floci:override-id":"my-fixed-id","env":"test"}' \
+  --endpoint-url http://localhost:4566
+# the API is now reachable at the stable id "my-fixed-id"
+```
+
+The override key is consumed rather than stored, so it never appears in the tags the API returns. Any
+other tags in the same request are kept. Because an ID cannot change after creation, supplying either
+override key to `TagResource` is rejected with `BadRequestException`.
+
+Values must be non-blank and must not contain whitespace, control characters, or `/`, `?`, `#`, since
+those would break the endpoint URL. An invalid value is rejected with `BadRequestException`.
+
+> [!NOTE]
+> API Gateway previously used a `_custom_id_` tag for this. It still works so existing setups keep
+> running, and it is now stripped from the returned tags the same way, but it is deprecated: prefer
+> `floci:override-id`. If both are present, `floci:override-id` wins, which lets you set both during a
+> migration. The `_custom_id_` key is API Gateway specific and is not reserved for any other service.
+
 ## API Gateway v1 (REST APIs) {#v1}
 
 **Protocol:** REST JSON

--- a/docs/services/api-gateway.md
+++ b/docs/services/api-gateway.md
@@ -24,6 +24,10 @@ override key to `TagResource` is rejected with `BadRequestException`.
 Values must be non-blank and must not contain whitespace, control characters, or `/`, `?`, `#`, since
 those would break the endpoint URL. An invalid value is rejected with `BadRequestException`.
 
+Creating a second API with an override ID that already exists in the region is rejected with
+`ConflictException` instead of overwriting the existing API, matching how KMS and Cognito treat
+duplicate override IDs.
+
 > [!NOTE]
 > API Gateway previously used a `_custom_id_` tag for this. It still works so existing setups keep
 > running, and it is now stripped from the returned tags the same way, but it is deprecated: prefer

--- a/src/main/java/io/github/hectorvent/floci/core/common/ReservedTags.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ReservedTags.java
@@ -13,9 +13,18 @@ public final class ReservedTags {
     public static final String OVERRIDE_ID_KEY = RESERVED_PREFIX + "override-id";
     public static final String OVERRIDE_COGNITO_CLIENT_ID_KEY = RESERVED_PREFIX + "override-cognito-client-id";
     public static final String OVERRIDE_COGNITO_CLIENT_SECRET_KEY = RESERVED_PREFIX + "override-cognito-client-secret";
+
+    /**
+     * API Gateway accepted a custom id through this key before {@link #OVERRIDE_ID_KEY} existed. It is
+     * API Gateway specific and deprecated: still honored on create, but no longer persisted in the
+     * resource tags. Other services never supported it and must not start reserving it.
+     */
+    public static final String DEPRECATED_API_GATEWAY_CUSTOM_ID_KEY = "_custom_id_";
+
     private static final String INVALID_PARAMETER_EXCEPTION = "InvalidParameterException";
     private static final String VALIDATION_EXCEPTION = "ValidationException";
     private static final String TAG_EXCEPTION = "TagException";
+    private static final String BAD_REQUEST_EXCEPTION = "BadRequestException";
     private static final String CONTROL_CHARACTER_ERROR_MESSAGE = "Override %s must not contain control characters.";
 
     private ReservedTags() {
@@ -27,6 +36,21 @@ public final class ReservedTags {
 
     public static String extractOverrideUserPoolId(Map<String, String> tags) {
         return getOverride(tags, OVERRIDE_ID_KEY, ReservedTags::validateOverrideId, "Resource ID", INVALID_PARAMETER_EXCEPTION);
+    }
+
+    /**
+     * API Gateway v1 and v2 override id. {@link #OVERRIDE_ID_KEY} wins when both keys are present, so a
+     * caller migrating off {@link #DEPRECATED_API_GATEWAY_CUSTOM_ID_KEY} can set both during a rollout.
+     * Uses {@code BadRequestException}, which is what CreateRestApi and CreateApi declare.
+     */
+    public static String extractOverrideApiId(Map<String, String> tags) {
+        String override = getOverride(tags, OVERRIDE_ID_KEY, ReservedTags::validateOverrideId,
+                "Resource ID", BAD_REQUEST_EXCEPTION);
+        if (override != null) {
+            return override;
+        }
+        return getOverride(tags, DEPRECATED_API_GATEWAY_CUSTOM_ID_KEY, ReservedTags::validateOverrideId,
+                "Resource ID", BAD_REQUEST_EXCEPTION);
     }
 
     public static String extractOverrideCognitoClientId(Map<String, String> tags) {
@@ -48,6 +72,36 @@ public final class ReservedTags {
             }
         });
         return stripped;
+    }
+
+    /**
+     * Like {@link #stripReservedTags(Map)} but also drops API Gateway's deprecated custom-id key, so an
+     * id override never survives into the tags the API returns.
+     */
+    public static Map<String, String> stripApiGatewayReservedTags(Map<String, String> tags) {
+        Map<String, String> stripped = stripReservedTags(tags);
+        stripped.remove(DEPRECATED_API_GATEWAY_CUSTOM_ID_KEY);
+        return stripped;
+    }
+
+    /**
+     * API Gateway update-path guard. An id override only makes sense at create time, so both the
+     * reserved keys and the deprecated custom-id key are rejected here, with API Gateway's declared
+     * error code rather than the {@code ValidationException} the shared guard uses.
+     */
+    public static void rejectApiGatewayReservedTagsOnUpdate(Map<String, String> tags) {
+        if (tags == null) {
+            return;
+        }
+        for (String key : tags.keySet()) {
+            if (isReserved(key) || DEPRECATED_API_GATEWAY_CUSTOM_ID_KEY.equals(key)) {
+                throw new AwsException(
+                        BAD_REQUEST_EXCEPTION,
+                        "Reserved tag key " + key + " can only be supplied during resource creation.",
+                        400
+                );
+            }
+        }
     }
 
     public static void rejectReservedTagsOnUpdate(Map<String, String> tags) {

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
@@ -175,6 +175,10 @@ public class ApiGatewayService {
 
         String customId = ReservedTags.extractOverrideApiId(tags);
         String apiId = customId != null ? customId : shortId(10);
+        if (apiStore.get(apiKey(region, apiId)).isPresent()) {
+            throw new AwsException("ConflictException",
+                    "REST API with id '" + apiId + "' already exists", 409);
+        }
 
         RestApi api = new RestApi();
         api.setId(apiId);

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.ReservedTags;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.apigateway.model.Account;
@@ -172,15 +173,15 @@ public class ApiGatewayService {
         Map<String, String> tags = request.get("tags") instanceof Map<?, ?> m
                 ? (Map<String, String>) m : new HashMap<>();
 
-        String customId = tags.get("_custom_id_");
-        String apiId = (customId != null && !customId.isBlank()) ? customId : shortId(10);
+        String customId = ReservedTags.extractOverrideApiId(tags);
+        String apiId = customId != null ? customId : shortId(10);
 
         RestApi api = new RestApi();
         api.setId(apiId);
         api.setName(name);
         api.setDescription(description);
         api.setCreatedDate(System.currentTimeMillis() / 1000L);
-        api.setTags(tags);
+        api.setTags(ReservedTags.stripApiGatewayReservedTags(tags));
 
         EndpointConfiguration endpointConfiguration = new EndpointConfiguration();
         if (request.get(EPC_KEY) instanceof Map<?, ?> epMap) {
@@ -1045,6 +1046,7 @@ public class ApiGatewayService {
     }
 
     public void tagResource(String region, String apiId, Map<String, String> tags) {
+        ReservedTags.rejectApiGatewayReservedTagsOnUpdate(tags);
         RestApi api = getRestApi(region, apiId);
         api.getTags().putAll(tags);
         apiStore.put(apiKey(region, apiId), api);

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
@@ -85,9 +85,14 @@ public class ApiGatewayV2Service {
         @SuppressWarnings("unchecked")
         Map<String, String> tags = (Map<String, String>) request.get("tags");
         String overrideId = ReservedTags.extractOverrideApiId(tags);
+        String apiId = overrideId != null ? overrideId : shortId(10);
+        if (apiStore.get(apiKey(region, apiId)).isPresent()) {
+            throw new AwsException("ConflictException",
+                    "API with id '" + apiId + "' already exists", 409);
+        }
 
         Api api = new Api();
-        api.setApiId(overrideId != null ? overrideId : shortId(10));
+        api.setApiId(apiId);
         api.setName(name);
         api.setProtocolType(protocolType);
         api.setCreatedDate(System.currentTimeMillis());

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.ReservedTags;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -81,8 +82,12 @@ public class ApiGatewayV2Service {
             routeSelectionExpression = "${request.method} ${request.path}";
         }
 
+        @SuppressWarnings("unchecked")
+        Map<String, String> tags = (Map<String, String>) request.get("tags");
+        String overrideId = ReservedTags.extractOverrideApiId(tags);
+
         Api api = new Api();
-        api.setApiId(shortId(10));
+        api.setApiId(overrideId != null ? overrideId : shortId(10));
         api.setName(name);
         api.setProtocolType(protocolType);
         api.setCreatedDate(System.currentTimeMillis());
@@ -96,10 +101,8 @@ public class ApiGatewayV2Service {
             api.setApiEndpoint(String.format("https://%s.execute-api.%s.amazonaws.com", api.getApiId(), region));
         }
 
-        @SuppressWarnings("unchecked")
-        Map<String, String> tags = (Map<String, String>) request.get("tags");
         if (tags != null) {
-            api.setTags(tags);
+            api.setTags(ReservedTags.stripApiGatewayReservedTags(tags));
         }
 
         @SuppressWarnings("unchecked")
@@ -162,6 +165,7 @@ public class ApiGatewayV2Service {
         if (request.containsKey("tags")) {
             @SuppressWarnings("unchecked")
             Map<String, String> tags = (Map<String, String>) request.get("tags");
+            ReservedTags.rejectApiGatewayReservedTagsOnUpdate(tags);
             api.setTags(tags);
         }
         if (request.containsKey("corsConfiguration")) {
@@ -884,6 +888,7 @@ public class ApiGatewayV2Service {
     }
 
     public void tagResource(String resourceArn, Map<String, String> tags) {
+        ReservedTags.rejectApiGatewayReservedTagsOnUpdate(tags);
         String[] parsed = parseArn(resourceArn);
         String region = parsed[0];
         String apiId  = parsed[1];

--- a/src/test/java/io/github/hectorvent/floci/core/common/ReservedTagsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/ReservedTagsTest.java
@@ -84,6 +84,116 @@ class ReservedTagsTest {
         assertEquals("ValidationException", exception.getErrorCode());
     }
 
+    // ──────────────────────────── API Gateway override id ────────────────────────────
+
+    @Test
+    void extractOverrideApiIdReturnsNullForNullInput() {
+        assertNull(ReservedTags.extractOverrideApiId(null));
+    }
+
+    @Test
+    void extractOverrideApiIdReturnsNullWhenNeitherKeyPresent() {
+        assertNull(ReservedTags.extractOverrideApiId(Map.of("env", "test")));
+    }
+
+    @Test
+    void extractOverrideApiIdReadsReservedOverrideKey() {
+        assertEquals("my-api", ReservedTags.extractOverrideApiId(
+                Map.of(ReservedTags.OVERRIDE_ID_KEY, "my-api", "env", "test")));
+    }
+
+    @Test
+    void extractOverrideApiIdFallsBackToDeprecatedCustomIdKey() {
+        assertEquals("legacy-api", ReservedTags.extractOverrideApiId(
+                Map.of(ReservedTags.DEPRECATED_API_GATEWAY_CUSTOM_ID_KEY, "legacy-api")));
+    }
+
+    @Test
+    void extractOverrideApiIdPrefersReservedKeyOverDeprecatedKey() {
+        assertEquals("winner", ReservedTags.extractOverrideApiId(Map.of(
+                ReservedTags.OVERRIDE_ID_KEY, "winner",
+                ReservedTags.DEPRECATED_API_GATEWAY_CUSTOM_ID_KEY, "loser")));
+    }
+
+    @Test
+    void extractOverrideApiIdRejectsBlankValueWithApiGatewayErrorCode() {
+        AwsException exception = assertThrows(
+                AwsException.class,
+                () -> ReservedTags.extractOverrideApiId(Map.of(ReservedTags.OVERRIDE_ID_KEY, "   "))
+        );
+
+        assertEquals("BadRequestException", exception.getErrorCode());
+        assertEquals(400, exception.getHttpStatus());
+    }
+
+    @Test
+    void extractOverrideApiIdRejectsUnsupportedCharacters() {
+        for (String bad : new String[] {"has/slash", "has?query", "has#fragment"}) {
+            AwsException exception = assertThrows(
+                    AwsException.class,
+                    () -> ReservedTags.extractOverrideApiId(Map.of(ReservedTags.OVERRIDE_ID_KEY, bad)),
+                    "expected rejection for " + bad
+            );
+            assertEquals("BadRequestException", exception.getErrorCode());
+        }
+    }
+
+    @Test
+    void extractOverrideApiIdValidatesTheDeprecatedKeyToo() {
+        AwsException exception = assertThrows(
+                AwsException.class,
+                () -> ReservedTags.extractOverrideApiId(
+                        Map.of(ReservedTags.DEPRECATED_API_GATEWAY_CUSTOM_ID_KEY, "has/slash"))
+        );
+
+        assertEquals("BadRequestException", exception.getErrorCode());
+    }
+
+    @Test
+    void stripApiGatewayReservedTagsRemovesBothOverrideKeys() {
+        Map<String, String> tags = new LinkedHashMap<>();
+        tags.put("env", "test");
+        tags.put(ReservedTags.OVERRIDE_ID_KEY, "my-api");
+        tags.put(ReservedTags.DEPRECATED_API_GATEWAY_CUSTOM_ID_KEY, "legacy-api");
+        tags.put("team", "platform");
+
+        assertEquals(Map.of("env", "test", "team", "platform"),
+                ReservedTags.stripApiGatewayReservedTags(tags));
+    }
+
+    @Test
+    void stripReservedTagsLeavesDeprecatedCustomIdForOtherServices() {
+        // _custom_id_ is API Gateway specific. KMS and Cognito use the shared strip and must keep it.
+        Map<String, String> tags = Map.of(ReservedTags.DEPRECATED_API_GATEWAY_CUSTOM_ID_KEY, "legacy-api");
+
+        assertEquals(tags, ReservedTags.stripReservedTags(tags));
+    }
+
+    @Test
+    void rejectApiGatewayReservedTagsOnUpdateAllowsNormalTags() {
+        assertDoesNotThrow(() -> ReservedTags.rejectApiGatewayReservedTagsOnUpdate(Map.of("env", "test")));
+        assertDoesNotThrow(() -> ReservedTags.rejectApiGatewayReservedTagsOnUpdate(null));
+    }
+
+    @Test
+    void rejectApiGatewayReservedTagsOnUpdateRejectsBothOverrideKeys() {
+        for (String key : new String[] {
+                ReservedTags.OVERRIDE_ID_KEY, ReservedTags.DEPRECATED_API_GATEWAY_CUSTOM_ID_KEY}) {
+            AwsException exception = assertThrows(
+                    AwsException.class,
+                    () -> ReservedTags.rejectApiGatewayReservedTagsOnUpdate(Map.of(key, "too-late")),
+                    "expected rejection for " + key
+            );
+            assertEquals("BadRequestException", exception.getErrorCode());
+        }
+    }
+
+    @Test
+    void rejectReservedTagsOnUpdateIgnoresDeprecatedCustomIdForOtherServices() {
+        assertDoesNotThrow(() -> ReservedTags.rejectReservedTagsOnUpdate(
+                Map.of(ReservedTags.DEPRECATED_API_GATEWAY_CUSTOM_ID_KEY, "legacy-api")));
+    }
+
     @Test
     void rejectUnknownReservedTagsRejectsReservedTagsWithUserPoolTaggingException() {
         AwsException exception = assertThrows(

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayIntegrationTest.java
@@ -373,12 +373,12 @@ class ApiGatewayIntegrationTest {
                 .statusCode(404);
     }
 
-    // ──────────────────────────── _custom_id_ tag ────────────────────────────
+    // ──────────────────────────── _custom_id_ tag (deprecated) ────────────────────────────
 
     @Test @Order(50)
     void createRestApi_customIdTag_usesTagValueAsApiId() {
         String body = """
-                {"name":"custom-id-api","tags":{"_custom_id_":"MYCUSTOMNAME"}}
+                {"name":"custom-id-api","tags":{"_custom_id_":"MYCUSTOMNAME","env":"test"}}
                 """;
         given()
                 .contentType(ContentType.JSON)
@@ -387,7 +387,9 @@ class ApiGatewayIntegrationTest {
                 .then()
                 .statusCode(201)
                 .body("id", equalTo("MYCUSTOMNAME"))
-                .body("tags._custom_id_", equalTo("MYCUSTOMNAME"));
+                // The override key is consumed, not persisted; unrelated tags survive.
+                .body("tags._custom_id_", nullValue())
+                .body("tags.env", equalTo("test"));
     }
 
     @Test @Order(51)
@@ -400,10 +402,88 @@ class ApiGatewayIntegrationTest {
                 .body("name", equalTo("custom-id-api"));
     }
 
+    // ──────────────────────────── floci:override-id tag ────────────────────────────
+
     @Test @Order(52)
+    void createRestApi_flociOverrideIdTag_usesTagValueAsApiId() {
+        String body = """
+                {"name":"override-id-api","tags":{"floci:override-id":"MYOVERRIDEID"}}
+                """;
+        given()
+                .contentType(ContentType.JSON)
+                .body(body)
+                .when().post("/restapis")
+                .then()
+                .statusCode(201)
+                .body("id", equalTo("MYOVERRIDEID"))
+                .body("tags._custom_id_", nullValue())
+                .body("tags.'floci:override-id'", nullValue());
+    }
+
+    @Test @Order(53)
+    void createRestApi_bothOverrideKeys_prefersFlociOverrideId() {
+        String body = """
+                {"name":"both-keys-api","tags":{"floci:override-id":"WINNER","_custom_id_":"LOSER"}}
+                """;
+        given()
+                .contentType(ContentType.JSON)
+                .body(body)
+                .when().post("/restapis")
+                .then()
+                .statusCode(201)
+                .body("id", equalTo("WINNER"));
+    }
+
+    @Test @Order(54)
+    void createRestApi_blankOverrideId_isRejected() {
+        String body = """
+                {"name":"blank-override-api","tags":{"floci:override-id":"   "}}
+                """;
+        given()
+                .contentType(ContentType.JSON)
+                .body(body)
+                .when().post("/restapis")
+                .then()
+                .statusCode(400)
+                .body("message", containsString("must not be blank"));
+    }
+
+    @Test @Order(55)
+    void createRestApi_overrideIdWithPathSeparator_isRejected() {
+        String body = """
+                {"name":"bad-override-api","tags":{"floci:override-id":"has/slash"}}
+                """;
+        given()
+                .contentType(ContentType.JSON)
+                .body(body)
+                .when().post("/restapis")
+                .then()
+                .statusCode(400)
+                .body("message", containsString("unsupported characters"));
+    }
+
+    @Test @Order(56)
+    void getRestApi_flociOverrideId_resolvesById() {
+        given()
+                .when().get("/restapis/MYOVERRIDEID")
+                .then()
+                .statusCode(200)
+                .body("id", equalTo("MYOVERRIDEID"))
+                .body("name", equalTo("override-id-api"));
+    }
+
+    @Test @Order(58)
     void deleteRestApi_customId() {
         given()
                 .when().delete("/restapis/MYCUSTOMNAME")
+                .then()
+                .statusCode(202);
+        given()
+                .when().delete("/restapis/MYOVERRIDEID")
+                .then()
+                .statusCode(202);
+        given()
+                .when().delete("/restapis/WINNER")
                 .then()
                 .statusCode(202);
     }

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayIntegrationTest.java
@@ -463,6 +463,26 @@ class ApiGatewayIntegrationTest {
     }
 
     @Test @Order(56)
+    void createRestApi_duplicateOverrideId_isRejectedWithConflict() {
+        String body = """
+                {"name":"duplicate-override-api","tags":{"floci:override-id":"MYOVERRIDEID"}}
+                """;
+        given()
+                .contentType(ContentType.JSON)
+                .body(body)
+                .when().post("/restapis")
+                .then()
+                .statusCode(409)
+                .body("message", containsString("already exists"));
+        // The original API is untouched.
+        given()
+                .when().get("/restapis/MYOVERRIDEID")
+                .then()
+                .statusCode(200)
+                .body("name", equalTo("override-id-api"));
+    }
+
+    @Test @Order(57)
     void getRestApi_flociOverrideId_resolvesById() {
         given()
                 .when().get("/restapis/MYOVERRIDEID")

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2IntegrationTest.java
@@ -330,4 +330,86 @@ class ApiGatewayV2IntegrationTest {
                 .then()
                 .statusCode(404);
     }
+
+    // ──────────────────────────── Override IDs ────────────────────────────
+
+    @Test @Order(100)
+    void createApi_deprecatedCustomIdTag_usesTagValueAsApiId() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"custom-id-api","protocolType":"HTTP","tags":{"_custom_id_":"MYV2CUSTOM","env":"test"}}
+                        """)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .body("apiId", equalTo("MYV2CUSTOM"))
+                .body("tags._custom_id_", nullValue())
+                .body("tags.env", equalTo("test"));
+    }
+
+    @Test @Order(101)
+    void createApi_flociOverrideIdTag_usesTagValueAsApiId() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"override-id-api","protocolType":"HTTP","tags":{"floci:override-id":"MYV2OVERRIDE"}}
+                        """)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .body("apiId", equalTo("MYV2OVERRIDE"))
+                .body("tags.'floci:override-id'", nullValue());
+    }
+
+    @Test @Order(102)
+    void createApi_blankOverrideId_isRejected() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"blank-override","protocolType":"HTTP","tags":{"floci:override-id":"  "}}
+                        """)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test @Order(103)
+    void getApi_overrideId_resolvesById() {
+        given()
+                .when().get("/v2/apis/MYV2CUSTOM")
+                .then()
+                .statusCode(200)
+                .body("apiId", equalTo("MYV2CUSTOM"));
+    }
+
+    @Test @Order(104)
+    void tagApi_withOverrideKey_isRejectedAfterCreation() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"tags":{"floci:override-id":"TOOLATE"}}
+                        """)
+                .when().post("/v2/tags/arn:aws:apigateway:us-east-1::/apis/MYV2OVERRIDE")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test @Order(105)
+    void tagApi_withDeprecatedCustomIdKey_isRejectedAfterCreation() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"tags":{"_custom_id_":"TOOLATE"}}
+                        """)
+                .when().post("/v2/tags/arn:aws:apigateway:us-east-1::/apis/MYV2OVERRIDE")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test @Order(106)
+    void deleteApis_customAndOverrideId() {
+        given().when().delete("/v2/apis/MYV2CUSTOM").then().statusCode(204);
+        given().when().delete("/v2/apis/MYV2OVERRIDE").then().statusCode(204);
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2IntegrationTest.java
@@ -375,6 +375,24 @@ class ApiGatewayV2IntegrationTest {
     }
 
     @Test @Order(103)
+    void createApi_duplicateOverrideId_isRejectedWithConflict() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"duplicate-override","protocolType":"HTTP","tags":{"floci:override-id":"MYV2OVERRIDE"}}
+                        """)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(409)
+                .body("message", containsString("already exists"));
+        given()
+                .when().get("/v2/apis/MYV2OVERRIDE")
+                .then()
+                .statusCode(200)
+                .body("name", equalTo("override-id-api"));
+    }
+
+    @Test @Order(104)
     void getApi_overrideId_resolvesById() {
         given()
                 .when().get("/v2/apis/MYV2CUSTOM")
@@ -383,7 +401,7 @@ class ApiGatewayV2IntegrationTest {
                 .body("apiId", equalTo("MYV2CUSTOM"));
     }
 
-    @Test @Order(104)
+    @Test @Order(105)
     void tagApi_withOverrideKey_isRejectedAfterCreation() {
         given()
                 .contentType(ContentType.JSON)
@@ -395,7 +413,7 @@ class ApiGatewayV2IntegrationTest {
                 .statusCode(400);
     }
 
-    @Test @Order(105)
+    @Test @Order(106)
     void tagApi_withDeprecatedCustomIdKey_isRejectedAfterCreation() {
         given()
                 .contentType(ContentType.JSON)
@@ -407,7 +425,7 @@ class ApiGatewayV2IntegrationTest {
                 .statusCode(400);
     }
 
-    @Test @Order(106)
+    @Test @Order(107)
     void deleteApis_customAndOverrideId() {
         given().when().delete("/v2/apis/MYV2CUSTOM").then().statusCode(204);
         given().when().delete("/v2/apis/MYV2OVERRIDE").then().statusCode(204);


### PR DESCRIPTION
## Summary

Continues @Marcel2603's work in #1593, rebased onto current `main` and re-implemented against the
per-service extractor pattern that #1486 introduced after that PR was opened. Original commit is
carried as a co-author.

API IDs are generated randomly, so endpoint URLs change on every recreate. v1 accepted an
undocumented `_custom_id_` tag and echoed it back as a normal tag; v2 had no override mechanism at
all. Other services (KMS, Cognito) already pin IDs through the reserved `floci:override-id` tag.

- `CreateRestApi` (v1) and `CreateApi` (v2) both accept `floci:override-id`
- override keys are consumed rather than stored, so they no longer appear in the returned tags
- values are validated instead of used verbatim
- supplying either override key to `TagResource` is rejected, since an ID cannot change after creation
- `_custom_id_` still works as a deprecated fallback and is now stripped too; `floci:override-id` wins
  when both are present, so callers can set both during a migration

```bash
aws apigateway create-rest-api \
  --name my-api \
  --tags '{"floci:override-id":"my-fixed-id","env":"test"}' \
  --endpoint-url http://localhost:4566
# reachable at the stable id "my-fixed-id"; "env" is kept, the override key is not returned
```

Closes #1593

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Reserved-tag ID overrides are a Floci testing affordance, not an AWS API, so the wire-contract
question here is the error code. Verified against `service-2.json` for both services:

- `BadRequestException` is declared by `CreateRestApi`, `CreateApi`, and `TagResource` on
  [apigateway](https://github.com/boto/botocore/blob/develop/botocore/data/apigateway/2015-07-09/service-2.json)
  and [apigatewayv2](https://github.com/boto/botocore/blob/develop/botocore/data/apigatewayv2/2018-11-29/service-2.json),
  so that is what both the create and tag paths raise.
- The shared `rejectReservedTagsOnUpdate` helper raises `ValidationException`, which **neither**
  service declares. Reusing it would have produced an error code SDK clients cannot map to a typed
  exception, so API Gateway gets its own guard rather than sharing that one.

Validation now runs through `ReservedTags.getOverride`, which rejects blank values, whitespace,
control characters, and `/`, `?`, `#`. Those last three would produce an API at an unreachable
endpoint URL, so failing fast on create is better than succeeding into a broken resource.

## Notes on scope

`_custom_id_` is kept **API Gateway specific**. The earlier approach reserved it globally by
extending `ReservedTags.isReserved`, which would also have stripped it from KMS keys and Cognito
pools and started rejecting it on their updates. Only those two services call the shared helpers and
neither uses the key, but silently changing their tag behaviour is out of scope here, so this adds
`stripApiGatewayReservedTags` / `rejectApiGatewayReservedTagsOnUpdate` instead. Two tests pin that
boundary by asserting the shared helpers still treat `_custom_id_` as an ordinary tag.

Tagging is v2-only in Floci (`POST /v2/tags/{resourceArn}`); v1's `ApiGatewayService.tagResource` is
not wired to a route, so its guard is defensive and the update-rejection tests live in the v2 suite
where the endpoint exists.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

### Validation

`./mvnw test -Dtest='ReservedTagsTest,ApiGateway*Test,Kms*Test,Cognito*Test,CloudFormation*Test'`
→ **1165 tests, 0 failures**. The KMS and Cognito suites are included deliberately since they share
`ReservedTags`.

One existing assertion changed: `createRestApi_customIdTag_usesTagValueAsApiId` previously asserted
`tags._custom_id_` was echoed back. It now asserts the key is absent and that an unrelated tag in the
same request survives.
