### PR TITLE
fix(cloudwatch): warn on unsupported Logs Insights filter operators

### DIFF
--- a/docs/services/cloudwatch.md
+++ b/docs/services/cloudwatch.md
@@ -69,14 +69,14 @@ Unsupported syntax never fails the query, so it is worth knowing how each case d
 | Input | Result |
 |---|---|
 | An unsupported command (`stats`, `parse`, ...) | Skipped with a warning in the server log. No aggregation happens |
-| A `filter` whose operator is not `=`, `!=` or `==` — for example `like /ERROR/` or `=~ /ERROR/` | The whole stage is dropped with a warning, so **every** row is returned |
-| A `filter` using `<`, `<=`, `>` or `>=` | The `=` is taken as the operator and the rest of the token becomes part of the field name, which then resolves to nothing — so the row never matches and you get **no** rows. No warning is logged |
+| A `filter` whose operator is not `=`, `!=` or `==` — for example `<`, `<=`, `>`, `>=`, `like /ERROR/` or `=~ /ERROR/` | The whole stage is dropped with a warning, so **every** row is returned |
+| A `filter` combining conditions with `and` / `or` — for example `filter level = 'ERROR' and status = 200` | Only the leftmost operator is parsed; the rest of the line becomes the compared value, so nothing matches and you get **no** rows. No warning is logged |
 | A projected field that does not exist | Rendered as an empty string. No warning |
 | A `sort` direction other than `asc` / `desc` | Treated as ascending. No warning |
 
 In short, a query can come back either wider or narrower than intended without any error. When a
-result set looks wrong, check the server log for `Ignoring unsupported Logs Insights ...` — and
-note that the `>=` case above produces no log line at all.
+result set looks wrong, check the server log for `Ignoring unsupported Logs Insights ...` — and note
+that the compound-filter case above produces no log line at all.
 
 For simple substring matching, `FilterLogEvents` is the more predictable option today. Note that
 Floci matches `--filter-pattern` as a plain substring of the message; the real filter-pattern

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/LogsInsightsQuery.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/LogsInsightsQuery.java
@@ -30,8 +30,9 @@ import java.util.Set;
  * {@code @ptr}, or a dotted path into the JSON log message (e.g. {@code params.job_id}, {@code level}).
  *
  * <p>This is intentionally <em>not</em> a full Insights implementation: unsupported commands
