### PR TITLE
fix(cloudformation): AWS::IAM::ManagedPolicy exposes PolicyArn for Fn::GetAtt

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -2155,7 +2155,13 @@ public class CloudFormationResourceProvisioner {
         var policy = iamService.createPolicy(policyName, "/", null, document, Map.of());
         r.getAttributes().put(ROLLBACK_OWNED_ATTR, "true");
         r.setPhysicalId(policy.getArn());
+        // PolicyArn is the attribute CloudFormation documents for this type, and what a template
+        // written against AWS asks for. Without it Fn::GetAtt does not resolve and the unresolved
+        // literal reaches whatever consumed it — a role's ManagedPolicyArns, typically, which then
+        // fails with "policy does not exist" and rolls the stack back. "Arn" stays for callers
+        // already using it.
         r.getAttributes().put("Arn", policy.getArn());
+        r.getAttributes().put("PolicyArn", policy.getArn());
         r.getAttributes().put("ManagedPolicyRoleTargets", String.join("\n", roleNames));
 
         LinkedHashSet<String> attachedRoleNames = new LinkedHashSet<>();

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIamAttachmentProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIamAttachmentProvisionerTest.java
@@ -190,6 +190,28 @@ class CloudFormationIamAttachmentProvisionerTest {
     }
 
     @Test
+    void managedPolicyExposesPolicyArnForGetAtt() {
+        // PolicyArn is the attribute CloudFormation documents for AWS::IAM::ManagedPolicy. Without
+        // it Fn::GetAtt does not resolve and the unresolved literal reaches the consuming resource.
+        String policyArn = "arn:aws:iam::" + ACCOUNT_ID + ":policy/test-policy";
+        IamPolicy policy = new IamPolicy();
+        policy.setArn(policyArn);
+        when(iamService.createPolicy("test-policy", "/", null, policyDocument(), Map.of()))
+                .thenReturn(policy);
+
+        StackResource result = provision("ManagedPolicy", "AWS::IAM::ManagedPolicy", """
+                {
+                  "ManagedPolicyName": "test-policy",
+                  "PolicyDocument": {"Version": "2012-10-17", "Statement": []}
+                }
+                """);
+
+        assertEquals(policyArn, result.getAttributes().get("PolicyArn"));
+        assertEquals(policyArn, result.getAttributes().get("Arn"));
+        assertEquals(policyArn, result.getPhysicalId());
+    }
+
+    @Test
     void cleanupFailureDoesNotMaskPrimaryFailureOrSkipDeletion() {
         IamRole role = role("cleanup-role");
         when(iamService.createRole("cleanup-role", "/", emptyTrustPolicy(), null, 3600, Map.of()))


### PR DESCRIPTION
Fixes #2082. (Refiles #2055, which was closed for having no description.)

CloudFormation documents `PolicyArn` as the `Fn::GetAtt` attribute for `AWS::IAM::ManagedPolicy`. The provisioner recorded the created policy only under `Arn`, so `Fn::GetAtt [<policy>, PolicyArn]` did not resolve and the unresolved literal propagated into whatever consumed it — typically a role's `ManagedPolicyArns`, which then failed with `Policy <logicalId>.PolicyArn does not exist` and rolled the stack back, several resources away from the cause.

Both keys are now recorded. `Arn` stays so anything already reading it is unaffected.

Test: `managedPolicyExposesPolicyArnForGetAtt` in `CloudFormationIamAttachmentProvisionerTest` asserts the provisioned resource carries `PolicyArn`, `Arn` and the physical id. 28 tests in that class pass.

Found while deploying a CDK-authored estate to Floci for aws-bench, where this rolled back the stack that creates the benchmark's QA roles.