### PR TITLE
fix(lambda): propagate image inspection failures

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ImageCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ImageCacheService.java
@@ -124,9 +124,6 @@ public class ImageCacheService {
             return true;
         } catch (com.github.dockerjava.api.exception.NotFoundException e) {
             return false;
-        } catch (Exception e) {
-            LOG.debugv("Could not check local image presence for {0}: {1}", imageUri, e.getMessage());
-            return false;
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ImageCacheServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ImageCacheServiceTest.java
@@ -1,21 +1,67 @@
 package io.github.hectorvent.floci.services.lambda.launcher;
 
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.InspectImageCmd;
+import com.github.dockerjava.api.command.PullImageCmd;
+import com.github.dockerjava.api.command.PullImageResultCallback;
 import com.github.dockerjava.api.exception.DockerClientException;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.exception.InternalServerErrorException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.exception.UnauthorizedException;
+import io.github.hectorvent.floci.config.EmulatorConfig;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class ImageCacheServiceTest {
 
     private static final String IMAGE = "public.ecr.aws/docker/library/alpine:latest";
+
+    @Test
+    void pullsImageWhenInspectionReportsNotFound() throws Exception {
+        DockerClient dockerClient = mock(DockerClient.class);
+        InspectImageCmd inspectImage = mock(InspectImageCmd.class);
+        PullImageCmd pullImage = mock(PullImageCmd.class);
+        PullImageResultCallback callback = mock(PullImageResultCallback.class);
+        when(dockerClient.inspectImageCmd(IMAGE)).thenReturn(inspectImage);
+        when(inspectImage.exec()).thenThrow(new NotFoundException("image not found"));
+        when(dockerClient.pullImageCmd(IMAGE)).thenReturn(pullImage);
+        when(pullImage.withAuthConfig(any())).thenReturn(pullImage);
+        when(pullImage.exec(any(PullImageResultCallback.class))).thenReturn(callback);
+
+        newService(dockerClient).ensureImageExists(IMAGE);
+
+        verify(pullImage).exec(any(PullImageResultCallback.class));
+        verify(callback).awaitCompletion(5, TimeUnit.MINUTES);
+    }
+
+    @Test
+    void propagatesImageInspectionFailureWithoutPulling() {
+        DockerClient dockerClient = mock(DockerClient.class);
+        InspectImageCmd inspectImage = mock(InspectImageCmd.class);
+        DockerClientException failure = new DockerClientException("daemon unavailable");
+        when(dockerClient.inspectImageCmd(IMAGE)).thenReturn(inspectImage);
+        when(inspectImage.exec()).thenThrow(failure);
+
+        DockerClientException thrown = assertThrows(DockerClientException.class,
+                () -> newService(dockerClient).ensureImageExists(IMAGE));
+
+        assertSame(failure, thrown);
+        verify(dockerClient, never()).pullImageCmd(IMAGE);
+    }
 
     @Test
     void succeedsOnFirstAttempt() throws Exception {
@@ -114,5 +160,13 @@ class ImageCacheServiceTest {
                     throw new InterruptedException("interrupted mid-pull");
                 }));
         assertEquals(1, calls.get());
+    }
+
+    private static ImageCacheService newService(DockerClient dockerClient) {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.DockerConfig dockerConfig = mock(EmulatorConfig.DockerConfig.class);
+        when(config.docker()).thenReturn(dockerConfig);
+        when(dockerConfig.registryCredentials()).thenReturn(List.of());
+        return new ImageCacheService(dockerClient, config);
     }
 }


### PR DESCRIPTION
## Summary

- treat Docker `NotFoundException` as the only signal that a local image is absent
- propagate other image-inspection failures instead of starting a misleading pull
- cover both the absent-image pull path and the inspection-error path with focused tests

## Root cause

`isLocalImagePresent` caught every non-`NotFoundException` and returned `false`. A Docker daemon or transport failure was therefore indistinguishable from an absent image, so `ensureImageExists` attempted a pull and obscured the original error.

## Validation

- `mvn -B -o test -Dtest=ImageCacheServiceTest`
- 11 tests passed on JDK 25, including a regression that failed before the production change
- `git diff --check`

Fixes #2230.

AI assistance: OpenAI Codex was used during implementation and testing. I reviewed the complete change and remain responsible for it.
