### PR TITLE
fix(iam,lambda): return resource tags in Get and Create responses

### DIFF
--- a/compatibility-tests/compat-terraform/main.tf
+++ b/compatibility-tests/compat-terraform/main.tf
@@ -458,3 +458,41 @@ resource "aws_iam_role_policy_attachment" "emr_service_role" {
 output "managed_policy_role_arn" {
   value = aws_iam_role.managed_policy_attach.arn
 }
+
+# The provider reads tags off the GetRole/GetPolicy/GetFunction response rather than by calling
+# List*Tags, so a tagged resource that does not echo them back applies cleanly and then diffs on
+# every subsequent plan. The re-plan assertion below is what catches that.
+resource "aws_iam_role" "tagged" {
+  name               = "floci-compat-tagged-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+
+  tags = {
+    Environment = "compat"
+    Owner       = "floci"
+  }
+}
+
+resource "aws_iam_policy" "tagged" {
+  name        = "floci-compat-tagged-policy"
+  description = "Tagged policy used to assert tags survive a round trip"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "s3:GetObject"
+      Resource = "*"
+    }]
+  })
+
+  tags = {
+    Environment = "compat"
+  }
+}
+
+output "tagged_role_arn" {
+  value = aws_iam_role.tagged.arn
+}
+
+output "tagged_policy_arn" {
+  value = aws_iam_policy.tagged.arn
+}

--- a/compatibility-tests/compat-terraform/test/terraform.bats
+++ b/compatibility-tests/compat-terraform/test/terraform.bats
@@ -295,3 +295,55 @@ setup() {
     assert_failure
     assert_output --partial "NoSuchEntity"
 }
+
+# Tags are stored and readable via ListRoleTags, but the provider reads them off the
+# GetRole response. Omitting them there made every tagged role read back untagged.
+@test "Terraform: GetRole returns the role's tags" {
+    run aws_cmd iam get-role --role-name floci-compat-tagged-role \
+        --query "Role.Tags[?Key=='Environment'].Value" --output text
+    assert_success
+    assert_output "compat"
+}
+
+@test "Terraform: GetPolicy returns the policy's tags" {
+    policy_arn=$(aws_cmd iam list-policies --scope Local \
+        --query "Policies[?PolicyName=='floci-compat-tagged-policy'].Arn" --output text)
+    run aws_cmd iam get-policy --policy-arn "$policy_arn" \
+        --query "Policy.Tags[?Key=='Environment'].Value" --output text
+    assert_success
+    assert_output "compat"
+}
+
+# The other half of the contract: IAM's listing operations deliberately return a subset
+# of attributes. ListRoles "does not return the following attributes, even though they
+# are an attribute of the returned object: PermissionsBoundary, RoleLastUsed, Tags".
+# Emitting them here would deviate from AWS in the opposite direction.
+@test "Terraform: ListRoles omits tags even for a tagged role" {
+    run aws_cmd iam list-roles \
+        --query "Roles[?RoleName=='floci-compat-tagged-role'].Tags" --output text
+    assert_success
+    refute_output --partial "compat"
+}
+
+@test "Terraform: ListPolicies omits tags and description even for a tagged policy" {
+    run aws_cmd iam list-policies --scope Local \
+        --query "Policies[?PolicyName=='floci-compat-tagged-policy'].[Tags,Description]" \
+        --output text
+    assert_success
+    refute_output --partial "compat"
+    refute_output --partial "round trip"
+}
+
+# The assertion that actually matters for the drift class: tags that do not survive the
+# round trip apply cleanly and then re-plan dirty forever.
+@test "Terraform: re-planning the tagged IAM resources reports no changes" {
+    cd "$TF_DIR"
+    run terraform plan -var="endpoint=${FLOCI_ENDPOINT}" -input=false -no-color -detailed-exitcode \
+        -target=aws_iam_role.tagged \
+        -target=aws_iam_policy.tagged
+    if [ "$status" -eq 2 ]; then
+        echo "# drift detected on re-plan:" >&3
+        echo "$output" >&3
+    fi
+    [ "$status" -eq 0 ]
+}

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
@@ -199,7 +199,7 @@ public class IamQueryHandler {
         IamUser user = iamService.createUser(userName, path);
         if (!tags.isEmpty()) iamService.tagUser(userName, tags);
         user = iamService.getUser(userName);
-        String result = new XmlBuilder().start("User").raw(userXml(user)).end("User").build();
+        String result = new XmlBuilder().start("User").raw(userXml(user, true)).end("User").build();
         return Response.ok(AwsQueryResponse.envelope("CreateUser", AwsNamespaces.IAM, result)).build();
     }
 
