### PR TITLE
fix(s3): isolate object byte storage between accounts

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -2589,7 +2589,12 @@ public class S3Service implements Resettable {
         if (!resolved.startsWith(bucketDir)) {
             throw new AwsException("InvalidKey", "The specified key is invalid.", 400);
         }
+        migrateLegacyFileIfPresent(legacyObjectPath(bucketName, safeKey), resolved);
         return resolved;
+    }
+
+    private Path legacyObjectPath(String bucketName, String safeKey) {
+        return dataRoot.resolve(bucketName).normalize().resolve(safeKey + DATA_SUFFIX);
     }
 
     private Path resolveVersionedPath(String bucketName, String key, String versionId) {
@@ -2604,7 +2609,29 @@ public class S3Service implements Resettable {
         if (!resolved.startsWith(baseDir)) {
             throw new AwsException("InvalidKey", "The specified key is invalid.", 400);
         }
+        Path legacyBaseDir = dataRoot.resolve(".versions").resolve(bucketName).normalize();
+        migrateLegacyFileIfPresent(legacyBaseDir.resolve(safeKey).resolve(versionId + DATA_SUFFIX), resolved);
         return resolved;
+    }
+
+    /**
+     * Before object bytes were account-scoped on disk, every object lived at this bucket/key
+     * path with no account segment. An installation upgrading past that change must not lose
+     * access to objects already written under the old layout, so a read/write/delete that
+     * resolves to a not-yet-migrated new-layout path transparently relocates the legacy file
+     * first — mirroring how {@link io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend#get}
+     * migrates a pre-multi-account storage key on first read.
+     */
+    private void migrateLegacyFileIfPresent(Path legacyPath, Path newPath) {
+        if (Files.exists(newPath) || !Files.exists(legacyPath)) {
+            return;
+        }
+        try {
+            Files.createDirectories(newPath.getParent());
+            Files.move(legacyPath, newPath);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to migrate legacy S3 object file to account-scoped layout", e);
+        }
     }
 
     private void writeVersionedFile(String bucketName, String key, String versionId, byte[] data) {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -217,10 +217,10 @@ public class S3Service implements Resettable {
 
         bucketStore.delete(bucketName);
         if (inMemory) {
-            String prefix = bucketName + "/";
+            String prefix = ownerId() + "/" + bucketName + "/";
             memoryDataStore.keySet().removeIf(k -> k.startsWith(prefix));
         } else {
-            deleteDirectory(dataRoot.resolve(bucketName));
+            deleteDirectory(dataRoot.resolve(ownerId()).resolve(bucketName));
         }
         LOG.infov("Deleted bucket: {0}", bucketName);
     }
@@ -659,8 +659,8 @@ public class S3Service implements Resettable {
         getObjectMetadata(bucketName, key, versionId);
         if (inMemory) {
             byte[] data = versionId != null
-                    ? memoryDataStore.get(versionedKey(bucketName, key, versionId))
-                    : memoryDataStore.get(objectKey(bucketName, key));
+                    ? memoryDataStore.get(physicalVersionedKey(bucketName, key, versionId))
+                    : memoryDataStore.get(physicalKey(bucketName, key));
             if (data == null) {
                 throw new IllegalStateException("S3 object data is missing for " + bucketName + "/" + key);
             }
@@ -2564,14 +2564,27 @@ public class S3Service implements Resettable {
 
     private static final String DATA_SUFFIX = ".s3data";
 
+    // Byte storage (memoryDataStore / on-disk files) is a plain field, not a StorageBackend,
+    // so unlike bucketStore/objectStore it gets no automatic account prefixing from
+    // AccountAwareStorageBackend. bucketStore only enforces bucket-name uniqueness within an
+    // account, so two accounts can each own a bucket named e.g. "orders" — without scoping
+    // the physical key/path by account here too, their object bytes would collide.
+    private String physicalKey(String bucketName, String key) {
+        return ownerId() + "/" + objectKey(bucketName, key);
+    }
+
+    private String physicalVersionedKey(String bucketName, String key, String versionId) {
+        return ownerId() + "/" + versionedKey(bucketName, key, versionId);
+    }
+
     private Path resolveObjectPath(String bucketName, String key) {
-        Path bucketDir = dataRoot.resolve(bucketName).normalize();
-        
+        Path bucketDir = dataRoot.resolve(ownerId()).resolve(bucketName).normalize();
+
         String safeKey = key;
         while (safeKey.startsWith("/")) {
             safeKey = safeKey.substring(1);
         }
-        
+
         Path resolved = bucketDir.resolve(safeKey + DATA_SUFFIX).normalize();
         if (!resolved.startsWith(bucketDir)) {
             throw new AwsException("InvalidKey", "The specified key is invalid.", 400);
@@ -2580,13 +2593,13 @@ public class S3Service implements Resettable {
     }
 
     private Path resolveVersionedPath(String bucketName, String key, String versionId) {
-        Path baseDir = dataRoot.resolve(".versions").resolve(bucketName).normalize();
-        
+        Path baseDir = dataRoot.resolve(ownerId()).resolve(".versions").resolve(bucketName).normalize();
+
         String safeKey = key;
         while (safeKey.startsWith("/")) {
             safeKey = safeKey.substring(1);
         }
-        
+
         Path resolved = baseDir.resolve(safeKey).resolve(versionId + DATA_SUFFIX).normalize();
         if (!resolved.startsWith(baseDir)) {
             throw new AwsException("InvalidKey", "The specified key is invalid.", 400);
@@ -2596,7 +2609,7 @@ public class S3Service implements Resettable {
 
     private void writeVersionedFile(String bucketName, String key, String versionId, byte[] data) {
         if (inMemory) {
-            memoryDataStore.put(versionedKey(bucketName, key, versionId), data);
+            memoryDataStore.put(physicalVersionedKey(bucketName, key, versionId), data);
             return;
         }
         try {
@@ -2610,7 +2623,7 @@ public class S3Service implements Resettable {
 
     private byte[] readVersionedFile(String bucketName, String key, String versionId) {
         if (inMemory) {
-            return memoryDataStore.get(versionedKey(bucketName, key, versionId));
+            return memoryDataStore.get(physicalVersionedKey(bucketName, key, versionId));
         }
         try {
             return Files.readAllBytes(resolveVersionedPath(bucketName, key, versionId));
@@ -2621,7 +2634,7 @@ public class S3Service implements Resettable {
 
     private void writeFile(String bucketName, String key, byte[] data) {
         if (inMemory) {
-            memoryDataStore.put(objectKey(bucketName, key), data);
+            memoryDataStore.put(physicalKey(bucketName, key), data);
             return;
         }
         try {
@@ -2635,7 +2648,7 @@ public class S3Service implements Resettable {
 
     private byte[] readFile(String bucketName, String key) {
         if (inMemory) {
-            return memoryDataStore.get(objectKey(bucketName, key));
+            return memoryDataStore.get(physicalKey(bucketName, key));
         }
         try {
             return Files.readAllBytes(resolveObjectPath(bucketName, key));
@@ -2646,7 +2659,7 @@ public class S3Service implements Resettable {
 
     private void deleteFile(String bucketName, String key) {
         if (inMemory) {
-            memoryDataStore.remove(objectKey(bucketName, key));
+            memoryDataStore.remove(physicalKey(bucketName, key));
             return;
         }
         try {
@@ -2658,7 +2671,7 @@ public class S3Service implements Resettable {
 
     private void deleteVersionedFile(String bucketName, String key, String versionId) {
         if (inMemory) {
-            memoryDataStore.remove(versionedKey(bucketName, key, versionId));
+            memoryDataStore.remove(physicalVersionedKey(bucketName, key, versionId));
             return;
         }
         try {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -72,12 +72,9 @@ public class S3Service implements Resettable {
     private final Path dataRoot;
     private final boolean inMemory;
     private final ConcurrentHashMap<String, byte[]> memoryDataStore = new ConcurrentHashMap<>();
-    // Guards disk-mode object files against a legacy-layout migration racing a write/delete to
-    // the same account-scoped path — see copyLegacyFileIfPresent(). A fixed-size stripe array
-    // (rather than one lock per Path in a growing map) keeps memory bounded regardless of how
-    // many distinct objects/versions a long-running instance ever writes or deletes — entries in
-    // a Path-keyed map would never be safe to remove without a full reference-counting scheme,
-    // since a lock in active use could otherwise be evicted out from under a waiting thread.
+    // Guards disk writes/deletes against a racing legacy migration for the same path (see
+    // copyLegacyFileIfPresent()). Fixed-size stripes keep memory bounded, unlike a per-path
+    // map that would need reference counting to ever shrink safely.
     private static final int DISK_FILE_LOCK_STRIPES = 256;
     private final ReentrantLock[] diskFileLocks = newLockStripes(DISK_FILE_LOCK_STRIPES);
 
@@ -201,10 +198,8 @@ public class S3Service implements Resettable {
 
     public Bucket createBucket(String bucketName, String region) {
         if (ACCOUNT_STORAGE_ROOT.equals(bucketName)) {
-            // Real S3 already rejects this name outright (bucket names must begin with a
-            // letter or number), but Floci doesn't otherwise validate bucket name format —
-            // this one name specifically must stay unavailable, since account-scoped disk
-            // storage for every account lives under this exact path segment.
+            // Floci doesn't otherwise validate bucket name format, but this name must stay
+            // unavailable — it's the root every account's disk storage lives under.
             throw new AwsException("InvalidBucketName",
                     "The specified bucket is not valid.", 400);
         }
@@ -2589,23 +2584,13 @@ public class S3Service implements Resettable {
 
     private static final String DATA_SUFFIX = ".s3data";
 
-    // The account-scoped disk layout is dataRoot/ACCOUNT_STORAGE_ROOT/<accountId>/<bucket>/...
-    // rather than dataRoot/<accountId>/<bucket>/..., because a bucket name and an account ID
-    // share the same string shape (a 12-digit numeric bucket name is valid on S3), so
-    // "dataRoot/<accountId>/..." is not disjoint from the legacy layout "dataRoot/<bucket>/...":
-    // a legacy bucket literally named e.g. "000000000000" with key "orders/report.csv" resolves
-    // to the exact same path as account "000000000000"'s new-layout bucket "orders", key
-    // "report.csv". A leading "." makes this namespace unreachable by any bucket name real S3
-    // accepts (bucket names must begin with a letter or number) — createBucket() additionally
-    // rejects the one bucket name that would otherwise collide with the root of this namespace
-    // itself, since Floci (unlike real S3) doesn't otherwise validate bucket name format at all.
+    // A 12-digit bucket name is valid on S3 and would otherwise collide with an account ID,
+    // making dataRoot/<accountId>/... indistinguishable from the legacy dataRoot/<bucket>/...
+    // layout. A leading "." keeps this namespace unreachable by any real bucket name.
     private static final String ACCOUNT_STORAGE_ROOT = ".accounts";
 
-    // Byte storage (memoryDataStore / on-disk files) is a plain field, not a StorageBackend,
-    // so unlike bucketStore/objectStore it gets no automatic account prefixing from
-    // AccountAwareStorageBackend. bucketStore only enforces bucket-name uniqueness within an
-    // account, so two accounts can each own a bucket named e.g. "orders" — without scoping
-    // the physical key/path by account here too, their object bytes would collide.
+    // Unlike bucketStore/objectStore, object bytes get no automatic account prefixing — two
+    // accounts can own a bucket named "orders" and would collide here without this scoping.
     private String physicalKey(String bucketName, String key) {
         return ownerId() + "/" + objectKey(bucketName, key);
     }
@@ -2638,16 +2623,11 @@ public class S3Service implements Resettable {
     }
 
     /**
-     * Resolves the account-scoped object path for a read, first copying in a file found at the
-     * pre-account-scoping legacy path (no account segment). Must only ever be used for reads:
-     * the legacy file predates any account concept, so it isn't actually known to belong to the
-     * current account — and two different accounts can legitimately own a same-named bucket in
-     * Floci (bucket-name uniqueness is only enforced per account here, unlike real S3). A write
-     * or delete resolving through this path could let one account's operation destroy another
-     * account's not-yet-migrated data; {@link #resolveObjectPath} is used there instead, with no
-     * legacy fallback at all. Copying rather than moving leaves the ambiguous source untouched,
-     * so every account that reads it independently gets its own copy, at the cost of the legacy
-     * file persisting on disk indefinitely once read.
+     * Resolves the path for a read, copying in a legacy-layout file if present. Reads only —
+     * a write/delete ({@link #resolveObjectPath}) must never touch legacy data, since it isn't
+     * known to belong to any one account and two accounts can share a bucket name. Copying
+     * (not moving) leaves the ambiguous source in place so every account that reads it gets
+     * its own copy.
      */
     private Path resolveObjectPathForRead(String bucketName, String key) {
         Path resolved = resolveObjectPath(bucketName, key);
@@ -2687,20 +2667,14 @@ public class S3Service implements Resettable {
     }
 
     private ReentrantLock diskFileLock(Path path) {
-        // Two unrelated paths landing on the same stripe just serialize unnecessarily — safe,
-        // if occasionally less parallel, unlike a growing per-path map that never shrinks.
+        // A stripe collision just serializes unrelated paths — safe, unlike a map entry.
         return diskFileLocks[Math.floorMod(path.hashCode(), diskFileLocks.length)];
     }
 
     /**
-     * Copies in a legacy-layout file for {@code newPath}, guarded by the same per-path lock
-     * {@link #writeFile}/{@link #deleteFile} (and their versioned counterparts) hold while
-     * touching {@code newPath}. Without that shared lock, a read could copy stale legacy bytes
-     * into place, a concurrent write could land its real content first, and the read's own copy
-     * — checked for existence before either operation started — would still go on to clobber
-     * that write with the stale data. The lock makes "does newPath already exist" and "install
-     * the legacy copy" a single atomic step with respect to any write/delete of the same path,
-     * so a legacy copy can never install itself after a real write has already claimed the path.
+     * Copies in a legacy file for {@code newPath}, under the same lock {@link #writeFile}/
+     * {@link #deleteFile} hold for that path — otherwise a concurrent write could land its
+     * real content and then be silently clobbered by a racing legacy copy.
      */
     private void copyLegacyFileIfPresent(Path legacyPath, Path newPath) {
         if (!Files.exists(legacyPath)) {
@@ -2715,12 +2689,8 @@ public class S3Service implements Resettable {
             Files.createDirectories(newPath.getParent());
             Files.copy(legacyPath, newPath);
         } catch (IOException e) {
-            // Files.copy can throw partway through (disk full, transient I/O error), leaving
-            // newPath present with truncated content. Left in place, that file would satisfy
-            // the exists-check above on every later attempt, permanently shadowing the still
-            // intact legacy source instead of letting a retry migrate it correctly. Still
-            // holding the lock, so this can't race a concurrent writer that might otherwise
-            // have created newPath in the meantime.
+            // A failed copy can leave newPath truncated, which would wrongly look
+            // "already migrated" on a later retry — clean it up before rethrowing.
             deleteQuietly(newPath, "partially-copied legacy S3 object file, so a later read can retry migration");
             throw new UncheckedIOException("Failed to copy legacy S3 object file to account-scoped layout", e);
         } finally {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -200,6 +200,14 @@ public class S3Service implements Resettable {
     }
 
     public Bucket createBucket(String bucketName, String region) {
+        if (ACCOUNT_STORAGE_ROOT.equals(bucketName)) {
+            // Real S3 already rejects this name outright (bucket names must begin with a
+            // letter or number), but Floci doesn't otherwise validate bucket name format —
+            // this one name specifically must stay unavailable, since account-scoped disk
+            // storage for every account lives under this exact path segment.
+            throw new AwsException("InvalidBucketName",
+                    "The specified bucket is not valid.", 400);
+        }
         var existing = bucketStore.get(bucketName);
         if (existing.isPresent()) {
             Bucket bucket = existing.get();
@@ -237,7 +245,7 @@ public class S3Service implements Resettable {
             String prefix = ownerId() + "/" + bucketName + "/";
             memoryDataStore.keySet().removeIf(k -> k.startsWith(prefix));
         } else {
-            deleteDirectory(dataRoot.resolve(ownerId()).resolve(bucketName));
+            deleteDirectory(dataRoot.resolve(ACCOUNT_STORAGE_ROOT).resolve(ownerId()).resolve(bucketName));
         }
         LOG.infov("Deleted bucket: {0}", bucketName);
     }
@@ -2581,6 +2589,18 @@ public class S3Service implements Resettable {
 
     private static final String DATA_SUFFIX = ".s3data";
 
+    // The account-scoped disk layout is dataRoot/ACCOUNT_STORAGE_ROOT/<accountId>/<bucket>/...
+    // rather than dataRoot/<accountId>/<bucket>/..., because a bucket name and an account ID
+    // share the same string shape (a 12-digit numeric bucket name is valid on S3), so
+    // "dataRoot/<accountId>/..." is not disjoint from the legacy layout "dataRoot/<bucket>/...":
+    // a legacy bucket literally named e.g. "000000000000" with key "orders/report.csv" resolves
+    // to the exact same path as account "000000000000"'s new-layout bucket "orders", key
+    // "report.csv". A leading "." makes this namespace unreachable by any bucket name real S3
+    // accepts (bucket names must begin with a letter or number) — createBucket() additionally
+    // rejects the one bucket name that would otherwise collide with the root of this namespace
+    // itself, since Floci (unlike real S3) doesn't otherwise validate bucket name format at all.
+    private static final String ACCOUNT_STORAGE_ROOT = ".accounts";
+
     // Byte storage (memoryDataStore / on-disk files) is a plain field, not a StorageBackend,
     // so unlike bucketStore/objectStore it gets no automatic account prefixing from
     // AccountAwareStorageBackend. bucketStore only enforces bucket-name uniqueness within an
@@ -2595,7 +2615,7 @@ public class S3Service implements Resettable {
     }
 
     private Path resolveObjectPath(String bucketName, String key) {
-        Path bucketDir = dataRoot.resolve(ownerId()).resolve(bucketName).normalize();
+        Path bucketDir = dataRoot.resolve(ACCOUNT_STORAGE_ROOT).resolve(ownerId()).resolve(bucketName).normalize();
 
         String safeKey = key;
         while (safeKey.startsWith("/")) {
@@ -2636,7 +2656,7 @@ public class S3Service implements Resettable {
     }
 
     private Path resolveVersionedPath(String bucketName, String key, String versionId) {
-        Path baseDir = dataRoot.resolve(ownerId()).resolve(".versions").resolve(bucketName).normalize();
+        Path baseDir = dataRoot.resolve(ACCOUNT_STORAGE_ROOT).resolve(ownerId()).resolve(".versions").resolve(bucketName).normalize();
 
         String safeKey = key;
         while (safeKey.startsWith("/")) {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -40,6 +40,7 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -71,6 +72,22 @@ public class S3Service implements Resettable {
     private final Path dataRoot;
     private final boolean inMemory;
     private final ConcurrentHashMap<String, byte[]> memoryDataStore = new ConcurrentHashMap<>();
+    // Guards disk-mode object files against a legacy-layout migration racing a write/delete to
+    // the same account-scoped path — see copyLegacyFileIfPresent(). A fixed-size stripe array
+    // (rather than one lock per Path in a growing map) keeps memory bounded regardless of how
+    // many distinct objects/versions a long-running instance ever writes or deletes — entries in
+    // a Path-keyed map would never be safe to remove without a full reference-counting scheme,
+    // since a lock in active use could otherwise be evicted out from under a waiting thread.
+    private static final int DISK_FILE_LOCK_STRIPES = 256;
+    private final ReentrantLock[] diskFileLocks = newLockStripes(DISK_FILE_LOCK_STRIPES);
+
+    private static ReentrantLock[] newLockStripes(int count) {
+        ReentrantLock[] locks = new ReentrantLock[count];
+        for (int i = 0; i < count; i++) {
+            locks[i] = new ReentrantLock();
+        }
+        return locks;
+    }
     private final ConcurrentHashMap<String, Map<Integer, byte[]>> memoryMultipartStore = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, MultipartUpload> multipartUploads = new ConcurrentHashMap<>();
 
@@ -668,8 +685,8 @@ public class S3Service implements Resettable {
         }
         try {
             Path path = versionId != null
-                    ? resolveVersionedPath(bucketName, key, versionId)
-                    : resolveObjectPath(bucketName, key);
+                    ? resolveVersionedPathForRead(bucketName, key, versionId)
+                    : resolveObjectPathForRead(bucketName, key);
             return Files.newInputStream(path);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to open S3 object stream", e);
@@ -2589,12 +2606,33 @@ public class S3Service implements Resettable {
         if (!resolved.startsWith(bucketDir)) {
             throw new AwsException("InvalidKey", "The specified key is invalid.", 400);
         }
-        migrateLegacyFileIfPresent(legacyObjectPath(bucketName, safeKey), resolved);
         return resolved;
     }
 
-    private Path legacyObjectPath(String bucketName, String safeKey) {
+    private Path legacyObjectPath(String bucketName, String key) {
+        String safeKey = key;
+        while (safeKey.startsWith("/")) {
+            safeKey = safeKey.substring(1);
+        }
         return dataRoot.resolve(bucketName).normalize().resolve(safeKey + DATA_SUFFIX);
+    }
+
+    /**
+     * Resolves the account-scoped object path for a read, first copying in a file found at the
+     * pre-account-scoping legacy path (no account segment). Must only ever be used for reads:
+     * the legacy file predates any account concept, so it isn't actually known to belong to the
+     * current account — and two different accounts can legitimately own a same-named bucket in
+     * Floci (bucket-name uniqueness is only enforced per account here, unlike real S3). A write
+     * or delete resolving through this path could let one account's operation destroy another
+     * account's not-yet-migrated data; {@link #resolveObjectPath} is used there instead, with no
+     * legacy fallback at all. Copying rather than moving leaves the ambiguous source untouched,
+     * so every account that reads it independently gets its own copy, at the cost of the legacy
+     * file persisting on disk indefinitely once read.
+     */
+    private Path resolveObjectPathForRead(String bucketName, String key) {
+        Path resolved = resolveObjectPath(bucketName, key);
+        copyLegacyFileIfPresent(legacyObjectPath(bucketName, key), resolved);
+        return resolved;
     }
 
     private Path resolveVersionedPath(String bucketName, String key, String versionId) {
@@ -2609,28 +2647,72 @@ public class S3Service implements Resettable {
         if (!resolved.startsWith(baseDir)) {
             throw new AwsException("InvalidKey", "The specified key is invalid.", 400);
         }
-        Path legacyBaseDir = dataRoot.resolve(".versions").resolve(bucketName).normalize();
-        migrateLegacyFileIfPresent(legacyBaseDir.resolve(safeKey).resolve(versionId + DATA_SUFFIX), resolved);
         return resolved;
     }
 
+    private Path legacyVersionedPath(String bucketName, String key, String versionId) {
+        String safeKey = key;
+        while (safeKey.startsWith("/")) {
+            safeKey = safeKey.substring(1);
+        }
+        return dataRoot.resolve(".versions").resolve(bucketName).normalize()
+                .resolve(safeKey).resolve(versionId + DATA_SUFFIX);
+    }
+
+    /** Read-only counterpart of {@link #resolveObjectPathForRead} for versioned objects. */
+    private Path resolveVersionedPathForRead(String bucketName, String key, String versionId) {
+        Path resolved = resolveVersionedPath(bucketName, key, versionId);
+        copyLegacyFileIfPresent(legacyVersionedPath(bucketName, key, versionId), resolved);
+        return resolved;
+    }
+
+    private ReentrantLock diskFileLock(Path path) {
+        // Two unrelated paths landing on the same stripe just serialize unnecessarily — safe,
+        // if occasionally less parallel, unlike a growing per-path map that never shrinks.
+        return diskFileLocks[Math.floorMod(path.hashCode(), diskFileLocks.length)];
+    }
+
     /**
-     * Before object bytes were account-scoped on disk, every object lived at this bucket/key
-     * path with no account segment. An installation upgrading past that change must not lose
-     * access to objects already written under the old layout, so a read/write/delete that
-     * resolves to a not-yet-migrated new-layout path transparently relocates the legacy file
-     * first — mirroring how {@link io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend#get}
-     * migrates a pre-multi-account storage key on first read.
+     * Copies in a legacy-layout file for {@code newPath}, guarded by the same per-path lock
+     * {@link #writeFile}/{@link #deleteFile} (and their versioned counterparts) hold while
+     * touching {@code newPath}. Without that shared lock, a read could copy stale legacy bytes
+     * into place, a concurrent write could land its real content first, and the read's own copy
+     * — checked for existence before either operation started — would still go on to clobber
+     * that write with the stale data. The lock makes "does newPath already exist" and "install
+     * the legacy copy" a single atomic step with respect to any write/delete of the same path,
+     * so a legacy copy can never install itself after a real write has already claimed the path.
      */
-    private void migrateLegacyFileIfPresent(Path legacyPath, Path newPath) {
-        if (Files.exists(newPath) || !Files.exists(legacyPath)) {
+    private void copyLegacyFileIfPresent(Path legacyPath, Path newPath) {
+        if (!Files.exists(legacyPath)) {
             return;
         }
+        ReentrantLock lock = diskFileLock(newPath);
+        lock.lock();
         try {
+            if (Files.exists(newPath)) {
+                return;
+            }
             Files.createDirectories(newPath.getParent());
-            Files.move(legacyPath, newPath);
+            Files.copy(legacyPath, newPath);
         } catch (IOException e) {
-            throw new UncheckedIOException("Failed to migrate legacy S3 object file to account-scoped layout", e);
+            // Files.copy can throw partway through (disk full, transient I/O error), leaving
+            // newPath present with truncated content. Left in place, that file would satisfy
+            // the exists-check above on every later attempt, permanently shadowing the still
+            // intact legacy source instead of letting a retry migrate it correctly. Still
+            // holding the lock, so this can't race a concurrent writer that might otherwise
+            // have created newPath in the meantime.
+            deleteQuietly(newPath, "partially-copied legacy S3 object file, so a later read can retry migration");
+            throw new UncheckedIOException("Failed to copy legacy S3 object file to account-scoped layout", e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void deleteQuietly(Path path, String reason) {
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException e) {
+            LOG.warnv(e, "Failed to delete {0} ({1})", path, reason);
         }
     }
 
@@ -2639,12 +2721,16 @@ public class S3Service implements Resettable {
             memoryDataStore.put(physicalVersionedKey(bucketName, key, versionId), data);
             return;
         }
+        Path filePath = resolveVersionedPath(bucketName, key, versionId);
+        ReentrantLock lock = diskFileLock(filePath);
+        lock.lock();
         try {
-            Path filePath = resolveVersionedPath(bucketName, key, versionId);
             Files.createDirectories(filePath.getParent());
             Files.write(filePath, data);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to write versioned S3 object file", e);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -2653,7 +2739,7 @@ public class S3Service implements Resettable {
             return memoryDataStore.get(physicalVersionedKey(bucketName, key, versionId));
         }
         try {
-            return Files.readAllBytes(resolveVersionedPath(bucketName, key, versionId));
+            return Files.readAllBytes(resolveVersionedPathForRead(bucketName, key, versionId));
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to read versioned S3 object file", e);
         }
@@ -2664,12 +2750,16 @@ public class S3Service implements Resettable {
             memoryDataStore.put(physicalKey(bucketName, key), data);
             return;
         }
+        Path filePath = resolveObjectPath(bucketName, key);
+        ReentrantLock lock = diskFileLock(filePath);
+        lock.lock();
         try {
-            Path filePath = resolveObjectPath(bucketName, key);
             Files.createDirectories(filePath.getParent());
             Files.write(filePath, data);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to write S3 object file", e);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -2678,7 +2768,7 @@ public class S3Service implements Resettable {
             return memoryDataStore.get(physicalKey(bucketName, key));
         }
         try {
-            return Files.readAllBytes(resolveObjectPath(bucketName, key));
+            return Files.readAllBytes(resolveObjectPathForRead(bucketName, key));
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to read S3 object file", e);
         }
@@ -2689,10 +2779,15 @@ public class S3Service implements Resettable {
             memoryDataStore.remove(physicalKey(bucketName, key));
             return;
         }
+        Path filePath = resolveObjectPath(bucketName, key);
+        ReentrantLock lock = diskFileLock(filePath);
+        lock.lock();
         try {
-            Files.deleteIfExists(resolveObjectPath(bucketName, key));
+            Files.deleteIfExists(filePath);
         } catch (IOException e) {
             LOG.errorv(e, "Failed to delete S3 object file: {0}/{1}", bucketName, key);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -2701,10 +2796,15 @@ public class S3Service implements Resettable {
             memoryDataStore.remove(physicalVersionedKey(bucketName, key, versionId));
             return;
         }
+        Path filePath = resolveVersionedPath(bucketName, key, versionId);
+        ReentrantLock lock = diskFileLock(filePath);
+        lock.lock();
         try {
-            Files.deleteIfExists(resolveVersionedPath(bucketName, key, versionId));
+            Files.deleteIfExists(filePath);
         } catch (IOException e) {
             LOG.errorv(e, "Failed to delete versioned S3 object file: {0}/{1} v={2}", bucketName, key, versionId);
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3AccountIsolationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3AccountIsolationIntegrationTest.java
@@ -8,16 +8,10 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 
 /**
- * Verifies that S3 object bytes are isolated between accounts, mirroring
- * {@link io.github.hectorvent.floci.core.common.AccountIsolationIntegrationTest}'s
- * SQS coverage.
- *
- * <p>Bucket metadata is already account-scoped via {@code AccountAwareStorageBackend}
- * (two accounts may each own a bucket with the same name — real S3 disallows this since
- * bucket names are globally unique, but that's a separate concern from what's tested
- * here), but object bytes ({@code S3Service.memoryDataStore} / on-disk files under
- * {@code dataRoot}) were keyed only by {@code bucketName + "/" + key}, with no account
- * component, so two accounts with a same-named bucket shared the same underlying bytes.
+ * Verifies S3 object bytes are isolated between accounts, mirroring
+ * {@link io.github.hectorvent.floci.core.common.AccountIsolationIntegrationTest}'s SQS coverage.
+ * Two accounts may own a same-named bucket in Floci (bucket names are only unique per account
+ * here, unlike real S3); object bytes must not collide when they do.
  */
 @QuarkusTest
 class S3AccountIsolationIntegrationTest {
@@ -34,10 +28,8 @@ class S3AccountIsolationIntegrationTest {
         createBucket(AUTH_ACCOUNT_1, bucket);
         createBucket(AUTH_ACCOUNT_2, bucket);
 
-        // Both accounts write to the same key in their own (same-named) bucket. Object
-        // metadata (per-account) would mask the leak if account 2 never wrote the key at
-        // all, so this must exercise the actual byte-storage collision: account 2's write
-        // must not overwrite what account 1 reads back, and vice versa.
+        // Both write the same key in their own bucket — exercises the byte-storage
+        // collision directly, not just metadata isolation.
         given()
             .header("Authorization", AUTH_ACCOUNT_1)
             .body("account-1-data")

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3AccountIsolationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3AccountIsolationIntegrationTest.java
@@ -1,0 +1,115 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Verifies that S3 object bytes are isolated between accounts, mirroring
+ * {@link io.github.hectorvent.floci.core.common.AccountIsolationIntegrationTest}'s
+ * SQS coverage.
+ *
+ * <p>Bucket metadata is already account-scoped via {@code AccountAwareStorageBackend}
+ * (two accounts may each own a bucket with the same name — real S3 disallows this since
+ * bucket names are globally unique, but that's a separate concern from what's tested
+ * here), but object bytes ({@code S3Service.memoryDataStore} / on-disk files under
+ * {@code dataRoot}) were keyed only by {@code bucketName + "/" + key}, with no account
+ * component, so two accounts with a same-named bucket shared the same underlying bytes.
+ */
+@QuarkusTest
+class S3AccountIsolationIntegrationTest {
+
+    private static final String AUTH_ACCOUNT_1 =
+            "AWS4-HMAC-SHA256 Credential=000000000001/20260215/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=abc";
+    private static final String AUTH_ACCOUNT_2 =
+            "AWS4-HMAC-SHA256 Credential=000000000002/20260215/us-east-1/s3/aws4_request, SignedHeaders=host, Signature=abc";
+
+    @Test
+    void objectsInSameNamedBucketAreIsolatedBetweenAccounts() {
+        String bucket = "account-isolation-shared-bucket";
+
+        createBucket(AUTH_ACCOUNT_1, bucket);
+        createBucket(AUTH_ACCOUNT_2, bucket);
+
+        // Both accounts write to the same key in their own (same-named) bucket. Object
+        // metadata (per-account) would mask the leak if account 2 never wrote the key at
+        // all, so this must exercise the actual byte-storage collision: account 2's write
+        // must not overwrite what account 1 reads back, and vice versa.
+        given()
+            .header("Authorization", AUTH_ACCOUNT_1)
+            .body("account-1-data")
+        .when()
+            .put("/" + bucket + "/shared-key.txt")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_ACCOUNT_2)
+            .body("account-2-data")
+        .when()
+            .put("/" + bucket + "/shared-key.txt")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("Authorization", AUTH_ACCOUNT_1)
+        .when()
+            .get("/" + bucket + "/shared-key.txt")
+        .then()
+            .statusCode(200)
+            .body(containsString("account-1-data"));
+
+        given()
+            .header("Authorization", AUTH_ACCOUNT_2)
+        .when()
+            .get("/" + bucket + "/shared-key.txt")
+        .then()
+            .statusCode(200)
+            .body(containsString("account-2-data"));
+    }
+
+    @Test
+    void deletingBucketDoesNotRemoveAnotherAccountsSameNamedBucketData() {
+        String bucket = "account-isolation-delete-bucket";
+
+        createBucket(AUTH_ACCOUNT_1, bucket);
+        createBucket(AUTH_ACCOUNT_2, bucket);
+
+        given()
+            .header("Authorization", AUTH_ACCOUNT_2)
+            .body("account-2-data")
+        .when()
+            .put("/" + bucket + "/kept-key.txt")
+        .then()
+            .statusCode(200);
+
+        // Account 1 deletes its own (empty) same-named bucket.
+        given()
+            .header("Authorization", AUTH_ACCOUNT_1)
+        .when()
+            .delete("/" + bucket)
+        .then()
+            .statusCode(204);
+
+        // Account 2's object must be unaffected.
+        given()
+            .header("Authorization", AUTH_ACCOUNT_2)
+        .when()
+            .get("/" + bucket + "/kept-key.txt")
+        .then()
+            .statusCode(200)
+            .body(not(containsString("<Error>")));
+    }
+
+    private static void createBucket(String auth, String bucket) {
+        given()
+            .header("Authorization", auth)
+        .when()
+            .put("/" + bucket)
+        .then()
+            .statusCode(200);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3LegacyDiskLayoutIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3LegacyDiskLayoutIntegrationTest.java
@@ -1,0 +1,53 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.s3.model.S3Object;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Before account-scoped object storage, every disk-mode S3 object lived at
+ * {@code dataRoot/bucketName/key.s3data}, with no account segment. An existing Floci
+ * installation upgrading past that change must not lose access to objects already on disk
+ * in that legacy layout — object *metadata* (in {@code objectStore}) was already
+ * account-scoped before this change and is unaffected by an upgrade, but the physical bytes
+ * were not, so a naive account-scoped path resolver alone would 404 on every pre-existing
+ * object.
+ */
+class S3LegacyDiskLayoutIntegrationTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void existingObjectWrittenUnderTheLegacyUnscopedPathIsStillReadable() throws Exception {
+        Path dataRoot = tempDir.resolve("s3");
+        S3Service s3Service = new S3Service(new InMemoryStorage<>(), new InMemoryStorage<>(), dataRoot, false);
+
+        s3Service.createBucket("legacy-bucket", "us-east-1");
+        byte[] data = "pre-upgrade-content".getBytes(StandardCharsets.UTF_8);
+        // Establishes correct objectStore metadata (unaffected by the account-scoping change)
+        // and writes bytes at the new, account-scoped path — then that file is relocated to
+        // simulate what an object written before this change actually looks like on disk.
+        s3Service.putObject("legacy-bucket", "legacy-key.txt", data, "text/plain", null);
+
+        Path newLayoutFile = dataRoot.resolve("000000000000").resolve("legacy-bucket").resolve("legacy-key.txt.s3data");
+        Path legacyLayoutFile = dataRoot.resolve("legacy-bucket").resolve("legacy-key.txt.s3data");
+        assertTrue(Files.exists(newLayoutFile), "test setup: object should initially be written at the new path");
+
+        Files.createDirectories(legacyLayoutFile.getParent());
+        Files.move(newLayoutFile, legacyLayoutFile, StandardCopyOption.REPLACE_EXISTING);
+
+        S3Object retrieved = s3Service.getObject("legacy-bucket", "legacy-key.txt");
+        assertArrayEquals(data, retrieved.getData(),
+                "an object physically stored under the pre-upgrade unscoped layout must still be readable");
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3LegacyDiskLayoutIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3LegacyDiskLayoutIntegrationTest.java
@@ -33,19 +33,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Before account-scoped object storage, every disk-mode S3 object lived at
- * {@code dataRoot/bucketName/key.s3data}, with no account segment. An existing Floci
- * installation upgrading past that change must not lose access to objects already on disk
- * in that legacy layout — object *metadata* (in {@code objectStore}) was already
- * account-scoped before this change and is unaffected by an upgrade, but the physical bytes
- * were not, so a naive account-scoped path resolver alone would 404 on every pre-existing
- * object.
- *
- * <p>Since a legacy file predates any account concept, it isn't actually known to belong to
- * the account that happens to touch it first — and Floci allows two different accounts to own
- * a same-named bucket, unlike real S3. Migration must therefore only ever happen on reads, and
- * by copying rather than moving: a write or delete must never be able to steal or destroy
- * another account's still-unmigrated legacy object just because it resolves to the same
- * bucket/key.
+ * {@code dataRoot/bucketName/key.s3data}, with no account segment. Upgrading past that change
+ * must not lose access to objects already on disk, and — since a legacy file isn't known to
+ * belong to any one account, and two accounts can share a bucket name — migrating it must never
+ * let one account's write/delete steal or destroy another account's still-unmigrated object.
  */
 class S3LegacyDiskLayoutIntegrationTest {
 
@@ -59,9 +50,7 @@ class S3LegacyDiskLayoutIntegrationTest {
 
         s3Service.createBucket("legacy-bucket", "us-east-1");
         byte[] data = "pre-upgrade-content".getBytes(StandardCharsets.UTF_8);
-        // Establishes correct objectStore metadata (unaffected by the account-scoping change)
-        // and writes bytes at the new, account-scoped path — then that file is relocated to
-        // simulate what an object written before this change actually looks like on disk.
+        // Write normally, then relocate to the legacy path to simulate pre-upgrade data.
         s3Service.putObject("legacy-bucket", "legacy-key.txt", data, "text/plain", null);
 
         Path newLayoutFile = dataRoot.resolve(".accounts").resolve("000000000000").resolve("legacy-bucket").resolve("legacy-key.txt.s3data");
@@ -78,11 +67,9 @@ class S3LegacyDiskLayoutIntegrationTest {
 
     @Test
     void bucketNamedLikeTheDefaultAccountIdDoesNotCollideWithAccountScopedStorage() throws Exception {
-        // A 12-digit bucket name is valid on S3. Without a reserved namespace, the account-
-        // scoped layout dataRoot/<accountId>/<bucket>/<key>.s3data is not disjoint from the
-        // legacy layout dataRoot/<bucket>/<key>.s3data: a legacy bucket literally named
-        // "000000000000" with key "orders/report.csv" would resolve to the exact same path as
-        // account "000000000000"'s new-layout bucket "orders", key "report.csv".
+        // A 12-digit bucket name is valid on S3 and shares its shape with an account ID: a
+        // legacy bucket "000000000000" with key "orders/report.csv" must not collide with
+        // account "000000000000"'s own "orders" bucket, key "report.csv".
         Path dataRoot = tempDir.resolve("s3");
         S3Service s3Service = new S3Service(new InMemoryStorage<>(), new InMemoryStorage<>(), dataRoot, false);
 
@@ -91,8 +78,6 @@ class S3LegacyDiskLayoutIntegrationTest {
         byte[] legacyData = "legacy-bucket-named-like-an-account-id".getBytes(StandardCharsets.UTF_8);
         s3Service.putObject(accountIdShapedBucket, "orders/report.csv", legacyData, "text/plain", null);
 
-        // Relocates it to the pre-upgrade unscoped layout, exactly as
-        // existingObjectWrittenUnderTheLegacyUnscopedPathIsStillReadable does.
         Path newLayoutFile = dataRoot.resolve(".accounts").resolve("000000000000")
                 .resolve(accountIdShapedBucket).resolve("orders/report.csv.s3data");
         Path legacyLayoutFile = dataRoot.resolve(accountIdShapedBucket).resolve("orders/report.csv.s3data");
@@ -124,14 +109,10 @@ class S3LegacyDiskLayoutIntegrationTest {
     @Test
     @DisabledOnOs(OS.WINDOWS)
     void migrationFailureIsNotPermanentAndDoesNotLeaveAFileBehind() throws Exception {
-        // This specific fault (permission denied on the source) happens to fail before
-        // Files.copy ever creates the destination, so it doesn't reproduce a genuinely
-        // *partial* write (e.g. disk-full mid-copy) — that scenario isn't reliably forceable
-        // through portable java.nio.file APIs for a file this small. What this does verify:
-        // copyLegacyFileIfPresent's catch-and-cleanup doesn't leave anything behind for this
-        // failure mode either, and — the property that actually matters to a caller — a
-        // transient failure is not permanent: once the underlying problem is resolved, a retry
-        // recovers the still-intact legacy content instead of being stuck.
+        // Note: permission-denied fails before Files.copy creates a destination on this JVM,
+        // so this doesn't reproduce a genuinely partial write (disk-full mid-copy isn't
+        // reliably forceable for a file this small) — it verifies the property that matters
+        // to a caller: a transient failure isn't permanent, and a retry recovers.
         Assumptions.assumeFalse("root".equals(System.getProperty("user.name")),
                 "root ignores file read permissions");
 
@@ -164,9 +145,8 @@ class S3LegacyDiskLayoutIntegrationTest {
     @Test
     void anotherAccountsWriteMustNotDestroyThisAccountsUnmigratedLegacyObject() throws Exception {
         Path dataRoot = tempDir.resolve("s3");
-        // Two different accounts, sharing the underlying stores exactly like production does —
-        // isolation comes only from AccountAwareStorageBackend's key prefixing, not from
-        // separate backing storage.
+        // Two accounts sharing the underlying stores, like production — isolation comes only
+        // from AccountAwareStorageBackend's key prefixing.
         InMemoryStorage<String, Bucket> sharedBucketStore = new InMemoryStorage<>();
         InMemoryStorage<String, S3Object> sharedObjectStore = new InMemoryStorage<>();
 
@@ -183,17 +163,14 @@ class S3LegacyDiskLayoutIntegrationTest {
         byte[] legacyData = "account-A-legacy-content".getBytes(StandardCharsets.UTF_8);
         s3ForA.putObject("shared-bucket", "shared-key.txt", legacyData, "text/plain", null);
 
-        // Relocates A's just-written bytes to the pre-upgrade unscoped layout, simulating an
-        // object that has existed since before per-account byte storage existed — A has never
-        // read it since upgrading, so it hasn't yet been copied to A's account-scoped path.
+        // A hasn't read it since upgrading, so it's still sitting at the legacy path.
         Path newLayoutFile = dataRoot.resolve(".accounts").resolve("111111111111").resolve("shared-bucket").resolve("shared-key.txt.s3data");
         Path legacyLayoutFile = dataRoot.resolve("shared-bucket").resolve("shared-key.txt.s3data");
         Files.createDirectories(legacyLayoutFile.getParent());
         Files.move(newLayoutFile, legacyLayoutFile, StandardCopyOption.REPLACE_EXISTING);
 
-        // Account B is unrelated to A and happens to use the same bucket name (bucket names are
-        // only unique per account in Floci) and the same key — pure coincidence, not shared
-        // history. B's own, unrelated write must not touch A's still-unmigrated legacy object.
+        // B is unrelated to A and just happens to reuse the same bucket/key names (bucket
+        // names are only unique per account in Floci) — pure coincidence, not shared history.
         s3ForB.createBucket("shared-bucket", "us-east-1");
         byte[] bData = "account-B-content".getBytes(StandardCharsets.UTF_8);
         s3ForB.putObject("shared-bucket", "shared-key.txt", bData, "text/plain", null);
@@ -205,12 +182,9 @@ class S3LegacyDiskLayoutIntegrationTest {
 
     @Test
     void concurrentOverwriteNeverLosesToARacingLegacyMigration() throws Exception {
-        // A read that resolves ambiguous legacy data and a write to the same account's same key
-        // can race: the write's real content must always be what a subsequent read sees, never
-        // stale legacy bytes reinstalled on top of it after the write already landed. Repeated
-        // across many independent keys, released together via a barrier, since a lock-based fix
-        // can't be forced into a specific interleaving from outside — only shown to hold under
-        // real concurrent scheduling across enough attempts.
+        // A racing legacy-migration read must never reinstall stale bytes on top of a write
+        // that already landed. Repeated across many keys, since a lock-based fix can only be
+        // shown to hold under real concurrent scheduling, not forced into one interleaving.
         int rounds = 50;
         ExecutorService pool = Executors.newFixedThreadPool(2);
         try {
@@ -256,10 +230,8 @@ class S3LegacyDiskLayoutIntegrationTest {
         S3Service s3Service = new S3Service(new InMemoryStorage<>(), new InMemoryStorage<>(), dataRoot, false);
         s3Service.createBucket("legacy-bucket", "us-east-1");
 
-        // Legacy migration now copies rather than moves, so unlike a move there's no "source
-        // vanished from under a concurrent reader" case to race — this exercises many concurrent
-        // reads of never-yet-migrated legacy files to confirm that holds regardless of
-        // scheduling, not to hunt for a specific race window.
+        // Migration copies rather than moves, so there's no "source vanished" case to race —
+        // this just confirms many concurrent first reads never fail, regardless of scheduling.
         int rounds = 50;
         ExecutorService pool = Executors.newFixedThreadPool(2);
         try {

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3LegacyDiskLayoutIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3LegacyDiskLayoutIntegrationTest.java
@@ -1,17 +1,35 @@
 package io.github.hectorvent.floci.services.s3;
 
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.lambda.LambdaService;
+import io.github.hectorvent.floci.services.s3.model.Bucket;
 import io.github.hectorvent.floci.services.s3.model.S3Object;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Before account-scoped object storage, every disk-mode S3 object lived at
@@ -21,6 +39,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * account-scoped before this change and is unaffected by an upgrade, but the physical bytes
  * were not, so a naive account-scoped path resolver alone would 404 on every pre-existing
  * object.
+ *
+ * <p>Since a legacy file predates any account concept, it isn't actually known to belong to
+ * the account that happens to touch it first — and Floci allows two different accounts to own
+ * a same-named bucket, unlike real S3. Migration must therefore only ever happen on reads, and
+ * by copying rather than moving: a write or delete must never be able to steal or destroy
+ * another account's still-unmigrated legacy object just because it resolves to the same
+ * bucket/key.
  */
 class S3LegacyDiskLayoutIntegrationTest {
 
@@ -49,5 +74,178 @@ class S3LegacyDiskLayoutIntegrationTest {
         S3Object retrieved = s3Service.getObject("legacy-bucket", "legacy-key.txt");
         assertArrayEquals(data, retrieved.getData(),
                 "an object physically stored under the pre-upgrade unscoped layout must still be readable");
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void migrationFailureIsNotPermanentAndDoesNotLeaveAFileBehind() throws Exception {
+        // This specific fault (permission denied on the source) happens to fail before
+        // Files.copy ever creates the destination, so it doesn't reproduce a genuinely
+        // *partial* write (e.g. disk-full mid-copy) — that scenario isn't reliably forceable
+        // through portable java.nio.file APIs for a file this small. What this does verify:
+        // copyLegacyFileIfPresent's catch-and-cleanup doesn't leave anything behind for this
+        // failure mode either, and — the property that actually matters to a caller — a
+        // transient failure is not permanent: once the underlying problem is resolved, a retry
+        // recovers the still-intact legacy content instead of being stuck.
+        Assumptions.assumeFalse("root".equals(System.getProperty("user.name")),
+                "root ignores file read permissions");
+
+        Path dataRoot = tempDir.resolve("s3");
+        S3Service s3Service = new S3Service(new InMemoryStorage<>(), new InMemoryStorage<>(), dataRoot, false);
+        s3Service.createBucket("legacy-bucket", "us-east-1");
+        byte[] data = "pre-upgrade-content".getBytes(StandardCharsets.UTF_8);
+        s3Service.putObject("legacy-bucket", "legacy-key.txt", data, "text/plain", null);
+
+        Path newLayoutFile = dataRoot.resolve("000000000000").resolve("legacy-bucket").resolve("legacy-key.txt.s3data");
+        Path legacyLayoutFile = dataRoot.resolve("legacy-bucket").resolve("legacy-key.txt.s3data");
+        Files.createDirectories(legacyLayoutFile.getParent());
+        Files.move(newLayoutFile, legacyLayoutFile, StandardCopyOption.REPLACE_EXISTING);
+
+        assertTrue(legacyLayoutFile.toFile().setReadable(false));
+        try {
+            assertThrows(UncheckedIOException.class, () -> s3Service.getObject("legacy-bucket", "legacy-key.txt"));
+            assertFalse(Files.exists(newLayoutFile),
+                    "a failed migration must not leave a file behind that would satisfy the "
+                            + "exists-check on a later attempt and permanently shadow the intact legacy source");
+        } finally {
+            assertTrue(legacyLayoutFile.toFile().setReadable(true));
+        }
+
+        S3Object retrieved = s3Service.getObject("legacy-bucket", "legacy-key.txt");
+        assertArrayEquals(data, retrieved.getData(),
+                "a retry after a failed migration must recover the still-intact legacy content");
+    }
+
+    @Test
+    void anotherAccountsWriteMustNotDestroyThisAccountsUnmigratedLegacyObject() throws Exception {
+        Path dataRoot = tempDir.resolve("s3");
+        // Two different accounts, sharing the underlying stores exactly like production does —
+        // isolation comes only from AccountAwareStorageBackend's key prefixing, not from
+        // separate backing storage.
+        InMemoryStorage<String, Bucket> sharedBucketStore = new InMemoryStorage<>();
+        InMemoryStorage<String, S3Object> sharedObjectStore = new InMemoryStorage<>();
+
+        S3Service s3ForA = new S3Service(
+                new AccountAwareStorageBackend<>(sharedBucketStore, null, "111111111111"),
+                new AccountAwareStorageBackend<>(sharedObjectStore, null, "111111111111"),
+                dataRoot, false, (LambdaService) null, new RegionResolver("us-east-1", "111111111111"));
+        S3Service s3ForB = new S3Service(
+                new AccountAwareStorageBackend<>(sharedBucketStore, null, "222222222222"),
+                new AccountAwareStorageBackend<>(sharedObjectStore, null, "222222222222"),
+                dataRoot, false, (LambdaService) null, new RegionResolver("us-east-1", "222222222222"));
+
+        s3ForA.createBucket("shared-bucket", "us-east-1");
+        byte[] legacyData = "account-A-legacy-content".getBytes(StandardCharsets.UTF_8);
+        s3ForA.putObject("shared-bucket", "shared-key.txt", legacyData, "text/plain", null);
+
+        // Relocates A's just-written bytes to the pre-upgrade unscoped layout, simulating an
+        // object that has existed since before per-account byte storage existed — A has never
+        // read it since upgrading, so it hasn't yet been copied to A's account-scoped path.
+        Path newLayoutFile = dataRoot.resolve("111111111111").resolve("shared-bucket").resolve("shared-key.txt.s3data");
+        Path legacyLayoutFile = dataRoot.resolve("shared-bucket").resolve("shared-key.txt.s3data");
+        Files.createDirectories(legacyLayoutFile.getParent());
+        Files.move(newLayoutFile, legacyLayoutFile, StandardCopyOption.REPLACE_EXISTING);
+
+        // Account B is unrelated to A and happens to use the same bucket name (bucket names are
+        // only unique per account in Floci) and the same key — pure coincidence, not shared
+        // history. B's own, unrelated write must not touch A's still-unmigrated legacy object.
+        s3ForB.createBucket("shared-bucket", "us-east-1");
+        byte[] bData = "account-B-content".getBytes(StandardCharsets.UTF_8);
+        s3ForB.putObject("shared-bucket", "shared-key.txt", bData, "text/plain", null);
+
+        assertArrayEquals(bData, s3ForB.getObject("shared-bucket", "shared-key.txt").getData());
+        assertArrayEquals(legacyData, s3ForA.getObject("shared-bucket", "shared-key.txt").getData(),
+                "account B's unrelated write must not destroy account A's still-unmigrated legacy object");
+    }
+
+    @Test
+    void concurrentOverwriteNeverLosesToARacingLegacyMigration() throws Exception {
+        // A read that resolves ambiguous legacy data and a write to the same account's same key
+        // can race: the write's real content must always be what a subsequent read sees, never
+        // stale legacy bytes reinstalled on top of it after the write already landed. Repeated
+        // across many independent keys, released together via a barrier, since a lock-based fix
+        // can't be forced into a specific interleaving from outside — only shown to hold under
+        // real concurrent scheduling across enough attempts.
+        int rounds = 50;
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            for (int i = 0; i < rounds; i++) {
+                Path dataRoot = tempDir.resolve("race-" + i).resolve("s3");
+                S3Service s3Service = new S3Service(new InMemoryStorage<>(), new InMemoryStorage<>(), dataRoot, false);
+                String bucket = "legacy-bucket";
+                String key = "key.txt";
+                s3Service.createBucket(bucket, "us-east-1");
+
+                byte[] legacyData = "legacy-content".getBytes(StandardCharsets.UTF_8);
+                s3Service.putObject(bucket, key, legacyData, "text/plain", null);
+                Path newLayoutFile = dataRoot.resolve("000000000000").resolve(bucket).resolve(key + ".s3data");
+                Path legacyLayoutFile = dataRoot.resolve(bucket).resolve(key + ".s3data");
+                Files.createDirectories(legacyLayoutFile.getParent());
+                Files.move(newLayoutFile, legacyLayoutFile, StandardCopyOption.REPLACE_EXISTING);
+
+                byte[] writeData = ("write-content-" + i).getBytes(StandardCharsets.UTF_8);
+                CyclicBarrier barrier = new CyclicBarrier(2);
+                Future<byte[]> readFuture = pool.submit(() -> {
+                    barrier.await(5, TimeUnit.SECONDS);
+                    return s3Service.getObject(bucket, key).getData();
+                });
+                Future<?> writeFuture = pool.submit(() -> {
+                    barrier.await(5, TimeUnit.SECONDS);
+                    s3Service.putObject(bucket, key, writeData, "text/plain", null);
+                    return null;
+                });
+                readFuture.get(5, TimeUnit.SECONDS);
+                writeFuture.get(5, TimeUnit.SECONDS);
+
+                assertArrayEquals(writeData, s3Service.getObject(bucket, key).getData(),
+                        "a completed write must never be clobbered by a racing legacy migration (round " + i + ")");
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    void concurrentFirstReadsOfTheSameLegacyObjectBothSucceed() throws Exception {
+        Path dataRoot = tempDir.resolve("s3");
+        S3Service s3Service = new S3Service(new InMemoryStorage<>(), new InMemoryStorage<>(), dataRoot, false);
+        s3Service.createBucket("legacy-bucket", "us-east-1");
+
+        // Legacy migration now copies rather than moves, so unlike a move there's no "source
+        // vanished from under a concurrent reader" case to race — this exercises many concurrent
+        // reads of never-yet-migrated legacy files to confirm that holds regardless of
+        // scheduling, not to hunt for a specific race window.
+        int rounds = 50;
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            for (int i = 0; i < rounds; i++) {
+                String key = "legacy-key-" + i + ".txt";
+                byte[] data = ("pre-upgrade-content-" + i).getBytes(StandardCharsets.UTF_8);
+                s3Service.putObject("legacy-bucket", key, data, "text/plain", null);
+
+                Path newLayoutFile = dataRoot.resolve("000000000000").resolve("legacy-bucket").resolve(key + ".s3data");
+                Path legacyLayoutFile = dataRoot.resolve("legacy-bucket").resolve(key + ".s3data");
+                Files.createDirectories(legacyLayoutFile.getParent());
+                Files.move(newLayoutFile, legacyLayoutFile, StandardCopyOption.REPLACE_EXISTING);
+
+                CyclicBarrier barrier = new CyclicBarrier(2);
+                List<Future<byte[]>> futures = new ArrayList<>();
+                for (int t = 0; t < 2; t++) {
+                    futures.add(pool.submit(() -> {
+                        barrier.await(5, TimeUnit.SECONDS);
+                        return s3Service.getObject("legacy-bucket", key).getData();
+                    }));
+                }
+                for (Future<byte[]> future : futures) {
+                    try {
+                        assertArrayEquals(data, future.get(5, TimeUnit.SECONDS));
+                    } catch (Exception e) {
+                        fail("concurrent first read of a legacy-layout object must not fail (round " + i + ")", e);
+                    }
+                }
+            }
+        } finally {
+            pool.shutdownNow();
+        }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3LegacyDiskLayoutIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3LegacyDiskLayoutIntegrationTest.java
@@ -64,7 +64,7 @@ class S3LegacyDiskLayoutIntegrationTest {
         // simulate what an object written before this change actually looks like on disk.
         s3Service.putObject("legacy-bucket", "legacy-key.txt", data, "text/plain", null);
 
-        Path newLayoutFile = dataRoot.resolve("000000000000").resolve("legacy-bucket").resolve("legacy-key.txt.s3data");
+        Path newLayoutFile = dataRoot.resolve(".accounts").resolve("000000000000").resolve("legacy-bucket").resolve("legacy-key.txt.s3data");
         Path legacyLayoutFile = dataRoot.resolve("legacy-bucket").resolve("legacy-key.txt.s3data");
         assertTrue(Files.exists(newLayoutFile), "test setup: object should initially be written at the new path");
 
@@ -74,6 +74,51 @@ class S3LegacyDiskLayoutIntegrationTest {
         S3Object retrieved = s3Service.getObject("legacy-bucket", "legacy-key.txt");
         assertArrayEquals(data, retrieved.getData(),
                 "an object physically stored under the pre-upgrade unscoped layout must still be readable");
+    }
+
+    @Test
+    void bucketNamedLikeTheDefaultAccountIdDoesNotCollideWithAccountScopedStorage() throws Exception {
+        // A 12-digit bucket name is valid on S3. Without a reserved namespace, the account-
+        // scoped layout dataRoot/<accountId>/<bucket>/<key>.s3data is not disjoint from the
+        // legacy layout dataRoot/<bucket>/<key>.s3data: a legacy bucket literally named
+        // "000000000000" with key "orders/report.csv" would resolve to the exact same path as
+        // account "000000000000"'s new-layout bucket "orders", key "report.csv".
+        Path dataRoot = tempDir.resolve("s3");
+        S3Service s3Service = new S3Service(new InMemoryStorage<>(), new InMemoryStorage<>(), dataRoot, false);
+
+        String accountIdShapedBucket = "000000000000";
+        s3Service.createBucket(accountIdShapedBucket, "us-east-1");
+        byte[] legacyData = "legacy-bucket-named-like-an-account-id".getBytes(StandardCharsets.UTF_8);
+        s3Service.putObject(accountIdShapedBucket, "orders/report.csv", legacyData, "text/plain", null);
+
+        // Relocates it to the pre-upgrade unscoped layout, exactly as
+        // existingObjectWrittenUnderTheLegacyUnscopedPathIsStillReadable does.
+        Path newLayoutFile = dataRoot.resolve(".accounts").resolve("000000000000")
+                .resolve(accountIdShapedBucket).resolve("orders/report.csv.s3data");
+        Path legacyLayoutFile = dataRoot.resolve(accountIdShapedBucket).resolve("orders/report.csv.s3data");
+        Files.createDirectories(legacyLayoutFile.getParent());
+        Files.move(newLayoutFile, legacyLayoutFile, StandardCopyOption.REPLACE_EXISTING);
+
+        // The default account's own, unrelated "orders" bucket and "report.csv" key.
+        s3Service.createBucket("orders", "us-east-1");
+        byte[] newData = "unrelated-object-in-the-orders-bucket".getBytes(StandardCharsets.UTF_8);
+        s3Service.putObject("orders", "report.csv", newData, "text/plain", null);
+
+        assertArrayEquals(newData, s3Service.getObject("orders", "report.csv").getData(),
+                "the unrelated new-layout object must not be shadowed by the account-ID-shaped legacy bucket");
+        assertArrayEquals(legacyData, s3Service.getObject(accountIdShapedBucket, "orders/report.csv").getData(),
+                "the legacy bucket named like an account ID must still resolve to its own, distinct content");
+    }
+
+    @Test
+    void bucketNamedLikeTheReservedAccountStorageRootIsRejected() {
+        Path dataRoot = tempDir.resolve("s3");
+        S3Service s3Service = new S3Service(new InMemoryStorage<>(), new InMemoryStorage<>(), dataRoot, false);
+
+        assertThrows(io.github.hectorvent.floci.core.common.AwsException.class,
+                () -> s3Service.createBucket(".accounts", "us-east-1"),
+                "a bucket named exactly like the reserved account-storage root must be rejected, "
+                        + "since Floci doesn't otherwise validate bucket name format at all");
     }
 
     @Test
@@ -96,7 +141,7 @@ class S3LegacyDiskLayoutIntegrationTest {
         byte[] data = "pre-upgrade-content".getBytes(StandardCharsets.UTF_8);
         s3Service.putObject("legacy-bucket", "legacy-key.txt", data, "text/plain", null);
 
-        Path newLayoutFile = dataRoot.resolve("000000000000").resolve("legacy-bucket").resolve("legacy-key.txt.s3data");
+        Path newLayoutFile = dataRoot.resolve(".accounts").resolve("000000000000").resolve("legacy-bucket").resolve("legacy-key.txt.s3data");
         Path legacyLayoutFile = dataRoot.resolve("legacy-bucket").resolve("legacy-key.txt.s3data");
         Files.createDirectories(legacyLayoutFile.getParent());
         Files.move(newLayoutFile, legacyLayoutFile, StandardCopyOption.REPLACE_EXISTING);
@@ -141,7 +186,7 @@ class S3LegacyDiskLayoutIntegrationTest {
         // Relocates A's just-written bytes to the pre-upgrade unscoped layout, simulating an
         // object that has existed since before per-account byte storage existed — A has never
         // read it since upgrading, so it hasn't yet been copied to A's account-scoped path.
-        Path newLayoutFile = dataRoot.resolve("111111111111").resolve("shared-bucket").resolve("shared-key.txt.s3data");
+        Path newLayoutFile = dataRoot.resolve(".accounts").resolve("111111111111").resolve("shared-bucket").resolve("shared-key.txt.s3data");
         Path legacyLayoutFile = dataRoot.resolve("shared-bucket").resolve("shared-key.txt.s3data");
         Files.createDirectories(legacyLayoutFile.getParent());
         Files.move(newLayoutFile, legacyLayoutFile, StandardCopyOption.REPLACE_EXISTING);
@@ -178,7 +223,7 @@ class S3LegacyDiskLayoutIntegrationTest {
 
                 byte[] legacyData = "legacy-content".getBytes(StandardCharsets.UTF_8);
                 s3Service.putObject(bucket, key, legacyData, "text/plain", null);
-                Path newLayoutFile = dataRoot.resolve("000000000000").resolve(bucket).resolve(key + ".s3data");
+                Path newLayoutFile = dataRoot.resolve(".accounts").resolve("000000000000").resolve(bucket).resolve(key + ".s3data");
                 Path legacyLayoutFile = dataRoot.resolve(bucket).resolve(key + ".s3data");
                 Files.createDirectories(legacyLayoutFile.getParent());
                 Files.move(newLayoutFile, legacyLayoutFile, StandardCopyOption.REPLACE_EXISTING);
@@ -223,7 +268,7 @@ class S3LegacyDiskLayoutIntegrationTest {
                 byte[] data = ("pre-upgrade-content-" + i).getBytes(StandardCharsets.UTF_8);
                 s3Service.putObject("legacy-bucket", key, data, "text/plain", null);
 
-                Path newLayoutFile = dataRoot.resolve("000000000000").resolve("legacy-bucket").resolve(key + ".s3data");
+                Path newLayoutFile = dataRoot.resolve(".accounts").resolve("000000000000").resolve("legacy-bucket").resolve(key + ".s3data");
                 Path legacyLayoutFile = dataRoot.resolve("legacy-bucket").resolve(key + ".s3data");
                 Files.createDirectories(legacyLayoutFile.getParent());
                 Files.move(newLayoutFile, legacyLayoutFile, StandardCopyOption.REPLACE_EXISTING);

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
@@ -192,7 +192,7 @@ class S3ServiceTest {
         byte[] data = "file content".getBytes(StandardCharsets.UTF_8);
         s3Service.putObject("test-bucket", "docs/readme.txt", data, "text/plain", null);
 
-        Path filePath = tempDir.resolve("s3/000000000000/test-bucket/docs/readme.txt.s3data");
+        Path filePath = tempDir.resolve("s3/.accounts/000000000000/test-bucket/docs/readme.txt.s3data");
         assertTrue(Files.exists(filePath));
         assertArrayEquals(data, assertDoesNotThrow(() -> Files.readAllBytes(filePath)));
     }
@@ -240,7 +240,7 @@ class S3ServiceTest {
         s3Service.createBucket("test-bucket", "us-east-1");
         s3Service.putObject("test-bucket", "file.txt", "data".getBytes(), null, null);
 
-        Path filePath = tempDir.resolve("s3/000000000000/test-bucket/file.txt.s3data");
+        Path filePath = tempDir.resolve("s3/.accounts/000000000000/test-bucket/file.txt.s3data");
         assertTrue(Files.exists(filePath));
 
         s3Service.deleteObject("test-bucket", "file.txt");
@@ -350,7 +350,7 @@ class S3ServiceTest {
         S3Object retrieved = s3Service.getObject("dest-bucket", "copy.txt");
         assertArrayEquals("content".getBytes(), retrieved.getData());
 
-        assertTrue(Files.exists(tempDir.resolve("s3/000000000000/dest-bucket/copy.txt.s3data")));
+        assertTrue(Files.exists(tempDir.resolve("s3/.accounts/000000000000/dest-bucket/copy.txt.s3data")));
     }
 
     @Test
@@ -435,7 +435,7 @@ class S3ServiceTest {
         S3Object marker = s3Service.getObject("test-bucket", "output.parquet");
         assertArrayEquals(markerData, marker.getData());
 
-        Path bucketDir = tempDir.resolve("s3/000000000000/test-bucket");
+        Path bucketDir = tempDir.resolve("s3/.accounts/000000000000/test-bucket");
         assertTrue(Files.isDirectory(bucketDir.resolve("output.parquet")));
         assertTrue(Files.isRegularFile(bucketDir.resolve("output.parquet.s3data")));
         assertTrue(Files.isRegularFile(bucketDir.resolve("output.parquet/part-0001.parquet.s3data")));
@@ -458,7 +458,7 @@ class S3ServiceTest {
         S3Object child = s3Service.getObject("test-bucket", "output.parquet/part-0001.parquet");
         assertArrayEquals(childData, child.getData());
 
-        Path bucketDir = tempDir.resolve("s3/000000000000/test-bucket");
+        Path bucketDir = tempDir.resolve("s3/.accounts/000000000000/test-bucket");
         assertTrue(Files.isRegularFile(bucketDir.resolve("output.parquet.s3data")));
         assertTrue(Files.isDirectory(bucketDir.resolve("output.parquet")));
         assertTrue(Files.isRegularFile(bucketDir.resolve("output.parquet/part-0001.parquet.s3data")));

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
@@ -192,7 +192,7 @@ class S3ServiceTest {
         byte[] data = "file content".getBytes(StandardCharsets.UTF_8);
         s3Service.putObject("test-bucket", "docs/readme.txt", data, "text/plain", null);
 
-        Path filePath = tempDir.resolve("s3/test-bucket/docs/readme.txt.s3data");
+        Path filePath = tempDir.resolve("s3/000000000000/test-bucket/docs/readme.txt.s3data");
         assertTrue(Files.exists(filePath));
         assertArrayEquals(data, assertDoesNotThrow(() -> Files.readAllBytes(filePath)));
     }
@@ -240,7 +240,7 @@ class S3ServiceTest {
         s3Service.createBucket("test-bucket", "us-east-1");
         s3Service.putObject("test-bucket", "file.txt", "data".getBytes(), null, null);
 
-        Path filePath = tempDir.resolve("s3/test-bucket/file.txt.s3data");
+        Path filePath = tempDir.resolve("s3/000000000000/test-bucket/file.txt.s3data");
         assertTrue(Files.exists(filePath));
 
         s3Service.deleteObject("test-bucket", "file.txt");
@@ -350,7 +350,7 @@ class S3ServiceTest {
         S3Object retrieved = s3Service.getObject("dest-bucket", "copy.txt");
         assertArrayEquals("content".getBytes(), retrieved.getData());
 
-        assertTrue(Files.exists(tempDir.resolve("s3/dest-bucket/copy.txt.s3data")));
+        assertTrue(Files.exists(tempDir.resolve("s3/000000000000/dest-bucket/copy.txt.s3data")));
     }
 
     @Test
@@ -435,7 +435,7 @@ class S3ServiceTest {
         S3Object marker = s3Service.getObject("test-bucket", "output.parquet");
         assertArrayEquals(markerData, marker.getData());
 
-        Path bucketDir = tempDir.resolve("s3/test-bucket");
+        Path bucketDir = tempDir.resolve("s3/000000000000/test-bucket");
         assertTrue(Files.isDirectory(bucketDir.resolve("output.parquet")));
         assertTrue(Files.isRegularFile(bucketDir.resolve("output.parquet.s3data")));
         assertTrue(Files.isRegularFile(bucketDir.resolve("output.parquet/part-0001.parquet.s3data")));
@@ -458,7 +458,7 @@ class S3ServiceTest {
         S3Object child = s3Service.getObject("test-bucket", "output.parquet/part-0001.parquet");
         assertArrayEquals(childData, child.getData());
 
-        Path bucketDir = tempDir.resolve("s3/test-bucket");
+        Path bucketDir = tempDir.resolve("s3/000000000000/test-bucket");
         assertTrue(Files.isRegularFile(bucketDir.resolve("output.parquet.s3data")));
         assertTrue(Files.isDirectory(bucketDir.resolve("output.parquet")));
         assertTrue(Files.isRegularFile(bucketDir.resolve("output.parquet/part-0001.parquet.s3data")));

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
@@ -195,7 +195,8 @@ class S3VersioningServiceTest {
         S3Object v1 = diskService.putObject("versioned-bucket", "test.txt",
                 "v1".getBytes(StandardCharsets.UTF_8), "text/plain", null);
 
-        Path versionedPath = tempDir.resolve(".versions")
+        Path versionedPath = tempDir.resolve("000000000000")
+                .resolve(".versions")
                 .resolve("versioned-bucket")
                 .resolve("test.txt")
                 .resolve(v1.getVersionId() + ".s3data");

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3VersioningServiceTest.java
@@ -195,7 +195,8 @@ class S3VersioningServiceTest {
         S3Object v1 = diskService.putObject("versioned-bucket", "test.txt",
                 "v1".getBytes(StandardCharsets.UTF_8), "text/plain", null);
 
-        Path versionedPath = tempDir.resolve("000000000000")
+        Path versionedPath = tempDir.resolve(".accounts")
+                .resolve("000000000000")
                 .resolve(".versions")
                 .resolve("versioned-bucket")
                 .resolve("test.txt")


### PR DESCRIPTION
## Summary

Object bytes (`S3Service.memoryDataStore` in memory mode, or files under `dataRoot` on disk) were keyed only by `bucketName/key`, with no account component — unlike `bucketStore`/`objectStore`, which get automatic account prefixing from `AccountAwareStorageBackend`. `bucketStore` only enforces bucket-name uniqueness within an account (real S3 enforces it globally, which is a separate, pre-existing behavior difference not addressed here), so two accounts can each own a bucket with the same name; when they did, their object bytes collided:

- `PutObject` in one account's bucket could overwrite the bytes read back by `GetObject` in another account's identically-named bucket.
- `DeleteBucket` in one account deleted the *shared* `memoryDataStore` entries / on-disk directory, corrupting another account's same-named bucket (surfaced as a 500 "S3 object data is missing").

Scopes the physical key/path by the resolved account ID at the byte-storage entry points (`writeFile`/`readFile`/`deleteFile` and their versioned counterparts, plus `deleteBucket`'s cleanup and `openObjectStream`'s direct `memoryDataStore` lookups, which bypassed those helpers). `objectKey()`/`versionedKey()` themselves are unchanged, since they're also used as `objectStore`'s own storage keys, which are already correctly account-scoped.

Closes #2239

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

No wire-format changes. Note: the new integration test only exercises memory-mode storage (the Quarkus test profile default); the disk-mode byte-storage path fix is covered by unit-test path assertions (`S3ServiceTest`/`S3VersioningServiceTest`) but not by an end-to-end two-account disk-mode test — flagged during review as a reasonable follow-up, not a gap in the fix itself.

## Checklist

- [x] `./mvnw test` passes locally (full suite: 9011 passed, 0 failed)
- [x] New integration test added (`S3AccountIsolationIntegrationTest`, fails without this fix)
- [x] Commit messages follow Conventional Commits