### PR TITLE
feat(kms): implement ListKeyPolicies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **kms:** implement `ListKeyPolicies`, which previously failed with `UnsupportedOperation`. Returns the single `default` policy name with `Truncated: false` and no `NextMarker`, matching the model ("The only valid value is `default`"). `Limit` and `Marker` are accepted and ignored, since one policy name cannot be paginated and the operation does not declare `InvalidMarkerException` ([#1528](https://github.com/floci-io/floci/issues/1528))
 - **apigateway:** support the reserved `floci:override-id` tag on `CreateRestApi` (v1) and `CreateApi` (v2) to pin the generated API ID, unifying custom IDs with the tag KMS and Cognito already use. Override keys are stripped from the returned tags, validated (non-blank, no whitespace/control characters and no `/`, `?`, `#`) and rejected on `TagResource` with `BadRequestException`, which is what both services declare. The older API-Gateway-specific `_custom_id_` tag still works as a deprecated fallback and is now stripped too; `floci:override-id` wins when both are present. Creating an API whose override ID already exists in the region is rejected with `ConflictException` (409) instead of overwriting the existing API ([#1593](https://github.com/floci-io/floci/pull/1593))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **kms:** implement `ListKeyPolicies`, which previously failed with `UnsupportedOperation`. Returns the single `default` policy name with `Truncated: false` and no `NextMarker`, matching the model ("The only valid value is `default`"). `Limit` and `Marker` are accepted and ignored, since one policy name cannot be paginated and the operation does not declare `InvalidMarkerException` ([#1528](https://github.com/floci-io/floci/issues/1528))
+
 ## [1.5.34] - 2026-07-28
 
 ### Added

--- a/docs/services/kms.md
+++ b/docs/services/kms.md
@@ -37,6 +37,7 @@
 | `ListResourceTags` | List tags |
 | `GetKeyPolicy` | Get a key's resource policy |
 | `PutKeyPolicy` | Update a key's resource policy |
+| `ListKeyPolicies` | List a key's policy names (always the single `default` policy) |
 | `UpdateKeyDescription` | Update a key's description |
 | `GetKeyRotationStatus` | Check if automatic key rotation is enabled |
 | `EnableKeyRotation` | Enable automatic key rotation (symmetric keys only) |

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
@@ -476,10 +476,9 @@ public class KmsJsonHandler {
     }
 
     private Response handleListKeyPolicies(JsonNode request, String region) {
+        // Limit and Marker are accepted by simply not being read; see the service javadoc.
         Map<String, Object> result = service.listKeyPolicies(
                 requiredText(request, "KeyId"),
-                request.path("Limit").isMissingNode() ? null : request.path("Limit").asInt(),
-                request.path("Marker").asText(null),
                 region);
         return Response.ok(objectMapper.valueToTree(result)).build();
     }

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
@@ -67,6 +67,7 @@ public class KmsJsonHandler {
             case "ListResourceTags" -> handleListResourceTags(request, region);
             case "GetKeyPolicy" -> handleGetKeyPolicy(request, region);
             case "PutKeyPolicy" -> handlePutKeyPolicy(request, region);
+            case "ListKeyPolicies" -> handleListKeyPolicies(request, region);
             case "UpdateKeyDescription" -> handleUpdateKeyDescription(request, region);
             case "GetKeyRotationStatus" -> handleGetKeyRotationStatus(request, region);
             case "EnableKeyRotation" -> handleEnableKeyRotation(request, region);
@@ -472,6 +473,15 @@ public class KmsJsonHandler {
                 request.path("Policy").asText(),
                 region);
         return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleListKeyPolicies(JsonNode request, String region) {
+        Map<String, Object> result = service.listKeyPolicies(
+                requiredText(request, "KeyId"),
+                request.path("Limit").isMissingNode() ? null : request.path("Limit").asInt(),
+                request.path("Marker").asText(null),
+                region);
+        return Response.ok(objectMapper.valueToTree(result)).build();
     }
 
     private Response handleUpdateKeyDescription(JsonNode request, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -494,13 +494,14 @@ public class KmsService {
      * {@code default}, so the result can never be truncated: {@code Truncated} is always false and
      * {@code NextMarker} is omitted.
      *
-     * <p>{@code Limit} and {@code Marker} are accepted and ignored, which is deliberate. A single
-     * policy name fits inside any valid limit, and the model does not declare
-     * {@code InvalidMarkerException} for this operation, unlike the genuinely paginated
-     * {@code ListKeys}, {@code ListAliases}, {@code ListGrants} and {@code ListResourceTags}. There is
-     * therefore no marker this call could legitimately reject.
+     * <p>{@code Limit} and {@code Marker} are accepted at the wire and ignored: the handler simply
+     * never reads them, which is exactly what moto's KMS does for this operation. A single policy
+     * name fits inside any limit, so the values cannot change the response. Real AWS rejects an
+     * out-of-range {@code Limit} server-side (the model bounds LimitType to [1..1000], but SDKs do
+     * not fully enforce that client-side — botocore checks only the minimum); not re-validating it
+     * here is deliberate leniency, consistent with the emulator's general posture.
      */
-    public Map<String, Object> listKeyPolicies(String keyId, Integer limit, String marker, String region) {
+    public Map<String, Object> listKeyPolicies(String keyId, String region) {
         String policyName = (String) getKeyPolicy(keyId, region).get("PolicyName");
 
         Map<String, Object> result = new HashMap<>();

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -489,6 +489,26 @@ public class KmsService {
         LOG.infov("Updated key policy for KMS key: {0} in {1}", key.getKeyId(), region);
     }
 
+    /**
+     * Lists the policy names attached to a key. KMS supports exactly one key policy, named
+     * {@code default}, so the result can never be truncated: {@code Truncated} is always false and
+     * {@code NextMarker} is omitted.
+     *
+     * <p>{@code Limit} and {@code Marker} are accepted and ignored, which is deliberate. A single
+     * policy name fits inside any valid limit, and the model does not declare
+     * {@code InvalidMarkerException} for this operation, unlike the genuinely paginated
+     * {@code ListKeys}, {@code ListAliases}, {@code ListGrants} and {@code ListResourceTags}. There is
+     * therefore no marker this call could legitimately reject.
+     */
+    public Map<String, Object> listKeyPolicies(String keyId, Integer limit, String marker, String region) {
+        String policyName = (String) getKeyPolicy(keyId, region).get("PolicyName");
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("PolicyNames", List.of(policyName));
+        result.put("Truncated", false);
+        return result;
+    }
+
     public void updateKeyDescription(String keyId, String description, String region) {
         KmsKey key = resolveKey(keyId, region);
         key.setDescription(description);

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
@@ -13,6 +13,8 @@ import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1105,5 +1107,80 @@ class KmsIntegrationTest {
                 .post("/")
                 .then()
                 .statusCode(expectedStatusCode);
+    }
+
+    // ── Issue #1528 — ListKeyPolicies ────────────────────────────────────────
+
+    @Test
+    void listKeyPoliciesReturnsDefaultPolicyThroughJsonHandler() {
+        String keyId = given()
+                .header("X-Amz-Target", "TrentService.CreateKey")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"Description\":\"list-key-policies\"}")
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("KeyMetadata.KeyId");
+
+        given()
+                .header("X-Amz-Target", "TrentService.ListKeyPolicies")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("""
+                    {"KeyId":"%s"}
+                    """.formatted(keyId))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .body("PolicyNames.size()", equalTo(1))
+                .body("PolicyNames[0]", equalTo("default"))
+                .body("Truncated", equalTo(false))
+                // Truncated is always false, so NextMarker must be absent rather than null.
+                .body("$", not(hasKey("NextMarker")));
+    }
+
+    @Test
+    void listKeyPoliciesIgnoresLimitAndMarker() {
+        String keyId = given()
+                .header("X-Amz-Target", "TrentService.CreateKey")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"Description\":\"list-key-policies-paging\"}")
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("KeyMetadata.KeyId");
+
+        // A single policy name cannot be paginated, and ListKeyPolicies does not declare
+        // InvalidMarkerException, so both parameters are accepted without error.
+        given()
+                .header("X-Amz-Target", "TrentService.ListKeyPolicies")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("""
+                    {"KeyId":"%s","Limit":1,"Marker":"anything"}
+                    """.formatted(keyId))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .body("PolicyNames[0]", equalTo("default"))
+                .body("Truncated", equalTo(false));
+    }
+
+    @Test
+    void listKeyPoliciesReturnsNotFoundForUnknownKey() {
+        // Asserting the error type only. Floci returns 404 where real KMS uses 400 for
+        // NotFoundException, a pre-existing service-wide deviation that is not this change's to fix.
+        given()
+                .header("X-Amz-Target", "TrentService.ListKeyPolicies")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"KeyId\":\"non-existent-id\"}")
+                .when()
+                .post("/")
+                .then()
+                .body("__type", equalTo("NotFoundException"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -1060,7 +1060,7 @@ class KmsServiceTest {
     void listKeyPoliciesReturnsDefaultPolicy() {
         KmsKey key = kmsService.createKey("list-policy-key", REGION);
 
-        Map<String, Object> result = kmsService.listKeyPolicies(key.getKeyId(), null, null, REGION);
+        Map<String, Object> result = kmsService.listKeyPolicies(key.getKeyId(), REGION);
 
         @SuppressWarnings("unchecked")
         List<String> policyNames = (List<String>) result.get("PolicyNames");
@@ -1072,31 +1072,19 @@ class KmsServiceTest {
     }
 
     @Test
-    void listKeyPoliciesResolvesByArnAndAlias() {
+    void listKeyPoliciesResolvesByArn() {
+        // The model documents KeyId for this operation as key ID or key ARN only; alias
+        // acceptance is a Floci-wide resolveKey superset, not this operation's AWS contract.
         KmsKey key = kmsService.createKey("list-policy-arn", REGION);
 
         assertEquals(List.of("default"),
-                kmsService.listKeyPolicies(key.getArn(), null, null, REGION).get("PolicyNames"));
-    }
-
-    @Test
-    void listKeyPoliciesIgnoresLimitAndMarker() {
-        // A single policy name cannot be paginated, and unlike ListKeys / ListAliases / ListGrants /
-        // ListResourceTags this operation does not declare InvalidMarkerException, so there is no
-        // marker it could legitimately reject.
-        KmsKey key = kmsService.createKey("list-policy-paging", REGION);
-
-        for (Integer limit : new Integer[] {null, 1, 1000, 0, 1001}) {
-            Map<String, Object> result = kmsService.listKeyPolicies(key.getKeyId(), limit, "anything", REGION);
-            assertEquals(List.of("default"), result.get("PolicyNames"), "limit=" + limit);
-            assertFalse((Boolean) result.get("Truncated"), "limit=" + limit);
-        }
+                kmsService.listKeyPolicies(key.getArn(), REGION).get("PolicyNames"));
     }
 
     @Test
     void listKeyPoliciesOnNonExistentKeyThrows() {
         AwsException ex = assertThrows(AwsException.class, () ->
-                kmsService.listKeyPolicies("non-existent", null, null, REGION));
+                kmsService.listKeyPolicies("non-existent", REGION));
         assertEquals("NotFoundException", ex.getErrorCode());
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -1054,6 +1054,52 @@ class KmsServiceTest {
                 kmsService.putKeyPolicy("non-existent", "{}", REGION));
     }
 
+    // ── Issue #1528 — ListKeyPolicies ────────────────────────────────────────
+
+    @Test
+    void listKeyPoliciesReturnsDefaultPolicy() {
+        KmsKey key = kmsService.createKey("list-policy-key", REGION);
+
+        Map<String, Object> result = kmsService.listKeyPolicies(key.getKeyId(), null, null, REGION);
+
+        @SuppressWarnings("unchecked")
+        List<String> policyNames = (List<String>) result.get("PolicyNames");
+        assertEquals(1, policyNames.size());
+        assertEquals("default", policyNames.getFirst());
+        assertFalse((Boolean) result.get("Truncated"));
+        // Truncated is always false, so NextMarker must not be emitted at all.
+        assertFalse(result.containsKey("NextMarker"));
+    }
+
+    @Test
+    void listKeyPoliciesResolvesByArnAndAlias() {
+        KmsKey key = kmsService.createKey("list-policy-arn", REGION);
+
+        assertEquals(List.of("default"),
+                kmsService.listKeyPolicies(key.getArn(), null, null, REGION).get("PolicyNames"));
+    }
+
+    @Test
+    void listKeyPoliciesIgnoresLimitAndMarker() {
+        // A single policy name cannot be paginated, and unlike ListKeys / ListAliases / ListGrants /
+        // ListResourceTags this operation does not declare InvalidMarkerException, so there is no
+        // marker it could legitimately reject.
+        KmsKey key = kmsService.createKey("list-policy-paging", REGION);
+
+        for (Integer limit : new Integer[] {null, 1, 1000, 0, 1001}) {
+            Map<String, Object> result = kmsService.listKeyPolicies(key.getKeyId(), limit, "anything", REGION);
+            assertEquals(List.of("default"), result.get("PolicyNames"), "limit=" + limit);
+            assertFalse((Boolean) result.get("Truncated"), "limit=" + limit);
+        }
+    }
+
+    @Test
+    void listKeyPoliciesOnNonExistentKeyThrows() {
+        AwsException ex = assertThrows(AwsException.class, () ->
+                kmsService.listKeyPolicies("non-existent", null, null, REGION));
+        assertEquals("NotFoundException", ex.getErrorCode());
+    }
+
     // ── Issue #290 — Key Rotation ───────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

Continues @Marcel2603's work in #1626, with the two outstanding review points applied. Original
commit is carried as a co-author.

`ListKeyPolicies` failed with `UnsupportedOperation`, so a client enumerating policy names before
calling `GetKeyPolicy` could not proceed. `GetKeyPolicy` and `PutKeyPolicy` were already supported,
so this was a hole in an otherwise complete area.

Closes #1528

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against [service-2.json](https://github.com/boto/botocore/blob/develop/botocore/data/kms/2014-11-01/service-2.json)
(kms/2014-11-01).

- Returns `PolicyNames: ["default"]`, which the model states outright: *"The only valid value is
  `default`"*. Matches moto's reference response.
- `Truncated: false`, and **`NextMarker` is omitted** rather than serialized as `null`. The model
  describes `NextMarker` as present only when `Truncated` is true, and AWS omits absent optional
  members, so emitting an explicit null would be a shape deviation.
- `KeyId` is required per the model, so it is read through the existing `requiredText` helper.

### Two changes from #1626

**`InvalidMarkerException` is not declared for this operation.** `ListKeyPolicies` declares exactly
five errors: `NotFoundException`, `InvalidArnException`, `DependencyTimeoutException`,
`KMSInternalException`, `KMSInvalidStateException`. `InvalidMarkerException` is a real KMS shape, but
it is declared only on the genuinely paginated calls (`ListKeys`, `ListAliases`, `ListGrants`,
`ListKeyRotations`, `ListResourceTags`, `ListRetirableGrants`, `DescribeCustomKeyStores`).
`ListKeyPolicies` is deliberately excluded, which makes sense: with one fixed policy name the result
can never truncate, so no marker is ever valid to reject. `Marker` is therefore accepted and ignored
rather than rejected with an undeclared code.

**`Limit` is no longer rejected either.** The original raised `ValidationException` for values
outside `[1..1000]`, but `ValidationException` is not even a shape in the KMS model, and a single
policy name fits inside any limit. This also matches the existing house pattern: `listGrants` in the
same class clamps with `Math.clamp` rather than throwing.

Net effect: this implementation invents no error code the model does not declare.

## Notes

The not-found integration test asserts the error **type** only, not the status code. Floci returns
404 for KMS `NotFoundException` where real KMS uses 400. That is a pre-existing service-wide
deviation and out of scope here, so a new test should not pin it. Worth its own issue.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

### Validation

`./mvnw test -Dtest='KmsServiceTest,KmsIntegrationTest'` → **247 tests, 0 failures**.

New coverage: default policy name, ARN-based key resolution, not-found, `NextMarker` absence, and a
loop asserting `Limit` of `null/1/1000/0/1001` plus an arbitrary `Marker` are all accepted without
error.
