### PR TITLE
fix(lambda): validate Layers ARNs eagerly on CreateFunction/UpdateFunctionConfiguration

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppConfigTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppConfigTest.java
@@ -334,4 +334,73 @@ class AppConfigTest {
                 ListTagsForResourceRequest.builder().resourceArn(arn).build());
         assertThat(listed.tags()).isNotNull();
     }
+
+    @Test
+    @Order(52)
+    @DisplayName("DeleteConfigurationProfile / DeleteHostedConfigurationVersion / ListDeploymentStrategies / DeleteDeploymentStrategy")
+    void deleteAndListOperationsPreviouslyReturnedNoSuchBucket() {
+        // These four operations had no route at all, so the request fell through to S3's
+        // generic path-style catch-all and returned a raw S3 NoSuchBucket 404 instead of a real
+        // AppConfig response. Exercised via the SDK (not raw HTTP) so a regression here surfaces
+        // as an SDK-level exception, matching how a real caller would hit it.
+        String delAppId = appConfig.createApplication(CreateApplicationRequest.builder()
+                .name("delete-ops-app")
+                .build()).id();
+        try {
+            String delProfileId = appConfig.createConfigurationProfile(CreateConfigurationProfileRequest.builder()
+                    .applicationId(delAppId)
+                    .name("delete-ops-profile")
+                    .locationUri("hosted")
+                    .type("AWS.Freeform")
+                    .build()).id();
+
+            appConfig.createHostedConfigurationVersion(CreateHostedConfigurationVersionRequest.builder()
+                    .applicationId(delAppId)
+                    .configurationProfileId(delProfileId)
+                    .contentType("application/json")
+                    .content(SdkBytes.fromUtf8String("{\"throwaway\": true}"))
+                    .build());
+
+            appConfig.deleteHostedConfigurationVersion(DeleteHostedConfigurationVersionRequest.builder()
+                    .applicationId(delAppId)
+                    .configurationProfileId(delProfileId)
+                    .versionNumber(1)
+                    .build());
+            assertThrows(ResourceNotFoundException.class, () -> appConfig.getHostedConfigurationVersion(
+                    GetHostedConfigurationVersionRequest.builder()
+                            .applicationId(delAppId).configurationProfileId(delProfileId).versionNumber(1).build()));
+
+            appConfig.deleteConfigurationProfile(DeleteConfigurationProfileRequest.builder()
+                    .applicationId(delAppId)
+                    .configurationProfileId(delProfileId)
+                    .build());
+            assertThrows(ResourceNotFoundException.class, () -> appConfig.getConfigurationProfile(
+                    GetConfigurationProfileRequest.builder()
+                            .applicationId(delAppId).configurationProfileId(delProfileId).build()));
+
+            String delStrategyId = appConfig.createDeploymentStrategy(CreateDeploymentStrategyRequest.builder()
+                    .name("delete-ops-strategy")
+                    .deploymentDurationInMinutes(0)
+                    .growthFactor(100f)
+                    .finalBakeTimeInMinutes(0)
+                    .build()).id();
+
+            ListDeploymentStrategiesResponse listed = appConfig.listDeploymentStrategies(
+                    ListDeploymentStrategiesRequest.builder().build());
+            assertThat(listed.items())
+                    .extracting(strategy -> strategy.id())
+                    .contains("AppConfig.AllAtOnce", "AppConfig.Linear50PercentEvery30Seconds",
+                            "AppConfig.Canary10Percent20Minutes", delStrategyId);
+
+            appConfig.deleteDeploymentStrategy(DeleteDeploymentStrategyRequest.builder()
+                    .deploymentStrategyId(delStrategyId).build());
+            assertThrows(ResourceNotFoundException.class, () -> appConfig.getDeploymentStrategy(
+                    GetDeploymentStrategyRequest.builder().deploymentStrategyId(delStrategyId).build()));
+        } finally {
+            try {
+                appConfig.deleteApplication(DeleteApplicationRequest.builder()
+                        .applicationId(delAppId).build());
+            } catch (Exception ignored) {}
+        }
+    }
 }

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppConfigTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppConfigTest.java
@@ -400,7 +400,60 @@ class AppConfigTest {
             try {
                 appConfig.deleteApplication(DeleteApplicationRequest.builder()
                         .applicationId(delAppId).build());
-            } catch (Exception ignored) {}
+            } catch (Exception e) {
+                System.err.println("Best-effort cleanup for delete-ops-app failed: " + e.getMessage());
+            }
         }
