### PR TITLE
fix(dynamodb): compare Value when legacy Expected supplies Exists

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbConformanceChangesTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbConformanceChangesTest.java
@@ -652,6 +652,124 @@ class DynamoDbConformanceChangesTest {
     }
 
     // -----------------------------------------------------------------------
+    // Phase 10 — Legacy API: Expected with Exists
+    // -----------------------------------------------------------------------
+
+    @Test @Order(88)
+    @SuppressWarnings("deprecation")
+    void legacyExpectedExistsTrueComparesValue() {
+        // Version-guarded write pattern: Exists:true is paired with the version the caller
+        // last read. Both must be honoured — the attribute must exist AND still equal that value.
+        ddb.putItem(r -> r.tableName(TABLE).item(Map.of(
+                "pk", av("legacy-exp-version"), "sk", av("s"),
+                "version", AttributeValue.builder().n("5").build(),
+                "session", av("original"))));
+
+        Map<String, ExpectedAttributeValue> expectVersion5 = Map.of("version",
+                ExpectedAttributeValue.builder()
+                        .exists(true)
+                        .value(AttributeValue.builder().n("5").build())
+                        .build());
+
+        // The expectation is current → the write lands and bumps the version to 6.
+        ddb.updateItem(UpdateItemRequest.builder()
+                .tableName(TABLE)
+                .key(Map.of("pk", av("legacy-exp-version"), "sk", av("s")))
+                .attributeUpdates(Map.of("version", AttributeValueUpdate.builder()
+                        .value(AttributeValue.builder().n("6").build())
+                        .action(AttributeAction.PUT)
+                        .build()))
+                .expected(expectVersion5)
+                .build());
+
+        // The same expectation is now stale (stored version is 6) → must be rejected.
+        assertThatThrownBy(() -> ddb.updateItem(UpdateItemRequest.builder()
+                .tableName(TABLE)
+                .key(Map.of("pk", av("legacy-exp-version"), "sk", av("s")))
+                .attributeUpdates(Map.of("session", AttributeValueUpdate.builder()
+                        .action(AttributeAction.DELETE)
+                        .build()))
+                .expected(expectVersion5)
+                .build()))
+                .isInstanceOf(ConditionalCheckFailedException.class);
+
+        // PutItem and DeleteItem route through the same evaluation and must agree.
+        assertThatThrownBy(() -> ddb.putItem(r -> r
+                .tableName(TABLE)
+                .item(Map.of("pk", av("legacy-exp-version"), "sk", av("s"),
+                        "version", AttributeValue.builder().n("7").build()))
+                .expected(expectVersion5)))
+                .isInstanceOf(ConditionalCheckFailedException.class);
+
+        assertThatThrownBy(() -> ddb.deleteItem(r -> r
+                .tableName(TABLE)
+                .key(Map.of("pk", av("legacy-exp-version"), "sk", av("s")))
+                .expected(expectVersion5)))
+                .isInstanceOf(ConditionalCheckFailedException.class);
+
+        // None of the stale writes took effect.
+        GetItemResponse resp = ddb.getItem(r -> r
+                .tableName(TABLE)
+                .key(Map.of("pk", av("legacy-exp-version"), "sk", av("s"))));
+        assertThat(resp.item().get("version").n()).isEqualTo("6");
+        assertThat(resp.item().get("session").s()).isEqualTo("original");
+
+        // Exists:false still means "attribute must be absent".
+        assertThatThrownBy(() -> ddb.updateItem(UpdateItemRequest.builder()
+                .tableName(TABLE)
+                .key(Map.of("pk", av("legacy-exp-version"), "sk", av("s")))
+                .attributeUpdates(Map.of("note", AttributeValueUpdate.builder()
+                        .value(av("x")).action(AttributeAction.PUT).build()))
+                .expected(Map.of("version", ExpectedAttributeValue.builder().exists(false).build()))
+                .build()))
+                .isInstanceOf(ConditionalCheckFailedException.class);
+    }
+
+    @Test @Order(89)
+    @SuppressWarnings("deprecation")
+    void legacyExpectedRejectsInvalidExistsCombinations() {
+        // Exists:true with no Value — nothing to compare against.
+        DynamoDbException noValue = (DynamoDbException) catchThrowable(() -> ddb.updateItem(UpdateItemRequest.builder()
+                .tableName(TABLE)
+                .key(Map.of("pk", av("legacy-exp-invalid"), "sk", av("s")))
+                .attributeUpdates(Map.of("note", AttributeValueUpdate.builder()
+                        .value(av("x")).action(AttributeAction.PUT).build()))
+                .expected(Map.of("version", ExpectedAttributeValue.builder().exists(true).build()))
+                .build()));
+        assertThat(noValue).isNotNull();
+        assertThat(noValue.awsErrorDetails().errorCode()).isEqualTo("ValidationException");
+
+        // Exists:false alongside a Value — contradictory.
+        DynamoDbException falseWithValue = (DynamoDbException) catchThrowable(() -> ddb.updateItem(UpdateItemRequest.builder()
+                .tableName(TABLE)
+                .key(Map.of("pk", av("legacy-exp-invalid"), "sk", av("s")))
+                .attributeUpdates(Map.of("note", AttributeValueUpdate.builder()
+                        .value(av("x")).action(AttributeAction.PUT).build()))
+                .expected(Map.of("version", ExpectedAttributeValue.builder()
+                        .exists(false)
+                        .value(AttributeValue.builder().n("5").build())
+                        .build()))
+                .build()));
+        assertThat(falseWithValue).isNotNull();
+        assertThat(falseWithValue.awsErrorDetails().errorCode()).isEqualTo("ValidationException");
+
+        // Exists mixed with the ComparisonOperator form.
+        DynamoDbException mixedForms = (DynamoDbException) catchThrowable(() -> ddb.updateItem(UpdateItemRequest.builder()
+                .tableName(TABLE)
+                .key(Map.of("pk", av("legacy-exp-invalid"), "sk", av("s")))
+                .attributeUpdates(Map.of("note", AttributeValueUpdate.builder()
+                        .value(av("x")).action(AttributeAction.PUT).build()))
+                .expected(Map.of("version", ExpectedAttributeValue.builder()
+                        .exists(true)
+                        .comparisonOperator(ComparisonOperator.EQ)
+                        .attributeValueList(AttributeValue.builder().n("5").build())
+                        .build()))
+                .build()));
+        assertThat(mixedForms).isNotNull();
+        assertThat(mixedForms.awsErrorDetails().errorCode()).isEqualTo("ValidationException");
+    }
+
+    // -----------------------------------------------------------------------
     // Phase 11 — Enum validation fires before table lookup
     // -----------------------------------------------------------------------
 

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -570,6 +570,7 @@ public class DynamoDbJsonHandler {
     private void evaluateLegacyExpected(JsonNode existing, JsonNode expected, String conditionalOperator,
                                           String returnValuesOnConditionCheckFailure) {
         if (expected == null) return;
+        validateLegacyExpected(expected);
         boolean useOr = "OR".equals(conditionalOperator);
         boolean overall = !useOr;
         var fields = expected.fields();
@@ -579,10 +580,11 @@ public class DynamoDbJsonHandler {
             JsonNode condition = entry.getValue();
             JsonNode attrValue = existing != null ? existing.get(attrName) : null;
             boolean condResult;
-            if (condition.has("Exists")) {
-                boolean exists = condition.get("Exists").asBoolean();
-                condResult = exists ? attrValue != null : attrValue == null;
+            if (condition.has("Exists") && !condition.get("Exists").asBoolean()) {
+                condResult = attrValue == null;
             } else {
+                // Exists:true always carries a Value, so it evaluates as an attribute
+                // comparison exactly like a bare Value: must exist AND match.
                 condResult = dynamoDbService.matchesKeyConditionPublic(attrValue, normalizeLegacyCondition(condition));
             }
             if (useOr) overall = overall || condResult;
@@ -593,6 +595,46 @@ public class DynamoDbJsonHandler {
                 throw new ConditionalCheckFailedException(existing);
             } else {
                 throw new ConditionalCheckFailedException(null);
+            }
+        }
+    }
+
+    /**
+     * Validates every entry of a legacy Expected map before any condition is evaluated,
+     * matching the ExpectedAttributeValue rules documented by DynamoDB:
+     * <ul>
+     *   <li>{@code Exists: true} requires a {@code Value} — you cannot expect a value to exist
+     *       without saying which value.</li>
+     *   <li>{@code Exists: false} forbids a {@code Value} — you cannot expect an attribute to hold
+     *       a value while also expecting it to be absent.</li>
+     *   <li>{@code Exists} cannot be combined with the {@code ComparisonOperator} /
+     *       {@code AttributeValueList} form.</li>
+     * </ul>
+     */
+    private void validateLegacyExpected(JsonNode expected) {
+        var fields = expected.fields();
+        while (fields.hasNext()) {
+            var entry = fields.next();
+            String attrName = entry.getKey();
+            JsonNode condition = entry.getValue();
+            if (!condition.has("Exists")) {
+                continue;
+            }
+            if (condition.has("ComparisonOperator") || condition.has("AttributeValueList")) {
+                throw new AwsException("ValidationException",
+                        "One or more parameter values were invalid: Exists cannot be used with "
+                                + "ComparisonOperator or AttributeValueList for Attribute: " + attrName, 400);
+            }
+            boolean exists = condition.get("Exists").asBoolean();
+            if (exists && !condition.has("Value")) {
+                throw new AwsException("ValidationException",
+                        "One or more parameter values were invalid: Value must be provided when "
+                                + "Exists is true for Attribute: " + attrName, 400);
+            }
+            if (!exists && condition.has("Value")) {
+                throw new AwsException("ValidationException",
+                        "One or more parameter values were invalid: Value cannot be used when "
+                                + "Exists is false for Attribute: " + attrName, 400);
             }
         }
     }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -600,16 +600,18 @@ public class DynamoDbJsonHandler {
     }
 
     /**
-     * Validates every entry of a legacy Expected map before any condition is evaluated,
-     * matching the ExpectedAttributeValue rules documented by DynamoDB:
+     * Validates every entry of a legacy Expected map before any condition is evaluated.
+     * The rules and their precedence mirror ExpectedAttributeValue:
      * <ul>
-     *   <li>{@code Exists: true} requires a {@code Value} — you cannot expect a value to exist
-     *       without saying which value.</li>
-     *   <li>{@code Exists: false} forbids a {@code Value} — you cannot expect an attribute to hold
-     *       a value while also expecting it to be absent.</li>
-     *   <li>{@code Exists} cannot be combined with the {@code ComparisonOperator} /
-     *       {@code AttributeValueList} form.</li>
+     *   <li>{@code AttributeValueList} is only meaningful alongside a {@code ComparisonOperator}.</li>
+     *   <li>{@code Exists} cannot be combined with a {@code ComparisonOperator} — they are
+     *       alternative forms.</li>
+     *   <li>Without a {@code ComparisonOperator}, a {@code Value} is required unless
+     *       {@code Exists: false} asks for plain absence.</li>
+     *   <li>{@code Exists: false} forbids a {@code Value} — an attribute cannot be expected to
+     *       hold a value while also being expected to be absent.</li>
      * </ul>
+     * DynamoDB reports only the first offending entry, so validation stops at the first error.
      */
     private void validateLegacyExpected(JsonNode expected) {
         var fields = expected.fields();
@@ -617,26 +619,33 @@ public class DynamoDbJsonHandler {
             var entry = fields.next();
             String attrName = entry.getKey();
             JsonNode condition = entry.getValue();
-            if (!condition.has("Exists")) {
-                continue;
+            boolean hasComparisonOperator = condition.has("ComparisonOperator");
+            boolean hasExists = condition.has("Exists");
+            boolean hasValue = condition.has("Value");
+
+            if (condition.has("AttributeValueList") && !hasComparisonOperator) {
+                throw legacyExpectedValidationError(
+                        "AttributeValueList can only be used with a ComparisonOperator for Attribute: " + attrName);
             }
-            if (condition.has("ComparisonOperator") || condition.has("AttributeValueList")) {
-                throw new AwsException("ValidationException",
-                        "One or more parameter values were invalid: Exists cannot be used with "
-                                + "ComparisonOperator or AttributeValueList for Attribute: " + attrName, 400);
+            if (hasExists && hasComparisonOperator) {
+                throw legacyExpectedValidationError(
+                        "Exists and ComparisonOperator cannot be used together for Attribute: " + attrName);
             }
-            boolean exists = condition.get("Exists").asBoolean();
-            if (exists && !condition.has("Value")) {
-                throw new AwsException("ValidationException",
-                        "One or more parameter values were invalid: Value must be provided when "
-                                + "Exists is true for Attribute: " + attrName, 400);
+            boolean expectsValue = !hasExists || condition.get("Exists").asBoolean();
+            if (!hasComparisonOperator && expectsValue && !hasValue) {
+                throw legacyExpectedValidationError("Value must be provided when Exists is "
+                        + (hasExists ? "true" : "null") + " for Attribute: " + attrName);
             }
-            if (!exists && condition.has("Value")) {
-                throw new AwsException("ValidationException",
-                        "One or more parameter values were invalid: Value cannot be used when "
-                                + "Exists is false for Attribute: " + attrName, 400);
+            if (!expectsValue && hasValue) {
+                throw legacyExpectedValidationError(
+                        "Value cannot be used when Exists is false for Attribute: " + attrName);
             }
         }
+    }
+
+    private AwsException legacyExpectedValidationError(String detail) {
+        return new AwsException("ValidationException",
+                "1 validation error detected: One or more parameter values were invalid: " + detail, 400);
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -2438,9 +2438,10 @@ public class DynamoDbService {
                 yield attributeValuesEqual(attrValue, compareAttr);
             }
             case "NE" -> {
-                if (attrValue == null) yield true;
-                if (actual == null || compareValue == null) yield true;
-                yield !actual.equals(compareValue);
+                if (attrValue == null || compareAttr == null) {
+                    yield true;
+                }
+                yield !attributeValuesEqual(attrValue, compareAttr);
             }
             case "NULL" -> attrValue == null;
             case "NOT_NULL" -> attrValue != null;

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -2430,9 +2430,12 @@ public class DynamoDbService {
 
         return switch (op) {
             case "EQ" -> {
-                if (attrValue == null) yield false;
-                yield ExpressionEvaluator.compareAttributeValues(attrValue, compareAttr != null ? compareAttr : attrValue) == 0
-                        && actual != null && actual.equals(compareValue);
+                if (attrValue == null || compareAttr == null) {
+                    yield false;
+                }
+                // Deep equality, so set/list/map values compare by content rather than
+                // collapsing to an empty scalar and matching everything.
+                yield attributeValuesEqual(attrValue, compareAttr);
             }
             case "NE" -> {
                 if (attrValue == null) yield true;

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
@@ -1001,7 +1001,9 @@ final class ExpressionEvaluator {
         if (a.has("NS") && b.has("NS")) {
             JsonNode aArr = a.get("NS"), bArr = b.get("NS");
             if (aArr.size() != bArr.size()) return false;
-            var aSet = new java.util.HashSet<BigDecimal>();
+            // TreeSet membership goes through compareTo, so 1 and 1.0 are the same member.
+            // BigDecimal.equals() is scale-sensitive and would treat them as different.
+            var aSet = new java.util.TreeSet<BigDecimal>();
             try {
                 aArr.forEach(e -> aSet.add(new BigDecimal(e.asText())));
                 for (JsonNode e : bArr) { if (!aSet.contains(new BigDecimal(e.asText()))) return false; }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -2454,6 +2454,105 @@ given()
     }
 
     @Test
+    void legacyExpectedComparisonIsTypeStrict() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable9",
+                    "KeySchema": [{"AttributeName": "PK", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "PK", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable9",
+                    "Item": {"PK": {"S": "k1"}, "COUNT": {"N": "5"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // A string "5" is a different attribute value than the number 5, so EQ must not match.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable9",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {"COUNT": {"Exists": true, "Value": {"S": "5"}}},
+                    "AttributeUpdates": {"NOTE": {"Action": "PUT", "Value": {"S": "x"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ConditionalCheckFailedException"));
+
+        // ...and NE, being the inverse, must be satisfied by the type mismatch.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable9",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {
+                        "COUNT": {
+                            "ComparisonOperator": "NE",
+                            "AttributeValueList": [{"S": "5"}]
+                        }
+                    },
+                    "AttributeUpdates": {"NOTE": {"Action": "PUT", "Value": {"S": "type-strict"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.GetItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable9",
+                    "Key": {"PK": {"S": "k1"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Item.NOTE.S", equalTo("type-strict"));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "LegacyExpectedTable9"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
     void legacyExpectedRejectsInvalidExistsCombinations() {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -2283,7 +2283,8 @@ given()
                     "Item": {
                         "PK": {"S": "k1"},
                         "TAGS": {"SS": ["alpha", "beta"]},
-                        "ITEMS": {"L": [{"N": "1"}, {"S": "two"}]}
+                        "ITEMS": {"L": [{"N": "1"}, {"S": "two"}]},
+                        "SCORES": {"NS": ["1", "2.5"]}
                     }
                 }
                 """)
@@ -2327,6 +2328,41 @@ given()
         .then()
             .statusCode(400)
             .body("__type", equalTo("ConditionalCheckFailedException"));
+
+        // A number set with different members must not satisfy the condition.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable8",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {"SCORES": {"Exists": true, "Value": {"NS": ["1", "3.5"]}}},
+                    "AttributeUpdates": {"NOTE": {"Action": "PUT", "Value": {"S": "x"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ConditionalCheckFailedException"));
+
+        // Number set members compare numerically, so trailing zeros still match.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable8",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {"SCORES": {"Exists": true, "Value": {"NS": ["1.0", "2.50"]}}},
+                    "AttributeUpdates": {"NOTE": {"Action": "PUT", "Value": {"S": "numeric"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
 
         // Set equality is order-independent, so the same members in another order matches.
         given()

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -1930,6 +1930,425 @@ given()
     }
 
     @Test
+    void updateItemLegacyExpectedExistsTrueComparesValue() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable4",
+                    "KeySchema": [{"AttributeName": "PK", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "PK", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable4",
+                    "Item": {"PK": {"S": "k1"}, "VERSION": {"N": "5"}, "SESSION_DATA": {"S": "{}"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // A current expectation (stored VERSION == 5) is honoured → the write lands.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable4",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {"VERSION": {"Exists": true, "Value": {"N": "5"}}},
+                    "AttributeUpdates": {"VERSION": {"Action": "PUT", "Value": {"N": "6"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // A stale expectation (still claiming VERSION == 5, stored is 6) must be rejected.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable4",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {"VERSION": {"Exists": true, "Value": {"N": "5"}}},
+                    "AttributeUpdates": {"SESSION_DATA": {"Action": "DELETE"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ConditionalCheckFailedException"));
+
+        // The stale write must not have taken effect.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.GetItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable4",
+                    "Key": {"PK": {"S": "k1"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Item.VERSION.N", equalTo("6"))
+            .body("Item.SESSION_DATA.S", equalTo("{}"));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "LegacyExpectedTable4"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    void putAndDeleteItemLegacyExpectedExistsTrueComparesValue() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable5",
+                    "KeySchema": [{"AttributeName": "PK", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "PK", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable5",
+                    "Item": {"PK": {"S": "k1"}, "VERSION": {"N": "5"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // PutItem with a stale expectation → rejected.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable5",
+                    "Item": {"PK": {"S": "k1"}, "VERSION": {"N": "6"}},
+                    "Expected": {"VERSION": {"Exists": true, "Value": {"N": "4"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ConditionalCheckFailedException"));
+
+        // DeleteItem with a stale expectation → rejected.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable5",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {"VERSION": {"Exists": true, "Value": {"N": "4"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ConditionalCheckFailedException"));
+
+        // Neither write took effect.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.GetItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable5",
+                    "Key": {"PK": {"S": "k1"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Item.VERSION.N", equalTo("5"));
+
+        // DeleteItem with a matching expectation → succeeds.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable5",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {"VERSION": {"Exists": true, "Value": {"N": "5"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "LegacyExpectedTable5"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    void legacyExpectedExistsFalseAndConditionalOperator() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable6",
+                    "KeySchema": [{"AttributeName": "PK", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "PK", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable6",
+                    "Item": {"PK": {"S": "k1"}, "VERSION": {"N": "5"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Exists:false on a present attribute → rejected.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable6",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {"VERSION": {"Exists": false}},
+                    "AttributeUpdates": {"NOTE": {"Action": "PUT", "Value": {"S": "x"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ConditionalCheckFailedException"));
+
+        // Exists:false on an absent attribute → accepted.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable6",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {"NOTE": {"Exists": false}},
+                    "AttributeUpdates": {"NOTE": {"Action": "PUT", "Value": {"S": "x"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // AND (the default) requires every entry to hold — the second one does not.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable6",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {
+                        "VERSION": {"Exists": true, "Value": {"N": "5"}},
+                        "NOTE":    {"Exists": true, "Value": {"S": "other"}}
+                    },
+                    "AttributeUpdates": {"VERSION": {"Action": "PUT", "Value": {"N": "9"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ConditionalCheckFailedException"));
+
+        // OR only requires one entry to hold.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable6",
+                    "Key": {"PK": {"S": "k1"}},
+                    "ConditionalOperator": "OR",
+                    "Expected": {
+                        "VERSION": {"Exists": true, "Value": {"N": "5"}},
+                        "NOTE":    {"Exists": true, "Value": {"S": "other"}}
+                    },
+                    "AttributeUpdates": {"VERSION": {"Action": "PUT", "Value": {"N": "9"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "LegacyExpectedTable6"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    void legacyExpectedRejectsInvalidExistsCombinations() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable7",
+                    "KeySchema": [{"AttributeName": "PK", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "PK", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Exists:true without a Value — nothing to compare against.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable7",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {"VERSION": {"Exists": true}},
+                    "AttributeUpdates": {"NOTE": {"Action": "PUT", "Value": {"S": "x"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", containsString("Value must be provided when Exists is true"));
+
+        // Exists:false alongside a Value — contradictory.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable7",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {"VERSION": {"Exists": false, "Value": {"N": "5"}}},
+                    "AttributeUpdates": {"NOTE": {"Action": "PUT", "Value": {"S": "x"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", containsString("Value cannot be used when Exists is false"));
+
+        // Exists mixed with the ComparisonOperator form.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable7",
+                    "Item": {"PK": {"S": "k1"}},
+                    "Expected": {
+                        "VERSION": {
+                            "Exists": true,
+                            "ComparisonOperator": "EQ",
+                            "AttributeValueList": [{"N": "5"}]
+                        }
+                    }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", containsString("Exists cannot be used with"));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "LegacyExpectedTable7"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
     void updateAndDescribeContinuousBackups() {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -2364,6 +2364,51 @@ given()
         .then()
             .statusCode(200);
 
+        // NE is the inverse: a set that differs from the stored one satisfies the condition.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable8",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {
+                        "TAGS": {
+                            "ComparisonOperator": "NE",
+                            "AttributeValueList": [{"SS": ["alpha", "gamma"]}]
+                        }
+                    },
+                    "AttributeUpdates": {"NOTE": {"Action": "PUT", "Value": {"S": "differs"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // ...and a set equal to the stored one does not.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable8",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {
+                        "TAGS": {
+                            "ComparisonOperator": "NE",
+                            "AttributeValueList": [{"SS": ["beta", "alpha"]}]
+                        }
+                    },
+                    "AttributeUpdates": {"NOTE": {"Action": "PUT", "Value": {"S": "x"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ConditionalCheckFailedException"));
+
         // Set equality is order-independent, so the same members in another order matches.
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -2587,7 +2587,8 @@ given()
         .then()
             .statusCode(400)
             .body("__type", equalTo("ValidationException"))
-            .body("message", containsString("Value must be provided when Exists is true"));
+            .body("message", equalTo("1 validation error detected: One or more parameter values were invalid: "
+                    + "Value must be provided when Exists is true for Attribute: VERSION"));
 
         // Exists:false alongside a Value — contradictory.
         given()
@@ -2606,7 +2607,8 @@ given()
         .then()
             .statusCode(400)
             .body("__type", equalTo("ValidationException"))
-            .body("message", containsString("Value cannot be used when Exists is false"));
+            .body("message", equalTo("1 validation error detected: One or more parameter values were invalid: "
+                    + "Value cannot be used when Exists is false for Attribute: VERSION"));
 
         // Exists mixed with the ComparisonOperator form.
         given()
@@ -2630,7 +2632,68 @@ given()
         .then()
             .statusCode(400)
             .body("__type", equalTo("ValidationException"))
-            .body("message", containsString("Exists cannot be used with"));
+            .body("message", equalTo("1 validation error detected: One or more parameter values were invalid: "
+                    + "Exists and ComparisonOperator cannot be used together for Attribute: VERSION"));
+
+        // AttributeValueList is only meaningful with a ComparisonOperator, whether or not
+        // Exists is present — and that check takes precedence over the Exists rules.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable7",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {"VERSION": {"Exists": true, "AttributeValueList": [{"N": "5"}]}},
+                    "AttributeUpdates": {"NOTE": {"Action": "PUT", "Value": {"S": "x"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", equalTo("1 validation error detected: One or more parameter values were invalid: "
+                    + "AttributeValueList can only be used with a ComparisonOperator for Attribute: VERSION"));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable7",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {"VERSION": {"AttributeValueList": [{"N": "5"}]}},
+                    "AttributeUpdates": {"NOTE": {"Action": "PUT", "Value": {"S": "x"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", equalTo("1 validation error detected: One or more parameter values were invalid: "
+                    + "AttributeValueList can only be used with a ComparisonOperator for Attribute: VERSION"));
+
+        // An entry with neither Exists nor Value still needs a Value, reported as "Exists is null".
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable7",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {"VERSION": {}},
+                    "AttributeUpdates": {"NOTE": {"Action": "PUT", "Value": {"S": "x"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", equalTo("1 validation error detected: One or more parameter values were invalid: "
+                    + "Value must be provided when Exists is null for Attribute: VERSION"));
 
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -2257,6 +2257,122 @@ given()
     }
 
     @Test
+    void legacyExpectedComparesCollectionValues() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable8",
+                    "KeySchema": [{"AttributeName": "PK", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "PK", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable8",
+                    "Item": {
+                        "PK": {"S": "k1"},
+                        "TAGS": {"SS": ["alpha", "beta"]},
+                        "ITEMS": {"L": [{"N": "1"}, {"S": "two"}]}
+                    }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // A string set that differs from the stored one must not satisfy the condition.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable8",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {"TAGS": {"Exists": true, "Value": {"SS": ["alpha", "gamma"]}}},
+                    "AttributeUpdates": {"NOTE": {"Action": "PUT", "Value": {"S": "x"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ConditionalCheckFailedException"));
+
+        // A list that differs from the stored one must not satisfy the condition.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable8",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {"ITEMS": {"Exists": true, "Value": {"L": [{"N": "1"}, {"S": "three"}]}}},
+                    "AttributeUpdates": {"NOTE": {"Action": "PUT", "Value": {"S": "x"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ConditionalCheckFailedException"));
+
+        // Set equality is order-independent, so the same members in another order matches.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.UpdateItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable8",
+                    "Key": {"PK": {"S": "k1"}},
+                    "Expected": {"TAGS": {"Exists": true, "Value": {"SS": ["beta", "alpha"]}}},
+                    "AttributeUpdates": {"NOTE": {"Action": "PUT", "Value": {"S": "matched"}}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.GetItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "LegacyExpectedTable8",
+                    "Key": {"PK": {"S": "k1"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Item.NOTE.S", equalTo("matched"));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {"TableName": "LegacyExpectedTable8"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
     void legacyExpectedRejectsInvalidExistsCombinations() {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")


### PR DESCRIPTION
## Summary

Closes #2126

A legacy `Expected` entry that supplies **both** `Exists: true` **and** a `Value` was evaluated as an existence check only — the supplied `Value` was silently discarded, so any stale value satisfied the condition:

```json
"Expected": {"version": {"Exists": true, "Value": {"N": "5"}}}
```

`evaluateLegacyExpected()` treated the presence of `Exists` as short-circuiting the whole evaluation, so `Value` never reached the comparison. `PutItem`, `DeleteItem` and `UpdateItem` all route through that method, so all three were affected.

This is the wire form the AWS .NET SDK's object-persistence layer emits for `[DynamoDBVersion]` on every versioned save — it implements that attribute over the older `Expected` parameter. The practical effect is that optimistic locking appears to be in place but never holds: the guard is present on 100% of writes and ignored on 100% of writes, so conflicting writes land with no visible symptom.

Per the documented `ExpectedAttributeValue` semantics, `Exists: true` always carries a `Value` and means the attribute must exist **and** equal it — the same check as a bare `Value`, which already worked correctly. Only `Exists: false` is a pure absence check. The fix routes everything except `Exists: false` through the existing comparison path.

The combinations DynamoDB rejects now raise `ValidationException` instead of being silently accepted:

- `Exists: true` with no `Value`
- `Exists: false` alongside a `Value`
- `Exists` combined with `ComparisonOperator`
- `AttributeValueList` without a `ComparisonOperator`
- an entry carrying neither `Exists` nor `Value`

Validation runs across the `Expected` map before any condition is evaluated, and stops at the first offending entry — which is what the service does even when several entries are invalid.

### Collection values now compare by content

Follow-up within the same defect, raised in review: the comparator the legacy path delegates to reduced a non-scalar attribute value to an empty string, so **any** two collections of the same type compared as equal — a stale expectation on an `SS`/`NS`/`BS`/`L`/`M` value was always satisfied.

`EQ` now uses the existing `attributeValuesEqual()` deep-equality helper, the same one the modern `ConditionExpression` path uses (type-strict, `BigDecimal` for numbers, recursive for `M`/`L`, order-independent for sets). This also corrects `ComparisonOperator: EQ` and bare `Value`, which reached the same comparator. Covered by `legacyExpectedComparesCollectionValues`.

Reusing that helper surfaced a second defect inside it, also raised in review: number-set membership used a `HashSet<BigDecimal>`, and `BigDecimal.equals()` is scale-sensitive, so `1` and `1.0` counted as different members. Since `NS` elements are normalized on write while a supplied condition value is not, a valid condition on a numerically equivalent set was **rejected** and the guarded write blocked. Membership now goes through a `TreeSet`, whose `contains` uses `compareTo`. That fix applies to `ConditionExpression` as well, since it shares the helper.

`NE` had the inverse of the same collapse and is fixed alongside it — it compared the scalar projections, so any two collections looked equal and `NE` was always false, blocking a write whose attribute genuinely differed from the supplied set. It now negates `attributeValuesEqual()`, mirroring `EQ`. Null handling is unchanged: a missing attribute or missing comparison value still satisfies `NE`.

**Deliberately not changed:** the documentation describes `Value` and `ComparisonOperator` as incompatible, but the service **accepts** that combination — I checked. Existing tests in this repo rely on it, and they are right to. Rejecting it would have broken compatibility, so it stays as-is.

**Type strictness:** because `attributeValuesEqual()` compares types, `EQ` and `NE` no longer treat `{"S":"5"}` and `{"N":"5"}` as equal — previously they matched via their scalar string projections. DynamoDB treats those as distinct attribute values, so the new behaviour is the correct one, but it is a real change that no existing test pinned. `legacyExpectedComparisonIsTypeStrict` now pins it in both directions.

**Verified against DynamoDB.** Every behaviour in this PR was checked against the real service, not just the documentation. The same script was run against DynamoDB and against Floci, and all 21 outcomes match — same accept/reject, same error codes, same error messages. See the comment below for the full matrix.

Two things that verification changed:

- The validation messages now match the service verbatim, including the `1 validation error detected: ` prefix and `Exists and ComparisonOperator cannot be used together`, which differed from my first wording.
- It surfaced two rules I had missed: `AttributeValueList` without a `ComparisonOperator` is rejected (and takes precedence over the `Exists` rules, whether or not `Exists` is present), and an entry with neither `Exists` nor `Value` is rejected as `Value must be provided when Exists is null`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** with `Expected: {"version": {"Exists": true, "Value": {"N": "5"}}}`, floci returned true on existence alone and never compared `5` against the stored value. A version-guarded write whose expectation had gone stale was accepted and applied.

Reproduction (three requests):

1. Seed an item with `version = 5` plus a second attribute.
2. `UpdateItem` with `Expected` `version = 5`, bumping `version` to 6 → correctly accepted.
3. `UpdateItem` again with the now-stale `Expected` `version = 5`, deleting the second attribute → **accepted before this change**, and the second attribute was destroyed. It is now rejected with `ConditionalCheckFailedException`.

The same conflicting write expressed as a modern `ConditionExpression` was already rejected correctly, so only the legacy path was affected.

Verified with the AWS Java SDK v2 (the version already pinned in `compatibility-tests/sdk-test-java`) and the AWS CLI v2, against both the JVM and native builds.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

### Tests added

`src/test/.../DynamoDbIntegrationTest.java` (runs in CI):

- `updateItemLegacyExpectedExistsTrueComparesValue` — the three-request version-guard scenario above, asserting the stale write is rejected and the item is untouched
- `putAndDeleteItemLegacyExpectedExistsTrueComparesValue` — the same enforcement on `PutItem` and `DeleteItem`, plus a matching expectation still succeeding
- `legacyExpectedExistsFalseAndConditionalOperator` — `Exists: false` against present/absent attributes, and multi-attribute `Expected` under both `AND` and `OR`
- `legacyExpectedRejectsInvalidExistsCombinations` — every `ValidationException` case, asserting the exact message the service returns
- `legacyExpectedComparesCollectionValues` — set and list values compared by content under both `EQ` and `NE`, including order-independent set equality and numerically equivalent `NS` members (`1` vs `1.0`)
- `legacyExpectedComparisonIsTypeStrict` — a string `"5"` does not match a stored number `5` under `EQ`, and does satisfy `NE`

`compatibility-tests/sdk-test-java/.../DynamoDbConformanceChangesTest.java` (real SDK clients against a live instance):

- `legacyExpectedExistsTrueComparesValue`
- `legacyExpectedRejectsInvalidExistsCombinations`

All seven were confirmed to fail on `main` before the fix and pass after it. Full suite green (8174 tests). The pre-existing `ComparisonOperator` / `AttributeValueList` cases still pass, so the `else` branch is unregressed.
