### PR TITLE
fix(iam): seed AmazonAPIGatewayPushToCloudWatchLogs managed policy

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
@@ -127,6 +127,10 @@ final class AwsManagedPolicies {
         new ManagedPolicyDef("CloudWatchLambdaApplicationSignalsExecutionRolePolicy", "/",
                 "Provides write access to X-Ray and CloudWatch Application Signals log group."),
 
+        // API Gateway execution role policy
+        new ManagedPolicyDef("AmazonAPIGatewayPushToCloudWatchLogs", "/service-role/",
+                "Allows API Gateway to push logs to CloudWatch Logs."),
+
         // Config execution role policy
         new ManagedPolicyDef("AWSConfigRulesExecutionRole", "/service-role/",
                 "Allows AWS Config Rules Lambda functions to call AWS services and read the configuration of AWS resources."),

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
@@ -255,6 +255,25 @@ class IamIntegrationTest {
     }
 
     @Test
+    @Order(18)
+    void getApiGatewayPushToCloudWatchLogsPolicy() {
+        given()
+            .formParam("Action", "GetPolicy")
+            .formParam("PolicyArn",
+                    "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs")
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=test/20260227/us-east-1/iam/aws4_request")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("GetPolicyResponse.GetPolicyResult.Policy.PolicyName",
+                    equalTo("AmazonAPIGatewayPushToCloudWatchLogs"))
+            .body("GetPolicyResponse.GetPolicyResult.Policy.Arn",
+                    equalTo("arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"));
+    }
+
+    @Test
     @Order(9)
     void stsGetCallerIdentityFallsBackForUnseededFlociAccessKey() {
         given()


### PR DESCRIPTION
## Summary

Closes #2121

Floci seeds 52 AWS-managed policies at boot, but none of them matched API Gateway, so `AttachRolePolicy` for the standard `arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs` policy returned `NoSuchEntity`. This is the policy attached to the API Gateway CloudWatch-logs role that `aws_api_gateway_account` depends on, so it blocked the first apply of any Terraform config that enables API Gateway access logging.

## Changes

- Added `AmazonAPIGatewayPushToCloudWatchLogs` (`/service-role/`) to the seeded managed-policy catalog in `AwsManagedPolicies.java`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Tests

- Reproduced first: added `getApiGatewayPushToCloudWatchLogsPolicy` to `IamIntegrationTest`, confirmed it failed against unfixed `main` (`GetPolicy` returned 404 `NoSuchEntity`).
- Applied the fix, reran — now returns 200 with the expected `PolicyName`/`Arn`.
- Full IAM suite passes: `IamIntegrationTest` (50), `IamServiceTest` (60), `IamManagedPolicyAccountScopeTest` (7), `IamListEntitiesForPolicyIntegrationTest` (2), `SecurityAuditManagedPolicyIntegrationTest` (2) — 0 failures.
- Verified live end-to-end against a running instance (not just the test harness): `CreateRole` → `AttachRolePolicy` for this ARN → 200, confirmed attached via `ListAttachedRolePolicies`, then cleaned up.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)