### PR TITLE
fix(iam): include policy description in GetPolicy/ListPolicies/CreatePolicy responses

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
@@ -917,6 +917,7 @@ public class IamQueryHandler {
                 .elem("IsAttachable", true)
                 .elem("CreateDate", isoDate(p.getCreateDate()))
                 .elem("UpdateDate", isoDate(p.getUpdateDate()))
+                .elem("Description", p.getDescription())
                 .build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
@@ -450,13 +450,13 @@ public class IamQueryHandler {
         String document = getParam(params, "PolicyDocument");
         Map<String, String> tags = extractTags(params);
         IamPolicy policy = iamService.createPolicy(policyName, path, description, document, tags);
-        String result = new XmlBuilder().start("Policy").raw(policyXml(policy)).end("Policy").build();
+        String result = new XmlBuilder().start("Policy").raw(policyXml(policy, true)).end("Policy").build();
         return Response.ok(AwsQueryResponse.envelope("CreatePolicy", AwsNamespaces.IAM, result)).build();
     }
 
     private Response handleGetPolicy(MultivaluedMap<String, String> params) {
         IamPolicy policy = iamService.getPolicy(getParam(params, "PolicyArn"));
-        String result = new XmlBuilder().start("Policy").raw(policyXml(policy)).end("Policy").build();
+        String result = new XmlBuilder().start("Policy").raw(policyXml(policy, true)).end("Policy").build();
         return Response.ok(AwsQueryResponse.envelope("GetPolicy", AwsNamespaces.IAM, result)).build();
     }
 
@@ -470,7 +470,7 @@ public class IamQueryHandler {
                 getParam(params, "Scope"), getParam(params, "PathPrefix"));
         var xml = new XmlBuilder().start("Policies");
         for (IamPolicy p : policyList) {
-            xml.start("member").raw(policyXml(p)).end("member");
+            xml.start("member").raw(policyXml(p, false)).end("member");
         }
         xml.end("Policies").elem("IsTruncated", false);
         return Response.ok(AwsQueryResponse.envelope("ListPolicies", AwsNamespaces.IAM, xml.build())).build();
@@ -906,7 +906,13 @@ public class IamQueryHandler {
                 .build();
     }
 
-    private String policyXml(IamPolicy p) {
+    /**
+     * {@code includeDescription} is per-operation, not per-policy: AWS's own {@code Policy} model
+     * documents that {@code Description} "is included in the response to the GetPolicy operation.
+     * It is not included in the response to the ListPolicies operation" — CreatePolicy documents
+     * neither inclusion nor exclusion, so it's treated the same as GetPolicy.
+     */
+    private String policyXml(IamPolicy p, boolean includeDescription) {
         return new XmlBuilder()
                 .elem("PolicyName", p.getPolicyName())
                 .elem("PolicyId", p.getPolicyId())
@@ -917,7 +923,7 @@ public class IamQueryHandler {
                 .elem("IsAttachable", true)
                 .elem("CreateDate", isoDate(p.getCreateDate()))
                 .elem("UpdateDate", isoDate(p.getUpdateDate()))
-                .elem("Description", p.getDescription())
+                .elem("Description", includeDescription ? p.getDescription() : null)
                 .build();
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
@@ -689,6 +689,7 @@ class IamIntegrationTest {
             .body("CreatePolicyResponse.CreatePolicyResult.Policy.PolicyName", equalTo("TestPolicy"))
             .body("CreatePolicyResponse.CreatePolicyResult.Policy.PolicyId", startsWith("ANPA"))
             .body("CreatePolicyResponse.CreatePolicyResult.Policy.DefaultVersionId", equalTo("v1"))
+            .body("CreatePolicyResponse.CreatePolicyResult.Policy.Description", equalTo("Test managed policy"))
         .extract()
             .path("CreatePolicyResponse.CreatePolicyResult.Policy.Arn");
     }
@@ -705,7 +706,8 @@ class IamIntegrationTest {
             .post("/")
         .then()
             .statusCode(200)
-            .body("GetPolicyResponse.GetPolicyResult.Policy.PolicyName", equalTo("TestPolicy"));
+            .body("GetPolicyResponse.GetPolicyResult.Policy.PolicyName", equalTo("TestPolicy"))
+            .body("GetPolicyResponse.GetPolicyResult.Policy.Description", equalTo("Test managed policy"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
@@ -1081,6 +1081,11 @@ class IamIntegrationTest {
         .then()
             .statusCode(200);
 
+        // Asserting only the negative would pass vacuously if ListPolicies ever returned no
+        // members at all (a pagination bug, a scope-filter regression); the positive assertion
+        // proves the created policy is actually present before the absence check means anything.
+        // Matching the element itself, not the bare word "Description", also avoids colliding
+        // with a future policy name/path containing that substring.
         given()
             .formParam("Action", "ListPolicies")
             .formParam("Scope", "Local")
@@ -1090,6 +1095,7 @@ class IamIntegrationTest {
             .post("/")
         .then()
             .statusCode(200)
-            .body(not(containsString("Description")));
+            .body(containsString("ListPoliciesOmitCheckPolicy"))
+            .body(not(containsString("<Description>")));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
@@ -1056,4 +1056,40 @@ class IamIntegrationTest {
             .body("ErrorResponse.Error.Code", equalTo("NoSuchEntity"))
             .body("ErrorResponse.Error.Message", not(containsString("null")));
     }
+
+    @Test
+    @Order(74)
+    void listPoliciesOmitsDescription() {
+        // AWS's own Policy model documents this explicitly: Description "is included in the
+        // response to the GetPolicy operation. It is not included in the response to the
+        // ListPolicies operation." Unlike GetPolicy/CreatePolicy (which do include it), no
+        // member returned by ListPolicies should ever carry a Description element — checking
+        // the raw response for the tag at all, rather than a specific policy's value, is what
+        // actually pins the shared-helper regression this guards against: folding the element
+        // back into policyXml() unconditionally would reintroduce it for every member, not just
+        // the one this test happens to create.
+        given()
+            .formParam("Action", "CreatePolicy")
+            .formParam("PolicyName", "ListPoliciesOmitCheckPolicy")
+            .formParam("Path", "/")
+            .formParam("PolicyDocument", POLICY_DOCUMENT)
+            .formParam("Description", "Should not appear in ListPolicies")
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=test/20260227/us-east-1/iam/aws4_request")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .formParam("Action", "ListPolicies")
+            .formParam("Scope", "Local")
+            .header("Authorization",
+                    "AWS4-HMAC-SHA256 Credential=test/20260227/us-east-1/iam/aws4_request")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(not(containsString("Description")));
+    }
 }


### PR DESCRIPTION
Fixes #2154.

## Bug

`GetPolicy`, `ListPolicies`, and `CreatePolicy` all built their response via the shared
`policyXml()` helper in `IamQueryHandler.java`, which never emitted a `Description` element —
even when the policy was created with one, and even though the sibling `roleXml()` (right above
it) does emit `Description` for roles. `IamPolicy` (the model) and `IamService.createPolicy()`
both handle the field correctly; it was only dropped on the way out to the client.

Real AWS's `GetPolicy` returns `Description` (see the
[API docs](https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetPolicy.html)'s own sample
response). Consumers that diff against real AWS behavior — e.g. Terraform's AWS provider — see the
description as permanently missing on every read, and since IAM policy descriptions are immutable
(force-new on the AWS provider), this forces a destroy+recreate of the policy on every apply, even
when nothing in the underlying config changed.

## Fix

One line: add `.elem("Description", p.getDescription())` to `policyXml()`, matching the existing
pattern in `roleXml()`. `XmlBuilder.elem()` already skips the element when the value is `null`, so
this is a strict superset of the previous output — no behavior change for policies without one.

## Tests

Added `Description` assertions to the existing `createPolicy()` and `getPolicy()` integration
tests in `IamIntegrationTest` — both already pass a `Description` on `CreatePolicy` but weren't
asserting on it in the response, so they didn't catch this. Ran locally (Java 25):

```
IamIntegrationTest:              49/49 passed
IamServiceTest:                  60/60 passed
IamManagedPolicyAccountScopeTest: 7/7 passed
IamConcurrencyTest:               13/13 passed
```
