### PR TITLE
feat(cloudformation): honor resource-level DeletionPolicy

### DIFF
--- a/docs/services/cloudformation.md
+++ b/docs/services/cloudformation.md
@@ -118,6 +118,36 @@ Resources provisioned by `CreateStack` / `UpdateStack` land in the **caller's ac
 (determined from the request's access key — see [Multi-Account Isolation](../configuration/multi-account.md)).
 Deleting the stack removes them from that same account.
 
+## Deletion Policies
+
+A resource's [`DeletionPolicy`](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-attribute-deletionpolicy.html)
+attribute is honored on `DeleteStack` and on the rollback of a failed `CreateStack`:
+
+| Value | `DeleteStack` | Rollback of the create that made the resource |
+|---|---|---|
+| `Delete` (default) | deleted | deleted |
+| `Retain` | kept | kept |
+| `RetainExceptOnCreate` | kept | deleted |
+
+A kept resource is reported as `DELETE_SKIPPED` in `DescribeStackEvents` and does not fail the
+deletion — the stack still reaches `DELETE_COMPLETE` while the resource keeps existing. This also
+lets a stack owning a non-empty S3 bucket be deleted, since the bucket is never touched.
+
+Deviations from AWS to be aware of:
+
+- `Snapshot` deletes the resource without taking a snapshot; floci has no snapshot support for the
+  types AWS allows it on.
+- Every resource defaults to `Delete`. AWS instead defaults `AWS::RDS::DBCluster`, and
+  `AWS::RDS::DBInstance` without a `DBClusterIdentifier`, to `Snapshot`.
+- Unrecognized values are treated as `Delete`.
+- An update that removes a resource from the template does not delete it (or consult its policy);
+  only the new template's resources are provisioned. AWS applies `DeletionPolicy` to update-time
+  removals as well.
+- After `DeleteStack` completes, a retained resource's `DELETE_SKIPPED` record is only visible
+  through `DescribeStackEvents` for the deleted stack, not `DescribeStackResources`.
+- `UpdateReplacePolicy`, and the `RetainExceptOnCreate` request parameter of `CreateStack` /
+  `UpdateStack`, are not implemented.
+
 ## StackSets
 
 StackSets deploy a single template into many target accounts and regions:

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
@@ -454,6 +454,7 @@ public class CloudFormationService {
                 for (String logicalId : sortedLogicalIds) {
                     JsonNode resDef = resources.get(logicalId);
                     String type = resDef.path("Type").asText();
+                    String deletionPolicy = resDef.path("DeletionPolicy").asText(null);
                     JsonNode props = resDef.path("Properties");
 
                     CloudFormationTemplateEngine engine = new CloudFormationTemplateEngine(
@@ -479,6 +480,9 @@ public class CloudFormationService {
                                 engine, region, accountId, stack.getStackName(),
                                 resource.getPhysicalId(), resource.getAttributes());
                     }
+                    // Both branches return a fresh StackResource, so the policy is carried over here
+                    // rather than on the instance the loop started with.
+                    resource.setDeletionPolicy(deletionPolicy);
                     stack.getResources().put(logicalId, resource);
 
                     physicalIds.put(logicalId, resource.getPhysicalId());
@@ -632,6 +636,9 @@ public class CloudFormationService {
             if (resource.getPhysicalId() == null || (!completed && !ownedFailedResource)) {
                 continue;
             }
+            if (skipRetainedResource(stack, resource, true)) {
+                continue;
+            }
             addEvent(stack, resource.getLogicalId(), resource.getPhysicalId(),
                     resource.getResourceType(), "DELETE_IN_PROGRESS", null);
             try {
@@ -665,6 +672,9 @@ public class CloudFormationService {
                 boolean deletable = "CREATE_COMPLETE".equals(resource.getStatus())
                         || "DELETE_FAILED".equals(resource.getStatus());
                 if (resource.getPhysicalId() == null || !deletable) {
+                    continue;
+                }
+                if (skipRetainedResource(stack, resource, false)) {
                     continue;
                 }
                 addEvent(stack, resource.getLogicalId(), resource.getPhysicalId(),
@@ -717,6 +727,29 @@ public class CloudFormationService {
             stack.setStatus("DELETE_FAILED");
             stack.setStatusReason(e.getMessage());
         }
+    }
+
+    /**
+     * Applies a resource's {@code DeletionPolicy}. {@code Retain} keeps the resource on every stack
+     * operation; {@code RetainExceptOnCreate} keeps it too, except when the create that made it is
+     * rolled back. Every other value — including {@code Snapshot}, which floci cannot snapshot —
+     * falls through to a normal delete, matching the default.
+     *
+     * @return {@code true} when the resource was kept and reported as {@code DELETE_SKIPPED}
+     */
+    private boolean skipRetainedResource(Stack stack, StackResource resource, boolean createRollback) {
+        String policy = resource.getDeletionPolicy();
+        boolean retained = "Retain".equals(policy)
+                || (!createRollback && "RetainExceptOnCreate".equals(policy));
+        if (!retained) {
+            return false;
+        }
+        resource.setStatus("DELETE_SKIPPED");
+        addEvent(stack, resource.getLogicalId(), resource.getPhysicalId(),
+                resource.getResourceType(), "DELETE_SKIPPED", null);
+        LOG.infov("Retained {0} ({1}) in stack {2}: DeletionPolicy {3}",
+                resource.getResourceType(), resource.getPhysicalId(), stack.getStackName(), policy);
+        return true;
     }
 
     private Map<String, Boolean> resolveConditions(JsonNode template, Map<String, String> params,

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/model/StackResource.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/model/StackResource.java
@@ -13,6 +13,7 @@ public class StackResource {
     private String logicalId;
     private String physicalId;
     private String resourceType;
+    private String deletionPolicy;
     private String status = "CREATE_IN_PROGRESS";
     private String statusReason;
     private Instant timestamp = Instant.now();
@@ -24,6 +25,8 @@ public class StackResource {
     public void setPhysicalId(String physicalId) { this.physicalId = physicalId; }
     public String getResourceType() { return resourceType; }
     public void setResourceType(String resourceType) { this.resourceType = resourceType; }
+    public String getDeletionPolicy() { return deletionPolicy; }
+    public void setDeletionPolicy(String deletionPolicy) { this.deletionPolicy = deletionPolicy; }
     public String getStatus() { return status; }
     public void setStatus(String status) { this.status = status; }
     public String getStatusReason() { return statusReason; }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationDeletionPolicyIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationDeletionPolicyIntegrationTest.java
@@ -1,0 +1,243 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Verifies the resource-level {@code DeletionPolicy} attribute (issue #1555): {@code Retain} keeps a
+ * resource on every stack operation, {@code RetainExceptOnCreate} keeps it everywhere except the
+ * rollback of the create that made it, and any other value falls through to the default delete.
+ *
+ * <p>Exercised through S3 buckets — the case the attribute is most used for, and one whose survival
+ * is directly observable without Docker.
+ */
+@QuarkusTest
+class CloudFormationDeletionPolicyIntegrationTest {
+
+    @Test
+    void retainKeepsANonEmptyBucketAndTheStackStillCompletesTheDelete() throws InterruptedException {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String bucket = "cfn-retain-bucket-" + suffix;
+        String stackName = "cfn-retain-stack-" + suffix;
+
+        String template = """
+            {
+              "Resources": {
+                "MyBucket": {
+                  "Type": "AWS::S3::Bucket",
+                  "DeletionPolicy": "Retain",
+                  "Properties": { "BucketName": "%s" }
+                }
+              }
+            }
+            """.formatted(bucket);
+
+        String stackId = createStack(stackName, template);
+
+        given()
+            .contentType("text/plain")
+            .body("kept")
+        .when()
+            .put("/" + bucket + "/object.txt")
+        .then()
+            .statusCode(200);
+
+        deleteStack(stackName);
+
+        // A deleted bucket would have failed on its objects instead (issue #1539), so reaching
+        // DELETE_COMPLETE is itself evidence that the bucket was never touched.
+        awaitStackStatus(stackId, "DELETE_COMPLETE");
+
+        given()
+        .when()
+            .get("/" + bucket + "/object.txt")
+        .then()
+            .statusCode(200)
+            .body(containsString("kept"));
+
+        assertThat(describeStackEvents(stackId),
+                containsString("<ResourceStatus>DELETE_SKIPPED</ResourceStatus>"));
+    }
+
+    @Test
+    void retainExceptOnCreateKeepsTheBucketWhenTheStackIsDeleted() throws InterruptedException {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String bucket = "cfn-reoc-delete-bucket-" + suffix;
+        String stackName = "cfn-reoc-delete-stack-" + suffix;
+
+        String template = """
+            {
+              "Resources": {
+                "MyBucket": {
+                  "Type": "AWS::S3::Bucket",
+                  "DeletionPolicy": "RetainExceptOnCreate",
+                  "Properties": { "BucketName": "%s" }
+                }
+              }
+            }
+            """.formatted(bucket);
+
+        String stackId = createStack(stackName, template);
+        deleteStack(stackName);
+        awaitStackStatus(stackId, "DELETE_COMPLETE");
+
+        assertBucketExists(bucket);
+    }
+
+    @Test
+    void rollingBackAFailedCreateDeletesRetainExceptOnCreateButKeepsRetain() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String keptBucket = "cfn-rollback-retain-bucket-" + suffix;
+        String rolledBackBucket = "cfn-rollback-reoc-bucket-" + suffix;
+        String stackName = "cfn-rollback-policy-stack-" + suffix;
+
+        // DependsOn forces both buckets to provision before BadSecret fails (setting SecretString
+        // and GenerateSecretString together is invalid), which triggers the create rollback.
+        String template = """
+            {
+              "Resources": {
+                "KeptBucket": {
+                  "Type": "AWS::S3::Bucket",
+                  "DeletionPolicy": "Retain",
+                  "Properties": { "BucketName": "%s" }
+                },
+                "RolledBackBucket": {
+                  "Type": "AWS::S3::Bucket",
+                  "DeletionPolicy": "RetainExceptOnCreate",
+                  "DependsOn": "KeptBucket",
+                  "Properties": { "BucketName": "%s" }
+                },
+                "BadSecret": {
+                  "Type": "AWS::SecretsManager::Secret",
+                  "DependsOn": "RolledBackBucket",
+                  "Properties": {
+                    "Name": "cfn-rollback-policy-secret-%s",
+                    "SecretString": "explicit",
+                    "GenerateSecretString": { "PasswordLength": 32 }
+                  }
+                }
+              }
+            }
+            """.formatted(keptBucket, rolledBackBucket, suffix);
+
+        String stackId = createStack(stackName, template);
+
+        assertThat(describeStacks(stackId), containsString("<StackStatus>ROLLBACK_COMPLETE</StackStatus>"));
+        assertBucketExists(keptBucket);
+        assertBucketDeleted(rolledBackBucket);
+    }
+
+    @Test
+    void bucketsWithoutARetainingPolicyAreStillDeleted() throws InterruptedException {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String defaulted = "cfn-policy-default-bucket-" + suffix;
+        String explicitDelete = "cfn-policy-delete-bucket-" + suffix;
+        String unrecognized = "cfn-policy-unknown-bucket-" + suffix;
+        String stackName = "cfn-policy-delete-stack-" + suffix;
+
+        String template = """
+            {
+              "Resources": {
+                "Defaulted": {
+                  "Type": "AWS::S3::Bucket",
+                  "Properties": { "BucketName": "%s" }
+                },
+                "ExplicitDelete": {
+                  "Type": "AWS::S3::Bucket",
+                  "DeletionPolicy": "Delete",
+                  "Properties": { "BucketName": "%s" }
+                },
+                "Unrecognized": {
+                  "Type": "AWS::S3::Bucket",
+                  "DeletionPolicy": "Keep",
+                  "Properties": { "BucketName": "%s" }
+                }
+              }
+            }
+            """.formatted(defaulted, explicitDelete, unrecognized);
+
+        String stackId = createStack(stackName, template);
+        deleteStack(stackName);
+        awaitStackStatus(stackId, "DELETE_COMPLETE");
+
+        assertBucketDeleted(defaulted);
+        assertBucketDeleted(explicitDelete);
+        assertBucketDeleted(unrecognized);
+    }
+
+    private static String createStack(String stackName, String template) {
+        String xml = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().asString();
+
+        int start = xml.indexOf("<StackId>") + "<StackId>".length();
+        return xml.substring(start, xml.indexOf("</StackId>", start));
+    }
+
+    private static void deleteStack(String stackName) {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DeleteStack")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    /** DeleteStack runs asynchronously, and a deleted stack stays describable by its stack ID. */
+    private static void awaitStackStatus(String stackId, String status) throws InterruptedException {
+        String xml = "";
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            xml = describeStacks(stackId);
+            if (xml.contains("<StackStatus>" + status + "</StackStatus>")) {
+                return;
+            }
+            Thread.sleep(50);
+        }
+        fail("stack " + stackId + " never reached " + status + ": " + xml);
+    }
+
+    private static String describeStacks(String stackId) {
+        return cfnQuery("DescribeStacks", stackId).then().statusCode(200).extract().asString();
+    }
+
+    private static String describeStackEvents(String stackId) {
+        return cfnQuery("DescribeStackEvents", stackId).then().statusCode(200).extract().asString();
+    }
+
+    private static Response cfnQuery(String action, String stackId) {
+        return given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", action)
+            .formParam("StackName", stackId)
+        .when()
+            .post("/");
+    }
+
+    private static void assertBucketExists(String bucket) {
+        bucketRequest(bucket).then().statusCode(200);
+    }
+
+    private static void assertBucketDeleted(String bucket) {
+        bucketRequest(bucket).then().statusCode(404);
+    }
+
+    private static Response bucketRequest(String bucket) {
+        return given().header("Host", bucket + ".localhost").when().get("/");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1555.

A resource's `DeletionPolicy` was never read off the template, so every managed resource was deleted regardless of what it declared — `deleteStackResources` and `rollbackCreatedResources` both called `provisioner.delete` unconditionally. This reads the attribute in `executeTemplate` and applies it at both sites; they are the only two callers of `provisioner.delete`, and StackSets inherit it since `deleteStackInstances` delegates to `deleteStack`.

| Value | `DeleteStack` | Rollback of the create that made the resource |
|---|---|---|
| `Delete` (default) | deleted | deleted |
| `Retain` | kept | kept |
| `RetainExceptOnCreate` | kept | deleted |

A kept resource is reported as `DELETE_SKIPPED` — on the resource and as a stack event — and is not counted as a failed delete, so the stack still reaches `DELETE_COMPLETE`. That makes `Retain` the AWS-sanctioned escape hatch for the non-empty-bucket case in #1539 this issue came out of. The attribute is re-read on every `UpdateStack`, so adding or removing it takes effect on the next delete.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

`RetainExceptOnCreate` semantics and the `Delete` default are from the [`DeletionPolicy` attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-attribute-deletionpolicy.html) reference. `DELETE_SKIPPED` is a real stack event and not only a resource status — [View stack events](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/view-stack-events.html) documents it in the `describe-stack-events` field table ("The `DELETE_SKIPPED` status applies to resources with a deletion policy attribute of retain"), so both surfaces are set.

Divergences, documented in `docs/services/cloudformation.md` rather than half-implemented:

- **`Snapshot` is treated as `Delete`.** AWS *does* delete the resource under `Snapshot`; floci just cannot take the snapshot for the eight types AWS supports it on.
- **Defaults are uniform.** AWS defaults `AWS::RDS::DBCluster`, and `AWS::RDS::DBInstance` without a `DBClusterIdentifier`, to `Snapshot`. floci deletes those today, so that is not a new divergence.
- **No update-time removal leg.** AWS applies `DeletionPolicy` when an update drops a resource from the template, but `executeTemplate` iterates only the new template's logical IDs and never removes dropped resources — so there is nothing to gate yet. Pre-existing, left alone. Replacement during an update is separate: AWS excludes it from `DeletionPolicy`, which is what `UpdateReplacePolicy` covers, and that is not implemented either.
- **Unrecognized values are treated as `Delete`.** I could not find what AWS returns for an invalid value, so I did not invent an error code — I can add validation if you know the real behavior.

## Checklist

- [x] `./mvnw test` passes locally *(with pre-existing Docker-dependent failures unrelated to this change — see the test note)*
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

New `CloudFormationDeletionPolicyIntegrationTest`, 4 tests: `Retain` surviving the delete of a stack that owns a non-empty bucket, `RetainExceptOnCreate` surviving a delete, a failed create whose rollback deletes the `RetainExceptOnCreate` bucket while the `Retain` one in the same stack survives, and default / explicit `Delete` / unrecognized values still deleting. Reverting the source change fails 3 of the 4. It checks bucket survival through the S3 API rather than CloudFormation's own bookkeeping, and uses RestAssured to match the existing `services/cloudformation` tests, none of which use the AWS SDK.

Test note: the only CloudFormation failure on this machine is `CloudFormationIntegrationTest.createStack_ecrAutoName_isLowercase`, which needs a Docker daemon this machine does not have — it fails identically on a pristine `main` tree with the same single-test command, so it is pre-existing and untouched by this diff (package-scoped runs: 194/1 before, 198/1 after; the 4 new tests are green). The remaining local failures sit in container-backed subsystems on a machine with no Docker daemon and are unrelated to CloudFormation.

No handler action changed, so the generated action tables are untouched.
