### PR TITLE
fix(s3): apply CreateBucketConfiguration tags on bucket creation

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -331,6 +331,15 @@ public class S3Controller {
             }
             String region = locationConstraint != null ? locationConstraint : regionResolver.resolveRegion(httpHeaders);
             s3Service.createBucket(bucket, region);
+            // CreateBucketConfiguration may carry a <Tags> array; AWS applies those tags to the
+            // new bucket, so a follow-up GetBucketTagging / ListTagsForResource must return them.
+            if (body != null && body.length > 0) {
+                Map<String, String> creationTags = XmlParser.extractPairs(
+                        new String(body, StandardCharsets.UTF_8), "Tag", "Key", "Value");
+                if (!creationTags.isEmpty()) {
+                    s3Service.putBucketTagging(bucket, creationTags);
+                }
+            }
             String lockEnabled = httpHeaders.getHeaderString("x-amz-bucket-object-lock-enabled");
             if ("true".equalsIgnoreCase(lockEnabled)) {
                 s3Service.putBucketVersioning(bucket, "Enabled");

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntegrationTest.java
@@ -362,6 +362,44 @@ class S3IntegrationTest {
     }
 
     @Test
+    @Order(21)
+    void createBucketAppliesTagsFromCreateBucketConfiguration() {
+        String bucket = "tagged-at-create-bucket";
+        String createBucketConfiguration = """
+                <CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                    <Tags>
+                        <Tag>
+                            <Key>owner</Key>
+                            <Value>data-team</Value>
+                        </Tag>
+                    </Tags>
+                </CreateBucketConfiguration>
+                """;
+
+        given()
+            .contentType("application/xml")
+            .body(createBucketConfiguration)
+        .when()
+            .put("/" + bucket)
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + bucket + "?tagging")
+        .then()
+            .statusCode(200)
+            .body(containsString("owner"))
+            .body(containsString("data-team"));
+
+        given()
+        .when()
+            .delete("/" + bucket)
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
     @Order(20)
     void headBucketReturnsStoredRegionForLocationConstraintBucket() {
         String bucket = "eu-head-bucket";


### PR DESCRIPTION
## Summary

`CreateBucket` accepted a `<Tags>` array in the request body but ignored it. The body was parsed for `LocationConstraint` only, so tags supplied at creation were silently dropped: the request returned 200, and a following `GetBucketTagging` / S3 Control `ListTagsForResource` reported an empty tag set.

This parses the same `<Tag>` key/value pairs `handlePutBucketTagging` already parses, and routes them through the existing `s3Service.putBucketTagging` once the bucket exists. No new imports, no new methods, no signature changes.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behaviour:** tags passed in `CreateBucketConfiguration` were discarded.

AWS applies them. The [CreateBucket API reference](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html) shows `Tags` in the request syntax and documents it as *"An array of tags that you can apply to the bucket that you're creating"*, gated on the `s3:TagResource` permission.

**How this surfaces in practice.** The AWS Terraform provider (6.57.1) sends bucket tags this way rather than via a separate `PutBucketTagging` call — from `TF_LOG=trace`:

```xml
<CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Tags><Tag><Key>owner</Key><Value>data-team</Value></Tag></Tags></CreateBucketConfiguration>
```

Against Floci, an `aws_s3_bucket` with a `tags` map applies cleanly but lands with `tags = {}` in state, so **every subsequent plan proposes to add them again** — a diff that never converges. The provider reads them back through S3 Control `ListTagsForResource`, which Floci implements; only the write path at creation was missing.

**Verified end to end**, Terraform 1.15.8 + AWS provider 6.57.1, same config and provider against both images:

| | state `tags` | plan right after apply | `get-bucket-tagging` |
|---|---|---|---|
| 1.5.34 | `{}` | `+ "owner" = "data-team"`, `1 to change` | empty `TagSet` |
| this branch | `"owner" = "data-team"` | **No changes** | `TagSet` with the tag |

## Checklist

- [x] `./mvnw test` passes locally — see the note below
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

### Note on the test run

`S3IntegrationTest` (125 tests) passes on Linux:

```
[INFO] Tests run: 125, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

Run in `eclipse-temurin:25-jdk`. I ran that class rather than the whole suite.

On **Windows** the same class reports 1 failure, `copyObjectWithQuestionMarkInSourceKeySucceeds` — the setup `PUT` of an object key containing a percent-encoded `?` is rejected with `InvalidKey`, expected 200 got 400. That is **unrelated to this change and pre-existing**: it fails identically in a clean worktree at `9bbe9ffe` (this branch's parent, none of these changes present), and it passes on Linux both with and without this change. Looks like a platform difference in URI decoding before key validation. Happy to open a separate issue if that is useful.

### One design question for a maintainer

`createBucket` treats a repeat create in `us-east-1` as idempotent. As written, this change would then **overwrite** existing tags on that path. AWS documents the re-create case as resetting ACLs and says nothing about tags, so skipping them when the bucket already existed is an equally defensible reading. Happy to change it.

Disclosure: this was written with Claude Code. I've reviewed the change and it's small — the parse and the store call both reuse what `handlePutBucketTagging` already does.

What's actually verified rather than asserted:

- `S3IntegrationTest`, 125 tests, 0 failures on `eclipse-temurin:25-jdk`.
- The before/after table is two real `terraform apply` runs against `floci/floci:1.5.34` and a locally-built image from this branch, same config and provider version.
- The pre-existing Windows failure was confirmed by running that single test in a clean worktree at `9bbe9ffe`.

The idempotent-create question above is the part I'd most like a maintainer's opinion on — I don't think the AWS docs settle it.
