### PR TITLE
test(lambda): wait for the parked poll in the extension shutdown stop race

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServerTest.java
@@ -1043,11 +1043,14 @@ class RuntimeApiServerTest {
                                 .GET().build(),
                         HttpResponse.BodyHandlers.ofString());
 
-                // Give the request just enough time to actually connect and park server-side
-                // (a few ms is plenty on localhost) before racing stop() against it — without
-                // this, stop() can close the listening socket before the connection is even
-                // established, which isn't the race we're testing.
-                Thread.sleep(5);
+                // Wait for the poll to actually park before racing stop() against it. A fixed
+                // sleep only *assumes* it parked: on a loaded machine the sleep expires first,
+                // stop() closes the listening socket while the request is still in flight, and
+                // the client sees the connection die (EOFException) rather than the SHUTDOWN
+                // this test is about. Same reasoning as
+                // extensionRegister_racedAgainstStop_eventuallyDeliversShutdown.
+                assertTrue(awaitExtensionParked(freshServer, extensionId, 5000),
+                        "extension never parked on /event/next; the stop() race was never set up");
                 freshServer.stop();
 
                 HttpResponse<String> response = asyncNext.get(5, TimeUnit.SECONDS);


### PR DESCRIPTION
## Summary

`RuntimeApiServerTest.extensionShutdown_racedAgainstStop_isNeverOrphaned` is flaky in CI, failing with `java.io.EOFException: EOF reached while reading`. It still races `stop()` against a `Thread.sleep(5)` — the pattern #2131 replaced with `awaitExtensionParked(...)` in the sibling test but left in place here.

This reuses that same helper, so the race is set up against a poll that has provably parked rather than one assumed to have parked.

Follow-up to #2131, whose reasoning applies verbatim:

> A sleep here is not enough: it asserts the request has parked without checking, and on a loaded machine it expires first, so `stop()` closes the socket while the request is still in flight. The poll then never reaches the handler, `stop()`'s fan-out finds no waiting context to hand SHUTDOWN to, and the client sees the connection die (`EOFException` […]) rather than the SHUTDOWN this test is about.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore — test-only (`test:`)

## Impact

It fails across unrelated branches, so it reads as "CI is unreliable" rather than as a problem with any one PR:

| branch | failing test | date |
|---|---|---|
| `fix/extension-register-race-test-flake` (#2131 itself) | `extensionShutdown_racedAgainstStop_isNeverOrphaned` | 08-05 |
| #1805 (RDS parameter groups) | `extensionRegister_racedAgainstStop_eventuallyDeliversShutdown` | 08-06 |
| #1820 (CloudFront serving) | `extensionShutdown_racedAgainstStop_isNeverOrphaned` | 08-06 |
| #1823 (StepFunctions ResultWriter) | `extensionShutdown_racedAgainstStop_isNeverOrphaned` | 08-06 |

None of those three touches Lambda.

## How it was reproduced

The flake never appears on an idle machine — the class passes 3/3 unconstrained, which is why it only ever showed up in CI. It reproduces reliably under CPU starvation:

```bash
docker run --rm --cpus=1 -v <tree>:/work -v floci-m2:/root/.m2 \
  -v /var/run/docker.sock:/var/run/docker.sock -w /work eclipse-temurin:25-jdk \
  ./mvnw -B -ntp -Dtest='RuntimeApiServerTest' -DfailIfNoSpecifiedTests=false test
```

- **Unpatched, `--cpus=1`:** `extensionShutdown_racedAgainstStop_isNeverOrphaned` fails with `EOFException` — the CI failure, on demand.
- **Patched, `--cpus=1`:** 45/45 green across repeated runs.

That recipe may be worth keeping for any timing-sensitive test that only fails in CI.

## Known remaining case

`extensionRegister_racedAgainstStop_eventuallyDeliversShutdown` failed once on #1805 **despite** already having the park-wait from #2131, so there is a second and rarer path — plausibly shutdown ordering on the server side rather than test timing, since the poll had provably parked. I could not reproduce that one under `--cpus=1` and haven't guessed at a fix; flagging it so it isn't assumed closed by this PR.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added — n/a, this fixes an existing test
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
