### PR TITLE
fix(apigateway): match Content-Type case-insensitively in Lambda proxy responses

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -766,7 +766,7 @@ public class ApiGatewayExecuteController {
         }
     }
 
-    private Response buildProxyResponse(InvokeResult result) {
+    Response buildProxyResponse(InvokeResult result) {
         if (result.getPayload() == null || result.getPayload().length == 0) {
             return Response.status(result.getFunctionError() != null ? 502 : result.getStatusCode()).build();
         }

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -793,9 +793,7 @@ public class ApiGatewayExecuteController {
                 String bodyStr = bodyNode.asText();
                 boolean isBase64 = node.path("isBase64Encoded").asBoolean(false);
                 byte[] bytes = isBase64 ? Base64.getDecoder().decode(bodyStr) : bodyStr.getBytes();
-                String ct = MediaType.APPLICATION_JSON;
-                JsonNode ctNode = node.path("headers").path("Content-Type");
-                if (!ctNode.isMissingNode() && !ctNode.isNull()) ct = ctNode.asText();
+                String ct = findHeaderIgnoreCase(respHeaders, "Content-Type").orElse(MediaType.APPLICATION_JSON);
                 builder.entity(bytes).type(ct);
             }
             return builder.build();
@@ -803,6 +801,22 @@ public class ApiGatewayExecuteController {
             LOG.warnv("Failed to parse Lambda response: {0}", e.getMessage());
             return Response.status(502).entity(result.getPayload()).type(MediaType.APPLICATION_JSON).build();
         }
+    }
+
+    /**
+     * HTTP header names are case-insensitive on the wire (RFC 7230 §3.2), and Lambda proxy
+     * integrations commonly return lowercased names (e.g. the AWS Lambda Web Adapter emits
+     * "content-type", not "Content-Type"). A plain JsonNode#path lookup is exact-case and
+     * silently misses those, so Content-Type detection needs to scan case-insensitively.
+     */
+    private static java.util.Optional<String> findHeaderIgnoreCase(JsonNode headersNode, String name) {
+        if (headersNode == null || !headersNode.isObject()) return java.util.Optional.empty();
+        var it = headersNode.fields();
+        while (it.hasNext()) {
+            var e = it.next();
+            if (e.getKey().equalsIgnoreCase(name)) return java.util.Optional.of(e.getValue().asText());
+        }
+        return java.util.Optional.empty();
     }
 
     // ──────────────────────────── AWS (non-proxy) ────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -810,11 +810,17 @@ public class ApiGatewayExecuteController {
      * silently misses those, so Content-Type detection needs to scan case-insensitively.
      */
     private static java.util.Optional<String> findHeaderIgnoreCase(JsonNode headersNode, String name) {
-        if (headersNode == null || !headersNode.isObject()) return java.util.Optional.empty();
+        if (headersNode == null || !headersNode.isObject()) {
+            return java.util.Optional.empty();
+        }
         var it = headersNode.fields();
         while (it.hasNext()) {
             var e = it.next();
-            if (e.getKey().equalsIgnoreCase(name)) return java.util.Optional.of(e.getValue().asText());
+            if (e.getKey().equalsIgnoreCase(name)) {
+                return e.getValue().isNull()
+                        ? java.util.Optional.empty()
+                        : java.util.Optional.of(e.getValue().asText());
+            }
         }
         return java.util.Optional.empty();
     }

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -44,6 +44,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
@@ -793,7 +794,9 @@ public class ApiGatewayExecuteController {
                 String bodyStr = bodyNode.asText();
                 boolean isBase64 = node.path("isBase64Encoded").asBoolean(false);
                 byte[] bytes = isBase64 ? Base64.getDecoder().decode(bodyStr) : bodyStr.getBytes();
-                String ct = findHeaderIgnoreCase(respHeaders, "Content-Type").orElse(MediaType.APPLICATION_JSON);
+                String ct = findHeaderIgnoreCase(multiHeaders, "Content-Type")
+                        .or(() -> findHeaderIgnoreCase(respHeaders, "Content-Type"))
+                        .orElse(MediaType.APPLICATION_JSON);
                 builder.entity(bytes).type(ct);
             }
             return builder.build();
@@ -808,21 +811,22 @@ public class ApiGatewayExecuteController {
      * integrations commonly return lowercased names (e.g. the AWS Lambda Web Adapter emits
      * "content-type", not "Content-Type"). A plain JsonNode#path lookup is exact-case and
      * silently misses those, so Content-Type detection needs to scan case-insensitively.
+     * Handles both the "headers" shape (single string value) and the "multiValueHeaders"
+     * shape (array value, first element wins).
      */
-    private static java.util.Optional<String> findHeaderIgnoreCase(JsonNode headersNode, String name) {
+    private static Optional<String> findHeaderIgnoreCase(JsonNode headersNode, String name) {
         if (headersNode == null || !headersNode.isObject()) {
-            return java.util.Optional.empty();
+            return Optional.empty();
         }
         var it = headersNode.fields();
         while (it.hasNext()) {
             var e = it.next();
             if (e.getKey().equalsIgnoreCase(name)) {
-                return e.getValue().isNull()
-                        ? java.util.Optional.empty()
-                        : java.util.Optional.of(e.getValue().asText());
+                JsonNode value = e.getValue().isArray() ? e.getValue().get(0) : e.getValue();
+                return value == null || value.isNull() ? Optional.empty() : Optional.of(value.asText());
             }
         }
-        return java.util.Optional.empty();
+        return Optional.empty();
     }
 
     // ──────────────────────────── AWS (non-proxy) ────────────────────────────

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteControllerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteControllerTest.java
@@ -157,4 +157,15 @@ class ApiGatewayExecuteControllerTest {
                 """));
         assertEquals("application/json", response.getMediaType().toString());
     }
+
+    @Test
+    void buildProxyResponseDefaultsToJsonWhenContentTypeIsJsonNull() {
+        // A JSON-null Content-Type must fall back to the default, the same as a missing header —
+        // not be coerced to the literal string "null" (an invalid media type).
+        ApiGatewayExecuteController controller = controller(new ObjectMapper());
+        Response response = controller.buildProxyResponse(proxyPayload("""
+                {"statusCode":200,"headers":{"content-type":null},"body":"{}"}
+                """));
+        assertEquals("application/json", response.getMediaType().toString());
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteControllerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteControllerTest.java
@@ -168,4 +168,29 @@ class ApiGatewayExecuteControllerTest {
                 """));
         assertEquals("application/json", response.getMediaType().toString());
     }
+
+    @Test
+    void buildProxyResponseMatchesContentTypeInMultiValueHeaders() {
+        // multiValueHeaders is a fully valid way to return any header, including Content-Type —
+        // not just repeated ones — and must be scanned the same as headers.
+        ApiGatewayExecuteController controller = controller(new ObjectMapper());
+        Response response = controller.buildProxyResponse(proxyPayload("""
+                {"statusCode":200,"multiValueHeaders":{"content-type":["application/xml"]},"body":"<a/>"}
+                """));
+        assertEquals("application/xml", response.getMediaType().toString());
+    }
+
+    @Test
+    void buildProxyResponseMultiValueHeadersTakesPrecedenceOverHeaders() {
+        // API Gateway merges headers and multiValueHeaders, with multiValueHeaders winning
+        // on conflicts.
+        ApiGatewayExecuteController controller = controller(new ObjectMapper());
+        Response response = controller.buildProxyResponse(proxyPayload("""
+                {"statusCode":200,\
+                "headers":{"Content-Type":"text/plain"},\
+                "multiValueHeaders":{"Content-Type":["application/xml"]},\
+                "body":"<a/>"}
+                """));
+        assertEquals("application/xml", response.getMediaType().toString());
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteControllerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteControllerTest.java
@@ -3,11 +3,14 @@ package io.github.hectorvent.floci.services.apigateway;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -108,5 +111,50 @@ class ApiGatewayExecuteControllerTest {
         assertEquals(
                 objectMapper.valueToTree(List.of("first", "second", "third")),
                 event.path("multiValueHeaders").path("X-Dup"));
+    }
+
+    // ── Lambda proxy response Content-Type header matching ──────
+
+    private static InvokeResult proxyPayload(String payloadJson) {
+        return new InvokeResult(200, null, payloadJson.getBytes(StandardCharsets.UTF_8), null, "req-1");
+    }
+
+    @Test
+    void buildProxyResponseMatchesLowercaseContentType() {
+        // The AWS Lambda Web Adapter sidecar (and many handlers) emit lowercase header names.
+        ApiGatewayExecuteController controller = controller(new ObjectMapper());
+        Response response = controller.buildProxyResponse(proxyPayload("""
+                {"statusCode":404,"headers":{"content-type":"application/problem+json"},"body":"{}"}
+                """));
+        assertEquals("application/problem+json", response.getMediaType().toString());
+    }
+
+    @Test
+    void buildProxyResponseMatchesExactCaseContentType() {
+        // The pre-existing exact-case path must keep working — this is a regression guard,
+        // not a new behavior.
+        ApiGatewayExecuteController controller = controller(new ObjectMapper());
+        Response response = controller.buildProxyResponse(proxyPayload("""
+                {"statusCode":200,"headers":{"Content-Type":"text/plain"},"body":"hi"}
+                """));
+        assertEquals("text/plain", response.getMediaType().toString());
+    }
+
+    @Test
+    void buildProxyResponseMatchesMixedCaseContentType() {
+        ApiGatewayExecuteController controller = controller(new ObjectMapper());
+        Response response = controller.buildProxyResponse(proxyPayload("""
+                {"statusCode":200,"headers":{"CONTENT-TYPE":"application/xml"},"body":"<a/>"}
+                """));
+        assertEquals("application/xml", response.getMediaType().toString());
+    }
+
+    @Test
+    void buildProxyResponseDefaultsToJsonWhenNoContentTypeHeaderPresent() {
+        ApiGatewayExecuteController controller = controller(new ObjectMapper());
+        Response response = controller.buildProxyResponse(proxyPayload("""
+                {"statusCode":200,"headers":{"X-Other":"value"},"body":"{}"}
+                """));
+        assertEquals("application/json", response.getMediaType().toString());
     }
 }


### PR DESCRIPTION
## Summary

`buildProxyResponse` re-derives the response Content-Type with an exact-case JSON field lookup (`node.path("headers").path("Content-Type")`), even though the header-copy loop just above it already handles arbitrary casing correctly by iterating every field. Lambda proxy integrations commonly return lowercased header names — e.g. the AWS Lambda Web Adapter sidecar returns `content-type`, not `Content-Type` — which the exact-case lookup misses, silently falling back to `application/json` regardless of what the Lambda actually set. HTTP header names are case-insensitive on the wire (RFC 7230 §3.2), so this affected every response whose handler didn't happen to use the exact AWS-console casing, most visibly every RFC 9457 `application/problem+json` error response.

Two related gaps surfaced during review and are folded into this PR rather than deferred, since they're the same bug in the same method:

- A JSON-null `Content-Type` value was coerced to the literal string `"null"` instead of falling back to the default, producing an invalid media type.
- `findHeaderIgnoreCase` only scanned `headers`, not `multiValueHeaders` — but Lambda proxy responses can set Content-Type via either, and API Gateway prefers `multiValueHeaders` on conflicts. The old code would silently overwrite a Lambda's real Content-Type with the `application/json` default whenever it arrived via `multiValueHeaders`.

## What changed

- Replaces the exact-case lookup with a case-insensitive scan (`findHeaderIgnoreCase`) reusing the already-fetched headers node.
- Widens `buildProxyResponse`'s visibility to package-private (matching `dispatch()`'s existing visibility) so it's directly unit-testable without standing up a full Lambda invoke.
- `findHeaderIgnoreCase` returns `Optional.empty()` for a JSON-null value instead of the string `"null"`.
- `findHeaderIgnoreCase` now also unwraps array values (the `multiValueHeaders` shape), and Content-Type resolution checks `multiValueHeaders` first, falling back to `headers` — matching API Gateway's own merge precedence.

