### PR TITLE
fix(appconfig): accept top-level resource ARNs in TagResource/ListTagsForResource

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppConfigTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppConfigTest.java
@@ -306,4 +306,32 @@ class AppConfigTest {
             } catch (Exception ignored) {}
         }
     }
+
+    @Test
+    @Order(51)
+    @DisplayName("TagResource / ListTagsForResource - deploymentstrategy ARN (top-level, not nested under application/)")
+    void tagDeploymentStrategyViaSdk() {
+        // deploymentstrategy/extension/extensionassociation ARNs don't nest under application/
+        // like every other AppConfig resource tested above - a naive ARN parser can end up
+        // hardcoding the application/ prefix and rejecting these as invalid, even though AWS
+        // documents all three as taggable (see e.g. AWS::AppConfig::DeploymentStrategy's Tags
+        // property). This asserts the SDK call succeeds end-to-end, not just that some ARN shape
+        // is accepted internally.
+        String tagStrategyId = appConfig.createDeploymentStrategy(CreateDeploymentStrategyRequest.builder()
+                .name("tag-roundtrip-strategy")
+                .deploymentDurationInMinutes(0)
+                .growthFactor(100f)
+                .finalBakeTimeInMinutes(0)
+                .build()).id();
+        String arn = "arn:aws:appconfig:us-east-1:000000000000:deploymentstrategy/" + tagStrategyId;
+
+        appConfig.tagResource(TagResourceRequest.builder()
+                .resourceArn(arn)
+                .tags(java.util.Map.of("env", "prod"))
+                .build());
+
+        ListTagsForResourceResponse listed = appConfig.listTagsForResource(
+                ListTagsForResourceRequest.builder().resourceArn(arn).build());
+        assertThat(listed.tags()).isNotNull();
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigTagHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigTagHandler.java
@@ -22,11 +22,10 @@ import java.util.Set;
  *   <li>{@code arn:aws:appconfig:<region>:<account>:extension/<extensionId>}
  *   <li>{@code arn:aws:appconfig:<region>:<account>:extensionassociation/<associationId>}
  * </ul>
- * Only application-level tags are stored; every other resource type above is a real,
- * taggable AppConfig resource per the API (unlike e.g. hostedconfigurationversion, which AWS
- * does not support tagging for at all), so its ARN shape is accepted, but the tag call itself
- * is a no-op - this satisfies callers (e.g. Terraform's AWS provider) that read tags back after
- * a write without erroring on a resource type Floci doesn't yet persist tags for.
+ * Only application-level tags are actually stored; every other recognized ARN shape above is
+ * accepted (not rejected with a 400) but the tag call itself is a no-op - this satisfies callers
+ * (e.g. Terraform's AWS provider) that read tags back after a write without erroring on a resource
+ * type Floci doesn't yet persist tags for.
  */
 @ApplicationScoped
 public class AppConfigTagHandler implements TagHandler {

--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigTagHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigTagHandler.java
@@ -8,6 +8,7 @@ import jakarta.inject.Inject;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * {@link TagHandler} implementation for AppConfig.
@@ -17,9 +18,15 @@ import java.util.Map;
  *   <li>{@code arn:aws:appconfig:<region>:<account>:application/<appId>}
  *   <li>{@code arn:aws:appconfig:<region>:<account>:application/<appId>/environment/<envId>}
  *   <li>{@code arn:aws:appconfig:<region>:<account>:application/<appId>/configurationprofile/<profileId>}
+ *   <li>{@code arn:aws:appconfig:<region>:<account>:deploymentstrategy/<strategyId>}
+ *   <li>{@code arn:aws:appconfig:<region>:<account>:extension/<extensionId>}
+ *   <li>{@code arn:aws:appconfig:<region>:<account>:extensionassociation/<associationId>}
  * </ul>
- * Only application-level tags are stored; environment and configurationprofile tag calls
- * are accepted (no-op) to satisfy Terraform provider reads.
+ * Only application-level tags are stored; every other resource type above is a real,
+ * taggable AppConfig resource per the API (unlike e.g. hostedconfigurationversion, which AWS
+ * does not support tagging for at all), so its ARN shape is accepted, but the tag call itself
+ * is a no-op - this satisfies callers (e.g. Terraform's AWS provider) that read tags back after
+ * a write without erroring on a resource type Floci doesn't yet persist tags for.
  */
 @ApplicationScoped
 public class AppConfigTagHandler implements TagHandler {
@@ -68,6 +75,13 @@ public class AppConfigTagHandler implements TagHandler {
 
     private record ResourceRef(String type, String id) {}
 
+    // The AppConfig resource types AWS documents as taggable that are NOT nested under
+    // application/... (see e.g. the Tags property on AWS::AppConfig::DeploymentStrategy,
+    // AWS::AppConfig::Extension, and AWS::AppConfig::ExtensionAssociation) - every other
+    // taggable type (application, environment, configurationprofile) already nests under
+    // application/ and is handled by the branch below.
+    private static final Set<String> TOP_LEVEL_TYPES = Set.of("deploymentstrategy", "extension", "extensionassociation");
+
     private static ResourceRef parseArn(String arn) {
         // arn:aws:appconfig:<region>:<account>:<resource>
         String resource;
@@ -77,6 +91,9 @@ public class AppConfigTagHandler implements TagHandler {
             throw new AwsException("BadRequestException", "Invalid resource ARN: " + arn, 400);
         }
         String[] parts = resource.split("/");
+        if (parts.length == 2 && TOP_LEVEL_TYPES.contains(parts[0])) {
+            return new ResourceRef(parts[0], parts[1]);
+        }
         if (parts.length >= 2 && "application".equals(parts[0])) {
             // application/<appId>
             if (parts.length == 2) return new ResourceRef("application", parts[1]);

--- a/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
@@ -346,7 +346,7 @@ class AppConfigIntegrationTest {
     }
 
     @Test @Order(24)
-    void tagExtensionAndExtensionAssociationArnsAreAcceptedNotRejected() {
+    void listTagsForExtensionAndExtensionAssociationArnsIsAcceptedNotRejected() {
         String extensionArn = "arn:aws:appconfig:us-east-1:000000000000:extension/some-extension-id";
         String associationArn = "arn:aws:appconfig:us-east-1:000000000000:extensionassociation/some-association-id";
         given()

--- a/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
@@ -317,7 +317,51 @@ class AppConfigIntegrationTest {
                 .body("Tags", anEmptyMap());
     }
 
+    // ──────────── Tags on top-level (non-application-nested) resource ARNs ────────────
+    // deploymentstrategy/extension/extensionassociation are real, taggable AppConfig resource
+    // types per the API - unlike environment/deployment above, their ARNs don't nest under
+    // application/..., so they need their own top-level branch in AppConfigTagHandler#parseArn.
+    // Regression coverage for that ARN-shape acceptance; no tag storage exists for these types
+    // yet (same no-op precedent as environment/deployment above), so only 200-not-400 is asserted.
+
     @Test @Order(22)
+    void listTagsForDeploymentStrategyArnIsAcceptedNotRejected() {
+        String arn = "arn:aws:appconfig:us-east-1:000000000000:deploymentstrategy/" + strategyId;
+        given()
+                .when().get("/tags/" + arn)
+                .then()
+                .statusCode(200)
+                .body("Tags", anEmptyMap());
+    }
+
+    @Test @Order(23)
+    void tagDeploymentStrategyArnIsAcceptedNotRejected() {
+        String arn = "arn:aws:appconfig:us-east-1:000000000000:deploymentstrategy/" + strategyId;
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"Tags\": {\"env\": \"local\"}}")
+                .when().post("/tags/" + arn)
+                .then()
+                .statusCode(204);
+    }
+
+    @Test @Order(24)
+    void tagExtensionAndExtensionAssociationArnsAreAcceptedNotRejected() {
+        String extensionArn = "arn:aws:appconfig:us-east-1:000000000000:extension/some-extension-id";
+        String associationArn = "arn:aws:appconfig:us-east-1:000000000000:extensionassociation/some-association-id";
+        given()
+                .when().get("/tags/" + extensionArn)
+                .then()
+                .statusCode(200)
+                .body("Tags", anEmptyMap());
+        given()
+                .when().get("/tags/" + associationArn)
+                .then()
+                .statusCode(200)
+                .body("Tags", anEmptyMap());
+    }
+
+    @Test @Order(25)
     void emptyConfigurationReturnsEmptyPayload() {
         emptyAppId = given()
                 .contentType(ContentType.JSON)


### PR DESCRIPTION
## Bug

`AppConfigTagHandler#parseArn` hardcodes the assumption that every AppConfig resource ARN nests
under `application/...`:

```java
if (parts.length >= 2 && "application".equals(parts[0])) { ... }
throw new AwsException("BadRequestException", "Invalid resource ARN: " + arn, 400);
```

That's true for `environment` and `configurationprofile` ARNs (`application/{appId}/environment/{envId}`,
etc.), but AWS documents `deploymentstrategy`, `extension`, and `extensionassociation` as real,
taggable AppConfig resources that are **not** nested under `application/` - e.g.
`arn:aws:appconfig:{region}:{account}:deploymentstrategy/{id}`. Verified against AWS's own
CloudFormation resource docs before scoping this: `AWS::AppConfig::DeploymentStrategy`,
`AWS::AppConfig::Extension`, and `AWS::AppConfig::ExtensionAssociation` all have a `Tags`
property.

For a `deploymentstrategy/{id}` ARN, `parts[0]` is `"deploymentstrategy"`, not `"application"`, so
`TagResource`/`ListTagsForResource` reject it with a 400 - even though it's a valid, taggable
resource.

## Fix

Adds a `TOP_LEVEL_TYPES` set (`deploymentstrategy`, `extension`, `extensionassociation`) checked
before the `application/` branch. Tag storage for these types remains a no-op, matching the
existing precedent for `environment`/`configurationprofile` (accepted, but not yet persisted) -
this fixes the ARN-shape rejection, not tag persistence for new resource types.

Deliberately did **not** touch the existing `parts.length == 6` branch, which currently
over-accepts `hostedconfigurationversion` ARNs as taggable even though AWS doesn't support tagging
that resource type at all (confirmed via its CloudFormation docs - no `Tags` property). That's a
separate, pre-existing issue; keeping this PR scoped to the reported bug rather than bundling an
unrelated fix into a shared helper (lesson from #2155's review - a one-line fix to a shared helper
can resolve one AWS-compatibility gap while introducing another).

## Tests

- `AppConfigIntegrationTest`: added 3 new tests covering `deploymentstrategy`/`extension`/`extensionassociation`
  ARN acceptance (200/204, not 400) in the existing tag-lifecycle section.
- `compatibility-tests/sdk-test-java` `AppConfigTest`: added an SDK round-trip test
  (`tagDeploymentStrategyViaSdk`) using the real AWS SDK v2 client against a live instance.

Ran locally (JDK 25):
```
AppConfigIntegrationTest (unit):        25/25 passed
AppConfigTest (SDK compat, live):       15/15 passed
```