### PR TITLE
fix(ec2): keep the source on security group rules

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/ec2.bats
+++ b/compatibility-tests/sdk-test-awscli/test/ec2.bats
@@ -5,11 +5,22 @@ setup() {
     load 'test_helper/common-setup'
     PREFIX_LIST_NAME="bats-prefix-list-$(unique_name)"
     PREFIX_LIST_ID=""
+    SG_VPC_ID=""
+    SG_SOURCE_ID=""
+    SG_TARGET_ID=""
 }
 
 teardown() {
     if [ -n "$PREFIX_LIST_ID" ]; then
         aws_cmd ec2 delete-managed-prefix-list --prefix-list-id "$PREFIX_LIST_ID" >/dev/null 2>&1 || true
+    fi
+    for sg in "$SG_TARGET_ID" "$SG_SOURCE_ID"; do
+        if [ -n "$sg" ]; then
+            aws_cmd ec2 delete-security-group --group-id "$sg" >/dev/null 2>&1 || true
+        fi
+    done
+    if [ -n "$SG_VPC_ID" ]; then
+        aws_cmd ec2 delete-vpc --vpc-id "$SG_VPC_ID" >/dev/null 2>&1 || true
     fi
 }
 
@@ -133,4 +144,54 @@ create_prefix_list() {
     assert_success
     id=$(json_get "$output" '.PrefixLists[0].PrefixListId')
     [ "$id" = "pl-63a5400a" ]
+}
+
+# Creates a VPC holding a source and a target security group, and sets SG_VPC_ID,
+# SG_SOURCE_ID and SG_TARGET_ID.
+create_sg_pair() {
+    local out
+    out=$(aws_cmd ec2 create-vpc --cidr-block 10.0.0.0/16)
+    SG_VPC_ID=$(json_get "$out" '.Vpc.VpcId')
+    out=$(aws_cmd ec2 create-security-group \
+        --group-name "$(unique_name bats-sg-source)" \
+        --description "traffic source" --vpc-id "$SG_VPC_ID")
+    SG_SOURCE_ID=$(json_get "$out" '.GroupId')
+    out=$(aws_cmd ec2 create-security-group \
+        --group-name "$(unique_name bats-sg-target)" \
+        --description "traffic target" --vpc-id "$SG_VPC_ID")
+    SG_TARGET_ID=$(json_get "$out" '.GroupId')
+}
+
+@test "EC2: ingress rule keeps its source security group" {
+    create_sg_pair
+
+    # The CLI serializes UserIdGroupPairs under the wire name "Groups", so this exercises the
+    # form the reporter of #2190 actually sent.
+    run aws_cmd ec2 authorize-security-group-ingress --group-id "$SG_TARGET_ID" \
+        --ip-permissions "IpProtocol=tcp,FromPort=443,ToPort=443,UserIdGroupPairs=[{GroupId=$SG_SOURCE_ID,Description=from-source-sg}]"
+    assert_success
+    ref=$(json_get "$output" '.SecurityGroupRules[0].ReferencedGroupInfo.GroupId')
+    [ "$ref" = "$SG_SOURCE_ID" ]
+
+    # Control: the CIDR form of the same rule.
+    aws_cmd ec2 authorize-security-group-ingress --group-id "$SG_TARGET_ID" \
+        --ip-permissions 'IpProtocol=tcp,FromPort=8443,ToPort=8443,IpRanges=[{CidrIp=10.0.0.0/8,Description=control}]' >/dev/null
+
+    run aws_cmd ec2 describe-security-groups --group-ids "$SG_TARGET_ID"
+    assert_success
+    gid=$(json_get "$output" '.SecurityGroups[0].IpPermissions[] | select(.FromPort==443) | .UserIdGroupPairs[0].GroupId')
+    [ "$gid" = "$SG_SOURCE_ID" ]
+    desc=$(json_get "$output" '.SecurityGroups[0].IpPermissions[] | select(.FromPort==443) | .UserIdGroupPairs[0].Description')
+    [ "$desc" = "from-source-sg" ]
+    cidr=$(json_get "$output" '.SecurityGroups[0].IpPermissions[] | select(.FromPort==8443) | .IpRanges[0].CidrIp')
+    [ "$cidr" = "10.0.0.0/8" ]
+
+    run aws_cmd ec2 describe-security-group-rules --filters "Name=group-id,Values=$SG_TARGET_ID"
+    assert_success
+    ref=$(json_get "$output" '.SecurityGroupRules[] | select(.FromPort==443) | .ReferencedGroupInfo.GroupId')
+    [ "$ref" = "$SG_SOURCE_ID" ]
+    desc=$(json_get "$output" '.SecurityGroupRules[] | select(.FromPort==443) | .Description')
+    [ "$desc" = "from-source-sg" ]
+    cidr=$(json_get "$output" '.SecurityGroupRules[] | select(.FromPort==8443) | .CidrIpv4')
+    [ "$cidr" = "10.0.0.0/8" ]
 }

--- a/docs/services/ec2.md
+++ b/docs/services/ec2.md
@@ -202,10 +202,10 @@ Floci seeds the following resources on first use in each region so Terraform, th
 | CreateSecurityGroup | Creates a security group in a VPC. |
 | DescribeSecurityGroups | Lists or returns stored security groups. |
 | DeleteSecurityGroup | Deletes a security group from the local EC2 store. |
-| AuthorizeSecurityGroupIngress | Adds inbound permissions to a security group. |
-| AuthorizeSecurityGroupEgress | Adds outbound permissions to a security group. |
-| RevokeSecurityGroupIngress | Removes inbound permissions from a security group. |
-| RevokeSecurityGroupEgress | Removes outbound permissions from a security group. |
+| AuthorizeSecurityGroupIngress | Adds inbound permissions. Sources may be IPv4 ranges, IPv6 ranges, or another security group (`UserIdGroupPairs`, sent on the wire as `Groups`); prefix list sources are not stored. One rule is stored per source, each carrying its own description. |
+| AuthorizeSecurityGroupEgress | Adds outbound permissions, with the same source types as the inbound call. |
+| RevokeSecurityGroupIngress | Removes inbound permissions. Matches on protocol and port range only, so it removes every permission on that port regardless of source. |
+| RevokeSecurityGroupEgress | Removes outbound permissions, matched the same way as the inbound call. |
 | DescribeSecurityGroupRules | Lists stored security group rules. |
 | ModifySecurityGroupRules | Updates supported fields on security group rules. |
 | UpdateSecurityGroupRuleDescriptionsIngress | Updates descriptions on matching inbound security group rules. |

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -322,6 +322,15 @@ public class Ec2QueryHandler {
         throw new AwsException("InvalidParameterValue", name + " is not a valid boolean.", 400);
     }
 
