### PR TITLE
fix(stepfunctions): publish execution status after its terminal fields

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -205,8 +205,8 @@ public class AslExecutor {
                     runUnderExecutionAccount(sm, () -> doExecute(sm, exec, history, onUpdate)));
             f.get(300, TimeUnit.SECONDS);
         } catch (java.util.concurrent.TimeoutException e) {
-            exec.setStatus("TIMED_OUT");
             exec.setStopDate(System.currentTimeMillis() / 1000.0);
+            exec.setStatus("TIMED_OUT");
             onUpdate.accept(exec, history);
         } catch (Exception e) {
             LOG.warnv("Sync execution wait failed for {0}: {1}", exec.getExecutionArn(), e.getMessage());
@@ -329,12 +329,12 @@ public class AslExecutor {
                     onUpdate.accept(exec, history);
                     return;
                 } catch (Exception e) {
-                    exec.setStatus("FAILED");
-                    exec.setStopDate(System.currentTimeMillis() / 1000.0);
                     String runtimeError = "States.Runtime";
                     String runtimeCause = e.getMessage() != null ? e.getMessage() : "Unknown error";
                     exec.setError(runtimeError);
                     exec.setCause(runtimeCause);
+                    exec.setStopDate(System.currentTimeMillis() / 1000.0);
+                    exec.setStatus("FAILED");
                     addEvent(history, eventId, "ExecutionFailed", null,
                             Map.of("error", runtimeError, "cause", runtimeCause));
                     onUpdate.accept(exec, history);
@@ -342,17 +342,25 @@ public class AslExecutor {
                 }
             }
 
-            exec.setStatus("SUCCEEDED");
+            // Status is the publication point, so it is set last. describeExecution hands out this
+            // same live Execution, so a client polling for SUCCEEDED between setStatus and setOutput
+            // would read a terminal execution with a null output, which real Step Functions never
+            // returns. The same ordering applies to every terminal path below.
             exec.setOutput(currentInput.toString());
             exec.setStopDate(System.currentTimeMillis() / 1000.0);
+            exec.setStatus("SUCCEEDED");
             addEvent(history, eventId, "ExecutionSucceeded", null,
                     Map.of("output", currentInput.toString()));
             onUpdate.accept(exec, history);
 
         } catch (Exception e) {
             LOG.warnv("ASL execution failed for {0}: {1}", exec.getExecutionArn(), e.getMessage());
-            exec.setStatus("FAILED");
+            // This path previously set only the status, leaving error and cause null forever on an
+            // execution DescribeExecution reports as FAILED.
+            exec.setError("States.Runtime");
+            exec.setCause(e.getMessage() != null ? e.getMessage() : "Unknown error");
             exec.setStopDate(System.currentTimeMillis() / 1000.0);
+            exec.setStatus("FAILED");
             onUpdate.accept(exec, history);
         }
     }
