### PR TITLE
fix(apigateway): create the stage when CreateDeployment carries a stageName

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
@@ -469,7 +469,42 @@ public class ApiGatewayService {
         Deployment deployment = new Deployment(shortId(10), description, System.currentTimeMillis() / 1000L);
         deploymentStore.put(deploymentKey(region, apiId, deployment.id()), deployment);
         LOG.infov("Created deployment {0} for API {1}", deployment.id(), apiId);
+
+        String stageName = (String) request.get("stageName");
+        if (stageName != null && !stageName.isBlank()) {
+            deployStage(region, apiId, stageName, deployment.id(), request);
+        }
         return deployment;
+    }
+
+    /**
+     * Points {@code stageName} at {@code deploymentId}, creating the stage if it doesn't exist.
+     *
+     * <p>The API does not document collision behavior. Repointing preserves existing stage
+     * settings and supports repeated deployments.
+     */
+    private void deployStage(String region, String apiId, String stageName, String deploymentId,
+                             Map<String, Object> request) {
+        String key = stageKey(region, apiId, stageName);
+        long now = System.currentTimeMillis() / 1000L;
+        Stage stage = stageStore.get(key).orElse(null);
+        if (stage == null) {
+            stage = new Stage();
+            stage.setStageName(stageName);
+            stage.setCreatedDate(now);
+            stage.setDescription((String) request.get("stageDescription"));
+        }
+        stage.setDeploymentId(deploymentId);
+        stage.setLastUpdatedDate(now);
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> variables = (Map<String, String>) request.get("variables");
+        if (variables != null) {
+            stage.setVariables(variables);
+        }
+
+        stageStore.put(key, stage);
+        LOG.infov("Deployed stage {0} of API {1} to deployment {2}", stageName, apiId, deploymentId);
     }
 
     public List<Deployment> getDeployments(String region, String apiId) {

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayDeploymentStageNameIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayDeploymentStageNameIntegrationTest.java
@@ -1,0 +1,204 @@
+package io.github.hectorvent.floci.services.apigateway;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * {@code CreateDeployment} with a {@code stageName} must create the stage as a side effect,
+ * leaving the deployed API immediately invokable.
+ *
+ * <p>Terraform's {@code aws_api_gateway_deployment} takes a {@code stage_name} and relies on
+ * this; without it a configuration that has no separate {@code aws_api_gateway_stage} applies
+ * cleanly and then serves {@code {"message":"Stage not found"}} on every route.
+ *
+ * @see <a href="https://github.com/floci-io/floci/issues/2120">Issue #2120</a>
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ApiGatewayDeploymentStageNameIntegrationTest {
+
+    private static final String STAGE = "local";
+
+    private static String apiId;
+    private static String resourceId;
+    private static String firstDeploymentId;
+
+    @Test @Order(1)
+    void createApiWithAMockRoute() {
+        apiId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"name\":\"stage-repro\"}")
+                .when().post("/restapis")
+                .then()
+                .statusCode(201)
+                .extract().path("id");
+
+        String rootId = given()
+                .when().get("/restapis/" + apiId + "/resources")
+                .then()
+                .statusCode(200)
+                .extract().path("item[0].id");
+
+        resourceId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"pathPart\":\"health\"}")
+                .when().post("/restapis/" + apiId + "/resources/" + rootId)
+                .then()
+                .statusCode(201)
+                .extract().path("id");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"authorizationType\":\"NONE\"}")
+                .when().put("/restapis/" + apiId + "/resources/" + resourceId + "/methods/GET")
+                .then()
+                .statusCode(201);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"type\":\"MOCK\",\"requestTemplates\":{\"application/json\":\"{\\\"statusCode\\\": 200}\"}}")
+                .when().put("/restapis/" + apiId + "/resources/" + resourceId + "/methods/GET/integration")
+                .then()
+                .statusCode(201);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"responseParameters\":{}}")
+                .when().put("/restapis/" + apiId + "/resources/" + resourceId + "/methods/GET/responses/200")
+                .then()
+                .statusCode(201);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"selectionPattern\":\"\",\"responseTemplates\":{\"application/json\":\"{\\\"status\\\":\\\"ok\\\"}\"}}")
+                .when().put("/restapis/" + apiId + "/resources/" + resourceId + "/methods/GET/integration/responses/200")
+                .then()
+                .statusCode(201);
+    }
+
+    // ── the reported bug ──────────────────────────────────────────────────────
+
+    @Test @Order(2)
+    void createDeploymentWithStageName_createsTheStage() {
+        firstDeploymentId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"stageName\":\"" + STAGE + "\",\"stageDescription\":\"from deploy\"}")
+                .when().post("/restapis/" + apiId + "/deployments")
+                .then()
+                .statusCode(201)
+                .extract().path("id");
+
+        // Previously GetStages was empty here — no stage was ever created.
+        given()
+                .when().get("/restapis/" + apiId + "/stages")
+                .then()
+                .statusCode(200)
+                .body("item.stageName", hasItem(STAGE))
+                .body("item.find { it.stageName == '" + STAGE + "' }.deploymentId",
+                        equalTo(firstDeploymentId));
+    }
+
+    @Test @Order(3)
+    void theDeployedApiIsImmediatelyInvokable() {
+        // Previously: {"message":"Stage not found"}
+        given()
+                .when().get("/restapis/" + apiId + "/" + STAGE + "/_user_request_/health")
+                .then()
+                .statusCode(200)
+                .body("status", equalTo("ok"));
+    }
+
+    @Test @Order(4)
+    void getStageReturnsTheStageDirectly() {
+        given()
+                .when().get("/restapis/" + apiId + "/stages/" + STAGE)
+                .then()
+                .statusCode(200)
+                .body("stageName", equalTo(STAGE))
+                .body("deploymentId", equalTo(firstDeploymentId))
+                .body("description", equalTo("from deploy"));
+    }
+
+    // ── redeploy re-points the existing stage (repeated terraform apply) ──────
+
+    @Test @Order(5)
+    void redeployingRepointsTheSameStageAtTheNewDeployment() {
+        String secondDeploymentId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"stageName\":\"" + STAGE + "\"}")
+                .when().post("/restapis/" + apiId + "/deployments")
+                .then()
+                .statusCode(201)
+                .extract().path("id");
+
+        given()
+                .when().get("/restapis/" + apiId + "/stages/" + STAGE)
+                .then()
+                .statusCode(200)
+                .body("deploymentId", equalTo(secondDeploymentId))
+                // the original stage settings survive the redeploy
+                .body("description", equalTo("from deploy"));
+
+        // still exactly one stage — a redeploy must not fan out duplicates
+        given()
+                .when().get("/restapis/" + apiId + "/stages")
+                .then()
+                .statusCode(200)
+                .body("item.findAll { it.stageName == '" + STAGE + "' }", hasSize(1));
+
+        given()
+                .when().get("/restapis/" + apiId + "/" + STAGE + "/_user_request_/health")
+                .then()
+                .statusCode(200)
+                .body("status", equalTo("ok"));
+    }
+
+    @Test @Order(6)
+    void stageVariablesFromTheDeploymentRequestAreApplied() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"stageName\":\"" + STAGE + "\",\"variables\":{\"lambdaAlias\":\"LIVE\"}}")
+                .when().post("/restapis/" + apiId + "/deployments")
+                .then()
+                .statusCode(201);
+
+        given()
+                .when().get("/restapis/" + apiId + "/stages/" + STAGE)
+                .then()
+                .statusCode(200)
+                .body("variables.lambdaAlias", equalTo("LIVE"));
+    }
+
+    // ── without stageName nothing is deployed (unchanged behaviour) ───────────
+
+    @Test @Order(7)
+    void createDeploymentWithoutStageName_createsNoStage() {
+        String otherApiId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"name\":\"no-stage-repro\"}")
+                .when().post("/restapis")
+                .then()
+                .statusCode(201)
+                .extract().path("id");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"description\":\"no stage\"}")
+                .when().post("/restapis/" + otherApiId + "/deployments")
+                .then()
+                .statusCode(201);
+
+        given()
+                .when().get("/restapis/" + otherApiId + "/stages")
+                .then()
+                .statusCode(200)
+                .body("item", hasSize(0));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2120.

CreateDeployment ignored stageName: it stored a deployment but did not create the named stage. GetStages remained empty, and invocation returned {"message":"Stage not found"}.

## Behavior

CreateDeployment now creates the named stage pointing at the new deployment. On a later deployment with the same name, it repoints that stage while retaining its other settings; request variables are still applied. This supports repeated Terraform applies. The AWS API reference does not document named-stage collision behavior, so this is an intentional compatibility decision rather than a claimed AWS invariant.

A deployment without stageName remains unchanged and creates no stage.

## Tests

ApiGatewayDeploymentStageNameIntegrationTest covers seven cases using a REST API and MOCK GET /health route:

- named stages appear in GetStages and GetStage
- the deployed route returns 200 instead of Stage not found
- a redeploy updates one existing stage without duplication
- stage description and request variables are covered
- deployments without stageName create no stage

Validation:

- JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home ./mvnw test -Dtest=ApiGatewayDeploymentStageNameIntegrationTest
- 7 passed

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Docs or chore

## Checklist

- [x] New integration coverage is included
- [x] Focused regression test passes locally on Java 25
- [x] Commit message follows Conventional Commits
- [x] The branch is refreshed from the latest main before this update