### PR TITLE
fix(s3vectors): return cosine distance from queries

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3VectorsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/S3VectorsTest.java
@@ -173,6 +173,7 @@ class S3VectorsTest {
                         .queryVector(VectorData.builder().float32(1.0f, 0.1f, 0.0f).build())
                         .topK(1)
                         .returnMetadata(true)
+                        .returnDistance(true)
                         .build()
         );
         assertThat(response.vectors()).hasSize(1);

--- a/src/main/java/io/github/hectorvent/floci/services/s3vectors/S3VectorsController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3vectors/S3VectorsController.java
@@ -394,11 +394,13 @@ public class S3VectorsController {
         );
 
         boolean returnMetadata = request.returnMetadata() != null && request.returnMetadata();
+        boolean returnDistance = request.returnDistance() != null && request.returnDistance();
 
         List<QueryResultRepresentation> reps = results.stream()
                 .map(res -> {
                     Map<String, Object> metadata = returnMetadata ? res.getVector().getMetadata() : null;
-                    return new QueryResultRepresentation(res.getVector().getKey(), res.getDistance(), metadata);
+                    Double distance = returnDistance ? res.getDistance() : null;
+                    return new QueryResultRepresentation(res.getVector().getKey(), distance, metadata);
                 })
                 .toList();
 

--- a/src/main/java/io/github/hectorvent/floci/services/s3vectors/S3VectorsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3vectors/S3VectorsService.java
@@ -182,20 +182,13 @@ public class S3VectorsService {
                     break;
                 case "cosine":
                 default:
-                    distance = calculateCosineSimilarity(queryVector, v.getData());
+                    distance = calculateCosineDistance(queryVector, v.getData());
                     break;
             }
             results.add(new QueryResult(v, distance));
         }
 
-        // Sorting:
-        // For Euclidean distance, smaller distance is closer (ascending)
-        // For Cosine similarity, larger score is closer (descending)
-        if ("euclidean".equals(metric)) {
-            results.sort(Comparator.comparingDouble(QueryResult::getDistance));
-        } else {
-            results.sort((r1, r2) -> Double.compare(r2.getDistance(), r1.getDistance()));
-        }
+        results.sort(Comparator.comparingDouble(QueryResult::getDistance));
 
         return results.stream().limit(topK).collect(Collectors.toList());
     }
@@ -214,6 +207,11 @@ public class S3VectorsService {
         }
         if (normA == 0.0 || normB == 0.0) return 0.0;
         return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
+    }
+
+    private double calculateCosineDistance(List<Float> v1, List<Float> v2) {
+        double similarity = calculateCosineSimilarity(v1, v2);
+        return 1.0 - Math.max(-1.0, Math.min(1.0, similarity));
     }
 
     private double calculateEuclideanDistance(List<Float> v1, List<Float> v2) {

--- a/src/main/java/io/github/hectorvent/floci/services/s3vectors/S3VectorsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3vectors/S3VectorsService.java
@@ -224,15 +224,6 @@ public class S3VectorsService {
         return Math.sqrt(sum);
     }
 
-    private double calculateDotProduct(List<Float> v1, List<Float> v2) {
-        if (v1 == null || v2 == null || v1.size() != v2.size()) return 0.0;
-        double dotProduct = 0.0;
-        for (int i = 0; i < v1.size(); i++) {
-            dotProduct += v1.get(i) * v2.get(i);
-        }
-        return dotProduct;
-    }
-
     public static class QueryResult {
         private final VectorData vector;
         private final double distance;

--- a/src/test/java/io/github/hectorvent/floci/services/s3vectors/S3VectorsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3vectors/S3VectorsIntegrationTest.java
@@ -204,20 +204,23 @@ class S3VectorsIntegrationTest {
                     "vectorBucketName": "%s",
                     "indexName": "%s",
                     "queryVector": {
-                        "float32": [1.0, 0.1, 0.0]
+                        "float32": [1.0, 0.0, 0.0]
                     },
-                    "topK": 1,
-                    "returnMetadata": true
+                    "topK": 2,
+                    "returnMetadata": true,
+                    "returnDistance": true
                 }
                 """.formatted(BUCKET_NAME, INDEX_NAME))
         .when()
             .post("/QueryVectors")
         .then()
             .statusCode(200)
-            .body("vectors", hasSize(1))
+            .body("vectors", hasSize(2))
             .body("vectors[0].key", equalTo("v1"))
-            .body("vectors[0].distance", notNullValue())
-            .body("vectors[0].metadata.label", equalTo("first"));
+            .body("vectors[0].distance", equalTo(0.0f))
+            .body("vectors[0].metadata.label", equalTo("first"))
+            .body("vectors[1].key", equalTo("v2"))
+            .body("vectors[1].distance", equalTo(1.0f));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/s3vectors/S3VectorsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3vectors/S3VectorsIntegrationTest.java
@@ -225,6 +225,29 @@ class S3VectorsIntegrationTest {
 
     @Test
     @Order(10)
+    void queryVectors_withoutReturnDistance_omitsDistance() {
+        given()
+            .contentType(JSON_CONTENT_TYPE)
+            .body("""
+                {
+                    "vectorBucketName": "%s",
+                    "indexName": "%s",
+                    "queryVector": {
+                        "float32": [1.0, 0.0, 0.0]
+                    },
+                    "topK": 1
+                }
+                """.formatted(BUCKET_NAME, INDEX_NAME))
+        .when()
+            .post("/QueryVectors")
+        .then()
+            .statusCode(200)
+            .body("vectors", hasSize(1))
+            .body("vectors[0]", not(hasKey("distance")));
+    }
+
+    @Test
+    @Order(11)
     void deleteVectors() {
         given()
             .contentType(JSON_CONTENT_TYPE)
@@ -259,7 +282,7 @@ class S3VectorsIntegrationTest {
     }
 
     @Test
-    @Order(11)
+    @Order(12)
     void deleteIndex() {
         given()
             .contentType(JSON_CONTENT_TYPE)
@@ -290,7 +313,7 @@ class S3VectorsIntegrationTest {
     }
 
     @Test
-    @Order(12)
+    @Order(13)
     void deleteVectorBucket() {
         given()
             .contentType(JSON_CONTENT_TYPE)


### PR DESCRIPTION
## Summary

- Return AWS-compatible cosine distance from S3 Vectors `QueryVectors` instead of cosine similarity.
- Order cosine query results nearest-first by their reported distance.
- Add integration coverage for exact-match and orthogonal-vector distances.

Closes #2162

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Cosine query results now report `1 - cosineSimilarity` in `distance`: an
identical vector is `0.0`, an orthogonal vector is `1.0`, and results are
ordered by ascending distance.

## Checklist

- [ ] `./mvnw test` passes locally (not run; targeted integration suite run below)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Validation

- `JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home ./mvnw test -Dtest=S3VectorsIntegrationTest` (12 passed)
- Confirmed the regression test fails when the previous similarity behavior is restored.
