### PR TITLE
fix(cloudwatch): reject invalid log event tokens

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
@@ -366,6 +366,8 @@ public class CloudWatchLogsService {
             int end = parseTokenIndex(nextToken, 2);
             pageEnd = Math.min(end, total);
             pageStart = Math.max(pageEnd - maxEvents, 0);
+        } else if (nextToken != null) {
+            throw invalidNextToken();
         } else if (!startFromHead) {
             pageEnd = total;
             pageStart = Math.max(total - maxEvents, 0);
@@ -379,11 +381,20 @@ public class CloudWatchLogsService {
     }
 
     private int parseTokenIndex(String token, int prefixLen) {
+        int index;
         try {
-            return Integer.parseInt(token.substring(prefixLen));
+            index = Integer.parseInt(token.substring(prefixLen));
         } catch (NumberFormatException e) {
-            return 0;
+            throw invalidNextToken();
         }
+        if (index < 0) {
+            throw invalidNextToken();
+        }
+        return index;
+    }
+
+    private AwsException invalidNextToken() {
+        return new AwsException("InvalidParameterException", "The specified nextToken is invalid.", 400);
     }
 
     public record FilteredLogEventsResult(List<LogEvent> events, String nextToken) {}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsServiceTest.java
@@ -374,6 +374,64 @@ class CloudWatchLogsServiceTest {
     }
 
     @Test
+    void getLogEventsRejectsMalformedNextToken() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.createLogStream("/app/logs", "stream-1", REGION);
+        putEvents("/app/logs", "stream-1", System.currentTimeMillis(), 3);
+
+        AwsException exception = assertThrows(AwsException.class, () ->
+                service.getLogEvents("/app/logs", "stream-1", null, null, 10, true, "f/not-a-token", REGION));
+
+        assertEquals("InvalidParameterException", exception.getErrorCode());
+        assertEquals(400, exception.getHttpStatus());
+        assertEquals("The specified nextToken is invalid.", exception.getMessage());
+    }
+
+    @Test
+    void getLogEventsRejectsNegativeNextToken() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.createLogStream("/app/logs", "stream-1", REGION);
+        putEvents("/app/logs", "stream-1", System.currentTimeMillis(), 3);
+
+        AwsException exception = assertThrows(AwsException.class, () ->
+                service.getLogEvents("/app/logs", "stream-1", null, null, 10, true, "b/-1", REGION));
+
+        assertEquals("InvalidParameterException", exception.getErrorCode());
+        assertEquals(400, exception.getHttpStatus());
+        assertEquals("The specified nextToken is invalid.", exception.getMessage());
+    }
+
+    @Test
+    void getLogEventsRejectsOverflowNextToken() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.createLogStream("/app/logs", "stream-1", REGION);
+        putEvents("/app/logs", "stream-1", System.currentTimeMillis(), 3);
+
+        AwsException exception = assertThrows(AwsException.class, () ->
+                service.getLogEvents("/app/logs", "stream-1", null, null, 10, true, "f/2147483648", REGION));
+
+        assertEquals("InvalidParameterException", exception.getErrorCode());
+        assertEquals(400, exception.getHttpStatus());
+        assertEquals("The specified nextToken is invalid.", exception.getMessage());
+    }
+
+    @Test
+    void getLogEventsRejectsUnrecognizedNextTokens() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.createLogStream("/app/logs", "stream-1", REGION);
+        putEvents("/app/logs", "stream-1", System.currentTimeMillis(), 3);
+
+        for (String token : List.of("", "x/1", "garbage")) {
+            AwsException exception = assertThrows(AwsException.class, () ->
+                    service.getLogEvents("/app/logs", "stream-1", null, null, 10, true, token, REGION));
+
+            assertEquals("InvalidParameterException", exception.getErrorCode());
+            assertEquals(400, exception.getHttpStatus());
+            assertEquals("The specified nextToken is invalid.", exception.getMessage());
+        }
+    }
+
+    @Test
     void getLogEventsStartFromTailWithNoToken() {
         service.createLogGroup("/app/logs", null, null, REGION);
         service.createLogStream("/app/logs", "stream-1", REGION);


### PR DESCRIPTION
## Summary

- Reject malformed CloudWatch Logs `GetLogEvents` pagination tokens instead of silently restarting pagination.
- Return the existing AWS-compatible `InvalidParameterException` response with HTTP 400 for malformed, negative, overflow, empty, unknown-prefix, and separator-less tokens.
- Preserve null-token and valid forward/backward pagination behavior.

Refs #2226

## Validation

- `CloudWatchLogsServiceTest`: 39 tests passed.
- `CloudWatchLogsServiceTest,CloudWatchLogsHandlerTest`: 54 tests passed.
- Full test suite: 7,052 tests passed; 0 failures, 0 errors, 9 skipped.
- `./mvnw -B -DskipTests package`: passed.

