### PR TITLE
fix(codebuild): stabilize start and retry responses

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildService.java
@@ -448,10 +448,11 @@ public class CodeBuildService {
         build.setPhases(new CopyOnWriteArrayList<>());
 
         buildsFor(region).put(buildId, build);
+        Build responseBuild = copyBuild(build);
 
         runner.startBuild(region, build, project, buildspecOverride);
 
-        return build;
+        return responseBuild;
     }
 
     public Build getBuild(String region, String buildId) {
@@ -502,5 +503,28 @@ public class CodeBuildService {
         return startBuild(region, account, original.getProjectName(),
                 null, original.getEnvironment(), original.getArtifacts(),
                 null, original.getTimeoutInMinutes(), null, null);
+    }
+
+    private Build copyBuild(Build source) {
+        Build copy = new Build();
+        copy.setId(source.getId());
+        copy.setArn(source.getArn());
+        copy.setBuildNumber(source.getBuildNumber());
+        copy.setBuildStatus(source.getBuildStatus());
+        copy.setBuildComplete(source.getBuildComplete());
+        copy.setCurrentPhase(source.getCurrentPhase());
+        copy.setProjectName(source.getProjectName());
+        copy.setInitiator(source.getInitiator());
+        copy.setStartTime(source.getStartTime());
+        copy.setEndTime(source.getEndTime());
+        copy.setSource(source.getSource());
+        copy.setArtifacts(source.getArtifacts());
+        copy.setEnvironment(source.getEnvironment());
+        copy.setLogs(source.getLogs());
+        copy.setPhases(source.getPhases() != null ? new ArrayList<>(source.getPhases()) : null);
+        copy.setTimeoutInMinutes(source.getTimeoutInMinutes());
+        copy.setQueuedTimeoutInMinutes(source.getQueuedTimeoutInMinutes());
+        copy.setEncryptionKey(source.getEncryptionKey());
+        return copy;
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/codebuild/CodeBuildServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/codebuild/CodeBuildServicePersistenceTest.java
@@ -5,6 +5,7 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.codebuild.model.Build;
 import io.github.hectorvent.floci.services.codebuild.model.Project;
 import io.github.hectorvent.floci.services.codebuild.model.ProjectArtifacts;
 import io.github.hectorvent.floci.services.codebuild.model.ProjectEnvironment;
@@ -20,6 +21,8 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -82,6 +85,38 @@ class CodeBuildServicePersistenceTest {
         assertNull(reloaded.batchGetProjects(REGION, List.of("p2")).stream().findFirst().orElse(null));
     }
 
+    @Test
+    void startAndRetryBuildResponsesUseAcceptedBuildSnapshot() {
+        CodeBuildRunner runner = mock(CodeBuildRunner.class);
+        doAnswer(invocation -> {
+            Build build = invocation.getArgument(1, Build.class);
+            build.setBuildStatus("FAILED");
+            build.setBuildComplete(true);
+            build.setCurrentPhase("COMPLETED");
+            return null;
+        }).when(runner).startBuild(any(), any(), any(), any());
+
+        CodeBuildService service = serviceWithStorage(new SharedStorageFactory(), runner);
+        service.createProject(REGION, ACCOUNT, "p1", "demo",
+                source("NO_SOURCE"), null, null, artifacts("NO_ARTIFACTS"), null,
+                new ProjectEnvironment(), "arn:aws:iam::" + ACCOUNT + ":role/cb",
+                null, null, null, null, null, null, null);
+
+        Build startResponse = service.startBuild(REGION, ACCOUNT, "p1", null,
+                null, null, null, null, null, null);
+        assertEquals("IN_PROGRESS", startResponse.getBuildStatus());
+        assertEquals(false, startResponse.getBuildComplete());
+        assertEquals("SUBMITTED", startResponse.getCurrentPhase());
+        assertEquals("FAILED", service.getBuild(REGION, startResponse.getId()).getBuildStatus());
+
+        Build retryResponse = service.retryBuild(REGION, ACCOUNT, startResponse.getId());
+        assertEquals("IN_PROGRESS", retryResponse.getBuildStatus());
+        assertEquals(false, retryResponse.getBuildComplete());
+        assertEquals("SUBMITTED", retryResponse.getCurrentPhase());
+        assertTrue(retryResponse.getBuildNumber() > startResponse.getBuildNumber());
+        assertEquals("FAILED", service.getBuild(REGION, retryResponse.getId()).getBuildStatus());
+    }
+
     private static ProjectSource source(String type) {
         ProjectSource s = new ProjectSource();
         s.setType(type);
@@ -95,8 +130,12 @@ class CodeBuildServicePersistenceTest {
     }
 
     private static CodeBuildService serviceWithStorage(StorageFactory storage) {
+        return serviceWithStorage(storage, mock(CodeBuildRunner.class));
+    }
+
+    private static CodeBuildService serviceWithStorage(StorageFactory storage, CodeBuildRunner runner) {
         CodeBuildService service = new CodeBuildService(
-                mock(CodeBuildRunner.class), mock(EmulatorConfig.class), storage);
+                runner, mock(EmulatorConfig.class), storage);
         service.initializeStorage();
         return service;
     }


### PR DESCRIPTION
## Summary

`StartBuild` and `RetryBuild` returned the same mutable `Build` object that the asynchronous runner
updates. A fast local build could therefore reach a terminal state before the HTTP response was
serialized, making an accepted request appear to have failed synchronously.

This change captures a detached response snapshot before starting the runner while keeping the
stored build live for later `BatchGetBuilds` calls.

## Type of change

- [x] Bug fix (non-breaking change)

## AWS compatibility

AWS returns a `Build` object from both `StartBuild` and `RetryBuild`. Its lifecycle fields describe
the build state represented by that response, while subsequent reads can observe later asynchronous
state.

Floci now returns a stable accepted response with `buildStatus: IN_PROGRESS`,
`buildComplete: false`, and `currentPhase: SUBMITTED`. The stored build then advances through the
normal runner lifecycle independently. This avoids imposing a later phase on the response when the
AWS API contract does not require one deterministic immediate phase.

Sources:

- https://docs.aws.amazon.com/codebuild/latest/APIReference/API_StartBuild.html
- https://docs.aws.amazon.com/codebuild/latest/APIReference/API_RetryBuild.html
- https://docs.aws.amazon.com/codebuild/latest/APIReference/API_Build.html

## Verification

- `mise exec java@25 -- ./mvnw test -Dtest=CodeBuildServicePersistenceTest`
- Regression coverage forces the runner to mutate the stored build immediately and verifies stable
  `StartBuild` and `RetryBuild` responses.
- `git diff --check`

## Checklist

- [x] The change follows the project style guidelines.
- [x] The change has been self-reviewed.
- [x] A focused regression test proves the fix.
- [x] No new endpoints or custom wire formats were introduced.
