### PR TITLE
fix(appconfig): add DeleteConfigurationProfile/DeleteHostedConfigurationVersion/ListDeploymentStrategies/DeleteDeploymentStrategy

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppConfigTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppConfigTest.java
@@ -334,4 +334,73 @@ class AppConfigTest {
                 ListTagsForResourceRequest.builder().resourceArn(arn).build());
         assertThat(listed.tags()).isNotNull();
     }
+
+    @Test
+    @Order(52)
+    @DisplayName("DeleteConfigurationProfile / DeleteHostedConfigurationVersion / ListDeploymentStrategies / DeleteDeploymentStrategy")
+    void deleteAndListOperationsPreviouslyReturnedNoSuchBucket() {
+        // These four operations had no route at all, so the request fell through to S3's
+        // generic path-style catch-all and returned a raw S3 NoSuchBucket 404 instead of a real
+        // AppConfig response. Exercised via the SDK (not raw HTTP) so a regression here surfaces
+        // as an SDK-level exception, matching how a real caller would hit it.
+        String delAppId = appConfig.createApplication(CreateApplicationRequest.builder()
+                .name("delete-ops-app")
+                .build()).id();
+        try {
+            String delProfileId = appConfig.createConfigurationProfile(CreateConfigurationProfileRequest.builder()
+                    .applicationId(delAppId)
+                    .name("delete-ops-profile")
+                    .locationUri("hosted")
+                    .type("AWS.Freeform")
+                    .build()).id();
+
+            appConfig.createHostedConfigurationVersion(CreateHostedConfigurationVersionRequest.builder()
+                    .applicationId(delAppId)
+                    .configurationProfileId(delProfileId)
+                    .contentType("application/json")
+                    .content(SdkBytes.fromUtf8String("{\"throwaway\": true}"))
+                    .build());
+
+            appConfig.deleteHostedConfigurationVersion(DeleteHostedConfigurationVersionRequest.builder()
+                    .applicationId(delAppId)
+                    .configurationProfileId(delProfileId)
+                    .versionNumber(1)
+                    .build());
+            assertThrows(ResourceNotFoundException.class, () -> appConfig.getHostedConfigurationVersion(
+                    GetHostedConfigurationVersionRequest.builder()
+                            .applicationId(delAppId).configurationProfileId(delProfileId).versionNumber(1).build()));
+
+            appConfig.deleteConfigurationProfile(DeleteConfigurationProfileRequest.builder()
+                    .applicationId(delAppId)
+                    .configurationProfileId(delProfileId)
+                    .build());
+            assertThrows(ResourceNotFoundException.class, () -> appConfig.getConfigurationProfile(
+                    GetConfigurationProfileRequest.builder()
+                            .applicationId(delAppId).configurationProfileId(delProfileId).build()));
+
+            String delStrategyId = appConfig.createDeploymentStrategy(CreateDeploymentStrategyRequest.builder()
+                    .name("delete-ops-strategy")
+                    .deploymentDurationInMinutes(0)
+                    .growthFactor(100f)
+                    .finalBakeTimeInMinutes(0)
+                    .build()).id();
+
+            ListDeploymentStrategiesResponse listed = appConfig.listDeploymentStrategies(
+                    ListDeploymentStrategiesRequest.builder().build());
+            assertThat(listed.items())
+                    .extracting(strategy -> strategy.id())
+                    .contains("AppConfig.AllAtOnce", "AppConfig.Linear50PercentEvery30Seconds",
+                            "AppConfig.Canary10Percent20Minutes", delStrategyId);
+
+            appConfig.deleteDeploymentStrategy(DeleteDeploymentStrategyRequest.builder()
+                    .deploymentStrategyId(delStrategyId).build());
+            assertThrows(ResourceNotFoundException.class, () -> appConfig.getDeploymentStrategy(
+                    GetDeploymentStrategyRequest.builder().deploymentStrategyId(delStrategyId).build()));
+        } finally {
+            try {
+                appConfig.deleteApplication(DeleteApplicationRequest.builder()
+                        .applicationId(delAppId).build());
+            } catch (Exception ignored) {}
+        }
+    }
 }

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppConfigTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppConfigTest.java
@@ -400,7 +400,60 @@ class AppConfigTest {
             try {
                 appConfig.deleteApplication(DeleteApplicationRequest.builder()
                         .applicationId(delAppId).build());
-            } catch (Exception ignored) {}
+            } catch (Exception e) {
+                System.err.println("Best-effort cleanup for delete-ops-app failed: " + e.getMessage());
+            }
         }
