### PR TITLE
feat(logs): support log group deletion protection

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudWatchLogsDeletionProtectionTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudWatchLogsDeletionProtectionTest.java
@@ -1,0 +1,97 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.cloudwatchlogs.model.LogGroup;
+import software.amazon.awssdk.services.cloudwatchlogs.model.ValidationException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("CloudWatch Logs deletion protection")
+class CloudWatchLogsDeletionProtectionTest {
+
+    @Test
+    @DisplayName("defaults off and can be enabled and disabled by name")
+    void defaultsOffAndUpdatesByName() {
+        String groupName = "/test/" + TestFixtures.uniqueName("logs-deletion-protection-default");
+        try (CloudWatchLogsClient logs = TestFixtures.cloudWatchLogsClient()) {
+            try {
+                logs.createLogGroup(request -> request.logGroupName(groupName));
+                assertThat(findLogGroup(logs, groupName))
+                        .get()
+                        .extracting(LogGroup::deletionProtectionEnabled)
+                        .isEqualTo(false);
+
+                logs.putLogGroupDeletionProtection(request -> request
+                        .logGroupIdentifier(groupName)
+                        .deletionProtectionEnabled(true));
+                assertThat(findLogGroup(logs, groupName))
+                        .get()
+                        .extracting(LogGroup::deletionProtectionEnabled)
+                        .isEqualTo(true);
+
+                logs.putLogGroupDeletionProtection(request -> request
+                        .logGroupIdentifier(groupName)
+                        .deletionProtectionEnabled(false));
+                assertThat(findLogGroup(logs, groupName))
+                        .get()
+                        .extracting(LogGroup::deletionProtectionEnabled)
+                        .isEqualTo(false);
+            } finally {
+                deleteIfPresent(logs, groupName);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("create-time protection blocks deletion until disabled by ARN")
+    void createTimeProtectionBlocksDeletionUntilDisabledByArn() {
+        String groupName = "/test/" + TestFixtures.uniqueName("logs-deletion-protection-create");
+        try (CloudWatchLogsClient logs = TestFixtures.cloudWatchLogsClient()) {
+            try {
+                logs.createLogGroup(request -> request
+                        .logGroupName(groupName)
+                        .deletionProtectionEnabled(true));
+                LogGroup group = findLogGroup(logs, groupName).orElseThrow();
+                assertThat(group.deletionProtectionEnabled()).isTrue();
+
+                assertThatThrownBy(() -> logs.deleteLogGroup(request -> request.logGroupName(groupName)))
+                        .isInstanceOfSatisfying(ValidationException.class, error -> {
+                            assertThat(error.awsErrorDetails().errorCode()).isEqualTo("ValidationException");
+                            assertThat(error.getMessage()).containsIgnoringCase("deletion protection");
+                        });
+
+                logs.putLogGroupDeletionProtection(request -> request
+                        .logGroupIdentifier(group.arn())
+                        .deletionProtectionEnabled(false));
+                logs.deleteLogGroup(request -> request.logGroupName(groupName));
+
+                assertThat(findLogGroup(logs, groupName)).isEmpty();
+            } finally {
+                deleteIfPresent(logs, groupName);
+            }
+        }
+    }
+
+    private static Optional<LogGroup> findLogGroup(CloudWatchLogsClient logs, String groupName) {
+        return logs.describeLogGroups(request -> request.logGroupNamePrefix(groupName))
+                .logGroups()
+                .stream()
+                .filter(group -> groupName.equals(group.logGroupName()))
+                .findFirst();
+    }
+
+    private static void deleteIfPresent(CloudWatchLogsClient logs, String groupName) {
+        if (findLogGroup(logs, groupName).isEmpty()) {
+            return;
+        }
+        logs.putLogGroupDeletionProtection(request -> request
+                .logGroupIdentifier(groupName)
+                .deletionProtectionEnabled(false));
+        logs.deleteLogGroup(request -> request.logGroupName(groupName));
+    }
+}

--- a/docs/services/cloudwatch.md
+++ b/docs/services/cloudwatch.md
@@ -15,6 +15,7 @@ Floci supports both CloudWatch Logs and CloudWatch Metrics.
 |---|---|
 | `CreateLogGroup` | Create a log group |
 | `DeleteLogGroup` | Delete a log group |
+| `PutLogGroupDeletionProtection` | Enable or disable deletion protection for a log group by name or ARN |
 | `DescribeLogGroups` | List log groups |
 | `CreateLogStream` | Create a log stream inside a log group |
 | `DeleteLogStream` | Delete a log stream |
@@ -37,6 +38,10 @@ Floci supports both CloudWatch Logs and CloudWatch Metrics.
 | `StartQuery` | Start a Logs Insights query (see [Logs Insights](#logs-insights)) |
 | `GetQueryResults` | Get the status and results of a Logs Insights query |
 | `StopQuery` | Stop a query that has not completed yet |
+
+Log group deletion protection defaults to disabled and is persisted with the log group. When it is
+enabled, `DeleteLogGroup` returns `ValidationException` until protection is explicitly disabled
+with `PutLogGroupDeletionProtection`.
 
 Two actions are currently simplified:
 

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
@@ -45,6 +45,7 @@ public class CloudWatchLogsHandler {
             case "FilterLogEvents" -> handleFilterLogEvents(request, region);
             case "PutRetentionPolicy" -> handlePutRetentionPolicy(request, region);
             case "DeleteRetentionPolicy" -> handleDeleteRetentionPolicy(request, region);
+            case "PutLogGroupDeletionProtection" -> handlePutLogGroupDeletionProtection(request, region);
             case "TagLogGroup" -> handleTagLogGroup(request, region);
             case "UntagLogGroup" -> handleUntagLogGroup(request, region);
             case "ListTagsLogGroup" -> handleListTagsLogGroup(request, region);
@@ -76,6 +77,20 @@ public class CloudWatchLogsHandler {
     private Response handleDeleteLogGroup(JsonNode request, String region) {
         String name = request.path("logGroupName").asText();
         logsService.deleteLogGroup(name, region);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    /**
+     * Floci does not retain log-group deletion protection state, but the AWS
+     * control plane requires callers to disable it before deleting a group.
+     * Accepting the operation keeps that lifecycle sequence protocol-compatible.
+     */
+    private Response handlePutLogGroupDeletionProtection(JsonNode request, String region) {
+        String identifier = request.path("logGroupIdentifier").asText(null);
+        if (identifier == null || identifier.isBlank()) {
+            throw new AwsException("InvalidParameterException", "logGroupIdentifier is required", 400);
+        }
+        resolveLogGroupName(request);
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
@@ -69,8 +69,9 @@ public class CloudWatchLogsHandler {
         String name = request.path("logGroupName").asText();
         Integer retentionInDays = request.has("retentionInDays")
                 ? request.path("retentionInDays").asInt() : null;
+        boolean deletionProtectionEnabled = request.path("deletionProtectionEnabled").asBoolean(false);
         Map<String, String> tags = extractTags(request.path("tags"));
-        logsService.createLogGroup(name, retentionInDays, tags, region);
+        logsService.createLogGroup(name, retentionInDays, tags, deletionProtectionEnabled, region);
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 
@@ -80,17 +81,17 @@ public class CloudWatchLogsHandler {
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 
-    /**
-     * Floci does not retain log-group deletion protection state, but the AWS
-     * control plane requires callers to disable it before deleting a group.
-     * Accepting the operation keeps that lifecycle sequence protocol-compatible.
-     */
     private Response handlePutLogGroupDeletionProtection(JsonNode request, String region) {
         String identifier = request.path("logGroupIdentifier").asText(null);
         if (identifier == null || identifier.isBlank()) {
-            throw new AwsException("InvalidParameterException", "logGroupIdentifier is required", 400);
+            throw new AwsException("InvalidParameterException", "logGroupIdentifier is required.", 400);
         }
-        resolveLogGroupName(request);
+        JsonNode enabled = request.get("deletionProtectionEnabled");
+        if (enabled == null || !enabled.isBoolean()) {
+            throw new AwsException("InvalidParameterException", "deletionProtectionEnabled is required.", 400);
+        }
+        String groupName = extractLogGroupNameFromArn(identifier);
+        logsService.putLogGroupDeletionProtection(groupName, enabled.booleanValue(), region);
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 
@@ -108,6 +109,7 @@ public class CloudWatchLogsHandler {
             if (g.getRetentionInDays() != null) {
                 node.put("retentionInDays", g.getRetentionInDays());
             }
+            node.put("deletionProtectionEnabled", g.isDeletionProtectionEnabled());
             node.put("storedBytes", 0);
             node.put("metricFilterCount", 0);
             groupsArray.add(node);

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
@@ -126,6 +126,11 @@ public class CloudWatchLogsService {
     // ──────────────────────────── Log Groups ────────────────────────────
 
     public void createLogGroup(String name, Integer retentionInDays, Map<String, String> tags, String region) {
+        createLogGroup(name, retentionInDays, tags, false, region);
+    }
+
+    public void createLogGroup(String name, Integer retentionInDays, Map<String, String> tags,
+                               boolean deletionProtectionEnabled, String region) {
         if (name == null || name.isBlank()) {
             throw new AwsException("InvalidParameterException", "logGroupName is required.", 400);
         }
@@ -138,6 +143,7 @@ public class CloudWatchLogsService {
         group.setLogGroupName(name);
         group.setCreatedTime(System.currentTimeMillis());
         group.setRetentionInDays(retentionInDays);
+        group.setDeletionProtectionEnabled(deletionProtectionEnabled);
         if (tags != null) {
             group.setTags(new HashMap<>(tags));
         }
@@ -147,9 +153,15 @@ public class CloudWatchLogsService {
 
     public void deleteLogGroup(String name, String region) {
         String key = groupKey(region, name);
-        groupStore.get(key)
+        LogGroup group = groupStore.get(key)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
                         "The specified log group does not exist: " + name, 400));
+        if (group.isDeletionProtectionEnabled()) {
+            throw new AwsException("ValidationException",
+                    "The specified log group has deletion protection enabled. "
+                            + "Disable deletion protection before deleting the log group.",
+                    400);
+        }
 
         // Cascade: delete all streams and events for this group
         String streamPrefix = streamKeyPrefix(region, name);
@@ -185,6 +197,15 @@ public class CloudWatchLogsService {
         });
         result.sort(Comparator.comparing(LogGroup::getLogGroupName));
         return result;
+    }
+
+    public void putLogGroupDeletionProtection(String groupName, boolean enabled, String region) {
+        String key = groupKey(region, groupName);
+        LogGroup group = groupStore.get(key)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "The specified log group does not exist: " + groupName, 400));
+        group.setDeletionProtectionEnabled(enabled);
+        groupStore.put(key, group);
     }
 
     public void putRetentionPolicy(String groupName, int days, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/model/LogGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/model/LogGroup.java
@@ -13,6 +13,7 @@ public class LogGroup {
     private String logGroupName;
     private long createdTime;
     private Integer retentionInDays;
+    private boolean deletionProtectionEnabled;
     private Map<String, String> tags = new HashMap<>();
 
     public LogGroup() {}
@@ -25,6 +26,11 @@ public class LogGroup {
 
     public Integer getRetentionInDays() { return retentionInDays; }
     public void setRetentionInDays(Integer retentionInDays) { this.retentionInDays = retentionInDays; }
+
+    public boolean isDeletionProtectionEnabled() { return deletionProtectionEnabled; }
+    public void setDeletionProtectionEnabled(boolean deletionProtectionEnabled) {
+        this.deletionProtectionEnabled = deletionProtectionEnabled;
+    }
 
     public Map<String, String> getTags() { return tags; }
     public void setTags(Map<String, String> tags) { this.tags = tags; }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandlerTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -99,14 +100,99 @@ class CloudWatchLogsHandlerTest {
     }
 
     @Test
-    void putLogGroupDeletionProtectionAcceptsTheDeleteLifecycleOperation() {
+    void createLogGroupWithDeletionProtectionIsReturnedByDescribeLogGroups() {
+        String protectedGroup = GROUP + "-created-protected";
+        ObjectNode create = MAPPER.createObjectNode();
+        create.put("logGroupName", protectedGroup);
+        create.put("deletionProtectionEnabled", true);
+
+        handler.handle("CreateLogGroup", create, REGION);
+
+        ObjectNode describe = MAPPER.createObjectNode();
+        describe.put("logGroupNamePrefix", protectedGroup);
+        JsonNode group = ((JsonNode) handler.handle("DescribeLogGroups", describe, REGION).getEntity())
+                .path("logGroups").get(0);
+        assertEquals(protectedGroup, group.path("logGroupName").asText());
+        assertTrue(group.path("deletionProtectionEnabled").asBoolean());
+    }
+
+    @Test
+    void putLogGroupDeletionProtectionPersistsByName() {
         ObjectNode request = MAPPER.createObjectNode();
         request.put("logGroupIdentifier", GROUP);
-        request.put("deletionProtectionEnabled", false);
+        request.put("deletionProtectionEnabled", true);
 
         Response response = handler.handle("PutLogGroupDeletionProtection", request, REGION);
 
         assertEquals(200, response.getStatus());
+        assertTrue(service.describeLogGroups(GROUP, REGION).getFirst().isDeletionProtectionEnabled());
+    }
+
+    @Test
+    void putLogGroupDeletionProtectionAcceptsArnIdentifier() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("logGroupIdentifier", GROUP_ARN);
+        request.put("deletionProtectionEnabled", true);
+
+        handler.handle("PutLogGroupDeletionProtection", request, REGION);
+
+        assertTrue(service.describeLogGroups(GROUP, REGION).getFirst().isDeletionProtectionEnabled());
+    }
+
+    @Test
+    void putLogGroupDeletionProtectionRequiresIdentifier() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("deletionProtectionEnabled", true);
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> handler.handle("PutLogGroupDeletionProtection", request, REGION));
+
+        assertEquals("InvalidParameterException", error.getErrorCode());
+    }
+
+    @Test
+    void putLogGroupDeletionProtectionRequiresBoolean() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("logGroupIdentifier", GROUP);
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> handler.handle("PutLogGroupDeletionProtection", request, REGION));
+
+        assertEquals("InvalidParameterException", error.getErrorCode());
+    }
+
+    @Test
+    void putLogGroupDeletionProtectionRequiresExistingGroup() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("logGroupIdentifier", "/missing");
+        request.put("deletionProtectionEnabled", true);
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> handler.handle("PutLogGroupDeletionProtection", request, REGION));
+
+        assertEquals("ResourceNotFoundException", error.getErrorCode());
+    }
+
+    @Test
+    void protectedLogGroupCannotBeDeletedUntilProtectionIsDisabled() {
+        ObjectNode protection = MAPPER.createObjectNode();
+        protection.put("logGroupIdentifier", GROUP);
+        protection.put("deletionProtectionEnabled", true);
+        handler.handle("PutLogGroupDeletionProtection", protection, REGION);
+
+        ObjectNode deletion = MAPPER.createObjectNode();
+        deletion.put("logGroupName", GROUP);
+        AwsException error = assertThrows(AwsException.class,
+                () -> handler.handle("DeleteLogGroup", deletion, REGION));
+        assertEquals("ValidationException", error.getErrorCode());
+        assertThat(error.getMessage(), containsString("Disable deletion protection"));
+
+        protection.put("deletionProtectionEnabled", false);
+        handler.handle("PutLogGroupDeletionProtection", protection, REGION);
+        Response response = handler.handle("DeleteLogGroup", deletion, REGION);
+
+        assertEquals(200, response.getStatus());
+        assertFalse(service.logGroupExists(GROUP, REGION));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandlerTest.java
@@ -99,6 +99,17 @@ class CloudWatchLogsHandlerTest {
     }
 
     @Test
+    void putLogGroupDeletionProtectionAcceptsTheDeleteLifecycleOperation() {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("logGroupIdentifier", GROUP);
+        request.put("deletionProtectionEnabled", false);
+
+        Response response = handler.handle("PutLogGroupDeletionProtection", request, REGION);
+
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
     void describeLogStreamsByLogGroupIdentifierArnWithWildcardSuffix() {
         ObjectNode request = MAPPER.createObjectNode();
         request.put("logGroupIdentifier", GROUP_ARN_WILDCARD);

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsServiceTest.java
@@ -43,6 +43,15 @@ class CloudWatchLogsServiceTest {
         List<LogGroup> groups = service.describeLogGroups(null, REGION);
         assertEquals(1, groups.size());
         assertEquals("/app/logs", groups.getFirst().getLogGroupName());
+        assertFalse(groups.getFirst().isDeletionProtectionEnabled());
+    }
+
+    @Test
+    void createLogGroupWithDeletionProtectionEnabled() {
+        service.createLogGroup("/app/protected", null, null, true, REGION);
+
+        LogGroup group = service.describeLogGroups("/app/protected", REGION).getFirst();
+        assertTrue(group.isDeletionProtectionEnabled());
     }
 
     @Test
@@ -70,6 +79,29 @@ class CloudWatchLogsServiceTest {
     void deleteLogGroupNotFoundThrows() {
         assertThrows(AwsException.class, () ->
                 service.deleteLogGroup("/missing", REGION));
+    }
+
+    @Test
+    void protectedLogGroupMustBeDisabledBeforeDeletion() {
+        service.createLogGroup("/app/protected", null, null, true, REGION);
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.deleteLogGroup("/app/protected", REGION));
+        assertEquals("ValidationException", error.getErrorCode());
+        assertTrue(service.logGroupExists("/app/protected", REGION));
+
+        service.putLogGroupDeletionProtection("/app/protected", false, REGION);
+        service.deleteLogGroup("/app/protected", REGION);
+
+        assertFalse(service.logGroupExists("/app/protected", REGION));
+    }
+
+    @Test
+    void putLogGroupDeletionProtectionRequiresExistingGroup() {
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.putLogGroupDeletionProtection("/missing", true, REGION));
+
+        assertEquals("ResourceNotFoundException", error.getErrorCode());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Add the complete CloudWatch Logs deletion-protection lifecycle: create-time configuration, persisted updates by name or ARN, describe readback, and protected-delete enforcement.

| Request | Behavior |
|---|---|
| `CreateLogGroup` without `deletionProtectionEnabled` | Defaults to `false` |
| `CreateLogGroup` with protection enabled | Persists and reports `true` |
| `PutLogGroupDeletionProtection` with a name or ARN | Enables or disables protection |
| `DescribeLogGroups` | Returns `deletionProtectionEnabled` |
| `DeleteLogGroup` while protected | Returns `ValidationException` until protection is disabled |

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified with AWS SDK for Java 2.44.14 against an isolated Floci instance. The SDK lifecycle test covers default and create-time state, name and ARN updates, describe readback, protected deletion, and deletion after disabling protection.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Validation

- `./mvnw test -Dtest=CloudWatchLogsServiceTest,CloudWatchLogsHandlerTest` — 60 passed
- `FLOCI_ENDPOINT=http://127.0.0.1:14566 ../../mvnw test -Dtest=CloudWatchLogsDeletionProtectionTest` — 2 passed against an isolated Floci instance
- `make PYTHON='uv run --with pytest --with pyyaml python' docs-test docs-check` — 20 tooling tests passed; docs clean
- `./mvnw test` — 9,286 tests, 0 failures, 0 errors, 9 skipped