## Test plan

- [x] `buildProxyResponseMatchesLowercaseContentType`: lowercase `content-type` header is matched.
- [x] `buildProxyResponseMatchesExactCaseContentType`: exact-case `Content-Type` still works (regression guard).
- [x] `buildProxyResponseMatchesMixedCaseContentType`: mixed-case `CONTENT-TYPE` is matched.
- [x] `buildProxyResponseDefaultsToJsonWhenNoContentTypeHeaderPresent`: absent header still defaults to `application/json`.
- [x] `buildProxyResponseDefaultsToJsonWhenContentTypeIsJsonNull`: JSON-null header value defaults to `application/json` rather than the literal string `"null"`.
- [x] `buildProxyResponseMatchesContentTypeInMultiValueHeaders`: Content-Type set only via `multiValueHeaders` is detected.
- [x] `buildProxyResponseMultiValueHeadersTakesPrecedenceOverHeaders`: when both `headers` and `multiValueHeaders` set Content-Type, `multiValueHeaders` wins.
- [x] Verified by reverting `findHeaderIgnoreCase` to the old exact-case lookup: the lowercase and mixed-case tests fail (2 of 4) while the exact-case and no-header tests keep passing, confirming none of the four are vacuous.
- [x] Verified by reverting the `multiValueHeaders` scan: the two new multi-value tests fail (2 of 2) against the array-unaware lookup, confirming they exercise the fix.
- [x] Full `apigateway` test suite passes.
