### PR TITLE
test(lambda): wait for the parked poll instead of sleeping in extension stop race

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/model/RegisteredExtension.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/model/RegisteredExtension.java
@@ -50,6 +50,15 @@ public class RegisteredExtension {
     }
 
     /**
+     * Whether a poll is currently parked, without consuming it — unlike
+     * {@link #takeWaitingContext()}, which clears the context as it hands it over. Called under the
+     * owning server's lock, like the rest of this class.
+     */
+    public boolean hasWaitingContext() {
+        return waitingContext != null;
+    }
+
+    /**
      * Records that this extension has issued its first {@code /extension/event/next}, which is
      * what AWS treats as the extension being init-ready (registering alone only obtains an
      * identifier). Called under the owning server's lock, like the rest of this class.

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServer.java
@@ -218,6 +218,25 @@ public class RuntimeApiServer {
         return latch.await(timeoutMs, java.util.concurrent.TimeUnit.MILLISECONDS);
     }
 
+    /**
+     * True when this extension is currently parked on {@code /extension/event/next} — its request
+     * reached the handler and was stored as the waiting context rather than answered immediately.
+     *
+     * <p>Package-private and used only by tests that race {@link #stop()} against a poll already in
+     * flight. Such a test cannot use a sleep to decide the poll has landed: the request parking is
+     * what makes {@code stop()}'s SHUTDOWN fan-out see a waiting context instead of queueing the
+     * event for a connection that is about to be torn down, and on a loaded machine an arbitrary
+     * sleep expires before that happens. Polling this instead makes the wait condition-based.
+     *
+     * <p>Read under {@code lock}, per the locking discipline in the class doc.
+     */
+    boolean isExtensionParked(String identifier) {
+        synchronized (lock) {
+            RegisteredExtension extension = extensions.get(identifier);
+            return extension != null && extension.hasWaitingContext();
+        }
+    }
+
     public CompletableFuture<Void> start() {
         CompletableFuture<Void> started = new CompletableFuture<>();
 

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServerTest.java
@@ -1152,9 +1152,15 @@ class RuntimeApiServerTest {
                                 .header("Lambda-Extension-Identifier", extensionId)
                                 .GET().build(),
                         HttpResponse.BodyHandlers.ofString());
-                // Give the request time to actually connect and park before stop() closes
-                // the listening socket — see extensionShutdown_racedAgainstStop_isNeverOrphaned.
-                Thread.sleep(5);
+                // Wait for the poll to actually park before racing stop() against it. A sleep here
+                // is not enough: it asserts the request has parked without checking, and on a
+                // loaded machine it expires first, so stop() closes the socket while the request
+                // is still in flight. The poll then never reaches the handler, stop()'s fan-out
+                // finds no waiting context to hand SHUTDOWN to, and the client sees the connection
+                // die (EOFException, or ConnectException if it lost the race even earlier) rather
+                // than the SHUTDOWN this test is about.
+                assertTrue(awaitExtensionParked(freshServer, extensionId, 5000),
+                        "extension never parked on /event/next; the stop() race was never set up");
                 freshServer.stop();
 
                 HttpResponse<String> response = asyncNext.get(5, TimeUnit.SECONDS);
@@ -1371,5 +1377,24 @@ class RuntimeApiServerTest {
             }
         }
         throw new IOException("no free port in " + TEST_PORT_BASE + "-" + (TEST_PORT_BASE + TEST_PORT_RANGE));
+    }
+
+    /**
+     * Polls until the extension is parked on {@code /extension/event/next}, so a test can race
+     * {@code stop()} against a poll that has provably landed rather than one assumed to have
+     * landed after a fixed sleep.
+     *
+     * @return true if it parked within the timeout; false if it never did.
+     */
+    private static boolean awaitExtensionParked(RuntimeApiServer server, String extensionId, long timeoutMs)
+            throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
+        while (System.nanoTime() < deadline) {
+            if (server.isExtensionParked(extensionId)) {
+                return true;
+            }
+            Thread.sleep(1);
+        }
+        return server.isExtensionParked(extensionId);
     }
 }


### PR DESCRIPTION
## Summary

`extensionRegister_racedAgainstStop_eventuallyDeliversShutdown` set up its `stop()` race with `Thread.sleep(5)`, assuming the extension's `/event/next` poll had parked server-side. The sleep only assumes it. Under load it expires first, so `stop()` closes the listening socket while the request is still in flight — the poll never reaches the handler, `stop()`'s SHUTDOWN fan-out finds no waiting context, and the client's `get()` throws instead of returning the SHUTDOWN.

Surfaces as `EOFException` (connection accepted, then torn down) or `ConnectException` (lost the race earlier). It failed CI this way on #1760.

Replaces the sleep with a condition-based wait on a new package-private `RuntimeApiServer.isExtensionParked(...)`.

## What changed

- `Thread.sleep(5)` -> `awaitExtensionParked(...)`, polling until the poll has provably parked.
- New package-private `RuntimeApiServer.isExtensionParked(String)`, read under `lock` per the class's documented locking discipline.
- `RegisteredExtension.hasWaitingContext()` — a non-consuming peek, unlike `takeWaitingContext()`.

No change to shutdown behavior.

## Test plan

Local, with 24 spinners on 12 cores:

| Check | Result |
|---|---|
| Original test under load | fails — reproduces the CI failure |
| Fixed test, identical load | passes |
| Fixed test, with the "poll `pendingEvents` before checking `stopped`" handler fix reverted | fails — regression still caught |
| Full lambda suite | 466/466 pass |

The third row is the point: the flake is gone without weakening the regression the test exists to cover.

Then validated on CI runners, running the full 8317-test suite four times (the flake only appears under that load, not when running the race tests alone):

| Variant | Result |
|---|---|
| Pristine `main` | 4/4 pass |
| This branch | 4/4 pass |

Two further changes were tried and dropped after the same four-run comparison showed them failing 3/4: applying the same wait to the sibling `extensionShutdown_racedAgainstStop_isNeverOrphaned` test, and reordering `stop()` to close the listener after dispatching SHUTDOWN. Neither is in this PR. The sibling test keeps its existing `Thread.sleep(5)`.