### PR TITLE
fix(cloudwatch): return logStreamName on FilterLogEvents results

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
@@ -194,7 +194,7 @@ public class CloudWatchLogsHandler {
                 logsService.filterLogEvents(groupName, streamNames, startTime, endTime, filterPattern, limit, region);
 
         ObjectNode response = objectMapper.createObjectNode();
-        response.set("events", buildEventsArray(result.events()));
+        response.set("events", buildFilteredEventsArray(result.events()));
         if (result.nextToken() != null) {
             response.put("nextToken", result.nextToken());
         }
@@ -450,14 +450,34 @@ public class CloudWatchLogsHandler {
     private ArrayNode buildEventsArray(List<LogEvent> events) {
         ArrayNode array = objectMapper.createArrayNode();
         for (LogEvent e : events) {
-            ObjectNode node = objectMapper.createObjectNode();
-            node.put("eventId", e.getEventId());
-            node.put("timestamp", e.getTimestamp());
-            node.put("message", e.getMessage());
-            node.put("ingestionTime", e.getIngestionTime());
+            array.add(buildEventNode(e));
+        }
+        return array;
+    }
+
+    /**
+     * Serializes FilteredLogEvent, which carries {@code logStreamName} on top of the GetLogEvents
+     * shape. The field is what attributes a match back to the stream that emitted it, and real AWS
+     * returns it on every FilterLogEvents result; GetLogEvents omits it, so it stays out of
+     * {@link #buildEventsArray}.
+     */
+    private ArrayNode buildFilteredEventsArray(List<CloudWatchLogsService.FilteredEvent> events) {
+        ArrayNode array = objectMapper.createArrayNode();
+        for (CloudWatchLogsService.FilteredEvent filtered : events) {
+            ObjectNode node = buildEventNode(filtered.event());
+            node.put("logStreamName", filtered.logStreamName());
             array.add(node);
         }
         return array;
+    }
+
+    private ObjectNode buildEventNode(LogEvent e) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("eventId", e.getEventId());
+        node.put("timestamp", e.getTimestamp());
+        node.put("message", e.getMessage());
+        node.put("ingestionTime", e.getIngestionTime());
+        return node;
     }
 
     private Map<String, String> extractTags(JsonNode tagsNode) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
@@ -386,7 +386,14 @@ public class CloudWatchLogsService {
         }
     }
 
