### PR TITLE
feat(elbv2): honor preserve_host_header parameter

### DIFF
--- a/docs/services/elb.md
+++ b/docs/services/elb.md
@@ -91,6 +91,7 @@ Floci supports Application Load Balancers (ALB) and Network Load Balancers (NLB)
 - `DeleteRule` is rejected with `OperationNotPermitted` for the default rule.
 - `DescribeSSLPolicies` returns a pre-seeded list of standard AWS SSL policies (`ELBSecurityPolicy-*`).
 - `DescribeAccountLimits` returns standard default limits (e.g., 50 load balancers per region, 100 target groups, etc.).
+- `routing.http.preserve_host_header.enabled` (default `false`) controls whether the original client Host header is forwarded to targets unchanged, or replaced with the target's `host:port`.
 
 ## ARN Format
 

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
@@ -47,6 +47,7 @@ public class ElbV2DataPlane {
     private static final List<String> HOP_BY_HOP_HEADERS = List.of(
             "connection", "keep-alive", "transfer-encoding", "upgrade", "te", "trailers", "proxy-authorization", "proxy-authenticate"
     );
+    private static final String PRESERVE_HOST_HEADER_ATTRIBUTE = "routing.http.preserve_host_header.enabled";
 
     @Inject
     Vertx vertx;
@@ -78,7 +79,7 @@ public class ElbV2DataPlane {
 
     private HttpClient proxyClient;
 
-    private record ListenerBinding(int port, String host) {}
+    private record ListenerBinding(int port, String host, String loadBalancerArn) {}
 
     @PostConstruct
     void init() {
@@ -204,7 +205,7 @@ public class ElbV2DataPlane {
     private ListenerBinding binding(Listener listener, String region) {
         LoadBalancer loadBalancer = elbV2Service.getLoadBalancer(region, listener.getLoadBalancerArn());
         String host = loadBalancer != null ? normalizeHost(loadBalancer.getDnsName()) : listener.getLoadBalancerArn();
-        return new ListenerBinding(listener.getPort(), host);
+        return new ListenerBinding(listener.getPort(), host, listener.getLoadBalancerArn());
     }
 
     private void handleRequest(io.vertx.core.http.HttpServerRequest req, int port) {
@@ -226,7 +227,7 @@ public class ElbV2DataPlane {
         List<CompiledRule> chain = ref.get();
         for (CompiledRule compiled : chain) {
             if (compiled.matches(req)) {
-                executeAction(req, compiled.action, region);
+                executeAction(req, compiled.action, region, listenerArn);
                 return;
             }
         }
@@ -262,20 +263,20 @@ public class ElbV2DataPlane {
         return normalized;
     }
 
-    private void executeAction(io.vertx.core.http.HttpServerRequest req, Action action, String region) {
+    private void executeAction(io.vertx.core.http.HttpServerRequest req, Action action, String region, String listenerArn) {
         if (action == null) {
             req.response().setStatusCode(502).end("No action");
             return;
         }
         switch (action.getType() != null ? action.getType() : "") {
-            case "forward" -> executeForward(req, action, region);
+            case "forward" -> executeForward(req, action, region, listenerArn);
             case "redirect" -> executeRedirect(req, action);
             case "fixed-response" -> executeFixedResponse(req, action);
             default -> req.response().setStatusCode(502).end("Unsupported action type");
         }
     }
 
-    private void executeForward(io.vertx.core.http.HttpServerRequest req, Action action, String region) {
+    private void executeForward(io.vertx.core.http.HttpServerRequest req, Action action, String region, String listenerArn) {
         String tgArn = resolveTgArn(action);
         if (tgArn == null) {
             req.response().setStatusCode(502).end("No target group");
@@ -311,7 +312,19 @@ public class ElbV2DataPlane {
         int idx = Math.abs(counter.getAndIncrement() % candidates.size());
         TargetDescription target = candidates.get(idx);
         int targetPort = ElbV2HealthChecker.effectivePort(target, tg);
-        proxyRequest(req, ElbV2TargetResolver.resolveHost(ec2Service, tg, target), targetPort);
+        proxyRequest(req, ElbV2TargetResolver.resolveHost(ec2Service, tg, target), targetPort,
+                preserveHostHeader(listenerArn, region));
+    }
+
+    private boolean preserveHostHeader(String listenerArn, String region) {
+        ListenerBinding binding = listenerBindings.get(listenerArn);
+        if (binding == null) {
+            return false;
+        }
+        LoadBalancer loadBalancer = elbV2Service.getLoadBalancer(region, binding.loadBalancerArn());
+        return loadBalancer != null
+                && loadBalancer.getAttributes() != null
+                && Boolean.parseBoolean(loadBalancer.getAttributes().get(PRESERVE_HOST_HEADER_ATTRIBUTE));
     }
 
     private void invokeLambdaTarget(io.vertx.core.http.HttpServerRequest req, String functionArn, String region) {
@@ -460,7 +473,8 @@ public class ElbV2DataPlane {
         return tuples.get(tuples.size() - 1).getTargetGroupArn();
     }
 
-    private void proxyRequest(io.vertx.core.http.HttpServerRequest req, String host, int port) {
+    private void proxyRequest(io.vertx.core.http.HttpServerRequest req, String host, int port,
+                              boolean preserveHostHeader) {
         req.bodyHandler(body -> {
             RequestOptions opts = new RequestOptions()
                     .setHost(host)
@@ -474,7 +488,9 @@ public class ElbV2DataPlane {
                                 clientReq.putHeader(entry.getKey(), entry.getValue());
                             }
                         });
-                        clientReq.putHeader("Host", host + ":" + port);
+                        if (!preserveHostHeader) {
+                            clientReq.putHeader("Host", host + ":" + port);
+                        }
                         clientReq.send(body)
                                 .onSuccess(resp -> {
                                     req.response().setStatusCode(resp.statusCode());

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2PreserveHostHeaderIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2PreserveHostHeaderIntegrationTest.java
@@ -1,0 +1,194 @@
+package io.github.hectorvent.floci.services.elbv2;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+@TestProfile(ElbV2PreserveHostHeaderIntegrationTest.RealElbV2DataPlaneProfile.class)
+class ElbV2PreserveHostHeaderIntegrationTest {
+
+    public static final class RealElbV2DataPlaneProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci.services.elbv2.mock", "false");
+        }
+    }
+
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260803/us-east-1/elasticloadbalancing/aws4_request";
+    private static final int LISTENER_PORT = 7794;
+    private static final String CLIENT_HOST = "client.example.test:8443";
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    void preservesHostHeaderWhenLoadBalancerAttributeIsEnabled() throws Exception {
+        HttpServer backend = vertx.createHttpServer()
+                .requestHandler(request -> request.response().end(request.getHeader("Host")))
+                .listen(0, "127.0.0.1")
+                .toCompletionStage()
+                .toCompletableFuture()
+                .get(2, TimeUnit.SECONDS);
+
+        String loadBalancerArn = null;
+        String targetGroupArn = null;
+        String listenerArn = null;
+        try {
+            loadBalancerArn = createLoadBalancer();
+            targetGroupArn = createTargetGroup(backend.actualPort());
+            registerTarget(targetGroupArn, backend.actualPort());
+            listenerArn = createListener(loadBalancerArn, targetGroupArn);
+
+            assertForwardedHost("127.0.0.1:" + backend.actualPort());
+
+            enableHostHeaderPreservation(loadBalancerArn);
+
+            assertForwardedHost(CLIENT_HOST);
+        } finally {
+            deleteListener(listenerArn);
+            deleteTargetGroup(targetGroupArn);
+            deleteLoadBalancer(loadBalancerArn);
+            backend.close().toCompletionStage().toCompletableFuture().get(2, TimeUnit.SECONDS);
+        }
+    }
+
+    private static String createLoadBalancer() {
+        return given()
+                .formParam("Action", "CreateLoadBalancer")
+                .formParam("Name", "preserve-host-header-lb")
+                .formParam("Type", "application")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.LoadBalancerArn");
+    }
+
+    private static String createTargetGroup(int backendPort) {
+        return given()
+                .formParam("Action", "CreateTargetGroup")
+                .formParam("Name", "preserve-host-header-tg")
+                .formParam("Protocol", "HTTP")
+                .formParam("Port", backendPort)
+                .formParam("TargetType", "ip")
+                .formParam("HealthCheckEnabled", "false")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("CreateTargetGroupResponse.CreateTargetGroupResult.TargetGroups.member.TargetGroupArn");
+    }
+
+    private static void registerTarget(String targetGroupArn, int backendPort) {
+        given()
+                .formParam("Action", "RegisterTargets")
+                .formParam("TargetGroupArn", targetGroupArn)
+                .formParam("Targets.member.1.Id", "127.0.0.1")
+                .formParam("Targets.member.1.Port", backendPort)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+    }
+
+    private static String createListener(String loadBalancerArn, String targetGroupArn) {
+        return given()
+                .formParam("Action", "CreateListener")
+                .formParam("LoadBalancerArn", loadBalancerArn)
+                .formParam("Protocol", "HTTP")
+                .formParam("Port", LISTENER_PORT)
+                .formParam("DefaultActions.member.1.Type", "forward")
+                .formParam("DefaultActions.member.1.TargetGroupArn", targetGroupArn)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("CreateListenerResponse.CreateListenerResult.Listeners.member.ListenerArn");
+    }
+
+    private static void enableHostHeaderPreservation(String loadBalancerArn) {
+        given()
+                .formParam("Action", "ModifyLoadBalancerAttributes")
+                .formParam("LoadBalancerArn", loadBalancerArn)
+                .formParam("Attributes.member.1.Key", "routing.http.preserve_host_header.enabled")
+                .formParam("Attributes.member.1.Value", "true")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+    }
+
+    private static void assertForwardedHost(String expectedHost) {
+        await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> given()
+                .baseUri("http://127.0.0.1")
+                .port(LISTENER_PORT)
+                .header("Host", CLIENT_HOST)
+            .when()
+                .get("/")
+            .then()
+                .statusCode(200)
+                .body(equalTo(expectedHost)));
+    }
+
+    private static void deleteListener(String listenerArn) {
+        if (listenerArn != null) {
+            given()
+                    .formParam("Action", "DeleteListener")
+                    .formParam("ListenerArn", listenerArn)
+                    .header("Authorization", AUTH)
+                .when()
+                    .post("/")
+                .then()
+                    .statusCode(anyOf(equalTo(200), equalTo(204)));
+        }
+    }
+
+    private static void deleteTargetGroup(String targetGroupArn) {
+        if (targetGroupArn != null) {
+            given()
+                    .formParam("Action", "DeleteTargetGroup")
+                    .formParam("TargetGroupArn", targetGroupArn)
+                    .header("Authorization", AUTH)
+                .when()
+                    .post("/")
+                .then()
+                    .statusCode(anyOf(equalTo(200), equalTo(204)));
+        }
+    }
+
+    private static void deleteLoadBalancer(String loadBalancerArn) {
+        if (loadBalancerArn != null) {
+            given()
+                    .formParam("Action", "DeleteLoadBalancer")
+                    .formParam("LoadBalancerArn", loadBalancerArn)
+                    .header("Authorization", AUTH)
+                .when()
+                    .post("/")
+                .then()
+                    .statusCode(anyOf(equalTo(200), equalTo(204)));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Hello!
This PR updates the ELBv2 service to honor the `preserve_host_header` parameter.

It propagates the load balancer's ARN through the ElbV2DataPlane instance in order to retrieve the current value of `routing.http.preserve_host_header.enabled` in `executeForward`/`proxyRequest` 

## Type of change

- [ ] Bug fix (`fix:`)
- [X] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

Change tested with a simple echo server running on ECS behind an ALB.

Stack deployed through terraform with hashicorp/aws 6.57.1.

Without the patch/with `preserve_host_header=false`:

```
curl \                                               
  -H 'Host: example.com' \
  http://localhost:8088/
{"host":"172.17.0.3:8080"}
```

With the patch + `preserve_host_header=true`:

```
curl \
  -H 'Host: example.com' \
  http://localhost:8088/
{"host":"example.com"}
```

## Checklist

- [X] `./mvnw test` passes locally
- [X] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->

