### PR TITLE
feat(cloudcontrol): read EC2 instances, launch templates and instance profiles

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlService.java
@@ -5,6 +5,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.model.GroupIdentifier;
+import io.github.hectorvent.floci.services.ec2.model.Instance;
+import io.github.hectorvent.floci.services.ec2.model.LaunchTemplate;
+import io.github.hectorvent.floci.services.ec2.model.Reservation;
+import io.github.hectorvent.floci.services.iam.model.InstanceProfile;
 import io.github.hectorvent.floci.services.ec2.model.SecurityGroup;
 import io.github.hectorvent.floci.services.ec2.model.Subnet;
 import io.github.hectorvent.floci.services.ec2.model.Vpc;
@@ -45,8 +50,76 @@ public class CloudControlService {
             case "AWS::EC2::SecurityGroup" -> securityGroups(region);
             case "AWS::IAM::Role" -> roles();
             case "AWS::IAM::User" -> users();
+            case "AWS::EC2::Instance" -> instances(region);
+            case "AWS::EC2::LaunchTemplate" -> launchTemplates(region);
+            case "AWS::IAM::InstanceProfile" -> instanceProfiles();
             default -> List.of();
         };
+    }
+
+    /**
+     * Cloud Control reports a resource's current model, not an echo of what was asked for, so an
+     * instance has to carry the values only the running resource has — its addresses, its state,
+     * and the subnet and security groups it actually landed in. A caller that provisions through
+     * Cloud Control and then reads the resource back has no other way to reach them.
+     */
+    private List<ResourceDescription> instances(String region) {
+        List<ResourceDescription> resources = new ArrayList<>();
+        for (Reservation reservation : ec2Service.describeInstances(region, List.of(), Map.of())) {
+            for (Instance instance : reservation.getInstances()) {
+                ObjectNode properties = mapper.createObjectNode();
+                properties.put("InstanceId", instance.getInstanceId());
+                putIfPresent(properties, "ImageId", instance.getImageId());
+                putIfPresent(properties, "InstanceType", instance.getInstanceType());
+                putIfPresent(properties, "SubnetId", instance.getSubnetId());
+                putIfPresent(properties, "VpcId", instance.getVpcId());
+                putIfPresent(properties, "PrivateIp", instance.getPrivateIpAddress());
+                putIfPresent(properties, "PublicIp", instance.getPublicIpAddress());
+                putIfPresent(properties, "AvailabilityZone",
+                        instance.getPlacement() == null ? null : instance.getPlacement().getAvailabilityZone());
+                if (instance.getState() != null) {
+                    putIfPresent(properties, "State", instance.getState().getName());
+                }
+                if (instance.getSecurityGroups() != null && !instance.getSecurityGroups().isEmpty()) {
+                    var groups = properties.putArray("SecurityGroupIds");
+                    for (GroupIdentifier g : instance.getSecurityGroups()) {
+                        if (g.getGroupId() != null) groups.add(g.getGroupId());
+                    }
+                }
+                resources.add(new ResourceDescription(instance.getInstanceId(), propertiesString(properties)));
+            }
+        }
+        return resources;
+    }
+
+    private List<ResourceDescription> launchTemplates(String region) {
+        List<ResourceDescription> resources = new ArrayList<>();
+        for (LaunchTemplate lt : ec2Service.describeLaunchTemplates(region, List.of(), List.of(), Map.of())) {
+            ObjectNode properties = mapper.createObjectNode();
+            properties.put("LaunchTemplateId", lt.getLaunchTemplateId());
+            putIfPresent(properties, "LaunchTemplateName", lt.getLaunchTemplateName());
+            putIfPresent(properties, "LatestVersionNumber", lt.getLatestVersionNumber());
+            putIfPresent(properties, "DefaultVersionNumber", lt.getDefaultVersionNumber());
+            resources.add(new ResourceDescription(lt.getLaunchTemplateId(), propertiesString(properties)));
+        }
+        return resources;
+    }
+
+    private List<ResourceDescription> instanceProfiles() {
+        List<ResourceDescription> resources = new ArrayList<>();
+        for (InstanceProfile profile : iamService.listInstanceProfiles("/")) {
+            ObjectNode properties = mapper.createObjectNode();
+            properties.put("InstanceProfileName", profile.getInstanceProfileName());
+            putIfPresent(properties, "Arn", profile.getArn());
+            putIfPresent(properties, "Path", profile.getPath());
+            resources.add(new ResourceDescription(profile.getInstanceProfileName(), propertiesString(properties)));
+        }
+        return resources;
+    }
+
+    /** Cloud Control omits a property it has no value for rather than reporting a null. */
+    private static void putIfPresent(ObjectNode node, String name, String value) {
+        if (value != null && !value.isBlank()) node.put(name, value);
     }
 
     private List<ResourceDescription> s3Buckets() {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlIntegrationTest.java
@@ -86,6 +86,26 @@ class CloudControlIntegrationTest {
         assertListed("AWS::IAM::Role", "CloudControlRole", "RoleName");
     }
 
+    @Test
+    void listResourcesReportsAnInstancesRuntimeModel() {
+        // Cloud Control reports a resource's current model, not an echo of the desired state, so
+        // an instance has to carry what only the running resource knows — its addresses and the
+        // subnet it landed in. A caller that provisions through Cloud Control and reads back has
+        // no other route to them.
+        String instanceId = given()
+                .formParam("Action", "RunInstances")
+                .formParam("ImageId", "ami-0abcdef1234567890")
+                .formParam("InstanceType", "t3.micro")
+                .formParam("MinCount", "1")
+                .formParam("MaxCount", "1")
+                .header("Authorization", EC2_AUTH)
+                .when().post("/")
+                .then().statusCode(200)
+                .extract().path("RunInstancesResponse.instancesSet.item.instanceId");
+
+        assertListed("AWS::EC2::Instance", instanceId, "InstanceType");
+    }
+
     private void assertListed(String typeName, String identifier, String propertyName) {
         assertListed(typeName, identifier, propertyName, "application/x-amz-json-1.1");
     }


### PR DESCRIPTION
Refs #2043 (partial).

`ListResources` covered six types; `AWS::EC2::Instance`, `AWS::EC2::LaunchTemplate` and `AWS::IAM::InstanceProfile` were not among them, so a caller that provisions one through Cloud Control could not read it back — and a tool whose AWS provider reaches these types only through its Cloud Control proxy could not observe its own estate at all.

Cloud Control reports a resource's *current* model rather than an echo of the desired state, so an instance carries what only the running resource knows: private and public addresses, state, availability zone, and the subnet and security groups it actually landed in. A property with no value is omitted rather than reported as null, matching Cloud Control.

`GetResource` reads through the same list, so it resolves these types once the list does.

This addresses the missing-types half of #2043. It does **not** address the other half — making an unsupported type distinguishable from a supported type with no resources — which needs a decision about what Cloud Control should return for a type it has no schema for.

Test: `listResourcesReportsAnInstancesRuntimeModel` runs an instance and asserts Cloud Control lists it with its model. 436 tests across the Cloud Control, EC2 and IAM suites pass.