### PR TITLE
perf(docker): stop duplicating the native binary into a second image layer

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Stage native binary for packaging
         run: |
           mkdir -p native/arm64
-          cp target/*-runner native/arm64/
+          cp target/*-runner native/arm64/application
           # include any sidecar .so the runtime image may need (matches nightly artifact set)
           cp target/*.so native/arm64/ 2>/dev/null || true
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -130,8 +130,11 @@ jobs:
           name: native-arm64
           path: native/arm64/
 
-      - name: Make binaries executable
-        run: chmod +x native/amd64/*-runner native/arm64/*-runner
+      - name: Stage binaries under a fixed name
+        run: |
+          for arch in amd64 arm64; do
+            mv native/$arch/*-runner native/$arch/application
+          done
 
       - name: Set created timestamp
         id: created

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,8 +116,11 @@ jobs:
           name: native-arm64
           path: native/arm64/
 
-      - name: Make binaries executable
-        run: chmod +x native/amd64/*-runner native/arm64/*-runner
+      - name: Stage binaries under a fixed name
+        run: |
+          for arch in amd64 arm64; do
+            mv native/$arch/*-runner native/$arch/application
+          done
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 

--- a/docker/Dockerfile.native
+++ b/docker/Dockerfile.native
@@ -63,11 +63,9 @@ ARG VERSION=latest
 ENV FLOCI_VERSION=${VERSION}
 ENV FLOCI_STORAGE_PERSISTENT_PATH=/app/data
 
-COPY --from=build /app/target/*-runner /app/application
+COPY --chmod=755 --from=build /app/target/*-runner /app/application
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY --chmod=755 docker/localstack-parity.sh /usr/local/bin/localstack-parity.sh
-
-RUN chmod +x /app/application
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["/app/application"]

--- a/docker/Dockerfile.native-package
+++ b/docker/Dockerfile.native-package
@@ -34,8 +34,7 @@ RUN mkdir -p /app/data \
 
 VOLUME /app/data
 
-COPY --chown=1001:root native/${TARGETARCH}/ /app/
-RUN mv /app/*-runner /app/application && chmod +x /app/application
+COPY --chmod=755 --chown=1001:root native/${TARGETARCH}/ /app/
 
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY --chmod=755 docker/localstack-parity.sh /usr/local/bin/localstack-parity.sh


### PR DESCRIPTION
## Summary

`docker/Dockerfile.native-package` — the Dockerfile that CI and releases build — wrote the native binary into the image twice. From `podman history floci/floci:1.5.34` (linux/arm64):

```
110 MB   ubi9-minimal base
18.8 MB  microdnf install shadow-utils + gosu
196 MB   COPY --chown=1001:root native/<arch>/ /app/
196 MB   RUN mv /app/*-runner /app/application && chmod +x /app/application
```

A layer records the post-change state of every file it touches, not a delta, so a `RUN` that renames or chmods a large file rewrites that whole file into a new layer. The second 196 MB layer is a byte-for-byte second copy of the binary, and it is stored, pushed and pulled every time. `docker/Dockerfile.native` had the same bug in a simpler form — `COPY` followed by `RUN chmod +x /app/application`.

The fix is to set the mode in the `COPY` itself, and to move the rename out of the image and into the build pipeline, which now stages the binary as `native/<arch>/application`:

```diff
-COPY --chown=1001:root native/${TARGETARCH}/ /app/
-RUN mv /app/*-runner /app/application && chmod +x /app/application
+COPY --chmod=755 --chown=1001:root native/${TARGETARCH}/ /app/
```

Three workflows stage that directory and all three now write the fixed name: `release.yml` and `nightly.yml` (which `download-artifact` into `native/<arch>/`, so their existing `chmod +x` step becomes the rename) and `compatibility.yml` (which copies straight out of `target/`). `--chmod` is already used for the entrypoint scripts in both Dockerfiles, so the syntax is proven on the builders in use.

The directory `COPY` is kept rather than narrowed to `native/<arch>/application`, because `/app` also carries `quarkus-artifact.properties` and a single-file copy would silently drop it.

### Image size

Measured with podman 5.8.2 on linux/arm64, rebuilding `Dockerfile.native-package` against `floci/floci:1.5.34`. Both sides carry a 196 MB binary (195,956,552 B rebuilt vs 195,954,872 B released), so this is like for like:

| | before (`1.5.34`) | after | delta |
|---|---|---|---|
| uncompressed | 521 MB | **325 MB** | −196 MB (−37.6%) |
| compressed | 168.1 MB | **104.1 MB** | −64.0 MB (−38.1%) |
| layers | 8 | 6 | −2 |

`podman history` after the change — one copy of the binary, nothing else moved:

```
196 MB   COPY --chmod=755 --chown=1001:root native/arm64/ /app/
18.8 MB  microdnf install shadow-utils + gosu
110 MB   ubi9-minimal base
```

Compressed figures are the sum of `gzip -6` over each layer blob, which is what a registry stores and a client downloads. That method reports 168.1 MB for `1.5.34` against the 166.1 MB Docker Hub displays for the same tag — within 1.2%, so the "after" figure should be read with the same tolerance.

`Dockerfile.native` is not built by any workflow (it is the from-source path in `docs/configuration/docker-images.md`), and gets the same treatment:

| | before | after | delta |
|---|---|---|---|
| uncompressed | 443 MB | **247 MB** | −196 MB (−44.2%) |

Both of those were built from the same cached build stage, so the binary is byte-identical (195,956,552 B) on each side.

### No behaviour change

The resulting filesystem differs in exactly one attribute across the whole image — `quarkus-artifact.properties` is now `0755` rather than `0644`, because `--chmod` applies to every file in the staged directory:

| path | before | after |
|---|---|---|
| `/app` | `drwxrwxr-x 1001:0` | `drwxrwxr-x 1001:0` |
| `/app/data` | `drwxrwxr-x 1001:0` | `drwxrwxr-x 1001:0` |
| `/app/application` | `-rwxr-xr-x 1001:0` | `-rwxr-xr-x 1001:0` |
| `/app/quarkus-artifact.properties` | `-rw-r--r-- 1001:0` | `-rwxr-xr-x 1001:0` |

`/app` and `/app/data` keep group-write and `uid 1001:gid 0`, which is what the `io.openshift.*` labels on this image need for arbitrary-uid runs.

The exec bit on `/app/application` is load-bearing: [`docker/entrypoint.sh`](https://github.com/floci-io/floci/blob/0142dc434f98ba14a13236196c72036839a1e84b/docker/entrypoint.sh#L73) selects the default command with `[ -x /app/application ]`, and falls through to the JVM layout if that test fails. Setting the mode in the `COPY` keeps that guarantee inside the Dockerfile instead of making it depend on the file mode in the build context.

Verified on the rebuilt image:

| check | result |
|---|---|
| container starts, `GET /_floci/health` | 200, 69/69 services `running` |
| empty-argv entrypoint fallback (the `[ -x ]` branch) | healthy |
| `HEALTHCHECK` command, run in-container | exit 0 |

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore — `perf:`, packaging only, no Java source in the diff

## AWS Compatibility

No wire-protocol change. The diff touches two Dockerfiles and three workflow files and no Java source, so no emulated action, request parsing or response shape is affected. The behavioural surface that could have moved is the image's own runtime contract — entrypoint command selection, health check, and the file ownership and modes the container depends on — and that is covered in the table above.

## Checklist

- [ ] `./mvnw test` passes locally — not run; no Java sources are touched by this PR. Verification was done against built images, above.
- [ ] New or updated integration test added — n/a. `compatibility.yml` already builds `Dockerfile.native-package` from a staged `native/arm64/` and runs the native compat suite against the result, so the staging change is exercised by existing CI.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
