### PR TITLE
fix(ec2): type a security group rule's tags as security-group-rule

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -2481,19 +2481,45 @@ public class Ec2Service implements ContainerTeardown {
     }
 
     private String inferResourceType(String resourceId) {
-        if (resourceId.startsWith("i-")) return "instance";
-        if (resourceId.startsWith("vpc-")) return "vpc";
-        if (resourceId.startsWith("subnet-")) return "subnet";
-        if (resourceId.startsWith("sgr-")) return "security-group-rule";
-        if (resourceId.startsWith("sg-")) return "security-group";
-        if (resourceId.startsWith("igw-")) return "internet-gateway";
-        if (resourceId.startsWith("rtb-")) return "route-table";
-        if (resourceId.startsWith("key-")) return "key-pair";
-        if (resourceId.startsWith("eipalloc-")) return "elastic-ip";
-        if (resourceId.startsWith("lt-")) return "launch-template";
-        if (resourceId.startsWith("vpce-")) return "vpc-endpoint";
-        if (resourceId.startsWith("nat-")) return "natgateway";
-        if (resourceId.startsWith("pl-")) return "prefix-list";
+        if (resourceId.startsWith("i-")) {
+            return "instance";
+        }
+        if (resourceId.startsWith("vpc-")) {
+            return "vpc";
+        }
+        if (resourceId.startsWith("subnet-")) {
+            return "subnet";
+        }
+        if (resourceId.startsWith("sgr-")) {
+            return "security-group-rule";
+        }
+        if (resourceId.startsWith("sg-")) {
+            return "security-group";
+        }
+        if (resourceId.startsWith("igw-")) {
+            return "internet-gateway";
+        }
+        if (resourceId.startsWith("rtb-")) {
+            return "route-table";
+        }
+        if (resourceId.startsWith("key-")) {
+            return "key-pair";
+        }
+        if (resourceId.startsWith("eipalloc-")) {
+            return "elastic-ip";
+        }
+        if (resourceId.startsWith("lt-")) {
+            return "launch-template";
+        }
+        if (resourceId.startsWith("vpce-")) {
+            return "vpc-endpoint";
+        }
+        if (resourceId.startsWith("nat-")) {
+            return "natgateway";
+        }
+        if (resourceId.startsWith("pl-")) {
+            return "prefix-list";
+        }
         return "unknown";
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -2484,6 +2484,7 @@ public class Ec2Service implements ContainerTeardown {
         if (resourceId.startsWith("i-")) return "instance";
         if (resourceId.startsWith("vpc-")) return "vpc";
         if (resourceId.startsWith("subnet-")) return "subnet";
+        if (resourceId.startsWith("sgr-")) return "security-group-rule";
         if (resourceId.startsWith("sg-")) return "security-group";
         if (resourceId.startsWith("igw-")) return "internet-gateway";
         if (resourceId.startsWith("rtb-")) return "route-table";

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -911,10 +911,14 @@ class Ec2ServiceTest {
                 Map.of("resource-id", List.of(ruleId))).getFirst().get("resourceType"));
         assertEquals(1, service.describeTags("us-east-1",
                 Map.of("resource-type", List.of("security-group-rule"))).size());
-        // The group itself must keep its own type.
+
+        // Tag the group as well, so the sg- classification is genuinely exercised rather than
+        // read off an empty result.
+        service.createTags("us-east-1", List.of(groupId), List.of(new Tag("env", "prod")));
         assertEquals("security-group", service.describeTags("us-east-1",
-                Map.of("resource-id", List.of(groupId))).stream()
-                .findFirst().map(t -> t.get("resourceType")).orElse("security-group"));
+                Map.of("resource-id", List.of(groupId))).getFirst().get("resourceType"));
+        assertEquals(1, service.describeTags("us-east-1",
+                Map.of("resource-type", List.of("security-group"))).size());
     }
 
     private static EmulatorConfig mockConfig(boolean ec2Mock) {

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -12,6 +12,8 @@ import io.github.hectorvent.floci.services.ec2.model.GroupIdentifier;
 import io.github.hectorvent.floci.services.ec2.model.Instance;
 import io.github.hectorvent.floci.services.ec2.model.LaunchTemplate;
 import io.github.hectorvent.floci.services.ec2.model.ManagedPrefixList;
+import io.github.hectorvent.floci.services.ec2.model.IpPermission;
+import io.github.hectorvent.floci.services.ec2.model.IpRange;
 import io.github.hectorvent.floci.services.ec2.model.PrefixListEntry;
 import io.github.hectorvent.floci.services.ec2.model.NetworkInterface;
 import io.github.hectorvent.floci.services.ec2.model.Reservation;
@@ -885,6 +887,34 @@ class Ec2ServiceTest {
         service.deleteTags("us-east-1", List.of(created.getPrefixListId()), List.of(new Tag("env", null)));
         assertTrue(service.describeManagedPrefixLists("us-east-1", List.of(created.getPrefixListId()), Map.of())
                 .getFirst().getTags().isEmpty());
+    }
+
+    /**
+     * A rule's tags already reach the store and the rule itself; only DescribeTags mistyped them,
+     * so a resource-type filter never matched.
+     */
+    @Test
+    void tagsOnASecurityGroupRuleAreTypedAsSecurityGroupRule() {
+        Ec2Service service = prefixListService();
+        String groupId = service.createSecurityGroup("us-east-1", "db", "db", null).getGroupId();
+        IpPermission perm = new IpPermission();
+        perm.setIpProtocol("tcp");
+        perm.setFromPort(443);
+        perm.setToPort(443);
+        perm.getIpRanges().add(new IpRange("10.0.0.0/8", null));
+        String ruleId = service.authorizeSecurityGroupIngress("us-east-1", groupId, List.of(perm))
+                .getFirst().getSecurityGroupRuleId();
+
+        service.createTags("us-east-1", List.of(ruleId), List.of(new Tag("env", "prod")));
+
+        assertEquals("security-group-rule", service.describeTags("us-east-1",
+                Map.of("resource-id", List.of(ruleId))).getFirst().get("resourceType"));
+        assertEquals(1, service.describeTags("us-east-1",
+                Map.of("resource-type", List.of("security-group-rule"))).size());
+        // The group itself must keep its own type.
+        assertEquals("security-group", service.describeTags("us-east-1",
+                Map.of("resource-id", List.of(groupId))).stream()
+                .findFirst().map(t -> t.get("resourceType")).orElse("security-group"));
     }
 
     private static EmulatorConfig mockConfig(boolean ec2Mock) {


### PR DESCRIPTION
Closes #2270.

`inferResourceType` had no `sgr-` case, so `DescribeTags` reported a security group rule's tags as `resourceType: unknown`, and a `resource-type=security-group-rule` filter never matched them.

The tags themselves were already correct — `createTags` stores them and `updateResourceTags` mirrors them onto the rule — so only the aggregation surface was wrong. Same shape as the `pl-` gap fixed in #2105.

## Verified against a live AWS account

```
$ aws ec2 describe-tags --filters Name=resource-id,Values=sgr-…
sgr-…   security-group-rule   env   probe

$ aws ec2 describe-tags --filters Name=resource-type,Values=security-group-rule
sgr-…   env
```

## Tests

One case in `Ec2ServiceTest` covering the direct lookup, the `resource-type` filter, and that a security group keeps its own type. Full suite green at 9619 tests.

## Note for review

The naive reading is that `sgr-` has to be tested before `sg-`, since one looks like a prefix of the other. It does not: `"sgr-0abc".startsWith("sg-")` is `false`, because the third character is `r` rather than `-`. I checked by running the test against a build with the arm placed *after* `sg-`, and it still passed — so the placement here is for readability rather than correctness, and I have deliberately not written a comment claiming otherwise.
