### PR TITLE
fix(cloudformation): honor stack status filters

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationQueryHandler.java
@@ -455,7 +455,10 @@ public class CloudFormationQueryHandler {
     // ── ListStacks ────────────────────────────────────────────────────────────
 
     private Response listStacks(MultivaluedMap<String, String> params, String region) {
-        List<Stack> stacks = cfnService.listStacks(region);
+        List<String> statusFilter = extractList(params, "StackStatusFilter.member.");
+        List<Stack> stacks = cfnService.listStacks(region).stream()
+                .filter(stack -> statusFilter.isEmpty() || statusFilter.contains(stack.getStatus()))
+                .toList();
         XmlBuilder xml = new XmlBuilder()
                 .start("ListStacksResponse", CF_NS)
                 .start("ListStacksResult")

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationListStacksIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationListStacksIntegrationTest.java
@@ -1,0 +1,77 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+@QuarkusTest
+class CloudFormationListStacksIntegrationTest {
+
+    @Test
+    void listStacksReturnsOnlyRequestedStatuses() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String completeStack = "list-stacks-complete-" + suffix;
+        String rolledBackStack = "list-stacks-rollback-" + suffix;
+
+        createStack(completeStack, """
+                {
+                  "Resources": {
+                    "Parameter": {
+                      "Type": "AWS::SSM::Parameter",
+                      "Properties": {
+                        "Name": "/list-stacks/%s",
+                        "Type": "String",
+                        "Value": "complete"
+                      }
+                    }
+                  }
+                }
+                """.formatted(suffix));
+        createStack(rolledBackStack, """
+                {
+                  "Resources": {
+                    "InvalidSecret": {
+                      "Type": "AWS::SecretsManager::Secret",
+                      "Properties": {
+                        "Name": "list-stacks-invalid-%s",
+                        "SecretString": "explicit",
+                        "GenerateSecretString": { "PasswordLength": 32 }
+                      }
+                    }
+                  }
+                }
+                """.formatted(suffix));
+
+        String response = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ListStacks")
+            .formParam("StackStatusFilter.member.1", "ROLLBACK_COMPLETE")
+            .formParam("StackStatusFilter.member.2", "DELETE_FAILED")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract()
+            .asString();
+
+        assertThat(response, containsString("<StackName>" + rolledBackStack + "</StackName>"));
+        assertThat(response, containsString("<StackStatus>ROLLBACK_COMPLETE</StackStatus>"));
+        assertThat(response, not(containsString("<StackName>" + completeStack + "</StackName>")));
+    }
+
+    private static void createStack(String stackName, String template) {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2242

- Honor repeated `StackStatusFilter.member.N` query parameters in `ListStacks`.
- Preserve the existing unfiltered response when no status filter is supplied.
- Add end-to-end coverage for filtering a mixed `CREATE_COMPLETE` and `ROLLBACK_COMPLETE` stack set.

## Validation

- `./mvnw test -Dtest=CloudFormationListStacksIntegrationTest,CloudFormationDeleteIdempotencyIntegrationTest`