### PR TITLE
chore(compat): align pinned SDK versions across the Python, Java, and CDK suites

### DIFF
--- a/compatibility-tests/compat-cdk/package.json
+++ b/compatibility-tests/compat-cdk/package.json
@@ -10,13 +10,13 @@
     "cdk": "cdk"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.171.1",
+    "aws-cdk-lib": "2.264.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.2",
-    "aws-cdk": "2.171.1",
-    "aws-cdk-local": "^2.0.0",
+    "aws-cdk": "2.1135.1",
+    "aws-cdk-local": "^3.0.4",
     "typescript": "~5.7.0"
   }
 }

--- a/compatibility-tests/compat-cdk/test/test_helper/common-setup.bash
+++ b/compatibility-tests/compat-cdk/test/test_helper/common-setup.bash
@@ -24,6 +24,9 @@ export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
 export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-test}"
 export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-test}"
 export AWS_ENDPOINT_URL="$FLOCI_ENDPOINT"
+# aws-cdk-local v3 requires AWS_ENDPOINT_URL_S3; use Floci's virtual-hosted S3 domain so
+# <bucket>.s3.localhost.floci.io resolves (public DNS locally; Floci's embedded DNS in Docker).
+export AWS_ENDPOINT_URL_S3="http://s3.localhost.floci.io:4566"
 
 aws_cmd() {
     aws --endpoint-url "$FLOCI_ENDPOINT" --region "$AWS_DEFAULT_REGION" --output json "$@"

--- a/compatibility-tests/compat-cdk/test/test_helper/common-setup.bash
+++ b/compatibility-tests/compat-cdk/test/test_helper/common-setup.bash
@@ -26,7 +26,7 @@ export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-test}"
 export AWS_ENDPOINT_URL="$FLOCI_ENDPOINT"
 # aws-cdk-local v3 requires AWS_ENDPOINT_URL_S3; use Floci's virtual-hosted S3 domain so
 # <bucket>.s3.localhost.floci.io resolves (public DNS locally; Floci's embedded DNS in Docker).
-export AWS_ENDPOINT_URL_S3="http://s3.localhost.floci.io:4566"
+export AWS_ENDPOINT_URL_S3="${AWS_ENDPOINT_URL_S3:-http://s3.localhost.floci.io:4566}"
 
 aws_cmd() {
     aws --endpoint-url "$FLOCI_ENDPOINT" --region "$AWS_DEFAULT_REGION" --output json "$@"

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -16,8 +16,8 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <aws.sdk.version>2.44.14</aws.sdk.version>
-        <awsjavasdk.version>2.44.14</awsjavasdk.version>
+        <aws.sdk.version>2.52.0</aws.sdk.version>
+        <awsjavasdk.version>2.52.0</awsjavasdk.version>
         <jackson.version>2.18.8</jackson.version>
         <kafka.clients.version>3.9.2</kafka.clients.version>
         <netty.version>4.1.135.Final</netty.version>

--- a/compatibility-tests/sdk-test-python/requirements.txt
+++ b/compatibility-tests/sdk-test-python/requirements.txt
@@ -1,5 +1,5 @@
-boto3==1.37.1
-botocore==1.37.1
+boto3==1.43.69
+botocore==1.43.69
 cryptography>=42.0.0
 pytest>=8.0.0
 pytest-timeout>=2.3.0


### PR DESCRIPTION
## Summary

Aligns the exact-pinned SDK versions in the compatibility suites to a common recent
baseline (Aug 2026), so they no longer span a wide release window (follow-up to the
version-drift discussion at https://github.com/orgs/floci-io/discussions/2233):

- `sdk-test-python`: boto3 / botocore `1.37.1` → `1.43.69`
- `sdk-test-java`: AWS SDK for Java v2 `2.44.14` → `2.52.0`
- `compat-cdk`: aws-cdk-lib `2.171.1` → `2.264.0`, aws-cdk `2.171.1` → `2.1135.1`, aws-cdk-local `^2.0.0` → `^3.0.4`

Bumping boto3/botocore also restores the current SES v2 model (97 → 112 operations,
including the `Tenant*` / `ReputationEntity*` families).

The aws-cdk 2.1000+ CLI (decoupled from the library version line) publishes template assets
to S3 using virtual-hosted-style URLs and needs aws-cdk-local v3. `AWS_ENDPOINT_URL_S3` is
pointed at Floci's virtual-hosted domain (`http://s3.localhost.floci.io:4566`) so the SDK
builds `<bucket>.s3.localhost.floci.io`, which resolves via public DNS locally and via Floci's
embedded DNS (already injected with `--dns` in the compat workflow) inside the Docker network,
instead of the unresolvable `<bucket>.floci`.

Go / Node / AWS CLI / Terraform / OpenTofu float to latest by design and are unchanged.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No production/service behavior change — only compat-suite SDK versions are updated. All
compatibility suites pass in CI with the bumped versions.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
