### PR TITLE
fix(lambda): scope resource-policy statements to the request Qualifier

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -479,12 +479,13 @@ public class LambdaController {
     @Path("/functions/{functionName}/policy")
     public Response addPermission(@Context HttpHeaders headers,
                                   @PathParam("functionName") String functionName,
+                                  @QueryParam("Qualifier") String qualifier,
                                   String body) {
         String region = regionResolver.resolveRegion(headers);
         try {
             @SuppressWarnings("unchecked")
             Map<String, Object> request = objectMapper.readValue(body, Map.class);
-            Map<String, Object> statement = lambdaService.addPermission(region, functionName, request);
+            Map<String, Object> statement = lambdaService.addPermission(region, functionName, qualifier, request);
             String statementJson = objectMapper.writeValueAsString(statement);
             ObjectNode root = objectMapper.createObjectNode();
             root.put("Statement", statementJson);
@@ -499,10 +500,11 @@ public class LambdaController {
     @GET
     @Path("/functions/{functionName}/policy")
     public Response getPolicy(@Context HttpHeaders headers,
-                              @PathParam("functionName") String functionName) {
+                              @PathParam("functionName") String functionName,
+                              @QueryParam("Qualifier") String qualifier) {
         String region = regionResolver.resolveRegion(headers);
         try {
-            Map<String, Object> data = lambdaService.getPolicy(region, functionName);
+            Map<String, Object> data = lambdaService.getPolicy(region, functionName, qualifier);
             @SuppressWarnings("unchecked")
             Map<String, Object> policy = (Map<String, Object>) data.get("policy");
             String policyJson = objectMapper.writeValueAsString(policy);
@@ -521,9 +523,10 @@ public class LambdaController {
     @Path("/functions/{functionName}/policy/{statementId}")
     public Response removePermission(@Context HttpHeaders headers,
                                      @PathParam("functionName") String functionName,
-                                     @PathParam("statementId") String statementId) {
+                                     @PathParam("statementId") String statementId,
+                                     @QueryParam("Qualifier") String qualifier) {
         String region = regionResolver.resolveRegion(headers);
-        lambdaService.removePermission(region, functionName, statementId);
+        lambdaService.removePermission(region, functionName, qualifier, statementId);
         return Response.noContent().build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -1394,13 +1394,34 @@ public class LambdaService {
 
     // ──────────────────────────── Permissions (Policy) ────────────────────────────
 
-    public Map<String, Object> addPermission(String region, String functionName, Map<String, Object> request) {
-        LambdaFunction fn = getFunction(region, functionName);
+    /**
+     * The ARN a resource-policy statement is scoped to: the bare function ARN, or
+     * {@code <functionArn>:<qualifier>} for an alias/version-scoped permission.
+     *
+     * <p>AWS keeps a SEPARATE resource policy per qualifier, so the qualifier is part of a
+     * statement's identity — the same {@code StatementId} may exist on the function and on
+     * each alias. We derive that identity from the statement's own {@code Resource} rather
+     * than storing a parallel field, which keeps already-persisted (always unqualified)
+     * statements readable as the function's own policy (#2124).
+     */
+    private static String policyResourceArn(LambdaFunction fn, String qualifier) {
+        return qualifier == null ? fn.getFunctionArn() : fn.getFunctionArn() + ":" + qualifier;
+    }
+
+    private static boolean scopedTo(Map<String, Object> statement, String resourceArn) {
+        return resourceArn.equals(statement.get("Resource"));
+    }
+
+    public Map<String, Object> addPermission(String region, String functionName, String qualifier, Map<String, Object> request) {
+        LambdaArnUtils.ResolvedFunctionRef ref = resolveWithRegion(region, functionName, qualifier);
+        LambdaFunction fn = getFunction(region, ref.name());
+        String resourceArn = policyResourceArn(fn, ref.qualifier());
         String statementId = (String) request.get("StatementId");
         if (statementId == null || statementId.isBlank()) {
             throw new AwsException("InvalidParameterValueException", "StatementId is required", 400);
         }
         fn.getPolicies().stream()
+                .filter(s -> scopedTo(s, resourceArn))
                 .filter(s -> statementId.equals(s.get("Sid")))
                 .findFirst()
                 .ifPresent(s -> {
@@ -1424,7 +1445,7 @@ public class LambdaService {
             statement.put("Principal", principal);
         }
         statement.put("Action", action);
-        statement.put("Resource", fn.getFunctionArn());
+        statement.put("Resource", resourceArn);
         if (sourceArn != null) {
             statement.put("Condition", Map.of("ArnLike", Map.of("AWS:SourceArn", sourceArn)));
         } else if (sourceAccount != null) {
@@ -1437,22 +1458,30 @@ public class LambdaService {
         return statement;
     }
 
-    public Map<String, Object> getPolicy(String region, String functionName) {
-        LambdaFunction fn = getFunction(region, functionName);
-        if (fn.getPolicies().isEmpty()) {
+    public Map<String, Object> getPolicy(String region, String functionName, String qualifier) {
+        LambdaArnUtils.ResolvedFunctionRef ref = resolveWithRegion(region, functionName, qualifier);
+        LambdaFunction fn = getFunction(region, ref.name());
+        String resourceArn = policyResourceArn(fn, ref.qualifier());
+        List<Map<String, Object>> statements = fn.getPolicies().stream()
+                .filter(s -> scopedTo(s, resourceArn))
+                .toList();
+        if (statements.isEmpty()) {
             throw new AwsException("ResourceNotFoundException",
                     "Function not found: " + functionName, 404);
         }
         Map<String, Object> policy = new java.util.LinkedHashMap<>();
         policy.put("Version", "2012-10-17");
         policy.put("Id", "default");
-        policy.put("Statement", fn.getPolicies());
+        policy.put("Statement", statements);
         return Map.of("policy", policy, "revisionId", fn.getRevisionId());
     }
 
-    public void removePermission(String region, String functionName, String statementId) {
-        LambdaFunction fn = getFunction(region, functionName);
-        boolean removed = fn.getPolicies().removeIf(s -> statementId.equals(s.get("Sid")));
+    public void removePermission(String region, String functionName, String qualifier, String statementId) {
+        LambdaArnUtils.ResolvedFunctionRef ref = resolveWithRegion(region, functionName, qualifier);
+        LambdaFunction fn = getFunction(region, ref.name());
+        String resourceArn = policyResourceArn(fn, ref.qualifier());
+        boolean removed = fn.getPolicies()
+                .removeIf(s -> statementId.equals(s.get("Sid")) && scopedTo(s, resourceArn));
         if (!removed) {
             throw new AwsException("ResourceNotFoundException",
                     "Statement " + statementId + " not found in function " + functionName, 404);

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -1467,7 +1467,7 @@ public class LambdaService {
                 .toList();
         if (statements.isEmpty()) {
             throw new AwsException("ResourceNotFoundException",
-                    "Function not found: " + functionName, 404);
+                    "The resource you requested does not exist.", 404);
         }
         Map<String, Object> policy = new java.util.LinkedHashMap<>();
         policy.put("Version", "2012-10-17");

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaPermissionQualifierIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaPermissionQualifierIntegrationTest.java
@@ -1,0 +1,272 @@
+package io.github.hectorvent.floci.services.lambda;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * AddPermission / GetPolicy / RemovePermission must honour {@code ?Qualifier=} (#2124).
+ *
+ * <p>AWS keeps a SEPARATE resource policy per qualifier: an alias-scoped statement carries
+ * {@code <functionArn>:<alias>} as its Resource, is only visible through
+ * {@code GetPolicy?Qualifier=<alias>}, and the same StatementId may exist independently on
+ * the unqualified function. Floci previously ignored the qualifier entirely, so an
+ * alias-scoped permission could never be read back under its alias — which is what stops
+ * Terraform's {@code aws_lambda_permission} with {@code qualifier} from ever converging.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class LambdaPermissionQualifierIntegrationTest {
+
+    private static final String BASE    = "/2015-03-31";
+    private static final String FN      = "qualifier-perm-fn";
+    private static final String FN_ARN  = "arn:aws:lambda:us-east-1:000000000000:function:" + FN;
+    private static final String ALIAS   = "LIVE";
+    private static final String STMT_ID = "AllowExecutionFromAPIGateway";
+
+    private static final ObjectMapper OM = new ObjectMapper();
+
+    private static String addPermissionBody(String principal) {
+        return """
+            {
+                "StatementId": "%s",
+                "Action": "lambda:InvokeFunction",
+                "Principal": "%s"
+            }
+            """.formatted(STMT_ID, principal);
+    }
+
+    /** The single Resource string of the one statement in a GetPolicy response. */
+    private static String onlyStatementResource(String getPolicyResponse) throws Exception {
+        JsonNode statements = OM.readTree(OM.readTree(getPolicyResponse).get("Policy").asText())
+                .get("Statement");
+        assertEquals(1, statements.size(), "expected exactly one statement in this policy");
+        return statements.get(0).get("Resource").asText();
+    }
+
+    // ── setup ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(1)
+    void createFunctionVersionAndAlias() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "Runtime": "nodejs20.x",
+                    "Role": "arn:aws:iam::000000000000:role/lambda-role",
+                    "Handler": "index.handler"
+                }
+                """.formatted(FN))
+        .when()
+            .post(BASE + "/functions")
+        .then()
+            .statusCode(201);
+
+        given()
+            .contentType("application/json")
+            .body("{}")
+        .when()
+            .post(BASE + "/functions/" + FN + "/versions")
+        .then()
+            .statusCode(201);
+
+        given()
+            .contentType("application/json")
+            .body("""
+                { "Name": "%s", "FunctionVersion": "1" }
+                """.formatted(ALIAS))
+        .when()
+            .post(BASE + "/functions/" + FN + "/aliases")
+        .then()
+            .statusCode(201);
+    }
+
+    // ── AddPermission scopes the statement to the qualifier ───────────────────
+
+    @Test
+    @Order(2)
+    void addPermission_withQualifier_scopesResourceToTheAlias() throws Exception {
+        String response = given()
+            .contentType("application/json")
+            .body(addPermissionBody("apigateway.amazonaws.com"))
+        .when()
+            .post(BASE + "/functions/" + FN + "/policy?Qualifier=" + ALIAS)
+        .then()
+            .statusCode(201)
+            .body("Statement", notNullValue())
+            .extract().body().asString();
+
+        // The returned statement must name the ALIAS ARN. Before the fix this was the bare
+        // function ARN, so the permission was indistinguishable from an unqualified one.
+        String resource = OM.readTree(OM.readTree(response).get("Statement").asText())
+                .get("Resource").asText();
+        assertEquals(FN_ARN + ":" + ALIAS, resource);
+    }
+
+    @Test
+    @Order(3)
+    void getPolicy_withQualifier_returnsTheAliasStatement() throws Exception {
+        String response = given()
+        .when()
+            .get(BASE + "/functions/" + FN + "/policy?Qualifier=" + ALIAS)
+        .then()
+            .statusCode(200)
+            .body("Policy", notNullValue())
+            .body("RevisionId", notNullValue())
+            .extract().body().asString();
+
+        assertEquals(FN_ARN + ":" + ALIAS, onlyStatementResource(response));
+    }
+
+    /**
+     * The regression itself: the alias-scoped statement must NOT show up in the function's
+     * own policy. Previously GetPolicy returned identical payloads with and without the
+     * qualifier, so the provider could never tell the two apart.
+     */
+    @Test
+    @Order(4)
+    void getPolicy_withoutQualifier_doesNotSeeTheAliasStatement() {
+        given()
+        .when()
+            .get(BASE + "/functions/" + FN + "/policy")
+        .then()
+            .statusCode(404);
+    }
+
+    // ── the qualified and unqualified policies are independent ────────────────
+
+    @Test
+    @Order(5)
+    void addPermission_sameStatementIdUnqualified_isNotAConflict() {
+        given()
+            .contentType("application/json")
+            .body(addPermissionBody("s3.amazonaws.com"))
+        .when()
+            .post(BASE + "/functions/" + FN + "/policy")
+        .then()
+            .statusCode(201);
+    }
+
+    @Test
+    @Order(6)
+    void getPolicy_withoutQualifier_returnsOnlyTheUnqualifiedStatement() throws Exception {
+        String response = given()
+        .when()
+            .get(BASE + "/functions/" + FN + "/policy")
+        .then()
+            .statusCode(200)
+            .extract().body().asString();
+
+        assertEquals(FN_ARN, onlyStatementResource(response));
+    }
+
+    @Test
+    @Order(7)
+    void addPermission_duplicateWithinTheSameQualifier_stillConflicts() {
+        given()
+            .contentType("application/json")
+            .body(addPermissionBody("apigateway.amazonaws.com"))
+        .when()
+            .post(BASE + "/functions/" + FN + "/policy?Qualifier=" + ALIAS)
+        .then()
+            .statusCode(409);
+    }
+
+    // ── RemovePermission is likewise scoped ───────────────────────────────────
+
+    @Test
+    @Order(8)
+    void removePermission_withoutQualifier_leavesTheAliasStatement() throws Exception {
+        given()
+        .when()
+            .delete(BASE + "/functions/" + FN + "/policy/" + STMT_ID)
+        .then()
+            .statusCode(204);
+
+        // The unqualified policy is now empty...
+        given()
+        .when()
+            .get(BASE + "/functions/" + FN + "/policy")
+        .then()
+            .statusCode(404);
+
+        // ...while the alias keeps its own statement.
+        String response = given()
+        .when()
+            .get(BASE + "/functions/" + FN + "/policy?Qualifier=" + ALIAS)
+        .then()
+            .statusCode(200)
+            .extract().body().asString();
+
+        assertEquals(FN_ARN + ":" + ALIAS, onlyStatementResource(response));
+    }
+
+    @Test
+    @Order(9)
+    void removePermission_withUnknownQualifier_returns404() {
+        given()
+        .when()
+            .delete(BASE + "/functions/" + FN + "/policy/" + STMT_ID + "?Qualifier=NOPE")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(10)
+    void removePermission_withQualifier_removesTheAliasStatement() {
+        given()
+        .when()
+            .delete(BASE + "/functions/" + FN + "/policy/" + STMT_ID + "?Qualifier=" + ALIAS)
+        .then()
+            .statusCode(204);
+
+        given()
+        .when()
+            .get(BASE + "/functions/" + FN + "/policy?Qualifier=" + ALIAS)
+        .then()
+            .statusCode(404);
+    }
+
+    // ── the qualifier may also travel in the function name (arn:...:fn:ALIAS) ──
+
+    @Test
+    @Order(11)
+    void qualifierEmbeddedInTheFunctionName_isEquivalentToTheQueryParam() throws Exception {
+        given()
+            .contentType("application/json")
+            .body(addPermissionBody("events.amazonaws.com"))
+        .when()
+            .post(BASE + "/functions/" + FN + ":" + ALIAS + "/policy")
+        .then()
+            .statusCode(201);
+
+        String response = given()
+        .when()
+            .get(BASE + "/functions/" + FN + "/policy?Qualifier=" + ALIAS)
+        .then()
+            .statusCode(200)
+            .extract().body().asString();
+
+        assertEquals(FN_ARN + ":" + ALIAS, onlyStatementResource(response));
+    }
+
+    @Test
+    @Order(12)
+    void deleteFunction() {
+        given()
+        .when()
+            .delete(BASE + "/functions/" + FN)
+        .then()
+            .statusCode(204);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaPermissionQualifierIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaPermissionQualifierIntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -140,7 +141,9 @@ class LambdaPermissionQualifierIntegrationTest {
         .when()
             .get(BASE + "/functions/" + FN + "/policy")
         .then()
-            .statusCode(404);
+            .statusCode(404)
+            .body("__type", equalTo("ResourceNotFoundException"))
+            .body("message", equalTo("The resource you requested does not exist."));
     }
 
     // ── the qualified and unqualified policies are independent ────────────────


### PR DESCRIPTION
## Summary

Closes #2124.

`AddPermission`, `GetPolicy` and `RemovePermission` ignored the `Qualifier` query parameter. Every statement was stored against the **unqualified** function ARN, so an alias-scoped permission could never be read back under its alias:

- the returned statement's `Resource` was `...:function:my-fn` where AWS returns `...:function:my-fn:LIVE`
- `GetPolicy` with and without `?Qualifier=LIVE` returned **identical** payloads

That is what stops Terraform's `aws_lambda_permission` with `qualifier` set from ever converging: it creates the permission, polls `GetPolicy?Qualifier=<alias>` forever, and a later apply hits `ResourceConflictException` against a statement its read could never confirm — with no way to converge or clean up (`terraform import` also fails with *Cannot import non-existent remote object*).

## Fix

AWS keeps a **separate resource policy per qualifier**, so the qualifier is part of a statement's identity.

- `LambdaController` — declare `@QueryParam("Qualifier")` on the three policy endpoints and thread it through, matching the annotation already used by `LambdaUrlController` / `LambdaEventInvokeController`.
- `LambdaService` — resolve the ref through the existing `resolveWithRegion()` helper, so a qualifier **embedded in the function name** (`arn:...:function:my-fn:LIVE`, or `my-fn:LIVE`) is reconciled with the query-string value exactly as the function-URL endpoints already do (including the "derived qualifier does not match" 400).

The scope is derived from the statement's own `Resource` rather than a new stored field, so statements **persisted before this change** stay readable as the function's unqualified policy — no migration, no model change.

Resulting behaviour:

| Call | Before | After |
|---|---|---|
| `AddPermission?Qualifier=X` | `Resource` = function ARN | `Resource` = `<functionArn>:X` |
| `GetPolicy?Qualifier=X` | every statement | only that qualifier's statements (404 if none) |
| `RemovePermission?Qualifier=X` | removed by Sid anywhere | removes only within that qualifier |
| same `StatementId` on function *and* alias | 409 conflict | allowed — separate policies |
| duplicate within one qualifier | 409 | 409 (unchanged) |

**Deliberately out of scope:** qualifier *existence* is not validated (an unknown alias is accepted). The endpoints did not validate it before either, so adding that is a separate behaviour change rather than part of this fix — happy to fold it in if you'd prefer.

## Tests

New `LambdaPermissionQualifierIntegrationTest` — 12 cases over a function with a published version and a `LIVE` alias: the alias-scoped `Resource`, qualified vs unqualified isolation in both directions, same-`StatementId`-different-qualifier, duplicate-within-qualifier still conflicting, scoped removal (including an unknown qualifier → 404), and the qualifier arriving embedded in the function name.

**Verified fail-before / pass-after:** against the unfixed service **7 of the 12 fail**, with exactly the symptom from the report —

```
expected: <arn:aws:lambda:us-east-1:000000000000:function:qualifier-perm-fn:LIVE>
 but was: <arn:aws:lambda:us-east-1:000000000000:function:qualifier-perm-fn>
```

Full `Lambda*` suite: **235/237 pass**. The 2 failures are `LambdaReactiveSyncIntegrationTest` (`setupAndInitialInvoke`, `uploadV2AndVerifyAutoSync`), which I confirmed fail identically on a pristine `origin/main` — pre-existing and unrelated to this change. The existing `LambdaPermissionTagLayerIntegrationTest` (19 cases, all unqualified) stays green, covering backward compatibility.
