### PR TITLE
fix(lambda): drain parked extensions before closing the runtime API server

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServer.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.services.lambda.model.ExtensionEvent;
 import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
 import io.github.hectorvent.floci.services.lambda.model.PendingInvocation;
 import io.github.hectorvent.floci.services.lambda.model.RegisteredExtension;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
@@ -22,6 +23,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 /**
  * Per-container HTTP server implementing the AWS Lambda Runtime API and, for
@@ -468,7 +471,7 @@ public class RuntimeApiServer {
     public CompletableFuture<Void> stop() {
         CompletableFuture<Void> closed;
         List<RoutingContext> contextsToClose204;
-        List<Runnable> dispatches = new ArrayList<>();
+        List<Supplier<Future<Void>>> dispatches = new ArrayList<>();
         List<PendingInvocation> invocationsToFailContainerStopped;
 
         synchronized (lock) {
@@ -490,9 +493,10 @@ public class RuntimeApiServer {
                 RoutingContext waitingCtx = ext.takeWaitingContext();
                 if (waitingCtx != null) {
                     dispatches.add(() -> {
-                        if (!waitingCtx.response().ended()) {
-                            sendExtensionEvent(waitingCtx, shutdownEvent);
+                        if (waitingCtx.response().ended()) {
+                            return Future.succeededFuture();
                         }
+                        return sendExtensionEvent(waitingCtx, shutdownEvent);
                     });
                 } else {
                     ext.getPendingEvents().offer(shutdownEvent);
@@ -503,32 +507,52 @@ public class RuntimeApiServer {
             pendingQueue.clear();
         }
 
-        if (httpServer != null) {
-            httpServer.close(ar -> {
-                if (ar.succeeded()) {
-                    LOG.debugv("RuntimeApiServer on port {0} closed", String.valueOf(port));
-                    closed.complete(null);
-                } else {
-                    LOG.warnv(ar.cause(), "RuntimeApiServer on port {0} failed to close cleanly", String.valueOf(port));
-                    closed.completeExceptionally(ar.cause());
-                }
-            });
+        Runnable closeServer = () -> {
+            if (httpServer != null) {
+                httpServer.close(ar -> {
+                    if (ar.succeeded()) {
+                        LOG.debugv("RuntimeApiServer on port {0} closed", String.valueOf(port));
+                        closed.complete(null);
+                    } else {
+                        LOG.warnv(ar.cause(), "RuntimeApiServer on port {0} failed to close cleanly", String.valueOf(port));
+                        closed.completeExceptionally(ar.cause());
+                    }
+                });
+            } else {
+                closed.complete(null);
+            }
+        };
+
+        // Wake any parked /next pollers with 204 (container shutting down — runtime will exit) and
+        // dispatch SHUTDOWN to every extension already parked on /event/next, then close the HTTP
+        // server. Each write is scheduled on the event loop via vertx.runOnContext(...), and the
+        // server is closed only once every write's response has actually been flushed — tracked by
+        // remainingWrites, decremented from each end() future's completion rather than when the
+        // scheduled handler returns (response.end() is asynchronous, so the bytes are not on the
+        // wire yet when the handler returns). So a parked extension's SHUTDOWN — or a poller's 204
+        // — is fully written before its connection is torn down, instead of racing
+        // httpServer.close() and orphaning the extension with an EOF. See issue #2142.
+        int parkedWrites = contextsToClose204.size() + dispatches.size();
+        if (parkedWrites == 0) {
+            closeServer.run();
         } else {
-            closed.complete(null);
-        }
-
-        // Wake any parked /next pollers with 204 (container shutting down — runtime will exit).
-        for (RoutingContext ctx : contextsToClose204) {
-            vertx.runOnContext(v -> {
-                if (!ctx.response().ended()) {
-                    ctx.response().setStatusCode(204).end();
+            AtomicInteger remainingWrites = new AtomicInteger(parkedWrites);
+            Runnable afterWrite = () -> {
+                if (remainingWrites.decrementAndGet() == 0) {
+                    closeServer.run();
                 }
-            });
-        }
-
-        // Dispatch SHUTDOWN to every extension that was already parked on /event/next.
-        for (Runnable dispatch : dispatches) {
-            vertx.runOnContext(v -> dispatch.run());
+            };
+            for (RoutingContext ctx : contextsToClose204) {
+                vertx.runOnContext(v -> {
+                    Future<Void> written = ctx.response().ended()
+                            ? Future.succeededFuture()
+                            : ctx.response().setStatusCode(204).end();
+                    written.onComplete(ar -> afterWrite.run());
+                });
+            }
+            for (Supplier<Future<Void>> dispatch : dispatches) {
+                vertx.runOnContext(v -> dispatch.get().onComplete(ar -> afterWrite.run()));
+            }
         }
 
         // Fail queued invocations that were never consumed by /next.
@@ -657,7 +681,7 @@ public class RuntimeApiServer {
                 .end(body);
     }
 
-    private void sendExtensionEvent(RoutingContext ctx, ExtensionEvent event) {
+    private Future<Void> sendExtensionEvent(RoutingContext ctx, ExtensionEvent event) {
         JsonObject body = new JsonObject().put("eventType", event.getType().name());
         if (event.getType() == ExtensionEvent.Type.INVOKE) {
             body.put("requestId", event.getRequestId())
@@ -667,7 +691,7 @@ public class RuntimeApiServer {
             body.put("shutdownReason", event.getShutdownReason())
                     .put("deadlineMs", event.getDeadlineMs());
         }
-        ctx.response()
+        return ctx.response()
                 .setStatusCode(200)
                 .putHeader("Content-Type", "application/json")
                 .putHeader(EXTENSION_EVENT_ID_HEADER, UUID.randomUUID().toString())


### PR DESCRIPTION
RuntimeApiServer.stop() called httpServer.close() before the vertx.runOnContext(...) loops that write the 204 wake-ups and SHUTDOWN events to parked extensions. Because close() begins tearing down connections immediately — and is not guaranteed to run on the same event-loop context as those writes — a parked extension's SHUTDOWN response could be lost when close won the race, orphaning the extension. That surfaced as the intermittent EOFException failing RuntimeApiServerTest in CI across unrelated PRs.

Close the HTTP server only after every parked 204/SHUTDOWN write has run, tracked by a counter that fires the close once the last write completes. This holds even when the writes land on different event-loop contexts, so merely reordering the loops above the close (which narrows but does not close the window) is not relied upon.

Fixes #2142.

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->

