### PR TITLE
feat(ec2): add ReplaceRoute

### DIFF
--- a/docs/services/ec2.md
+++ b/docs/services/ec2.md
@@ -254,6 +254,7 @@ Floci seeds the following resources on first use in each region so Terraform, th
 | AssociateRouteTable | Associates a route table with a subnet. |
 | DisassociateRouteTable | Removes a route table association. |
 | CreateRoute | Adds a route to a route table. |
+| ReplaceRoute | Replaces the target of an existing route. |
 | DeleteRoute | Removes a route from a route table. |
 
 ### Network ACLs

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -156,7 +156,7 @@ public class AwsQueryController {
             "CreateInternetGateway", "DescribeInternetGateways", "DeleteInternetGateway",
             "AttachInternetGateway", "DetachInternetGateway",
             "CreateRouteTable", "DescribeRouteTables", "DeleteRouteTable",
-            "AssociateRouteTable", "DisassociateRouteTable", "CreateRoute", "DeleteRoute",
+            "AssociateRouteTable", "DisassociateRouteTable", "CreateRoute", "ReplaceRoute", "DeleteRoute",
             "CreateNetworkAcl", "DescribeNetworkAcls", "DeleteNetworkAcl",
             "CreateNetworkAclEntry", "ReplaceNetworkAclEntry", "DeleteNetworkAclEntry",
             "ReplaceNetworkAclAssociation",

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -28,6 +28,15 @@ public class Ec2QueryHandler {
     private static final DateTimeFormatter ISO_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
             .withZone(ZoneOffset.UTC);
 
+    /** ReplaceRoute targets AWS accepts that a stored {@code Route} cannot represent here. */
+    private static final List<String> UNSUPPORTED_ROUTE_TARGETS = List.of(
+            "CarrierGatewayId", "CoreNetworkArn", "EgressOnlyInternetGatewayId", "InstanceId",
+            "LocalGatewayId", "NetworkInterfaceId", "OdbNetworkArn",
+            "TransitGatewayId", "VpcEndpointId", "VpcPeeringConnectionId");
+
+    /** The gateway id a route table's built-in route carries (see Ec2Service#createRouteTable). */
+    private static final String LOCAL_GATEWAY_ID = "local";
+
     private final Ec2Service service;
     private final EmulatorConfig config;
     private final FlowLogService flowLogService;
@@ -123,6 +132,7 @@ public class Ec2QueryHandler {
                 case "AssociateRouteTable" -> handleAssociateRouteTable(params, region);
                 case "DisassociateRouteTable" -> handleDisassociateRouteTable(params, region);
                 case "CreateRoute" -> handleCreateRoute(params, region);
+                case "ReplaceRoute" -> handleReplaceRoute(params, region);
                 case "DeleteRoute" -> handleDeleteRoute(params, region);
                 // Network ACLs
                 case "CreateNetworkAcl" -> handleCreateNetworkAcl(params, region);
@@ -1497,6 +1507,33 @@ public class Ec2QueryHandler {
         String natGwId = p.getFirst("NatGatewayId");
         service.createRoute(region, rtId, dest, gwId, natGwId);
         return booleanResponse("CreateRoute");
+    }
+
+    private Response handleReplaceRoute(MultivaluedMap<String, String> p, String region) {
+        // A route holds only a gateway or a NAT gateway here. Every other AWS target keeps the
+        // UnsupportedOperation it returned before this action existed, rather than being accepted
+        // and quietly clearing the route it was meant to repoint.
+        for (String target : UNSUPPORTED_ROUTE_TARGETS) {
+            if (p.getFirst(target) != null) {
+                throw new AwsException("UnsupportedOperation",
+                        "ReplaceRoute with " + target + " is not supported.", 400);
+            }
+        }
+        String rtId = p.getFirst("RouteTableId");
+        String dest = p.getFirst("DestinationCidrBlock");
+        String gwId = p.getFirst("GatewayId");
+        String natGwId = p.getFirst("NatGatewayId");
+        // Resetting a route to the local target is expressible: `local` is the gateway id the
+        // route table's built-in route already carries, so it needs no new field on Route.
+        if (Boolean.parseBoolean(p.getFirst("LocalTarget"))) {
+            if (gwId != null || natGwId != null) {
+                throw new AwsException("InvalidParameterCombination",
+                        "ReplaceRoute takes exactly one target.", 400);
+            }
+            gwId = LOCAL_GATEWAY_ID;
+        }
+        service.replaceRoute(region, rtId, dest, gwId, natGwId);
+        return booleanResponse("ReplaceRoute");
     }
 
     private Response handleDeleteRoute(MultivaluedMap<String, String> p, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -2418,6 +2418,41 @@ public class Ec2Service implements ContainerTeardown {
         }
     }
 
+    public void replaceRoute(String region, String routeTableId, String destinationCidrBlock, String gatewayId, String natGatewayId) {
+        if (destinationCidrBlock == null || destinationCidrBlock.isBlank()) {
+            throw new AwsException("MissingParameter",
+                    "The request must include DestinationCidrBlock; routes are matched on their IPv4 destination.", 400);
+        }
+        // AWS takes exactly one target. Rejecting both-or-neither also keeps the targets this
+        // emulator cannot model (transit gateway, network interface, peering connection, ...) from
+        // silently clearing the route and reporting success.
+        boolean hasGateway = gatewayId != null && !gatewayId.isBlank();
+        boolean hasNatGateway = natGatewayId != null && !natGatewayId.isBlank();
+        if (hasGateway == hasNatGateway) {
+            throw new AwsException("InvalidParameterCombination",
+                    "ReplaceRoute takes exactly one target, and only GatewayId or NatGatewayId is supported.", 400);
+        }
+
+        ensureDefaultResources(region);
+        synchronized (lockFor(key(region, routeTableId))) {
+            RouteTable current = getRequiredRouteTable(region, routeTableId);
+            List<Route> next = new ArrayList<>(current.getRoutes());
+            Route existing = next.stream()
+                    .filter(r -> destinationCidrBlock.equals(r.getDestinationCidrBlock()))
+                    .findFirst()
+                    .orElseThrow(() -> new AwsException("InvalidRoute.NotFound",
+                            "The route identified by " + destinationCidrBlock + " does not exist", 400));
+
+            // The target the request does not name is cleared rather than carried over from the
+            // route being replaced.
+            Route replacement = new Route(destinationCidrBlock, hasGateway ? gatewayId : null, existing.getOrigin());
+            replacement.setNatGatewayId(hasNatGateway ? natGatewayId : null);
+            next.set(next.indexOf(existing), replacement);
+            current.setRoutes(next);
+            routeTables.put(key(region, routeTableId), current);
+        }
+    }
+
     public void deleteRoute(String region, String routeTableId, String destinationCidrBlock) {
         ensureDefaultResources(region);
         synchronized (lockFor(key(region, routeTableId))) {

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ReplaceRouteIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ReplaceRouteIntegrationTest.java
@@ -1,0 +1,338 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.junit.QuarkusTest;
+import static io.restassured.RestAssured.given;
+
+/**
+ * ReplaceRoute swaps the target of an existing route. AWS takes exactly one target per call, so
+ * the target the request does not name is cleared rather than carried over — these tests pin that,
+ * because a merge implementation would leave a route holding two targets at once.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class Ec2ReplaceRouteIntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/ec2/aws4_request";
+
+    private static final String DEFAULT_ROUTE = "0.0.0.0/0";
+    private static final String UNROUTED_CIDR = "198.51.100.0/24";
+    private static final String INTERNET_GATEWAY = "igw-0replace0route0test";
+    private static final String NAT_GATEWAY = "nat-0replace0route0test";
+    private static final String DEFAULT_ROUTE_NODE =
+            "DescribeRouteTablesResponse.routeTableSet.item.routeSet.item"
+                    + ".find { it.destinationCidrBlock == '0.0.0.0/0' }";
+    private static final String ROUTE_SET =
+            "DescribeRouteTablesResponse.routeTableSet.item.routeSet.item";
+
+    private static String routeTableId;
+
+    @Test
+    @Order(1)
+    void createRouteTableWithAnInternetGatewayRoute() {
+        String vpcId = given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "203.0.113.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+
+        routeTableId = given()
+            .formParam("Action", "CreateRouteTable")
+            .formParam("VpcId", vpcId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateRouteTableResponse.routeTable.routeTableId");
+
+        given()
+            .formParam("Action", "CreateRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationCidrBlock", DEFAULT_ROUTE)
+            .formParam("GatewayId", INTERNET_GATEWAY)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void replaceRouteSwapsTheGatewayForANatGatewayAndClearsTheOldTarget() {
+        given()
+            .formParam("Action", "ReplaceRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationCidrBlock", DEFAULT_ROUTE)
+            .formParam("NatGatewayId", NAT_GATEWAY)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ReplaceRouteResponse.return", equalTo("true"));
+
+        // The table also holds the local route CreateRouteTable inserts, so each assertion selects
+        // the route it means rather than the first item in the set.
+        String replaced = ROUTE_SET + ".find { it.destinationCidrBlock == '" + DEFAULT_ROUTE + "' }";
+        String local = ROUTE_SET + ".find { it.gatewayId == 'local' }";
+
+        String table = given()
+            .formParam("Action", "DescribeRouteTables")
+            .formParam("RouteTableId.1", routeTableId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(replaced + ".natGatewayId", equalTo(NAT_GATEWAY))
+            // The route keeps the origin it was created with — ReplaceRoute is not an origin value.
+            .body(replaced + ".origin", equalTo("CreateRoute"))
+            // ...and only the addressed route moved.
+            .body(local + ".origin", equalTo("CreateRouteTable"))
+            .extract().asString();
+
+        // The whole point of replace-not-merge: the internet gateway is gone from the table, not
+        // left sitting beside the NAT gateway on the same route.
+        assertThat(table, not(containsString(INTERNET_GATEWAY)));
+    }
+
+    @Test
+    @Order(3)
+    void replaceRouteOnAnUnknownDestinationIsRejected() {
+        given()
+            .formParam("Action", "ReplaceRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationCidrBlock", UNROUTED_CIDR)
+            .formParam("GatewayId", INTERNET_GATEWAY)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidRoute.NotFound"));
+    }
+
+    /**
+     * A target floci cannot model (transit gateway, network interface, peering connection, ...)
+     * arrives as neither GatewayId nor NatGatewayId. Reporting success while quietly clearing the
+     * route would be worse than the UnsupportedOperation callers got before this action existed.
+     */
+    @Test
+    @Order(5)
+    void replaceRouteWithNoSupportedTargetIsRejectedAndLeavesTheRouteAlone() {
+        given()
+            .formParam("Action", "ReplaceRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationCidrBlock", DEFAULT_ROUTE)
+            .formParam("TransitGatewayId", "tgw-0replace0route0test")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("UnsupportedOperation"));
+
+        given()
+            .formParam("Action", "DescribeRouteTables")
+            .formParam("RouteTableId.1", routeTableId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(ROUTE_SET + ".find { it.destinationCidrBlock == '" + DEFAULT_ROUTE + "' }.natGatewayId",
+                    equalTo(NAT_GATEWAY));
+    }
+
+    @Test
+    @Order(6)
+    void replaceRouteWithTwoTargetsIsRejected() {
+        given()
+            .formParam("Action", "ReplaceRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationCidrBlock", DEFAULT_ROUTE)
+            .formParam("GatewayId", INTERNET_GATEWAY)
+            .formParam("NatGatewayId", NAT_GATEWAY)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidParameterCombination"));
+    }
+
+    /**
+     * AWS lets the local route be repointed at a NAT gateway and then reset with LocalTarget, and
+     * both halves are expressible here because `local` is simply the gateway id that route carries.
+     * Supporting only the repoint would make the built-in route a one-way door.
+     */
+    @Test
+    @Order(8)
+    void theLocalRouteCanBeRepointedAndThenResetToLocal() {
+        String vpcCidr = "203.0.113.0/24";
+
+        given()
+            .formParam("Action", "ReplaceRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationCidrBlock", vpcCidr)
+            .formParam("NatGatewayId", NAT_GATEWAY)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .formParam("Action", "ReplaceRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationCidrBlock", vpcCidr)
+            .formParam("LocalTarget", "true")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ReplaceRouteResponse.return", equalTo("true"));
+
+        given()
+            .formParam("Action", "DescribeRouteTables")
+            .formParam("RouteTableId.1", routeTableId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(ROUTE_SET + ".find { it.destinationCidrBlock == '" + vpcCidr + "' }.gatewayId",
+                    equalTo("local"))
+            // The route was created by CreateRouteTable, so a replacement that hardcoded an origin
+            // instead of preserving one would show up right here.
+            .body(ROUTE_SET + ".find { it.destinationCidrBlock == '" + vpcCidr + "' }.origin",
+                    equalTo("CreateRouteTable"));
+    }
+
+    /** `--no-local-target` puts LocalTarget=false on the wire; it must not read as a target. */
+    @Test
+    @Order(9)
+    void anExplicitlyFalseLocalTargetIsNotTreatedAsATarget() {
+        given()
+            .formParam("Action", "ReplaceRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationCidrBlock", DEFAULT_ROUTE)
+            .formParam("GatewayId", INTERNET_GATEWAY)
+            .formParam("LocalTarget", "false")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ReplaceRouteResponse.return", equalTo("true"));
+
+        // ...and the NAT gateway this route used to carry is gone. Order 2 pins the gateway -> NAT
+        // direction; without this the reverse direction could carry the old target over unnoticed.
+        String table = given()
+            .formParam("Action", "DescribeRouteTables")
+            .formParam("RouteTableId.1", routeTableId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(DEFAULT_ROUTE_NODE + ".gatewayId", equalTo(INTERNET_GATEWAY))
+            .extract().asString();
+
+        assertThat(table, not(containsString(NAT_GATEWAY)));
+    }
+
+    /** A destination with no target at all must not blank the route and report success. */
+    @Test
+    @Order(10)
+    void replaceRouteWithNoTargetAtAllIsRejected() {
+        given()
+            .formParam("Action", "ReplaceRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationCidrBlock", DEFAULT_ROUTE)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidParameterCombination"));
+
+        given()
+            .formParam("Action", "DescribeRouteTables")
+            .formParam("RouteTableId.1", routeTableId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(DEFAULT_ROUTE_NODE + ".gatewayId", equalTo(INTERNET_GATEWAY));
+    }
+
+    /** LocalTarget is a target: pairing it with another one is still two targets. */
+    @Test
+    @Order(11)
+    void localTargetCombinedWithAnotherTargetIsRejected() {
+        given()
+            .formParam("Action", "ReplaceRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationCidrBlock", DEFAULT_ROUTE)
+            .formParam("LocalTarget", "true")
+            .formParam("GatewayId", INTERNET_GATEWAY)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidParameterCombination"));
+    }
+
+    /** An IPv6 or prefix-list ReplaceRoute carries no DestinationCidrBlock; it must not 500. */
+    @Test
+    @Order(7)
+    void replaceRouteWithoutAnIpv4DestinationIsRejected() {
+        given()
+            .formParam("Action", "ReplaceRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationIpv6CidrBlock", "::/0")
+            .formParam("GatewayId", INTERNET_GATEWAY)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("MissingParameter"));
+    }
+
+    @Test
+    @Order(4)
+    void replaceRouteOnAnUnknownRouteTableIsRejected() {
+        given()
+            .formParam("Action", "ReplaceRoute")
+            .formParam("RouteTableId", "rtb-0000000000000dead")
+            .formParam("DestinationCidrBlock", DEFAULT_ROUTE)
+            .formParam("GatewayId", INTERNET_GATEWAY)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidRouteTableID.NotFound"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds EC2 `ReplaceRoute`. Terraform calls it whenever an existing route changes target, so today a route table can be created but never updated — `terraform apply` fails with `UnsupportedOperation: Operation ReplaceRoute is not supported` and the only workaround is to recreate the table. Closes #2087.

The action replaces the target of the route matching `DestinationCidrBlock`. AWS takes **exactly one** target per call, so the target a request does not name is cleared rather than carried over — a merge would leave a route holding two targets at once, which AWS cannot produce. `origin` is preserved, since `ReplaceRoute` is not one of the documented origin values.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Wire shape is taken from the [ReplaceRoute API reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ReplaceRoute.html): request params, the `requestId` + `return` response (so it uses the existing `booleanResponse` helper, same as `CreateRoute`/`DeleteRoute`), and the "exactly one of the resources from the parameter list" rule that makes this replace-not-merge. Error codes come from the [EC2 error reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html), since the ReplaceRoute page lists no action-specific errors:

| condition | code |
|---|---|
| no route matches the destination | `InvalidRoute.NotFound` |
| route table does not exist | `InvalidRouteTableID.NotFound` (existing behaviour) |
| `DestinationCidrBlock` absent — an IPv6 or prefix-list request | `MissingParameter` |
| two targets, or none | `InvalidParameterCombination` |
| a target this emulator does not model | `UnsupportedOperation` |

Exercised with the AWS CLI against a local emulator in addition to the integration tests, including `--local-target` and `--no-local-target`. The tests drive the Query protocol directly through RestAssured rather than an SDK client — that matches the EC2 package, where none of the existing integration tests use `software.amazon.awssdk`.

**Scope — please read before reviewing the target list.** `Route` models a gateway and a NAT gateway. `LocalTarget` needs no new field either, because `local` is simply the gateway id a route table's built-in route already carries, so resetting to it is expressible and AWS's documented repoint-then-reset flow works end to end. The remaining ten targets (`TransitGatewayId`, `NetworkInterfaceId`, `VpcPeeringConnectionId`, `CarrierGatewayId`, `CoreNetworkArn`, `EgressOnlyInternetGatewayId`, `InstanceId`, `LocalGatewayId`, `OdbNetworkArn`, `VpcEndpointId`) are rejected with `UnsupportedOperation` before any mutation. That is deliberate: accepting them would have meant reporting success while clearing the target of a route that was previously correct, which is strictly worse than the loud failure callers get today. Supporting them properly means growing `Route`, which belongs in its own change.

Two things I would rather flag than have you find:

- **`LocalTarget=true` on a route other than the local one** is accepted here and produces a second route targeting `local`. AWS restricts the local target to the VPC's own CIDR. I left it unguarded because nothing in the surrounding code validates this class of thing — gateway existence, CIDR normalisation and duplicate destinations are all unchecked on `CreateRoute` today — so a check only here would be inconsistent. Happy to add one if you would rather.
- **The `AwsQueryController` action-list entry is a consistency fix, not a requirement.** Any request carrying an ec2-scoped SigV4 credential resolves the service before that list is read, so the reporter's case works without it; it matters only for requests with no resolvable credential scope.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

`Ec2ReplaceRouteIntegrationTest` is new — 11 tests. Full `-Dtest='Ec2*Test'` is **287 passing, 0 failures** across 15 classes on JDK 25. Each guard was checked by mutating it and confirming a test fails: reverting replace-not-merge to a merge, dropping the exactly-one-target check, hardcoding `origin`, removing the destination guard, disabling the unsupported-target loop, and turning the `LocalTarget` parse back into a presence check — each is caught by exactly one test.

One note on the docs row: `docs/services/ec2.md` has no `floci:actions` markers and `Ec2QueryHandler` sits under `deferred_handlers` in `tools/docs/services.yaml`, so the table is hand-maintained. I ran `regen_action_docs.py --strict` and the file is byte-identical afterwards, so the added row is exactly what the generator would emit.
