### PR TITLE
fix(ssm): report invalid batch parameter names

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ssm/SsmJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssm/SsmJsonHandler.java
@@ -19,8 +19,10 @@ import jakarta.ws.rs.core.Response;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @ApplicationScoped
 public class SsmJsonHandler {
@@ -110,7 +112,8 @@ public class SsmJsonHandler {
             parametersArray.add(parameterToNode(p));
         }
         response.set("Parameters", parametersArray);
-        response.set("InvalidParameters", objectMapper.createArrayNode());
+        response.set("InvalidParameters", invalidParameterNames(names,
+                params.stream().map(Parameter::getName).toList()));
         return Response.ok(response).build();
     }
 
@@ -145,8 +148,17 @@ public class SsmJsonHandler {
         ArrayNode deletedArray = objectMapper.createArrayNode();
         deleted.forEach(deletedArray::add);
         response.set("DeletedParameters", deletedArray);
-        response.set("InvalidParameters", objectMapper.createArrayNode());
+        response.set("InvalidParameters", invalidParameterNames(names, deleted));
         return Response.ok(response).build();
+    }
+
+    private ArrayNode invalidParameterNames(List<String> requestedNames, List<String> returnedNames) {
+        Set<String> returnedNameSet = new HashSet<>(returnedNames);
+        ArrayNode invalidNames = objectMapper.createArrayNode();
+        requestedNames.stream()
+                .filter(name -> !returnedNameSet.contains(name))
+                .forEach(invalidNames::add);
+        return invalidNames;
     }
 
     private Response handleGetParameterHistory(JsonNode request, String region) {

--- a/src/test/java/io/github/hectorvent/floci/services/ssm/SsmIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssm/SsmIntegrationTest.java
@@ -170,7 +170,8 @@ class SsmIntegrationTest {
             .post("/")
         .then()
             .statusCode(200)
-            .body("Parameters.size()", equalTo(2));
+            .body("Parameters.size()", equalTo(2))
+            .body("InvalidParameters", contains("/missing"));
     }
 
     @Test
@@ -230,7 +231,8 @@ class SsmIntegrationTest {
             .post("/")
         .then()
             .statusCode(200)
-            .body("DeletedParameters.size()", equalTo(2));
+            .body("DeletedParameters.size()", equalTo(2))
+            .body("InvalidParameters", contains("/missing"));
     }
 
     // ── Issue #956: DescribePatchBaselines / GetDefaultPatchBaseline (AWS-owned predefined) ──


### PR DESCRIPTION
## Summary

- Return unknown names through `InvalidParameters` for batch SSM get and delete operations.
- Cover mixed existing and missing names in the integration test.

## Testing

- `JAVA_HOME=/opt/homebrew/opt/openjdk@25 ./mvnw -q -Dtest=SsmIntegrationTest test`
