### PR TITLE
feat(cognito): implement ResendConfirmationCode

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -74,6 +74,7 @@ public class CognitoJsonHandler {
             case "AdminRespondToAuthChallenge" -> handleAdminRespondToAuthChallenge(request);
             case "SignUp" -> handleSignUp(request);
             case "ConfirmSignUp" -> handleConfirmSignUp(request);
+            case "ResendConfirmationCode" -> handleResendConfirmationCode(request);
             case "AdminConfirmSignUp" -> handleAdminConfirmSignUp(request);
             case "ChangePassword" -> handleChangePassword(request);
             case "ForgotPassword" -> handleForgotPassword(request);
@@ -557,6 +558,19 @@ public class CognitoJsonHandler {
                 request.path("ConfirmationCode").asText()
         );
         return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleResendConfirmationCode(JsonNode request) {
+        Map<String, String> deliveryDetails = service.resendConfirmationCode(
+                request.path("ClientId").asText(),
+                request.path("Username").asText()
+        );
+        ObjectNode response = objectMapper.createObjectNode();
+        ObjectNode delivery = response.putObject("CodeDeliveryDetails");
+        delivery.put("AttributeName", deliveryDetails.get("AttributeName"));
+        delivery.put("DeliveryMedium", deliveryDetails.get("DeliveryMedium"));
+        delivery.put("Destination", deliveryDetails.get("Destination"));
+        return Response.ok(response).build();
     }
 
     private Response handleAdminConfirmSignUp(JsonNode request) {

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -1251,6 +1251,51 @@ public class CognitoService {
                 deliveryTarget.deliveryMedium(), "Destination", deliveryTarget.destination());
     }
 
+    public Map<String, String> resendConfirmationCode(String clientId, String username) {
+        UserPoolClient client = clientStore.get(clientId)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException", "Client not found",
+                        400));
+        UserPool pool = describeUserPool(client.getUserPoolId());
+        CognitoUser user = adminGetUser(client.getUserPoolId(), username);
+        if (!"UNCONFIRMED".equals(user.getUserStatus())) {
+            throw new AwsException("NotAuthorizedException",
+                    "User cannot be confirmed. Current status is " + user.getUserStatus(), 400);
+        }
+        if (!isSignUpConfirmationEnabled(pool)) {
+            throw new AwsException("InvalidParameterException",
+                    "User pool does not have sign-up confirmation delivery configured", 400);
+        }
+
+        DeliveryTarget deliveryTarget = resolveSignUpDeliveryTarget(pool, user);
+        if (deliveryTarget == null) {
+            throw new AwsException("InvalidParameterException",
+                    "Cannot confirm user because email or phone_number is missing", 400);
+        }
+
+        ensureVerificationWiring();
+        verificationCodeService.invalidatePrevious(pool.getId(), user.getUsername(),
+                VerificationCode.Purpose.SIGNUP_CONFIRMATION);
+        try {
+            String code = verificationCodeService.issue(pool.getId(), user.getUsername(),
+                    VerificationCode.Purpose.SIGNUP_CONFIRMATION, Duration.ofHours(24));
+            messageDispatcher.dispatch(pool, user, VerificationCode.Purpose.SIGNUP_CONFIRMATION,
+                    code, List.of(deliveryTarget.deliveryMedium()));
+        } catch (VerificationCodeException e) {
+            throw mapVerificationCodeException(e);
+        } catch (RuntimeException e) {
+            verificationCodeService.invalidatePrevious(pool.getId(), user.getUsername(),
+                    VerificationCode.Purpose.SIGNUP_CONFIRMATION);
+            throw new AwsException("CodeDeliveryFailureException",
+                    "Failed to deliver the message.", 400);
+        }
+
+        return Map.of(
+                "AttributeName", deliveryTarget.attributeName(),
+                "DeliveryMedium", deliveryTarget.deliveryMedium(),
+                "Destination", deliveryTarget.destination()
+        );
+    }
+
     public void adminConfirmSignUp(String userPoolId, String username) {
         CognitoUser user = adminGetUser(userPoolId, username);
         user.setUserStatus("CONFIRMED");

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
@@ -462,6 +462,92 @@ class CognitoIntegrationTest {
     }
 
     @Test
+    void resendConfirmationCodeReplacesTheSignUpCode() throws Exception {
+        given().delete("/_aws/ses").then().statusCode(200);
+
+        JsonNode poolResponse = cognitoJson("CreateUserPool", """
+                {
+                  "PoolName": "ResendConfirmationCodePool",
+                  "AutoVerifiedAttributes": ["email"]
+                }
+                """);
+        String resendPoolId = poolResponse.path("UserPool").path("Id").asText();
+
+        JsonNode clientResponse = cognitoJson("CreateUserPoolClient", """
+                {
+                  "UserPoolId": "%s",
+                  "ClientName": "resend-confirmation-code-client"
+                }
+                """.formatted(resendPoolId));
+        String resendClientId = clientResponse.path("UserPoolClient").path("ClientId").asText();
+
+        String resendUsername = "resend+" + UUID.randomUUID() + "@example.com";
+        cognitoAction("SignUp", """
+                {
+                  "ClientId": "%s",
+                  "Username": "%s",
+                  "Password": "Passw0rd!",
+                  "UserAttributes": [
+                    { "Name": "email", "Value": "%s" }
+                  ]
+                }
+                """.formatted(resendClientId, resendUsername, resendUsername))
+                .then()
+                .statusCode(200);
+
+        String originalCode = fetchLatestSesVerificationCode(resendUsername);
+        given().delete("/_aws/ses").then().statusCode(200);
+
+        Response resendResponse = cognitoAction("ResendConfirmationCode", """
+                {
+                  "ClientId": "%s",
+                  "Username": "%s"
+                }
+                """.formatted(resendClientId, resendUsername));
+        resendResponse.then().statusCode(200);
+        assertEquals("email",
+                resendResponse.jsonPath().getString("CodeDeliveryDetails.AttributeName"));
+        assertEquals("EMAIL",
+                resendResponse.jsonPath().getString("CodeDeliveryDetails.DeliveryMedium"));
+        assertThat(resendResponse.jsonPath().getString("CodeDeliveryDetails.Destination"),
+                containsString("@"));
+
+        String replacementCode = fetchLatestSesVerificationCode(resendUsername);
+        assertNotEquals(originalCode, replacementCode);
+
+        cognitoAction("ConfirmSignUp", """
+                {
+                  "ClientId": "%s",
+                  "Username": "%s",
+                  "ConfirmationCode": "%s"
+                }
+                """.formatted(resendClientId, resendUsername, originalCode))
+                .then()
+                .statusCode(400)
+                .body("__type", org.hamcrest.Matchers.equalTo("CodeMismatchException"));
+
+        cognitoAction("ConfirmSignUp", """
+                {
+                  "ClientId": "%s",
+                  "Username": "%s",
+                  "ConfirmationCode": "%s"
+                }
+                """.formatted(resendClientId, resendUsername, replacementCode))
+                .then()
+                .statusCode(200);
+
+        cognitoAction("ResendConfirmationCode", """
+                {
+                  "ClientId": "%s",
+                  "Username": "%s"
+                }
+                """.formatted(resendClientId, resendUsername))
+                .then()
+                .statusCode(400)
+                .body("__type", org.hamcrest.Matchers.equalTo("NotAuthorizedException"));
+    }
+
+    @Test
     @Order(8)
     void forgotPasswordRequiresVerifiedRecoveryDestination() throws Exception {
         JsonNode poolResponse = cognitoJson("CreateUserPool", """


### PR DESCRIPTION
## Summary

Implement the Cognito `ResendConfirmationCode` action for unconfirmed users. Resending invalidates the previous sign-up code, issues a replacement, dispatches it through the configured email or SMS delivery channel, and returns `CodeDeliveryDetails`.

Closes #2067

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The implementation follows the Cognito IDP JSON 1.1 `ResendConfirmationCode` request and response shape. It validates the app client and user state, rejects confirmed users with `NotAuthorizedException`, replaces the previous confirmation code, and reports delivery failures as `CodeDeliveryFailureException`.

Verified through an AWS SDK integration test covering delivery details, old-code invalidation, successful confirmation with the replacement code, and rejection after confirmation.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

### Test evidence

- `JAVA_HOME=/Users/dzwicker/.sdkman/candidates/java/25-open ./mvnw -q -Dtest=CognitoIntegrationTest test`
- `JAVA_HOME=/Users/dzwicker/.sdkman/candidates/java/25-open ./mvnw -q test`