### PR TITLE
fix(sqs): delayed FIFO message no longer blocks its message group

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueue.java
@@ -120,9 +120,13 @@ class GuardedMessageQueue {
         // message from a previous ReceiveMessage call is blocked until that
         // message is deleted or its visibility expires. Within a single call
         // we may return multiple messages from the same group (preserving
-        // insertion order), up to MaxNumberOfMessages.
+        // insertion order), up to MaxNumberOfMessages. A not-visible message
+        // that was never claimed — no receipt handle — is only waiting out its
+        // DelaySeconds and must not lock its group.
         Set<String> groupsWithInFlight =
-                messages.stream().filter(msg -> !msg.isVisible() && msg.getMessageGroupId() != null)
+                messages.stream()
+                        .filter(msg -> !msg.isVisible() && msg.getReceiptHandle() != null
+                                && msg.getMessageGroupId() != null)
                         .map(Message::getMessageGroupId).collect(Collectors.toSet());
 
         for (Message msg : messages) {

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueueTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/GuardedMessageQueueTest.java
@@ -218,6 +218,27 @@ class GuardedMessageQueueTest {
         assertTrue(second.claimed().isEmpty());
     }
 
+    @Test
+    void fifoDelayedMessageDoesNotLockItsMessageGroup() {
+        // Only in-flight messages (claimed, within their visibility timeout)
+        // lock a FIFO message group. A message still waiting out its
+        // DelaySeconds was never claimed — no receipt handle — and must not
+        // make an already-visible message in the same group unreceivable.
+        Message visible = new Message("visible");
+        visible.setMessageGroupId("group1");
+        Message delayed = new Message("delayed");
+        delayed.setMessageGroupId("group1");
+        delayed.setVisibleAt(Instant.now().plusSeconds(60));
+
+        queue.addMessage(visible);
+        queue.addMessage(delayed);
+
+        var result = queue.claimVisibleMessages(10, 30, true, -1, null);
+        assertEquals(1, result.claimed().size(),
+                "A delayed message must not block its message group");
+        assertEquals("visible", result.claimed().get(0).getBody());
+    }
+
     // --- DLQ ---
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsFifoIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsFifoIntegrationTest.java
@@ -153,6 +153,71 @@ class SqsFifoIntegrationTest {
 
     @Test
     @Order(8)
+    void delayedMessageDoesNotBlockVisibleMessageInSameGroup() throws InterruptedException {
+        // Issue #2104: a message still waiting out DelaySeconds must not lock
+        // its message group — only in-flight messages do.
+        String delayQueueUrl = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", "fifo-delay-lock.fifo")
+            .formParam("Attribute.1.Name", "FifoQueue")
+            .formParam("Attribute.1.Value", "true")
+            .formParam("Attribute.2.Name", "DelaySeconds")
+            .formParam("Attribute.2.Value", "1")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath().getString("CreateQueueResponse.CreateQueueResult.QueueUrl");
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "SendMessage")
+            .formParam("QueueUrl", delayQueueUrl)
+            .formParam("MessageBody", "A")
+            .formParam("MessageGroupId", "group-a")
+            .formParam("MessageDeduplicationId", "a1")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        Thread.sleep(1100);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "SendMessage")
+            .formParam("QueueUrl", delayQueueUrl)
+            .formParam("MessageBody", "B")
+            .formParam("MessageGroupId", "group-a")
+            .formParam("MessageDeduplicationId", "b1")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ReceiveMessage")
+            .formParam("QueueUrl", delayQueueUrl)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Body>A</Body>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DeleteQueue")
+            .formParam("QueueUrl", delayQueueUrl)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(9)
     void deleteFifoQueue() {
         given()
             .contentType("application/x-www-form-urlencoded")

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -446,6 +446,26 @@ class SqsServiceTest {
     }
 
     @Test
+    void fifoDelayedMessageDoesNotBlockVisibleMessageInSameGroup() {
+        // Issue #2104: only in-flight messages lock a FIFO message group. A
+        // newly sent, still-delayed message must not make an already-visible
+        // message in the same group unreceivable.
+        String region = "eu-west-1";
+        Queue queue = sqsService.createQueue("delay-group-lock.fifo",
+                Map.of("ContentBasedDeduplication", "true", "DelaySeconds", "1"), region);
+        sqsService.sendMessage(queue.getQueueUrl(), "A", 0, "group1", null, region);
+
+        try { Thread.sleep(1100); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+
+        sqsService.sendMessage(queue.getQueueUrl(), "B", 0, "group1", null, region);
+
+        List<Message> received = sqsService.receiveMessage(queue.getQueueUrl(), 10, 0, 0, region);
+        assertEquals(1, received.size(),
+                "The already-visible message must be returned despite a delayed message in its group");
+        assertEquals("A", received.get(0).getBody());
+    }
+
+    @Test
     void fifoQueueIgnoresPerMessageDelaySeconds() {
         // AWS SQS FIFO queues only support queue-level DelaySeconds; any
         // per-message value is ignored. Here the queue default is 0 and the


### PR DESCRIPTION
## Summary

Closes #2104.

`GuardedMessageQueue.claimFifo()` builds its group-lock set with `!msg.isVisible()`, which matches not only in-flight messages but also messages still waiting out `DelaySeconds` (since #476 sets `visibleAt = now + delay` on send). A newly sent, still-delayed message therefore locked its message group and made an already-visible message in the same group unreceivable — permanently starving the group whenever a producer sends faster than `DelaySeconds`.

The fix narrows the predicate with `msg.getReceiptHandle() != null` — the same delayed-vs-in-flight discriminator `messageCounts()` already uses (#1285): a not-visible message that was never claimed can only be waiting out its delay.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

On real AWS SQS, only in-flight messages block the rest of their FIFO message group ("No additional messages from the same message group ID are returned until the first message is deleted or becomes visible again"); delayed messages block nothing. Floci returned an empty `ReceiveMessage` response where real AWS returns the visible message.

Verified with the exact reproduction from #2104 (AWS CLI 2.32.31 against `quarkus:dev`): after the fix the final `receive-message` returns `A` (MD5 `7fc56270e7a70fa81a5935b72eacbe29`) while `B` is still delayed, and `GetQueueAttributes` reports `visible=1 notVisible=0 delayed=1` right before the receive. A follow-up `receive-message` while `A` is in flight returns empty, confirming the cross-call group lock still works.

Regression tests added at all three levels: `GuardedMessageQueueTest` (lock predicate), `SqsServiceTest` (delay elapse through `SqsService.receiveMessage`), and `SqsFifoIntegrationTest` (Query protocol end-to-end). All three fail without the one-line fix.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Note on the full local run: all SQS suites pass (8200 tests total); the only failures in my environment are Docker-backed suites (DocDB, Neptune, ElastiCache, API Gateway authorizers, ELB) with `SocketTimeout`/port-bind errors, which fail identically on unmodified `main` on this machine (macOS + Docker), so they are unrelated to this change.