@@ -225,7 +225,7 @@ public class IamQueryHandler {
         // UserName is optional per the IAM model: it defaults to the user owning the
         // access key that signed the request.
         IamUser user = iamService.getUser(resolveUserName(params, authorization));
-        String result = new XmlBuilder().start("User").raw(userXml(user)).end("User").build();
+        String result = new XmlBuilder().start("User").raw(userXml(user, true)).end("User").build();
         return Response.ok(AwsQueryResponse.envelope("GetUser", AwsNamespaces.IAM, result)).build();
     }
 
@@ -240,7 +240,7 @@ public class IamQueryHandler {
         List<IamUser> userList = iamService.listUsers(pathPrefix);
         var xml = new XmlBuilder().start("Users");
         for (IamUser u : userList) {
-            xml.start("member").raw(userXml(u)).end("member");
+            xml.start("member").raw(userXml(u, false)).end("member");
         }
         xml.end("Users").elem("IsTruncated", false);
         return Response.ok(AwsQueryResponse.envelope("ListUsers", AwsNamespaces.IAM, xml.build())).build();
@@ -458,7 +458,7 @@ public class IamQueryHandler {
                 .start("Group").raw(groupXml(group)).end("Group")
                 .start("Users");
         for (IamUser u : members) {
-            xml.start("member").raw(userXml(u)).end("member");
+            xml.start("member").raw(userXml(u, false)).end("member");
         }
         xml.end("Users").elem("IsTruncated", false);
         return Response.ok(AwsQueryResponse.envelope("GetGroup", AwsNamespaces.IAM, xml.build())).build();
@@ -511,13 +511,13 @@ public class IamQueryHandler {
         int maxSession = getIntParam(params, "MaxSessionDuration", 3600);
         Map<String, String> tags = extractTags(params);
         IamRole role = iamService.createRole(roleName, path, trustPolicy, description, maxSession, tags);
-        String result = new XmlBuilder().start("Role").raw(roleXml(role)).end("Role").build();
+        String result = new XmlBuilder().start("Role").raw(roleXml(role, true)).end("Role").build();
         return Response.ok(AwsQueryResponse.envelope("CreateRole", AwsNamespaces.IAM, result)).build();
     }
 
     private Response handleGetRole(MultivaluedMap<String, String> params) {
         IamRole role = iamService.getRole(getParam(params, "RoleName"));
-        String result = new XmlBuilder().start("Role").raw(roleXml(role)).end("Role").build();
+        String result = new XmlBuilder().start("Role").raw(roleXml(role, true)).end("Role").build();
         return Response.ok(AwsQueryResponse.envelope("GetRole", AwsNamespaces.IAM, result)).build();
     }
 
@@ -531,7 +531,7 @@ public class IamQueryHandler {
                 getParam(params, "AWSServiceName"),
                 getParam(params, "CustomSuffix"),
                 getParam(params, "Description"));
-        String result = new XmlBuilder().start("Role").raw(roleXml(role)).end("Role").build();
+        String result = new XmlBuilder().start("Role").raw(roleXml(role, true)).end("Role").build();
         return Response.ok(AwsQueryResponse.envelope("CreateServiceLinkedRole", AwsNamespaces.IAM, result)).build();
     }
 
@@ -551,7 +551,7 @@ public class IamQueryHandler {
         List<IamRole> roleList = iamService.listRoles(getParam(params, "PathPrefix"));
         var xml = new XmlBuilder().start("Roles");
         for (IamRole r : roleList) {
-            xml.start("member").raw(roleXml(r)).end("member");
+            xml.start("member").raw(roleXml(r, false)).end("member");
         }
         xml.end("Roles").elem("IsTruncated", false);
         return Response.ok(AwsQueryResponse.envelope("ListRoles", AwsNamespaces.IAM, xml.build())).build();
@@ -1030,13 +1030,21 @@ public class IamQueryHandler {
     // XML serialization helpers
     // =========================================================================
 
-    private String userXml(IamUser u) {
+    /**
+     * {@code detailed} is per-operation, not per-user: ListUsers documents that "IAM
+     * resource-listing operations return a subset of the available attributes for the resource.
+     * This operation does not return the following attributes, even though they are an attribute
+     * of the returned object: PermissionsBoundary, Tags". GetGroup likewise lists its members
+     * without tags.
+     */
+    private String userXml(IamUser u, boolean detailed) {
         return new XmlBuilder()
                 .elem("Path", u.getPath())
                 .elem("UserName", u.getUserName())
                 .elem("UserId", u.getUserId())
                 .elem("Arn", u.getArn())
                 .elem("CreateDate", isoDate(u.getCreateDate()))
+                .raw(detailed ? tagsElement(u.getTags()) : "")
                 .build();
     }
 
@@ -1050,7 +1058,15 @@ public class IamQueryHandler {
                 .build();
     }
 
-    private String roleXml(IamRole r) {
+    /**
+     * {@code detailed} is per-operation, not per-role: ListRoles documents that "IAM
+     * resource-listing operations return a subset of the available attributes for the resource.
+     * This operation does not return the following attributes, even though they are an attribute
+     * of the returned object: PermissionsBoundary, RoleLastUsed, Tags". {@code Description} is
+     * deliberately not gated — it is absent from that exclusion list. Roles embedded in an
+     * instance profile are a subset too, as GetInstanceProfile's own example response shows.
+     */
+    private String roleXml(IamRole r, boolean detailed) {
         return new XmlBuilder()
                 .elem("Path", r.getPath())
                 .elem("RoleName", r.getRoleName())
@@ -1060,16 +1076,19 @@ public class IamQueryHandler {
                 .elem("MaxSessionDuration", (long) r.getMaxSessionDuration())
                 .elem("AssumeRolePolicyDocument", r.getAssumeRolePolicyDocument())
                 .elem("Description", r.getDescription())
+                .raw(detailed ? tagsElement(r.getTags()) : "")
                 .build();
     }
 
     /**
-     * {@code includeDescription} is per-operation, not per-policy: AWS's own {@code Policy} model
-     * documents that {@code Description} "is included in the response to the GetPolicy operation.
-     * It is not included in the response to the ListPolicies operation" — CreatePolicy documents
-     * neither inclusion nor exclusion, so it's treated the same as GetPolicy.
+     * {@code detailed} is per-operation, not per-policy: AWS's own {@code Policy} model documents
+     * that {@code Description} "is included in the response to the GetPolicy operation. It is not
+     * included in the response to the ListPolicies operation" — CreatePolicy documents neither
+     * inclusion nor exclusion, so it's treated the same as GetPolicy. ListPolicies excludes
+     * {@code Tags} on the same grounds ("this operation does not return tags"), so one flag
+     * governs both.
      */
-    private String policyXml(IamPolicy p, boolean includeDescription) {
+    private String policyXml(IamPolicy p, boolean detailed) {
         return new XmlBuilder()
                 .elem("PolicyName", p.getPolicyName())
                 .elem("PolicyId", p.getPolicyId())
@@ -1080,7 +1099,8 @@ public class IamQueryHandler {
                 .elem("IsAttachable", true)
                 .elem("CreateDate", isoDate(p.getCreateDate()))
                 .elem("UpdateDate", isoDate(p.getUpdateDate()))
-                .elem("Description", includeDescription ? p.getDescription() : null)
+                .elem("Description", detailed ? p.getDescription() : null)
+                .raw(detailed ? tagsElement(p.getTags()) : "")
                 .build();
     }
 
@@ -1115,7 +1135,7 @@ public class IamQueryHandler {
         for (String roleName : p.getRoleNames()) {
             try {
                 IamRole role = iamService.getRole(roleName);
-                xml.start("member").raw(roleXml(role)).end("member");
+                xml.start("member").raw(roleXml(role, false)).end("member");
             } catch (AwsException ignored) {}
         }
         return xml.end("Roles").build();
@@ -1138,6 +1158,22 @@ public class IamQueryHandler {
             xml.elem("member", name);
         }
         return xml.end("PolicyNames").elem("IsTruncated", false).build();
+    }
+
+    /**
+     * Renders the {@code <Tags>} wrapper for a resource, or nothing when it has no tags.
+     *
+     * <p>The AWS SDKs and the Terraform provider read a role's, policy's or user's tags off the
+     * Get/Create response rather than by calling List*Tags, so omitting this element makes every
+     * tagged resource read back untagged and diff on every plan. Emitting nothing rather than an
+     * empty {@code <Tags/>} keeps an untagged resource from reading back as having an empty tag
+     * set, which would be a diff of its own.
+     */
+    private String tagsElement(Map<String, String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return "";
+        }
+        return new XmlBuilder().start("Tags").raw(tagsXml(tags)).end("Tags").build();
     }
 
     private String tagsXml(Map<String, String> tags) {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -104,6 +104,17 @@ public class LambdaController {
             code.put("RepositoryType", "S3");
         }
 
+        // GetFunction carries the function's tags alongside Configuration and Code. Clients read
+        // them from here rather than calling ListTags, so omitting the field makes a tagged
+        // function read back untagged and diff on every plan. Unlike IAM, Lambda has no
+        // list-subset rule to gate this on — ListFunctions returns FunctionConfiguration, which
+        // has no Tags field at all.
+        Map<String, String> tags = fn.getTags();
+        if (tags != null && !tags.isEmpty()) {
+            ObjectNode tagsNode = root.putObject("Tags");
+            tags.forEach(tagsNode::put);
+        }
+
         return Response.ok(root).build();
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamResourceTagsInResponseTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamResourceTagsInResponseTest.java
@@ -1,0 +1,285 @@
+package io.github.hectorvent.floci.services.iam;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * The AWS SDKs and the Terraform provider read a role's, policy's or user's tags off the
+ * Create/Get response rather than by calling List*Tags. Tags were stored and were readable
+ * through ListRoleTags, but never serialized into these responses, so every tagged resource
+ * read back untagged and produced a permanent diff.
+ *
+ * <p>The inclusion is asymmetric, and the negative cases below pin that half: IAM's
+ * resource-listing operations deliberately return a subset of attributes, so ListRoles,
+ * ListUsers and ListPolicies must keep omitting tags.
+ */
+@QuarkusTest
+class IamResourceTagsInResponseTest {
+
+    private static final String IAM_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260807/us-east-1/iam/aws4_request";
+
+    private static final String TRUST_POLICY =
+            "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\","
+            + "\"Principal\":{\"Service\":\"ecs-tasks.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}";
+
+    private static final String POLICY_DOCUMENT =
+            "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\","
+            + "\"Action\":\"s3:GetObject\",\"Resource\":\"*\"}]}";
+
+    private static io.restassured.specification.RequestSpecification iam(String action) {
+        return given().header("Authorization", IAM_AUTH).formParam("Action", action);
+    }
+
+    // ── Detail operations must return tags ────────────────────────────────────
+
+    @Test
+    void createAndGetRoleEchoTheirTags() {
+        String role = "TagEchoRole";
+
+        iam("CreateRole")
+            .formParam("RoleName", role)
+            .formParam("Path", "/")
+            .formParam("AssumeRolePolicyDocument", TRUST_POLICY)
+            .formParam("Tags.member.1.Key", "Environment")
+            .formParam("Tags.member.1.Value", "dev")
+        .when().post("/").then()
+            .statusCode(200)
+            .body(containsString("<Tags>"))
+            .body(containsString("<Key>Environment</Key>"))
+            .body(containsString("<Value>dev</Value>"));
+
+        iam("GetRole")
+            .formParam("RoleName", role)
+        .when().post("/").then()
+            .statusCode(200)
+            .body(containsString("<Key>Environment</Key>"))
+            .body(containsString("<Value>dev</Value>"));
+    }
+
+    @Test
+    void getRoleOmitsTheTagsElementEntirelyWhenUntagged() {
+        String role = "UntaggedEchoRole";
+
+        iam("CreateRole")
+            .formParam("RoleName", role)
+            .formParam("Path", "/")
+            .formParam("AssumeRolePolicyDocument", TRUST_POLICY)
+        .when().post("/").then().statusCode(200);
+
+        // An empty <Tags/> would read back as a tag set the caller never configured.
+        iam("GetRole")
+            .formParam("RoleName", role)
+        .when().post("/").then()
+            .statusCode(200)
+            .body(not(containsString("<Tags>")));
+    }
+
+    @Test
+    void tagsAddedAfterCreationAppearOnGetRole() {
+        String role = "LaterTaggedRole";
+
+        iam("CreateRole")
+            .formParam("RoleName", role)
+            .formParam("Path", "/")
+            .formParam("AssumeRolePolicyDocument", TRUST_POLICY)
+        .when().post("/").then().statusCode(200);
+
+        iam("TagRole")
+            .formParam("RoleName", role)
+            .formParam("Tags.member.1.Key", "Team")
+            .formParam("Tags.member.1.Value", "platform")
+        .when().post("/").then().statusCode(200);
+
+        iam("GetRole")
+            .formParam("RoleName", role)
+        .when().post("/").then()
+            .statusCode(200)
+            .body(containsString("<Key>Team</Key>"))
+            .body(containsString("<Value>platform</Value>"));
+    }
+
+    @Test
+    void createServiceLinkedRoleEchoesNoTagsButStillSerializesTheRole() {
+        iam("CreateServiceLinkedRole")
+            .formParam("AWSServiceName", "elasticache.amazonaws.com")
+        .when().post("/").then()
+            .statusCode(200)
+            .body(containsString("<RoleName>"))
+            .body(not(containsString("<Tags>")));
+    }
+
+    @Test
+    void createAndGetPolicyEchoTheirTags() {
+        String policyName = "TagEchoPolicy";
+
+        String arn = iam("CreatePolicy")
+            .formParam("PolicyName", policyName)
+            .formParam("PolicyDocument", POLICY_DOCUMENT)
+            .formParam("Tags.member.1.Key", "Owner")
+            .formParam("Tags.member.1.Value", "data")
+        .when().post("/").then()
+            .statusCode(200)
+            .body(containsString("<Key>Owner</Key>"))
+            .extract().path("CreatePolicyResponse.CreatePolicyResult.Policy.Arn");
+
+        iam("GetPolicy")
+            .formParam("PolicyArn", arn)
+        .when().post("/").then()
+            .statusCode(200)
+            .body(containsString("<Key>Owner</Key>"))
+            .body(containsString("<Value>data</Value>"));
+    }
+
+    @Test
+    void createAndGetUserEchoTheirTags() {
+        String user = "TagEchoUser";
+
+        iam("CreateUser")
+            .formParam("UserName", user)
+            .formParam("Tags.member.1.Key", "CostCenter")
+            .formParam("Tags.member.1.Value", "1234")
+        .when().post("/").then()
+            .statusCode(200)
+            .body(containsString("<Key>CostCenter</Key>"));
+
+        iam("GetUser")
+            .formParam("UserName", user)
+        .when().post("/").then()
+            .statusCode(200)
+            .body(containsString("<Key>CostCenter</Key>"))
+            .body(containsString("<Value>1234</Value>"));
+    }
+
+    // ── Listing operations must keep omitting tags ────────────────────────────
+
+    @Test
+    void listRolesOmitsTagsEvenForATaggedRole() {
+        iam("CreateRole")
+            .formParam("RoleName", "ListSubsetRole")
+            .formParam("Path", "/")
+            .formParam("AssumeRolePolicyDocument", TRUST_POLICY)
+            .formParam("Tags.member.1.Key", "ListRolesMarker")
+            .formParam("Tags.member.1.Value", "must-not-be-listed")
+        .when().post("/").then().statusCode(200);
+
+        // "IAM resource-listing operations return a subset of the available attributes for the
+        // resource. This operation does not return the following attributes, even though they
+        // are an attribute of the returned object: PermissionsBoundary, RoleLastUsed, Tags."
+        iam("ListRoles")
+        .when().post("/").then()
+            .statusCode(200)
+            .body(containsString("<RoleName>ListSubsetRole</RoleName>"))
+            .body(not(containsString("<Tags>")))
+            .body(not(containsString("must-not-be-listed")));
+    }
+
+    @Test
+    void listRolesStillReturnsDescriptionWhichIsNotInTheExcludedSet() {
+        iam("CreateRole")
+            .formParam("RoleName", "DescribedListRole")
+            .formParam("Path", "/")
+            .formParam("AssumeRolePolicyDocument", TRUST_POLICY)
+            .formParam("Description", "kept-in-listings")
+        .when().post("/").then().statusCode(200);
+
+        iam("ListRoles")
+        .when().post("/").then()
+            .statusCode(200)
+            .body(containsString("kept-in-listings"));
+    }
+
+    @Test
+    void listUsersOmitsTagsEvenForATaggedUser() {
+        iam("CreateUser")
+            .formParam("UserName", "ListSubsetUser")
+            .formParam("Tags.member.1.Key", "ListUsersMarker")
+            .formParam("Tags.member.1.Value", "user-must-not-be-listed")
+        .when().post("/").then().statusCode(200);
+
+        iam("ListUsers")
+        .when().post("/").then()
+            .statusCode(200)
+            .body(containsString("<UserName>ListSubsetUser</UserName>"))
+            .body(not(containsString("<Tags>")))
+            .body(not(containsString("user-must-not-be-listed")));
+    }
+
+    @Test
+    void listPoliciesOmitsTagsAndDescriptionEvenForATaggedPolicy() {
+        iam("CreatePolicy")
+            .formParam("PolicyName", "ListSubsetPolicy")
+            .formParam("PolicyDocument", POLICY_DOCUMENT)
+            .formParam("Description", "policy-description-must-not-be-listed")
+            .formParam("Tags.member.1.Key", "ListPoliciesMarker")
+            .formParam("Tags.member.1.Value", "policy-must-not-be-listed")
+        .when().post("/").then().statusCode(200);
+
+        iam("ListPolicies")
+            .formParam("Scope", "Local")
+        .when().post("/").then()
+            .statusCode(200)
+            .body(containsString("<PolicyName>ListSubsetPolicy</PolicyName>"))
+            .body(not(containsString("<Tags>")))
+            .body(not(containsString("policy-must-not-be-listed")))
+            .body(not(containsString("policy-description-must-not-be-listed")));
+    }
+
+    @Test
+    void getGroupListsItsMembersWithoutTags() {
+        iam("CreateUser")
+            .formParam("UserName", "GroupMemberUser")
+            .formParam("Tags.member.1.Key", "GroupMarker")
+            .formParam("Tags.member.1.Value", "group-must-not-be-listed")
+        .when().post("/").then().statusCode(200);
+
+        iam("CreateGroup").formParam("GroupName", "TagSubsetGroup")
+        .when().post("/").then().statusCode(200);
+
+        iam("AddUserToGroup")
+            .formParam("GroupName", "TagSubsetGroup")
+            .formParam("UserName", "GroupMemberUser")
+        .when().post("/").then().statusCode(200);
+
+        iam("GetGroup")
+            .formParam("GroupName", "TagSubsetGroup")
+        .when().post("/").then()
+            .statusCode(200)
+            .body(containsString("<UserName>GroupMemberUser</UserName>"))
+            .body(not(containsString("<Tags>")))
+            .body(not(containsString("group-must-not-be-listed")));
+    }
+
+    @Test
+    void getInstanceProfileEmbedsItsRoleWithoutTags() {
+        iam("CreateRole")
+            .formParam("RoleName", "ProfileEmbeddedRole")
+            .formParam("Path", "/")
+            .formParam("AssumeRolePolicyDocument", TRUST_POLICY)
+            .formParam("Tags.member.1.Key", "ProfileMarker")
+            .formParam("Tags.member.1.Value", "profile-must-not-be-listed")
+        .when().post("/").then().statusCode(200);
+
+        iam("CreateInstanceProfile")
+            .formParam("InstanceProfileName", "TagSubsetProfile")
+        .when().post("/").then().statusCode(200);
+
+        iam("AddRoleToInstanceProfile")
+            .formParam("InstanceProfileName", "TagSubsetProfile")
+            .formParam("RoleName", "ProfileEmbeddedRole")
+        .when().post("/").then().statusCode(200);
+
+        // GetInstanceProfile's own example response shows the embedded role as a subset.
+        iam("GetInstanceProfile")
+            .formParam("InstanceProfileName", "TagSubsetProfile")
+        .when().post("/").then()
+            .statusCode(200)
+            .body(containsString("<RoleName>ProfileEmbeddedRole</RoleName>"))
+            .body(not(containsString("<Tags>")))
+            .body(not(containsString("profile-must-not-be-listed")));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaPermissionTagLayerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaPermissionTagLayerIntegrationTest.java
@@ -297,6 +297,26 @@ class LambdaPermissionTagLayerIntegrationTest {
             .body("LayerVersions", empty());
     }
 
+    // ── GetFunction tags ──────────────────────────────────────────────────────
+
+    /**
+     * The Terraform provider and the SDKs read a function's tags from GetFunction rather than by
+     * calling ListTags, so omitting the field made a tagged function read back untagged and diff
+     * on every plan. Runs after the untag above, so it also pins that GetFunction reflects a
+     * removed tag rather than serving a stale set.
+     */
+    @Test
+    @Order(19)
+    void getFunction_includesTags() {
+        given()
+        .when()
+            .get("/2015-03-31/functions/" + FN)
+        .then()
+            .statusCode(200)
+            .body("Tags.team", equalTo("platform"))
+            .body("Tags.env", nullValue());
+    }
+
     // ── cleanup ───────────────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
> [!NOTE]
> Rebased onto current `main` (`12154297`). Carries only its own two commits — `a8b6b27c` (production change) and `b3ff76b6` (tests). The earlier stacking on #2261 is resolved: that PR merged, so this targets `main` directly.

Closes #2199.

## Problem

IAM stores role, policy and user tags and serves them through `ListRoleTags`/`ListPolicyTags`/`ListUserTags`. Lambda does the same through `ListTags`. Neither ever serialized them into the Create/Get responses.

The AWS SDKs and the Terraform provider read tags off those responses rather than by calling `List*Tags` — the provider's transparent-tagging interceptor (`@Tags(identifierAttribute="arn")`) does this on every read. So every tagged `aws_iam_role`, `aws_iam_policy`, `aws_iam_user` and `aws_lambda_function` reads back untagged: the apply succeeds, and then `plan` never converges. An apply-only test cannot see this.

## The inclusion is asymmetric

Serializing tags unconditionally would deviate from AWS in the opposite direction. IAM's resource-listing operations deliberately return a subset of attributes:

| Operation | AWS documents |
|---|---|
| `ListRoles` | "does not return the following attributes, even though they are an attribute of the returned object: PermissionsBoundary, RoleLastUsed, **Tags**" |
| `ListUsers` | same, for PermissionsBoundary and **Tags** |
| `ListPolicies` | "this operation does not return **tags**" |

So `roleXml`, `userXml` and `policyXml` take a `detailed` flag, following the pattern #2155 established for the policy `Description`.

Two details worth a reviewer's eye:

- **A role's `Description` stays unconditional.** It is absent from the `ListRoles` exclusion list, so unlike policies it must keep appearing in listings. For policies one flag governs both `Description` and `Tags`, since `ListPolicies` excludes them on identical grounds — that is why #2155's `includeDescription` parameter is renamed to `detailed` rather than joined by a second flag.
- **Roles embedded in an instance profile are a subset too.** `GetInstanceProfile`'s and `ListInstanceProfiles`' own example responses both show the embedded `<member>` role without `<Tags>`, so `instanceProfileXml` passes `false`.

Call sites:

| `detailed = true` | `detailed = false` |
|---|---|
| `CreateRole`, `GetRole`, `CreateServiceLinkedRole` | `ListRoles` |
| `CreateUser`, `GetUser` | `ListUsers`, `GetGroup` |
| `CreatePolicy`, `GetPolicy` | `ListPolicies` |
| | roles embedded in `instanceProfileXml` |

`tagsElement` emits nothing rather than an empty `<Tags/>` for an untagged resource — an empty element reads back as a tag set the caller never configured, which is a diff of its own.

Lambda needs no such gate: `ListFunctions` returns `FunctionConfiguration`, which has no `Tags` field at all.

## Tests

`IamResourceTagsInResponseTest` (new, 12 cases) asserts **both** directions — the negative half is the point, since tests that only assert tags are present cannot catch over-inclusion. Verified by reverting the production change to the naive unconditional form: all 5 listing-subset cases fail, and pass again once the flag is restored.

`LambdaPermissionTagLayerIntegrationTest` gains a `GetFunction` case ordered after the untag, so it also pins that a removed tag is reflected rather than served stale.

Compat: a tagged role and a tagged policy in `compat-terraform`, with cases for the positive round trip, the listing-subset negatives, and **a clean second `terraform plan`** — the assertion that actually catches this drift class.

## Verification

- `./mvnw test` — full suite green on the rebased branch: 9929 tests, 0 failures, 0 errors, 9 skipped.
- IAM + Lambda targeted: 559 tests, 0 failures, 0 errors.
- `make docs-check` — clean; no handler actions change, so no `docs-sync` needed.
- `terraform fmt -check` — the only diff is a pre-existing unrelated `aws_db_instance` block on `main`, left untouched.

