### PR TITLE
fix(s3): ensure tags are added on multipart s3 uploads

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -1164,7 +1164,8 @@ public class S3Controller {
                         httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-algorithm"),
                         httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-key"),
                         httpHeaders.getHeaderString("x-amz-server-side-encryption-customer-key-MD5"),
-                        getChecksumAlgorithm(httpHeaders));
+                        getChecksumAlgorithm(httpHeaders),
+                        parseInlineTaggingHeader(httpHeaders.getHeaderString("x-amz-tagging")));
                 String xml = new XmlBuilder()
                         .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
                         .start("InitiateMultipartUploadResult", AwsNamespaces.S3)

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -1343,6 +1343,16 @@ public class S3Service implements Resettable {
                                                    String contentDisposition, String serverSideEncryption, String acl,
                                                    String sseCustomerAlgorithm, String sseCustomerKey, String sseCustomerKeyMd5,
                                                    String checksumAlgorithm) {
+        return initiateMultipartUpload(bucket, key, contentType, metadata, storageClass, contentDisposition,
+                serverSideEncryption, acl, sseCustomerAlgorithm, sseCustomerKey, sseCustomerKeyMd5,
+                checksumAlgorithm, null);
+    }
+
+    public MultipartUpload initiateMultipartUpload(String bucket, String key, String contentType,
+                                                   Map<String, String> metadata, String storageClass,
+                                                   String contentDisposition, String serverSideEncryption, String acl,
+                                                   String sseCustomerAlgorithm, String sseCustomerKey, String sseCustomerKeyMd5,
+                                                   String checksumAlgorithm, Map<String, String> tagging) {
         ensureBucketExists(bucket);
         if (acl != null && !acl.isBlank()) {
             cannedObjectAclXml(acl);
@@ -1363,6 +1373,9 @@ public class S3Service implements Resettable {
         }
         upload.setAcl(acl);
         upload.setChecksumAlgorithm(validateAndNormalizeChecksumAlgorithm(checksumAlgorithm));
+        if (tagging != null && !tagging.isEmpty()) {
+            upload.setTagging(new HashMap<>(tagging));
+        }
 
         if (inMemory) {
             memoryMultipartStore.put(upload.getUploadId(), new ConcurrentHashMap<>());
@@ -1494,7 +1507,8 @@ public class S3Service implements Resettable {
                             .withStorageClass(upload.getStorageClass())
                             .withContentDisposition(upload.getContentDisposition())
                             .withServerSideEncryption(upload.getServerSideEncryption())
-                            .withAcl(upload.getAcl()));
+                            .withAcl(upload.getAcl())
+                            .withTagging(upload.getTagging()));
             if (upload.getSseCustomerAlgorithm() != null) {
                 object.setSseCustomerAlgorithm(upload.getSseCustomerAlgorithm());
                 object.setSseCustomerKeyMd5(upload.getSseCustomerKeyMd5());

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/MultipartUpload.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/MultipartUpload.java
@@ -23,6 +23,7 @@ public class MultipartUpload {
     private String acl;
     private String checksumAlgorithm;
     private Map<String, String> metadata;
+    private Map<String, String> tagging;
     private Instant initiated;
     private final Map<Integer, Part> parts = new ConcurrentHashMap<>();
 
@@ -76,6 +77,9 @@ public class MultipartUpload {
 
     public Map<String, String> getMetadata() { return metadata; }
     public void setMetadata(Map<String, String> metadata) { this.metadata = metadata; }
+
+    public Map<String, String> getTagging() { return tagging; }
+    public void setTagging(Map<String, String> tagging) { this.tagging = tagging; }
 
     public Instant getInitiated() { return initiated; }
     public void setInitiated(Instant initiated) { this.initiated = initiated; }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartIntegrationTest.java
@@ -501,8 +501,67 @@ class S3MultipartIntegrationTest {
 
     @Test
     @Order(18)
+    void multipartUploadAppliesInlineTagging() {
+        String taggedKey = "tagged-multipart.bin";
+        String taggingUploadId = given()
+            .header("x-amz-tagging", "token=abc-123&teamId=42&note=hello%20world")
+        .when()
+            .post("/" + BUCKET + "/" + taggedKey + "?uploads")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath().getString("InitiateMultipartUploadResult.UploadId");
+
+        given()
+            .body("TaggedPartData")
+        .when()
+            .put("/" + BUCKET + "/" + taggedKey + "?uploadId=" + taggingUploadId + "&partNumber=1")
+        .then()
+            .statusCode(200);
+
+        String completeXml = """
+                <CompleteMultipartUpload>
+                    <Part><PartNumber>1</PartNumber><ETag>etag1</ETag></Part>
+                </CompleteMultipartUpload>""";
+        given()
+            .contentType("application/xml")
+            .body(completeXml)
+        .when()
+            .post("/" + BUCKET + "/" + taggedKey + "?uploadId=" + taggingUploadId)
+        .then()
+            .statusCode(200);
+
+        // Tags from the x-amz-tagging header on CreateMultipartUpload must be present
+        // on the completed object, including URL-decoded values.
+        given()
+        .when()
+            .get("/" + BUCKET + "/" + taggedKey + "?tagging")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Key>token</Key>"))
+            .body(containsString("<Value>abc-123</Value>"))
+            .body(containsString("<Key>teamId</Key>"))
+            .body(containsString("<Value>42</Value>"))
+            .body(containsString("<Key>note</Key>"))
+            .body(containsString("<Value>hello world</Value>"));
+    }
+
+    @Test
+    @Order(19)
+    void initiateMultipartUploadRejectsMalformedTaggingHeader() {
+        given()
+            .header("x-amz-tagging", "missing-equals-sign")
+        .when()
+            .post("/" + BUCKET + "/bad-tagging.bin?uploads")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidArgument"));
+    }
+
+    @Test
+    @Order(20)
     void cleanUp() {
         given().when().delete("/" + BUCKET + "/" + KEY).then().statusCode(204);
+        given().when().delete("/" + BUCKET + "/tagged-multipart.bin").then().statusCode(204);
         given().when().delete("/" + BUCKET + "/source-for-copy.bin").then().statusCode(204);
         given().when().delete("/" + BUCKET + "/copy-dest.bin").then().statusCode(204);
         given().when().delete("/" + BUCKET + "/sse-c-multipart.bin").then().statusCode(204);

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3MultipartServiceTest.java
@@ -95,6 +95,31 @@ class S3MultipartServiceTest {
     }
 
     @Test
+    void completeMultipartUploadAppliesTagging() {
+        MultipartUpload upload = s3Service.initiateMultipartUpload("test-bucket", "tagged.bin", null,
+                null, null, null, null, null, null, null, null, null,
+                Map.of("token", "abc-123", "teamId", "42"));
+        s3Service.uploadPart("test-bucket", "tagged.bin", upload.getUploadId(), 1, "part1".getBytes());
+
+        s3Service.completeMultipartUpload("test-bucket", "tagged.bin", upload.getUploadId(), List.of(1));
+
+        Map<String, String> tags = s3Service.getObjectTagging("test-bucket", "tagged.bin");
+        assertEquals(2, tags.size());
+        assertEquals("abc-123", tags.get("token"));
+        assertEquals("42", tags.get("teamId"));
+    }
+
+    @Test
+    void completeMultipartUploadWithoutTaggingLeavesObjectUntagged() {
+        MultipartUpload upload = s3Service.initiateMultipartUpload("test-bucket", "untagged.bin", null);
+        s3Service.uploadPart("test-bucket", "untagged.bin", upload.getUploadId(), 1, "part1".getBytes());
+
+        s3Service.completeMultipartUpload("test-bucket", "untagged.bin", upload.getUploadId(), List.of(1));
+
+        assertTrue(s3Service.getObjectTagging("test-bucket", "untagged.bin").isEmpty());
+    }
+
+    @Test
     void completeMultipartUploadMissingPart() {
         MultipartUpload upload = s3Service.initiateMultipartUpload("test-bucket", "file.bin", null);
         s3Service.uploadPart("test-bucket", "file.bin", upload.getUploadId(), 1, "part1".getBytes());


### PR DESCRIPTION
## Summary

Fixes a bug where tags were not present on the final object in s3 when tagging was specified via CreateMultiPartUpload

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior before was that the final object uploaded to floci were not tagged when the upload was done via multi-part upload.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
