### PR TITLE
chore: add an advisory open-PR limit notice

### DIFF
--- a/.github/workflows/pr-limit.yml
+++ b/.github/workflows/pr-limit.yml
@@ -1,0 +1,112 @@
+name: PR Limit Notice
+
+# Advisory guard: contributors may have at most 5 open PRs at a time. When one
+# is opened (or reopened) beyond that, this posts a polite reminder and adds
+# the `over-pr-limit` label. It never closes PRs or fails checks.
+#
+# Exempt: bot accounts (dependabot alone may hold many PRs) and maintainers
+# (OWNER/MEMBER/COLLABORATOR association). The label is removed automatically
+# only when this same PR is re-evaluated while the author is back under the
+# limit; stale labels on other PRs are cleaned up manually by maintainers.
+
+on:
+  # pull_request_target so the token has write access on fork PRs. This
+  # workflow never checks out or executes PR code — it only calls the GitHub
+  # API — so the elevated context is not exposed.
+  pull_request_target:
+    types: [opened, reopened]
+  # Manual test hook: evaluate an arbitrary PR (bypasses the exemptions).
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to evaluate'
+        required: true
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  # github.ref is the base branch under pull_request_target, so key on the PR
+  # number instead — otherwise every PR run would cancel every other.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+env:
+  PR_LIMIT: 5
+  LABEL: over-pr-limit
+
+jobs:
+  check-pr-limit:
+    name: Check author open-PR count
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Manual dispatch skips exemptions (it is a maintainer-driven test).
+    # Over-exempting via author_association is fine: the check is advisory.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.user.type != 'Bot' &&
+       !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association))
+
+    steps:
+      - name: Evaluate open-PR count and notify
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_AUTHOR: ${{ github.event.pull_request.user.login }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            PR_NUMBER="$INPUT_PR_NUMBER"
+            AUTHOR=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json author --jq .author.login)
+          else
+            PR_NUMBER="$EVENT_PR_NUMBER"
+            AUTHOR="$EVENT_AUTHOR"
+          fi
+
+          # Live list endpoint, not the search API — search indexing lags and
+          # can miss the PR that was just opened. The count includes the
+          # current PR, so "max 5 open" triggers at COUNT > 5.
+          COUNT=$(gh pr list --repo "$GITHUB_REPOSITORY" --author "$AUTHOR" \
+                    --state open --limit 100 --json number --jq 'length')
+          echo "Author $AUTHOR has $COUNT open PR(s); limit is $PR_LIMIT."
+
+          if [ "$COUNT" -le "$PR_LIMIT" ]; then
+            gh api -X DELETE \
+              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/$LABEL" \
+              > /dev/null 2>&1 || true
+            exit 0
+          fi
+
+          # Ensure the label exists (idempotent; self-heals if deleted).
+          gh label create "$LABEL" --repo "$GITHUB_REPOSITORY" --force \
+            --color fbca04 \
+            --description "Author has more than $PR_LIMIT open PRs — advisory only"
+
+          gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "$LABEL"
+
+          # Post the notice at most once per PR: skip when the marker comment
+          # already exists (e.g. the PR was closed and reopened).
+          if gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+               --paginate --jq '.[].body' | grep -qF 'pr-limit-notice'; then
+            echo "Notice already posted; skipping comment."
+            exit 0
+          fi
+
+          PR_LIST_URL="https://github.com/$GITHUB_REPOSITORY/pulls?q=is%3Apr+is%3Aopen+author%3A$AUTHOR"
+
+          # One paragraph per line: GitHub renders a single newline in a
+          # comment as a hard line break.
+          BODY=$(cat <<EOF
+          <!-- pr-limit-notice -->
+          👋 Thanks for the pull request!
+
+          It looks like you now have **$COUNT open pull requests** in this repository, which is above our advisory limit of **$PR_LIMIT**. To keep the review backlog focused and make sure every contribution gets proper attention, we ask contributors to shepherd their existing PRs to the finish line before opening new ones — responding to review feedback, rebasing, or closing any that are no longer needed.
+
+          Here is [your list of open PRs]($PR_LIST_URL). Nothing is blocked and this PR stays open — this is just a friendly nudge. The \`$LABEL\` label helps maintainers see at a glance which PRs to prioritize.
+
+          If some of these PRs are stacked or intentionally related, just say so here and a maintainer will take that into account.
+          EOF
+          )
+
+          gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$BODY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,9 +151,10 @@ Always implement the **real AWS wire protocol** — never invent custom endpoint
 
 1. Branch off `main`: `git checkout -b feature/my-feature`
 2. Open a PR targeting `main`.
-3. CI runs tests automatically — all checks must pass before merge.v
+3. CI runs tests automatically — all checks must pass before merge.
 4. Keep PRs focused — one feature or fix per PR.
 5. Reference any related issues in the PR description.
+6. Keep at most **5 open PRs** at a time. A bot leaves an advisory note and an `over-pr-limit` label on PRs opened beyond that — nothing gets closed or blocked, but please land or close your existing PRs before opening more.
 
 Docker images are never built on contributor PRs, so merging to `main` is always cheap.
 
@@ -187,10 +188,6 @@ git push origin release/1.1.x
 1. Fix on `main` via the normal PR process.
 2. Cherry-pick the merge commit onto the relevant `release/x.y.x` branch and push.
 3. If the bug only affects a release branch, open a PR directly against that branch.
-
-### Edge builds
-
-The `edge.yml` workflow publishes a JVM-only `floci/floci:edge` image from `main` every Monday at 00:00 UTC. It can also be triggered manually from the Actions tab.
 
 ## Testing Policy for Pull Requests
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -100,6 +100,8 @@ Quick summary:
 - [ ] New or updated integration test added
 - [ ] Commit messages follow Conventional Commits
 
+Please keep at most **5 open PRs** at a time — a bot leaves an advisory note (label `over-pr-limit`) on PRs opened beyond that. See [CONTRIBUTING.md](https://github.com/floci-io/floci/blob/main/CONTRIBUTING.md#pull-request-guidelines) for details.
+
 ## Reporting Security Issues
 
 Do **not** open public issues for security vulnerabilities. Use [GitHub private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) instead.


### PR DESCRIPTION
## Summary

Adds an advisory guard for contributors holding many open PRs at once. The review backlog is long
enough that one author with a large stack makes it harder for any single PR to get proper attention,
so this is a nudge rather than a gate.

On `opened` or `reopened`, a workflow counts the author's open PRs. Above five it adds an
`over-pr-limit` label and posts one comment linking their open PRs. It **never closes a PR and never
fails a check** — both code paths exit zero. Bots and maintainers are exempt, so dependabot can hold
as many as it needs.

The policy is documented in `CONTRIBUTING.md` and `docs/contributing.md`.

Also drops the `CONTRIBUTING.md` edge-builds section: it described the `edge.yml` workflow removed in
#691 and was the last remaining reference to it. Fixes a stray character in the adjacent CI line while
there.

### Details worth reviewing

- **`pull_request_target`** is used so the token can label PRs from forks. The workflow never checks
  out or executes PR code, it only calls the GitHub API, so the elevated context is not exposed to
  untrusted input.
- **Live `gh pr list`, not the search API**, because search indexing lags and can miss the PR that was
  just opened. The count includes the current PR, so the notice triggers at `COUNT > 5`.
- **Comment posted at most once per PR**, guarded by a `<!-- pr-limit-notice -->` marker, so a
  close/reopen cycle does not re-notify.
- **Label self-heals** via `gh label create --force`, and is removed automatically when the author is
  re-evaluated back under the limit. Stale labels on other PRs are cleaned up manually; that is called
  out in the workflow header.
- **Concurrency keys on the PR number** rather than `github.ref`, since under `pull_request_target`
  the ref is the base branch and every PR run would otherwise cancel every other.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

Not applicable. No emulated service, wire protocol, request or response shape is touched. The change
is a GitHub Actions workflow plus contributor documentation.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

The two test boxes are deliberately unticked rather than ticked inaccurately: this change touches no
Java, so the suite is unaffected and running it proves nothing about the change. Validation done
instead was parsing the workflow YAML and running `bash -n` over the extracted 54-line `run` block,
both clean. The `workflow_dispatch` hook exists so the notice can be exercised against a chosen PR
before relying on the `opened` trigger.
