### PR TITLE
feat: Add AWSCloudFormationReadOnlyAccess as a managed policy.

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
@@ -56,6 +56,8 @@ final class AwsManagedPolicies {
                 "Provides permissions required to use the CloudWatch agent on servers."),
         new ManagedPolicyDef("AWSLambdaFullAccess", "/",
                 "Provides full access to Lambda, S3, DynamoDB, CloudWatch Metrics and Logs."),
+        new ManagedPolicyDef("AWSCloudFormationReadOnlyAccess", "/",
+                "Provides read only access to Cloud Control and CloudFormation."),
         new ManagedPolicyDef("AWSCloudFormationFullAccess", "/",
                 "Provides full access to AWS CloudFormation."),
         new ManagedPolicyDef("AWSXRayDaemonWriteAccess", "/",

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamManagedPolicyAccountScopeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamManagedPolicyAccountScopeTest.java
@@ -82,6 +82,7 @@ class IamManagedPolicyAccountScopeTest {
                 .map(AwsManagedPolicies.ManagedPolicyDef::arn)
                 .toList();
         assertTrue(arns.contains(AwsManagedPolicies.ARN_PREFIX + "/AWSXRayDaemonWriteAccess"));
+        assertTrue(arns.contains(AwsManagedPolicies.ARN_PREFIX + "/AWSCloudFormationReadOnlyAccess"));
         assertTrue(arns.contains(AwsManagedPolicies.ARN_PREFIX + "/AWSCloudFormationFullAccess"));
         assertTrue(arns.contains(AwsManagedPolicies.ARN_PREFIX + "/AmazonElasticFileSystemClientFullAccess"));
     }


### PR DESCRIPTION
## Summary

Adds AWSCloudFormationReadOnlyAccess

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

