### PR TITLE
feat(lambda): support extra /etc/hosts entries on Lambda launch

### DIFF
--- a/docs/services/lambda.md
+++ b/docs/services/lambda.md
@@ -195,6 +195,7 @@ These AWS Lambda operations have no handler in Floci. Calls will return `404` or
 | `FLOCI_SERVICES_LAMBDA_HOT_RELOAD_ENABLED` | `false` | Enable bind-mount hot-reload via `S3Bucket=hot-reload` |
 | `FLOCI_SERVICES_LAMBDA_HOT_RELOAD_ALLOWED_PATHS` | *(unset)* | Comma-separated allowlist of host paths that may be bind-mounted |
 | `FLOCI_SERVICES_LAMBDA_DOCKER_NETWORK` | *(unset)* | Docker network to attach Lambda containers to (overrides `FLOCI_SERVICES_DOCKER_NETWORK`) |
+| `FLOCI_SERVICES_LAMBDA_EXTRA_HOSTS` | *(unset)* | Comma-separated `hostname:ip` entries added to each Lambda container's `/etc/hosts`; `ip` may be `host-gateway`, mirroring `docker run --add-host` |
 | `FLOCI_SERVICES_LAMBDA_DOCKER_HOST_OVERRIDE` | *(unset)* | Explicit host/IP that spawned Lambda containers use to reach Floci's Runtime API, bypassing auto-detection |
 
 ### Runtime API host override

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -1330,6 +1330,15 @@ public interface EmulatorConfig {
         Optional<String> dockerNetwork();
 
         /**
+         * Extra /etc/hosts entries added to every Lambda container, as "hostname:ip" pairs.
+         * The ip may be the literal "host-gateway" to map to the Docker host, mirroring
+         * {@code docker run --add-host hostname:host-gateway}.
+         *
+         * Env var: FLOCI_SERVICES_LAMBDA_EXTRA_HOSTS (comma-separated)
+         */
+        Optional<List<String>> extraHosts();
+
+        /**
          * Concurrent executions ceiling applied per region. AWS Lambda's
          * "account-level" concurrency is in fact a per-region quota (default 1000);
          * Floci mirrors that semantics and partitions counters by the region

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -219,6 +219,16 @@ public class ContainerLauncher {
 
         specBuilder.withEmbeddedDns();
 
+        // Inject additional hosts entries into the container if present
+        config.services().lambda().extraHosts().ifPresent(hosts -> hosts.forEach(entry -> {
+            int sep = entry.lastIndexOf(':');
+            if (sep <= 0 || sep == entry.length() - 1) {
+                LOG.warnv("Ignoring malformed lambda extra-hosts entry (expected hostname:ip): {0}", entry);
+                return;
+            }
+            specBuilder.withExtraHost(entry.substring(0, sep), entry.substring(sep + 1));
+        }));
+
         // Whether /var/task is served from a shared read-only volume (large code) or copied
         // directly into this container (small code). Decided once here so both the spec (below)
         // and the create->start copy block agree.

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -219,9 +219,11 @@ public class ContainerLauncher {
 
         specBuilder.withEmbeddedDns();
 
-        // Inject additional hosts entries into the container if present
+        // Inject extra hosts entries into the container if present. Split on the FIRST
+        // colon, mirroring docker --add-host: hostnames cannot contain colons, but IPv6
+        // addresses do (e.g. "db.internal:2001:db8::1").
         config.services().lambda().extraHosts().ifPresent(hosts -> hosts.forEach(entry -> {
-            int sep = entry.lastIndexOf(':');
+            int sep = entry.indexOf(':');
             if (sep <= 0 || sep == entry.length() - 1) {
                 LOG.warnv("Ignoring malformed lambda extra-hosts entry (expected hostname:ip): {0}", entry);
                 return;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -218,6 +218,7 @@ floci:
       region-concurrency-limit: 1000
       unreserved-concurrency-min: 100
       # aws-config-path:                      # Host path to bind-mount (read-only) at /opt/aws-config for real credential discovery
+      # extra-hosts:                          # Extra /etc/hosts entries for Lambda containers, "hostname:ip" ("host-gateway" allowed as ip)
       hot-reload:
         enabled: false
     apigateway:

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
@@ -478,7 +478,9 @@ class ContainerLauncherTest {
     void launchFunction_appliesConfiguredExtraHosts_skippingMalformedEntries() throws Exception {
         EmulatorConfig.LambdaServiceConfig lambda = config.services().lambda();
         when(lambda.extraHosts()).thenReturn(Optional.of(List.of(
-                "localhost:host-gateway", "db.internal:10.0.0.5", "malformed", ":9.9.9.9", "trailing:")));
+                "localhost:host-gateway", "db.internal:10.0.0.5",
+                "v6.internal:2001:db8::1", "v6end.internal:fd00::",
+                "malformed", ":9.9.9.9", "trailing:")));
 
         Path codePath = Files.createDirectory(tempDir.resolve("extra-hosts"));
 
@@ -495,7 +497,11 @@ class ContainerLauncherTest {
                 "configured hostname:host-gateway entry should be applied");
         assertTrue(extraHosts.contains("db.internal:10.0.0.5"),
                 "configured hostname:ip entry should be applied");
-        assertEquals(2, extraHosts.size(),
+        assertTrue(extraHosts.contains("v6.internal:2001:db8::1"),
+                "IPv6 addresses (containing colons) must survive the hostname/ip split");
+        assertTrue(extraHosts.contains("v6end.internal:fd00::"),
+                "IPv6 addresses ending in :: must not be classified as missing an ip");
+        assertEquals(4, extraHosts.size(),
                 "entries without a hostname and an ip must be skipped, not passed to Docker");
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
@@ -71,6 +71,7 @@ class ContainerLauncherTest {
         when(config.services()).thenReturn(services);
         when(services.lambda()).thenReturn(lambda);
         when(lambda.dockerNetwork()).thenReturn(Optional.empty());
+        lenient().when(lambda.extraHosts()).thenReturn(Optional.empty());
         lenient().when(lambda.awsConfigPath()).thenReturn(Optional.empty());
         when(config.docker()).thenReturn(docker);
         when(docker.logMaxSize()).thenReturn("10m");
@@ -471,6 +472,47 @@ class ContainerLauncherTest {
                 "AWS_SECRET_ACCESS_KEY should not be injected when awsConfigPath is set");
         assertTrue(env.stream().noneMatch(e -> e.startsWith("AWS_SESSION_TOKEN=")),
                 "AWS_SESSION_TOKEN should not be injected when awsConfigPath is set");
+    }
+
+    @Test
+    void launchFunction_appliesConfiguredExtraHosts_skippingMalformedEntries() throws Exception {
+        EmulatorConfig.LambdaServiceConfig lambda = config.services().lambda();
+        when(lambda.extraHosts()).thenReturn(Optional.of(List.of(
+                "localhost:host-gateway", "db.internal:10.0.0.5", "malformed", ":9.9.9.9", "trailing:")));
+
+        Path codePath = Files.createDirectory(tempDir.resolve("extra-hosts"));
+
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("extra-hosts-fn");
+        fn.setRuntime("nodejs20.x");
+        fn.setHandler("index.handler");
+        fn.setCodeLocalPath(codePath.toString());
+
+        launcher.launch(fn);
+
+        List<String> extraHosts = captureRealContainerSpec().extraHosts();
+        assertTrue(extraHosts.contains("localhost:host-gateway"),
+                "configured hostname:host-gateway entry should be applied");
+        assertTrue(extraHosts.contains("db.internal:10.0.0.5"),
+                "configured hostname:ip entry should be applied");
+        assertEquals(2, extraHosts.size(),
+                "entries without a hostname and an ip must be skipped, not passed to Docker");
+    }
+
+    @Test
+    void launchFunction_noExtraHostsByDefault() throws Exception {
+        Path codePath = Files.createDirectory(tempDir.resolve("no-extra-hosts"));
+
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("no-extra-hosts-fn");
+        fn.setRuntime("nodejs20.x");
+        fn.setHandler("index.handler");
+        fn.setCodeLocalPath(codePath.toString());
+
+        launcher.launch(fn);
+
+        assertTrue(captureRealContainerSpec().extraHosts().isEmpty(),
+                "no extra hosts when the config is unset (non-Linux host in this test)");
     }
 
     @Test


### PR DESCRIPTION
## Summary

This adds the ability to specify extra /etc/hosts entries in the lambda containers that Floci launches.

This provides additional flexibility for when the spawned lambda containers need to communicate in unusual networking setups - e.g. talk back to a service running on localhost instead of on the internal docker network.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore


## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)