### PR TITLE
fix(iot): match topic rules outside the default region

### DIFF
--- a/docs/services/iot.md
+++ b/docs/services/iot.md
@@ -124,7 +124,7 @@ Supported rule behavior:
 - MQTT-style topic filter matching for exact topics, `+`, and terminal `#`.
 - IoT Data `Publish` and MQTT publishes use the same rule dispatch path.
 - Rule matching is region-scoped: an IoT Data `Publish` evaluates the rules of the region named by its SigV4 credential, and a rule's actions target the rule's own region.
-- Publishes that carry no region — MQTT, or an unsigned IoT Data `Publish` — are evaluated against every region's rules.
+- Publishes that carry no region — MQTT, or an IoT Data `Publish` whose `Authorization` header is absent or not SigV4 — are evaluated against every region's rules.
 - `republish` action republishes the original payload to another MQTT topic through `IotMqttBrokerService`.
 - `sqs` action sends the original payload to an SQS queue through Floci's SQS service boundary.
 - `sns` action publishes the original payload to an SNS topic through Floci's SNS service boundary.

--- a/docs/services/iot.md
+++ b/docs/services/iot.md
@@ -123,6 +123,8 @@ Supported rule behavior:
 - SQL topic filter extraction for rules shaped like `SELECT * FROM 'topic/filter'`.
 - MQTT-style topic filter matching for exact topics, `+`, and terminal `#`.
 - IoT Data `Publish` and MQTT publishes use the same rule dispatch path.
+- Rule matching is region-scoped: an IoT Data `Publish` evaluates the rules of the region named by its SigV4 credential, and a rule's actions target the rule's own region.
+- Publishes that carry no region — MQTT, or an unsigned IoT Data `Publish` — are evaluated against every region's rules.
 - `republish` action republishes the original payload to another MQTT topic through `IotMqttBrokerService`.
 - `sqs` action sends the original payload to an SQS queue through Floci's SQS service boundary.
 - `sns` action publishes the original payload to an SNS topic through Floci's SNS service boundary.

--- a/src/main/java/io/github/hectorvent/floci/core/common/RegionResolver.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/RegionResolver.java
@@ -67,6 +67,21 @@ public class RegionResolver {
         return defaultRegion;
     }
 
