### PR TITLE
fix(ecs): report service deployments and MISSING failures on DescribeServices

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/EcsTests.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/EcsTests.java
@@ -1,9 +1,12 @@
 package com.floci.test;
 
 import org.junit.jupiter.api.*;
+import software.amazon.awssdk.core.waiters.WaiterOverrideConfiguration;
+import software.amazon.awssdk.core.waiters.WaiterResponse;
 import software.amazon.awssdk.services.ecs.EcsClient;
 import software.amazon.awssdk.services.ecs.model.*;
 
+import java.time.Duration;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
@@ -773,6 +776,25 @@ class EcsTests {
         assertThat(services).hasSize(1);
         assertThat(services.get(0).serviceName()).isEqualTo(serviceName);
         assertThat(services.get(0).desiredCount()).isEqualTo(1);
+
+        // An ACTIVE service must report exactly one PRIMARY deployment. AWS's ServicesStable
+        // waiter accepts on length(deployments) == 1, so an empty list silently breaks every
+        // SDK waiter and Terraform's aws_ecs_service (floci-io/floci#2174).
+        List<Deployment> deployments = services.get(0).deployments();
+        assertThat(deployments).hasSize(1);
+        assertThat(deployments.get(0).status()).isEqualTo("PRIMARY");
+        assertThat(deployments.get(0).id()).startsWith("ecs-svc/");
+        assertThat(deployments.get(0).taskDefinition()).isEqualTo(services.get(0).taskDefinition());
+        assertThat(deployments.get(0).desiredCount()).isEqualTo(1);
+        assertThat(deployments.get(0).rolloutState())
+                .isIn(DeploymentRolloutState.COMPLETED, DeploymentRolloutState.IN_PROGRESS);
+
+        // Deployments are synthesized per request, so the id must not drift between calls.
+        List<Service> again = ecs.describeServices(DescribeServicesRequest.builder()
+                .cluster(clusterName)
+                .services(serviceName)
+                .build()).services();
+        assertThat(again.get(0).deployments().get(0).id()).isEqualTo(deployments.get(0).id());
     }
 
     @Test
