### PR TITLE
fix(ses): pass the custom-verification-email store in the list-management test

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceListManagementTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceListManagementTest.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttribute
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.Contact;
 import io.github.hectorvent.floci.services.ses.model.ContactList;
+import io.github.hectorvent.floci.services.ses.model.CustomVerificationEmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
@@ -69,6 +70,7 @@ class SesServiceListManagementTest {
                 contactStore,
                 new InMemoryStorage<String, String>(),
                 new InMemoryStorage<String, ReceiptRuleSet>(),
+                new InMemoryStorage<String, CustomVerificationEmailTemplate>(),
                 smtpRelay,
                 new ObjectMapper(),
                 Clock.systemUTC());


### PR DESCRIPTION
## Summary

**`main` does not compile.** `SesServiceListManagementTest` calls a `SesService` constructor that no longer exists, so `mvn test` fails at `testCompile` before a single test runs ([run 31290736361](https://github.com/floci-io/floci/actions/runs/31290736361/job/93187294589)).

Two SES changes landed three minutes apart and collided semantically:

| | |
|---|---|
| `fa9ed910` **#1875** merged 02:33 | added `SesServiceListManagementTest`, calling `SesService(...)` with twelve stores |
| `aed50cc2` **#1840** merged 02:36 | added a thirteenth store for custom verification email templates, and updated the five sibling tests it could see |

The test this PR fixes did not exist on #1840's branch, so it was never updated. Neither change conflicts textually, both were green on their own branch, and the break only exists once both are present.

The fix is the missing argument, in the same position the five siblings already use.

## Attribution, for the record

This was **not** introduced by the commit whose run reported it. I checked out `aed50cc2` and ran `testCompile`: it fails identically one commit earlier. The run that went red was simply the first on `main` allowed to finish. Six PRs merged between 02:29 and 02:38 and each push cancelled the previous run, so five consecutive commits never reported:

```
02:38  failure    8b8f8377  ← first run allowed to complete
02:36  cancelled  aed50cc2  ← actually broke the build
02:34  cancelled  d039780e
02:33  cancelled  fa9ed910
02:32  cancelled  66fd109a
02:29  cancelled  42363886
```

Worth considering separately whether `main` should be exempt from CI concurrency cancellation. As it stands, a rapid merge train can keep a broken trunk invisible for as long as merges keep arriving, and the blame lands on whoever merges next.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

N/A. Test-only change; no emulated surface, no request or response shape, and no production code is touched.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

No new test: this repairs an existing one that could not compile. `./mvnw test` now runs clean at **8615 tests, 0 failures**, where on `main` it currently fails at `testCompile`. `SesServiceListManagementTest` itself passes 18/18 and the SES suite 746/746.
