### PR TITLE
fix(dynamodb): order Query by full composite sort key

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -753,13 +753,13 @@ public class DynamoDbService {
 
             String startItemKey = hasTableKeys
                     ? buildItemKeyFromNode(exclusiveStartKey, tablePkName, tableSkName)
-                    : buildItemKeyFromNode(exclusiveStartKey, pkName, skName);
+                    : buildItemKeyFromNode(exclusiveStartKey, pkName, sortKeyNames);
 
             int startIdx = -1;
             for (int i = 0; i < results.size(); i++) {
                 String thisKey = hasTableKeys
                         ? buildItemKeyFromNode(results.get(i), tablePkName, tableSkName)
-                        : buildItemKeyFromNode(results.get(i), pkName, skName);
+                        : buildItemKeyFromNode(results.get(i), pkName, sortKeyNames);
                 if (thisKey.equals(startItemKey)) {
                     startIdx = i;
                     break;
@@ -776,7 +776,7 @@ public class DynamoDbService {
         // Apply Limit (stops at N items)
         if (limit != null && limit > 0 && evaluatedItems.size() > limit) {
             JsonNode lastItem = evaluatedItems.get(limit - 1);
-            lastEvaluatedKey = buildKeyNode(table, lastItem, pkName, skName, indexName != null);
+            lastEvaluatedKey = buildKeyNode(table, lastItem, pkName, sortKeyNames, indexName != null);
             evaluatedItems = new ArrayList<>(evaluatedItems.subList(0, limit));
         }
 
@@ -787,7 +787,7 @@ public class DynamoDbService {
             for (int i = 0; i < evaluatedItems.size(); i++) {
                 int sz = DynamoDbItemSize.calculateItemSize(evaluatedItems.get(i));
                 if (accSize > 0 && accSize + sz > MAX_RESPONSE_BYTES) {
-                    lastEvaluatedKey = buildKeyNode(table, evaluatedItems.get(i - 1), pkName, skName, indexName != null);
+                    lastEvaluatedKey = buildKeyNode(table, evaluatedItems.get(i - 1), pkName, sortKeyNames, indexName != null);
                     evaluatedItems = new ArrayList<>(evaluatedItems.subList(0, i));
                     break;
                 }
@@ -2361,16 +2361,25 @@ public class DynamoDbService {
     }
 
     private String buildItemKeyFromNode(JsonNode item, String pkName, String skName) {
+        return buildItemKeyFromNode(item, pkName, skName == null ? List.of() : List.of(skName));
+    }
+
+    // Builds a cursor-matching string from the partition key plus every sort-key component in
+    // key-schema order. A composite (multi-RANGE) index cursor must incorporate all components,
+    // otherwise rows sharing the first RANGE value collapse to the same key and pagination can
+    // skip or duplicate items. See floci-io/floci#1675.
+    private String buildItemKeyFromNode(JsonNode item, String pkName, List<String> skNames) {
         JsonNode pkAttr = item.get(pkName);
         if (pkAttr == null) return "";
         String pk = extractScalarValue(pkAttr);
-        if (skName != null) {
+        StringBuilder key = new StringBuilder(pk != null ? pk : "");
+        for (String skName : skNames) {
             JsonNode skAttr = item.get(skName);
             if (skAttr != null) {
-                return pk + "#" + extractScalarValue(skAttr);
+                key.append("#").append(extractScalarValue(skAttr));
             }
         }
-        return pk != null ? pk : "";
+        return key.toString();
     }
 
     JsonNode buildKeyNode(TableDefinition table, JsonNode item, String pkName, String skName) {
@@ -2379,13 +2388,23 @@ public class DynamoDbService {
 
     JsonNode buildKeyNode(TableDefinition table, JsonNode item,
                           String pkName, String skName, boolean isIndexQuery) {
+        return buildKeyNode(table, item, pkName,
+                skName == null ? List.of() : List.of(skName), isIndexQuery);
+    }
+
+    // Emits a LastEvaluatedKey carrying the partition key plus every sort-key component in
+    // key-schema order (a composite index has more than one), and, for index queries, the base
+    // table key so the cursor uniquely identifies a row. Emitting only the first RANGE attribute
+    // loses composite key identity. See floci-io/floci#1675.
+    JsonNode buildKeyNode(TableDefinition table, JsonNode item,
+                          String pkName, List<String> skNames, boolean isIndexQuery) {
         com.fasterxml.jackson.databind.node.ObjectNode keyNode =
                 com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
         JsonNode pkAttr = item.get(pkName);
         if (pkAttr != null) {
             keyNode.set(pkName, pkAttr);
         }
-        if (skName != null) {
+        for (String skName : skNames) {
             JsonNode skAttr = item.get(skName);
             if (skAttr != null) {
                 keyNode.set(skName, skAttr);
@@ -2397,7 +2416,7 @@ public class DynamoDbService {
             if (!tablePk.equals(pkName) && item.get(tablePk) != null) {
                 keyNode.set(tablePk, item.get(tablePk));
             }
-            if (tableSk != null && !tableSk.equals(skName) && item.get(tableSk) != null) {
+            if (tableSk != null && !skNames.contains(tableSk) && item.get(tableSk) != null) {
                 keyNode.set(tableSk, item.get(tableSk));
             }
         }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -659,21 +659,25 @@ public class DynamoDbService {
         // Resolve key names: use GSI or table keys
         String pkName;
         String skName;
+        List<String> sortKeyNames;
         if (indexName != null) {
             var gsi = table.findGsi(indexName);
             if (gsi.isPresent()) {
                 pkName = gsi.get().getPartitionKeyName();
                 skName = gsi.get().getSortKeyName();
+                sortKeyNames = gsi.get().getSortKeyNames();
             } else {
                 var lsi = table.findLsi(indexName)
                         .orElseThrow(() -> new AwsException("ValidationException",
                                 "The table does not have the specified index: " + indexName, 400));
                 pkName = lsi.getPartitionKeyName();
                 skName = lsi.getSortKeyName();
+                sortKeyNames = lsi.getSortKeyNames();
             }
         } else {
             pkName = table.getPartitionKeyName();
             skName = table.getSortKeyName();
+            sortKeyNames = table.getSortKeyNames();
         }
 
         List<JsonNode> results = new ArrayList<>();
@@ -716,17 +720,25 @@ public class DynamoDbService {
         // Filter out TTL-expired items
         results = results.stream().filter(item -> !isExpired(item, table)).toList();
 
-        // Sort by sort key if present
-        if (skName != null) {
-            String finalSkName = skName;
+        // Sort by the full (possibly composite) sort key, comparing each attribute in key-schema
+        // order. Using only the first sort-key attribute would ignore the remaining components
+        // (e.g. a "requestStateQuery RANGE, createdAt RANGE" index would never order by createdAt),
+        // which in turn breaks ScanIndexForward=false. See floci-io/floci#1675.
+        if (!sortKeyNames.isEmpty()) {
+            List<String> finalSortKeyNames = sortKeyNames;
             results = new ArrayList<>(results);
             results.sort((a, b) -> {
-                JsonNode aAttr = a.get(finalSkName);
-                JsonNode bAttr = b.get(finalSkName);
-                if (aAttr == null && bAttr == null) return 0;
-                if (aAttr == null) return -1;
-                if (bAttr == null) return 1;
-                return ExpressionEvaluator.compareAttributeValues(aAttr, bAttr);
+                for (String name : finalSortKeyNames) {
+                    JsonNode aAttr = a.get(name);
+                    JsonNode bAttr = b.get(name);
+                    int cmp;
+                    if (aAttr == null && bAttr == null) cmp = 0;
+                    else if (aAttr == null) cmp = -1;
+                    else if (bAttr == null) cmp = 1;
+                    else cmp = ExpressionEvaluator.compareAttributeValues(aAttr, bAttr);
+                    if (cmp != 0) return cmp;
+                }
+                return 0;
             });
             if (Boolean.FALSE.equals(scanIndexForward)) {
                 Collections.reverse(results);

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/GlobalSecondaryIndex.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/GlobalSecondaryIndex.java
@@ -78,4 +78,15 @@ public class GlobalSecondaryIndex {
                 .findFirst()
                 .orElse(null);
     }
+
+    /**
+     * Returns all sort key attribute names in key-schema order. For a composite sort key this
+     * contains more than one element; ordering must consider all of them, not just the first.
+     */
+    public List<String> getSortKeyNames() {
+        return keySchema.stream()
+                .filter(k -> "RANGE".equals(k.getKeyType()))
+                .map(KeySchemaElement::getAttributeName)
+                .toList();
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/LocalSecondaryIndex.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/LocalSecondaryIndex.java
@@ -77,4 +77,15 @@ public class LocalSecondaryIndex {
                 .findFirst()
                 .orElse(null);
     }
+
+    /**
+     * Returns all sort key attribute names in key-schema order. For a composite sort key this
+     * contains more than one element; ordering must consider all of them, not just the first.
+     */
+    public List<String> getSortKeyNames() {
+        return keySchema.stream()
+                .filter(k -> "RANGE".equals(k.getKeyType()))
+                .map(KeySchemaElement::getAttributeName)
+                .toList();
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
@@ -211,6 +211,17 @@ public class TableDefinition {
                 .orElse(null);
     }
 
+    /**
+     * Returns all sort key attribute names in key-schema order. For a composite sort key this
+     * contains more than one element; ordering must consider all of them, not just the first.
+     */
+    public List<String> getSortKeyNames() {
+        return keySchema.stream()
+                .filter(k -> "RANGE".equals(k.getKeyType()))
+                .map(KeySchemaElement::getAttributeName)
+                .toList();
+    }
+
     public Optional<GlobalSecondaryIndex> findGsi(String indexName) {
         if (globalSecondaryIndexes == null) {
             return Optional.empty();

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbCompositeSortKeyQueryIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbCompositeSortKeyQueryIntegrationTest.java
@@ -1,0 +1,169 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Wire-protocol regression for floci-io/floci#1675: a Query against an index whose sort key is
+ * composite (more than one RANGE attribute, e.g. {@code state RANGE, createdAt RANGE}) must order
+ * by ALL sort-key attributes in key-schema order, so {@code ScanIndexForward=false} yields the
+ * reverse of the full composite order.
+ *
+ * <p>Previously only the first RANGE attribute (here {@code state}, identical across the rows) drove
+ * ordering: {@code createdAt} was ignored, and the stable sort merely preserved (or, when
+ * {@code ScanIndexForward=false}, reversed) base-table storage order. The items below are inserted
+ * so their storage order (requestId a, b, c) deliberately disagrees with {@code createdAt} order,
+ * so a correct result can only come from sorting on the second composite component.
+ *
+ * <p>DynamoDB natively supports multi-attribute composite keys on secondary indexes, so emulating
+ * full-key ordering is required for parity.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class DynamoDbCompositeSortKeyQueryIntegrationTest {
+
+    private static final String DYNAMODB_CONTENT_TYPE = "application/x-amz-json-1.0";
+    private static final String TABLE = "CompositeSortKeyRequests";
+    private static final String INDEX = "memberIndex";
+
+    // KeyCondition on the composite GSI: partition (memberName) + both sort components.
+    private static final String KEY_CONDITION =
+        "memberName = :pk AND #st = :st AND createdAt BETWEEN :from AND :to";
+    private static final String EXPRESSION_ATTRIBUTE_VALUES = """
+        {
+            ":pk": {"S": "alice"},
+            ":st": {"S": "ACTIVE"},
+            ":from": {"S": "1970-01-01T00:00:00Z"},
+            ":to": {"S": "2100-01-01T00:00:00Z"}
+        }
+        """;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    @Order(1)
+    void createTableWithCompositeSortKeyIndex() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeySchema": [
+                        {"AttributeName": "requestId", "KeyType": "HASH"}
+                    ],
+                    "AttributeDefinitions": [
+                        {"AttributeName": "requestId", "AttributeType": "S"},
+                        {"AttributeName": "memberName", "AttributeType": "S"},
+                        {"AttributeName": "state", "AttributeType": "S"},
+                        {"AttributeName": "createdAt", "AttributeType": "S"}
+                    ],
+                    "GlobalSecondaryIndexes": [
+                        {
+                            "IndexName": "%s",
+                            "KeySchema": [
+                                {"AttributeName": "memberName", "KeyType": "HASH"},
+                                {"AttributeName": "state", "KeyType": "RANGE"},
+                                {"AttributeName": "createdAt", "KeyType": "RANGE"}
+                            ],
+                            "Projection": {"ProjectionType": "ALL"}
+                        }
+                    ]
+                }
+                """.formatted(TABLE, INDEX))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("TableDescription.GlobalSecondaryIndexes[0].IndexName", equalTo(INDEX))
+            .body("TableDescription.GlobalSecondaryIndexes[0].KeySchema.size()", equalTo(3));
+    }
+
+    @Test
+    @Order(2)
+    void putItemsWhoseStorageOrderDisagreesWithCreatedAt() {
+        // Same memberName + state across all three; requestId (storage) order a, b, c is chosen to
+        // DISAGREE with createdAt order (a=:03, b=:01, c=:02).
+        String[] items = {
+            "{\"requestId\":{\"S\":\"a\"},\"memberName\":{\"S\":\"alice\"},"
+                + "\"state\":{\"S\":\"ACTIVE\"},\"createdAt\":{\"S\":\"2026-07-14T00:00:03Z\"}}",
+            "{\"requestId\":{\"S\":\"b\"},\"memberName\":{\"S\":\"alice\"},"
+                + "\"state\":{\"S\":\"ACTIVE\"},\"createdAt\":{\"S\":\"2026-07-14T00:00:01Z\"}}",
+            "{\"requestId\":{\"S\":\"c\"},\"memberName\":{\"S\":\"alice\"},"
+                + "\"state\":{\"S\":\"ACTIVE\"},\"createdAt\":{\"S\":\"2026-07-14T00:00:02Z\"}}"
+        };
+        for (String item : items) {
+            given()
+                .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+                .contentType(DYNAMODB_CONTENT_TYPE)
+                .body("{\"TableName\":\"" + TABLE + "\",\"Item\":" + item + "}")
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+        }
+    }
+
+    @Test
+    @Order(3)
+    void queryAscendingOrdersByFullCompositeSortKey() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "IndexName": "%s",
+                    "KeyConditionExpression": "%s",
+                    "ExpressionAttributeNames": {"#st": "state"},
+                    "ExpressionAttributeValues": %s,
+                    "ScanIndexForward": true
+                }
+                """.formatted(TABLE, INDEX, KEY_CONDITION, EXPRESSION_ATTRIBUTE_VALUES))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Count", equalTo(3))
+            .body("Items[0].createdAt.S", equalTo("2026-07-14T00:00:01Z"))
+            .body("Items[1].createdAt.S", equalTo("2026-07-14T00:00:02Z"))
+            .body("Items[2].createdAt.S", equalTo("2026-07-14T00:00:03Z"));
+    }
+
+    @Test
+    @Order(4)
+    void queryDescendingReversesFullCompositeSortKey() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "IndexName": "%s",
+                    "KeyConditionExpression": "%s",
+                    "ExpressionAttributeNames": {"#st": "state"},
+                    "ExpressionAttributeValues": %s,
+                    "ScanIndexForward": false
+                }
+                """.formatted(TABLE, INDEX, KEY_CONDITION, EXPRESSION_ATTRIBUTE_VALUES))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Count", equalTo(3))
+            .body("Items[0].createdAt.S", equalTo("2026-07-14T00:00:03Z"))
+            .body("Items[1].createdAt.S", equalTo("2026-07-14T00:00:02Z"))
+            .body("Items[2].createdAt.S", equalTo("2026-07-14T00:00:01Z"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbCompositeSortKeyQueryIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbCompositeSortKeyQueryIntegrationTest.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.services.dynamodb;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeAll;
@@ -8,8 +10,17 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Wire-protocol regression for floci-io/floci#1675: a Query against an index whose sort key is
@@ -165,5 +176,108 @@ class DynamoDbCompositeSortKeyQueryIntegrationTest {
             .body("Items[0].createdAt.S", equalTo("2026-07-14T00:00:03Z"))
             .body("Items[1].createdAt.S", equalTo("2026-07-14T00:00:02Z"))
             .body("Items[2].createdAt.S", equalTo("2026-07-14T00:00:01Z"));
+    }
+
+    /**
+     * A paginated Query over a composite-sort-key index must surface a LastEvaluatedKey that carries
+     * EVERY sort-key component, not just the first RANGE attribute. Emitting only {@code state}
+     * (identical across these rows) loses composite key identity: the cursor no longer pins the row
+     * it stopped on. This is the regression from PR review comment r3710297799 — pre-fix the cursor
+     * omitted {@code createdAt}.
+     */
+    @Test
+    @Order(5)
+    void paginatedQueryEmitsFullCompositeCursor() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "IndexName": "%s",
+                    "KeyConditionExpression": "%s",
+                    "ExpressionAttributeNames": {"#st": "state"},
+                    "ExpressionAttributeValues": %s,
+                    "ScanIndexForward": true,
+                    "Limit": 1
+                }
+                """.formatted(TABLE, INDEX, KEY_CONDITION, EXPRESSION_ATTRIBUTE_VALUES))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Count", equalTo(1))
+            // First ascending row by the full composite key is createdAt=:01 (requestId b).
+            .body("Items[0].createdAt.S", equalTo("2026-07-14T00:00:01Z"))
+            // Cursor pins that exact row: index keys (both components), plus the base-table key.
+            .body("LastEvaluatedKey.memberName.S", equalTo("alice"))
+            .body("LastEvaluatedKey.state.S", equalTo("ACTIVE"))
+            .body("LastEvaluatedKey.createdAt.S", equalTo("2026-07-14T00:00:01Z"))
+            .body("LastEvaluatedKey.requestId.S", notNullValue());
+    }
+
+    /**
+     * Walking every page with Limit=1 must return all three rows in full composite order, each
+     * exactly once, with the cursor advancing on every page (no repeat, no skip).
+     */
+    @Test
+    @Order(6)
+    void paginatedQueryWalksAllRowsExactlyOnceInCompositeOrder() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        List<String> collected = new ArrayList<>();
+        Set<String> seenCursors = new HashSet<>();
+        JsonNode exclusiveStartKey = null;
+        int pages = 0;
+
+        do {
+            String startClause = exclusiveStartKey == null
+                ? ""
+                : ",\n\"ExclusiveStartKey\": " + mapper.writeValueAsString(exclusiveStartKey);
+            String body = """
+                {
+                    "TableName": "%s",
+                    "IndexName": "%s",
+                    "KeyConditionExpression": "%s",
+                    "ExpressionAttributeNames": {"#st": "state"},
+                    "ExpressionAttributeValues": %s,
+                    "ScanIndexForward": true,
+                    "Limit": 1%s
+                }
+                """.formatted(TABLE, INDEX, KEY_CONDITION, EXPRESSION_ATTRIBUTE_VALUES, startClause);
+
+            String responseBody = given()
+                .header("X-Amz-Target", "DynamoDB_20120810.Query")
+                .contentType(DYNAMODB_CONTENT_TYPE)
+                .body(body)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract().body().asString();
+
+            JsonNode root = mapper.readTree(responseBody);
+            pages++;
+            for (JsonNode item : root.path("Items")) {
+                collected.add(item.path("createdAt").path("S").asText());
+            }
+
+            JsonNode lek = root.path("LastEvaluatedKey");
+            if (lek.isMissingNode() || lek.isNull()) {
+                exclusiveStartKey = null;
+            } else {
+                assertNotNull(lek.get("createdAt"),
+                        "LastEvaluatedKey missing composite component createdAt: " + lek);
+                String cursor = lek.toString();
+                assertTrue(seenCursors.add(cursor),
+                        "LastEvaluatedKey repeated — pagination did not advance: " + cursor);
+                exclusiveStartKey = lek;
+            }
+        } while (exclusiveStartKey != null && pages < 10);
+
+        assertEquals(List.of(
+                "2026-07-14T00:00:01Z",
+                "2026-07-14T00:00:02Z",
+                "2026-07-14T00:00:03Z"), collected,
+                "Expected all rows once, in full composite order");
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.dynamodb.model.AttributeDefinition;
 import io.github.hectorvent.floci.services.dynamodb.model.ConditionalCheckFailedException;
+import io.github.hectorvent.floci.services.dynamodb.model.GlobalSecondaryIndex;
 import io.github.hectorvent.floci.services.dynamodb.model.KeySchemaElement;
 import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -357,6 +358,66 @@ class DynamoDbServiceTest {
         assertEquals(List.of("o3", "o2", "o1"), results.items().stream()
                 .map(result -> result.get("orderId").get("S").asText())
                 .toList());
+    }
+
+    /**
+     * Regression for floci-io/floci#1675: a GSI whose sort key is composite (more than one RANGE
+     * attribute) must order by ALL sort-key attributes in schema order, so ScanIndexForward=false
+     * yields the reverse of the full composite order. Previously only the first RANGE attribute
+     * (here {@code state}, identical across the rows) was used, so {@code createdAt} never
+     * participated and ordering/reversal were effectively ignored.
+     */
+    @Test
+    void queryOnCompositeSortKeyGsiRespectsScanIndexForward() {
+        String region = "us-east-1";
+        GlobalSecondaryIndex gsi = new GlobalSecondaryIndex(
+                "memberIndex",
+                List.of(
+                        new KeySchemaElement("memberName", "HASH"),
+                        new KeySchemaElement("state", "RANGE"),
+                        new KeySchemaElement("createdAt", "RANGE")),
+                null, "ALL", null);
+        service.createTable("Requests",
+                List.of(new KeySchemaElement("requestId", "HASH")),
+                List.of(
+                        new AttributeDefinition("requestId", "S"),
+                        new AttributeDefinition("memberName", "S"),
+                        new AttributeDefinition("state", "S"),
+                        new AttributeDefinition("createdAt", "S")),
+                5L, 5L, List.of(gsi), region);
+
+        // Same memberName + state. Deliberately make base-table key order (requestId: a, b, c)
+        // DISAGREE with createdAt order, so a correct result can only come from sorting on the
+        // second composite component (createdAt) — not from incidental storage order.
+        service.putItem("Requests", item("requestId", "a", "memberName", "alice",
+                "state", "ACTIVE", "createdAt", "2026-07-14T00:00:03Z"), region);
+        service.putItem("Requests", item("requestId", "b", "memberName", "alice",
+                "state", "ACTIVE", "createdAt", "2026-07-14T00:00:01Z"), region);
+        service.putItem("Requests", item("requestId", "c", "memberName", "alice",
+                "state", "ACTIVE", "createdAt", "2026-07-14T00:00:02Z"), region);
+
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":pk", attributeValue("S", "alice"));
+        exprValues.set(":st", attributeValue("S", "ACTIVE"));
+        exprValues.set(":from", attributeValue("S", "1970-01-01T00:00:00Z"));
+        exprValues.set(":to", attributeValue("S", "2100-01-01T00:00:00Z"));
+        String kce = "memberName = :pk AND state = :st AND createdAt BETWEEN :from AND :to";
+
+        DynamoDbService.QueryResult ascending = service.query("Requests", null, exprValues,
+                kce, null, null, true, "memberIndex", null, null, region);
+        assertEquals(
+                List.of("2026-07-14T00:00:01Z", "2026-07-14T00:00:02Z", "2026-07-14T00:00:03Z"),
+                ascending.items().stream()
+                        .map(result -> result.get("createdAt").get("S").asText())
+                        .toList());
+
+        DynamoDbService.QueryResult descending = service.query("Requests", null, exprValues,
+                kce, null, null, false, "memberIndex", null, null, region);
+        assertEquals(
+                List.of("2026-07-14T00:00:03Z", "2026-07-14T00:00:02Z", "2026-07-14T00:00:01Z"),
+                descending.items().stream()
+                        .map(result -> result.get("createdAt").get("S").asText())
+                        .toList());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Query ordered results using only the first RANGE attribute returned by
`getSortKeyName()`. For an index with a composite sort key (more than one RANGE
attribute, e.g. `state RANGE, createdAt RANGE`), the remaining components were
ignored: when the first component tied across rows, the stable sort left items
in base-table storage order and `ScanIndexForward=false` merely reversed that
order, so the secondary component (e.g. `createdAt`) never drove ordering.

Sort by the full sort key instead — comparing each RANGE attribute in
key-schema order, short-circuiting on the first non-equal component, then
reversing for `ScanIndexForward=false`. Single-sort-key indexes are unaffected
(a one-element list preserves previous behavior).

Adds `getSortKeyNames()` to `GlobalSecondaryIndex`, `LocalSecondaryIndex` and
`TableDefinition`.

Closes #1675

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: a `Query` against an index with a multi-attribute composite
sort key returned items that were not ordered by the full key. Ties on the first
sort-key attribute fell back to storage order, and `ScanIndexForward=false` only
reversed that — so results diverged from DynamoDB, which orders by the entire
composite sort key. DynamoDB natively supports composite sort keys on secondary
indexes, so emulating full-key ordering is required for parity.

Verified with a wire-protocol (`DynamoDB_20120810.Query`) integration test: a GSI
keyed `[memberName HASH, state RANGE, createdAt RANGE]`, items whose storage
order deliberately disagrees with `createdAt`, asserting ascending order and the
exact reverse for `ScanIndexForward=false`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)