### PR TITLE
fix(ec2): delete key pairs by name through the storage backend

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1617,7 +1617,13 @@ public class Ec2Service implements ContainerTeardown {
         if (keyPairId != null && !keyPairId.isEmpty()) {
             keyPairs.delete(key(region, keyPairId));
         } else {
-            keyPairs.scan(k -> true).removeIf(k -> k.getRegion().equals(region) && k.getKeyName().equals(keyName));
+            // scan() returns a detached copy, so the key pair has to be resolved to its
+            // store key and deleted through the backend — mutating the scan result does
+            // not touch the store.
+            keyPairs.scan(k -> true).stream()
+                    .filter(k -> k.getRegion().equals(region) && k.getKeyName().equals(keyName))
+                    .map(KeyPair::getKeyPairId)
+                    .forEach(id -> keyPairs.delete(key(region, id)));
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -2660,6 +2660,50 @@ class Ec2IntegrationTest {
             .post("/")
         .then()
             .statusCode(200);
+
+        // DeleteKeyPair always answers 200, so the delete is only proven by a
+        // follow-up describe.
+        given()
+            .formParam("Action", "DescribeKeyPairs")
+            .formParam("KeyPairId.1", keyPairId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidKeyPair.NotFound"));
+    }
+
+    @Test
+    @Order(108)
+    void deleteKeyPairByName() {
+        given()
+            .formParam("Action", "CreateKeyPair")
+            .formParam("KeyName", "delete-by-name-key")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .formParam("Action", "DeleteKeyPair")
+            .formParam("KeyName", "delete-by-name-key")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .formParam("Action", "DescribeKeyPairs")
+            .formParam("KeyName.1", "delete-by-name-key")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidKeyPair.NotFound"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -375,6 +375,72 @@ class Ec2ServiceTest {
     }
 
     @Test
+    void deleteKeyPairByNameRemovesItFromTheStore() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+
+        service.createKeyPair("us-east-1", "by-name");
+        service.deleteKeyPair("us-east-1", "by-name", null);
+
+        // A deleted key pair is gone for good: describe by name must report NotFound
+        // rather than returning the key that DeleteKeyPair claimed to remove.
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.describeKeyPairs("us-east-1", List.of("by-name"), List.of()));
+        assertEquals("InvalidKeyPair.NotFound", error.getErrorCode());
+        assertTrue(service.describeKeyPairs("us-east-1", List.of(), List.of()).isEmpty());
+    }
+
+    @Test
+    void deleteKeyPairByNameLeavesOtherKeysAndRegionsIntact() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+
+        service.createKeyPair("us-east-1", "target");
+        service.createKeyPair("us-east-1", "bystander");
+        service.createKeyPair("eu-west-1", "target");
+
+        service.deleteKeyPair("us-east-1", "target", null);
+
+        // Deleting resolves through the store key, so it must not take the same-named
+        // key in another region — nor any other key in the same region — with it.
+        assertEquals(1, service.describeKeyPairs("us-east-1", List.of("bystander"), List.of()).size());
+        assertEquals(1, service.describeKeyPairs("eu-west-1", List.of("target"), List.of()).size());
+    }
+
+    @Test
+    void deleteKeyPairByIdRemovesItFromTheStore() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+
+        String keyPairId = service.createKeyPair("us-east-1", "by-id").getKeyPairId();
+        service.deleteKeyPair("us-east-1", null, keyPairId);
+
+        assertTrue(service.describeKeyPairs("us-east-1", List.of(), List.of()).isEmpty());
+    }
+
+    @Test
+    void deleteKeyPairForUnknownNameIsANoOp() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+
+        service.createKeyPair("us-east-1", "present-key");
+
+        // Real EC2 DeleteKeyPair is idempotent — deleting a key that does not exist
+        // succeeds rather than raising InvalidKeyPair.NotFound.
+        service.deleteKeyPair("us-east-1", "never-existed", null);
+
+        assertEquals(1, service.describeKeyPairs("us-east-1", List.of("present-key"), List.of()).size());
+    }
+
+    @Test
     void registerImageReusingSnapshotDoesNotOverwriteSnapshotMetadata() {
         Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
                 mock(Ec2PortForwardManager.class),


### PR DESCRIPTION
## Summary

`DeleteKeyPair` with `KeyName` returned HTTP 200 but never removed the key pair. The key stayed
visible to `DescribeKeyPairs`, and recreating it under the same name then failed with
`InvalidKeyPair.Duplicate`. Deleting by `KeyPairId` worked — only the by-name form was broken,
which is the form the AWS CLI docs lead with and the one most teardown scripts use.

```bash
# BEFORE the fix
aws --endpoint-url http://localhost:4566 ec2 create-key-pair --key-name my-key
aws --endpoint-url http://localhost:4566 ec2 delete-key-pair --key-name my-key
#   -> 200 OK, "return": true

aws --endpoint-url http://localhost:4566 ec2 describe-key-pairs --key-names my-key
#   -> still returns my-key          <- wrong: it was just deleted

aws --endpoint-url http://localhost:4566 ec2 create-key-pair --key-name my-key
#   -> InvalidKeyPair.Duplicate      <- wrong: cannot recreate a "deleted" key

# AFTER the fix
aws --endpoint-url http://localhost:4566 ec2 delete-key-pair --key-name my-key
aws --endpoint-url http://localhost:4566 ec2 describe-key-pairs --key-names my-key
#   -> InvalidKeyPair.NotFound       <- correct, matches real EC2
```

The practical impact is on delete-and-recreate loops: a test suite or Terraform run that works
against real AWS wedges against Floci, with no error to point at — the delete reports success.

Closes #2185

### Root cause

`Ec2Service.deleteKeyPair`, by-name branch:

```java
keyPairs.scan(k -> true).removeIf(k -> k.getRegion().equals(region) && k.getKeyName().equals(keyName));
```

`StorageBackend.scan` is documented to return a **detached copy** — "Callers may sort, filter, or
otherwise mutate the returned list without affecting the underlying store" — and both
implementations honour that (`InMemoryStorage` builds a fresh `ArrayList`, `PersistentStorage`
collects into `ArrayList::new`). So `removeIf` mutated a throwaway list and the store was never
touched. The statement is a guaranteed no-op that type-checks and reads like a delete.

The store is keyed by `key(region, keyPairId)`, so removal has to go through
`keyPairs.delete(storeKey)` — exactly what the by-id branch one line above already did.

### What changed

`Ec2Service.deleteKeyPair` now resolves matching key pairs to their IDs and deletes each through
the backend:

```java
keyPairs.scan(k -> true).stream()
        .filter(k -> k.getRegion().equals(region) && k.getKeyName().equals(keyName))
        .map(KeyPair::getKeyPairId)
        .forEach(id -> keyPairs.delete(key(region, id)));
```

Region scoping and the by-id branch are unchanged. Iterating the detached copy while deleting
from the store is safe precisely because the list is a copy, so there is no
concurrent-modification hazard.

Alternatives considered and rejected: adding `deleteIf(Predicate)` to `StorageBackend` (changes a
core interface used across many services to fix one call site); resolving via `describeKeyPairs`
(it throws `NotFound`, which would break `DeleteKeyPair`'s idempotency); re-keying the store by
name (a persisted-schema change for no behavioural gain).

### Why it was not caught

The only existing `DeleteKeyPair` test passes `KeyPairId` — the branch that already worked — and
asserts only `statusCode(200)`. Since `DeleteKeyPair` returns `<return>true</return>`
unconditionally, a 200 proves nothing about whether anything was removed. The by-name path had no
test at all. This PR closes both gaps.

### Risk / rollback

Low. Behaviour-only change to one internal method — no public signature, wire format, persisted
schema, or config touched. Rollback is reverting a single hunk.

`grep -rn "scan(.*)\.removeIf" src/main/java` returns exactly one hit — the line fixed here — so
this is a one-off rather than a pattern needing a sweep. Other `removeIf` calls in the codebase
operate on live collections and are legitimate.

Not in this PR: `scan()` returning a detached copy is easy to misuse this way and the compiler
cannot catch it. A `StorageBackend.deleteIf(...)`, or returning an explicitly immutable list,
would make the safe path the obvious one — but that is an interface change across two backends
and many call sites, so it belongs in its own issue rather than a bug fix.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** `DeleteKeyPair` with `KeyName` reported success (`<return>true</return>`,
HTTP 200) while leaving the key pair in the store, so a subsequent `DescribeKeyPairs` still
returned it and `CreateKeyPair` with the same name failed as a duplicate. Real EC2 removes the
key pair, after which describe reports `InvalidKeyPair.NotFound`.

Two AWS semantics were deliberately preserved rather than "tidied":

- **`DeleteKeyPair` is idempotent.** Deleting a name that does not exist succeeds in real EC2, so
  it remains a silent no-op here rather than raising `InvalidKeyPair.NotFound`. Pinned by
  `deleteKeyPairForUnknownNameIsANoOp`.
- **`DescribeKeyPairs` is not.** It *does* throw `InvalidKeyPair.NotFound` for a missing name.
  That asymmetry against `DeleteKeyPair` is correct AWS behaviour, not an inconsistency to fix —
  and it is what the new tests assert against.

Verified with AWS CLI 2.x against `./mvnw quarkus:dev` using the reproduction from #2185, plus
automated coverage over the Query-protocol wire format:

| Test | Exercises |
|---|---|
| `Ec2ServiceTest.deleteKeyPairByNameRemovesItFromTheStore` | The regression test — delete by name, then assert describe reports `InvalidKeyPair.NotFound` and the account is empty. |
| `Ec2ServiceTest.deleteKeyPairByNameLeavesOtherKeysAndRegionsIntact` | Guards against over-deletion: a same-named key in another region and a different key in the same region both survive. |
| `Ec2ServiceTest.deleteKeyPairByIdRemovesItFromTheStore` | Locks in the previously-untested by-id path, asserting actual removal rather than a 200. |
| `Ec2ServiceTest.deleteKeyPairForUnknownNameIsANoOp` | Pins AWS-correct idempotency so a future change doesn't add a `NotFound` throw. |
| `Ec2IntegrationTest.deleteKeyPairByName` | The issue's exact repro over the wire: CreateKeyPair → DeleteKeyPair by `KeyName` → DescribeKeyPairs returns 400 `InvalidKeyPair.NotFound`. |

Also strengthened the existing `Ec2IntegrationTest.deleteKeyPair` to follow its 200 with a
describe asserting the key is actually gone, so the by-id path cannot silently rot the same way.

**Red/green verified:** with the production hunk reverted and the new tests kept,
`deleteKeyPairByNameRemovesItFromTheStore` and `deleteKeyPairByName` both fail; with it applied,
both pass.

Suite results on this branch, rebased onto `3b760bd8`:

- Full suite (`./mvnw test`): **8692 run, 0 failures, 0 errors, 9 skipped** — BUILD SUCCESS.
- EC2 scope (`-Dtest='Ec2*'`): **292 run, 0 failures, 0 errors**.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
