### PR TITLE
fix(ec2): return AWS-parity MissingParameter for CreateSubnet without VpcId

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1302,6 +1302,9 @@ public class Ec2Service implements ContainerTeardown {
     // ─── Subnets ───────────────────────────────────────────────────────────────
 
     public Subnet createSubnet(String region, String vpcId, String cidrBlock, String availabilityZone) {
+        if (vpcId == null || vpcId.isBlank()) {
+            throw new AwsException("MissingParameter", "The request must contain the parameter VpcId", 400);
+        }
         ensureDefaultResources(region);
         getRequiredVpc(region, vpcId);
 

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -687,6 +687,22 @@ class Ec2IntegrationTest {
     }
 
     @Test
+    @Order(20)
+    void createSubnetWithBlankVpcIdReturnsMissingParameter() {
+        given()
+            .formParam("Action", "CreateSubnet")
+            .formParam("VpcId", "   ")
+            .formParam("CidrBlock", "10.0.2.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("MissingParameter"))
+            .body("Response.Errors.Error.Message", equalTo("The request must contain the parameter VpcId"));
+    }
+
+    @Test
     @Order(21)
     void describeSubnetById() {
         given()

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -672,6 +672,21 @@ class Ec2IntegrationTest {
     }
 
     @Test
+    @Order(20)
+    void createSubnetWithoutVpcIdReturnsMissingParameter() {
+        given()
+            .formParam("Action", "CreateSubnet")
+            .formParam("CidrBlock", "10.0.2.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("MissingParameter"))
+            .body("Response.Errors.Error.Message", equalTo("The request must contain the parameter VpcId"));
+    }
+
+    @Test
     @Order(21)
     void describeSubnetById() {
         given()

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -85,6 +85,21 @@ class Ec2ServiceTest {
     }
 
     @Test
+    void createSubnetRejectsBlankVpcIdInsteadOfNotFound() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+
+        AwsException error = assertThrows(AwsException.class, () -> service.createSubnet(
+                "us-east-1", "   ", "10.0.1.0/24", null));
+
+        assertEquals("MissingParameter", error.getErrorCode());
+        assertEquals("The request must contain the parameter VpcId", error.getMessage());
+        assertEquals(400, error.getHttpStatus());
+    }
+
+    @Test
     void runInstancesStoresArchitectureFromImageCatalog() {
         Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
                 mock(Ec2PortForwardManager.class),

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -70,6 +70,21 @@ class Ec2ServiceTest {
     }
 
     @Test
+    void createSubnetRequiresVpcIdInsteadOfNotFound() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+
+        AwsException error = assertThrows(AwsException.class, () -> service.createSubnet(
+                "us-east-1", null, "10.0.1.0/24", null));
+
+        assertEquals("MissingParameter", error.getErrorCode());
+        assertEquals("The request must contain the parameter VpcId", error.getMessage());
+        assertEquals(400, error.getHttpStatus());
+    }
+
+    @Test
     void runInstancesStoresArchitectureFromImageCatalog() {
         Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
                 mock(Ec2PortForwardManager.class),


### PR DESCRIPTION
## Summary
- `CreateSubnet` looked up a null `VpcId` directly, producing `InvalidVpcID.NotFound: The vpc ID 'null' does not exist` instead of AWS's actual `MissingParameter` error for a missing required parameter.
- Now returns `MissingParameter: The request must contain the parameter VpcId`, matching the pattern already used for `RunInstances`' `ImageId` check and matching real EC2 behavior (`VpcId` is required for `CreateSubnet`).

Fixes #2089.

## Test plan
- [x] Reproduced the original error against unfixed code: `InvalidVpcID.NotFound: The vpc ID 'null' does not exist`
- [x] Confirmed the fix replaces it with `MissingParameter: The request must contain the parameter VpcId`
- [x] Added unit test (`Ec2ServiceTest`) and HTTP-level integration test (`Ec2IntegrationTest`)
- [x] `Ec2IntegrationTest`, `Ec2ServiceTest`, `Ec2ServiceConcurrencyTest`, `Ec2ServicePersistenceTest`, `Ec2Phase2IntegrationTest` all pass