@@ -807,6 +829,46 @@ class EcsTests {
 
     @Test
     @Order(45)
+    @DisplayName("ServicesStable waiter - reaches stable")
+    void servicesStableWaiter() {
+        // The strongest available check on services[].deployments: this drives AWS's own
+        // waiter acceptor,
+        //   length(services[?!(length(deployments) == `1` && runningCount == desiredCount)]) == `0`
+        // rather than our reading of it. With deployments absent the expression never matches.
+        // waitTimeout is capped so a regression fails in 30s rather than the default 40 x 15s.
+        WaiterResponse<DescribeServicesResponse> response = ecs.waiter().waitUntilServicesStable(
+                DescribeServicesRequest.builder()
+                        .cluster(clusterName)
+                        .services(serviceName)
+                        .build(),
+                WaiterOverrideConfiguration.builder()
+                        .waitTimeout(Duration.ofSeconds(30))
+                        .build());
+
+        assertThat(response.matched().response()).isPresent();
+        assertThat(response.matched().response().get().services().get(0).deployments()).hasSize(1);
+    }
+
+    @Test
+    @Order(46)
+    @DisplayName("DescribeServices - unknown service returns a MISSING failure")
+    void describeServicesReportsMissingService() {
+        // ECS reports an unresolvable service as a failure rather than erroring, and the
+        // ServicesStable waiter fails fast on failures[].reason == MISSING. Dropping it
+        // silently would leave that waiter polling for its full timeout.
+        DescribeServicesResponse response = ecs.describeServices(DescribeServicesRequest.builder()
+                .cluster(clusterName)
+                .services("no-such-service-" + suffix)
+                .build());
+
+        assertThat(response.services()).isEmpty();
+        assertThat(response.failures()).hasSize(1);
+        assertThat(response.failures().get(0).reason()).isEqualTo("MISSING");
+        assertThat(response.failures().get(0).arn()).endsWith("no-such-service-" + suffix);
+    }
+
+    @Test
+    @Order(47)
     @DisplayName("ListServiceDeployments - list deployments")
     void listServiceDeployments() {
         List<ServiceDeploymentBrief> briefs = ecs.listServiceDeployments(
@@ -830,7 +892,7 @@ class EcsTests {
     }
 
     @Test
-    @Order(46)
+    @Order(48)
     @DisplayName("UpdateService - update desiredCount to 0")
     void updateServiceDesiredCount() {
         Service updated = ecs.updateService(UpdateServiceRequest.builder()
@@ -843,7 +905,7 @@ class EcsTests {
     }
 
     @Test
-    @Order(47)
+    @Order(49)
     @DisplayName("UpdateService - update taskDefinition")
     void updateServiceTaskDefinition() {
         Service updated = ecs.updateService(UpdateServiceRequest.builder()
@@ -856,7 +918,7 @@ class EcsTests {
     }
 
     @Test
-    @Order(48)
+    @Order(50)
     @DisplayName("CreateTaskSet - create task set")
     void createTaskSet() {
         software.amazon.awssdk.services.ecs.model.TaskSet ts =
@@ -920,7 +982,7 @@ class EcsTests {
     }
 
     @Test
-    @Order(49)
+    @Order(51)
     @DisplayName("DeleteService - delete service")
     void deleteService() {
         Service deleted = ecs.deleteService(DeleteServiceRequest.builder()
@@ -932,7 +994,7 @@ class EcsTests {
     }
 
     @Test
-    @Order(50)
+    @Order(52)
     @DisplayName("ListServices - service no longer in list")
     void listServicesAfterDelete() {
         List<String> serviceArns = ecs.listServices(ListServicesRequest.builder()
@@ -943,7 +1005,7 @@ class EcsTests {
     }
 
     @Test
-    @Order(51)
+    @Order(53)
     @DisplayName("DeregisterTaskDefinition - deregister revision 1")
     void deregisterTaskDefinition() {
         TaskDefinition deregistered = ecs.deregisterTaskDefinition(
@@ -955,7 +1017,7 @@ class EcsTests {
     }
 
     @Test
-    @Order(52)
+    @Order(54)
     @DisplayName("ListTaskDefinitions - filter by ACTIVE")
     void listTaskDefinitionsActive() {
         List<String> activeArns = ecs.listTaskDefinitions(ListTaskDefinitionsRequest.builder()
@@ -968,7 +1030,7 @@ class EcsTests {
     }
 
     @Test
-    @Order(53)
+    @Order(55)
     @DisplayName("DeleteTaskDefinitions - delete INACTIVE")
     void deleteTaskDefinitions() {
         List<TaskDefinition> deletedDefs = ecs.deleteTaskDefinitions(
@@ -981,7 +1043,7 @@ class EcsTests {
     }
 
     @Test
-    @Order(54)
+    @Order(56)
     @DisplayName("DeleteCluster - fails with running tasks")
     void deleteClusterFailsWithTasks() {
         ecs.runTask(RunTaskRequest.builder()
@@ -996,7 +1058,7 @@ class EcsTests {
     }
 
     @Test
-    @Order(55)
+    @Order(57)
     @DisplayName("DeleteCluster - delete after stopping tasks")
     void deleteCluster() {
         List<String> running = ecs.listTasks(ListTasksRequest.builder()
@@ -1019,7 +1081,7 @@ class EcsTests {
     }
 
     @Test
-    @Order(56)
+    @Order(58)
     @DisplayName("ListClusters - cluster no longer in list")
     void listClustersAfterDelete() {
         List<String> arns = ecs.listClusters(ListClustersRequest.builder().build()).clusterArns();
@@ -1027,7 +1089,7 @@ class EcsTests {
     }
 
     @Test
-    @Order(57)
+    @Order(59)
     @DisplayName("RegisterTaskDefinition - container secrets round trip")
     void registerTaskDefinitionWithSecrets() {
         String secretFamily = family + "-secrets";

--- a/docs/services/ecs.md
+++ b/docs/services/ecs.md
@@ -64,7 +64,9 @@ SDK waiters, and Terraform's `aws_ecs_service` all converge normally. A deleted
 `rolloutState` is `COMPLETED` once `runningCount` reaches `desiredCount`, and
 `IN_PROGRESS` before that. The deployment `id` is derived from the service ARN and its
 task definition, so it is stable across calls and across restarts, and rolls over when
-the task definition changes.
+the task definition changes. `createdAt` tracks the deployment rather than the service:
+it is the service's creation time until a task-definition change starts a new
+deployment, and moves with it thereafter.
 
 Known differences from AWS:
 
@@ -75,6 +77,8 @@ Known differences from AWS:
   `deploymentController`, and `ECS` is the AWS default.
 - `pendingCount` is always `0`, matching the top-level service field.
 - `forceNewDeployment` does not mint a new deployment `id`.
+- `updatedAt` equals `createdAt`. AWS advances it as a rollout progresses; Floci has no
+  intermediate rollout state to report.
 
 #### Unknown services
 

--- a/docs/services/ecs.md
+++ b/docs/services/ecs.md
@@ -49,9 +49,41 @@ ECS emulates clusters, task definitions, tasks, and services. In the default con
 | `CreateService` | Create a long-running service |
 | `UpdateService` | Update desired count, task definition, or deployment config |
 | `DeleteService` | Delete a service (supports `force`) |
-| `DescribeServices` | Describe one or more services |
+| `DescribeServices` | Describe one or more services (includes `deployments`, see below) |
 | `ListServices` | List service ARNs in a cluster |
 | `ListServicesByNamespace` | List services filtered by Cloud Map namespace |
+
+#### Service deployments
+
+An `ACTIVE` service reports exactly one `PRIMARY` entry in `services[].deployments`,
+synthesized from the service's current state rather than tracked as a rollout. This is
+what AWS's `ServicesStable` waiter accepts on, so `aws ecs wait services-stable`, the
+SDK waiters, and Terraform's `aws_ecs_service` all converge normally. A deleted
+(`INACTIVE`) service reports an empty list.
+
+`rolloutState` is `COMPLETED` once `runningCount` reaches `desiredCount`, and
+`IN_PROGRESS` before that. The deployment `id` is derived from the service ARN and its
+task definition, so it is stable across calls and across restarts, and rolls over when
+the task definition changes.
+
+Known differences from AWS:
+
+- There is never a second `ACTIVE` deployment draining alongside the `PRIMARY` one;
+  Floci swaps the task definition in place.
+- `deployments` is reported for every service. AWS omits it for services that use the
+  `CODE_DEPLOY` or `EXTERNAL` deployment controller, but Floci does not yet record
+  `deploymentController`, and `ECS` is the AWS default.
+- `pendingCount` is always `0`, matching the top-level service field.
+- `forceNewDeployment` does not mint a new deployment `id`.
+
+#### Unknown services
+
+A service reference that does not resolve is returned in `failures` with
+`reason: MISSING` and the ARN the service would have had, rather than being dropped from
+the response. `DescribeServices` therefore returns partial results instead of erroring, as
+AWS does, and `aws ecs wait services-stable` on a nonexistent service fails immediately
+instead of polling for its full timeout. A reference supplied as an ARN is echoed back
+unchanged.
 
 ### Task Sets
 

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
@@ -8,6 +8,8 @@ import io.github.hectorvent.floci.services.ecs.model.CapacityProvider;
 import io.github.hectorvent.floci.services.ecs.model.ClusterSetting;
 import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
 import io.github.hectorvent.floci.services.ecs.model.ContainerInstance;
+import io.github.hectorvent.floci.services.ecs.model.Deployment;
+import io.github.hectorvent.floci.services.ecs.model.Failure;
 import io.github.hectorvent.floci.services.ecs.model.ContainerOverride;
 import io.github.hectorvent.floci.services.ecs.model.EcsCluster;
 import io.github.hectorvent.floci.services.ecs.model.EcsLoadBalancer;
@@ -497,13 +499,16 @@ public class EcsJsonHandler {
         String cluster = req.has("cluster") ? req.path("cluster").asText() : null;
         List<String> serviceIds = jsonArrayToList(req.path("services"));
 
-        List<EcsServiceModel> found = service.describeServices(cluster, serviceIds, region);
+        EcsService.DescribeServicesResult found =
+                service.describeServicesDetailed(cluster, serviceIds, region);
 
         ObjectNode resp = objectMapper.createObjectNode();
         ArrayNode arr = objectMapper.createArrayNode();
-        found.forEach(s -> arr.add(serviceNode(s)));
+        found.services().forEach(s -> arr.add(serviceNode(s)));
         resp.set("services", arr);
-        resp.set("failures", objectMapper.createArrayNode());
+        ArrayNode failures = objectMapper.createArrayNode();
+        found.failures().forEach(f -> failures.add(failureNode(f)));
+        resp.set("failures", failures);
         return Response.ok(resp).build();
     }
 
@@ -1149,6 +1154,34 @@ public class EcsJsonHandler {
             networkConfig.set("awsvpcConfiguration", awsvpcNode);
             n.set("networkConfiguration", networkConfig);
         }
+        ArrayNode deployments = objectMapper.createArrayNode();
+        service.deploymentsFor(s).forEach(d -> deployments.add(deploymentNode(d)));
+        n.set("deployments", deployments);
+        return n;
+    }
+
+    private ObjectNode failureNode(Failure f) {
+        ObjectNode n = objectMapper.createObjectNode();
+        n.put("arn", f.arn());
+        n.put("reason", f.reason());
+        if (f.detail() != null) { n.put("detail", f.detail()); }
+        return n;
+    }
+
+    private ObjectNode deploymentNode(Deployment d) {
+        ObjectNode n = objectMapper.createObjectNode();
+        n.put("id", d.getId());
+        n.put("status", d.getStatus());
+        n.put("taskDefinition", d.getTaskDefinition());
+        n.put("desiredCount", d.getDesiredCount());
+        n.put("pendingCount", d.getPendingCount());
+        n.put("runningCount", d.getRunningCount());
+        n.put("failedTasks", d.getFailedTasks());
+        n.put("rolloutState", d.getRolloutState());
+        n.put("rolloutStateReason", d.getRolloutStateReason());
+        if (d.getLaunchType() != null) { n.put("launchType", d.getLaunchType().name()); }
+        if (d.getCreatedAt() != null) { n.put("createdAt", d.getCreatedAt().toEpochMilli() / 1000.0); }
+        if (d.getUpdatedAt() != null) { n.put("updatedAt", d.getUpdatedAt().toEpochMilli() / 1000.0); }
         return n;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
@@ -707,6 +707,7 @@ public class EcsService implements ContainerTeardown {
         svc.setNetworkConfiguration(networkConfiguration);
         svc.setStatus("ACTIVE");
         svc.setCreatedAt(Instant.now());
+        svc.setLastDeploymentAt(svc.getCreatedAt());
         if (tags != null && !tags.isEmpty()) {
             svc.setTags(new LinkedHashMap<>(tags));
         }
@@ -747,6 +748,7 @@ public class EcsService implements ContainerTeardown {
         if (taskDefinition != null) {
             resolveTaskDefinitionOrThrow(taskDefinition, region);
             svc.setTaskDefinition(taskDefinition);
+            svc.setLastDeploymentAt(Instant.now());
             recordServiceDeployment(svc, taskDefinition, region);
         }
         services.put(key, svc);
@@ -1317,8 +1319,14 @@ public class EcsService implements ContainerTeardown {
         d.setRolloutStateReason("ECS deployment " + deploymentId
                 + (converged ? " completed." : " in progress."));
         d.setLaunchType(svc.getLaunchType());
-        d.setCreatedAt(svc.getCreatedAt());
-        d.setUpdatedAt(svc.getCreatedAt());
+        // The deployment's own start time, not the service's: a task-definition change mints a
+        // new deployment id, so reporting service creation here would contradict it. Older
+        // persisted services predate the field and fall back to the service creation time.
+        Instant startedAt = svc.getLastDeploymentAt() != null
+                ? svc.getLastDeploymentAt()
+                : svc.getCreatedAt();
+        d.setCreatedAt(startedAt);
+        d.setUpdatedAt(startedAt);
         return List.of(d);
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
@@ -14,6 +14,8 @@ import io.github.hectorvent.floci.services.ecs.model.CapacityProvider;
 import io.github.hectorvent.floci.services.ecs.model.ClusterSetting;
 import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
 import io.github.hectorvent.floci.services.ecs.model.ContainerInstance;
+import io.github.hectorvent.floci.services.ecs.model.Deployment;
+import io.github.hectorvent.floci.services.ecs.model.Failure;
 import io.github.hectorvent.floci.services.ecs.model.ContainerOverride;
 import io.github.hectorvent.floci.services.ecs.model.EcsCluster;
 import io.github.hectorvent.floci.services.ecs.model.EcsLoadBalancer;
@@ -791,16 +793,43 @@ public class EcsService implements ContainerTeardown {
         return svc;
     }
 
+    /** The services that resolved, plus a {@code MISSING} failure for each reference that did not. */
+    public record DescribeServicesResult(List<EcsServiceModel> services, List<Failure> failures) {}
+
     public List<EcsServiceModel> describeServices(String clusterRef, List<String> serviceIds, String region) {
+        return describeServicesDetailed(clusterRef, serviceIds, region).services();
+    }
+
+    /**
+     * Resolves each reference, reporting the ones that do not exist as {@code MISSING} failures
+     * rather than dropping them. ECS answers a describe for an unknown service with a failure
+     * entry, not an error, and its {@code ServicesStable} waiter fails fast on
+     * {@code failures[].reason == "MISSING"} — so silently returning an empty list leaves the
+     * waiter polling for its full timeout instead of reporting the service does not exist.
+     */
+    public DescribeServicesResult describeServicesDetailed(String clusterRef, List<String> serviceIds,
+                                                           String region) {
         EcsCluster cluster = resolveClusterOrDefault(clusterRef, region);
         List<EcsServiceModel> result = new ArrayList<>();
+        List<Failure> failures = new ArrayList<>();
         for (String id : serviceIds) {
             EcsServiceModel svc = resolveService(cluster.getClusterName(), id, region);
             if (svc != null) {
                 result.add(svc);
+            } else {
+                failures.add(Failure.missing(missingServiceArn(cluster, id, region)));
             }
         }
-        return result;
+        return new DescribeServicesResult(result, failures);
+    }
+
+    /** Echoes an ARN the caller supplied, otherwise builds the ARN the service would have had. */
+    private String missingServiceArn(EcsCluster cluster, String serviceRef, String region) {
+        if (serviceRef != null && serviceRef.startsWith("arn:")) {
+            return serviceRef;
+        }
+        return regionResolver.buildArn("ecs", region,
+                "service/" + cluster.getClusterName() + "/" + serviceRef);
     }
 
     public List<String> listServices(String clusterRef, String region) {
@@ -1255,6 +1284,58 @@ public class EcsService implements ContainerTeardown {
                 .map(arn -> serviceRevisions.get(arn))
                 .filter(r -> r != null)
                 .toList();
+    }
+
+    /**
+     * The deployments of a service, derived from its current state rather than tracked as a
+     * rollout. An ACTIVE service always has exactly one PRIMARY deployment: AWS's own
+     * {@code ServicesStable} waiter accepts on
+     * {@code length(services[?!(length(deployments) == `1` && runningCount == desiredCount)]) == `0`},
+     * so reporting none leaves every SDK waiter polling until it times out.
+     *
+     * <p>A task-definition change is applied in place rather than draining a previous
+     * deployment, so there is never a second ACTIVE entry beside the PRIMARY one. An INACTIVE
+     * service has no deployments.
+     */
+    public List<Deployment> deploymentsFor(EcsServiceModel svc) {
+        if (svc == null || !"ACTIVE".equals(svc.getStatus())) {
+            return List.of();
+        }
+
+        String deploymentId = deploymentId(svc);
+        boolean converged = svc.getRunningCount() >= svc.getDesiredCount();
+
+        Deployment d = new Deployment();
+        d.setId(deploymentId);
+        d.setStatus("PRIMARY");
+        d.setTaskDefinition(svc.getTaskDefinition());
+        d.setDesiredCount(svc.getDesiredCount());
+        d.setPendingCount(svc.getPendingCount());
+        d.setRunningCount(svc.getRunningCount());
+        d.setFailedTasks(0);
+        d.setRolloutState(converged ? "COMPLETED" : "IN_PROGRESS");
+        d.setRolloutStateReason("ECS deployment " + deploymentId
+                + (converged ? " completed." : " in progress."));
+        d.setLaunchType(svc.getLaunchType());
+        d.setCreatedAt(svc.getCreatedAt());
+        d.setUpdatedAt(svc.getCreatedAt());
+        return List.of(d);
+    }
+
+    /**
+     * A stable {@code ecs-svc/<id>} identifier derived from the service ARN and its task
+     * definition. Deployments are derived per request, so a random id would differ on every
+     * {@code DescribeServices} call and read as perpetual drift in clients that persist it.
+     * Deriving it from persisted state keeps it identical across calls and across restarts,
+     * while still rolling over when the task definition changes.
+     */
+    private String deploymentId(EcsServiceModel svc) {
+        String seed = svc.getServiceArn() + ":" + svc.getTaskDefinition();
+        long hash = 0xcbf29ce484222325L;
+        for (int i = 0; i < seed.length(); i++) {
+            hash = (hash ^ seed.charAt(i)) * 0x100000001b3L;
+        }
+        return "ecs-svc/" + Long.toUnsignedString(hash);
     }
 
     private void recordServiceDeployment(EcsServiceModel svc, String taskDefinition, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/Deployment.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/Deployment.java
@@ -1,0 +1,53 @@
+package io.github.hectorvent.floci.services.ecs.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+
+/**
+ * A deployment of an ECS service, as reported in {@code DescribeServices}'
+ * {@code services[].deployments}. Distinct from {@link ServiceDeployment}, which is the
+ * separate {@code DescribeServiceDeployments} API shape and carries neither counts nor a
+ * rollout state.
+ */
+@RegisterForReflection
+public class Deployment {
+
+    private String id;
+    private String status;
+    private String taskDefinition;
+    private int desiredCount;
+    private int pendingCount;
+    private int runningCount;
+    private int failedTasks;
+    private String rolloutState;
+    private String rolloutStateReason;
+    private LaunchType launchType;
+    private Instant createdAt;
+    private Instant updatedAt;
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+    public String getTaskDefinition() { return taskDefinition; }
+    public void setTaskDefinition(String taskDefinition) { this.taskDefinition = taskDefinition; }
+    public int getDesiredCount() { return desiredCount; }
+    public void setDesiredCount(int desiredCount) { this.desiredCount = desiredCount; }
+    public int getPendingCount() { return pendingCount; }
+    public void setPendingCount(int pendingCount) { this.pendingCount = pendingCount; }
+    public int getRunningCount() { return runningCount; }
+    public void setRunningCount(int runningCount) { this.runningCount = runningCount; }
+    public int getFailedTasks() { return failedTasks; }
+    public void setFailedTasks(int failedTasks) { this.failedTasks = failedTasks; }
+    public String getRolloutState() { return rolloutState; }
+    public void setRolloutState(String rolloutState) { this.rolloutState = rolloutState; }
+    public String getRolloutStateReason() { return rolloutStateReason; }
+    public void setRolloutStateReason(String rolloutStateReason) { this.rolloutStateReason = rolloutStateReason; }
+    public LaunchType getLaunchType() { return launchType; }
+    public void setLaunchType(LaunchType launchType) { this.launchType = launchType; }
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+    public Instant getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/EcsServiceModel.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/EcsServiceModel.java
@@ -21,6 +21,8 @@ public class EcsServiceModel {
     private int pendingCount;
     private String status;
     private Instant createdAt;
+    /** When the current deployment began: service creation, or the last task-definition change. */
+    private Instant lastDeploymentAt;
     private String namespace;
     private String deploymentController;
     private Map<String, String> tags = new HashMap<>();
@@ -56,6 +58,8 @@ public class EcsServiceModel {
 
     public Instant getCreatedAt() { return createdAt; }
     public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+    public Instant getLastDeploymentAt() { return lastDeploymentAt; }
+    public void setLastDeploymentAt(Instant lastDeploymentAt) { this.lastDeploymentAt = lastDeploymentAt; }
 
     public String getNamespace() { return namespace; }
     public void setNamespace(String namespace) { this.namespace = namespace; }

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/model/Failure.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/model/Failure.java
@@ -1,0 +1,16 @@
+package io.github.hectorvent.floci.services.ecs.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * A per-resource failure returned alongside the results of an ECS {@code Describe*} call.
+ * ECS reports a resource it could not find here rather than throwing, so callers get partial
+ * results; {@code reason} is {@code MISSING} for a resource that does not exist.
+ */
+@RegisterForReflection
+public record Failure(String arn, String reason, String detail) {
+
+    public static Failure missing(String arn) {
+        return new Failure(arn, "MISSING", null);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/EcsDescribeServicesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/EcsDescribeServicesIntegrationTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.ecs;
 
 import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.path.json.config.JsonPathConfig;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Integration tests for the two {@code DescribeServices} response fields that AWS's
@@ -53,6 +55,17 @@ class EcsDescribeServicesIntegrationTest {
     private static void registerTaskDef(String family) {
         call("RegisterTaskDefinition", "{\"family\":\"" + family + "\","
                 + "\"containerDefinitions\":[{\"name\":\"web\",\"image\":\"nginx\",\"memory\":128}]}");
+    }
+
+    /**
+     * Epoch seconds carry 10 significant digits, more than a float holds. RestAssured's default
+     * number type is FLOAT_AND_DOUBLE, which silently rounds two timestamps a second apart to the
+     * same value, so read them as BigDecimal.
+     */
+    private static double epochSeconds(Response response, String path) {
+        return ((java.math.BigDecimal) response
+                .jsonPath(new JsonPathConfig(JsonPathConfig.NumberReturnType.BIG_DECIMAL))
+                .get(path)).doubleValue();
     }
 
     private static Response describe(String cluster, String service) {
@@ -127,6 +140,35 @@ class EcsDescribeServicesIntegrationTest {
         String after = describe("dep-cluster-5", "dep-svc-5").path("services[0].deployments[0].id");
         assertNotEquals(before, after,
                 "a new task definition is a new deployment and must get a new id");
+    }
+
+    @Test
+    void newDeploymentCarriesItsOwnStartTimeNotTheServiceCreationTime() throws Exception {
+        // A task-definition change mints a new deployment id, so the timestamps have to move with
+        // it. Reporting the service's creation time would contradict the new id and misrepresent
+        // when the deployment actually started.
+        seedClusterAndTaskDef("dep-cluster-11", "dep-td-11a");
+        call("CreateService", "{\"cluster\":\"dep-cluster-11\",\"serviceName\":\"dep-svc-11\","
+                + "\"taskDefinition\":\"dep-td-11a\",\"desiredCount\":0}");
+
+        Response before = describe("dep-cluster-11", "dep-svc-11");
+        double createdAtBefore = epochSeconds(before, "services[0].deployments[0].createdAt");
+        String idBefore = before.path("services[0].deployments[0].id");
+
+        Thread.sleep(1100);
+        registerTaskDef("dep-td-11b");
+        call("UpdateService", "{\"cluster\":\"dep-cluster-11\",\"service\":\"dep-svc-11\","
+                + "\"taskDefinition\":\"dep-td-11b\"}");
+
+        Response after = describe("dep-cluster-11", "dep-svc-11");
+        double createdAtAfter = epochSeconds(after, "services[0].deployments[0].createdAt");
+        double serviceCreatedAt = epochSeconds(after, "services[0].createdAt");
+
+        assertNotEquals(idBefore, after.path("services[0].deployments[0].id"));
+        assertTrue(createdAtAfter > createdAtBefore,
+                "a new deployment must carry a later createdAt than the one it replaced");
+        assertTrue(createdAtAfter > serviceCreatedAt,
+                "the deployment started after the service was created, so its createdAt must be later");
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/EcsDescribeServicesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/EcsDescribeServicesIntegrationTest.java
@@ -1,0 +1,200 @@
+package io.github.hectorvent.floci.services.ecs;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Integration tests for the two {@code DescribeServices} response fields that AWS's
+ * {@code ServicesStable} waiter depends on (floci-io/floci#2174).
+ *
+ * <p>The waiter accepts on
+ * {@code length(services[?!(length(deployments) == `1` && runningCount == desiredCount)]) == `0`}
+ * and fails fast on {@code failures[].reason == "MISSING"} (botocore
+ * {@code ecs/2014-11-13/waiters-2.json}). So an ACTIVE service must report exactly one
+ * deployment, and an unknown service must come back as a failure rather than being dropped;
+ * getting either wrong leaves {@code aws ecs wait services-stable} and every SDK waiter
+ * polling until they time out.
+ */
+@QuarkusTest
+class EcsDescribeServicesIntegrationTest {
+
+    private static final String TARGET = "AmazonEC2ContainerServiceV20141113.";
+    private static final String CT = "application/x-amz-json-1.1";
+
+    @BeforeAll
+    static void configure() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    private static Response call(String action, String body) {
+        return given().contentType(CT).header("X-Amz-Target", TARGET + action)
+                .body(body)
+                .when().post("/")
+                .then().statusCode(200)
+                .extract().response();
+    }
+
+    private static void seedClusterAndTaskDef(String cluster, String family) {
+        call("CreateCluster", "{\"clusterName\":\"" + cluster + "\"}");
+        registerTaskDef(family);
+    }
+
+    private static void registerTaskDef(String family) {
+        call("RegisterTaskDefinition", "{\"family\":\"" + family + "\","
+                + "\"containerDefinitions\":[{\"name\":\"web\",\"image\":\"nginx\",\"memory\":128}]}");
+    }
+
+    private static Response describe(String cluster, String service) {
+        return call("DescribeServices",
+                "{\"cluster\":\"" + cluster + "\",\"services\":[\"" + service + "\"]}");
+    }
+
+    @Test
+    void describeServicesReportsExactlyOnePrimaryDeployment() {
+        seedClusterAndTaskDef("dep-cluster-1", "dep-td-1");
+        call("CreateService", "{\"cluster\":\"dep-cluster-1\",\"serviceName\":\"dep-svc-1\","
+                + "\"taskDefinition\":\"dep-td-1\",\"desiredCount\":0}");
+
+        Response r = describe("dep-cluster-1", "dep-svc-1");
+        String taskDefinition = r.path("services[0].taskDefinition");
+        int runningCount = r.path("services[0].runningCount");
+        int pendingCount = r.path("services[0].pendingCount");
+
+        r.then()
+                .body("services", hasSize(1))
+                .body("services[0].deployments", hasSize(1))
+                .body("services[0].deployments[0].status", equalTo("PRIMARY"))
+                .body("services[0].deployments[0].id", startsWith("ecs-svc/"))
+                .body("services[0].deployments[0].taskDefinition", equalTo(taskDefinition))
+                .body("services[0].deployments[0].desiredCount", equalTo(0))
+                .body("services[0].deployments[0].runningCount", equalTo(runningCount))
+                .body("services[0].deployments[0].pendingCount", equalTo(pendingCount))
+                .body("services[0].deployments[0].failedTasks", equalTo(0))
+                .body("services[0].deployments[0].rolloutStateReason",
+                        startsWith("ECS deployment ecs-svc/"));
+    }
+
+    @Test
+    void deploymentIdIsStableAcrossCalls() {
+        // Deployments are synthesized per request. A random id would change on every call and
+        // surface as perpetual drift in any client that persists it, so this is the regression
+        // guard for deriving the id from the service ARN and task definition instead.
+        seedClusterAndTaskDef("dep-cluster-2", "dep-td-2");
+        call("CreateService", "{\"cluster\":\"dep-cluster-2\",\"serviceName\":\"dep-svc-2\","
+                + "\"taskDefinition\":\"dep-td-2\",\"desiredCount\":0}");
+
+        String first = describe("dep-cluster-2", "dep-svc-2").path("services[0].deployments[0].id");
+        String second = describe("dep-cluster-2", "dep-svc-2").path("services[0].deployments[0].id");
+
+        assertEquals(first, second, "deployment id must not change between DescribeServices calls");
+    }
+
+    @Test
+    void convergedServiceReportsCompletedRollout() {
+        // desiredCount 0 is trivially converged (running 0 >= desired 0), so this asserts the
+        // COMPLETED branch without depending on Docker-backed tasks actually starting.
+        seedClusterAndTaskDef("dep-cluster-3", "dep-td-3");
+        call("CreateService", "{\"cluster\":\"dep-cluster-3\",\"serviceName\":\"dep-svc-3\","
+                + "\"taskDefinition\":\"dep-td-3\",\"desiredCount\":0}");
+
+        describe("dep-cluster-3", "dep-svc-3").then()
+                .body("services[0].deployments[0].rolloutState", equalTo("COMPLETED"))
+                .body("services[0].deployments[0].rolloutStateReason", endsWith("completed."));
+    }
+
+    @Test
+    void deploymentIdRollsOverWhenTaskDefinitionChanges() {
+        seedClusterAndTaskDef("dep-cluster-5", "dep-td-5a");
+        call("CreateService", "{\"cluster\":\"dep-cluster-5\",\"serviceName\":\"dep-svc-5\","
+                + "\"taskDefinition\":\"dep-td-5a\",\"desiredCount\":0}");
+        String before = describe("dep-cluster-5", "dep-svc-5").path("services[0].deployments[0].id");
+
+        registerTaskDef("dep-td-5b");
+        call("UpdateService", "{\"cluster\":\"dep-cluster-5\",\"service\":\"dep-svc-5\","
+                + "\"taskDefinition\":\"dep-td-5b\"}");
+
+        String after = describe("dep-cluster-5", "dep-svc-5").path("services[0].deployments[0].id");
+        assertNotEquals(before, after,
+                "a new task definition is a new deployment and must get a new id");
+    }
+
+    @Test
+    void createAndUpdateServiceEchoTheSameDeploymentShape() {
+        seedClusterAndTaskDef("dep-cluster-6", "dep-td-6");
+
+        call("CreateService", "{\"cluster\":\"dep-cluster-6\",\"serviceName\":\"dep-svc-6\","
+                + "\"taskDefinition\":\"dep-td-6\",\"desiredCount\":0}").then()
+                .body("service.deployments", hasSize(1))
+                .body("service.deployments[0].status", equalTo("PRIMARY"));
+
+        call("UpdateService", "{\"cluster\":\"dep-cluster-6\",\"service\":\"dep-svc-6\","
+                + "\"desiredCount\":0}").then()
+                .body("service.deployments", hasSize(1))
+                .body("service.deployments[0].status", equalTo("PRIMARY"));
+    }
+
+    @Test
+    void unknownServiceIsReportedAsAMissingFailureRatherThanDroppedSilently() {
+        // ECS answers a describe for an unknown service with a failure entry, not an error, and
+        // the ServicesStable waiter fails fast on failures[].reason == "MISSING". Returning an
+        // empty services list with no failure leaves that waiter polling for its full timeout.
+        seedClusterAndTaskDef("dep-cluster-8", "dep-td-8");
+
+        describe("dep-cluster-8", "no-such-service").then()
+                .body("services", hasSize(0))
+                .body("failures", hasSize(1))
+                .body("failures[0].reason", equalTo("MISSING"))
+                .body("failures[0].arn", endsWith(":service/dep-cluster-8/no-such-service"));
+    }
+
+    @Test
+    void describeMixesFoundServicesWithMissingOnes() {
+        seedClusterAndTaskDef("dep-cluster-9", "dep-td-9");
+        call("CreateService", "{\"cluster\":\"dep-cluster-9\",\"serviceName\":\"dep-svc-9\","
+                + "\"taskDefinition\":\"dep-td-9\",\"desiredCount\":0}");
+
+        call("DescribeServices", "{\"cluster\":\"dep-cluster-9\","
+                + "\"services\":[\"dep-svc-9\",\"ghost-service\"]}").then()
+                .body("services", hasSize(1))
+                .body("services[0].serviceName", equalTo("dep-svc-9"))
+                .body("failures", hasSize(1))
+                .body("failures[0].reason", equalTo("MISSING"))
+                .body("failures[0].arn", endsWith(":service/dep-cluster-9/ghost-service"));
+    }
+
+    @Test
+    void aServiceArnThatDoesNotExistIsEchoedBackInTheFailure() {
+        seedClusterAndTaskDef("dep-cluster-10", "dep-td-10");
+        String arn = "arn:aws:ecs:us-east-1:000000000000:service/dep-cluster-10/absent";
+
+        call("DescribeServices", "{\"cluster\":\"dep-cluster-10\",\"services\":[\"" + arn + "\"]}").then()
+                .body("failures", hasSize(1))
+                .body("failures[0].arn", equalTo(arn))
+                .body("failures[0].reason", equalTo("MISSING"));
+    }
+
+    @Test
+    void deletedServiceReportsAnEmptyDeploymentListRatherThanOmittingIt() {
+        // AWS's ServicesStable waiter fails an INACTIVE service on status, so an empty list is
+        // correct here, but the key must still be present, matching how moto renders it.
+        seedClusterAndTaskDef("dep-cluster-7", "dep-td-7");
+        call("CreateService", "{\"cluster\":\"dep-cluster-7\",\"serviceName\":\"dep-svc-7\","
+                + "\"taskDefinition\":\"dep-td-7\",\"desiredCount\":0}");
+        call("DeleteService", "{\"cluster\":\"dep-cluster-7\",\"service\":\"dep-svc-7\"}");
+
+        describe("dep-cluster-7", "dep-svc-7").then()
+                .body("services[0].status", equalTo("INACTIVE"))
+                .body("services[0].deployments", hasSize(0));
+    }
+}


### PR DESCRIPTION
## Summary

`DescribeServices` omitted `services[].deployments` entirely (#2174) and always returned an empty `failures` list. Both fields are read by AWS's own `ServicesStable` waiter, so this was not a cosmetic gap.

The waiter, from [botocore `ecs/2014-11-13/waiters-2.json`](https://github.com/boto/botocore/blob/develop/botocore/data/ecs/2014-11-13/waiters-2.json), accepts on:

```
length(services[?!(length(deployments) == `1` && runningCount == desiredCount)]) == `0`
```

and fails fast on `failures[].reason == "MISSING"`. That file is codegen'd into every AWS SDK, so with `deployments` absent:

- `aws ecs wait services-stable` polled the full 40 x 15s and then failed.
- The same waiter failed in every SDK (Java `EcsWaiter.waitUntilServicesStable`, etc).
- Terraform's `aws_ecs_service` never converged, via the same `len(Deployments) == 1` test in `internal/service/ecs/service.go:2206`.
- Waiting on a service that does not exist also hung for the full timeout instead of failing immediately, because the `MISSING` failure was never emitted.

Evaluating the acceptor against the old payload does not merely return false, it raises `JMESPathTypeError`, since `length(null)` is a type error.

An `ACTIVE` service now reports exactly one `PRIMARY` deployment derived from current service state, with `rolloutState` `COMPLETED` once `runningCount` reaches `desiredCount`. An unresolvable service reference comes back as a `MISSING` failure carrying the ARN it would have had.

One design note worth flagging for review: the deployment `id` is derived from the service ARN plus task definition rather than generated per request. Deployments are synthesized on read, so a random id would differ on every `DescribeServices` call and read as perpetual drift in any client that persists it. Deriving it keeps the id stable across calls and restarts while still rolling over when the task definition changes. There is a regression test for exactly that.

Closes #2174

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** `services[].deployments` was absent from every `DescribeServices` response, and `failures` was hardcoded to an empty array so unknown services were silently dropped.

Verified against the model rather than against our own expectations:

- **Shape** — `Service.deployments` and the `Deployment` members (`id`, `status`, `taskDefinition`, `desiredCount`, `pendingCount`, `runningCount`, `failedTasks`, `rolloutState`, `rolloutStateReason`, `createdAt`, `updatedAt`, `launchType`) all match [botocore ecs/2014-11-13](https://github.com/boto/botocore/blob/develop/botocore/data/ecs/2014-11-13/service-2.json). `DeploymentRolloutState` is `COMPLETED | FAILED | IN_PROGRESS`; `Deployment.status` is `PRIMARY | ACTIVE | INACTIVE`; `Failure` is `arn` / `reason` / `detail`.
- **`ecs-svc/<id>` id format** is not documented in botocore. Grounded instead in moto (`moto/ecs/models.py:527,883,1710` and its service-deployment ARN regex at `:2060`).
- **`reason: "MISSING"`** likewise comes from moto (`describe_services`, `models.py:1673`) and is corroborated by the waiter's own failure acceptor.
- **Verified with AWS CLI v2** against a local Floci: the issue's exact reproduction now returns the field, and `aws ecs wait services-stable` returns in 1s where it previously ran to timeout.
- **Verified with AWS SDK for Java v2** in `sdk-test-java`, driving the real `EcsWaiter.waitUntilServicesStable` rather than asserting on fields, so the genuine JMESPath acceptor is exercised.

Known deviations are documented in `docs/services/ecs.md` rather than half-implemented: only one deployment (no draining `ACTIVE` alongside `PRIMARY`), no `deploymentController` gating (Floci does not record it yet, and `ECS` is the AWS default), `pendingCount` always 0, and `forceNewDeployment` not minting a new id.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Full suite: **8545 tests, 0 failures**. New `EcsDescribeServicesIntegrationTest` (9 cases) covers the exact member names, id stability across calls, id rollover on task-definition change, rollout state transitions, the empty list for an `INACTIVE` service, and the `MISSING` failure paths. `EcsTests` in `sdk-test-java` gains deployment assertions, a `ServicesStable` waiter test, and a `MISSING` failure test.