+    /**
+     * Reads the {@code IpPermissions.N} list of an authorize/revoke request.
+     *
+     * <p>Each permission carries up to four kinds of source, and every one of them has to be read
+     * here or it is silently dropped before the service layer ever sees it (#2190). Note the EC2
+     * Query protocol serializes the {@code UserIdGroupPairs} member under the wire name
+     * {@code Groups}, which is why a group reference arrives as
+     * {@code IpPermissions.1.Groups.1.GroupId} rather than under the SDK-facing field name.
+     */
     private List<IpPermission> parseIpPermissions(MultivaluedMap<String, String> p, String prefix) {
         List<IpPermission> perms = new ArrayList<>();
         for (int i = 1; ; i++) {
@@ -339,6 +348,28 @@ public class Ec2QueryHandler {
                 if (cidr == null) break;
                 String desc = p.getFirst(prefix + "." + i + ".IpRanges." + j + ".Description");
                 perm.getIpRanges().add(new IpRange(cidr, desc));
+            }
+            for (int j = 1; ; j++) {
+                String cidr = p.getFirst(prefix + "." + i + ".Ipv6Ranges." + j + ".CidrIpv6");
+                if (cidr == null) break;
+                String desc = p.getFirst(prefix + "." + i + ".Ipv6Ranges." + j + ".Description");
+                perm.getIpv6Ranges().add(new Ipv6Range(cidr, desc));
+            }
+            for (int j = 1; ; j++) {
+                String base = prefix + "." + i + ".Groups." + j;
+                String groupId = p.getFirst(base + ".GroupId");
+                String groupName = p.getFirst(base + ".GroupName");
+                String userId = p.getFirst(base + ".UserId");
+                String desc = p.getFirst(base + ".Description");
+                // A default-VPC caller may reference a group by name alone, so the loop cannot end
+                // on a missing GroupId.
+                if (groupId == null && groupName == null && userId == null && desc == null) break;
+                UserIdGroupPair pair = new UserIdGroupPair();
+                pair.setGroupId(groupId);
+                pair.setGroupName(groupName);
+                pair.setUserId(userId);
+                pair.setDescription(desc);
+                perm.getUserIdGroupPairs().add(pair);
             }
             perms.add(perm);
         }
@@ -2392,8 +2423,20 @@ public class Ec2QueryHandler {
         if (rule.getFromPort() != null) xml.elem("fromPort", String.valueOf(rule.getFromPort()));
         if (rule.getToPort() != null) xml.elem("toPort", String.valueOf(rule.getToPort()));
         xml.elem("cidrIpv4", rule.getCidrIpv4())
-                .elem("cidrIpv6", rule.getCidrIpv6())
-                .elem("description", rule.getDescription())
+                .elem("cidrIpv6", rule.getCidrIpv6());
+        // Guarded: unlike elem(), start()/end() emit even when every child is null, which would put
+        // an empty <referencedGroupInfo/> on every CIDR rule.
+        ReferencedSecurityGroup ref = rule.getReferencedGroupInfo();
+        if (ref != null) {
+            xml.start("referencedGroupInfo")
+                    .elem("groupId", ref.getGroupId())
+                    .elem("peeringStatus", ref.getPeeringStatus())
+                    .elem("userId", ref.getUserId())
+                    .elem("vpcId", ref.getVpcId())
+                    .elem("vpcPeeringConnectionId", ref.getVpcPeeringConnectionId())
+                    .end("referencedGroupInfo");
+        }
+        xml.elem("description", rule.getDescription())
                 .raw(tagSetXml(rule.getTags()));
         return xml.build();
     }
@@ -2867,7 +2910,10 @@ public class Ec2QueryHandler {
             xml.end("ipRanges")
                     .start("ipv6Ranges");
             for (Ipv6Range r : perm.getIpv6Ranges()) {
-                xml.start("item").elem("cidrIpv6", r.getCidrIpv6()).end("item");
+                xml.start("item")
+                        .elem("cidrIpv6", r.getCidrIpv6())
+                        .elem("description", r.getDescription())
+                        .end("item");
             }
             xml.end("ipv6Ranges")
                     .start("groups");
@@ -2876,6 +2922,7 @@ public class Ec2QueryHandler {
                         .elem("userId", g.getUserId())
                         .elem("groupId", g.getGroupId())
                         .elem("groupName", g.getGroupName())
+                        .elem("description", g.getDescription())
                         .end("item");
             }
             xml.end("groups").end("item");

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -351,7 +351,9 @@ public class Ec2QueryHandler {
             }
             for (int j = 1; ; j++) {
                 String cidr = p.getFirst(prefix + "." + i + ".Ipv6Ranges." + j + ".CidrIpv6");
-                if (cidr == null) break;
+                if (cidr == null) {
+                    break;
+                }
                 String desc = p.getFirst(prefix + "." + i + ".Ipv6Ranges." + j + ".Description");
                 perm.getIpv6Ranges().add(new Ipv6Range(cidr, desc));
             }
@@ -363,7 +365,9 @@ public class Ec2QueryHandler {
                 String desc = p.getFirst(base + ".Description");
                 // A default-VPC caller may reference a group by name alone, so the loop cannot end
                 // on a missing GroupId.
-                if (groupId == null && groupName == null && userId == null && desc == null) break;
+                if (groupId == null && groupName == null && userId == null && desc == null) {
+                    break;
+                }
                 UserIdGroupPair pair = new UserIdGroupPair();
                 pair.setGroupId(groupId);
                 pair.setGroupName(groupName);

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1739,7 +1739,9 @@ public class Ec2Service implements ContainerTeardown {
      * not check that a referenced group exists, for ids either.
      */
     private void resolveGroupReferences(String region, String vpcId, IpPermission perm) {
-        if (perm.getUserIdGroupPairs() == null) return;
+        if (perm.getUserIdGroupPairs() == null) {
+            return;
+        }
         for (UserIdGroupPair pair : perm.getUserIdGroupPairs()) {
             if (pair.getUserId() == null) {
                 pair.setUserId(accountId);

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -48,6 +48,7 @@ import io.github.hectorvent.floci.services.ec2.model.InternetGateway;
 import io.github.hectorvent.floci.services.ec2.model.InternetGatewayAttachment;
 import io.github.hectorvent.floci.services.ec2.model.IpPermission;
 import io.github.hectorvent.floci.services.ec2.model.IpRange;
+import io.github.hectorvent.floci.services.ec2.model.Ipv6Range;
 import io.github.hectorvent.floci.services.ec2.model.KeyPair;
 import io.github.hectorvent.floci.services.ec2.model.LaunchTemplate;
 import io.github.hectorvent.floci.services.ec2.model.LaunchTemplateData;
@@ -59,6 +60,7 @@ import io.github.hectorvent.floci.services.ec2.model.NetworkAclEntry;
 import io.github.hectorvent.floci.services.ec2.model.PrefixList;
 import io.github.hectorvent.floci.services.ec2.model.PrefixListEntry;
 import io.github.hectorvent.floci.services.ec2.model.Placement;
+import io.github.hectorvent.floci.services.ec2.model.ReferencedSecurityGroup;
 import io.github.hectorvent.floci.services.ec2.model.Reservation;
 import io.github.hectorvent.floci.services.ec2.model.Route;
 import io.github.hectorvent.floci.services.ec2.model.RouteTable;
@@ -68,6 +70,7 @@ import io.github.hectorvent.floci.services.ec2.model.SecurityGroupRule;
 import io.github.hectorvent.floci.services.ec2.model.Snapshot;
 import io.github.hectorvent.floci.services.ec2.model.Subnet;
 import io.github.hectorvent.floci.services.ec2.model.Tag;
+import io.github.hectorvent.floci.services.ec2.model.UserIdGroupPair;
 import io.github.hectorvent.floci.services.ec2.model.Volume;
 import io.github.hectorvent.floci.services.ec2.model.VolumeAttachment;
 import io.github.hectorvent.floci.services.ec2.model.Vpc;
@@ -1641,6 +1644,7 @@ public class Ec2Service implements ContainerTeardown {
             SecurityGroup sg = getRequiredSecurityGroup(region, groupId);
             List<IpPermission> next = new ArrayList<>(sg.getIpPermissions());
             for (IpPermission perm : permissions) {
+                resolveGroupReferences(region, sg.getVpcId(), perm);
                 next.add(perm);
                 rules.addAll(createRules(region, groupId, perm, false));
             }
@@ -1658,6 +1662,7 @@ public class Ec2Service implements ContainerTeardown {
             SecurityGroup sg = getRequiredSecurityGroup(region, groupId);
             List<IpPermission> next = new ArrayList<>(sg.getIpPermissionsEgress());
             for (IpPermission perm : permissions) {
+                resolveGroupReferences(region, sg.getVpcId(), perm);
                 next.add(perm);
                 rules.addAll(createRules(region, groupId, perm, true));
             }
@@ -1667,37 +1672,87 @@ public class Ec2Service implements ContainerTeardown {
         return rules;
     }
 
+    /**
+     * Flattens one permission into the {@link SecurityGroupRule} entries DescribeSecurityGroupRules
+     * serves. AWS gives every rule exactly one source, so a permission carrying several sources fans
+     * out into one rule each.
+     */
     private List<SecurityGroupRule> createRules(String region, String groupId, IpPermission perm, boolean egress) {
         List<SecurityGroupRule> rules = new ArrayList<>();
-        List<IpRange> ranges = perm.getIpRanges();
-        if (ranges == null || ranges.isEmpty()) {
-            SecurityGroupRule rule = new SecurityGroupRule();
-            rule.setSecurityGroupRuleId("sgr-" + randomHex(17));
-            rule.setGroupId(groupId);
-            rule.setGroupOwnerId(accountId);
-            rule.setEgress(egress);
-            rule.setIpProtocol(perm.getIpProtocol());
-            rule.setFromPort(perm.getFromPort());
-            rule.setToPort(perm.getToPort());
-            securityGroupRules.put(key(region, rule.getSecurityGroupRuleId()), rule);
-            rules.add(rule);
-        } else {
-            for (IpRange range : ranges) {
-                SecurityGroupRule rule = new SecurityGroupRule();
-                rule.setSecurityGroupRuleId("sgr-" + randomHex(17));
-                rule.setGroupId(groupId);
-                rule.setGroupOwnerId(accountId);
-                rule.setEgress(egress);
-                rule.setIpProtocol(perm.getIpProtocol());
-                rule.setFromPort(perm.getFromPort());
-                rule.setToPort(perm.getToPort());
+        if (perm.getIpRanges() != null) {
+            for (IpRange range : perm.getIpRanges()) {
+                SecurityGroupRule rule = newRule(groupId, perm, egress);
                 rule.setCidrIpv4(range.getCidrIp());
                 rule.setDescription(range.getDescription());
-                securityGroupRules.put(key(region, rule.getSecurityGroupRuleId()), rule);
                 rules.add(rule);
             }
         }
+        if (perm.getIpv6Ranges() != null) {
+            for (Ipv6Range range : perm.getIpv6Ranges()) {
+                SecurityGroupRule rule = newRule(groupId, perm, egress);
+                rule.setCidrIpv6(range.getCidrIpv6());
+                rule.setDescription(range.getDescription());
+                rules.add(rule);
+            }
+        }
+        if (perm.getUserIdGroupPairs() != null) {
+            for (UserIdGroupPair pair : perm.getUserIdGroupPairs()) {
+                SecurityGroupRule rule = newRule(groupId, perm, egress);
+                ReferencedSecurityGroup ref = new ReferencedSecurityGroup();
+                ref.setGroupId(pair.getGroupId());
+                ref.setUserId(pair.getUserId());
+                rule.setReferencedGroupInfo(ref);
+                rule.setDescription(pair.getDescription());
+                rules.add(rule);
+            }
+        }
+        // Real AWS rejects a permission with no source at all; Floci keeps accepting it, so it still
+        // needs a rule to describe.
+        if (rules.isEmpty()) {
+            rules.add(newRule(groupId, perm, egress));
+        }
+        for (SecurityGroupRule rule : rules) {
+            securityGroupRules.put(key(region, rule.getSecurityGroupRuleId()), rule);
+        }
         return rules;
+    }
+
+    private SecurityGroupRule newRule(String groupId, IpPermission perm, boolean egress) {
+        SecurityGroupRule rule = new SecurityGroupRule();
+        rule.setSecurityGroupRuleId("sgr-" + randomHex(17));
+        rule.setGroupId(groupId);
+        rule.setGroupOwnerId(accountId);
+        rule.setEgress(egress);
+        rule.setIpProtocol(perm.getIpProtocol());
+        rule.setFromPort(perm.getFromPort());
+        rule.setToPort(perm.getToPort());
+        return rule;
+    }
+
+    /**
+     * Fills in the source details AWS returns but a caller may leave out: an absent {@code UserId}
+     * is this account, and a reference made by group name is resolved to its group id so the
+     * flattened rule can carry a {@code referencedGroupInfo} (the AWS shape has no group name).
+     *
+     * <p>Group names are unique per VPC rather than per region, so resolution is confined to the
+     * VPC of the group being authorized. A name matching nothing there stays unresolved: Floci does
+     * not check that a referenced group exists, for ids either.
+     */
+    private void resolveGroupReferences(String region, String vpcId, IpPermission perm) {
+        if (perm.getUserIdGroupPairs() == null) return;
+        for (UserIdGroupPair pair : perm.getUserIdGroupPairs()) {
+            if (pair.getUserId() == null) {
+                pair.setUserId(accountId);
+            }
+            if (pair.getGroupId() == null && pair.getGroupName() != null) {
+                securityGroups.scan(k -> true).stream()
+                        .filter(sg -> sg.getRegion().equals(region)
+                                && Objects.equals(vpcId, sg.getVpcId())
+                                && pair.getGroupName().equals(sg.getGroupName()))
+                        .findFirst()
+                        .ifPresent(sg -> pair.setGroupId(sg.getGroupId()));
+            }
+        }
     }
 
     public void revokeSecurityGroupIngress(String region, String groupId, List<IpPermission> permissions) {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/Ipv6Range.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/Ipv6Range.java
@@ -16,6 +16,11 @@ public class Ipv6Range {
         this.cidrIpv6 = cidrIpv6;
     }
 
+    public Ipv6Range(String cidrIpv6, String description) {
+        this.cidrIpv6 = cidrIpv6;
+        this.description = description;
+    }
+
     public String getCidrIpv6() { return cidrIpv6; }
     public void setCidrIpv6(String cidrIpv6) { this.cidrIpv6 = cidrIpv6; }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/ReferencedSecurityGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/ReferencedSecurityGroup.java
@@ -1,0 +1,42 @@
+package io.github.hectorvent.floci.services.ec2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * The security group a {@link SecurityGroupRule} allows traffic from or to, as returned in the
+ * {@code referencedGroupInfo} member of DescribeSecurityGroupRules.
+ *
+ * <p>A rule carries exactly one source, so this is the group-reference counterpart of
+ * {@code cidrIpv4} / {@code cidrIpv6}. Note the shape has no group name: a reference authorized by
+ * name is resolved to its group id before the rule is stored.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ReferencedSecurityGroup {
+
+    private String groupId;
+    private String userId;
+    private String vpcId;
+    private String vpcPeeringConnectionId;
+    private String peeringStatus;
+
+    public ReferencedSecurityGroup() {}
+
+    public String getGroupId() { return groupId; }
+    public void setGroupId(String groupId) { this.groupId = groupId; }
+
+    public String getUserId() { return userId; }
+    public void setUserId(String userId) { this.userId = userId; }
+
+    public String getVpcId() { return vpcId; }
+    public void setVpcId(String vpcId) { this.vpcId = vpcId; }
+
+    public String getVpcPeeringConnectionId() { return vpcPeeringConnectionId; }
+    public void setVpcPeeringConnectionId(String vpcPeeringConnectionId) {
+        this.vpcPeeringConnectionId = vpcPeeringConnectionId;
+    }
+
+    public String getPeeringStatus() { return peeringStatus; }
+    public void setPeeringStatus(String peeringStatus) { this.peeringStatus = peeringStatus; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/SecurityGroupRule.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/SecurityGroupRule.java
@@ -19,6 +19,7 @@ public class SecurityGroupRule {
     private Integer toPort;
     private String cidrIpv4;
     private String cidrIpv6;
+    private ReferencedSecurityGroup referencedGroupInfo;
     private String description;
     private List<Tag> tags = new ArrayList<>();
 
@@ -50,6 +51,11 @@ public class SecurityGroupRule {
 
     public String getCidrIpv6() { return cidrIpv6; }
     public void setCidrIpv6(String cidrIpv6) { this.cidrIpv6 = cidrIpv6; }
+
+    public ReferencedSecurityGroup getReferencedGroupInfo() { return referencedGroupInfo; }
+    public void setReferencedGroupInfo(ReferencedSecurityGroup referencedGroupInfo) {
+        this.referencedGroupInfo = referencedGroupInfo;
+    }
 
     public String getDescription() { return description; }
     public void setDescription(String description) { this.description = description; }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/UserIdGroupPair.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/UserIdGroupPair.java
@@ -10,6 +10,7 @@ public class UserIdGroupPair {
     private String groupId;
     private String userId;
     private String groupName;
+    private String description;
 
     public UserIdGroupPair() {}
 
@@ -21,4 +22,7 @@ public class UserIdGroupPair {
 
     public String getGroupName() { return groupName; }
     public void setGroupName(String groupName) { this.groupName = groupName; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -883,10 +883,11 @@ class Ec2IntegrationTest {
         .then()
             .statusCode(200)
             .contentType("application/xml")
-            // Must contain at least the default egress-all rule plus the authorized
-            // ingress (ssh/22) and egress (tcp/443) rules
+            // Exactly the default egress-all rule plus the authorized ingress (ssh/22) and egress
+            // (tcp/443) rules. Exact, not "at least": each permission carries a single source, so a
+            // fan-out that double-emitted would still satisfy a lower bound.
             .body("DescribeSecurityGroupRulesResponse.securityGroupRuleSet.item.size()",
-                    greaterThanOrEqualTo(3))
+                    equalTo(3))
             .body("DescribeSecurityGroupRulesResponse.securityGroupRuleSet.item.groupId",
                     everyItem(equalTo(securityGroupId)));
     }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2SecurityGroupRuleSourcesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2SecurityGroupRuleSourcesIntegrationTest.java
@@ -1,0 +1,344 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * Issue #2190: a security group rule whose source is another security group must keep that source.
+ *
+ * <p>Transcribes the reported repro: authorize tcp/443 from a source group, plus a tcp/8443 CIDR
+ * rule as the control, then read both back. The source has to survive on three surfaces, since the
+ * report shows it lost on all three: the rule echoed by AuthorizeSecurityGroupIngress,
+ * DescribeSecurityGroups ({@code UserIdGroupPairs}) and DescribeSecurityGroupRules
+ * ({@code ReferencedGroupInfo}).
+ */
+@QuarkusTest
+class Ec2SecurityGroupRuleSourcesIntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/ec2/aws4_request";
+    private static final String ACCOUNT_ID = "000000000000";
+
+    @Test
+    void groupReferenceSurvivesAuthorizeAndBothDescribes() {
+        String vpcId = createVpc();
+        String sourceId = createSecurityGroup(uniqueName("source-ingress"), vpcId);
+        String targetId = createSecurityGroup(uniqueName("target-ingress"), vpcId);
+
+        // The rule under test: allow tcp/443 from another security group.
+        String authorizeBody = given()
+            .formParam("Action", "AuthorizeSecurityGroupIngress")
+            .formParam("GroupId", targetId)
+            .formParam("IpPermissions.1.IpProtocol", "tcp")
+            .formParam("IpPermissions.1.FromPort", "443")
+            .formParam("IpPermissions.1.ToPort", "443")
+            .formParam("IpPermissions.1.Groups.1.GroupId", sourceId)
+            .formParam("IpPermissions.1.Groups.1.Description", "from-source-sg")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().body().asString();
+
+        // The echoed rule is the first symptom in the report, so assert it before the describes.
+        // The exact fragment also pins the shape: a bare object with scalar children (no <item>
+        // wrapper), with description as a sibling rather than a child.
+        assertTrue(
+                authorizeBody.contains(referencedGroupInfoXml(sourceId)
+                        + "<description>from-source-sg</description>"),
+                "AuthorizeSecurityGroupIngress must echo the source group, got: " + authorizeBody);
+
+        // Control: the same group with a CIDR rule, which already worked.
+        authorizeCidrIngress(targetId, "8443", "10.0.0.0/8", "control");
+
+        given()
+            .formParam("Action", "DescribeSecurityGroups")
+            .formParam("GroupId.1", targetId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeSecurityGroupsResponse.securityGroupInfo.item.ipPermissions.item[0].fromPort",
+                    equalTo("443"))
+            .body("DescribeSecurityGroupsResponse.securityGroupInfo.item.ipPermissions.item[0].groups.item.groupId",
+                    equalTo(sourceId))
+            .body("DescribeSecurityGroupsResponse.securityGroupInfo.item.ipPermissions.item[0].groups.item.userId",
+                    equalTo(ACCOUNT_ID))
+            .body("DescribeSecurityGroupsResponse.securityGroupInfo.item.ipPermissions.item[0].groups.item.description",
+                    equalTo("from-source-sg"))
+            // The CIDR control is unchanged by the fan-out change.
+            .body("DescribeSecurityGroupsResponse.securityGroupInfo.item.ipPermissions.item[1].ipRanges.item.cidrIp",
+                    equalTo("10.0.0.0/8"))
+            .body("DescribeSecurityGroupsResponse.securityGroupInfo.item.ipPermissions.item[1].ipRanges.item.description",
+                    equalTo("control"));
+
+        given()
+            .formParam("Action", "DescribeSecurityGroupRules")
+            .formParam("Filter.1.Name", "group-id")
+            .formParam("Filter.1.Value.1", targetId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString(referencedGroupInfoXml(sourceId)
+                    + "<description>from-source-sg</description>"))
+            .body(containsString("<cidrIpv4>10.0.0.0/8</cidrIpv4>"))
+            // The group-reference rule carries a group, not a CIDR, and vice versa.
+            .body(not(containsString("<cidrIpv4>10.0.0.0/8</cidrIpv4><referencedGroupInfo>")));
+    }
+
+    @Test
+    void groupReferenceSurvivesOnEgress() {
+        String vpcId = createVpc();
+        String sourceId = createSecurityGroup(uniqueName("source-egress"), vpcId);
+        String targetId = createSecurityGroup(uniqueName("target-egress"), vpcId);
+
+        given()
+            .formParam("Action", "AuthorizeSecurityGroupEgress")
+            .formParam("GroupId", targetId)
+            .formParam("IpPermissions.1.IpProtocol", "tcp")
+            .formParam("IpPermissions.1.FromPort", "5432")
+            .formParam("IpPermissions.1.ToPort", "5432")
+            .formParam("IpPermissions.1.Groups.1.GroupId", sourceId)
+            .formParam("IpPermissions.1.Groups.1.Description", "to-database-sg")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<isEgress>true</isEgress>"))
+            .body(containsString(referencedGroupInfoXml(sourceId)));
+
+        given()
+            .formParam("Action", "DescribeSecurityGroups")
+            .formParam("GroupId.1", targetId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            // [0] is the default allow-all egress created with the group.
+            .body("DescribeSecurityGroupsResponse.securityGroupInfo.item.ipPermissionsEgress.item[1]"
+                    + ".groups.item.groupId", equalTo(sourceId))
+            .body("DescribeSecurityGroupsResponse.securityGroupInfo.item.ipPermissionsEgress.item[1]"
+                    + ".groups.item.description", equalTo("to-database-sg"));
+
+        given()
+            .formParam("Action", "DescribeSecurityGroupRules")
+            .formParam("Filter.1.Name", "group-id")
+            .formParam("Filter.1.Value.1", targetId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString(referencedGroupInfoXml(sourceId)
+                    + "<description>to-database-sg</description>"));
+    }
+
+    @Test
+    void groupReferenceByNameResolvesToGroupId() {
+        String vpcId = createVpc();
+        String sourceName = uniqueName("source-by-name");
+        String sourceId = createSecurityGroup(sourceName, vpcId);
+        String targetId = createSecurityGroup(uniqueName("target-by-name"), vpcId);
+
+        // A default-VPC caller may name the source group instead of identifying it, and
+        // ReferencedGroupInfo has no group name, so the id has to be resolved on the way in.
+        given()
+            .formParam("Action", "AuthorizeSecurityGroupIngress")
+            .formParam("GroupId", targetId)
+            .formParam("IpPermissions.1.IpProtocol", "tcp")
+            .formParam("IpPermissions.1.FromPort", "80")
+            .formParam("IpPermissions.1.ToPort", "80")
+            .formParam("IpPermissions.1.Groups.1.GroupName", sourceName)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString(referencedGroupInfoXml(sourceId)));
+
+        given()
+            .formParam("Action", "DescribeSecurityGroups")
+            .formParam("GroupId.1", targetId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeSecurityGroupsResponse.securityGroupInfo.item.ipPermissions.item.groups.item.groupId",
+                    equalTo(sourceId))
+            .body("DescribeSecurityGroupsResponse.securityGroupInfo.item.ipPermissions.item.groups.item.groupName",
+                    equalTo(sourceName));
+    }
+
+    @Test
+    void groupNameResolvesWithinTheTargetVpcOnly() {
+        String otherVpcId = createVpc();
+        String targetVpcId = createVpc();
+        // Group names are unique per VPC, not per region, so the same name can exist in both. Only
+        // the one sharing the target group's VPC may be resolved.
+        String sharedName = uniqueName("shared-name");
+        String decoyId = createSecurityGroup(sharedName, otherVpcId);
+        String wantedId = createSecurityGroup(sharedName, targetVpcId);
+        String targetId = createSecurityGroup(uniqueName("target-scoped"), targetVpcId);
+
+        given()
+            .formParam("Action", "AuthorizeSecurityGroupIngress")
+            .formParam("GroupId", targetId)
+            .formParam("IpPermissions.1.IpProtocol", "tcp")
+            .formParam("IpPermissions.1.FromPort", "8080")
+            .formParam("IpPermissions.1.ToPort", "8080")
+            .formParam("IpPermissions.1.Groups.1.GroupName", sharedName)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString(referencedGroupInfoXml(wantedId)))
+            .body(not(containsString(decoyId)));
+    }
+
+    @Test
+    void unknownGroupNameLeavesTheReferenceWithoutAnId() {
+        String vpcId = createVpc();
+        String targetId = createSecurityGroup(uniqueName("target-unknown-name"), vpcId);
+
+        // Floci does not validate the source group's existence on authorize, so a name that matches
+        // nothing must still round-trip as a name rather than fabricating an id or failing.
+        given()
+            .formParam("Action", "AuthorizeSecurityGroupIngress")
+            .formParam("GroupId", targetId)
+            .formParam("IpPermissions.1.IpProtocol", "tcp")
+            .formParam("IpPermissions.1.FromPort", "9000")
+            .formParam("IpPermissions.1.ToPort", "9000")
+            .formParam("IpPermissions.1.Groups.1.GroupName", uniqueName("no-such-group"))
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<referencedGroupInfo><userId>" + ACCOUNT_ID + "</userId>"
+                    + "</referencedGroupInfo>"));
+    }
+
+    @Test
+    void mixedSourcesFanOutToOneRulePerSource() {
+        String vpcId = createVpc();
+        String sourceId = createSecurityGroup(uniqueName("source-mixed"), vpcId);
+        String targetId = createSecurityGroup(uniqueName("target-mixed"), vpcId);
+
+        // One permission, four sources. AWS gives every rule exactly one source, so this must
+        // produce four rules and no sourceless one.
+        given()
+            .formParam("Action", "AuthorizeSecurityGroupIngress")
+            .formParam("GroupId", targetId)
+            .formParam("IpPermissions.1.IpProtocol", "tcp")
+            .formParam("IpPermissions.1.FromPort", "3306")
+            .formParam("IpPermissions.1.ToPort", "3306")
+            .formParam("IpPermissions.1.IpRanges.1.CidrIp", "10.1.0.0/16")
+            .formParam("IpPermissions.1.IpRanges.2.CidrIp", "10.2.0.0/16")
+            .formParam("IpPermissions.1.Ipv6Ranges.1.CidrIpv6", "2001:db8::/32")
+            .formParam("IpPermissions.1.Ipv6Ranges.1.Description", "v6-range")
+            .formParam("IpPermissions.1.Groups.1.GroupId", sourceId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("AuthorizeSecurityGroupIngressResponse.securityGroupRuleSet.item.size()", equalTo(4));
+
+        given()
+            .formParam("Action", "DescribeSecurityGroupRules")
+            .formParam("Filter.1.Name", "group-id")
+            .formParam("Filter.1.Value.1", targetId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            // The four fanned-out rules plus the group's own default egress rule.
+            .body("DescribeSecurityGroupRulesResponse.securityGroupRuleSet.item.size()", equalTo(5))
+            .body("DescribeSecurityGroupRulesResponse.securityGroupRuleSet.item.cidrIpv4",
+                    hasItems("10.1.0.0/16", "10.2.0.0/16"))
+            .body(containsString("<cidrIpv6>2001:db8::/32</cidrIpv6><description>v6-range</description>"))
+            .body(containsString(referencedGroupInfoXml(sourceId)));
+
+        given()
+            .formParam("Action", "DescribeSecurityGroups")
+            .formParam("GroupId.1", targetId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeSecurityGroupsResponse.securityGroupInfo.item.ipPermissions.item.ipv6Ranges"
+                    + ".item.cidrIpv6", equalTo("2001:db8::/32"))
+            .body("DescribeSecurityGroupsResponse.securityGroupInfo.item.ipPermissions.item.ipv6Ranges"
+                    + ".item.description", equalTo("v6-range"));
+    }
+
+    private String referencedGroupInfoXml(String groupId) {
+        return "<referencedGroupInfo><groupId>" + groupId + "</groupId>"
+                + "<userId>" + ACCOUNT_ID + "</userId></referencedGroupInfo>";
+    }
+
+    private String createVpc() {
+        return given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.0.0.0/16")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+    }
+
+    /** The suite shares one emulator and group names are unique per VPC, so never reuse one. */
+    private String uniqueName(String prefix) {
+        return prefix + "-" + System.nanoTime();
+    }
+
+    private String createSecurityGroup(String groupName, String vpcId) {
+        return given()
+            .formParam("Action", "CreateSecurityGroup")
+            .formParam("GroupName", groupName)
+            .formParam("GroupDescription", groupName)
+            .formParam("VpcId", vpcId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateSecurityGroupResponse.groupId");
+    }
+
+    private void authorizeCidrIngress(String groupId, String port, String cidr, String description) {
+        given()
+            .formParam("Action", "AuthorizeSecurityGroupIngress")
+            .formParam("GroupId", groupId)
+            .formParam("IpPermissions.1.IpProtocol", "tcp")
+            .formParam("IpPermissions.1.FromPort", port)
+            .formParam("IpPermissions.1.ToPort", port)
+            .formParam("IpPermissions.1.IpRanges.1.CidrIp", cidr)
+            .formParam("IpPermissions.1.IpRanges.1.Description", description)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServicePersistenceTest.java
@@ -11,6 +11,8 @@ import io.github.hectorvent.floci.services.ec2.model.ManagedPrefixList;
 import io.github.hectorvent.floci.services.ec2.model.PrefixListEntry;
 import io.github.hectorvent.floci.services.ec2.model.Instance;
 import io.github.hectorvent.floci.services.ec2.model.InternetGateway;
+import io.github.hectorvent.floci.services.ec2.model.IpPermission;
+import io.github.hectorvent.floci.services.ec2.model.UserIdGroupPair;
 import io.github.hectorvent.floci.services.ec2.model.Image;
 import io.github.hectorvent.floci.services.ec2.model.NetworkAcl;
 import io.github.hectorvent.floci.services.ec2.model.KeyPair;
@@ -117,6 +119,48 @@ class Ec2ServicePersistenceTest {
         assertEquals("corporate", firstVersion.getFirst().getDescription());
     }
 
+    @Test
+    void securityGroupRuleSourcesSurviveRestart(@TempDir Path dir) {
+        Ec2Service first = newService(dir);
+        Vpc vpc = first.createVpc(REGION, "10.0.0.0/16", false);
+        SecurityGroup source = first.createSecurityGroup(REGION, "source-sg", "traffic source", vpc.getVpcId());
+        SecurityGroup target = first.createSecurityGroup(REGION, "target-sg", "traffic target", vpc.getVpcId());
+
+        IpPermission perm = new IpPermission();
+        perm.setIpProtocol("tcp");
+        perm.setFromPort(443);
+        perm.setToPort(443);
+        UserIdGroupPair pair = new UserIdGroupPair();
+        pair.setGroupId(source.getGroupId());
+        pair.setDescription("from-source-sg");
+        perm.getUserIdGroupPairs().add(pair);
+        first.authorizeSecurityGroupIngress(REGION, target.getGroupId(), List.of(perm));
+
+        // A fresh service over the same persistent files = a restart with the same data dir. Note
+        // PersistentStorage.load() quarantines a broken deserialization into an EMPTY store, so the
+        // assertions below have to touch restored content or they would pass through that failure.
+        Ec2Service restarted = newService(dir);
+
+        SecurityGroup restoredGroup =
+                restarted.describeSecurityGroups(REGION, List.of(target.getGroupId()), List.of(), Map.of()).getFirst();
+        List<UserIdGroupPair> restoredPairs = restoredGroup.getIpPermissions().getFirst().getUserIdGroupPairs();
+        assertEquals(1, restoredPairs.size(), "group reference must survive restart");
+        assertEquals(source.getGroupId(), restoredPairs.getFirst().getGroupId());
+        assertEquals("000000000000", restoredPairs.getFirst().getUserId());
+        assertEquals("from-source-sg", restoredPairs.getFirst().getDescription());
+
+        // referencedGroupInfo is a nested object on the flattened rule, so a restart is the first
+        // place a broken serialization round trip would show up.
+        List<SecurityGroupRule> ingress =
+                restarted.describeSecurityGroupRules(REGION, List.of(target.getGroupId()), List.of()).stream()
+                        .filter(r -> !r.isEgress())
+                        .toList();
+        assertEquals(1, ingress.size(), "one rule per source, and only the ingress rule here");
+        assertEquals(source.getGroupId(), ingress.getFirst().getReferencedGroupInfo().getGroupId());
+        assertEquals("000000000000", ingress.getFirst().getReferencedGroupInfo().getUserId());
+        assertEquals("from-source-sg", ingress.getFirst().getDescription());
+    }
+
     private BlockDeviceMapping blockDeviceMapping(String snapshotId, int volumeSize) {
         EbsBlockDevice ebs = new EbsBlockDevice();
         ebs.setSnapshotId(snapshotId);
@@ -129,7 +173,12 @@ class Ec2ServicePersistenceTest {
 
     private Ec2Service newService(Path dir) {
         EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.Ec2ServiceConfig ec2 = mock(EmulatorConfig.Ec2ServiceConfig.class);
         when(config.defaultAccountId()).thenReturn("000000000000");
+        when(config.services()).thenReturn(services);
+        when(services.ec2()).thenReturn(ec2);
+        when(ec2.mock()).thenReturn(true);
         Ec2ImageCatalog imageCatalog = new Ec2ImageCatalog();
         return new Ec2Service(config, null, mock(Ec2PortForwardManager.class),
                 new AmiImageResolver(imageCatalog), imageCatalog,


### PR DESCRIPTION
## Summary

Closes #2190.

- A security group rule sourced from another security group keeps that source. `AuthorizeSecurityGroupIngress` and `-Egress` read only `IpPermissions.N.IpRanges.M.CidrIp`, so a group-referenced rule was accepted and then silently stripped: it came back with no source at all on the authorize response, on `DescribeSecurityGroups` and on `DescribeSecurityGroupRules`. "Allow traffic from security group X" is how an ALB is wired to its backend tasks, so that whole class of wiring could be created against Floci but never asserted afterwards.
- The gotcha behind the gap: the EC2 Query protocol serializes the `UserIdGroupPairs` member under the wire name **`Groups`**, so a group reference arrives as `IpPermissions.1.Groups.1.GroupId`, not under the SDK-facing field name. Captured from `aws ec2 authorize-security-group-ingress --debug` (CLI 2.33.2) and cross-checked against botocore's `locationName`s.
- IPv6 ranges were dropped by the same parse loop and are now read too, with their descriptions.
- One `SecurityGroupRule` per source entry, each keeping its own description, matching the AWS invariant that a rule holds exactly one source. A permission with no source at all still yields a single sourceless rule, as before.
- A reference made by group name resolves to its group id within the target group's VPC, since names are unique per VPC and `ReferencedSecurityGroup` has no name field to fall back on.

**Scope, stated plainly:** this covers authorize plus both read paths. **Revoke is unchanged** and still matches on protocol and port range alone, ignoring sources, so revoking `tcp/443` drops every permission on that port whatever its source. That is pre-existing (it already misfires between two CIDR permissions on the same port) and independent, so it is left for a follow-up rather than bundled here.

**Two things worth knowing:**

- Rules already created through this bug cannot be repaired on upgrade. Both stores lost the source at write time, so affected rules need recreating.
- An IPv6-only TCP ingress rule now publishes its host port, which it could not do while the ranges were dropped at the parse. `Ec2PortForwardManager` already treats IPv6 ranges as a CIDR source (`hasCidrSource`), so this is existing intent becoming reachable. Group references stay unpublished, as before.

**Deliberately not in this PR**, each independently broken today and worth its own review: source-aware revoke; revoke and delete leaving stale flattened rules behind (nothing calls `securityGroupRules.delete`); `ip-permission.*` describe filters, which fall through to `true`; and **prefix list sources**, which need `Ec2PortForwardManager.hasCidrSource()` taught to resolve a managed prefix list into its CIDRs in the same change, or a prefix-list-only rule would round-trip correctly while never opening its host port. Happy to file these as issues if useful.

## Review

External review by Codex (GPT-5.6) and GLM-5.2, two passes each. One finding applied: group-name resolution was region-scoped, which could bind a same-named group from the wrong VPC; it is now scoped to the target group's VPC and pinned by a test.

## Changes

```
 compatibility-tests/sdk-test-awscli/test/ec2.bats                          |  61 +++
 docs/services/ec2.md                                                       |   8 +-
 src/main/java/.../ec2/Ec2QueryHandler.java                                 |  53 ++-
 src/main/java/.../ec2/Ec2Service.java                                      | 101 +++--
 src/main/java/.../ec2/model/Ipv6Range.java                                 |   5 +
 src/main/java/.../ec2/model/ReferencedSecurityGroup.java                   |  41 ++ (new)
 src/main/java/.../ec2/model/SecurityGroupRule.java                         |   6 +
 src/main/java/.../ec2/model/UserIdGroupPair.java                           |   4 +
 src/test/java/.../ec2/Ec2IntegrationTest.java                              |   7 +-
 src/test/java/.../ec2/Ec2SecurityGroupRuleSourcesIntegrationTest.java      | 300 ++ (new)
 src/test/java/.../ec2/Ec2ServicePersistenceTest.java                       |  49 ++
```

## Test plan

- [x] New `Ec2SecurityGroupRuleSourcesIntegrationTest` (6 cases): the issue's repro end to end with the CIDR control, the egress path, group-name resolution, VPC-scoped resolution against a same-named decoy, an unresolvable name, and a mixed 2 CIDR + 1 IPv6 + 1 group permission asserting exactly 4 rules with one source each
- [x] Restart case added to `Ec2ServicePersistenceTest`: sources and descriptions survive a rebuild over the same files, on both `SecurityGroup.ipPermissions` and the flattened rules
- [x] `describeSecurityGroupRulesReturnsDefaultEgress` tightened from `>= 3` to `== 3`, so a fan-out that double-emitted fails instead of passing a lower bound
- [x] `./mvnw test -Dtest='Ec2*'` green (325 tests)
- [x] New AWS CLI compat case in `compatibility-tests/sdk-test-awscli/test/ec2.bats`, verified against a local build with CLI 2.33.2
- [x] `./mvnw test`: 9552 run, 11 failures, all in `ElastiCacheIntegrationTest` and all from host port 6379 already being bound on my machine ("Failed to start proxy for group ... on port 6379"). Unrelated to this change; everything else green

**CI note:** `mvn test` currently fails on `main` before this diff is applied. Three CloudFormation tests (`DynamoDbReplicaCfnProvisionerTest:34`, `EventBusDeleteOwnershipTest:41`, `EventBusProvisionOwnershipTest:54`) call `CloudFormationResourceProvisioner` with 32 args where 33 are required, since the `CloudFrontService` parameter from #1820 was never threaded into them. #2261 fixes exactly that, so this PR's CI should go green once it lands. I kept the fix out of this branch to avoid conflicting with it.