### PR TITLE
fix(pipes): register kafka-clients reflection metadata for native image

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/pipes/PipesKafkaConsumerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesKafkaConsumerManager.java
@@ -144,6 +144,10 @@ public class PipesKafkaConsumerManager {
         properties.put(ConsumerConfig.GROUP_ID_CONFIG, resolveConsumerGroupId(pipe, params));
         properties.put(ConsumerConfig.CLIENT_ID_CONFIG, "floci-pipes-" + UUID.randomUUID());
         properties.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, Integer.toString(resolveBatchSize(pipe, 100)));
+        // On by default (KIP-714). Floci has no reason to push metrics to a user's broker, and it
+        // makes the shaded protobuf serializer reflectively reachable on a path no broker we test
+        // against exercises.
+        properties.put(ConsumerConfig.ENABLE_METRICS_PUSH_CONFIG, "false");
         return properties;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/pipes/PipesKafkaConsumerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesKafkaConsumerManager.java
@@ -131,13 +131,12 @@ public class PipesKafkaConsumerManager {
         return resolveConsumerGroupId(pipe, kafkaParameters(pipe));
     }
 
-    private KafkaConsumer<byte[], byte[]> createConsumer(Pipe pipe) {
-        String bootstrapServers = resolveBootstrapServers(pipe);
-        String topicName = resolveTopicName(pipe);
+    /** Package-private so {@code PipesKafkaNativeSupportTest} guards the real settings, not a copy. */
+    Properties consumerProperties(Pipe pipe) {
         JsonNode params = kafkaParameters(pipe);
 
         Properties properties = new Properties();
-        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, resolveBootstrapServers(pipe));
         properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
@@ -145,11 +144,17 @@ public class PipesKafkaConsumerManager {
         properties.put(ConsumerConfig.GROUP_ID_CONFIG, resolveConsumerGroupId(pipe, params));
         properties.put(ConsumerConfig.CLIENT_ID_CONFIG, "floci-pipes-" + UUID.randomUUID());
         properties.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, Integer.toString(resolveBatchSize(pipe, 100)));
+        return properties;
+    }
+
+    private KafkaConsumer<byte[], byte[]> createConsumer(Pipe pipe) {
+        Properties properties = consumerProperties(pipe);
+        String topicName = resolveTopicName(pipe);
 
         KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(properties);
         consumer.subscribe(List.of(topicName));
         LOG.infov("Pipe {0}: subscribed Kafka consumer to topic {1} via {2}",
-                pipe.getName(), topicName, bootstrapServers);
+                pipe.getName(), topicName, properties.get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
         return consumer;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/pipes/PipesKafkaNativeSupport.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesKafkaNativeSupport.java
@@ -5,8 +5,6 @@ import org.apache.kafka.clients.consumer.CooperativeStickyAssignor;
 import org.apache.kafka.clients.consumer.RangeAssignor;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.utils.AppInfoParser;
-import org.apache.kafka.shaded.com.google.protobuf.ExtensionRegistry;
 
 /**
  * Registers the kafka-clients classes that GraalVM cannot discover statically.
@@ -17,10 +15,13 @@ import org.apache.kafka.shaded.com.google.protobuf.ExtensionRegistry;
  * consumer that cannot be constructed. {@link PipesPoller} logs that failure and moves on, leaving
  * a Kafka or MSK pipe reported as RUNNING while it delivers nothing.
  *
- * <p>{@code sasl.*} and {@code ssl.*} defaults are excluded deliberately. Floci connects over
- * PLAINTEXT so they are never instantiated, and registering {@code DefaultJwtValidator} aborts the
- * native build outright: its constructor references jose4j, an optional kafka-clients dependency
- * Floci does not ship. {@code PipesKafkaNativeSupportTest} guards both directions.
+ * <p>Every entry is config-resolved, and {@code PipesKafkaNativeSupportTest} derives its
+ * expectations the same way, so list and guard cannot drift. The tracing agent also reported
+ * {@code AppInfoParser.AppInfo}, {@code AppInfoParser.AppInfoMBean} and the shaded
+ * {@code ExtensionRegistry}; native pipes deliver without them, so they are omitted.
+ *
+ * <p>SASL and SSL defaults are excluded: Floci is PLAINTEXT-only, and {@code DefaultJwtValidator}
+ * fails the native build outright by referencing jose4j, an optional dependency Floci ships without.
  */
 @RegisterForReflection(targets = {
     // key.deserializer / value.deserializer — set explicitly by PipesKafkaConsumerManager
@@ -29,12 +30,7 @@ import org.apache.kafka.shaded.com.google.protobuf.ExtensionRegistry;
     RangeAssignor.class,
     CooperativeStickyAssignor.class,
     // metric.reporters — ConsumerConfig default
-    JmxReporter.class,
-    // MBean registered by AppInfoParser on consumer startup
-    AppInfoParser.AppInfo.class,
-    AppInfoParser.AppInfoMBean.class,
-    // shaded protobuf reached from the client telemetry reporter
-    ExtensionRegistry.class
+    JmxReporter.class
 })
 public class PipesKafkaNativeSupport {
 }

--- a/src/main/java/io/github/hectorvent/floci/services/pipes/PipesKafkaNativeSupport.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesKafkaNativeSupport.java
@@ -9,19 +9,16 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 /**
  * Registers the kafka-clients classes that GraalVM cannot discover statically.
  *
- * <p>Floci uses kafka-clients directly rather than through the Quarkus Kafka extension, and
- * kafka-clients ships no native-image metadata of its own. {@code AbstractConfig} resolves every
- * {@code CLASS}-typed consumer setting by name, so without these entries a native build produces a
- * consumer that cannot be constructed. {@link PipesPoller} logs that failure and moves on, leaving
- * a Kafka or MSK pipe reported as RUNNING while it delivers nothing.
+ * <p>kafka-clients ships no native-image metadata and Floci uses it directly rather than through
+ * the Quarkus Kafka extension. {@code AbstractConfig} resolves {@code CLASS}-typed settings by
+ * name, so without these a native build cannot construct a consumer — which {@link PipesPoller}
+ * swallows per poll cycle, leaving the pipe RUNNING and delivering nothing.
  *
- * <p>Every entry is config-resolved, and {@code PipesKafkaNativeSupportTest} derives its
- * expectations the same way, so list and guard cannot drift. The tracing agent also reported
- * {@code AppInfoParser.AppInfo}, {@code AppInfoParser.AppInfoMBean} and the shaded
- * {@code ExtensionRegistry}; native pipes deliver without them, so they are omitted.
+ * <p>Entries are exactly what {@link PipesKafkaConsumerManager#consumerProperties} resolves, and
+ * {@code PipesKafkaNativeSupportTest} reads that same method, so the two cannot drift.
  *
  * <p>SASL and SSL defaults are excluded: Floci is PLAINTEXT-only, and {@code DefaultJwtValidator}
- * fails the native build outright by referencing jose4j, an optional dependency Floci ships without.
+ * fails the native build by referencing jose4j, an optional dependency Floci omits.
  */
 @RegisterForReflection(targets = {
     // key.deserializer / value.deserializer — set explicitly by PipesKafkaConsumerManager

--- a/src/main/java/io/github/hectorvent/floci/services/pipes/PipesKafkaNativeSupport.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesKafkaNativeSupport.java
@@ -1,0 +1,40 @@
+package io.github.hectorvent.floci.services.pipes;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import org.apache.kafka.clients.consumer.CooperativeStickyAssignor;
+import org.apache.kafka.clients.consumer.RangeAssignor;
+import org.apache.kafka.common.metrics.JmxReporter;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.utils.AppInfoParser;
+import org.apache.kafka.shaded.com.google.protobuf.ExtensionRegistry;
+
+/**
+ * Registers the kafka-clients classes that GraalVM cannot discover statically.
+ *
+ * <p>Floci uses kafka-clients directly rather than through the Quarkus Kafka extension, and
+ * kafka-clients ships no native-image metadata of its own. {@code AbstractConfig} resolves every
+ * {@code CLASS}-typed consumer setting by name, so without these entries a native build produces a
+ * consumer that cannot be constructed. {@link PipesPoller} logs that failure and moves on, leaving
+ * a Kafka or MSK pipe reported as RUNNING while it delivers nothing.
+ *
+ * <p>{@code sasl.*} and {@code ssl.*} defaults are excluded deliberately. Floci connects over
+ * PLAINTEXT so they are never instantiated, and registering {@code DefaultJwtValidator} aborts the
+ * native build outright: its constructor references jose4j, an optional kafka-clients dependency
+ * Floci does not ship. {@code PipesKafkaNativeSupportTest} guards both directions.
+ */
+@RegisterForReflection(targets = {
+    // key.deserializer / value.deserializer — set explicitly by PipesKafkaConsumerManager
+    ByteArrayDeserializer.class,
+    // partition.assignment.strategy — ConsumerConfig defaults
+    RangeAssignor.class,
+    CooperativeStickyAssignor.class,
+    // metric.reporters — ConsumerConfig default
+    JmxReporter.class,
+    // MBean registered by AppInfoParser on consumer startup
+    AppInfoParser.AppInfo.class,
+    AppInfoParser.AppInfoMBean.class,
+    // shaded protobuf reached from the client telemetry reporter
+    ExtensionRegistry.class
+})
+public class PipesKafkaNativeSupport {
+}

--- a/src/test/java/io/github/hectorvent/floci/services/pipes/PipesKafkaNativeSupportTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/pipes/PipesKafkaNativeSupportTest.java
@@ -1,0 +1,96 @@
+package io.github.hectorvent.floci.services.pipes;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Guards {@link PipesKafkaNativeSupport} against kafka-clients upgrades.
+ *
+ * <p>A class missing from the registration only fails in native mode, and only as a swallowed
+ * poller warning, so this asserts the registration against the config kafka-clients actually
+ * resolves rather than against a hand-maintained list.
+ */
+class PipesKafkaNativeSupportTest {
+
+    private static final Predicate<String> TRANSPORT_SECURITY =
+            key -> key.startsWith("sasl.") || key.startsWith("ssl.");
+
+    @Test
+    @DisplayName("classes ConsumerConfig resolves reflectively are registered")
+    void registrationCoversReflectivelyResolvedClasses() {
+        Set<String> missing = new TreeSet<>(resolvedClasses(TRANSPORT_SECURITY.negate()));
+        missing.removeAll(registeredClassNames());
+
+        assertTrue(missing.isEmpty(),
+                "kafka-clients resolves these reflectively but PipesKafkaNativeSupport omits them, "
+                        + "so a native build cannot construct a consumer: " + missing);
+    }
+
+    @Test
+    @DisplayName("SASL and SSL defaults stay unregistered so native-image never links jose4j")
+    void registrationExcludesTransportSecurityDefaults() {
+        Set<String> unexpected = new TreeSet<>(resolvedClasses(TRANSPORT_SECURITY));
+        unexpected.retainAll(registeredClassNames());
+
+        assertTrue(unexpected.isEmpty(),
+                "Floci connects over PLAINTEXT and never instantiates these; registering them makes "
+                        + "native-image link optional dependencies and fail the build: " + unexpected);
+    }
+
+    private static Set<String> registeredClassNames() {
+        RegisterForReflection annotation =
+                PipesKafkaNativeSupport.class.getAnnotation(RegisterForReflection.class);
+        assertNotNull(annotation, "PipesKafkaNativeSupport must carry @RegisterForReflection");
+
+        Set<String> names = new TreeSet<>(Set.of(annotation.classNames()));
+        for (Class<?> target : annotation.targets()) {
+            names.add(target.getName());
+        }
+        return names;
+    }
+
+    /** Class-valued settings kafka-clients resolves for the properties PipesKafkaConsumerManager sets. */
+    private static Set<String> resolvedClasses(Predicate<String> keyFilter) {
+        Set<String> classes = new TreeSet<>();
+        consumerConfigValues().forEach((key, value) -> {
+            if (keyFilter.test(key)) {
+                collectClassNames(value, classes);
+            }
+        });
+        return classes;
+    }
+
+    private static void collectClassNames(Object value, Set<String> into) {
+        if (value instanceof Class<?> type) {
+            into.add(type.getName());
+        } else if (value instanceof Collection<?> collection) {
+            collection.forEach(element -> collectClassNames(element, into));
+        }
+    }
+
+    private static Map<String, ?> consumerConfigValues() {
+        Properties properties = new Properties();
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        properties.put(ConsumerConfig.GROUP_ID_CONFIG, "floci-pipes-test");
+        properties.put(ConsumerConfig.CLIENT_ID_CONFIG, "floci-pipes-test");
+        properties.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "100");
+        return new ConsumerConfig(properties).values();
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/pipes/PipesKafkaNativeSupportTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/pipes/PipesKafkaNativeSupportTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
@@ -17,11 +18,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Guards {@link PipesKafkaNativeSupport} against kafka-clients upgrades.
+ * Pins {@link PipesKafkaNativeSupport} to what {@code ConsumerConfig} resolves, in both directions:
+ * a newly resolved class must be registered, and nothing else may be.
  *
- * <p>A class missing from the registration only fails in native mode, and only as a swallowed
- * poller warning, so this asserts the registration against the config kafka-clients actually
- * resolves rather than against a hand-maintained list.
+ * <p>Scope: config-resolved classes only. Reflection always succeeds on the JVM, so a non-config
+ * lookup added by a future kafka-clients is only catchable by running a Kafka pipe against a
+ * native binary — no suite does that today.
  */
 class PipesKafkaNativeSupportTest {
 
@@ -31,7 +33,7 @@ class PipesKafkaNativeSupportTest {
     @Test
     @DisplayName("classes ConsumerConfig resolves reflectively are registered")
     void registrationCoversReflectivelyResolvedClasses() {
-        Set<String> missing = new TreeSet<>(resolvedClasses(TRANSPORT_SECURITY.negate()));
+        Set<String> missing = new TreeSet<>(expectedClassNames());
         missing.removeAll(registeredClassNames());
 
         assertTrue(missing.isEmpty(),
@@ -40,14 +42,26 @@ class PipesKafkaNativeSupportTest {
     }
 
     @Test
-    @DisplayName("SASL and SSL defaults stay unregistered so native-image never links jose4j")
-    void registrationExcludesTransportSecurityDefaults() {
-        Set<String> unexpected = new TreeSet<>(resolvedClasses(TRANSPORT_SECURITY));
-        unexpected.retainAll(registeredClassNames());
+    @DisplayName("nothing is registered that ConsumerConfig does not resolve")
+    void registrationContainsNothingUnjustified() {
+        Set<String> unexpected = new TreeSet<>(registeredClassNames());
+        unexpected.removeAll(expectedClassNames());
 
         assertTrue(unexpected.isEmpty(),
-                "Floci connects over PLAINTEXT and never instantiates these; registering them makes "
-                        + "native-image link optional dependencies and fail the build: " + unexpected);
+                "these are not config-resolved, so this test cannot guard them and they need a "
+                        + "native run to justify. SASL/SSL defaults in particular break the build — "
+                        + "DefaultJwtValidator drags in optional jose4j: " + unexpected);
+    }
+
+    /** Class-valued settings kafka-clients resolves, minus the transport security Floci never uses. */
+    private static Set<String> expectedClassNames() {
+        Set<String> classes = new TreeSet<>();
+        consumerConfigValues().forEach((key, value) -> {
+            if (TRANSPORT_SECURITY.negate().test(key)) {
+                collectClassNames(value, classes);
+            }
+        });
+        return classes;
     }
 
     private static Set<String> registeredClassNames() {
@@ -62,22 +76,26 @@ class PipesKafkaNativeSupportTest {
         return names;
     }
 
-    /** Class-valued settings kafka-clients resolves for the properties PipesKafkaConsumerManager sets. */
-    private static Set<String> resolvedClasses(Predicate<String> keyFilter) {
-        Set<String> classes = new TreeSet<>();
-        consumerConfigValues().forEach((key, value) -> {
-            if (keyFilter.test(key)) {
-                collectClassNames(value, classes);
-            }
-        });
-        return classes;
+    /**
+     * Mirrors {@code AbstractConfig.getConfiguredInstances}, which accepts a setting as either a
+     * {@code Class} or a class name — {@code metric.reporters} resolves to the latter. Values that
+     * do not name a class (bootstrap.servers, ssl.enabled.protocols) are not instantiable and so
+     * are not candidates.
+     */
+    private static void collectClassNames(Object value, Set<String> into) {
+        switch (value) {
+            case Class<?> type -> into.add(type.getName());
+            case Collection<?> collection -> collection.forEach(element -> collectClassNames(element, into));
+            case String name -> loadable(name).ifPresent(into::add);
+            case null, default -> { }
+        }
     }
 
-    private static void collectClassNames(Object value, Set<String> into) {
-        if (value instanceof Class<?> type) {
-            into.add(type.getName());
-        } else if (value instanceof Collection<?> collection) {
-            collection.forEach(element -> collectClassNames(element, into));
+    private static Optional<String> loadable(String className) {
+        try {
+            return Optional.of(Class.forName(className, false, ConsumerConfig.class.getClassLoader()).getName());
+        } catch (ClassNotFoundException | LinkageError e) {
+            return Optional.empty();
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/pipes/PipesKafkaNativeSupportTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/pipes/PipesKafkaNativeSupportTest.java
@@ -1,15 +1,17 @@
 package io.github.hectorvent.floci.services.pipes;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import io.github.hectorvent.floci.services.msk.MskService;
+import io.github.hectorvent.floci.services.pipes.model.Pipe;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Predicate;
@@ -18,21 +20,25 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Pins {@link PipesKafkaNativeSupport} to what {@code ConsumerConfig} resolves, in both directions:
- * a newly resolved class must be registered, and nothing else may be.
+ * Pins {@link PipesKafkaNativeSupport} to what {@code ConsumerConfig} resolves from
+ * {@link PipesKafkaConsumerManager#consumerProperties}, both ways: a newly resolved class must be
+ * registered, and nothing else may be. Reading that method rather than copying it means a new
+ * setting there is covered here too.
  *
  * <p>Scope: config-resolved classes only. Reflection always succeeds on the JVM, so a non-config
- * lookup added by a future kafka-clients is only catchable by running a Kafka pipe against a
- * native binary — no suite does that today.
+ * lookup from a future kafka-clients needs a Kafka pipe run against a native binary. The
+ * compatibility suite already runs against the native image; it has no Kafka source case yet.
  */
 class PipesKafkaNativeSupportTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private static final Predicate<String> TRANSPORT_SECURITY =
             key -> key.startsWith("sasl.") || key.startsWith("ssl.");
 
     @Test
     @DisplayName("classes ConsumerConfig resolves reflectively are registered")
-    void registrationCoversReflectivelyResolvedClasses() {
+    void registrationCoversReflectivelyResolvedClasses() throws Exception {
         Set<String> missing = new TreeSet<>(expectedClassNames());
         missing.removeAll(registeredClassNames());
 
@@ -43,7 +49,7 @@ class PipesKafkaNativeSupportTest {
 
     @Test
     @DisplayName("nothing is registered that ConsumerConfig does not resolve")
-    void registrationContainsNothingUnjustified() {
+    void registrationContainsNothingUnjustified() throws Exception {
         Set<String> unexpected = new TreeSet<>(registeredClassNames());
         unexpected.removeAll(expectedClassNames());
 
@@ -54,7 +60,7 @@ class PipesKafkaNativeSupportTest {
     }
 
     /** Class-valued settings kafka-clients resolves, minus the transport security Floci never uses. */
-    private static Set<String> expectedClassNames() {
+    private static Set<String> expectedClassNames() throws Exception {
         Set<String> classes = new TreeSet<>();
         consumerConfigValues().forEach((key, value) -> {
             if (TRANSPORT_SECURITY.negate().test(key)) {
@@ -77,10 +83,8 @@ class PipesKafkaNativeSupportTest {
     }
 
     /**
-     * Mirrors {@code AbstractConfig.getConfiguredInstances}, which accepts a setting as either a
-     * {@code Class} or a class name — {@code metric.reporters} resolves to the latter. Values that
-     * do not name a class (bootstrap.servers, ssl.enabled.protocols) are not instantiable and so
-     * are not candidates.
+     * Mirrors {@code AbstractConfig.getConfiguredInstances}: a setting may be a {@code Class} or a
+     * class name — {@code metric.reporters} is the latter. Values naming no class are not candidates.
      */
     private static void collectClassNames(Object value, Set<String> into) {
         switch (value) {
@@ -99,16 +103,20 @@ class PipesKafkaNativeSupportTest {
         }
     }
 
-    private static Map<String, ?> consumerConfigValues() {
-        Properties properties = new Properties();
-        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
-        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
-        properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
-        properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        properties.put(ConsumerConfig.GROUP_ID_CONFIG, "floci-pipes-test");
-        properties.put(ConsumerConfig.CLIENT_ID_CONFIG, "floci-pipes-test");
-        properties.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "100");
-        return new ConsumerConfig(properties).values();
+    private static Map<String, ?> consumerConfigValues() throws Exception {
+        PipesKafkaConsumerManager manager = new PipesKafkaConsumerManager(Mockito.mock(MskService.class));
+
+        Pipe pipe = new Pipe();
+        pipe.setName("native-support");
+        pipe.setSource("smk://localhost:9092");
+        pipe.setSourceParameters(MAPPER.readTree("""
+                {
+                  "SelfManagedKafkaParameters": {
+                    "TopicName": "orders"
+                  }
+                }
+                """));
+
+        return new ConsumerConfig(manager.consumerProperties(pipe)).values();
     }
 }


### PR DESCRIPTION
## Summary

#1260 added Kafka and MSK sources to EventBridge Pipes, but only verified them on the JVM. In the native image both source types silently deliver nothing.

Floci depends on `kafka-clients` directly rather than through the Quarkus Kafka extension, and `kafka-clients` ships no native-image metadata of its own. `AbstractConfig` resolves every `CLASS`-typed consumer setting by name, so the deserializers [we set explicitly](https://github.com/floci-io/floci/blob/0142dc434f98ba14a13236196c72036839a1e84b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesKafkaConsumerManager.java#L141) — plus the `ConsumerConfig` defaults for `partition.assignment.strategy` and `metric.reporters` — are never registered for reflection and the consumer cannot be constructed:

```
poll error: Invalid value org.apache.kafka.common.serialization.ByteArrayDeserializer
for configuration key.deserializer: Class ... could not be found. (ConfigException)
```

This is easy to miss because [PipesPoller catches and warns per poll cycle](https://github.com/floci-io/floci/blob/0142dc434f98ba14a13236196c72036839a1e84b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesPoller.java#L152-L157), so the pipe stays reported as `RUNNING` with no error surfaced to the caller.

The registration lives next to the only code that uses `kafka-clients`, following the existing `DockerJavaNativeSupport` holder pattern. Every entry is a class `ConsumerConfig` resolves, and `PipesKafkaNativeSupportTest` reads `PipesKafkaConsumerManager.consumerProperties` directly — not a copy of it — asserting equality in both directions, so a new setting on the consumer is covered automatically.

The consumer also sets `enable.metrics.push=false`. It defaults to true, and Floci has no reason to push client telemetry to a user's broker; it additionally keeps the shaded protobuf serializer off any reflective path.

`sasl.*` and `ssl.*` defaults are excluded deliberately. Floci connects over PLAINTEXT so they are never instantiated, and registering `DefaultJwtValidator` aborts the native build outright — its constructor references jose4j, an optional `kafka-clients` dependency we do not ship:

```
Fatal error: java.lang.NoClassDefFoundError: org/jose4j/keys/resolvers/VerificationKeyResolver
```

### Binary size

The native binary grows **196 MB → 210.7 MB** (linux/arm64, measured against `floci/floci:1.5.34`). The cost is not the metadata volume: registering one class costs the same as registering all four, because the closed-world analysis cannot see through `Utils.newInstance(Class.forName(...))` — on `main` the consumer's entire constructed graph is dead code, and the first reflective instantiation makes it live. Over half of what arrives is Kafka's auto-generated wire-protocol layer. Measured on macOS/arm64 with the same toolchain and flags throughout:

| registration | binary |
|---|---|
| none (current `main`) | 187.7 MB |
| `ByteArrayDeserializer` only | 201.5 MB |
| 3 classes | 201.9 MB |
| 4 classes (this PR) | 202.1 MB |

So there is nothing to trim — a minimal list costs the same as the complete one. The smaller binary on `main` only contains a Kafka consumer that cannot run.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No wire-protocol change. The incorrect behaviour was that a Kafka or MSK pipe created through the Pipes API reported `RUNNING` but delivered no records to its target in native mode, while behaving correctly on the JVM.

Verified end to end with AWS CLI 1.45.61 against a Kafka broker (`apache/kafka:4.1.0`) and an MSK cluster, producing to the topic and asserting delivery to the SQS target:

| | JVM | native (before) | native (after) |
|---|---|---|---|
| `smk://` → Pipes → SQS | 5/5 | **0/5** | 5/5 |
| MSK → Pipes → SQS | 5/5 | **0/5** | 5/5 |

Both source types failed identically before the fix, since they share `createConsumer`. The "after" column was run against the shipped image built from `docker/Dockerfile.native`, with Floci itself running as a container so MSK took the sibling-container path:

```
PipesKafkaConsumerManager] Pipe fpk-selfmanaged-pipe: subscribed Kafka consumer to topic ... via fpk-kafka:9092
PipesKafkaConsumerManager] Pipe fpk-msk-pipe:         subscribed Kafka consumer to topic ... via 10.89.0.7:9092
```

Zero `poll error` lines after the fix, against 20+ per pipe before it.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
