### PR TITLE
fix(s3): include EventBridgeConfiguration in GetBucketNotification response

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -1438,6 +1438,9 @@ public class S3Controller {
                 appendFilterRules(xml, ln.filterRules());
                 xml.end("CloudFunctionConfiguration");
             }
+            if (config.isEventBridgeEnabled()) {
+                xml.start("EventBridgeConfiguration").end("EventBridgeConfiguration");
+            }
             xml.end("NotificationConfiguration");
             return Response.ok(xml.build()).type(MediaType.APPLICATION_XML).build();
         } catch (AwsException e) {

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3EventBridgeIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3EventBridgeIntegrationTest.java
@@ -115,6 +115,13 @@ class S3EventBridgeIntegrationTest {
             .put("/eb-s3-test-bucket?notification")
         .then()
             .statusCode(200);
+
+        given()
+        .when()
+            .get("/eb-s3-test-bucket?notification")
+        .then()
+            .statusCode(200)
+            .body(containsString("<EventBridgeConfiguration"));
     }
 
     @Test
@@ -184,6 +191,13 @@ class S3EventBridgeIntegrationTest {
             .put("/eb-s3-test-bucket?notification")
         .then()
             .statusCode(200);
+
+        given()
+        .when()
+            .get("/eb-s3-test-bucket?notification")
+        .then()
+            .statusCode(200)
+            .body(not(containsString("EventBridgeConfiguration")));
 
         // Drain any leftover messages
         given()


### PR DESCRIPTION
## Summary

`PutBucketNotificationConfiguration` with `<EventBridgeConfiguration/>` correctly stores the flag, and S3 events are delivered to the default EventBridge bus — but `GetBucketNotificationConfiguration` never serializes the element back, so an EventBridge-only configuration always reads back as an empty `<NotificationConfiguration>`.

Consequences of the current behavior:
- Any client doing read-modify-write of the notification config (Terraform `aws_s3_bucket_notification`, setup scripts that merge configurations) reads "empty" and silently erases the EventBridge flag on write-back, after which S3→EventBridge delivery stops.
- Health checks that verify the configuration via GET false-negative even though delivery works.

The fix serializes `<EventBridgeConfiguration></EventBridgeConfiguration>` in the GET response when the stored flag is enabled, matching real S3.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior, reproduced with AWS CLI 2.x against floci 1.5.34: `aws s3api put-bucket-notification-configuration --notification-configuration '{"EventBridgeConfiguration": {}}'` returns 200 and delivery works (verified end-to-end via an EventBridge rule on the default bus receiving an `Object Created` event into an SQS target), but `aws s3api get-bucket-notification-configuration` returns an empty result. Real S3 returns `"EventBridgeConfiguration": {}` on read.

Verified after the fix with AWS CLI 2.x against a locally built patched image:
- EventBridge-only config reads back `{"EventBridgeConfiguration": {}}`
- A mixed config (QueueConfigurations + EventBridgeConfiguration) round-trips both

Queue/Topic/Lambda configurations already round-tripped correctly; only the EventBridge flag was missing from the GET serializer.

## Checklist

- [ ] `./mvnw test` passes locally — full suite run in a JDK 25 container: 8,074 tests, all 62 S3/EventBridge test classes pass with 0 failures/0 errors (including the new assertions); the only failing classes are Docker-in-Docker-dependent ones (Lambda containers, API Gateway authorizers, DocDB, Neptune, ECR, EC2) that cannot run in my sandbox, so leaving this unchecked for CI to confirm
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)