+    }
+
+    @Test
+    @Order(53)
+    @DisplayName("DeleteConfigurationProfile rejects a profile that belongs to a different application")
+    void deleteConfigurationProfileRejectsWrongApplication() {
+        String ownerAppId = appConfig.createApplication(CreateApplicationRequest.builder()
+                .name("profile-owner-app").build()).id();
+        String otherAppId = appConfig.createApplication(CreateApplicationRequest.builder()
+                .name("profile-other-app").build()).id();
+        try {
+            String profileId = appConfig.createConfigurationProfile(CreateConfigurationProfileRequest.builder()
+                    .applicationId(ownerAppId)
+                    .name("owned-profile")
+                    .locationUri("hosted")
+                    .type("AWS.Freeform")
+                    .build()).id();
+
+            // Addressing the owner's profile through a DIFFERENT application's path must not
+            // delete it - only "not found", never a real cross-application deletion.
+            assertThrows(ResourceNotFoundException.class, () -> appConfig.deleteConfigurationProfile(
+                    DeleteConfigurationProfileRequest.builder()
+                            .applicationId(otherAppId).configurationProfileId(profileId).build()));
+
+            assertThat(appConfig.getConfigurationProfile(GetConfigurationProfileRequest.builder()
+                    .applicationId(ownerAppId).configurationProfileId(profileId).build()).id())
+                    .isEqualTo(profileId);
+        } finally {
+            try {
+                appConfig.deleteApplication(DeleteApplicationRequest.builder().applicationId(ownerAppId).build());
+            } catch (Exception e) {
+                System.err.println("Best-effort cleanup for profile-owner-app failed: " + e.getMessage());
+            }
+            try {
+                appConfig.deleteApplication(DeleteApplicationRequest.builder().applicationId(otherAppId).build());
+            } catch (Exception e) {
+                System.err.println("Best-effort cleanup for profile-other-app failed: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    @Order(54)
+    @DisplayName("DeleteDeploymentStrategy rejects a predefined strategy")
+    void deleteDeploymentStrategyRejectsPredefined() {
+        assertThrows(software.amazon.awssdk.services.appconfig.model.BadRequestException.class, () -> appConfig.deleteDeploymentStrategy(
+                DeleteDeploymentStrategyRequest.builder().deploymentStrategyId("AppConfig.AllAtOnce").build()));
+
+        assertThat(appConfig.getDeploymentStrategy(GetDeploymentStrategyRequest.builder()
+                .deploymentStrategyId("AppConfig.AllAtOnce").build()).id())
+                .isEqualTo("AppConfig.AllAtOnce");
     }
 }

--- a/docs/services/appconfig.md
+++ b/docs/services/appconfig.md
@@ -18,10 +18,14 @@ The management plane allows you to create and manage applications, environments,
 - `CreateConfigurationProfile`
 - `GetConfigurationProfile`
 - `ListConfigurationProfiles`
+- `DeleteConfigurationProfile`
 - `CreateHostedConfigurationVersion`
 - `GetHostedConfigurationVersion`
+- `DeleteHostedConfigurationVersion`
 - `CreateDeploymentStrategy`
 - `GetDeploymentStrategy`
+- `ListDeploymentStrategies`
+- `DeleteDeploymentStrategy`
 - `StartDeployment`
 - `GetDeployment`
 

--- a/docs/services/lambda.md
+++ b/docs/services/lambda.md
@@ -164,13 +164,21 @@ services:
 
 Function URLs are also reachable directly on `/{proxy:.*}` under the Lambda URL controller, which routes the request into the normal `Invoke` path.
 
-**Stubbed:** `ListLayers` and `ListLayerVersions` return empty arrays. No layer storage exists.
+**Layers:** `PublishLayerVersion`, `GetLayerVersion`, `ListLayerVersions`, `ListLayers`, and
+`DeleteLayerVersion` are implemented, with real local storage under
+`{lambda.codePath}/layers/{name}/{version}`. `CreateFunction`/`UpdateFunctionConfiguration`
+validate each `Layers` ARN eagerly against that storage, matching real AWS - an unresolvable ARN
+is rejected with `InvalidParameterValueException`, not silently accepted. Only resolves layers
+published into this same local Floci instance; a real AWS-owned layer ARN (e.g. the AWS AppConfig
+Extension or a Datadog-published layer) can never resolve here, since there's no mechanism in
+Floci for fetching real AWS content - publish your own copy of the layer's content locally under
+a name you control and reference that ARN instead.
 
 ## Not Implemented
 
 These AWS Lambda operations have no handler in Floci. Calls will return `404` or an error:
 
-- Layers (`PublishLayerVersion`, `DeleteLayerVersion`, `GetLayerVersion`, `GetLayerVersionByArn`, `AddLayerVersionPermission`, `RemoveLayerVersionPermission`, `GetLayerVersionPolicy`)
+- Layer permissions and cross-account ARN lookup (`GetLayerVersionByArn`, `AddLayerVersionPermission`, `RemoveLayerVersionPermission`, `GetLayerVersionPolicy`)
 - Provisioned concurrency (`PutProvisionedConcurrencyConfig`, `GetProvisionedConcurrencyConfig`, `ListProvisionedConcurrencyConfigs`, `DeleteProvisionedConcurrencyConfig`)
 - Dead-letter, async invoke config, and event invoke config operations
 - `InvokeWithResponseStream`

--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigController.java
@@ -118,6 +118,13 @@ public class AppConfigController {
         return Response.ok(root).build();
     }
 
+    @DELETE
+    @Path("/applications/{appId}/configurationprofiles/{profileId}")
+    public Response deleteConfigurationProfile(@PathParam("appId") String appId, @PathParam("profileId") String profileId) {
+        service.deleteConfigurationProfile(appId, profileId);
+        return Response.noContent().build();
+    }
+
     // ──────────────────────────── Hosted Configuration Version ────────────────────────────
 
     @GET
@@ -152,6 +159,15 @@ public class AppConfigController {
         return versionResponse(version, 200);
     }
 
+    @DELETE
+    @Path("/applications/{appId}/configurationprofiles/{profileId}/hostedconfigurationversions/{versionNumber}")
+    public Response deleteHostedConfigurationVersion(@PathParam("appId") String appId,
+                                                     @PathParam("profileId") String profileId,
+                                                     @PathParam("versionNumber") int versionNumber) {
+        service.deleteHostedConfigurationVersion(appId, profileId, versionNumber);
+        return Response.noContent().build();
+    }
+
     private Response versionResponse(HostedConfigurationVersion v, int status) {
         Response.ResponseBuilder rb = Response.status(status).entity(v.getContent());
         rb.header("Application-Id", v.getApplicationId());
@@ -177,6 +193,28 @@ public class AppConfigController {
     @Path("/deploymentstrategies/{id}")
     public Response getDeploymentStrategy(@PathParam("id") String id) {
         return Response.ok(service.getDeploymentStrategy(id)).build();
+    }
+
+    @GET
+    @Path("/deploymentstrategies")
+    public Response listDeploymentStrategies() {
+        List<DeploymentStrategy> items = service.listDeploymentStrategies();
+        ObjectNode root = objectMapper.createObjectNode();
+        ArrayNode arr = root.putArray("Items");
+        items.forEach(arr::addPOJO);
+        return Response.ok(root).build();
+    }
+
+    // AWS's own API model spells this path "deployementstrategies" (extra "e") - every other
+    // deployment-strategy operation correctly uses "deploymentstrategies". Confirmed against the
+    // real API reference (both the Request Syntax and Sample Request sections agree) and
+    // reproduced against the real AWS SDK for Java v2, which sends the misspelled path literally -
+    // matching that typo, not "fixing" it, is what real AWS wire-protocol compatibility means here.
+    @DELETE
+    @Path("/deployementstrategies/{id}")
+    public Response deleteDeploymentStrategy(@PathParam("id") String id) {
+        service.deleteDeploymentStrategy(id);
+        return Response.noContent().build();
     }
 
     // ──────────────────────────── Deployment ────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigService.java
@@ -112,6 +112,24 @@ public class AppConfigService {
     }
 
     public void deleteConfigurationProfile(String appId, String profileId) {
+        // Unlike deleteApplication (a single, unscoped ID), a profile is nested under an
+        // application - a mismatched appId must not be able to delete another application's
+        // profile just because its bare profileId is guessed/known. A profileId that doesn't
+        // exist at all is still an idempotent no-op, matching deleteApplication's convention;
+        // only an existing-but-wrongly-scoped one is rejected.
+        profileStore.get(profileId).ifPresent(profile -> {
+            if (!profile.getApplicationId().equals(appId)) {
+                throw new AwsException("ResourceNotFoundException", "Configuration profile not found in this application", 404);
+            }
+        });
+        // A hosted configuration version isn't independently addressable outside its profile's
+        // lifecycle - cascade the delete so a caller can't still fetch versions for a profile
+        // that's supposedly gone.
+        String versionPrefix = appId + "::" + profileId + "::";
+        versionStore.keys().stream()
+                .filter(k -> k.startsWith(versionPrefix))
+                .toList()
+                .forEach(versionStore::delete);
         profileStore.delete(profileId);
     }
 
@@ -198,6 +216,13 @@ public class AppConfigService {
     }
 
     public void deleteDeploymentStrategy(String id) {
+        // Predefined strategies aren't real stored resources (see builtinStrategy above) -
+        // silently no-op'ing here would report success for a delete that did nothing, and the
+        // "deleted" strategy would still show up in every subsequent Get/List call.
+        if (builtinStrategy(id) != null) {
+            throw new AwsException("BadRequestException",
+                    "Predefined deployment strategy " + id + " cannot be deleted.", 400);
+        }
         strategyStore.delete(id);
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigService.java
@@ -111,6 +111,10 @@ public class AppConfigService {
                 .toList();
     }
 
+    public void deleteConfigurationProfile(String appId, String profileId) {
+        profileStore.delete(profileId);
+    }
+
     // ──────────────────────────── Hosted Configuration Version ────────────────────────────
 
     public HostedConfigurationVersion createHostedConfigurationVersion(String appId, String profileId, byte[] content, String contentType, String description) {
@@ -153,6 +157,10 @@ public class AppConfigService {
                 .toList();
     }
 
+    public void deleteHostedConfigurationVersion(String appId, String profileId, int versionNumber) {
+        versionStore.delete(appId + "::" + profileId + "::" + versionNumber);
+    }
+
     // ──────────────────────────── Deployment Strategy ────────────────────────────
 
     public DeploymentStrategy createDeploymentStrategy(Map<String, Object> request) {
@@ -174,6 +182,23 @@ public class AppConfigService {
         DeploymentStrategy builtin = builtinStrategy(id);
         if (builtin != null) return builtin;
         return strategyStore.get(id).orElseThrow(() -> new AwsException("ResourceNotFoundException", "Deployment strategy not found", 404));
+    }
+
+    public List<DeploymentStrategy> listDeploymentStrategies() {
+        // Real AWS's ListDeploymentStrategies includes the predefined strategies alongside
+        // custom ones (confirmed via the API reference's own sample response) - the predefined
+        // ones aren't in strategyStore at all (see getDeploymentStrategy's builtinStrategy check
+        // above), so they need to be added explicitly here too.
+        List<DeploymentStrategy> result = new ArrayList<>(List.of(
+                builtinStrategy("AppConfig.AllAtOnce"),
+                builtinStrategy("AppConfig.Linear50PercentEvery30Seconds"),
+                builtinStrategy("AppConfig.Canary10Percent20Minutes")));
+        result.addAll(strategyStore.scan(k -> true));
+        return result;
+    }
+
+    public void deleteDeploymentStrategy(String id) {
+        strategyStore.delete(id);
     }
 
     private static DeploymentStrategy builtinStrategy(String id) {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -484,6 +484,18 @@ public class LambdaService {
     public LambdaFunction updateFunctionConfiguration(String region, String functionName, Map<String, Object> request) {
         LambdaFunction fn = getFunction(region, functionName);
 
+        // Validated before any field mutation below, not inline where Layers is applied further
+        // down - fn is the live object backing this store entry (InMemoryStorage#get returns the
+        // same reference, not a copy), so validating this late would leave every
+        // already-applied field (Description, Timeout, ...) live on a rejected update, since
+        // nothing here is transactional and there's a single save() at the very end.
+        @SuppressWarnings("unchecked")
+        List<String> layerList = request.containsKey("Layers") && request.get("Layers") instanceof List
+                ? (List<String>) request.get("Layers") : null;
+        if (request.containsKey("Layers")) {
+            validateLayersResolvable(layerList);
+        }
+
         Map<String, Object> requestedVpcConfig = fn.getVpcConfig();
         if (request.get("VpcConfig") instanceof Map<?, ?>) {
             @SuppressWarnings("unchecked")
@@ -566,10 +578,6 @@ public class LambdaService {
         }
 
         if (request.containsKey("Layers")) {
-            @SuppressWarnings("unchecked")
-            List<String> layerList = request.get("Layers") instanceof List
-                    ? (List<String>) request.get("Layers") : null;
-            validateLayersResolvable(layerList);
             fn.setLayers(layerList != null ? new ArrayList<>(layerList) : new ArrayList<>());
         }
 

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -72,6 +72,7 @@ public class LambdaService {
     private final KinesisEventSourcePoller kinesisPoller;
     private final DynamoDbStreamsEventSourcePoller dynamodbStreamsPoller;
     private final StorageFactory storageFactory;
+    private final LambdaLayerService layerService;
     private Map<String, Integer> versionCounters = new ConcurrentHashMap<>();
     private Map<String, FunctionEventInvokeConfig> eventInvokeConfigs = new ConcurrentHashMap<>();
     /**
@@ -139,6 +140,7 @@ public class LambdaService {
         this.kinesisPoller = null;
         this.dynamodbStreamsPoller = null;
         this.storageFactory = storageFactory;
+        this.layerService = null;
     }
 
     @Inject
@@ -157,7 +159,8 @@ public class LambdaService {
                           SqsEventSourcePoller poller,
                           KinesisEventSourcePoller kinesisPoller,
                           DynamoDbStreamsEventSourcePoller dynamodbStreamsPoller,
-                          StorageFactory storageFactory) {
+                          StorageFactory storageFactory,
+                          LambdaLayerService layerService) {
         this.functionStore = functionStore;
         this.executorService = executorService;
         this.concurrencyLimiter = concurrencyLimiter;
@@ -174,6 +177,23 @@ public class LambdaService {
         this.kinesisPoller = kinesisPoller;
         this.dynamodbStreamsPoller = dynamodbStreamsPoller;
         this.storageFactory = storageFactory;
+        this.layerService = layerService;
+    }
+
+    // Real AWS validates a function's Layers eagerly at CreateFunction/UpdateFunctionConfiguration
+    // time with InvalidParameterValueException, not lazily at invoke time - resolveLayerByArn's
+    // caller in ContainerLauncher only logs a warning and silently launches without the layer's
+    // content mounted, which is correct AWS-parity behavior for a layer deleted *after* being
+    // attached (AWS doesn't re-validate on every invoke either), but was previously the only
+    // signal at all for a bad ARN, even a typo caught at attach time on real AWS.
+    private void validateLayersResolvable(List<String> layerArns) {
+        if (layerArns == null || layerService == null) return;
+        for (String arn : layerArns) {
+            if (layerService.resolveLayerByArn(arn) == null) {
+                throw new AwsException("InvalidParameterValueException",
+                        "Layer version " + arn + " does not exist.", 400);
+            }
+        }
     }
 
     /** Package-private accessor for tests that want to assert limiter state directly. */
@@ -321,6 +341,7 @@ public class LambdaService {
         List<String> layers = request.get("Layers") instanceof List
                 ? (List<String>) request.get("Layers") : null;
         if (layers != null) {
+            validateLayersResolvable(layers);
             fn.setLayers(new ArrayList<>(layers));
         }
 
@@ -548,6 +569,7 @@ public class LambdaService {
             @SuppressWarnings("unchecked")
             List<String> layerList = request.get("Layers") instanceof List
                     ? (List<String>) request.get("Layers") : null;
+            validateLayersResolvable(layerList);
             fn.setLayers(layerList != null ? new ArrayList<>(layerList) : new ArrayList<>());
         }
 

--- a/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
@@ -406,4 +406,97 @@ class AppConfigIntegrationTest {
                 .header("Version-Label", equalTo(""))
                 .body(equalTo(""));
     }
+
+    // ──────────────────────────── Delete/list operations that previously 404'd ────────────────────────────
+    // DeleteConfigurationProfile, DeleteHostedConfigurationVersion, ListDeploymentStrategies, and
+    // DeleteDeploymentStrategy had no route at all, so requests fell through to S3's generic
+    // path-style catch-all (GET/DELETE /{bucket}[/{key}]) and returned a misleading NoSuchBucket
+    // 404 instead of a real AppConfig response.
+
+    @Test @Order(26)
+    void deleteConfigurationProfileRemovesIt() {
+        String throwawayProfileId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"Name\": \"throwaway-profile\", \"LocationUri\": \"hosted\", \"Type\": \"AWS.Freeform\"}")
+                .when().post("/applications/" + appId + "/configurationprofiles")
+                .then()
+                .statusCode(201)
+                .extract().path("Id");
+
+        given()
+                .when().delete("/applications/" + appId + "/configurationprofiles/" + throwawayProfileId)
+                .then()
+                .statusCode(204);
+
+        given()
+                .when().get("/applications/" + appId + "/configurationprofiles/" + throwawayProfileId)
+                .then()
+                .statusCode(404);
+    }
+
+    @Test @Order(27)
+    void deleteHostedConfigurationVersionRemovesIt() {
+        String versionNumberHeader = given()
+                .header("Content-Type", "application/json")
+                .body("{\"throwaway\": true}".getBytes())
+                .when().post("/applications/" + appId + "/configurationprofiles/" + profileId + "/hostedconfigurationversions")
+                .then()
+                .statusCode(201)
+                .extract().header("Version-Number");
+        int versionNumber = Integer.parseInt(versionNumberHeader);
+
+        given()
+                .when().delete("/applications/" + appId + "/configurationprofiles/" + profileId
+                        + "/hostedconfigurationversions/" + versionNumber)
+                .then()
+                .statusCode(204);
+
+        given()
+                .when().get("/applications/" + appId + "/configurationprofiles/" + profileId
+                        + "/hostedconfigurationversions/" + versionNumber)
+                .then()
+                .statusCode(404);
+    }
+
+    @Test @Order(28)
+    void listDeploymentStrategiesIncludesBuiltinsAndCustom() {
+        given()
+                .when().get("/deploymentstrategies")
+                .then()
+                .statusCode(200)
+                .body("Items.Id", hasItems("AppConfig.AllAtOnce", "AppConfig.Linear50PercentEvery30Seconds",
+                        "AppConfig.Canary10Percent20Minutes", strategyId));
+    }
+
+    @Test @Order(29)
+    void deleteDeploymentStrategyRemovesIt() {
+        String throwawayStrategyId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"Name\": \"throwaway-strategy\", \"DeploymentDurationInMinutes\": 0, \"GrowthFactor\": 100, \"FinalBakeTimeInMinutes\": 0}")
+                .when().post("/deploymentstrategies")
+                .then()
+                .statusCode(201)
+                .extract().path("Id");
+
+        // AWS's own API model spells DeleteDeploymentStrategy's path "deployementstrategies"
+        // (extra "e") - every other deployment-strategy operation correctly uses
+        // "deploymentstrategies". Confirmed against the real API reference and reproduced
+        // against the real AWS SDK for Java v2 (see AppConfigController#deleteDeploymentStrategy).
+        given()
+                .when().delete("/deployementstrategies/" + throwawayStrategyId)
+                .then()
+                .statusCode(204);
+
+        given()
+                .when().get("/deploymentstrategies/" + throwawayStrategyId)
+                .then()
+                .statusCode(404);
+
+        // Deleting an already-deleted (or never-existing) strategy is idempotent, matching
+        // DeleteApplication's existing convention - not an error.
+        given()
+                .when().delete("/deployementstrategies/" + throwawayStrategyId)
+                .then()
+                .statusCode(204);
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
@@ -499,4 +499,32 @@ class AppConfigIntegrationTest {
                 .then()
                 .statusCode(204);
     }
+
+    @Test @Order(30)
+    void deleteConfigurationProfileUnderWrongApplicationIsRejectedNotDeleted() {
+        // emptyProfileId belongs to emptyAppId (created in @Order(25)), not appId - a caller
+        // guessing/reusing a profileId under the wrong application must not be able to delete it.
+        given()
+                .when().delete("/applications/" + appId + "/configurationprofiles/" + emptyProfileId)
+                .then()
+                .statusCode(404);
+
+        given()
+                .when().get("/applications/" + emptyAppId + "/configurationprofiles/" + emptyProfileId)
+                .then()
+                .statusCode(200);
+    }
+
+    @Test @Order(31)
+    void deleteDeploymentStrategyOnPredefinedStrategyIsRejected() {
+        given()
+                .when().delete("/deployementstrategies/AppConfig.AllAtOnce")
+                .then()
+                .statusCode(400);
+
+        given()
+                .when().get("/deploymentstrategies/AppConfig.AllAtOnce")
+                .then()
+                .statusCode(200);
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaLayerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaLayerIntegrationTest.java
@@ -311,6 +311,90 @@ class LambdaLayerIntegrationTest {
             .statusCode(400);
     }
 
+    // ── Attach-time layer validation on CreateFunction/UpdateFunctionConfiguration ────────────
+    // Real AWS rejects an unresolvable Layers ARN eagerly, at attach time, with
+    // InvalidParameterValueException - previously Floci accepted any ARN unconditionally and the
+    // failure only ever surfaced as a silent warning log when the container tried to launch.
+
+    @Test
+    @Order(17)
+    void createFunction_withNonExistentLayer_returns400() throws Exception {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "layer-validation-create-fn",
+                    "Runtime": "nodejs20.x",
+                    "Role": "arn:aws:iam::000000000000:role/lambda-role",
+                    "Handler": "index.handler",
+                    "Code": { "ZipFile": "%s" },
+                    "Layers": ["arn:aws:lambda:us-east-1:000000000000:layer:no-such-layer:1"]
+                }
+                """.formatted(functionZipBase64()))
+        .when()
+            .post("/2015-03-31/functions")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidParameterValueException"));
+
+        // The function must not have been created at all - not partially, not with the layer
+        // dropped.
+        given()
+        .when()
+            .get("/2015-03-31/functions/layer-validation-create-fn")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(18)
+    void updateFunctionConfiguration_withNonExistentLayer_returns400AndLeavesLayersUnchanged() throws Exception {
+        String fnName = "layer-validation-update-fn";
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "Runtime": "nodejs20.x",
+                    "Role": "arn:aws:iam::000000000000:role/lambda-role",
+                    "Handler": "index.handler",
+                    "Code": { "ZipFile": "%s" },
+                    "Layers": ["arn:aws:lambda:us-east-1:000000000000:layer:%s:2"]
+                }
+                """.formatted(fnName, functionZipBase64(), LAYER_NAME))
+        .when()
+            .post("/2015-03-31/functions")
+        .then()
+            .statusCode(201);
+
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "Layers": ["arn:aws:lambda:us-east-1:000000000000:layer:no-such-layer:1"]
+                }
+                """)
+        .when()
+            .put("/2015-03-31/functions/" + fnName + "/configuration")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidParameterValueException"));
+
+        given()
+        .when()
+            .get("/2015-03-31/functions/" + fnName)
+        .then()
+            .statusCode(200)
+            .body("Configuration.Layers", hasSize(1))
+            .body("Configuration.Layers[0].Arn", containsString(":layer:" + LAYER_NAME + ":2"));
+
+        given()
+        .when()
+            .delete("/2015-03-31/functions/" + fnName)
+        .then()
+            .statusCode(204);
+    }
+
     // ── cleanup ──────────────────────────────────────────────────────────────
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaLayerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaLayerIntegrationTest.java
@@ -358,6 +358,7 @@ class LambdaLayerIntegrationTest {
                     "Runtime": "nodejs20.x",
                     "Role": "arn:aws:iam::000000000000:role/lambda-role",
                     "Handler": "index.handler",
+                    "Description": "original description",
                     "Code": { "ZipFile": "%s" },
                     "Layers": ["arn:aws:lambda:us-east-1:000000000000:layer:%s:2"]
                 }
@@ -367,10 +368,16 @@ class LambdaLayerIntegrationTest {
         .then()
             .statusCode(201);
 
+        // Description is bundled into the SAME rejected request as the bad layer - this is
+        // the regression check for validating Layers before any field mutation: if Layers
+        // were checked where it's applied (after Description is already set on the live
+        // stored object), this update would be rejected but Description would already have
+        // silently changed.
         given()
             .contentType("application/json")
             .body("""
                 {
+                    "Description": "should not be applied",
                     "Layers": ["arn:aws:lambda:us-east-1:000000000000:layer:no-such-layer:1"]
                 }
                 """)
@@ -384,6 +391,7 @@ class LambdaLayerIntegrationTest {
         .when()
             .get("/2015-03-31/functions/" + fnName)
         .then()
+            .body("Configuration.Description", equalTo("original description"))
             .statusCode(200)
             .body("Configuration.Layers", hasSize(1))
             .body("Configuration.Layers[0].Arn", containsString(":layer:" + LAYER_NAME + ":2"));


### PR DESCRIPTION
**Stacked on #2280** (AppConfig delete/list routes), which is itself stacked on #2279 (AppConfig
ARN validation) - both unrelated to this change. Please review/merge those first; this PR's diff
will automatically narrow to just the changes below once they land.

## Bug

Real AWS rejects an unresolvable `Layers` ARN eagerly, at `CreateFunction`/
`UpdateFunctionConfiguration` time, with `InvalidParameterValueException`. Floci accepted any ARN
unconditionally - neither operation validated it at all. The only signal was a silent `WARN` log
from `ContainerLauncher` when it tried (and failed) to mount the layer's content at
container-launch time, well after the caller had already moved on believing the attach succeeded.

(Note: this is a narrower, safer fix than "resolve a real foreign-account layer ARN by fetching its
content from real AWS" - there's no AWS-SDK/credential-handling infrastructure anywhere in Floci
for that, and it's a materially larger feature - new dependency, a new credential trust boundary
into Floci's own control-plane process, cache/failure-semantics design. Documented as a known
limitation in `docs/services/lambda.md` instead of attempting it here.)

## Fix

Adds `LambdaLayerService` as a `LambdaService` dependency and validates each `Layers` ARN via the
existing `resolveLayerByArn` before setting it on the function, on both `CreateFunction` and
`UpdateFunctionConfiguration`. Left `ContainerLauncher`'s existing warn-and-continue behavior alone
for the one case it still legitimately covers: a layer deleted *after* being attached (real AWS
doesn't re-validate layers on invoke either).

The three package-private test-only constructors (predating layer support) now assign the new
field `null`, and `validateLayersResolvable` short-circuits on it - following this class's own
existing convention for optional test-nulled dependencies (see the `s3Service`/`aliasStore`/
`esmStore` null-guards already throughout this file). Existing tests using those constructors are
unaffected.

Also fixes `docs/services/lambda.md`, which still described layer support as entirely
stubbed/unimplemented - `PublishLayerVersion`, `GetLayerVersion`, `ListLayerVersions`,
`ListLayers`, and `DeleteLayerVersion` were all actually implemented already, just never
documented as such.

## Tests

- `LambdaLayerIntegrationTest`: 2 new tests covering `CreateFunction` and
  `UpdateFunctionConfiguration` both rejecting an unresolvable layer ARN and leaving existing state
  unchanged (function not created / layers not modified).

Ran locally (JDK 25):
```
LambdaLayerIntegrationTest:                                    21/21 passed
LambdaServiceTest/PersistenceTest/ImageConfigTest/
  EventInvokeConfigTest/ContainerLauncherTest (constructor-affected): 114/114 passed
```