### PR TITLE
fix(stepfunctions): wrap optimized lambda:invoke result in the Invoke envelope

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -501,12 +501,14 @@ public class AslExecutor {
         // Support Lambda resources: direct ARN or optimized integration
         String functionName = null;
         JsonNode lambdaPayload = input;
+        boolean optimizedLambdaInvoke = false;
 
         if (resource.contains(":lambda:") && resource.contains(":function:")) {
             // Direct Lambda ARN: arn:aws:lambda:region:account:function:name[:qualifier]
             functionName = extractLambdaFunctionName(resource);
         } else if (resource.equals("arn:aws:states:::lambda:invoke")) {
             // Optimized Lambda integration — function name and payload come from resolved input
+            optimizedLambdaInvoke = true;
             String fnRef = input.path("FunctionName").asText(null);
             if (fnRef != null) {
                 functionName = extractLambdaFunctionName(fnRef);
@@ -533,10 +535,20 @@ public class AslExecutor {
             }
 
             byte[] responseBytes = result.getPayload();
-            if (responseBytes != null && responseBytes.length > 0) {
-                return objectMapper.readTree(responseBytes);
+            JsonNode functionOutput = responseBytes != null && responseBytes.length > 0
+                    ? objectMapper.readTree(responseBytes)
+                    : NullNode.getInstance();
+
+            // A direct function ARN yields only the function output, while the optimized
+            // integration nests it in the Invoke response metadata.
+            if (!optimizedLambdaInvoke) {
+                return functionOutput;
             }
-            return NullNode.getInstance();
+            ObjectNode invokeResponse = objectMapper.createObjectNode();
+            invokeResponse.put("ExecutedVersion", fn.getVersion());
+            invokeResponse.set("Payload", functionOutput);
+            invokeResponse.put("StatusCode", result.getStatusCode());
+            return invokeResponse;
         }
 
         // DynamoDB optimized integrations (4 actions)

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorLambdaInvokeResultTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorLambdaInvokeResultTest.java
@@ -1,0 +1,237 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbJsonHandler;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
+import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
+import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
+import io.github.hectorvent.floci.services.lambda.model.InvocationType;
+import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
+import io.github.hectorvent.floci.services.lambda.model.LambdaFunction;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
+import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
+import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
+import io.github.hectorvent.floci.services.stepfunctions.model.StateMachine;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.mutiny.core.Vertx;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for the shape of a Lambda Task result.
+ *
+ * AWS returns the Invoke response envelope (ExecutedVersion / Payload / StatusCode) for the
+ * optimized "arn:aws:states:::lambda:invoke" integration, but only the function output for a
+ * directly specified function ARN. Reading a Lambda result through $.Payload or
+ * $states.result.Payload — the documented way — depends on that distinction.
+ */
+@QuarkusTest
+class AslExecutorLambdaInvokeResultTest {
+
+    private static final String REGION = "us-east-2";
+    private static final String ACCOUNT = "000000000000";
+    private static final String FUNCTION_NAME = "echo-lambda";
+    private static final String FUNCTION_ARN =
+            "arn:aws:lambda:%s:%s:function:%s".formatted(REGION, ACCOUNT, FUNCTION_NAME);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private AslExecutor executor;
+
+    @Inject
+    Vertx vertx;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        LambdaExecutorService lambdaExecutor = mock(LambdaExecutorService.class);
+        LambdaFunctionStore functionStore = mock(LambdaFunctionStore.class);
+        LambdaFunction function = new LambdaFunction();
+        function.setFunctionName(FUNCTION_NAME);
+        function.setFunctionArn(FUNCTION_ARN);
+
+        when(functionStore.get(REGION, FUNCTION_NAME)).thenReturn(Optional.of(function));
+        when(lambdaExecutor.invoke(eq(function), any(byte[].class), eq(InvocationType.RequestResponse)))
+                .thenAnswer(invocation -> {
+                    JsonNode event = objectMapper.readTree((byte[]) invocation.getArgument(1));
+                    byte[] output = objectMapper.writeValueAsBytes(objectMapper.createObjectNode()
+                            .put("marker", "RET")
+                            .set("echo", event));
+                    return new InvokeResult(200, null, output, null, "echo-request");
+                });
+
+        executor = new AslExecutor(
+                lambdaExecutor,
+                functionStore,
+                mock(DynamoDbService.class),
+                mock(DynamoDbJsonHandler.class),
+                mock(SqsJsonHandler.class),
+                mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
+                mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
+                mock(S3Service.class),
+                mock(io.github.hectorvent.floci.services.ecs.EcsService.class),
+                mock(io.github.hectorvent.floci.services.ecs.EcsJsonHandler.class),
+                objectMapper,
+                new JsonataEvaluator(objectMapper),
+                mock(Instance.class), mock(EmulatorConfig.class), vertx);
+    }
+
+    @Test
+    void optimizedInvokeNestsFunctionOutputInTheInvokeResponseEnvelope() throws Exception {
+        Execution execution = run("""
+                {
+                  "StartAt": "Call",
+                  "States": {
+                    "Call": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::lambda:invoke",
+                      "Parameters": {"FunctionName": "%s", "Payload": {"in": 1}},
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(FUNCTION_ARN));
+
+        assertEquals("SUCCEEDED", execution.getStatus());
+        JsonNode output = objectMapper.readTree(execution.getOutput());
+        assertEquals("$LATEST", output.path("ExecutedVersion").asText());
+        assertTrue(output.path("StatusCode").isInt());
+        assertEquals(200, output.path("StatusCode").asInt());
+        assertEquals("RET", output.path("Payload").path("marker").asText());
+        assertEquals(1, output.path("Payload").path("echo").path("in").asInt());
+        assertFalse(output.has("marker"));
+        assertEquals(3, output.size());
+    }
+
+    @Test
+    void directFunctionArnReturnsOnlyTheFunctionOutput() throws Exception {
+        Execution execution = run("""
+                {
+                  "StartAt": "Call",
+                  "States": {
+                    "Call": {
+                      "Type": "Task",
+                      "Resource": "%s",
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(FUNCTION_ARN));
+
+        assertEquals("SUCCEEDED", execution.getStatus());
+        JsonNode output = objectMapper.readTree(execution.getOutput());
+        assertEquals("RET", output.path("marker").asText());
+        assertEquals(1, output.path("echo").path("in").asInt());
+        assertFalse(output.has("Payload"));
+        assertFalse(output.has("StatusCode"));
+        assertFalse(output.has("ExecutedVersion"));
+    }
+
+    @Test
+    void resultSelectorReadsPayloadFromOptimizedInvokeResult() throws Exception {
+        Execution execution = run("""
+                {
+                  "StartAt": "Call",
+                  "States": {
+                    "Call": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::lambda:invoke",
+                      "Parameters": {"FunctionName": "%s", "Payload": {"in": 1}},
+                      "ResultSelector": {"marker.$": "$.Payload.marker", "status.$": "$.StatusCode"},
+                      "ResultPath": "$.lambda",
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(FUNCTION_ARN));
+
+        assertEquals("SUCCEEDED", execution.getStatus());
+        JsonNode output = objectMapper.readTree(execution.getOutput());
+        assertEquals("RET", output.path("lambda").path("marker").asText());
+        assertEquals(200, output.path("lambda").path("status").asInt());
+        assertEquals(1, output.path("in").asInt());
+    }
+
+    @Test
+    void outputPathPayloadUnwrapsTheOptimizedInvokeResult() throws Exception {
+        Execution execution = run("""
+                {
+                  "StartAt": "Call",
+                  "States": {
+                    "Call": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::lambda:invoke",
+                      "OutputPath": "$.Payload",
+                      "Parameters": {"Payload.$": "$", "FunctionName": "%s"},
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(FUNCTION_ARN));
+
+        assertEquals("SUCCEEDED", execution.getStatus());
+        JsonNode output = objectMapper.readTree(execution.getOutput());
+        assertEquals("RET", output.path("marker").asText());
+        assertEquals(1, output.path("echo").path("in").asInt());
+    }
+
+    @Test
+    void jsonataOutputResolvesStatesResultPayload() throws Exception {
+        Execution execution = run("""
+                {
+                  "QueryLanguage": "JSONata",
+                  "StartAt": "Call",
+                  "States": {
+                    "Call": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::lambda:invoke",
+                      "Arguments": {"FunctionName": "%s", "Payload": {"in": 1}},
+                      "Output": "{%% $states.result.Payload %%}",
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(FUNCTION_ARN));
+
+        assertEquals("SUCCEEDED", execution.getStatus());
+        JsonNode output = objectMapper.readTree(execution.getOutput());
+        assertEquals("RET", output.path("marker").asText());
+        assertEquals(1, output.path("echo").path("in").asInt());
+    }
+
+    private Execution run(String definition) {
+        StateMachine stateMachine = new StateMachine();
+        stateMachine.setName("lambda-invoke-result");
+        stateMachine.setStateMachineArn(
+                "arn:aws:states:%s:%s:stateMachine:lambda-invoke-result".formatted(REGION, ACCOUNT));
+        stateMachine.setRoleArn("arn:aws:iam::%s:role/test-role".formatted(ACCOUNT));
+        stateMachine.setDefinition(definition);
+
+        Execution execution = new Execution();
+        execution.setName("lambda-invoke-result-execution");
+        execution.setExecutionArn("arn:aws:states:%s:%s:execution:lambda-invoke-result:run-1"
+                .formatted(REGION, ACCOUNT));
+        execution.setStateMachineArn(stateMachine.getStateMachineArn());
+        execution.setInput("{\"in\":1}");
+
+        List<HistoryEvent> history = new ArrayList<>();
+        executor.executeSync(stateMachine, execution, history, (updated, events) -> {
+        });
+        return execution;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2110.

A Task using the optimized `arn:aws:states:::lambda:invoke` integration returned the Lambda function's return value directly as the task result, with no `ExecutedVersion` / `Payload` / `StatusCode` keys. Real Step Functions nests the function output inside the Invoke response metadata for this integration, which is why the AWS examples read a Lambda result through `$.Payload` (JSONPath) or `$states.result.Payload` (JSONata). Against the unwrapped result those references resolve to nothing, the state still succeeds, and the execution ends `SUCCEEDED` carrying empty data.

In `invokeResource()` the direct-ARN branch and the optimized branch shared one `if (functionName != null)` block, so the output was returned raw for both. This gates the wrap to the optimized branch. A directly specified function ARN still returns only the function output — the documented behavior for that form, and now covered by a regression test.

Old task result for `Resource: "arn:aws:states:::lambda:invoke"`, then new:

```json
{"marker":"RET","echo":{"in":1}}
```

```json
{"ExecutedVersion":"$LATEST","Payload":{"marker":"RET","echo":{"in":1}},"StatusCode":200}
```

**Note this changes the task result shape for existing users.** State machines that adapted to the unwrapped form — reading `$.marker` where AWS needs `$.Payload.marker`, or dropping the `OutputPath: "$.Payload"` that Workflow Studio sets by default — were already incompatible with real AWS and will now behave as they do there. Direct-ARN tasks, `.waitForTaskToken` tasks and every non-Lambda integration are unchanged.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

[Invoke Lambda with Step Functions](https://docs.aws.amazon.com/step-functions/latest/dg/connect-lambda.html): "When the `Task` result is returned, the function output is nested inside a dictionary of metadata", with an example carrying `ExecutedVersion`, `Payload`, `SdkHttpMetadata`, `SdkResponseMetadata` and `StatusCode: 200`. Same page: "The `Payload` field of the response is parsed from escaped Json to Json" (so `Payload` stays a parsed node, matching the existing `readTree`), and for the direct-ARN form, "the task result contains only the function output". The [Task state reference](https://docs.aws.amazon.com/step-functions/latest/dg/state-task.html) reads the optimized integration's result as `"Output": "{% $states.result.Payload %}"`, and [Workflow Studio's docs](https://docs.aws.amazon.com/step-functions/latest/dg/workflow-studio-process.html) state the default `OutputPath` for Lambda Invoke states is `$.Payload`, which "removes the additional metadata" — both only work if the envelope is there. The new tests cover both shapes.

Values come from real emulator state: `ExecutedVersion` from the resolved function's version (the same `fn.getVersion()` that `LambdaService.invoke()` reports since #2026), `StatusCode` from `InvokeResult`, `Payload` from the existing parse.

`SdkHttpMetadata` and `SdkResponseMetadata` are left out on purpose. Their contents are artifacts of a real HTTPS call — `Date`, `X-Amzn-Trace-Id`, `x-amzn-RequestId`, `Content-Length` — and floci invokes in process, so anything it put there would be invented. The documented read paths only touch the three keys emitted here, and a test pins the key set at exactly those three, so adding the blocks later is a deliberate change rather than a drift. Say the word if you want them and I'll add them.

Two pre-existing gaps this surfaces rather than fixes: `extractLambdaFunctionName` drops the qualifier (#1660), so a task using `Qualifier` or a qualified `FunctionName` still invokes `$LATEST` and will now report `ExecutedVersion: "$LATEST"` for it; and `InvocationType` is hardcoded to `RequestResponse`, so an `InvocationType: "Event"` task reports `200` where AWS reports `202`. Both want their own issue — I can file them if you'd like them tracked.

## Checklist

- [x] `./mvnw test` passes locally *(with pre-existing Docker-dependent failures unrelated to this change — see the test note)*
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

New Docker-free `AslExecutorLambdaInvokeResultTest`, modeled on `AslExecutorCatchTest` (mocked `LambdaExecutorService` + `LambdaFunctionStore`, driven through `executeSync`): the envelope and its exact key set, the direct-ARN raw-output guard, `ResultSelector` over `$.Payload.marker`, `OutputPath: "$.Payload"`, and JSONata `$states.result.Payload`. Reverting the `AslExecutor` change with the tests in place fails 4 of the 5, with the direct-ARN guard green on both sides. `make docs-check` passes; no handler action changed.

Test note: in the full `./mvnw test` (8393 tests) all 27 `services/stepfunctions` classes are green. The failures on this machine sit in container-backed subsystems (DocumentDB, Neptune, WebSockets, ECR, API Gateway authorizers) — there is no Docker daemon here, and the same classes fail identically on a clean `main` tree.