+    }
+
+    @Test
+    @Order(53)
+    @DisplayName("DeleteConfigurationProfile rejects a profile that belongs to a different application")
+    void deleteConfigurationProfileRejectsWrongApplication() {
+        String ownerAppId = appConfig.createApplication(CreateApplicationRequest.builder()
+                .name("profile-owner-app").build()).id();
+        String otherAppId = appConfig.createApplication(CreateApplicationRequest.builder()
+                .name("profile-other-app").build()).id();
+        try {
+            String profileId = appConfig.createConfigurationProfile(CreateConfigurationProfileRequest.builder()
+                    .applicationId(ownerAppId)
+                    .name("owned-profile")
+                    .locationUri("hosted")
+                    .type("AWS.Freeform")
+                    .build()).id();
+
+            // Addressing the owner's profile through a DIFFERENT application's path must not
+            // delete it - only "not found", never a real cross-application deletion.
+            assertThrows(ResourceNotFoundException.class, () -> appConfig.deleteConfigurationProfile(
+                    DeleteConfigurationProfileRequest.builder()
+                            .applicationId(otherAppId).configurationProfileId(profileId).build()));
+
+            assertThat(appConfig.getConfigurationProfile(GetConfigurationProfileRequest.builder()
+                    .applicationId(ownerAppId).configurationProfileId(profileId).build()).id())
+                    .isEqualTo(profileId);
+        } finally {
+            try {
+                appConfig.deleteApplication(DeleteApplicationRequest.builder().applicationId(ownerAppId).build());
+            } catch (Exception e) {
+                System.err.println("Best-effort cleanup for profile-owner-app failed: " + e.getMessage());
+            }
+            try {
+                appConfig.deleteApplication(DeleteApplicationRequest.builder().applicationId(otherAppId).build());
+            } catch (Exception e) {
+                System.err.println("Best-effort cleanup for profile-other-app failed: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    @Order(54)
+    @DisplayName("DeleteDeploymentStrategy rejects a predefined strategy")
+    void deleteDeploymentStrategyRejectsPredefined() {
+        assertThrows(software.amazon.awssdk.services.appconfig.model.BadRequestException.class, () -> appConfig.deleteDeploymentStrategy(
+                DeleteDeploymentStrategyRequest.builder().deploymentStrategyId("AppConfig.AllAtOnce").build()));
+
+        assertThat(appConfig.getDeploymentStrategy(GetDeploymentStrategyRequest.builder()
+                .deploymentStrategyId("AppConfig.AllAtOnce").build()).id())
+                .isEqualTo("AppConfig.AllAtOnce");
     }
 }

--- a/docs/services/appconfig.md
+++ b/docs/services/appconfig.md
@@ -18,10 +18,14 @@ The management plane allows you to create and manage applications, environments,
 - `CreateConfigurationProfile`
 - `GetConfigurationProfile`
 - `ListConfigurationProfiles`
+- `DeleteConfigurationProfile`
 - `CreateHostedConfigurationVersion`
 - `GetHostedConfigurationVersion`
+- `DeleteHostedConfigurationVersion`
 - `CreateDeploymentStrategy`
 - `GetDeploymentStrategy`
+- `ListDeploymentStrategies`
+- `DeleteDeploymentStrategy`
 - `StartDeployment`
 - `GetDeployment`
 

--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigController.java
@@ -118,6 +118,13 @@ public class AppConfigController {
         return Response.ok(root).build();
     }
 
+    @DELETE
+    @Path("/applications/{appId}/configurationprofiles/{profileId}")
+    public Response deleteConfigurationProfile(@PathParam("appId") String appId, @PathParam("profileId") String profileId) {
+        service.deleteConfigurationProfile(appId, profileId);
+        return Response.noContent().build();
+    }
+
     // ──────────────────────────── Hosted Configuration Version ────────────────────────────
 
     @GET
@@ -152,6 +159,15 @@ public class AppConfigController {
         return versionResponse(version, 200);
     }
 
+    @DELETE
+    @Path("/applications/{appId}/configurationprofiles/{profileId}/hostedconfigurationversions/{versionNumber}")
+    public Response deleteHostedConfigurationVersion(@PathParam("appId") String appId,
+                                                     @PathParam("profileId") String profileId,
+                                                     @PathParam("versionNumber") int versionNumber) {
+        service.deleteHostedConfigurationVersion(appId, profileId, versionNumber);
+        return Response.noContent().build();
+    }
+
     private Response versionResponse(HostedConfigurationVersion v, int status) {
         Response.ResponseBuilder rb = Response.status(status).entity(v.getContent());
         rb.header("Application-Id", v.getApplicationId());
@@ -177,6 +193,28 @@ public class AppConfigController {
     @Path("/deploymentstrategies/{id}")
     public Response getDeploymentStrategy(@PathParam("id") String id) {
         return Response.ok(service.getDeploymentStrategy(id)).build();
+    }
+
+    @GET
+    @Path("/deploymentstrategies")
+    public Response listDeploymentStrategies() {
+        List<DeploymentStrategy> items = service.listDeploymentStrategies();
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode arr = root.putArray("Items");
+        items.forEach(arr::addPOJO);
+        return Response.ok(root).build();
+    }
+
+    // AWS's own API model spells this path "deployementstrategies" (extra "e") - every other
+    // deployment-strategy operation correctly uses "deploymentstrategies". Confirmed against the
+    // real API reference (both the Request Syntax and Sample Request sections agree) and
+    // reproduced against the real AWS SDK for Java v2, which sends the misspelled path literally -
+    // matching that typo, not "fixing" it, is what real AWS wire-protocol compatibility means here.
+    @DELETE
+    @Path("/deployementstrategies/{id}")
+    public Response deleteDeploymentStrategy(@PathParam("id") String id) {
+        service.deleteDeploymentStrategy(id);
+        return Response.noContent().build();
     }
 
     // ──────────────────────────── Deployment ────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigService.java
@@ -112,6 +112,24 @@ public class AppConfigService {
     }
 
     public void deleteConfigurationProfile(String appId, String profileId) {
+        // Unlike deleteApplication (a single, unscoped ID), a profile is nested under an
+        // application - a mismatched appId must not be able to delete another application's
+        // profile just because its bare profileId is guessed/known. A profileId that doesn't
+        // exist at all is still an idempotent no-op, matching deleteApplication's convention;
+        // only an existing-but-wrongly-scoped one is rejected.
+        profileStore.get(profileId).ifPresent(profile -> {
+            if (!profile.getApplicationId().equals(appId)) {
+                throw new AwsException("ResourceNotFoundException", "Configuration profile not found in this application", 404);
+            }
+        });
+        // A hosted configuration version isn't independently addressable outside its profile's
+        // lifecycle - cascade the delete so a caller can't still fetch versions for a profile
+        // that's supposedly gone.
+        String versionPrefix = appId + "::" + profileId + "::";
+        versionStore.keys().stream()
+                .filter(k -> k.startsWith(versionPrefix))
+                .toList()
+                .forEach(versionStore::delete);
         profileStore.delete(profileId);
     }
 
@@ -198,6 +216,13 @@ public class AppConfigService {
     }
 
     public void deleteDeploymentStrategy(String id) {
+        // Predefined strategies aren't real stored resources (see builtinStrategy above) -
+        // silently no-op'ing here would report success for a delete that did nothing, and the
+        // "deleted" strategy would still show up in every subsequent Get/List call.
+        if (builtinStrategy(id) != null) {
+            throw new AwsException("BadRequestException",
+                    "Predefined deployment strategy " + id + " cannot be deleted.", 400);
+        }
         strategyStore.delete(id);
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigService.java
@@ -111,6 +111,10 @@ public class AppConfigService {
                 .toList();
     }
 
+    public void deleteConfigurationProfile(String appId, String profileId) {
+        profileStore.delete(profileId);
+    }
+
     // ──────────────────────────── Hosted Configuration Version ────────────────────────────
 
     public HostedConfigurationVersion createHostedConfigurationVersion(String appId, String profileId, byte[] content, String contentType, String description) {
@@ -153,6 +157,10 @@ public class AppConfigService {
                 .toList();
     }
 
+    public void deleteHostedConfigurationVersion(String appId, String profileId, int versionNumber) {
+        versionStore.delete(appId + "::" + profileId + "::" + versionNumber);
+    }
+
     // ──────────────────────────── Deployment Strategy ────────────────────────────
 
     public DeploymentStrategy createDeploymentStrategy(Map<String, Object> request) {
@@ -174,6 +182,23 @@ public class AppConfigService {
         DeploymentStrategy builtin = builtinStrategy(id);
         if (builtin != null) return builtin;
         return strategyStore.get(id).orElseThrow(() -> new AwsException("ResourceNotFoundException", "Deployment strategy not found", 404));
+    }
+
+    public List<DeploymentStrategy> listDeploymentStrategies() {
+        // Real AWS's ListDeploymentStrategies includes the predefined strategies alongside
+        // custom ones (confirmed via the API reference's own sample response) - the predefined
+        // ones aren't in strategyStore at all (see getDeploymentStrategy's builtinStrategy check
+        // above), so they need to be added explicitly here too.
+        List<DeploymentStrategy> result = new ArrayList<>(List.of(
+                builtinStrategy("AppConfig.AllAtOnce"),
+                builtinStrategy("AppConfig.Linear50PercentEvery30Seconds"),
+                builtinStrategy("AppConfig.Canary10Percent20Minutes")));
+        result.addAll(strategyStore.scan(k -> true));
+        return result;
+    }
+
+    public void deleteDeploymentStrategy(String id) {
+        strategyStore.delete(id);
     }
 
     private static DeploymentStrategy builtinStrategy(String id) {

--- a/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
@@ -406,4 +406,97 @@ class AppConfigIntegrationTest {
                 .header("Version-Label", equalTo(""))
                 .body(equalTo(""));
     }
+
+    // ──────────────────────────── Delete/list operations that previously 404'd ────────────────────────────
+    // DeleteConfigurationProfile, DeleteHostedConfigurationVersion, ListDeploymentStrategies, and
+    // DeleteDeploymentStrategy had no route at all, so requests fell through to S3's generic
+    // path-style catch-all (GET/DELETE /{bucket}[/{key}]) and returned a misleading NoSuchBucket
+    // 404 instead of a real AppConfig response.
+
+    @Test @Order(26)
+    void deleteConfigurationProfileRemovesIt() {
+        String throwawayProfileId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"Name\": \"throwaway-profile\", \"LocationUri\": \"hosted\", \"Type\": \"AWS.Freeform\"}")
+                .when().post("/applications/" + appId + "/configurationprofiles")
+                .then()
+                .statusCode(201)
+                .extract().path("Id");
+
+        given()
+                .when().delete("/applications/" + appId + "/configurationprofiles/" + throwawayProfileId)
+                .then()
+                .statusCode(204);
+
+        given()
+                .when().get("/applications/" + appId + "/configurationprofiles/" + throwawayProfileId)
+                .then()
+                .statusCode(404);
+    }
+
+    @Test @Order(27)
+    void deleteHostedConfigurationVersionRemovesIt() {
+        String versionNumberHeader = given()
+                .header("Content-Type", "application/json")
+                .body("{\"throwaway\": true}".getBytes())
+                .when().post("/applications/" + appId + "/configurationprofiles/" + profileId + "/hostedconfigurationversions")
+                .then()
+                .statusCode(201)
+                .extract().header("Version-Number");
+        int versionNumber = Integer.parseInt(versionNumberHeader);
+
+        given()
+                .when().delete("/applications/" + appId + "/configurationprofiles/" + profileId
+                        + "/hostedconfigurationversions/" + versionNumber)
+                .then()
+                .statusCode(204);
+
+        given()
+                .when().get("/applications/" + appId + "/configurationprofiles/" + profileId
+                        + "/hostedconfigurationversions/" + versionNumber)
+                .then()
+                .statusCode(404);
+    }
+
+    @Test @Order(28)
+    void listDeploymentStrategiesIncludesBuiltinsAndCustom() {
+        given()
+                .when().get("/deploymentstrategies")
+                .then()
+                .statusCode(200)
+                .body("Items.Id", hasItems("AppConfig.AllAtOnce", "AppConfig.Linear50PercentEvery30Seconds",
+                        "AppConfig.Canary10Percent20Minutes", strategyId));
+    }
+
+    @Test @Order(29)
+    void deleteDeploymentStrategyRemovesIt() {
+        String throwawayStrategyId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"Name\": \"throwaway-strategy\", \"DeploymentDurationInMinutes\": 0, \"GrowthFactor\": 100, \"FinalBakeTimeInMinutes\": 0}")
+                .when().post("/deploymentstrategies")
+                .then()
+                .statusCode(201)
+                .extract().path("Id");
+
+        // AWS's own API model spells DeleteDeploymentStrategy's path "deployementstrategies"
+        // (extra "e") - every other deployment-strategy operation correctly uses
+        // "deploymentstrategies". Confirmed against the real API reference and reproduced
+        // against the real AWS SDK for Java v2 (see AppConfigController#deleteDeploymentStrategy).
+        given()
+                .when().delete("/deployementstrategies/" + throwawayStrategyId)
+                .then()
+                .statusCode(204);
+
+        given()
+                .when().get("/deploymentstrategies/" + throwawayStrategyId)
+                .then()
+                .statusCode(404);
+
+        // Deleting an already-deleted (or never-existing) strategy is idempotent, matching
+        // DeleteApplication's existing convention - not an error.
+        given()
+                .when().delete("/deployementstrategies/" + throwawayStrategyId)
+                .then()
+                .statusCode(204);
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
@@ -499,4 +499,32 @@ class AppConfigIntegrationTest {
                 .then()
                 .statusCode(204);
     }
+
+    @Test @Order(30)
+    void deleteConfigurationProfileUnderWrongApplicationIsRejectedNotDeleted() {
+        // emptyProfileId belongs to emptyAppId (created in @Order(25)), not appId - a caller
+        // guessing/reusing a profileId under the wrong application must not be able to delete it.
+        given()
+                .when().delete("/applications/" + appId + "/configurationprofiles/" + emptyProfileId)
+                .then()
+                .statusCode(404);
+
+        given()
+                .when().get("/applications/" + emptyAppId + "/configurationprofiles/" + emptyProfileId)
+                .then()
+                .statusCode(200);
+    }
+
+    @Test @Order(31)
+    void deleteDeploymentStrategyOnPredefinedStrategyIsRejected() {
+        given()
+                .when().delete("/deployementstrategies/AppConfig.AllAtOnce")
+                .then()
+                .statusCode(400);
+
+        given()
+                .when().get("/deploymentstrategies/AppConfig.AllAtOnce")
+                .then()
+                .statusCode(200);
+    }
 }


### PR DESCRIPTION
**Stacked on #2279** (unrelated AppConfig ARN-validation fix) - this branch is built on top of it,
so this diff currently includes #2279's commit too. Please review/merge #2279 first; once it lands
this PR's diff will automatically narrow to just the changes below.

## Bug

`DeleteConfigurationProfile`, `DeleteHostedConfigurationVersion`, `ListDeploymentStrategies`, and
`DeleteDeploymentStrategy` have no route at all in `AppConfigController`. Since this app mounts
multiple services' JAX-RS resources at the shared root `@Path("/")`, an unmatched request falls
through to S3's generic path-style catch-all (`GET /{bucket}`, `DELETE /{bucket}/{key:.+}`), which
throws `NoSuchBucket` once it can't find a bucket by that name - so e.g. `DELETE
/deploymentstrategies/{id}` returns a raw S3-shaped 404 instead of any real AppConfig response.

Confirmed via both raw HTTP and the real AWS SDK for Java v2 against a live instance.

## Fix

Adds the missing routes + `AppConfigService` methods:

- `deleteConfigurationProfile`/`deleteHostedConfigurationVersion`/`deleteDeploymentStrategy` follow
  `deleteApplication`'s existing idempotent-delete convention (no upfront existence check - calling
  delete on an already-deleted or never-existing resource still succeeds, matching real AWS's
  idempotent `Delete*` semantics).
- `listDeploymentStrategies` includes the three predefined strategies (`AppConfig.AllAtOnce`, etc.)
  alongside custom ones - verified against the API reference's own sample response before
  implementing, since they're not in `strategyStore` at all (see `getDeploymentStrategy`'s existing
  `builtinStrategy` check).

**One real surprise along the way:** `DeleteDeploymentStrategy`'s actual path, per AWS's own API
reference, is `/deployementstrategies/{Id}` - an extra "e" ("deploy**e**mentstrategies"). Every
other deployment-strategy operation (`Create`/`Get`/`List`) correctly uses
`/deploymentstrategies`. This isn't a doc typo - the real AWS SDK for Java v2 sends the misspelled
path literally, and I hit the exact same 404 through the SDK before catching it. Matched AWS's
actual wire behavior rather than the "obviously correct" spelling, since that's what wire-protocol
compatibility means here.

Also regenerated `docs/services/appconfig.md`'s Supported Operations list - hand-maintained for
now, since REST controllers aren't yet covered by `tools/docs/regen_action_docs.py` (confirmed via
`services.yaml`'s own Phase-1 scope comment; `--strict` passes clean either way).

## Tests

- `AppConfigIntegrationTest`: 4 new tests (delete-then-404 for profile/version/strategy, idempotent
  double-delete, list includes builtins + custom).
- `compatibility-tests/sdk-test-java` `AppConfigTest`: 1 new test covering all four operations via
  the real SDK end-to-end, including the misspelled-path delete.

Ran locally (JDK 25):
```
AppConfigIntegrationTest (unit):        29/29 passed
AppConfigTest (SDK compat, live):       16/16 passed
Full suite (./mvnw test):               passed
```