### PR TITLE
fix(cloudformation): pass the CloudFront service argument in the provisioner tests

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/DynamoDbReplicaCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/DynamoDbReplicaCfnProvisionerTest.java
@@ -34,7 +34,7 @@ class DynamoDbReplicaCfnProvisionerTest {
         provisioner = new CloudFormationResourceProvisioner(
                 null, null, null, dynamoDbService, null, null, null, null, null, null,
                 null, null, null, null, null, null, mapper, null, null, null, null, null,
-                null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, null,
                 new CloudFormationResourceRegistry(List.of()));
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/EventBusDeleteOwnershipTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/EventBusDeleteOwnershipTest.java
@@ -45,7 +45,7 @@ class EventBusDeleteOwnershipTest {
                 new ObjectMapper(),
                 null, null, null, null, null, null, null,
                 null, null, null, null, null, null, null,
-                null,
+                null, null,
                 new CloudFormationResourceRegistry(List.of()));
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/EventBusProvisionOwnershipTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/EventBusProvisionOwnershipTest.java
@@ -58,7 +58,7 @@ class EventBusProvisionOwnershipTest {
                 MAPPER,
                 null, null, null, null, null, null, null,
                 null, null, null, null, null, null, null,
-                null,
+                null, null,
                 new CloudFormationResourceRegistry(List.of()));
     }
 


### PR DESCRIPTION
> [!NOTE]
> ## Stack position: this is the base
>
> **#2262 is stacked on top of this PR** and targets this branch, not `main`.
>
> Merge this one **first**; #2262 then retargets to `main` automatically.
>
> This PR is self-contained — review it on its own. It changes test sources only.

`main` does not compile.

## Cause

#1820 added a `CloudFrontService cloudFrontService` parameter to the `CloudFormationResourceProvisioner` constructor. Three tests that construct that provisioner directly landed from other branches around the same time and were never updated:

| Test | From |
|---|---|
| `EventBusProvisionOwnershipTest` | #1807 |
| `EventBusDeleteOwnershipTest` | #1807 |
| `DynamoDbReplicaCfnProvisionerTest` | #1811 |

None of those PRs touched #1820's files, so each passed CI on its own branch and the break only appeared once they had all landed:

```
constructor CloudFormationResourceProvisioner in class
io.github.hectorvent.floci.services.cloudformation.CloudFormationResourceProvisioner
cannot be applied to given types;
```

`./mvnw test-compile` fails on `main`, so no test can run.

## Fix

All three supplied 33 arguments to a 34-parameter constructor. Adds the missing `null` in the `cloudFrontService` position, immediately before the resource registry argument.

Since this has now recurred twice, I swept **every** remaining `new CloudFormationResourceProvisioner(` call site in the tree rather than fixing them reactively. The other six already match, so nine of nine now agree with the constructor.

Test sources only — no production behaviour changes.

## Verification

- `./mvnw test-compile` — clean.
- `./mvnw test -Dtest='EventBusProvisionOwnershipTest,EventBusDeleteOwnershipTest,DynamoDbReplicaCfnProvisionerTest'` — 15 tests, 0 failures, 0 errors.
- Rebased onto current `main` (`a29464ab`).

## Note for maintainers

This is the second time a constructor change to `CloudFormationResourceProvisioner` has broken `main` through a semantically-conflicting merge that Git saw no textual conflict in. A 34-argument constructor built entirely of positional `null`s in tests makes this failure mode both easy to hit and silent until merge. Worth considering a test builder or a small parameter object so adding a service does not require editing every fixture — happy to open a separate issue if that is wanted.