@@ -2563,12 +2571,12 @@ public class AslExecutor {
     }
 
     private void failExecution(Execution exec, List<HistoryEvent> history, AtomicLong eventId, FailStateException e) {
-        exec.setStatus("FAILED");
-        exec.setStopDate(System.currentTimeMillis() / 1000.0);
         String failError = e.error != null ? e.error : "States.Runtime";
         String failCause = e.cause != null ? e.cause : "";
         exec.setError(failError);
         exec.setCause(failCause);
+        exec.setStopDate(System.currentTimeMillis() / 1000.0);
+        exec.setStatus("FAILED");
         addEvent(history, eventId, "ExecutionFailed", null,
                 Map.of("error", failError, "cause", failCause));
     }

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
@@ -255,8 +255,8 @@ public class StepFunctionsService implements Resettable {
         if (!"RUNNING".equals(exec.getStatus())) {
             return;
         }
-        exec.setStatus("ABORTED");
         exec.setStopDate(System.currentTimeMillis() / 1000.0);
+        exec.setStatus("ABORTED");
         executionStore.put(arn, exec);
 
         List<HistoryEvent> history = historyCache.getOrDefault(arn, new ArrayList<>());

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorTerminalStateTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorTerminalStateTest.java
@@ -1,0 +1,147 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbJsonHandler;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
+import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
+import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
+import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
+import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
+import io.github.hectorvent.floci.services.stepfunctions.model.StateMachine;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.mutiny.core.Vertx;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Guards the terminal metadata written on the outer catch in {@code doExecute}, the path that
+ * previously set only the status and left {@code error} and {@code cause} null permanently on an
+ * execution DescribeExecution reports as FAILED.
+ *
+ * <p>A missing state reaches it deterministically: the "State not found" throw sits outside the
+ * per-state try, so it unwinds the whole execution loop rather than being caught as a state
+ * failure. The field ordering this class does not assert is untestable from here, since the window
+ * between two adjacent setters is a few instructions wide.
+ */
+@QuarkusTest
+class AslExecutorTerminalStateTest {
+
+    private static final String REGION = "us-east-2";
+    private static final String ACCOUNT = "000000000000";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private AslExecutor executor;
+
+    @Inject
+    Vertx vertx;
+
+    @BeforeEach
+    void setUp() {
+        executor = new AslExecutor(
+                mock(LambdaExecutorService.class),
+                mock(LambdaFunctionStore.class),
+                mock(DynamoDbService.class),
+                mock(DynamoDbJsonHandler.class),
+                mock(SqsJsonHandler.class),
+                mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
+                mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
+                mock(S3Service.class),
+                mock(io.github.hectorvent.floci.services.ecs.EcsService.class),
+                mock(io.github.hectorvent.floci.services.ecs.EcsJsonHandler.class),
+                objectMapper,
+                new JsonataEvaluator(objectMapper),
+                mock(Instance.class), mock(EmulatorConfig.class), vertx);
+    }
+
+    @Test
+    void executionFailedOnTheOuterCatchCarriesErrorAndCause() {
+        Execution execution = run("""
+                {
+                  "StartAt": "NoSuchState",
+                  "States": {
+                    "Unreachable": {
+                      "Type": "Succeed"
+                    }
+                  }
+                }
+                """);
+
+        assertEquals("FAILED", execution.getStatus());
+        assertEquals("States.Runtime", execution.getError());
+        assertEquals("State not found: NoSuchState", execution.getCause());
+        assertNotNull(execution.getStopDate());
+    }
+
+    @Test
+    void executionFailedOnAnUnresolvableNextCarriesErrorAndCause() {
+        Execution execution = run("""
+                {
+                  "StartAt": "First",
+                  "States": {
+                    "First": {
+                      "Type": "Pass",
+                      "Next": "Vanished"
+                    }
+                  }
+                }
+                """);
+
+        assertEquals("FAILED", execution.getStatus());
+        assertEquals("States.Runtime", execution.getError());
+        assertEquals("State not found: Vanished", execution.getCause());
+        assertNotNull(execution.getStopDate());
+    }
+
+    @Test
+    void succeededExecutionCarriesItsOutputAndStopDate() {
+        Execution execution = run("""
+                {
+                  "StartAt": "Only",
+                  "States": {
+                    "Only": {
+                      "Type": "Pass",
+                      "End": true
+                    }
+                  }
+                }
+                """);
+
+        assertEquals("SUCCEEDED", execution.getStatus());
+        assertNotNull(execution.getOutput());
+        assertNotNull(execution.getStopDate());
+    }
+
+    private Execution run(String definition) {
+        StateMachine stateMachine = new StateMachine();
+        stateMachine.setName("terminal-state-test");
+        stateMachine.setStateMachineArn(
+                "arn:aws:states:%s:%s:stateMachine:terminal-state-test".formatted(REGION, ACCOUNT));
+        stateMachine.setRoleArn("arn:aws:iam::%s:role/test-role".formatted(ACCOUNT));
+        stateMachine.setDefinition(definition);
+
+        Execution execution = new Execution();
+        execution.setName("terminal-state-execution");
+        execution.setExecutionArn(
+                "arn:aws:states:%s:%s:execution:terminal-state-test:terminal-state-execution"
+                        .formatted(REGION, ACCOUNT));
+        execution.setStateMachineArn(stateMachine.getStateMachineArn());
+        execution.setInput("{}");
+
+        List<HistoryEvent> history = new ArrayList<>();
+        executor.executeSync(stateMachine, execution, history, (updated, events) -> {
+        });
+        return execution;
+    }
+}


### PR DESCRIPTION
## Summary

`DescribeExecution` returns the live `Execution` instance from the store, and the executor mutates it in place with the status set *before* the fields that describe it. A client polling for a terminal status can therefore observe `SUCCEEDED` with a null `output`, which real Step Functions never returns.

This is what reddened `main` in [run 31457665686](https://github.com/floci-io/floci/actions/runs/31457665686): the poll in `StepFunctionsPassParametersIntegrationTest` landed inside the window and Jackson rejected the null document with `IllegalArgumentException: argument "content" is null`. It is intermittent (one failure in the last fifteen `main` runs) because the window is two adjacent field writes wide. It is not caused by #2079, which merely happened to be the merge commit running at the time.

The status is now the publication point on every terminal path: the terminal fields are written first, `setStatus(...)` last.

| Location | Path |
|---|---|
| `AslExecutor:345` | `SUCCEEDED` (the one that broke CI) |
| `AslExecutor:332` | `FAILED`, runtime exception |
| `AslExecutor:353` | `FAILED`, outer catch |
| `AslExecutor:2571` | `failExecution` |
| `AslExecutor:208` | `TIMED_OUT` |
| `StepFunctionsService:258` | `ABORTED` in `stopExecution` |

The outer catch was worse than a race: it set only the status, so an execution failing there reported `FAILED` with a null `error` and `cause` **permanently**. It now records both.

Fixes the intermittent `main` failure in run 31457665686.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The incorrect behaviour was user visible, not only test visible. Polling `DescribeExecution` until the status is terminal and then reading `output` is the documented pattern and what the SDK waiters do. Against Floci that poll could return `SUCCEEDED` with no `output`, and separately `FAILED` with no `error` or `cause`. Real Step Functions never returns a terminal execution without its terminal fields.

No request or response shape, field name or error code changed, so there is no wire contract change to verify against the model.

## Checklist

- [ ] `./mvnw test` passes locally — ran the affected suites rather than the full build: `-Dtest='StepFunctions*,Asl*'` gives **222 tests, 0 failures, 0 errors**. Leaving this unticked rather than overclaim; CI runs the full suite.
- [ ] New or updated integration test added — **deliberately none, see below**
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

### Why there is no new test

I wrote a concurrent polling integration test and then ran it against the *unfixed* code to check it actually caught the bug. It passed, so it was worthless as a regression guard and I discarded it rather than ship a green test that proves nothing.

The reason is structural: executions here start and complete inside the same millisecond while an HTTP round trip is tens of milliseconds, so a black box poll cannot land in a window that is a few instructions wide. There is no seam to observe from either, since `onUpdate` fires after every setter and so sees identical state before and after this change.

Existing coverage does guard the fields themselves, just not their ordering: `StepFunctionsJsonataIntegrationTest` asserts `error` and `cause` on failed executions in several places, so a regression that dropped those fields would go red.

## Follow up, not in this PR

The outer catch in `doExecute` still emits no `ExecutionFailed` history event, unlike the other two `FAILED` paths, so `GetExecutionHistory` is missing it. Fixing that needs `AtomicLong eventId` hoisted out of the `try` where it is declared (`AslExecutor:281`), which is beyond the scope of an ordering fix.

Reordering shrinks the window to a couple of instructions but is not a memory model guarantee, since the store hands out the live object. The stronger fix is to build the terminal state and write it through the store in a single `put`. Happy to do that instead if preferred.
