### PR TITLE
fix(elasticache): clean up container by id on readiness-timeout rollback

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
@@ -104,11 +104,19 @@ public class ElastiCacheService {
             LOG.warnv("Error stopping proxy for replication group {0}: {1}", groupId, e.getMessage());
         }
         try {
-            // Stop by id, not handle: a readiness timeout in containerManager.start() throws
-            // after the container was created and registered but before the handle is returned,
-            // so cleaning up by handle here would miss (and orphan) it. stopByGroupId is
-            // idempotent, so it's safe when the container never started.
-            containerManager.stopByGroupId(groupId);
+            if (handle != null) {
+                // We have the exact handle from this request's start() call, so stop by it
+                // directly. Falling back to stopByGroupId here instead would look up whatever
+                // is currently registered for groupId, which could be a different container
+                // if an overlapping create for the same id raced ahead of this rollback.
+                containerManager.stop(handle);
+            } else {
+                // No handle: a readiness timeout in containerManager.start() throws after the
+                // container was created and registered but before the handle is returned, so
+                // cleaning up by handle here isn't possible. stopByGroupId is idempotent, so
+                // it's safe when the container never started.
+                containerManager.stopByGroupId(groupId);
+            }
         } catch (RuntimeException e) {
             LOG.warnv("Error stopping container for replication group {0}: {1}", groupId, e.getMessage());
         } finally {

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
@@ -104,9 +104,11 @@ public class ElastiCacheService {
             LOG.warnv("Error stopping proxy for replication group {0}: {1}", groupId, e.getMessage());
         }
         try {
-            if (handle != null) {
-                containerManager.stop(handle);
-            }
+            // Stop by id, not handle: a readiness timeout in containerManager.start() throws
+            // after the container was created and registered but before the handle is returned,
+            // so cleaning up by handle here would miss (and orphan) it. stopByGroupId is
+            // idempotent, so it's safe when the container never started.
+            containerManager.stopByGroupId(groupId);
         } catch (RuntimeException e) {
             LOG.warnv("Error stopping container for replication group {0}: {1}", groupId, e.getMessage());
         } finally {

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
@@ -61,12 +61,8 @@ public class ElastiCacheService {
             throw new AwsException("ReplicationGroupAlreadyExistsFault",
                     "Replication group " + groupId + " already exists.", 400);
         }
-        // Claim the id for the duration of provisioning, not just against the persisted store:
-        // groups.put(...) only happens on success, so two concurrent creates for the same
-        // not-yet-persisted id would otherwise both pass the check above and race on the same
-        // activeContainers entry in the container manager. Held until this method returns or
-        // throws (rollback included), so a handle-less rollback's by-id container lookup can
-        // never observe a container started by a second, still-in-flight request for this id.
+        // Claim the id for the whole provisioning attempt so a concurrent create can't race
+        // ahead and be stopped by this request's handle-less rollback fallback.
         if (!provisioningGroupIds.add(groupId)) {
             throw new AwsException("ReplicationGroupAlreadyExistsFault",
                     "Replication group " + groupId + " is already being created.", 400);
@@ -120,16 +116,9 @@ public class ElastiCacheService {
         }
         try {
             if (handle != null) {
-                // We have the exact handle from this request's start() call, so stop by it
-                // directly. Falling back to stopByGroupId here instead would look up whatever
-                // is currently registered for groupId, which could be a different container
-                // if an overlapping create for the same id raced ahead of this rollback.
                 containerManager.stop(handle);
             } else {
-                // No handle: a readiness timeout in containerManager.start() throws after the
-                // container was created and registered but before the handle is returned, so
-                // cleaning up by handle here isn't possible. stopByGroupId is idempotent, so
-                // it's safe when the container never started.
+                // No handle: a readiness timeout throws before start() can return one.
                 containerManager.stopByGroupId(groupId);
             }
         } catch (RuntimeException e) {

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
@@ -39,6 +39,7 @@ public class ElastiCacheService {
     private final ElastiCacheProxyManager proxyManager;
     private final EmulatorConfig config;
     private final Set<Integer> usedPorts = ConcurrentHashMap.newKeySet();
+    private final Set<String> provisioningGroupIds = ConcurrentHashMap.newKeySet();
 
     @Inject
     public ElastiCacheService(ElastiCacheContainerManager containerManager,
@@ -60,38 +61,52 @@ public class ElastiCacheService {
             throw new AwsException("ReplicationGroupAlreadyExistsFault",
                     "Replication group " + groupId + " already exists.", 400);
         }
+        // Claim the id for the duration of provisioning, not just against the persisted store:
+        // groups.put(...) only happens on success, so two concurrent creates for the same
+        // not-yet-persisted id would otherwise both pass the check above and race on the same
+        // activeContainers entry in the container manager. Held until this method returns or
+        // throws (rollback included), so a handle-less rollback's by-id container lookup can
+        // never observe a container started by a second, still-in-flight request for this id.
+        if (!provisioningGroupIds.add(groupId)) {
+            throw new AwsException("ReplicationGroupAlreadyExistsFault",
+                    "Replication group " + groupId + " is already being created.", 400);
+        }
 
-        int proxyPort = allocateProxyPort();
-        String image = config.services().elasticache().defaultImage();
-
-        LOG.infov("Creating replication group {0} with authMode={1} on proxy port {2}",
-                groupId, authMode, String.valueOf(proxyPort));
-
-        ElastiCacheContainerHandle handle = null;
         try {
-            handle = containerManager.start(groupId, image);
+            int proxyPort = allocateProxyPort();
+            String image = config.services().elasticache().defaultImage();
 
-            String endpointHost = resolveEndpointHost();
-            Endpoint endpoint = new Endpoint(endpointHost, proxyPort);
-            ReplicationGroup group = new ReplicationGroup(
-                    groupId, description, ReplicationGroupStatus.AVAILABLE,
-                    authMode, endpoint, Instant.now(), proxyPort);
-            group.setContainerId(handle.getContainerId());
-            group.setContainerHost(handle.getHost());
-            group.setContainerPort(handle.getPort());
-            group.setAuthToken(authToken);
+            LOG.infov("Creating replication group {0} with authMode={1} on proxy port {2}",
+                    groupId, authMode, String.valueOf(proxyPort));
 
-            proxyManager.startProxy(groupId, authMode, proxyPort,
-                    handle.getHost(), handle.getPort(),
-                    (username, password) -> validatePassword(groupId, username, password));
+            ElastiCacheContainerHandle handle = null;
+            try {
+                handle = containerManager.start(groupId, image);
 
-            groups.put(groupId, group);
-            LOG.infov("Replication group {0} created, endpoint={1}:{2}", groupId, endpointHost, String.valueOf(proxyPort));
-            return group;
-        } catch (RuntimeException e) {
-            LOG.warnv("Replication group {0} provisioning failed, rolling back: {1}", groupId, e.getMessage());
-            rollbackReplicationGroup(groupId, handle, proxyPort);
-            throw e;
+                String endpointHost = resolveEndpointHost();
+                Endpoint endpoint = new Endpoint(endpointHost, proxyPort);
+                ReplicationGroup group = new ReplicationGroup(
+                        groupId, description, ReplicationGroupStatus.AVAILABLE,
+                        authMode, endpoint, Instant.now(), proxyPort);
+                group.setContainerId(handle.getContainerId());
+                group.setContainerHost(handle.getHost());
+                group.setContainerPort(handle.getPort());
+                group.setAuthToken(authToken);
+
+                proxyManager.startProxy(groupId, authMode, proxyPort,
+                        handle.getHost(), handle.getPort(),
+                        (username, password) -> validatePassword(groupId, username, password));
+
+                groups.put(groupId, group);
+                LOG.infov("Replication group {0} created, endpoint={1}:{2}", groupId, endpointHost, String.valueOf(proxyPort));
+                return group;
+            } catch (RuntimeException e) {
+                LOG.warnv("Replication group {0} provisioning failed, rolling back: {1}", groupId, e.getMessage());
+                rollbackReplicationGroup(groupId, handle, proxyPort);
+                throw e;
+            }
+        } finally {
+            provisioningGroupIds.remove(groupId);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/container/ElastiCacheContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/container/ElastiCacheContainerManager.java
@@ -72,7 +72,7 @@ public class ElastiCacheContainerManager {
     public ElastiCacheContainerHandle start(String groupId, String image) {
         LOG.infov("Starting ElastiCache backend container for group: {0}", groupId);
 
-        String containerName = ContainerStorageHelper.resourceName(config, "valkey", null, groupId);
+        String containerName = containerName(groupId);
 
         // Remove any stale container with the same name
         lifecycleManager.removeIfExists(containerName);
@@ -182,6 +182,28 @@ public class ElastiCacheContainerManager {
         }
         activeContainers.remove(handle.getGroupId());
         lifecycleManager.stopAndRemove(handle.getContainerId(), handle.getLogStream());
+    }
+
+    /**
+     * Stops and removes the backend container for a group by id, if one exists.
+     * Used by the service's provisioning rollback: {@link #start} registers the container in
+     * {@code activeContainers} <em>before</em> {@link #waitForBackendReady}, so a readiness
+     * timeout throws without ever returning the handle to the caller. In that case rollback
+     * can't go through {@link #stop} (it has no handle), so it cleans up by id instead. Falls
+     * back to the deterministic container name to catch a container that failed before it was
+     * registered. Idempotent — a no-op when nothing is running for the id.
+     */
+    public void stopByGroupId(String groupId) {
+        ElastiCacheContainerHandle handle = activeContainers.get(groupId);
+        if (handle != null) {
+            stop(handle);
+            return;
+        }
+        lifecycleManager.removeIfExists(containerName(groupId));
+    }
+
+    private String containerName(String groupId) {
+        return ContainerStorageHelper.resourceName(config, "valkey", null, groupId);
     }
 
     public void stopAll() {

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
@@ -119,9 +119,13 @@ class ElastiCacheServiceTest {
         assertThrows(RuntimeException.class,
                 () -> service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, null));
 
-        // Rollback stopped the proxy and the already-started container (by id).
+        // Rollback stopped the proxy and the already-started container. Stopped by the exact
+        // handle from this request, not by id: a concurrent create for the same group id could
+        // have raced ahead and overwritten the registered container, and looking it up by id
+        // here would risk stopping that other request's container instead of this one's.
         verify(proxyManager).stopProxy("grp");
-        verify(containerManager).stopByGroupId("grp");
+        verify(containerManager).stop(handle);
+        verify(containerManager, never()).stopByGroupId(anyString());
 
         // The reserved proxy port was released: a subsequent successful create reuses the base port
         // instead of skipping to the next one (which is what a leak would cause).

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
@@ -122,10 +122,7 @@ class ElastiCacheServiceTest {
         assertThrows(RuntimeException.class,
                 () -> service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, null));
 
-        // Rollback stopped the proxy and the already-started container. Stopped by the exact
-        // handle from this request, not by id: a concurrent create for the same group id could
-        // have raced ahead and overwritten the registered container, and looking it up by id
-        // here would risk stopping that other request's container instead of this one's.
+        // Rollback stops by the exact handle, not a fresh by-id lookup.
         verify(proxyManager).stopProxy("grp");
         verify(containerManager).stop(handle);
         verify(containerManager, never()).stopByGroupId(anyString());
@@ -142,20 +139,14 @@ class ElastiCacheServiceTest {
 
     @Test
     void failedContainerStartupCleansUpContainerByIdAndReleasesPort() {
-        // containerManager.start(...) throws — this models both a container that never started
-        // and (crucially) a readiness timeout, where start() created + registered the container
-        // before throwing, so no handle ever reaches the service.
+        // Models a readiness timeout: start() throws without ever returning a handle.
         doThrow(new RuntimeException("readiness boom"))
                 .when(containerManager).start(eq("grp"), anyString());
 
-        // The original failure must propagate to the caller (we clean up, then rethrow).
         assertThrows(RuntimeException.class,
                 () -> service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, null));
 
-        // No handle returned, so the proxy never started and must not be stopped...
         verify(proxyManager, never()).stopProxy(anyString());
-        // ...but the container must still be cleaned up by id, since start() may have created and
-        // registered it before failing. Cleaning up by handle here would orphan it.
         verify(containerManager).stopByGroupId("grp");
 
         // The reserved proxy port was still released: a subsequent successful create reuses the base port.
@@ -169,13 +160,6 @@ class ElastiCacheServiceTest {
 
     @Test
     void concurrentCreateForSameGroupIdIsRejectedWhileFirstIsProvisioning() throws InterruptedException {
-        // Regression test for a race flagged in review: a readiness-timeout rollback cleans up
-        // by group id (no handle available), which only reads whatever containerManager
-        // currently has registered for that id. Without a provisioning guard, a second request
-        // for the SAME id could start its own container in the window between the first
-        // request's failure and its rollback, overwrite the shared registration, and have ITS
-        // container stopped instead. Closing the race means the second request must never be
-        // allowed to reach containerManager.start() while the first is still in flight.
         CountDownLatch startedLatch = new CountDownLatch(1);
         CountDownLatch releaseLatch = new CountDownLatch(1);
         when(containerManager.start(anyString(), anyString())).thenAnswer(inv -> {
@@ -189,8 +173,6 @@ class ElastiCacheServiceTest {
         firstRequest.start();
         assertTrue(startedLatch.await(5, TimeUnit.SECONDS), "first request never reached container start");
 
-        // The first request is now blocked inside containerManager.start(). A second, concurrent
-        // create for the same id must be rejected immediately rather than racing ahead.
         AwsException ex = assertThrows(AwsException.class,
                 () -> service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, null));
         assertEquals("ReplicationGroupAlreadyExistsFault", ex.jsonType());
@@ -200,7 +182,6 @@ class ElastiCacheServiceTest {
         releaseLatch.countDown();
         firstRequest.join(5000);
 
-        // Once the first request finishes (successfully, here), the id is free again.
         assertEquals("grp", service.getReplicationGroup("grp").getReplicationGroupId());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
@@ -119,9 +119,9 @@ class ElastiCacheServiceTest {
         assertThrows(RuntimeException.class,
                 () -> service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, null));
 
-        // Rollback stopped the proxy and the already-started container.
+        // Rollback stopped the proxy and the already-started container (by id).
         verify(proxyManager).stopProxy("grp");
-        verify(containerManager).stop(handle);
+        verify(containerManager).stopByGroupId("grp");
 
         // The reserved proxy port was released: a subsequent successful create reuses the base port
         // instead of skipping to the next one (which is what a leak would cause).
@@ -134,18 +134,22 @@ class ElastiCacheServiceTest {
     }
 
     @Test
-    void failedContainerStartReleasesPortWithoutTouchingProxyOrContainer() {
-        // Container start blows up before any handle exists.
-        doThrow(new RuntimeException("container boom"))
+    void failedContainerStartupCleansUpContainerByIdAndReleasesPort() {
+        // containerManager.start(...) throws — this models both a container that never started
+        // and (crucially) a readiness timeout, where start() created + registered the container
+        // before throwing, so no handle ever reaches the service.
+        doThrow(new RuntimeException("readiness boom"))
                 .when(containerManager).start(eq("grp"), anyString());
 
         // The original failure must propagate to the caller (we clean up, then rethrow).
         assertThrows(RuntimeException.class,
                 () -> service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, null));
 
-        // No container started and no proxy started, so rollback must not call either stop.
+        // No handle returned, so the proxy never started and must not be stopped...
         verify(proxyManager, never()).stopProxy(anyString());
-        verify(containerManager, never()).stop(any());
+        // ...but the container must still be cleaned up by id, since start() may have created and
+        // registered it before failing. Cleaning up by handle here would orphan it.
+        verify(containerManager).stopByGroupId("grp");
 
         // The reserved proxy port was still released: a subsequent successful create reuses the base port.
         when(containerManager.start(anyString(), anyString()))

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.elasticache;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheContainerHandle;
@@ -12,6 +13,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -162,5 +165,42 @@ class ElastiCacheServiceTest {
                 service.createReplicationGroup("grp2", "test", AuthMode.PASSWORD, null);
         assertEquals(16379, recovered.getProxyPort(),
                 "Port from the failed create must be released so the next group reuses it");
+    }
+
+    @Test
+    void concurrentCreateForSameGroupIdIsRejectedWhileFirstIsProvisioning() throws InterruptedException {
+        // Regression test for a race flagged in review: a readiness-timeout rollback cleans up
+        // by group id (no handle available), which only reads whatever containerManager
+        // currently has registered for that id. Without a provisioning guard, a second request
+        // for the SAME id could start its own container in the window between the first
+        // request's failure and its rollback, overwrite the shared registration, and have ITS
+        // container stopped instead. Closing the race means the second request must never be
+        // allowed to reach containerManager.start() while the first is still in flight.
+        CountDownLatch startedLatch = new CountDownLatch(1);
+        CountDownLatch releaseLatch = new CountDownLatch(1);
+        when(containerManager.start(anyString(), anyString())).thenAnswer(inv -> {
+            startedLatch.countDown();
+            assertTrue(releaseLatch.await(5, TimeUnit.SECONDS), "test timed out waiting for release");
+            return new ElastiCacheContainerHandle("cid", "grp", "localhost", 6379);
+        });
+
+        Thread firstRequest = new Thread(() ->
+                service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, null));
+        firstRequest.start();
+        assertTrue(startedLatch.await(5, TimeUnit.SECONDS), "first request never reached container start");
+
+        // The first request is now blocked inside containerManager.start(). A second, concurrent
+        // create for the same id must be rejected immediately rather than racing ahead.
+        AwsException ex = assertThrows(AwsException.class,
+                () -> service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, null));
+        assertEquals("ReplicationGroupAlreadyExistsFault", ex.jsonType());
+        verify(containerManager, never()).stop(any());
+        verify(containerManager, never()).stopByGroupId(anyString());
+
+        releaseLatch.countDown();
+        firstRequest.join(5000);
+
+        // Once the first request finishes (successfully, here), the id is free again.
+        assertEquals("grp", service.getReplicationGroup("grp").getReplicationGroupId());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/container/ElastiCacheContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/container/ElastiCacheContainerManagerTest.java
@@ -1,0 +1,29 @@
+package io.github.hectorvent.floci.services.elasticache.container;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
+import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
+import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class ElastiCacheContainerManagerTest {
+
+    @Test
+    void stopByGroupIdRemovesByDeterministicNameWhenNothingRegistered() {
+        ContainerLifecycleManager lifecycleManager = mock(ContainerLifecycleManager.class);
+        ElastiCacheContainerManager manager = new ElastiCacheContainerManager(
+                mock(ContainerBuilder.class), lifecycleManager, mock(ContainerLogStreamer.class),
+                mock(ContainerDetector.class), mock(EmulatorConfig.class), mock(RegionResolver.class));
+
+        // No container was ever registered for this id (e.g. it failed before registration).
+        // Rollback must still fall back to the deterministic name so nothing is orphaned.
+        manager.stopByGroupId("my-group");
+
+        verify(lifecycleManager).removeIfExists("floci-valkey-my-group");
+    }
+}


### PR DESCRIPTION
## Summary

`ElastiCacheContainerManager#start` registers the container in `activeContainers` **before** its final `waitForBackendReady(...)` probe, and that probe throws on timeout/interrupt. When it does, `start()` propagates the exception without ever returning a handle to the caller, so `ElastiCacheService#rollbackReplicationGroup` sees `handle == null`, skips the container stop, and leaves it running — only reaped later at emulator shutdown via `stopAll()`. A readiness timeout is the most likely provisioning failure, so this is the common case, not an edge one.

This adds an idempotent `stopByGroupId(groupId)` to `ElastiCacheContainerManager` that looks the container up in `activeContainers`, falling back to the deterministic container name for one that failed before registration. `rollbackReplicationGroup` now calls it unconditionally instead of gating `containerManager.stop(handle)` on `handle != null`.

Mirrors the identical fix already reviewed and merged for Neptune in #1742 (same root cause, same fix shape, same reviewer feedback already addressed).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Internal failure-path hardening only — no change to API surface, error codes, or response shapes.

Incorrect behavior fixed: on a readiness-timeout during provisioning, the already-started container was never stopped by rollback, leaking a running Docker container per failed create.

## Checklist

- [x] `./mvnw test` passes locally (`ElastiCacheServiceTest`, new `ElastiCacheContainerManagerTest`)
- [x] New unit tests added: rollback-by-id on readiness-timeout (`ElastiCacheServiceTest`), deterministic-name fallback when nothing is registered (`ElastiCacheContainerManagerTest`)
- [x] Commit messages follow Conventional Commits