+
+    /**
+     * Resolves the region from a SigV4 Authorization credential scope, or
+     * null when the header is absent or carries no parseable credential —
+     * for callers that treat an unresolved region differently from the
+     * default region.
+     */
+    public String resolveRegionFromAuthOrNull(String authorizationHeader) {
+        if (authorizationHeader == null || authorizationHeader.isEmpty()) {
+            return null;
+        }
+        Matcher matcher = CREDENTIAL_REGION_PATTERN.matcher(authorizationHeader);
+        return matcher.find() ? matcher.group(1) : null;
+    }
+
     public String getDefaultRegion() {
         return defaultRegion;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotDataController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotDataController.java
@@ -89,9 +89,8 @@ public class IotDataController {
                             @QueryParam("retain") Boolean retain,
                             @QueryParam("qos") Integer qos,
                             byte[] payload) {
-        // Unsigned data-plane publishes carry no region
-        String authorization = headers.getHeaderString("Authorization");
-        String region = authorization == null || authorization.isBlank() ? null : regionResolver.resolveRegionFromAuth(authorization);
+        // Unsigned or non-SigV4 publishes carry no usable region; both count as unresolved
+        String region = regionResolver.resolveRegionFromAuthOrNull(headers.getHeaderString("Authorization"));
         iotService.publish(topic, payload == null ? new byte[0] : payload, Boolean.TRUE.equals(retain), qos == null ? 0 : qos, region);
         return Response.ok(objectMapper.createObjectNode()).build();
     }

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotDataController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotDataController.java
@@ -84,11 +84,15 @@ public class IotDataController {
     @POST
     @Path("/topics/{topic: .+}")
     @Consumes(MediaType.WILDCARD)
-    public Response publish(@PathParam("topic") String topic,
+    public Response publish(@Context HttpHeaders headers,
+                            @PathParam("topic") String topic,
                             @QueryParam("retain") Boolean retain,
                             @QueryParam("qos") Integer qos,
                             byte[] payload) {
-        iotService.publish(topic, payload == null ? new byte[0] : payload, Boolean.TRUE.equals(retain), qos == null ? 0 : qos);
+        // Unsigned data-plane publishes carry no region
+        String authorization = headers.getHeaderString("Authorization");
+        String region = authorization == null || authorization.isBlank() ? null : regionResolver.resolveRegionFromAuth(authorization);
+        iotService.publish(topic, payload == null ? new byte[0] : payload, Boolean.TRUE.equals(retain), qos == null ? 0 : qos, region);
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotMqttBrokerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotMqttBrokerService.java
@@ -223,7 +223,7 @@ public class IotMqttBrokerService {
             return;
         }
 
-        iotService.get().publish(topic, payload, message.isRetain(), message.qosLevel().value());
+        iotService.get().publish(topic, payload, message.isRetain(), message.qosLevel().value(), null);
         fanOut(topic, payload, false);
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotService.java
@@ -526,10 +526,10 @@ public class IotService {
     }
 
     public void publish(String topic, byte[] payload) {
-        publish(topic, payload, false, 0);
+        publish(topic, payload, false, 0, null);
     }
 
-    public void publish(String topic, byte[] payload, boolean retain, int qos) {
+    public void publish(String topic, byte[] payload, boolean retain, int qos, String region) {
         byte[] eventPayload = payload == null ? new byte[0] : payload;
         if (retain) {
             if (eventPayload.length == 0) {
@@ -543,7 +543,7 @@ public class IotService {
                 retainedMessageStore.put(retainedMessageKey(topic), retained);
             }
         }
-        handlePublish(topic, eventPayload, true);
+        handlePublish(topic, eventPayload, true, region);
     }
 
     public void deleteConnection(String clientId, boolean cleanSession) {
@@ -889,17 +889,27 @@ public class IotService {
         topicRuleStore.put(topicRuleKey(region, ruleName), rule);
     }
 
-    void handlePublish(String topic, byte[] payload, boolean evaluateRules) {
+    void handlePublish(String topic, byte[] payload, boolean evaluateRules, String region) {
         byte[] eventPayload = payload == null ? new byte[0] : payload;
         publishEventRecorder.record(topic, eventPayload);
         if (!evaluateRules) {
             return;
         }
-        for (IotTopicRule rule : listTopicRules(config.defaultRegion())) {
+        for (IotTopicRule rule : rulesForPublish(region)) {
             if (!rule.isRuleDisabled() && topicMatches(extractTopicPattern(rule.getSql()), topic)) {
                 executeTopicRule(rule, eventPayload);
             }
         }
+    }
+
+    private List<IotTopicRule> rulesForPublish(String region) {
+        if (region != null) {
+            return listTopicRules(region);
+        }
+        // MQTT and unsigned data-plane publishes carry no region, so every region's rules apply.
+        return topicRuleStore.scan(key -> true).stream()
+                .sorted(Comparator.comparing(IotTopicRule::getRuleName))
+                .toList();
     }
 
     void handleReservedMqttPublish(String topic, byte[] payload, BiConsumer<String, byte[]> publisher) {
@@ -990,6 +1000,7 @@ public class IotService {
     }
 
     private void executeTopicRule(IotTopicRule rule, byte[] payload) {
+        String ruleRegion = AwsArnUtils.regionOrDefault(rule.getRuleArn(), config.defaultRegion());
         try {
             JsonNode actions = objectMapper.readTree(rule.getActionsJson());
             if (!actions.isArray()) {
@@ -1000,7 +1011,7 @@ public class IotService {
                 if (republish.isObject()) {
                     String targetTopic = republish.path("topic").asText(null);
                     if (targetTopic != null && !targetTopic.isBlank()) {
-                        handlePublish(targetTopic, payload, false);
+                        handlePublish(targetTopic, payload, false, ruleRegion);
                         mqttBrokerService.publish(targetTopic, payload);
                     }
                 }
@@ -1011,14 +1022,14 @@ public class IotService {
                         String body = sqs.path("useBase64").asBoolean(false)
                                 ? Base64.getEncoder().encodeToString(payload)
                                 : new String(payload, StandardCharsets.UTF_8);
-                        sqsService.sendMessage(queueUrl, body, 0, config.defaultRegion());
+                        sqsService.sendMessage(queueUrl, body, 0, ruleRegion);
                     }
                 }
                 JsonNode sns = action.path("sns");
                 if (sns.isObject()) {
                     String targetArn = sns.path("targetArn").asText(null);
                     if (targetArn != null && !targetArn.isBlank()) {
-                        snsService.publish(targetArn, null, new String(payload, StandardCharsets.UTF_8), null, config.defaultRegion());
+                        snsService.publish(targetArn, null, new String(payload, StandardCharsets.UTF_8), null, ruleRegion);
                     }
                 }
                 JsonNode s3 = action.path("s3");
@@ -1034,21 +1045,21 @@ public class IotService {
                     String streamName = kinesis.path("streamName").asText(null);
                     String partitionKey = kinesis.path("partitionKey").asText("floci-iot");
                     if (streamName != null && !streamName.isBlank()) {
-                        kinesisService.putRecord(streamName, payload, partitionKey, config.defaultRegion());
+                        kinesisService.putRecord(streamName, payload, partitionKey, ruleRegion);
                     }
                 }
                 JsonNode dynamoDBv2 = action.path("dynamoDBv2");
                 if (dynamoDBv2.isObject()) {
                     String tableName = dynamoDBv2.path("putItem").path("tableName").asText(null);
                     if (tableName != null && !tableName.isBlank()) {
-                        dynamoDbService.putItem(tableName, toDynamoDbItem(payload), config.defaultRegion());
+                        dynamoDbService.putItem(tableName, toDynamoDbItem(payload), ruleRegion);
                     }
                 }
                 JsonNode lambda = action.path("lambda");
                 if (lambda.isObject()) {
                     String functionArn = lambda.path("functionArn").asText(null);
                     if (functionArn != null && !functionArn.isBlank()) {
-                        lambdaService.invoke(config.defaultRegion(), functionArn, payload, InvocationType.Event);
+                        lambdaService.invoke(ruleRegion, functionArn, payload, InvocationType.Event);
                     }
                 }
             }

--- a/src/test/java/io/github/hectorvent/floci/core/common/RegionResolverTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/RegionResolverTest.java
@@ -43,6 +43,26 @@ class RegionResolverTest {
     }
 
     @Test
+    void resolveRegionFromAuthOrNullReturnsCredentialRegion() {
+        assertEquals("eu-west-1", resolver.resolveRegionFromAuthOrNull(
+                "AWS4-HMAC-SHA256 Credential=AKID/20260215/eu-west-1/iotdata/aws4_request, " +
+                "SignedHeaders=host, Signature=abc123"));
+    }
+
+    @Test
+    void resolveRegionFromAuthOrNullIsNullWhereResolveReturnsDefault() {
+        assertNull(resolver.resolveRegionFromAuthOrNull("Bearer some-token"));
+        assertEquals("us-east-1", resolver.resolveRegionFromAuth("Bearer some-token"));
+    }
+
+    @Test
+    void resolveRegionFromAuthOrNullIsNullForAbsentOrBlank() {
+        assertNull(resolver.resolveRegionFromAuthOrNull(null));
+        assertNull(resolver.resolveRegionFromAuthOrNull(""));
+        assertNull(resolver.resolveRegionFromAuthOrNull(" "));
+    }
+
+    @Test
     void fallsBackToDefaultWhenEmptyAuthHeader() {
         HttpHeaders headers = stubHeaders("");
         assertEquals("us-east-1", resolver.resolveRegion(headers));

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotTopicRuleIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotTopicRuleIntegrationTest.java
@@ -349,6 +349,22 @@ class IotTopicRuleIntegrationTest {
     }
 
     @Test
+    void nonSigV4AuthorizationPublishEvaluatesRulesInEveryRegion() throws Exception {
+        createRepublishRule("eu-west-1", "bearerRule", "devices/regional/bearer", "devices/regional/bearer-republished");
+
+        given()
+            .header("Authorization", "Bearer not-sigv4")
+            .contentType("text/plain")
+            .body("bearer-payload")
+        .when()
+            .post("/topics/devices/regional/bearer")
+        .then()
+            .statusCode(200);
+
+        awaitPublishedEvent("devices/regional/bearer-republished", "bearer-payload".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
     void topicRuleActionTargetsTheRuleRegion() {
         String queueUrl = createQueue("regional-iot-rule-queue", "eu-west-1");
         createQueue("regional-iot-rule-queue", "us-east-1");

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotTopicRuleIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotTopicRuleIntegrationTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.iot;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.ValidatableResponse;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -287,6 +288,108 @@ class IotTopicRuleIntegrationTest {
     }
 
     @Test
+    void topicRuleMatchesOnlyPublishesInItsOwnRegion() throws Exception {
+        createEuWest1RepublishRule("regionalMatchRule", "devices/regional/match", "devices/regional/match-republished");
+
+        given()
+            .header("Authorization", auth("eu-west-1", "iotdata"))
+            .contentType("text/plain")
+            .body("eu-west-1-payload")
+        .when()
+            .post("/topics/devices/regional/match")
+        .then()
+            .statusCode(200);
+
+        awaitPublishedEvent("devices/regional/match-republished", "eu-west-1-payload".getBytes(StandardCharsets.UTF_8));
+
+        given()
+            .header("Authorization", auth("us-east-1", "iotdata"))
+            .contentType("text/plain")
+            .body("us-east-1-payload")
+        .when()
+            .post("/topics/devices/regional/match")
+        .then()
+            .statusCode(200);
+
+        assertFalse(eventRecorder.recentEvents().stream()
+                .anyMatch(event -> "devices/regional/match-republished".equals(event.topic())
+                        && Arrays.equals("us-east-1-payload".getBytes(StandardCharsets.UTF_8), event.payload())));
+    }
+
+    @Test
+    void unsignedPublishEvaluatesRulesInEveryRegion() throws Exception {
+        createEuWest1RepublishRule("regionalUnsignedRule", "devices/regional/unsigned", "devices/regional/unsigned-republished");
+
+        given()
+            .contentType("text/plain")
+            .body("unsigned-payload")
+        .when()
+            .post("/topics/devices/regional/unsigned")
+        .then()
+            .statusCode(200);
+
+        awaitPublishedEvent("devices/regional/unsigned-republished", "unsigned-payload".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void regionlessPublishFiresEveryMatchingRegionsRule() throws Exception {
+        createRepublishRule("eu-west-1", "fanoutRuleEu", "devices/regional/fanout", "devices/regional/fanout-eu");
+        createRepublishRule("ap-south-1", "fanoutRuleAp", "devices/regional/fanout", "devices/regional/fanout-ap");
+
+        given()
+            .contentType("text/plain")
+            .body("fanout-payload")
+        .when()
+            .post("/topics/devices/regional/fanout")
+        .then()
+            .statusCode(200);
+
+        awaitPublishedEvent("devices/regional/fanout-eu", "fanout-payload".getBytes(StandardCharsets.UTF_8));
+        awaitPublishedEvent("devices/regional/fanout-ap", "fanout-payload".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void topicRuleActionTargetsTheRuleRegion() {
+        String queueUrl = createQueue("regional-iot-rule-queue", "eu-west-1");
+        createQueue("regional-iot-rule-queue", "us-east-1");
+
+        given()
+            .header("Authorization", auth("eu-west-1", "iot"))
+            .contentType("application/json")
+            .body("""
+                {
+                  "topicRulePayload": {
+                    "sql": "SELECT * FROM 'devices/regional/sqs'",
+                    "actions": [
+                      {
+                        "sqs": {
+                          "roleArn": "arn:aws:iam::000000000000:role/iot-rule-role",
+                          "queueUrl": "%s"
+                        }
+                      }
+                    ]
+                  }
+                }
+                """.formatted(queueUrl))
+        .when()
+            .put("/rules/regionalSqsRule")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", auth("eu-west-1", "iotdata"))
+            .contentType("text/plain")
+            .body("regional-sqs-payload")
+        .when()
+            .post("/topics/devices/regional/sqs")
+        .then()
+            .statusCode(200);
+
+        receiveMessage(queueUrl, "eu-west-1").body(containsString("regional-sqs-payload"));
+        receiveMessage(queueUrl, "us-east-1").body(not(containsString("regional-sqs-payload")));
+    }
+
+    @Test
     void topicRuleConflictReplaceDeleteAndTagsMatchMvpLifecycle() {
         given()
             .contentType("application/json")
@@ -379,6 +482,67 @@ class IotTopicRuleIntegrationTest {
         .then()
             .statusCode(404)
             .body("__type", equalTo("ResourceNotFoundException"));
+    }
+
+    private static String auth(String region, String service) {
+        return "AWS4-HMAC-SHA256 Credential=AKID/20260215/" + region + "/" + service
+                + "/aws4_request, SignedHeaders=host, Signature=abc";
+    }
+
+    private void createEuWest1RepublishRule(String ruleName, String sourceTopic, String targetTopic) {
+        createRepublishRule("eu-west-1", ruleName, sourceTopic, targetTopic);
+    }
+
+    private void createRepublishRule(String region, String ruleName, String sourceTopic, String targetTopic) {
+        given()
+            .header("Authorization", auth(region, "iot"))
+            .contentType("application/json")
+            .body("""
+                {
+                  "topicRulePayload": {
+                    "sql": "SELECT * FROM '%s'",
+                    "actions": [
+                      {
+                        "republish": {
+                          "roleArn": "arn:aws:iam::000000000000:role/iot-rule-role",
+                          "topic": "%s"
+                        }
+                      }
+                    ]
+                  }
+                }
+                """.formatted(sourceTopic, targetTopic))
+        .when()
+            .put("/rules/" + ruleName)
+        .then()
+            .statusCode(200)
+            .body("ruleArn", equalTo("arn:aws:iot:" + region + ":000000000000:rule/" + ruleName));
+    }
+
+    private String createQueue(String queueName, String region) {
+        return given()
+            .header("Authorization", auth(region, "sqs"))
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", queueName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath().getString("CreateQueueResponse.CreateQueueResult.QueueUrl");
+    }
+
+    private ValidatableResponse receiveMessage(String queueUrl, String region) {
+        return given()
+            .header("Authorization", auth(region, "sqs"))
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ReceiveMessage")
+            .formParam("QueueUrl", queueUrl)
+            .formParam("MaxNumberOfMessages", "1")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
     }
 
     private void awaitPublishedEvent(String topic, byte[] payload) throws InterruptedException {


### PR DESCRIPTION
## Summary

Closes #2065.

Topic rules are stored per region (`topicRuleKey(region, ruleName)`), but `IotService#handlePublish` looked them up with a hardcoded `config.defaultRegion()`. A rule created anywhere else was stored, gettable and listable yet never evaluated — every action was silently dropped while `Publish` still returned 200. `executeTopicRule` repeated the hardcoding, so even a matched rule delivered to default-region resources.

- `IotDataController.publish` took no `@Context HttpHeaders` at all. It now resolves the region from the request's SigV4 credential, like the four shadow endpoints in that same controller, and passes it down.
- `handlePublish` evaluates that region's rules instead of the default region's.
- `executeTopicRule` reads the rule's own region off its `ruleArn` via the existing `AwsArnUtils.regionOrDefault` and gives that to the sinks. No new state — `ruleArn` already carries the creation region. This part changes nothing observable: a rule outside the default region never fired at all, and one inside it resolves to the region it already used.

#2149 is centralizing "did region resolution actually resolve anything" into `RegionResolver#isRegionUnresolved`. This path needs the region itself, not just the boolean, so it adds `RegionResolver#resolveRegionFromAuthOrNull` — same predicate, returns the region or null; a publish whose `Authorization` header isn't SigV4 counts as region-less too, not as a default-region publish. If #2149 lands first I'll fold the two helpers together on the rebase.

## The one call I'd like you to make

**What should a publish that carries no region evaluate?** On AWS the region carrier is the endpoint hostname — SigV4, X.509 and custom-authorizer publishes all reach `<prefix>-ats.iot.<region>.amazonaws.com`. Floci serves every region on one port and `describeEndpoint` returns a region-less authority, so there's nothing to read: MQTT has no carrier, and an unsigned publish has no credential to parse.

I made those evaluate every region's rules, which is what keeps the reporter's unsigned path working. The cost, stated plainly: when rules in N regions match the same topic, one region-less publish now fires all N — measured, 2 regions gave 2 republishes and 3 gave 3. Today it fires at most the default region's, and AWS fires exactly one.

`ApiGatewayService.resolveRestApiRegion` hits the same ambiguity and answers it differently — it prefers the request's region and scans only on a miss, returning one region. If you'd rather have AWS's single delivery, the same-shaped fix is to prefer the default region's rules and scan the rest only when none match. That's a few lines in the private helper `rulesForPublish` and I'll send it. Just say which.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The incorrect behavior: a rule created in a non-default region matched nothing, and a matched rule's actions targeted the default region.

IoT Core's rules-engine data plane is per-region ([endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/iot-core.html)), and no sink action carries a region of its own — the only region-bearing field in the whole action union is `http.auth.sigv4.signingRegion` ([CreateTopicRule](https://docs.aws.amazon.com/iot/latest/apireference/API_CreateTopicRule.html)). Destinations are same-region by default: *"Define the rule in the same AWS Region as another service's resource so that the rule action can interact with that resource"* ([rule actions](https://docs.aws.amazon.com/iot/latest/developerguide/iot-rule-actions.html)). So the rule's own region is the right resolution for the sinks.

One documented exception I did **not** implement: SQS may be cross-region — *"The region in this URL doesn't need to be the same AWS Region as your AWS IoT rule"* ([SQS rule action](https://docs.aws.amazon.com/iot/latest/developerguide/sqs-rule-action.html)). Floci's queue URLs carry no region, so a cross-region `queueUrl` isn't representable today; that's a separate change to SQS's URL shape.

Left out of scope, both pre-existing: `handleReservedMqttPublish` still hardcodes the default region for shadow topics, and the `republish` loop guard is untouched.

## Tests

Five cases in `IotTopicRuleIntegrationTest`, existing `@QuarkusTest` + RestAssured style, no Docker:

- `topicRuleMatchesOnlyPublishesInItsOwnRegion` — an `eu-west-1` rule fires for an `eu-west-1`-signed publish, not a `us-east-1`-signed one.
- `unsignedPublishEvaluatesRulesInEveryRegion` — an unsigned publish reaches a rule outside the default region.
- `regionlessPublishFiresEveryMatchingRegionsRule` — pins the fan-out count above, so the trade-off is a test and not just a paragraph.
- `nonSigV4AuthorizationPublishEvaluatesRulesInEveryRegion` — a publish whose `Authorization` header isn't SigV4 (a bearer token) counts as region-less too.
- `topicRuleActionTargetsTheRuleRegion` — same queue name in both regions; an `eu-west-1` rule's `sqs` action lands in the `eu-west-1` queue and leaves `us-east-1` empty.

All five fail against unmodified `src/main`. `./mvnw test -Dtest='Iot*Test'` goes from 50 to 55, 0 failures.

## Checklist

- [x] `./mvnw test` passes locally *(with pre-existing Docker-dependent failures unrelated to this change — no IoT class fails)*
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Five new tests in `IotTopicRuleIntegrationTest`, plus three on the resolver helper (suite 50 → 55, green, no Docker): a rule matches a publish signed for its own region; a publish signed for another region does not match; an unsigned publish reaches a rule outside the default region; and one region-less publish with matching rules in two regions fires both — pinning the fan-out trade-off above so changing it is a deliberate edit, not drift. The SQS sink test asserts delivery lands in the rule's region queue and not the default region's. With `src/main` stashed, the region tests fail against the old behavior and pass with the fix.