-    public record FilteredLogEventsResult(List<LogEvent> events, String nextToken) {}
+    /**
+     * A FilterLogEvents match paired with the stream that emitted it. FilterLogEvents is the
+     * cross-stream API, so the stream is what lets a caller attribute a hit; GetLogEvents needs
+     * no such pairing because the caller named the stream in the request.
+     */
+    public record FilteredEvent(String logStreamName, LogEvent event) {}
+
+    public record FilteredLogEventsResult(List<FilteredEvent> events, String nextToken) {}
 
     public FilteredLogEventsResult filterLogEvents(String groupName, List<String> streamNames,
                                                     Long startTime, Long endTime,
@@ -396,25 +403,31 @@ public class CloudWatchLogsService {
                 maxEventsPerQuery);
 
         String groupPrefix = groupKeyPrefix(region) + groupName + "::";
-        List<LogEvent> all = new ArrayList<>();
+        List<String> requested = streamNames == null ? List.of() : streamNames;
 
-        if (streamNames != null && !streamNames.isEmpty()) {
-            for (String sn : streamNames) {
-                String eventPrefix = eventKeyPrefix(region, groupName, sn);
-                all.addAll(eventStore.scan(k -> k.startsWith(eventPrefix)));
+        // Walk keys rather than values: the key is the only place the emitting stream is
+        // recorded, so reading it back is what lets each match carry its stream name. It also
+        // keeps a stream-restricted filter to one pass over the keyset instead of one scan per
+        // requested stream, since every scan walks the whole keyset regardless of its prefix.
+        List<FilteredEvent> all = new ArrayList<>();
+        for (String key : eventStore.keys()) {
+            if (!key.startsWith(groupPrefix)) {
+                continue;
             }
-        } else {
-            // All streams in group
-            all.addAll(eventStore.scan(k -> k.startsWith(groupPrefix)));
+            String streamName = streamNameFromEventKey(key, groupPrefix);
+            if (!requested.isEmpty() && !requested.contains(streamName)) {
+                continue;
+            }
+            eventStore.get(key).ifPresent(e -> all.add(new FilteredEvent(streamName, e)));
         }
 
-        all.sort(EVENT_ORDER);
+        all.sort(Comparator.comparing(FilteredEvent::event, EVENT_ORDER));
 
-        List<LogEvent> result = all.stream()
-                .filter(e -> (startTime == null || e.getTimestamp() >= startTime)
-                        && (endTime == null || e.getTimestamp() <= endTime))
-                .filter(e -> filterPattern == null || filterPattern.isBlank()
-                        || e.getMessage().contains(filterPattern))
+        List<FilteredEvent> result = all.stream()
+                .filter(f -> (startTime == null || f.event().getTimestamp() >= startTime)
+                        && (endTime == null || f.event().getTimestamp() <= endTime))
+                .filter(f -> filterPattern == null || filterPattern.isBlank()
+                        || f.event().getMessage().contains(filterPattern))
                 .limit(maxEvents)
                 .toList();
 
@@ -690,6 +703,21 @@ public class CloudWatchLogsService {
                                     long timestamp, String uuid) {
         return region + "::" + groupName + "::" + streamName + "::"
                 + String.format("%015d", timestamp) + "::" + uuid;
+    }
+
+    /**
+     * Recover the emitting stream from an event key, which {@link #eventKey} lays out as
+     * {@code <region>::<group>::<stream>::<timestamp>::<uuid>}. The stream is bounded by the
+     * caller's group prefix on the left and by the trailing timestamp and uuid on the right, both
+     * of which are generated here and contain no "::", so the name comes back whole even though
+     * nothing stops a caller from creating a stream whose name holds a ':'.
+     */
+    private static String streamNameFromEventKey(String eventKey, String groupPrefix) {
+        int uuidSeparator = eventKey.lastIndexOf("::");
+        int timestampSeparator = uuidSeparator < 0 ? -1 : eventKey.lastIndexOf("::", uuidSeparator - 1);
+        return timestampSeparator < groupPrefix.length()
+                ? eventKey.substring(groupPrefix.length())
+                : eventKey.substring(groupPrefix.length(), timestampSeparator);
     }
 
     private static String subscriptionFilterKeyPrefix(String region, String logGroupName) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandlerTest.java
@@ -208,6 +208,56 @@ class CloudWatchLogsHandlerTest {
         JsonNode events = ((ObjectNode) response.getEntity()).path("events");
         assertEquals(1, events.size());
         assertThat(events.get(0).path("message").asText(), containsString("ERROR"));
+        assertEquals(STREAM, events.get(0).path("logStreamName").asText());
+    }
+
+    @Test
+    void filterLogEventsAttributesEachMatchToItsStream() {
+        // FilterLogEvents spans streams, so a caller can only attribute a hit if the response
+        // says which stream emitted it.
+        String otherStream = "postgresql.log.2026-06-05";
+        service.createLogStream(GROUP, otherStream, REGION);
+
+        long now = System.currentTimeMillis();
+        service.putLogEvents(GROUP, STREAM, java.util.List.of(
+                java.util.Map.of("timestamp", now, "message", "ERROR: from first")
+        ), REGION);
+        service.putLogEvents(GROUP, otherStream, java.util.List.of(
+                java.util.Map.of("timestamp", now + 1, "message", "ERROR: from second")
+        ), REGION);
+
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("logGroupName", GROUP);
+        request.put("filterPattern", "ERROR");
+
+        Response response = handler.handle("FilterLogEvents", request, REGION);
+
+        assertEquals(200, response.getStatus());
+        JsonNode events = ((ObjectNode) response.getEntity()).path("events");
+        assertEquals(2, events.size());
+        assertEquals(STREAM, events.get(0).path("logStreamName").asText());
+        assertEquals(otherStream, events.get(1).path("logStreamName").asText());
+    }
+
+    @Test
+    void getLogEventsOmitsLogStreamName() {
+        // OutputLogEvent has no logStreamName in real AWS: the caller named the stream in the
+        // request, so echoing it back would be a shape floci invents.
+        long now = System.currentTimeMillis();
+        service.putLogEvents(GROUP, STREAM, java.util.List.of(
+                java.util.Map.of("timestamp", now, "message", "only one stream here")
+        ), REGION);
+
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("logGroupName", GROUP);
+        request.put("logStreamName", STREAM);
+
+        Response response = handler.handle("GetLogEvents", request, REGION);
+
+        assertEquals(200, response.getStatus());
+        JsonNode events = ((ObjectNode) response.getEntity()).path("events");
+        assertEquals(1, events.size());
+        assertTrue(events.get(0).path("logStreamName").isMissingNode());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsServiceTest.java
@@ -217,7 +217,7 @@ class CloudWatchLogsServiceTest {
 
         assertEquals(10, result.events().size());
         for (int i = 0; i < 10; i++) {
-            assertEquals("SEQLINE-" + i, result.events().get(i).getMessage(),
+            assertEquals("SEQLINE-" + i, result.events().get(i).event().getMessage(),
                     "event at index " + i + " out of ingestion order");
         }
     }
@@ -254,7 +254,87 @@ class CloudWatchLogsServiceTest {
         CloudWatchLogsService.FilteredLogEventsResult result = service.filterLogEvents(
                 "/app/logs", null, null, null, "ERROR", 100, REGION);
         assertEquals(2, result.events().size());
-        assertTrue(result.events().stream().allMatch(e -> e.getMessage().contains("ERROR")));
+        assertTrue(result.events().stream().allMatch(f -> f.event().getMessage().contains("ERROR")));
+    }
+
+    @Test
+    void filterLogEventsCarriesEmittingStreamPerEvent() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.createLogStream("/app/logs", "stream-1", REGION);
+        service.createLogStream("/app/logs", "stream-2", REGION);
+
+        long now = System.currentTimeMillis();
+        service.putLogEvents("/app/logs", "stream-1",
+                List.of(Map.of("timestamp", now, "message", "ERROR: from one")), REGION);
+        service.putLogEvents("/app/logs", "stream-2",
+                List.of(Map.of("timestamp", now + 1, "message", "ERROR: from two")), REGION);
+
+        CloudWatchLogsService.FilteredLogEventsResult result = service.filterLogEvents(
+                "/app/logs", null, null, null, "ERROR", 100, REGION);
+
+        assertEquals(2, result.events().size());
+        assertEquals("stream-1", result.events().get(0).logStreamName());
+        assertEquals("stream-2", result.events().get(1).logStreamName());
+    }
+
+    @Test
+    void filterLogEventsRestrictedToNamedStreamsSkipsTheRest() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.createLogStream("/app/logs", "stream-1", REGION);
+        service.createLogStream("/app/logs", "stream-2", REGION);
+
+        long now = System.currentTimeMillis();
+        service.putLogEvents("/app/logs", "stream-1",
+                List.of(Map.of("timestamp", now, "message", "keep me")), REGION);
+        service.putLogEvents("/app/logs", "stream-2",
+                List.of(Map.of("timestamp", now + 1, "message", "drop me")), REGION);
+
+        CloudWatchLogsService.FilteredLogEventsResult result = service.filterLogEvents(
+                "/app/logs", List.of("stream-2"), null, null, null, 100, REGION);
+
+        assertEquals(1, result.events().size());
+        assertEquals("stream-2", result.events().getFirst().logStreamName());
+        assertEquals("drop me", result.events().getFirst().event().getMessage());
+    }
+
+    @Test
+    void filterLogEventsDoesNotLeakEventsFromAPrefixSiblingGroup() {
+        // "/app/logs" must not sweep up "/app/logs-archive": the key layout separates the group
+        // from the stream with "::", so the group prefix has to be matched with it.
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.createLogStream("/app/logs", "stream-1", REGION);
+        service.createLogGroup("/app/logs-archive", null, null, REGION);
+        service.createLogStream("/app/logs-archive", "stream-1", REGION);
+
+        long now = System.currentTimeMillis();
+        service.putLogEvents("/app/logs", "stream-1",
+                List.of(Map.of("timestamp", now, "message", "live")), REGION);
+        service.putLogEvents("/app/logs-archive", "stream-1",
+                List.of(Map.of("timestamp", now, "message", "archived")), REGION);
+
+        CloudWatchLogsService.FilteredLogEventsResult result = service.filterLogEvents(
+                "/app/logs", null, null, null, null, 100, REGION);
+
+        assertEquals(1, result.events().size());
+        assertEquals("live", result.events().getFirst().event().getMessage());
+    }
+
+    @Test
+    void filterLogEventsRecoversStreamNamesHoldingAColon() {
+        // AWS forbids ':' in a stream name but floci does not enforce that, so the stream a match
+        // is attributed to must not depend on the name being AWS-legal.
+        String awkward = "app:worker:1";
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.createLogStream("/app/logs", awkward, REGION);
+
+        service.putLogEvents("/app/logs", awkward,
+                List.of(Map.of("timestamp", System.currentTimeMillis(), "message", "hello")), REGION);
+
+        CloudWatchLogsService.FilteredLogEventsResult result = service.filterLogEvents(
+                "/app/logs", null, null, null, null, 100, REGION);
+
+        assertEquals(1, result.events().size());
+        assertEquals(awkward, result.events().getFirst().logStreamName());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `FilterLogEvents` returns `logStreamName` on every event, so a caller searching a whole log group can attribute each match to the stream that emitted it. Real AWS returns it on every `FilteredLogEvent`; Floci served `FilterLogEvents` and `GetLogEvents` from one serializer that omitted it, so cross-stream attribution was lost with no error to signal it.
- `GetLogEvents` is unchanged. Its `OutputLogEvent` carries no `logStreamName` in real AWS, because the caller named the stream in the request.
- The stream name is derived from the event's storage key rather than persisted on the event, so it is already correct for events written before this change and needs no backfill.
- `filterLogEvents` walks the keyset once instead of running one full keyset scan per requested stream, since a scan walks every key regardless of the prefix it filters on.

Closes #2210

## Why derive rather than store

The issue suggests carrying the stream name through to the serializer, which most directly means setting it on `LogEvent` at ingestion. That is what #2228 anticipates: every event already in the store deserializes with `logStreamName: null`, and since events now survive restarts, that cohort is permanent without a backfill pass.

Reading the name off the storage key avoids that class of problem. Keys are already `<region>::<group>::<stream>::<timestamp>::<uuid>`, so the key is an authoritative record of the emitter for every event ever written. Nothing is persisted twice, there is no null cohort, and there is no migration to run.

The name is read back between the caller's group prefix and the trailing timestamp and uuid, both generated in `eventKey`, so it survives a stream name containing a `:`. AWS forbids that, but `createLogStream` does not enforce it, so the parse does not depend on the restriction holding.

If that reading is right, #2228 can be closed alongside this. Happy to add a backfill instead if you would rather the field live on the event.

## Test plan

- [x] `CloudWatchLogsServiceTest`: per-event stream attribution across two streams, stream-restricted filtering, prefix-sibling group isolation (`/app/logs` must not sweep up `/app/logs-archive`), and a stream name containing `:`
- [x] `CloudWatchLogsHandlerTest`: `logStreamName` present on `FilterLogEvents` results in both the name and ARN request forms, absent from `GetLogEvents`
- [x] `./mvnw test -Dtest=CloudWatchLogsServiceTest,CloudWatchLogsHandlerTest` — 56 pass
- [ ] Full local suite is inconclusive on this machine: `ElastiCacheIntegrationTest`, `ElbV2*IntegrationTest` and `ApiGatewayV2AlbIntegrationTest` fail on host port collisions (6379 and 7782/7793/7794 already bound), identically on a branch that touches none of that code. Leaving the full run to CI.
