### PR TITLE
fix(ec2): reject prefix list names AWS reserves for its own lists

### DIFF
--- a/docs/services/ec2.md
+++ b/docs/services/ec2.md
@@ -286,6 +286,11 @@ Two AWS-managed prefix lists exist in every region without being created —
 read-only, and served by both `DescribePrefixLists` and `DescribeManagedPrefixLists`;
 modifying or deleting one returns `UnsupportedOperation`.
 
+A customer-managed list may not take a name AWS reserves for its own: `com.amazonaws.`,
+`com.amazon.` or `com.aws.`, each including the trailing dot. `CreateManagedPrefixList`
+rejects those with `InvalidParameterValue`; a name that merely resembles one, such as
+`com.amazonaws-internal`, is allowed.
+
 Entries are versioned. A prefix list starts at version 1, and each `ModifyManagedPrefixList`
 that adds or removes entries stores a new version and bumps the counter, so
 `GetManagedPrefixListEntries` can serve an earlier `TargetVersion`. Renaming the list or

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -569,6 +569,16 @@ public class Ec2Service implements ContainerTeardown {
     private static final List<String> RESERVED_PREFIX_LIST_NAME_PREFIXES =
             List.of("com.amazonaws.", "com.amazon.", "com.aws.");
 
+    /** AWS applies the reserved-name rule to a rename as well as a create. */
+    private void requireUnreservedPrefixListName(String prefixListName) {
+        for (String reserved : RESERVED_PREFIX_LIST_NAME_PREFIXES) {
+            if (prefixListName.startsWith(reserved)) {
+                throw new AwsException("InvalidParameterValue",
+                        "The prefix list name cannot begin with (com.amazonaws., com.amazon., com.aws.).", 400);
+            }
+        }
+    }
+
     private List<ManagedPrefixList> awsManagedPrefixLists(String region) {
         return List.of(
                 awsManagedPrefixList(region, "pl-63a5400a", "com.amazonaws." + region + ".s3",
@@ -602,12 +612,7 @@ public class Ec2Service implements ContainerTeardown {
         if (prefixListName == null || prefixListName.isBlank()) {
             throw new AwsException("MissingParameter", "The request must contain the parameter PrefixListName.", 400);
         }
-        for (String reserved : RESERVED_PREFIX_LIST_NAME_PREFIXES) {
-            if (prefixListName.startsWith(reserved)) {
-                throw new AwsException("InvalidParameterValue",
-                        "The prefix list name cannot begin with (com.amazonaws., com.amazon., com.aws.).", 400);
-            }
-        }
+        requireUnreservedPrefixListName(prefixListName);
         if (!"IPv4".equals(addressFamily) && !"IPv6".equals(addressFamily)) {
             throw new AwsException("InvalidParameterValue",
                     "Invalid value '" + addressFamily + "' for addressFamily. Valid values are IPv4 and IPv6.", 400);
@@ -718,6 +723,7 @@ public class Ec2Service implements ContainerTeardown {
                 list.setMaxEntries(maxEntries);
             }
             if (prefixListName != null && !prefixListName.isBlank()) {
+                requireUnreservedPrefixListName(prefixListName);
                 list.setPrefixListName(prefixListName);
             }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -562,6 +562,13 @@ public class Ec2Service implements ContainerTeardown {
     // Managed prefix lists
     // =========================================================================
 
+    /**
+     * Name prefixes AWS reserves for its own gateway-endpoint lists. The trailing dot is part of
+     * each: {@code com.amazonaws-probe} is accepted on AWS, so matching without it over-rejects.
+     */
+    private static final List<String> RESERVED_PREFIX_LIST_NAME_PREFIXES =
+            List.of("com.amazonaws.", "com.amazon.", "com.aws.");
+
     private List<ManagedPrefixList> awsManagedPrefixLists(String region) {
         return List.of(
                 awsManagedPrefixList(region, "pl-63a5400a", "com.amazonaws." + region + ".s3",
@@ -594,6 +601,12 @@ public class Ec2Service implements ContainerTeardown {
                                                      List<Tag> prefixListTags) {
         if (prefixListName == null || prefixListName.isBlank()) {
             throw new AwsException("MissingParameter", "The request must contain the parameter PrefixListName.", 400);
+        }
+        for (String reserved : RESERVED_PREFIX_LIST_NAME_PREFIXES) {
+            if (prefixListName.startsWith(reserved)) {
+                throw new AwsException("InvalidParameterValue",
+                        "The prefix list name cannot begin with (com.amazonaws., com.amazon., com.aws.).", 400);
+            }
         }
         if (!"IPv4".equals(addressFamily) && !"IPv6".equals(addressFamily)) {
             throw new AwsException("InvalidParameterValue",

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -729,6 +729,28 @@ class Ec2ServiceTest {
         }
     }
 
+    /**
+     * Verified against a live AWS account: the three dotted prefixes are rejected, and the
+     * trailing dot matters — {@code com.amazonaws-probe} and {@code comamazonaws.probe} are both
+     * accepted there, so a dotless prefix match would refuse names AWS allows.
+     */
+    @Test
+    void createManagedPrefixListRejectsNamesReservedByAws() {
+        Ec2Service service = prefixListService();
+
+        for (String reserved : new String[] {"com.amazonaws.probe", "com.amazon.probe", "com.aws.probe"}) {
+            AwsException error = assertThrows(AwsException.class, () -> service.createManagedPrefixList(
+                    "us-east-1", reserved, "IPv4", 5, List.of(), List.of()), "expected rejection for " + reserved);
+            assertEquals("InvalidParameterValue", error.getErrorCode());
+        }
+
+        // Names that only look reserved are still allowed.
+        for (String allowed : new String[] {"com.amazonaws-probe", "comamazonaws.probe", "corp"}) {
+            assertEquals(allowed, service.createManagedPrefixList(
+                    "us-east-1", allowed, "IPv4", 5, List.of(), List.of()).getPrefixListName());
+        }
+    }
+
     @Test
     void describeManagedPrefixListsFiltersByName() {
         Ec2Service service = prefixListService();

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -751,6 +751,29 @@ class Ec2ServiceTest {
         }
     }
 
+    /**
+     * Verified against a live AWS account: the rename path applies the same rule, and rejecting it
+     * leaves the existing name in place. A lookalike is still allowed.
+     */
+    @Test
+    void renamingToAReservedNameIsRejected() {
+        Ec2Service service = prefixListService();
+        ManagedPrefixList list = service.createManagedPrefixList("us-east-1", "corp", "IPv4", 5,
+                List.of(), List.of());
+
+        AwsException error = assertThrows(AwsException.class, () -> service.modifyManagedPrefixList(
+                "us-east-1", list.getPrefixListId(), null, "com.amazonaws.us-east-1.s3", null,
+                List.of(), List.of()));
+        assertEquals("InvalidParameterValue", error.getErrorCode());
+        assertEquals("corp", service.describeManagedPrefixLists("us-east-1",
+                List.of(list.getPrefixListId()), Map.of()).getFirst().getPrefixListName());
+
+        service.modifyManagedPrefixList("us-east-1", list.getPrefixListId(), null,
+                "com.amazonaws-renamed", null, List.of(), List.of());
+        assertEquals("com.amazonaws-renamed", service.describeManagedPrefixLists("us-east-1",
+                List.of(list.getPrefixListId()), Map.of()).getFirst().getPrefixListName());
+    }
+
     @Test
     void describeManagedPrefixListsFiltersByName() {
         Ec2Service service = prefixListService();


### PR DESCRIPTION
Closes #2273.

`CreateManagedPrefixList` accepted names beginning `com.amazonaws.`, `com.amazon.` or `com.aws.`, which AWS refuses — so a customer list could shadow a seeded gateway-endpoint one such as `com.amazonaws.eu-central-1.s3`. Raised by @hectorvent while reviewing #2105.

Rejected now with `InvalidParameterValue` and AWS's own message.

## The trailing dot matters

Each reserved prefix includes its dot. Checked against a live AWS account:

| Name | Real AWS |
|---|---|
| `com.amazonaws.probe` | `InvalidParameterValue` |
| `com.amazon.probe` | `InvalidParameterValue` |
| `com.aws.probe` | `InvalidParameterValue` |
| `com.amazonaws-probe` | **accepted** |
| `comamazonaws.probe` | **accepted** |

So the obvious `startsWith("com.amazonaws")` is wrong — it refuses `com.amazonaws-probe`, which AWS allows. I confirmed that failure mode rather than assuming it: with the dots dropped from the constant, the test errors on `com.amazonaws-probe`.

## Tests

One case in `Ec2ServiceTest` asserting both directions — the three reserved prefixes rejected, and `com.amazonaws-probe`, `comamazonaws.probe` and a plain name still accepted, so the over-rejection cannot be reintroduced silently.

Full suite green at 9619 tests. `tools/docs/regen_action_docs.py --strict` reports no drift.
