### PR TITLE
fix(lambda): disable HTTP/2 cleartext on the runtime API server

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/runtime/RuntimeApiServer.java
@@ -451,7 +451,18 @@ public class RuntimeApiServer {
     private void tryListen(CompletableFuture<Void> started, Router router, long deadline) {
         if (started.isDone()) return;
         httpServer = vertx.createHttpServer(new HttpServerOptions()
-                .setMaxFormAttributeSize(-1));
+                .setMaxFormAttributeSize(-1)
+                // Real AWS's Runtime/Extensions API is plain HTTP/1.1. Vert.x defaults to
+                // accepting an h2c upgrade, which the JDK HttpClient used in tests and by some
+                // language runtimes opts into unless told otherwise. That multiplexes every
+                // request from one client (e.g. an extension's register + its own /event/next
+                // long-poll) onto a single connection/stream-set, so stop()'s close of that
+                // connection can race a just-flushed response's HTTP/2 stream-completion
+                // bookkeeping instead of tearing down an already-idle connection — see #2180.
+                // Disabling h2c makes the client fall back to a plain HTTP/1.1 request
+                // automatically (no client-side change needed) and matches AWS's actual wire
+                // protocol.
+                .setHttp2ClearTextEnabled(false));
         httpServer.requestHandler(router).listen(port, "0.0.0.0", result -> {
             if (result.succeeded()) {
                 LOG.infov("RuntimeApiServer started on port {0}", String.valueOf(port));


### PR DESCRIPTION
## Summary

Closes #2180.

`RuntimeApiServerTest.extensionRegister_racedAgainstStop_eventuallyDeliversShutdown` flaked intermittently (~1 in 8500 runs) with an `EOFException` from the JDK HTTP/2 client, surviving #2156's fix for the write-vs-close ordering bug. `stop()` already waits for each parked write's flush to complete before closing the `httpServer` (that's what #2156 added), but a completed flush only confirms the bytes were handed to the local socket, not that the peer received them before the connection is torn down — the HTTP/2 stream/connection-close bookkeeping for a multiplexed h2c connection can still race that same close.

**Fix**: disable HTTP/2 cleartext (`setHttp2ClearTextEnabled(false)`) on the `RuntimeApiServer`'s `HttpServerOptions`. Real AWS's Runtime/Extensions API is plain HTTP/1.1 — floci doesn't need HTTP/2 here at all. Disabling h2c removes the whole class of multiplexed-connection races this flake falls into; the JDK `HttpClient` (which defaults to attempting an h2c upgrade over plaintext) automatically falls back to a normal HTTP/1.1 request when the server doesn't offer the upgrade, so no client-side or test change was needed.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: floci was accepting HTTP/2 (h2c) connections on the Runtime/Extensions API server, which real AWS Lambda's runtime API never speaks (it's plain HTTP/1.1). That divergence is what let this flake happen at all — HTTP/1.1's simpler one-request-per-connection-turn semantics don't have the multiplexed stream-vs-connection-close ordering this race depended on.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

### Testing details

No new test — the existing racing test (`extensionRegister_racedAgainstStop_eventuallyDeliversShutdown`, 300 iterations/run) is the regression coverage. Ran it 5x (1500 iterations total) with this change, 0 failures, plus the full `RuntimeApiServerTest` class and the rest of the lambda module's test suite (`ContainerLauncherTest`, `LambdaImageConfigTest`, `WarmPoolTest`, `LambdaExecutorServiceTest`) — all green. 1500 iterations doesn't fully prove a ~1-in-8500 flake is gone, so I'd like this to run in CI for a while before calling it conclusively fixed; happy to add an h2c-specific regression test if reviewers want tighter coverage than "the flake didn't reproduce."

Also checked PR #2098 (open, restructures `stop()` into `quiesce()`/`close()` for a different bug, #2091) — it doesn't touch this code path or fix this race, so this change is independent of it.