### PR TITLE
docs: restore navigation for existing pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
       - develop
     paths:
       - 'docs/**'
+      - 'mkdocs.yml'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
     - Environment Variables: configuration/environment-variables.md
     - Docker Images: configuration/docker-images.md
     - Docker Compose: configuration/docker-compose.md
+    - Docker Configuration: configuration/docker.md
     - Ports Reference: configuration/ports.md
     - Multi-Account Isolation: configuration/multi-account.md
     - Storage Modes: configuration/storage.md
@@ -80,6 +81,7 @@ nav:
     - SES: services/ses.md
     - S3: services/s3.md
     - S3 Tables: services/s3tables.md
+    - S3 Vectors: services/s3vectors.md
     - DynamoDB: services/dynamodb.md
     - Lambda: services/lambda.md
     - Lambda MicroVMs: services/lambda-microvms.md
@@ -99,6 +101,7 @@ nav:
     - RDS: services/rds.md
     - RDS Data API: services/rds-data.md
     - MSK (Kafka): services/msk.md
+    - Amazon MQ: services/amazonmq.md
     - Glue: services/glue.md
     - Neptune: services/neptune.md
     - DocumentDB: services/docdb.md
@@ -123,6 +126,7 @@ nav:
     - Bedrock AgentCore: services/bedrock-agentcore.md
     - ELB v2: services/elb.md
     - Auto Scaling: services/autoscaling.md
+    - Application Auto Scaling: services/applicationautoscaling.md
     - Elastic Beanstalk: services/elastic-beanstalk.md
     - CodeBuild: services/codebuild.md
     - AWS Batch: services/batch.md


### PR DESCRIPTION
## Summary

- add the existing Docker Configuration, Amazon MQ, Application Auto Scaling, and S3 Vectors pages to the MkDocs navigation
- make `mkdocs.yml` changes trigger the documentation deployment workflow
- keep the moved `configuration/application-yml.md` stub out of the navigation

This addresses the navigation gaps that are present on the current `main` branch. The issue's Control Tower and Vellum Health paths do not exist on the current default branch, so this PR intentionally does not add them.

Closes #2204

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

Documentation and workflow-trigger changes only; no AWS protocol or runtime behavior changes.

## Validation

- `make docs-check`
- `make docs-test` — 20 passed
- `python -m mkdocs build`
- `actionlint .github/workflows/docs.yml`
- `git diff --check origin/main...HEAD`

`python -m mkdocs build --strict` still reports the same pre-existing broken-link warning as current `main`. This PR reduces current `main`'s orphan-page report from six pages to two: the intentionally excluded moved `configuration/application-yml.md` stub and the unrelated proposed `design/bedrock-agentcore.md` design note added after this PR was opened.

## Checklist

- [ ] `./mvnw test` passes locally — not run: this docs-only change does not trigger the Java CI workflow, and the local host has JDK 21 while Floci requires JDK 25
- [ ] New or updated integration test added — not applicable: no runtime behavior changes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)