### PR TITLE
fix(s3): accept a percent-encoded bucket/key separator in copy sources

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -1923,15 +1923,8 @@ public class S3Controller {
 
     private Response handleCopyObject(String copySource, String destBucket, String destKey,
                                       String contentType, HttpHeaders httpHeaders) {
-        // copySource format: /bucket/key or bucket/key, where key is URL-encoded
-        String source = copySource.startsWith("/") ? copySource.substring(1) : copySource;
-
-        int slashIndex = source.indexOf('/');
-        if (slashIndex <= 0) {
-            throw new AwsException("InvalidArgument", "Invalid copy source: " + copySource, 400);
-        }
-        String sourceBucket = decodeCopySourceComponent(source.substring(0, slashIndex), copySource);
-        ParsedCopySource sourceObject = parseCopySourceObject(source.substring(slashIndex + 1), copySource);
+        CopySourceRef sourceObject = parseCopySource(copySource);
+        String sourceBucket = sourceObject.bucket();
         String copyContentEncoding = toPersistedContentEncoding(httpHeaders.getHeaderString("Content-Encoding"));
         String copyContentDisposition = httpHeaders.getHeaderString("Content-Disposition");
         String copyCacheControl = httpHeaders.getHeaderString("Cache-Control");
@@ -1982,15 +1975,8 @@ public class S3Controller {
 
     private Response handleUploadPartCopy(String copySource, String destBucket, String destKey,
                                            String uploadId, int partNumber, HttpHeaders httpHeaders) {
-        // copySource format: /bucket/key or bucket/key, where key is URL-encoded
-        String source = copySource.startsWith("/") ? copySource.substring(1) : copySource;
-
-        int slashIndex = source.indexOf('/');
-        if (slashIndex <= 0) {
-            throw new AwsException("InvalidArgument", "Invalid copy source: " + copySource, 400);
-        }
-        String sourceBucket = decodeCopySourceComponent(source.substring(0, slashIndex), copySource);
-        ParsedCopySource sourceObject = parseCopySourceObject(source.substring(slashIndex + 1), copySource);
+        CopySourceRef sourceObject = parseCopySource(copySource);
+        String sourceBucket = sourceObject.bucket();
         String copySourceRange = httpHeaders.getHeaderString("x-amz-copy-source-range");
         String eTag = s3Service.uploadPartCopy(destBucket, destKey, uploadId, partNumber,
                 sourceBucket, sourceObject.objectKey(), sourceObject.versionId(), copySourceRange,
@@ -2877,6 +2863,72 @@ public class S3Controller {
     }
 
     /**
+     * Splits a raw {@code x-amz-copy-source} header into decoded source bucket, object key and optional
+     * {@code versionId}. Shared by {@code CopyObject} and {@code UploadPartCopy}.
+     *
+     * <p>The bucket/key separator may arrive as a literal {@code '/'} or percent-encoded as {@code %2F}:
+     * the AWS SDK for .NET encodes the whole copy source, so a v4 client sends
+     * {@code bucket%2Ffolder%2Fkey.txt} with no literal slash at all. Both forms name the same object, so
+     * whichever separator appears first delimits the bucket. Bucket names admit neither {@code '/'} nor
+     * {@code '%'}, so the first occurrence of either is unambiguously the separator and never part of the
+     * bucket name.
+     *
+     * <p>The split still happens before decoding, so an encoded {@code %2F} inside the key stays key
+     * content instead of being promoted to a path separator. {@code parseCopySourceObject} documents how
+     * the remainder is split into key and {@code versionId}.
+     *
+     * @param copySource raw header value, with or without a leading separator
+     * @return decoded bucket, key and {@code versionId} ({@code null} version when absent)
+     * @throws AwsException {@code InvalidArgument} when no separator follows a non-empty bucket, or when a
+     *                      component is not valid percent-encoding
+     */
+    private CopySourceRef parseCopySource(String copySource) {
+        String source = stripLeadingSeparator(copySource);
+        int separator = indexOfBucketSeparator(source);
+        if (separator <= 0) {
+            throw new AwsException("InvalidArgument", "Invalid copy source: " + copySource, 400);
+        }
+        int keyStart = separator + (source.charAt(separator) == '/' ? 1 : 3);
+        String bucket = decodeCopySourceComponent(source.substring(0, separator), copySource);
+        ParsedCopySource object = parseCopySourceObject(source.substring(keyStart), copySource);
+        return new CopySourceRef(bucket, object.objectKey(), object.versionId());
+    }
+
+    /** Drops the optional leading separator, in either its literal or percent-encoded form. */
+    private static String stripLeadingSeparator(String copySource) {
+        if (copySource.startsWith("/")) {
+            return copySource.substring(1);
+        }
+        if (indexOfEncodedSlash(copySource) == 0) {
+            return copySource.substring(3);
+        }
+        return copySource;
+    }
+
+    /** Index of the bucket/key separator: the first literal {@code '/'} or {@code %2F}, or -1 if neither. */
+    private static int indexOfBucketSeparator(String source) {
+        int literal = source.indexOf('/');
+        int encoded = indexOfEncodedSlash(source);
+        if (literal < 0) {
+            return encoded;
+        }
+        if (encoded < 0) {
+            return literal;
+        }
+        return Math.min(literal, encoded);
+    }
+
+    /** Index of the first {@code %2F} or {@code %2f} sequence, or -1 when there is none. */
+    private static int indexOfEncodedSlash(String source) {
+        for (int i = source.indexOf('%'); i >= 0 && i + 2 < source.length(); i = source.indexOf('%', i + 1)) {
+            if (source.charAt(i + 1) == '2' && (source.charAt(i + 2) == 'F' || source.charAt(i + 2) == 'f')) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
      * Splits the raw {@code CopyObject}/{@code UploadPartCopy} copy-source remainder into decoded S3 object
      * key and optional source {@code versionId}.
      * <ul>
@@ -2940,5 +2992,8 @@ public class S3Controller {
     }
 
     private record ParsedCopySource(String objectKey, String versionId) {
+    }
+
+    private record CopySourceRef(String bucket, String objectKey, String versionId) {
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -480,6 +480,64 @@ class S3IntegrationTest {
     }
 
     @Test
+    @Order(119)
+    void copyObjectWithPercentEncodedBucketSeparatorSucceeds() {
+        // The AWS SDK for .NET percent-encodes the whole copy source, so a v4 client sends
+        // "bucket%2Ffolder%2Fkey.txt" with no literal slash anywhere in the header.
+        String bucket = "copy-encoded-separator-bucket";
+        String srcKey = "folder/file.txt";
+
+        given().put("/" + bucket).then().statusCode(200);
+        given()
+            .contentType("text/plain")
+            .body("encoded separator")
+        .when()
+            .put("/" + bucket + "/" + srcKey)
+        .then()
+            .statusCode(200);
+
+        // Fully encoded, no leading separator: the .NET wire format.
+        given()
+            .header("x-amz-copy-source", bucket + "%2Ffolder%2Ffile.txt")
+        .when()
+            .put("/" + bucket + "/copied/dotnet.txt")
+        .then()
+            .statusCode(200)
+            .body(containsString("CopyObjectResult"));
+
+        // Lowercase %2f, and a leading encoded separator, name the same object.
+        given()
+            .header("x-amz-copy-source", "%2F" + bucket + "%2ffolder%2ffile.txt")
+        .when()
+            .put("/" + bucket + "/copied/lowercase.txt")
+        .then()
+            .statusCode(200)
+            .body(containsString("CopyObjectResult"));
+
+        // Mixed: encoded bucket separator, literal slash inside the key.
+        given()
+            .header("x-amz-copy-source", bucket + "%2Ffolder/file.txt")
+        .when()
+            .put("/" + bucket + "/copied/mixed.txt")
+        .then()
+            .statusCode(200)
+            .body(containsString("CopyObjectResult"));
+
+        for (String copied : new String[] {"dotnet", "lowercase", "mixed"}) {
+            given()
+            .when()
+                .get("/" + bucket + "/copied/" + copied + ".txt")
+            .then()
+                .statusCode(200)
+                .body(equalTo("encoded separator"));
+            given().delete("/" + bucket + "/copied/" + copied + ".txt");
+        }
+
+        given().delete("/" + bucket + "/" + srcKey);
+        given().delete("/" + bucket);
+    }
+
+    @Test
     @Order(120)
     void copyObjectWithQuestionMarkInSourceKeySucceeds() {
         String sourceBucket = "copy-question-source-bucket";
@@ -550,6 +608,15 @@ class S3IntegrationTest {
         .then()
             .statusCode(400)
             .body(containsString("InvalidArgument"));
+
+        // Decoding still rejects a malformed key reached through an encoded separator.
+        given()
+            .header("x-amz-copy-source", "test-bucket%2F%ZZinvalid")
+        .when()
+            .put("/test-bucket/dest-key")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidArgument"));
     }
 
     @Test
@@ -557,6 +624,23 @@ class S3IntegrationTest {
     void copyObjectWithEmptyBucketReturns400() {
         given()
             .header("x-amz-copy-source", "/key-only-no-bucket")
+        .when()
+            .put("/test-bucket/dest-key")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidArgument"));
+
+        // A source with no separator at all names no bucket, encoded form included.
+        given()
+            .header("x-amz-copy-source", "key-only-no-bucket")
+        .when()
+            .put("/test-bucket/dest-key")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidArgument"));
+
+        given()
+            .header("x-amz-copy-source", "%2Fkey-only-no-bucket")
         .when()
             .put("/test-bucket/dest-key")
         .then()

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
@@ -264,6 +264,7 @@ class S3MultipartIntegrationTest {
                 <CompleteMultipartUpload>
                     <Part><PartNumber>1</PartNumber><ETag>etag1</ETag></Part>
                     <Part><PartNumber>2</PartNumber><ETag>etag2</ETag></Part>
+                    <Part><PartNumber>3</PartNumber><ETag>etag3</ETag></Part>
                 </CompleteMultipartUpload>""";
         given()
             .contentType("application/xml")
@@ -273,13 +274,15 @@ class S3MultipartIntegrationTest {
         .then()
             .statusCode(200);
 
-        // Verify contents: full source + ranged slice
+        // Verify contents: full source, ranged slice, then the same slice copied
+        // through the percent-encoded separator. The last four bytes prove the
+        // encoded source resolved to the same object, not just that it returned 200.
         given()
         .when()
             .get("/" + BUCKET + "/copy-dest.bin")
         .then()
             .statusCode(200)
-            .body(equalTo("ABCDEFGHIJCDEF"));
+            .body(equalTo("ABCDEFGHIJCDEFCDEF"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
@@ -247,6 +247,18 @@ class S3MultipartIntegrationTest {
             .body(containsString("<CopyPartResult"))
             .body(containsString("<ETag>"));
 
+        // Percent-encoded bucket/key separator: the AWS SDK for .NET encodes the whole
+        // copy source, so the header carries no literal slash.
+        given()
+            .header("x-amz-copy-source", BUCKET + "%2Fsource-for-copy.bin")
+            .header("x-amz-copy-source-range", "bytes=2-5")
+        .when()
+            .put("/" + BUCKET + "/copy-dest.bin?uploadId=" + copyUploadId + "&partNumber=3")
+        .then()
+            .statusCode(200)
+            .body(containsString("<CopyPartResult"))
+            .body(containsString("<ETag>"));
+
         // Complete the upload
         String completeXml = """
                 <CompleteMultipartUpload>


### PR DESCRIPTION
## Summary

- Restores `CopyObject` and `UploadPartCopy` for the AWS SDK for .NET. That SDK percent-encodes the whole `x-amz-copy-source` value, so a v4 client sends `bucket%2Ffolder%2Fkey.txt` with no literal slash anywhere. Since 1.5.34 the bucket/key split runs on the raw header via `indexOf('/')`, finds no separator, and every copy from that SDK fails with 400 `InvalidArgument`.
- Wider than a nested-key problem: copies of top-level keys fail too, so on 1.5.34 no .NET `CopyObjectAsync` call succeeds at all.
- Treats whichever comes first, a literal `/` or an encoded `%2F`, as the bucket/key separator. Bucket names admit neither `/` nor `%`, so the first occurrence of either is unambiguously the separator and never part of the bucket name.
- Keeps the split before decoding, so #1924's behaviour is intact: an encoded slash inside a key stays key content, a literal `?` (raw or `%3F`) is still preserved, and `?versionId=` still parses as a query.
- Also fixes the mixed form `bucket%2Ffolder/key.txt`, which previously decoded the bucket as `bucket/folder`.
- Both handlers now share one `parseCopySource` helper instead of duplicating the split.

Closes #2038

## Reproduction

Ran a real `AWSSDK.S3` 4.0.101 client against the published images. Every copy below is a plain `CopyObjectAsync`:

| Key | 1.5.33-compat | 1.5.34-compat | this branch |
|-----|---------------|---------------|-------------|
| `folder/file.txt` | pass | 400 `InvalidArgument` | pass |
| `top.txt` | pass | 400 `InvalidArgument` | pass |
| `a/b/c/deep.txt` | pass | 400 `InvalidArgument` | pass |
| `folder/with space.txt` | pass | 400 `InvalidArgument` | pass |

The error message shows the wire format: `Invalid copy source: dotnet-movetest%2Ffolder%2Ffile.txt`.

The AWS CLI is unaffected because it sends literal slashes, which is why the compatibility suite did not catch this. There is no .NET SDK in the compat matrix.

## Changes

```
 .../hectorvent/floci/services/s3/S3Controller.java | 91 +++++++++++++++++-----
 .../floci/services/s3/S3IntegrationTest.java       | 84 ++++++++++++++++++++
 .../services/s3/S3MultipartIntegrationTest.java    | 12 +++
 3 files changed, 169 insertions(+), 18 deletions(-)
```

## Test plan

- [x] Full suite green: 8104 tests, 0 failures, 0 errors, 9 skipped
- [x] New `copyObjectWithPercentEncodedBucketSeparatorSucceeds` covers the fully-encoded .NET wire format, lowercase `%2f`, a leading encoded separator, and the mixed encoded-separator/literal-slash form, asserting copied content each time
- [x] `uploadPartCopy` extended with an encoded-separator part, since both handlers share the helper. The part is completed and its bytes asserted, so a parse resolving the wrong key fails on content rather than passing on status
- [x] `copyObjectWithMalformedEncodedSourceReturns400` extended with `bucket%2F%ZZinvalid`, confirming decoding still rejects malformed input reached through the new path
- [x] `copyObjectWithEmptyBucketReturns400` extended with the separator-less and `%2F`-leading forms, so a source naming no bucket is still a 400
- [x] Existing `copyObjectWithQuestionMarkInSourceKeySucceeds` (#1924 regression test) still passes unchanged
- [x] Real AWSSDK.S3 v4 client passes end-to-end against a patched build