- * (e.g. {@code stats}, {@code parse}) are ignored with a warning. Pipes ({@code |}) inside quoted
- * filter values are respected and do not split the query into stages.
+ * (e.g. {@code stats}, {@code parse}) and unsupported filter operators (e.g. {@code >=},
+ * {@code like}) are ignored with a warning. Pipes ({@code |}) inside quoted filter values are
+ * respected and do not split the query into stages.
  */
 final class LogsInsightsQuery {
 
@@ -154,6 +155,10 @@ final class LogsInsightsQuery {
                 }
             } else if (c == '\'' || c == '"') {
                 quote = c;
+            } else if (expr.startsWith(">=", i) || expr.startsWith("<=", i) || expr.startsWith("=~", i)) {
+                // The '=' in >=, <= and =~ would be read as equality below, mangling the field
+                // (>=, <=) or the value (=~) into a dead match; stop so they warn instead.
+                break;
             } else if (i > 0) {
                 String op = expr.startsWith("!=", i) ? "!="
                         : expr.startsWith("==", i) ? "=="

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsInsightsQueryTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsInsightsQueryTest.java
@@ -483,6 +483,43 @@ class CloudWatchLogsInsightsQueryTest {
     }
 
     @Test
+    void unsupportedFilterOperatorsDropTheStageInsteadOfMisparsing() {
+        String group = "search/query-operators";
+        String stream = "s-1";
+        createGroupStream(service, group, stream);
+        put(group, stream, BASE_MS + 1000, "INFO", "JOB-1", "info-line");
+        put(group, stream, BASE_MS + 2000, "ERROR", "JOB-1", "error-line");
+
+        // '>=', '<=' and '=~' used to lose their comparison character to the equality scan, leaving a
+        // dead field ("level >") that silently matched nothing. None of these is supported, so each one
+        // drops the whole stage with a warning and every row comes back.
+        for (String expr : List.of("level >= 'INFO'", "level <= 'INFO'", "level =~ /INFO/", ">= 'INFO'",
+                "level > 'INFO'", "level < 'INFO'", "level like /INFO/", "level not like /INFO/",
+                "level in ['INFO']")) {
+            assertEquals(2, rowsFor(group, "fields @message | filter " + expr).size(),
+                    "unsupported operator must drop the whole filter stage: " + expr);
+        }
+    }
+
+    @Test
+    void supportedFilterOperatorsStillParse() {
+        String group = "search/query-equality";
+        String stream = "s-1";
+        createGroupStream(service, group, stream);
+        put(group, stream, BASE_MS + 1000, "INFO", "JOB-1", "info-line");
+        put(group, stream, BASE_MS + 2000, "ERROR", "JOB-1", "error-line");
+        putRaw(service, group, stream, BASE_MS + 3000, idLog("REQ>=42", "quoted"));
+
+        assertEquals(1, rowsFor(group, "fields @message | filter level = 'ERROR'").size());
+        assertEquals(1, rowsFor(group, "fields @message | filter level == 'ERROR'").size());
+        assertEquals(2, rowsFor(group, "fields @message | filter level != 'ERROR'").size());
+
+        // A '>=' inside the quoted value is not an operator — the real '=' still wins.
+        assertEquals("REQ>=42",
+                rowsFor(group, "fields params.id | filter params.id = 'REQ>=42'").get(0).get("params.id"));
+    }
+
+    @Test
     void statisticsReportScannedAndMatched() {
         String group = "data-studio/insights";
         String stream = "s-1";
@@ -593,6 +630,15 @@ class CloudWatchLogsInsightsQueryTest {
         createGroupStream(svc, group, stream);
         putRaw(svc, group, stream, BASE_MS + 2000, jobLog("INFO", "x", "JOB-1"));
         return svc;
+    }
+
+    /** Run {@code query} over the full window on the default service and return its completed rows. */
+    private List<LinkedHashMap<String, String>> rowsFor(String group, String query) {
+        long startSec = BASE_MS / 1000 - 10;
+        CloudWatchLogsService.QueryState state = service.getQueryResults(
+                service.startQuery(List.of(group), startSec, startSec + 86400, query, null, REGION));
+        assertEquals("Complete", state.status());
+        return state.rows();
     }
 
     private void createGroupStream(CloudWatchLogsService svc, String group, String stream) {


### PR DESCRIPTION
<!-- PR title (Conventional Commit, CI-validated): -->
<!-- fix(cloudwatch): warn on unsupported Logs Insights filter operators -->

## Summary

`filter @message >= "x"` returns **no** rows and logs nothing. `parseFilter` scans for the leftmost `!=`, `==` or `=` outside a quoted value, so the `=` inside `>=` wins: the `>` is absorbed into the field name (`@message >`), that name resolves to `null` for every row, and every row is dropped. `<=` fails the same way. `=~` fails in the other direction — the field survives but the value becomes the literal `~ /ERROR/`, an equality nothing matches. In all three cases the query looks like it filtered, and there is nothing in the server log to say otherwise.

This stops the operator scan when it reaches one of those three, so control falls through to the `Ignoring unsupported Logs Insights filter` warning that `<`, `>`, `like`, `not like` and `in` already reach — the stage is dropped and every row comes back, consistent with the rest of the subset. It's four lines in `parseFilter`. `>` and `<` are deliberately not listed: they contain no `=`, so they already take that path.

That's what @TAKEDA-Takashi asked for in the issue — "recognising those operators as unsupported (rather than splitting on the `=`) would at least route them through the existing warning path". `=~` comes along because #2044 already documents it as warn-and-drop, so this makes the code match the docs that shipped in 1.6.0.

`Refs #2042`, not `Closes` — this is the half of that issue that doesn't depend on the open design question. Mapping:

| Example from #2042 | Before | After |
|---|---|---|
| `filter @message >= "x"` | no rows, no warning | stage dropped with a warning, every row — **fixed** |
| `filter @message <= "x"` | no rows, no warning | same — **fixed** |
| `filter @message =~ /ERROR/` | no rows, no warning | same — **fixed** (not called out in the issue, but it mis-parses for the same reason) |
| `filter @message like /ERROR/` | every row, warning | unchanged — already the warn path |
| `stats count() as cnt` | raw rows, warning | unchanged — already the warn path |
| A projected field that doesn't exist | empty string, no warning | unchanged — out of scope |
| A `sort` direction other than `asc` / `desc` | ascending, no warning | unchanged — out of scope |

Left alone on purpose: whether an unparseable stage should fail at `StartQuery` or surface as `status: Failed` at `GetQueryResults`. #1160 made unsupported S3 Select expressions fail explicitly and that's the precedent the issue points at, but applying it to `>=` alone would be a third behaviour next to the warn-and-drop that `like`, `in` and `stats` already get. Whether the whole subset should start failing is your call; either way it lands at this same site. Compound `and` / `or` filters are mis-parsed too — that needs a real expression parser, so this PR documents that case instead of fixing it.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

`>=`, `<=` and `=~` are all documented [filter](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax-Filter.html) syntax that Floci was silently mis-parsing rather than rejecting. This PR implements none of them and makes no claim about what real AWS returns for a `>=` comparison on a string field. The client still sees `Complete` and a superset — what changes is that the dropped operator is announced in the server log instead of vanishing. (`==`, which Floci also accepts, isn't AWS syntax and is untouched.)

The incorrect behaviour, concretely: a valid Logs Insights query came back with zero rows, no error and no log line, so nothing told the caller the filter hadn't run.

Two operators in the degradation table in `docs/services/cloudwatch.md` were under the wrong row — `=~` under warn-and-drop when it actually mis-parsed to zero rows, and bare `<` / `>` under silent-zero-rows when they already warned. Both now sit in the one warn-and-drop row. The table gains a row for the compound `and` / `or` case, since that's the remaining way a query comes back narrower with no log line and the old table had no row left describing it. `CloudWatchLogsHandler` is on `deferred_handlers` in `tools/docs/services.yaml`, so that table is hand-maintained and `make docs-check` is a no-op for it.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

`./mvnw test -Dtest='CloudWatch*Test'` is 110/110 green, up from 108 on `main`. In a full `./mvnw test` the only red is the Lambda/Docker-backed integration set (API Gateway authorizers, WebSocket routes, ECR/Neptune/DocDb) — no Docker daemon here; nothing under `cloudwatch/` fails.

Two tests in `CloudWatchLogsInsightsQueryTest`. The first loops `>=`, `<=` and `=~` — including a leading `>=` with no field in front of it — plus the five operators that already warned, and asserts each one drops the stage; it fails on `main` with `unsupported operator must drop the whole filter stage: level >= 'INFO' ==> expected: <2> but was: <0>`. The second checks `=`, `==` and `!=` still match, and that `filter params.id = 'REQ>=42'` still parses as equality against the literal — the leftmost operator still wins, so a `>=` inside the value stays part of the value.
