### PR TITLE
feat(iam): seed AWSCloudFormationReadOnlyAccess

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
@@ -62,6 +62,10 @@ final class AwsManagedPolicies {
                 "Allows write permissions to the AWS X-Ray daemon."),
         new ManagedPolicyDef("AmazonElasticFileSystemClientFullAccess", "/",
                 "Provides root client access to an Amazon EFS file system."),
+        // Attached by the roles `cdk bootstrap` creates, so without it the CDKToolkit stack
+        // rolls back and no CDK app can be deployed.
+        new ManagedPolicyDef("AWSCloudFormationReadOnlyAccess", "/",
+                "Provides access to AWS CloudFormation via the AWS Management Console."),
         new ManagedPolicyDef("AWSCloudTrail_FullAccess", "/",
                 "Provides full access to AWS CloudTrail."),
         new ManagedPolicyDef("AWSCloudTrail_ReadOnlyAccess", "/",

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
@@ -590,6 +590,12 @@ class IamServiceTest {
         assertTrue(admin.getPolicyId().startsWith("ANPA"));
         assertEquals("v1", admin.getDefaultVersionId());
 
+        // Attached by the roles `cdk bootstrap` creates; without it CDKToolkit rolls back.
+        IamPolicy cfnReadOnly = iamService.getPolicy(
+                "arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess");
+        assertEquals("AWSCloudFormationReadOnlyAccess", cfnReadOnly.getPolicyName());
+        assertEquals("/", cfnReadOnly.getPath());
+
         IamPolicy lambda = iamService.getPolicy(
                 "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole");
         assertEquals("AWSLambdaBasicExecutionRole", lambda.getPolicyName());


### PR DESCRIPTION
Fixes #2058.

`cdk bootstrap` attaches this AWS-managed policy to the roles in its CDKToolkit stack. The catalog did not carry it, so bootstrap failed with `Policy arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess does not exist.` and rolled back — blocking every CDK deployment against the emulator, since bootstrap is a prerequisite.

`AdministratorAccess` and `ReadOnlyAccess` were already seeded; this is the remaining one bootstrap needs.

Test: `seedAwsManagedPolicies` now asserts the policy resolves with path `/`. 59 tests in `IamServiceTest` pass.
