### PR TITLE
refactor(s3): move website folder-resolution policy into S3Service

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -808,7 +808,7 @@ public class S3Controller {
             return fullObjectResponse(bucket, key, versionId, obj, overrides, includeChecksum);
         } catch (AwsException e) {
             emitCloudTrailEvent("GetObject", bucket, key, 0L, 0L, e.getErrorCode(), e.getMessage());
-            if (isWebsiteErrorDocumentTrigger(e) && isWebsiteRequest(httpHeaders, uriInfo)) {
+            if (S3Service.isWebsiteErrorDocumentTrigger(e) && isWebsiteRequest(httpHeaders, uriInfo)) {
                 Response websiteError = serveWebsiteErrorResponse(bucket, authorization, e);
                 if (websiteError != null) {
                     return websiteError;
@@ -995,7 +995,7 @@ public class S3Controller {
             return resp.build();
         } catch (AwsException e) {
             emitCloudTrailEvent("HeadObject", bucket, key, 0L, 0L, e.getErrorCode(), e.getMessage());
-            if (isWebsiteErrorDocumentTrigger(e) && isWebsiteRequest(httpHeaders, uriInfo)) {
+            if (S3Service.isWebsiteErrorDocumentTrigger(e) && isWebsiteRequest(httpHeaders, uriInfo)) {
                 Response websiteError = serveWebsiteErrorResponse(bucket, authorization, e);
                 if (websiteError != null) {
                     return headOnlyResponse(websiteError);
@@ -2216,96 +2216,56 @@ public class S3Controller {
      */
     private Response serveWebsiteObject(String bucket, String key,
                                         S3Service.RequestAuthorization authorization) {
-        WebsiteConfiguration cfg;
-        try {
-            cfg = s3Service.getBucketWebsite(bucket);
-        } catch (AwsException e) {
-            // Only "no website configuration" means fall through to normal handling; a real error
-            // (e.g. NoSuchBucket) must propagate rather than be masked as "not a website".
-            if (!"NoSuchWebsiteConfiguration".equals(e.getErrorCode())) {
-                throw e;
-            }
-            return null;
-        }
-        String index = cfg.getIndexDocument();
-        if (index == null) {
-            return null;
-        }
-        // The routing layer strips a trailing slash from the object key, so recover the "directory"
-        // intent from the raw request path: a trailing slash (or the site root) means "serve this
-        // prefix's index document"; the prefix is the key without any trailing slash.
-        var request = currentVertxRequest.getCurrent().request();
-        String rawPath = request.path();
-        boolean directory = key.isEmpty() || rawPath.endsWith("/");
-        String prefix = key.endsWith("/") ? key.substring(0, key.length() - 1) : key;
-
-        if (directory) {
-            String indexKey = prefix.isEmpty() ? index : prefix + "/" + index;
-            try {
-                s3Service.authorizeGetObject(bucket, indexKey, null, authorization);
-                S3Object indexObj = s3Service.headObject(bucket, indexKey, null);
-                // A website endpoint serves the index document with no response-header overrides and no
-                // checksum headers (no viewer sends response-* or x-amz-checksum-mode to a website endpoint).
-                return fullObjectResponse(bucket, indexKey, null, indexObj,
-                        new ResponseHeaderOverrides(null, null, null, null, null, null), false);
-            } catch (AwsException e) {
-                if (!isWebsiteErrorDocumentTrigger(e)) {
-                    throw e;
-                }
-                Response err = serveErrorDocument(bucket, cfg, authorization, e.getHttpStatus());
-                return err != null ? err : xmlErrorResponse(e);
-            }
-        }
-        // Not slash-terminated: an exact object is served by the normal path; a prefix that exists only
-        // as a "folder" (an index document lives beneath it) 302-redirects to the slash-terminated form
-        // so the page's relative asset URLs resolve against the right base (matching real S3).
-        if (!s3Service.objectExists(bucket, prefix) && s3Service.objectExists(bucket, prefix + "/" + index)) {
-            // The query string is deliberately dropped: real S3 answers
-            // GET /photos?code=abc&state=xyz with a bare "Location: /photos/" (verified against a
-            // live website endpoint in us-east-1, same for HEAD and for nested prefixes).
-            return Response.status(Response.Status.FOUND)
-                    .header("Location", rawPath + "/")
-                    .build();
-        }
-        return null;
+        // The routing layer strips a trailing slash from the object key, so the "directory" intent
+        // has to be recovered from the raw request path before handing off to the service.
+        String rawPath = currentVertxRequest.getCurrent().request().path();
+        return renderWebsiteResolution(bucket,
+                s3Service.resolveWebsiteRequest(bucket, key, rawPath.endsWith("/"), authorization),
+                rawPath);
     }
 
     private Response serveWebsiteErrorResponse(String bucket,
                                                S3Service.RequestAuthorization authorization,
                                                AwsException cause) {
         try {
-            WebsiteConfiguration webConfig = s3Service.getBucketWebsite(bucket);
-            return serveErrorDocument(bucket, webConfig, authorization, cause.getHttpStatus());
+            return renderWebsiteResolution(bucket,
+                    s3Service.resolveWebsiteError(bucket, authorization, cause.getHttpStatus()), null);
         } catch (AwsException websiteException) {
-            if (!"NoSuchWebsiteConfiguration".equals(websiteException.getErrorCode())) {
-                return xmlErrorResponse(websiteException);
-            }
-            return null;
+            return xmlErrorResponse(websiteException);
         }
     }
 
-    private Response serveErrorDocument(String bucket, WebsiteConfiguration cfg,
-                                        S3Service.RequestAuthorization authorization, int status) {
-        int responseStatus = status == 403 ? 403 : 404;
-        if (cfg.getErrorDocument() == null) {
-            return defaultWebsiteErrorResponse(responseStatus);
-        }
-        try {
-            s3Service.authorizeGetObject(bucket, cfg.getErrorDocument(), null, authorization);
-            S3Object err = s3Service.getObject(bucket, cfg.getErrorDocument());
-            return Response.status(responseStatus)
-                    .entity(err.getData())
-                    .type(err.getContentType())
-                    .header("Content-Length", err.getSize())
-                    .header("x-amz-error-code", websiteErrorCode(responseStatus))
-                    .header("x-amz-error-message", websiteErrorMessage(responseStatus))
-                    .build();
-        } catch (AwsException e) {
-            if (!isWebsiteErrorDocumentTrigger(e)) {
-                throw e;
-            }
-            return defaultWebsiteErrorResponse(responseStatus);
-        }
+    /**
+     * Render a {@link S3Service.WebsiteResolution} as HTTP. {@code rawPath} is only needed for the
+     * directory redirect; pass {@code null} where that outcome cannot occur. Returns {@code null}
+     * for {@code NotAWebsite}, meaning "fall through to the normal object path".
+     */
+    private Response renderWebsiteResolution(String bucket, S3Service.WebsiteResolution resolution,
+                                             String rawPath) {
+        return switch (resolution) {
+            // A website endpoint serves the index document with no response-header overrides and no
+            // checksum headers (no viewer sends response-* or x-amz-checksum-mode to a website endpoint).
+            case S3Service.WebsiteResolution.ServeObject(String key, S3Object object) ->
+                    fullObjectResponse(bucket, key, null, object,
+                            new ResponseHeaderOverrides(null, null, null, null, null, null), false);
+            // The query string is deliberately dropped: real S3 answers
+            // GET /photos?code=abc&state=xyz with a bare "Location: /photos/" (verified against a
+            // live website endpoint in us-east-1, same for HEAD and for nested prefixes).
+            case S3Service.WebsiteResolution.RedirectToDirectory() ->
+                    Response.status(Response.Status.FOUND)
+                            .header("Location", rawPath + "/")
+                            .build();
+            case S3Service.WebsiteResolution.ErrorDocument(S3Object object, int status) ->
+                    Response.status(status)
+                            .entity(object.getData())
+                            .type(object.getContentType())
+                            .header("Content-Length", object.getSize())
+                            .header("x-amz-error-code", websiteErrorCode(status))
+                            .header("x-amz-error-message", websiteErrorMessage(status))
+                            .build();
+            case S3Service.WebsiteResolution.DefaultError(int status) -> defaultWebsiteErrorResponse(status);
+            case S3Service.WebsiteResolution.NotAWebsite() -> null;
+        };
     }
 
     private static Response defaultWebsiteErrorResponse(int status) {
@@ -2317,10 +2277,6 @@ public class S3Controller {
                 .header("x-amz-error-code", websiteErrorCode(status))
                 .header("x-amz-error-message", websiteErrorMessage(status))
                 .build();
-    }
-
-    private static boolean isWebsiteErrorDocumentTrigger(AwsException e) {
-        return "NoSuchKey".equals(e.getErrorCode()) || "AccessDenied".equals(e.getErrorCode());
     }
 
     private static String websiteErrorCode(int status) {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -1221,6 +1221,133 @@ public class S3Service implements Resettable {
         LOG.infov("Deleted website configuration for bucket: {0}", bucketName);
     }
 
+    /**
+     * What a website-endpoint request resolves to. The service decides <em>what</em> to serve;
+     * the controller decides how to render it as HTTP. Keeping the decision here means the policy
+     * is unit-testable without standing up the HTTP layer.
+     */
+    public sealed interface WebsiteResolution {
+
+        /** Serve {@code object} (already read and authorized) as the response body. */
+        record ServeObject(String key, S3Object object) implements WebsiteResolution {}
+
+        /**
+         * The request names a "folder" that only exists as a prefix with an index document
+         * beneath it: redirect to the slash-terminated form so the page's relative asset URLs
+         * resolve against the right base. The target is built by the caller, which is the only
+         * layer that knows the raw request path.
+         */
+        record RedirectToDirectory() implements WebsiteResolution {}
+
+        /** Serve the bucket's custom error document with {@code status}. */
+        record ErrorDocument(S3Object object, int status) implements WebsiteResolution {}
+
+        /** No usable custom error document: render S3's built-in error page with {@code status}. */
+        record DefaultError(int status) implements WebsiteResolution {}
+
+        /** Not a website request — fall through to the normal object path. */
+        record NotAWebsite() implements WebsiteResolution {}
+    }
+
+    /**
+     * Resolve a request against a bucket's website configuration.
+     * <p>
+     * {@code directoryRequest} is the caller's answer to "did the client ask for a directory?" —
+     * the routing layer strips the trailing slash from the object key, so only the caller can see
+     * the slash that distinguishes {@code /docs/} (serve {@code docs/index.html}) from
+     * {@code /docs} (redirect to {@code /docs/}). The site root is always a directory request.
+     * <p>
+     * Returns {@link WebsiteResolution.NotAWebsite} when the request should be served by the
+     * normal object path — an exact object hit, or a bucket with no website configuration. The
+     * index read is authorized (a no-op unless S3 auth enforcement is enabled), matching the
+     * object-serving path.
+     */
+    public WebsiteResolution resolveWebsiteRequest(String bucket, String key, boolean directoryRequest,
+                                                   RequestAuthorization authorization) {
+        WebsiteConfiguration cfg;
+        try {
+            cfg = getBucketWebsite(bucket);
+        } catch (AwsException e) {
+            // Only "no website configuration" means fall through to normal handling; a real error
+            // (e.g. NoSuchBucket) must propagate rather than be masked as "not a website".
+            if (!"NoSuchWebsiteConfiguration".equals(e.getErrorCode())) {
+                throw e;
+            }
+            return new WebsiteResolution.NotAWebsite();
+        }
+        String index = cfg.getIndexDocument();
+        if (index == null) {
+            return new WebsiteResolution.NotAWebsite();
+        }
+        boolean directory = key.isEmpty() || directoryRequest;
+        String prefix = key.endsWith("/") ? key.substring(0, key.length() - 1) : key;
+
+        if (directory) {
+            String indexKey = prefix.isEmpty() ? index : prefix + "/" + index;
+            try {
+                authorizeGetObject(bucket, indexKey, null, authorization);
+                return new WebsiteResolution.ServeObject(indexKey, headObject(bucket, indexKey, null));
+            } catch (AwsException e) {
+                if (!isWebsiteErrorDocumentTrigger(e)) {
+                    throw e;
+                }
+                return resolveErrorDocument(bucket, cfg, authorization, e.getHttpStatus());
+            }
+        }
+        // Not slash-terminated: an exact object is served by the normal path; a prefix that exists
+        // only as a "folder" (an index document lives beneath it) redirects to the slash-terminated
+        // form, matching real S3.
+        if (!objectExists(bucket, prefix) && objectExists(bucket, prefix + "/" + index)) {
+            return new WebsiteResolution.RedirectToDirectory();
+        }
+        return new WebsiteResolution.NotAWebsite();
+    }
+
+    /**
+     * Resolve the error response for a website request that already failed, so a website endpoint
+     * answers with the bucket's error document rather than S3's REST XML.
+     * <p>
+     * Returns {@link WebsiteResolution.NotAWebsite} when the bucket has no website configuration.
+     * Any other failure propagates, so the caller renders the real error instead of hiding it
+     * behind an error document.
+     */
+    public WebsiteResolution resolveWebsiteError(String bucket, RequestAuthorization authorization, int status) {
+        try {
+            return resolveErrorDocument(bucket, getBucketWebsite(bucket), authorization, status);
+        } catch (AwsException e) {
+            if (!"NoSuchWebsiteConfiguration".equals(e.getErrorCode())) {
+                throw e;
+            }
+            return new WebsiteResolution.NotAWebsite();
+        }
+    }
+
+    private WebsiteResolution resolveErrorDocument(String bucket, WebsiteConfiguration cfg,
+                                                   RequestAuthorization authorization, int status) {
+        int responseStatus = status == 403 ? 403 : 404;
+        if (cfg.getErrorDocument() == null) {
+            return new WebsiteResolution.DefaultError(responseStatus);
+        }
+        try {
+            authorizeGetObject(bucket, cfg.getErrorDocument(), null, authorization);
+            return new WebsiteResolution.ErrorDocument(getObject(bucket, cfg.getErrorDocument()), responseStatus);
+        } catch (AwsException e) {
+            if (!isWebsiteErrorDocumentTrigger(e)) {
+                throw e;
+            }
+            return new WebsiteResolution.DefaultError(responseStatus);
+        }
+    }
+
+    /**
+     * Whether a failure should be answered with the bucket's website error document rather than
+     * S3's REST XML error. Callers use this to decide whether the website error path is worth
+     * attempting at all.
+     */
+    public static boolean isWebsiteErrorDocumentTrigger(AwsException e) {
+        return "NoSuchKey".equals(e.getErrorCode()) || "AccessDenied".equals(e.getErrorCode());
+    }
+
     public void deleteBucketTagging(String bucketName) {
         Bucket bucket = bucketStore.get(bucketName)
                 .orElseThrow(() -> new AwsException("NoSuchBucket",

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
@@ -12,6 +12,7 @@ import io.github.hectorvent.floci.services.s3.model.ObjectAttributeName;
 import io.github.hectorvent.floci.services.s3.model.PutObjectOptions;
 import io.github.hectorvent.floci.services.s3.model.Bucket;
 import io.github.hectorvent.floci.services.s3.model.S3Object;
+import io.github.hectorvent.floci.services.s3.model.WebsiteConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -618,5 +619,138 @@ class S3ServiceTest {
         // Retrieve using the same literal key (S3 keys are opaque strings)
         S3Object got = s3Service.getObject("test-bucket", "docs/../file.txt");
         assertArrayEquals(data, got.getData());
+    }
+
+    // =========================================================================
+    // Website request resolution
+    //
+    // The HTTP rendering of these outcomes is covered end-to-end by
+    // S3WebsiteIntegrationTest; these pin the policy itself, with no HTTP layer.
+    // =========================================================================
+
+    private static final S3Service.RequestAuthorization UNSIGNED =
+            new S3Service.RequestAuthorization(false, null);
+
+    private void websiteBucket(String index, String errorDoc) {
+        s3Service.createBucket("site", "us-east-1");
+        s3Service.putBucketWebsite("site", new WebsiteConfiguration(index, errorDoc));
+    }
+
+    @Test
+    void resolveWebsiteRequestServesIndexForDirectoryRequest() {
+        websiteBucket("index.html", null);
+        s3Service.putObject("site", "docs/index.html", "hi".getBytes(), "text/html", null);
+
+        var resolution = s3Service.resolveWebsiteRequest("site", "docs", true, UNSIGNED);
+
+        var serve = assertInstanceOf(S3Service.WebsiteResolution.ServeObject.class, resolution);
+        assertEquals("docs/index.html", serve.key());
+    }
+
+    @Test
+    void resolveWebsiteRequestServesRootIndexWhenKeyIsEmpty() {
+        websiteBucket("index.html", null);
+        s3Service.putObject("site", "index.html", "root".getBytes(), "text/html", null);
+
+        // The site root is a directory request even though the caller saw no trailing slash.
+        var resolution = s3Service.resolveWebsiteRequest("site", "", false, UNSIGNED);
+
+        assertEquals("index.html",
+                assertInstanceOf(S3Service.WebsiteResolution.ServeObject.class, resolution).key());
+    }
+
+    @Test
+    void resolveWebsiteRequestRedirectsFolderWithoutTrailingSlash() {
+        websiteBucket("index.html", null);
+        s3Service.putObject("site", "docs/index.html", "hi".getBytes(), "text/html", null);
+
+        // No trailing slash, no object at "docs", but an index lives beneath it.
+        var resolution = s3Service.resolveWebsiteRequest("site", "docs", false, UNSIGNED);
+
+        assertInstanceOf(S3Service.WebsiteResolution.RedirectToDirectory.class, resolution);
+    }
+
+    @Test
+    void resolveWebsiteRequestPrefersExactObjectOverFolderRedirect() {
+        websiteBucket("index.html", null);
+        s3Service.putObject("site", "docs", "exact".getBytes(), "text/plain", null);
+        s3Service.putObject("site", "docs/index.html", "hi".getBytes(), "text/html", null);
+
+        // An exact object hit is served by the normal object path, not redirected.
+        var resolution = s3Service.resolveWebsiteRequest("site", "docs", false, UNSIGNED);
+
+        assertInstanceOf(S3Service.WebsiteResolution.NotAWebsite.class, resolution);
+    }
+
+    @Test
+    void resolveWebsiteRequestFallsBackToErrorDocumentWhenIndexMissing() {
+        websiteBucket("index.html", "error.html");
+        s3Service.putObject("site", "error.html", "oops".getBytes(), "text/html", null);
+
+        var resolution = s3Service.resolveWebsiteRequest("site", "missing", true, UNSIGNED);
+
+        var err = assertInstanceOf(S3Service.WebsiteResolution.ErrorDocument.class, resolution);
+        assertEquals(404, err.status());
+        assertArrayEquals("oops".getBytes(), err.object().getData());
+    }
+
+    @Test
+    void resolveWebsiteRequestFallsBackToDefaultErrorWhenNoErrorDocumentConfigured() {
+        websiteBucket("index.html", null);
+
+        var resolution = s3Service.resolveWebsiteRequest("site", "missing", true, UNSIGNED);
+
+        assertEquals(404,
+                assertInstanceOf(S3Service.WebsiteResolution.DefaultError.class, resolution).status());
+    }
+
+    @Test
+    void resolveWebsiteRequestFallsBackToDefaultErrorWhenErrorDocumentItselfMissing() {
+        // Configured but never uploaded: S3 serves its built-in page rather than 500-ing.
+        websiteBucket("index.html", "error.html");
+
+        var resolution = s3Service.resolveWebsiteRequest("site", "missing", true, UNSIGNED);
+
+        assertEquals(404,
+                assertInstanceOf(S3Service.WebsiteResolution.DefaultError.class, resolution).status());
+    }
+
+    @Test
+    void resolveWebsiteRequestIsNotAWebsiteWithoutConfiguration() {
+        s3Service.createBucket("plain", "us-east-1");
+
+        var resolution = s3Service.resolveWebsiteRequest("plain", "any", true, UNSIGNED);
+
+        assertInstanceOf(S3Service.WebsiteResolution.NotAWebsite.class, resolution);
+    }
+
+    @Test
+    void resolveWebsiteRequestPropagatesRealBucketErrors() {
+        // A missing bucket must surface as NoSuchBucket, not be masked as "not a website".
+        AwsException error = assertThrows(AwsException.class,
+                () -> s3Service.resolveWebsiteRequest("no-such-bucket", "any", true, UNSIGNED));
+        assertEquals("NoSuchBucket", error.getErrorCode());
+    }
+
+    @Test
+    void resolveWebsiteErrorReturnsNotAWebsiteWithoutConfiguration() {
+        s3Service.createBucket("plain", "us-east-1");
+
+        assertInstanceOf(S3Service.WebsiteResolution.NotAWebsite.class,
+                s3Service.resolveWebsiteError("plain", UNSIGNED, 404));
+    }
+
+    @Test
+    void resolveWebsiteErrorMapsForbiddenToItsOwnStatus() {
+        websiteBucket("index.html", "error.html");
+        s3Service.putObject("site", "error.html", "denied".getBytes(), "text/html", null);
+
+        // 403 keeps its status; everything else collapses to 404, matching S3.
+        assertEquals(403,
+                assertInstanceOf(S3Service.WebsiteResolution.ErrorDocument.class,
+                        s3Service.resolveWebsiteError("site", UNSIGNED, 403)).status());
+        assertEquals(404,
+                assertInstanceOf(S3Service.WebsiteResolution.ErrorDocument.class,
+                        s3Service.resolveWebsiteError("site", UNSIGNED, 500)).status());
     }
 }


### PR DESCRIPTION
## Summary

Moves the website folder-resolution policy #1815 added to `S3Controller` down into `S3Service`,
the follow-up @hectorvent asked for in [review of #1815](https://github.com/floci-io/floci/pull/1815#issuecomment-5200526773)
("moving the ~90 lines of folder-resolution policy from `S3Controller` into `S3Service` would keep
the controller thin").

As #2140 flagged, this is deliberately **not** a verbatim move. The code being moved reads the raw
Vert.x request path and returns `jakarta.ws.rs.core.Response`, while `S3Service` has zero
`jakarta.ws.rs` and `io.vertx` imports — moving it as-is would pull the HTTP layer into the service
and break the convention the refactor exists to strengthen.

So the split is policy vs. rendering:

```java
// S3Service — decides WHAT to serve
public sealed interface WebsiteResolution {
    record ServeObject(String key, S3Object object)     implements WebsiteResolution {}
    record RedirectToDirectory()                        implements WebsiteResolution {}
    record ErrorDocument(S3Object object, int status)   implements WebsiteResolution {}
    record DefaultError(int status)                     implements WebsiteResolution {}
    record NotAWebsite()                                implements WebsiteResolution {}
}

WebsiteResolution resolveWebsiteRequest(String bucket, String key, boolean directoryRequest,
                                        RequestAuthorization authorization);
WebsiteResolution resolveWebsiteError(String bucket, RequestAuthorization authorization, int status);
```

`S3Controller` keeps the one input only it can supply — whether the client asked for a directory,
which the routing layer's trailing-slash stripping otherwise hides — and pattern-matches the
result into a `Response`.

Net effect: `S3Controller` **−44 lines** (+42 / −86), and `S3Service` still has **zero** HTTP-layer
imports.

Closes #2140

### Three deviations from the shape sketched in the issue

Each is a deliberate call, and easy to revert if you'd rather have the original shape:

1. **`RedirectToDirectory` carries no `path`.** The issue sketched `RedirectToDirectory(String path)`,
   but the redirect target is `rawPath + "/"` and only the controller knows `rawPath`. Putting it in
   the record would reintroduce exactly the HTTP dependency this refactor removes.
2. **`ServeObject` / `ErrorDocument` carry the already-read `S3Object`, not just a key.** The service
   has to read the object anyway to decide between serving it and falling back to the error document.
   Returning only a key would force a redundant second lookup in the controller and open a gap
   between the decision and the render.
3. **`isWebsiteErrorDocumentTrigger` moved to `S3Service` as `public static`.** "Which errors trigger
   the error document" is policy, and the controller has two other call sites for it — leaving a
   private copy behind would have duplicated the rule in both layers.

Also removed one line of dead code: `serveWebsiteObject` had
`return err != null ? err : xmlErrorResponse(e);`, but `serveErrorDocument` never returned `null`
(every path either returns a response or throws), so the fallback was unreachable.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore — specifically `refactor:`, per the type set the Conventional Commits workflow accepts

## AWS Compatibility

**No behaviour change** — this is a pure restructure, so there is no wire-protocol delta to verify.
The guarantee is that the contract #1815 established stays byte-identical:

- `S3WebsiteIntegrationTest` (25 tests) passes **completely untouched** — no test was edited,
  renamed, or re-ordered in this PR. That was the acceptance condition #2140 set, and it is the
  real evidence here.
- The two cases #1815 settled empirically against a live `us-east-1` website endpoint are preserved
  verbatim, with their explanatory comments carried across: the folder 302 emits a **bare**
  `Location: /docs/` with the query string dropped, and a sub-resource-looking query such as
  `/docs/?tagging` stays an ordinary website request serving `docs/index.html`.
- `403` keeps its own status; every other failure collapses to `404`, matching S3.

### Tests

`./mvnw test` — **8698 run, 0 failures, 0 errors, 9 skipped**. BUILD SUCCESS.
Full S3 scope (`-Dtest='S3*Test'`) — 714 run, 0 failures. `make docs-check` passes.

11 new cases in `S3ServiceTest` pin the policy directly, which is most of the value of the move —
before this, none of it could be exercised without standing up the HTTP layer:

| Test | Exercises |
|---|---|
| `resolveWebsiteRequestServesIndexForDirectoryRequest` | `/docs/` serves `docs/index.html` |
| `resolveWebsiteRequestServesRootIndexWhenKeyIsEmpty` | site root is a directory request even with no trailing slash |
| `resolveWebsiteRequestRedirectsFolderWithoutTrailingSlash` | `/docs` redirects when an index lives beneath it |
| `resolveWebsiteRequestPrefersExactObjectOverFolderRedirect` | an exact object hit wins over the folder redirect |
| `resolveWebsiteRequestFallsBackToErrorDocumentWhenIndexMissing` | missing index serves the custom error document |
| `resolveWebsiteRequestFallsBackToDefaultErrorWhenNoErrorDocumentConfigured` | no error document configured → built-in page |
| `resolveWebsiteRequestFallsBackToDefaultErrorWhenErrorDocumentItselfMissing` | configured but never uploaded → built-in page, not a 500 |
| `resolveWebsiteRequestIsNotAWebsiteWithoutConfiguration` | plain bucket falls through to the normal object path |
| `resolveWebsiteRequestPropagatesRealBucketErrors` | `NoSuchBucket` surfaces instead of being masked as "not a website" |
| `resolveWebsiteErrorReturnsNotAWebsiteWithoutConfiguration` | error path falls through for non-website buckets |
| `resolveWebsiteErrorMapsForbiddenToItsOwnStatus` | 403 keeps 403; 500 collapses to 404 |

These run in **0.5s** against **7.2s** for the HTTP-layer equivalents.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
