### PR TITLE
fix(apigateway): honor configured execute-api hostname

### DIFF
--- a/compatibility-tests/sdk-test-node/tests/apigatewayv2-execute-api-subdomain.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/apigatewayv2-execute-api-subdomain.test.ts
@@ -59,6 +59,12 @@ function builtinSuffixHost(apiId: string): string {
   return `${apiId}.execute-api.localhost.floci.io${port}`;
 }
 
+function configuredHostnameHost(apiId: string, region: string): string {
+  const endpoint = new URL(ENDPOINT);
+  const port = endpoint.port ? `:${endpoint.port}` : '';
+  return `${apiId}.execute-api.${region}.${endpoint.hostname}${port}`;
+}
+
 /**
  * A Management API client that presents an execute-api Host header while still connecting to the
  * real test endpoint. A build-step middleware overrides the `Host` header (before SigV4 signing)
@@ -181,6 +187,21 @@ describe('API Gateway v2 execute-api subdomain routing', () => {
 
     await expect(
       mgmt.send(new PostToConnectionCommand({ ConnectionId: 'does-not-exist', Data: Buffer.from('hi') }))
+    ).rejects.toMatchObject({ name: 'GoneException' });
+  });
+
+  it('routes @connections through the region-bearing configured hostname (not S3)', async () => {
+    const region = 'ap-northeast-2';
+    const stage = 'prod';
+    const apiId = await createWsApiWithStage('configured-host-conn', region, stage);
+    const host = configuredHostnameHost(apiId, region);
+    const mgmt = managementClientForHost(host, stage, region);
+
+    // The Node compatibility container connects to the Compose service at floci:4566, while
+    // FLOCI_HOSTNAME=floci. Present the AWS-shaped region-bearing virtual host through the SDK's
+    // signed Host header so this proves configured-host routing without wildcard DNS.
+    await expect(
+      mgmt.send(new GetConnectionCommand({ ConnectionId: 'does-not-exist' }))
     ).rejects.toMatchObject({ name: 'GoneException' });
   });
 

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteApiHostFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteApiHostFilter.java
@@ -12,6 +12,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.ext.Provider;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 import java.net.URI;
@@ -25,23 +26,15 @@ import java.util.regex.Pattern;
 public class ApiGatewayExecuteApiHostFilter implements ContainerRequestFilter {
 
     private static final Logger LOG = Logger.getLogger(ApiGatewayExecuteApiHostFilter.class);
-    // Accepts both the region-bearing AWS shape and Floci's built-in DNS suffixes:
-    //   {apiId}.execute-api.{region}.localhost[:port]        (local, region-bearing)
-    //   {apiId}.execute-api.{region}.amazonaws.com           (real AWS shape)
-    //   {apiId}.execute-api.localhost.floci.io               (built-in suffix, regionless)
-    //   {apiId}.execute-api.localhost.localstack.cloud       (built-in suffix, regionless)
-    // AWS's invoke URL carries the region in the hostname, so the region-bearing form is the
-    // primary target; the regionless built-in suffixes are kept for local convenience (region is
-    // then recovered from the SigV4 scope or a cross-region apiId lookup). Group 1 = apiId.
-    private static final Pattern EXECUTE_API_HOST = Pattern.compile(
-            "^([a-z0-9-]+)\\.execute-api\\."
-                    + "(?:[a-z]{2}-[a-z-]+-\\d+\\.(?:localhost|amazonaws\\.com)"
-                    + "|localhost\\.(?:floci\\.io|localstack\\.cloud))$",
+    private static final Pattern EXECUTE_API_PREFIX = Pattern.compile("^([a-z0-9-]+)\\.execute-api\\.(.+)$",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern AWS_REGION = Pattern.compile("^[a-z]{2}-[a-z-]+-\\d+$",
             Pattern.CASE_INSENSITIVE);
 
     private final ApiGatewayLookup apiGatewayLookup;
     private final RegionResolver regionResolver;
     private final ApiGatewayExecuteRouteContext routeContext;
+    private final String baseHostname;
 
     @Inject
     public ApiGatewayExecuteApiHostFilter(ApiGatewayV2Service apiGatewayV2Service,
@@ -67,18 +60,24 @@ public class ApiGatewayExecuteApiHostFilter implements ContainerRequestFilter {
             public void requireStage(String region, String apiId, String stageName) {
                 apiGatewayV2Service.getStage(region, apiId, stageName);
             }
-        }, regionResolver, routeContext);
+        }, regionResolver, routeContext, null);
     }
 
     ApiGatewayExecuteApiHostFilter(ApiGatewayLookup apiGatewayLookup, RegionResolver regionResolver) {
-        this(apiGatewayLookup, regionResolver, new ApiGatewayExecuteRouteContext());
+        this(apiGatewayLookup, regionResolver, new ApiGatewayExecuteRouteContext(), "localhost");
     }
 
     ApiGatewayExecuteApiHostFilter(ApiGatewayLookup apiGatewayLookup, RegionResolver regionResolver,
                                    ApiGatewayExecuteRouteContext routeContext) {
+        this(apiGatewayLookup, regionResolver, routeContext, "localhost");
+    }
+
+    ApiGatewayExecuteApiHostFilter(ApiGatewayLookup apiGatewayLookup, RegionResolver regionResolver,
+                                   ApiGatewayExecuteRouteContext routeContext, String baseHostname) {
         this.apiGatewayLookup = apiGatewayLookup;
         this.regionResolver = regionResolver;
         this.routeContext = routeContext;
+        this.baseHostname = baseHostname;
     }
 
     @Override
@@ -88,12 +87,10 @@ public class ApiGatewayExecuteApiHostFilter implements ContainerRequestFilter {
             return;
         }
 
-        Matcher matcher = EXECUTE_API_HOST.matcher(stripPort(host));
-        if (!matcher.matches()) {
+        String apiId = extractApiId(host, baseHostname != null ? baseHostname : configuredHostname());
+        if (apiId == null) {
             return;
         }
-
-        String apiId = matcher.group(1).toLowerCase(Locale.ROOT);
         // Region: the host label when it is a real AWS region (…execute-api.{region}.…), else the
         // SigV4 credential scope. The cross-region apiId scan (resolveApiRegion) is the final
         // fallback so an API created outside the default region still resolves — including on the
@@ -185,17 +182,63 @@ public class ApiGatewayExecuteApiHostFilter implements ContainerRequestFilter {
     }
 
     /**
-     * Extracts the {@code apiId} from an execute-api virtual host, or {@code null} when the host
-     * is not an execute-api host. Shared with the WebSocket {@code $connect} handler so the host
-     * grammar lives in exactly one place (this filter and the handler must agree on which hosts
-     * are execute-api hosts).
+     * Resolves the optional hostname override at request time so native images do not capture a
+     * build-time value before container-specific environment configuration is applied.
+     */
+    public static String configuredHostname() {
+        return ConfigProvider.getConfig().getOptionalValue("floci.hostname", String.class).orElse("localhost");
+    }
+
+    /**
+     * Extracts the {@code apiId} from an execute-api virtual host using the configured hostname.
+     */
+    public static String extractApiIdForConfiguredHostname(String host) {
+        return extractApiId(host, configuredHostname());
+    }
+
+    /**
+     * Extracts the {@code apiId} from an execute-api virtual host using the default local hostname.
+     *
+     * @see #extractApiId(String, String)
      */
     public static String extractApiId(String host) {
+        return extractApiId(host, "localhost");
+    }
+
+    /**
+     * Extracts the {@code apiId} from an execute-api virtual host, or {@code null} when the host
+     * is not an execute-api host. Region-bearing hosts accept the configured Floci hostname, the
+     * local {@code localhost} form, and AWS's {@code amazonaws.com} form. The public built-in
+     * suffixes remain regionless convenience forms.
+     */
+    public static String extractApiId(String host, String baseHostname) {
         if (host == null) {
             return null;
         }
-        Matcher matcher = EXECUTE_API_HOST.matcher(stripPort(host));
-        return matcher.matches() ? matcher.group(1).toLowerCase(Locale.ROOT) : null;
+
+        Matcher matcher = EXECUTE_API_PREFIX.matcher(stripPort(host));
+        if (!matcher.matches()) {
+            return null;
+        }
+
+        String tail = matcher.group(2);
+        if ("localhost.floci.io".equalsIgnoreCase(tail)
+                || "localhost.localstack.cloud".equalsIgnoreCase(tail)) {
+            return matcher.group(1).toLowerCase(Locale.ROOT);
+        }
+
+        int firstDot = tail.indexOf('.');
+        if (firstDot <= 0 || !AWS_REGION.matcher(tail.substring(0, firstDot)).matches()) {
+            return null;
+        }
+
+        String endpointHost = tail.substring(firstDot + 1);
+        if ("localhost".equalsIgnoreCase(endpointHost)
+                || "amazonaws.com".equalsIgnoreCase(endpointHost)
+                || (baseHostname != null && baseHostname.equalsIgnoreCase(endpointHost))) {
+            return matcher.group(1).toLowerCase(Locale.ROOT);
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteApiHostFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteApiHostFilter.java
@@ -1,9 +1,11 @@
 package io.github.hectorvent.floci.services.apigateway;
 
+import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.services.apigatewayv2.ApiGatewayV2Service;
 import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
@@ -12,7 +14,6 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.ext.Provider;
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
 import java.net.URI;
@@ -23,6 +24,7 @@ import java.util.regex.Pattern;
 @Provider
 @PreMatching
 @Priority(9)
+@ApplicationScoped
 public class ApiGatewayExecuteApiHostFilter implements ContainerRequestFilter {
 
     private static final Logger LOG = Logger.getLogger(ApiGatewayExecuteApiHostFilter.class);
@@ -39,7 +41,8 @@ public class ApiGatewayExecuteApiHostFilter implements ContainerRequestFilter {
     @Inject
     public ApiGatewayExecuteApiHostFilter(ApiGatewayV2Service apiGatewayV2Service,
                                           RegionResolver regionResolver,
-                                          ApiGatewayExecuteRouteContext routeContext) {
+                                          ApiGatewayExecuteRouteContext routeContext,
+                                          EmulatorConfig config) {
         this(new ApiGatewayLookup() {
             @Override
             public String resolveApiRegion(String preferredRegion, String apiId) {
@@ -60,7 +63,7 @@ public class ApiGatewayExecuteApiHostFilter implements ContainerRequestFilter {
             public void requireStage(String region, String apiId, String stageName) {
                 apiGatewayV2Service.getStage(region, apiId, stageName);
             }
-        }, regionResolver, routeContext, null);
+        }, regionResolver, routeContext, config.hostname().orElse("localhost"));
     }
 
     ApiGatewayExecuteApiHostFilter(ApiGatewayLookup apiGatewayLookup, RegionResolver regionResolver) {
@@ -87,7 +90,7 @@ public class ApiGatewayExecuteApiHostFilter implements ContainerRequestFilter {
             return;
         }
 
-        String apiId = extractApiId(host, baseHostname != null ? baseHostname : configuredHostname());
+        String apiId = extractApiId(host, baseHostname);
         if (apiId == null) {
             return;
         }
@@ -179,30 +182,6 @@ public class ApiGatewayExecuteApiHostFilter implements ContainerRequestFilter {
         boolean executeApiEndpointDisabled(String region, String apiId);
 
         void requireStage(String region, String apiId, String stageName);
-    }
-
-    /**
-     * Resolves the optional hostname override at request time so native images do not capture a
-     * build-time value before container-specific environment configuration is applied.
-     */
-    public static String configuredHostname() {
-        return ConfigProvider.getConfig().getOptionalValue("floci.hostname", String.class).orElse("localhost");
-    }
-
-    /**
-     * Extracts the {@code apiId} from an execute-api virtual host using the configured hostname.
-     */
-    public static String extractApiIdForConfiguredHostname(String host) {
-        return extractApiId(host, configuredHostname());
-    }
-
-    /**
-     * Extracts the {@code apiId} from an execute-api virtual host using the default local hostname.
-     *
-     * @see #extractApiId(String, String)
-     */
-    public static String extractApiId(String host) {
-        return extractApiId(host, "localhost");
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/websocket/WebSocketHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/websocket/WebSocketHandler.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.apigateway.ApiGatewayExecuteApiHostFilter;
 import io.github.hectorvent.floci.services.apigatewayv2.ApiGatewayV2Service;
 import io.github.hectorvent.floci.services.apigatewayv2.model.Api;
 import io.github.hectorvent.floci.services.apigatewayv2.model.Integration;
@@ -97,7 +98,7 @@ public class WebSocketHandler {
      */
     private void handleSubdomainWebSocketUpgrade(RoutingContext ctx) {
         String host = resolveRequestHost(ctx);
-        String apiId = io.github.hectorvent.floci.services.apigateway.ApiGatewayExecuteApiHostFilter.extractApiId(host);
+        String apiId = ApiGatewayExecuteApiHostFilter.extractApiIdForConfiguredHostname(host);
         if (apiId == null) {
             ctx.next();
             return;

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/websocket/WebSocketHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/websocket/WebSocketHandler.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.apigatewayv2.websocket;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.services.apigateway.ApiGatewayExecuteApiHostFilter;
@@ -46,6 +47,7 @@ public class WebSocketHandler {
     private final WebSocketIntegrationInvoker integrationInvoker;
     private final WebSocketAuthorizerService authorizerService;
     private final RegionResolver regionResolver;
+    private final String baseHostname;
     private final ObjectMapper objectMapper;
     private final io.vertx.core.Vertx vertx;
 
@@ -57,6 +59,7 @@ public class WebSocketHandler {
                             WebSocketIntegrationInvoker integrationInvoker,
                             WebSocketAuthorizerService authorizerService,
                             RegionResolver regionResolver,
+                            EmulatorConfig config,
                             ObjectMapper objectMapper,
                             io.vertx.core.Vertx vertx) {
         this.apiGatewayV2Service = apiGatewayV2Service;
@@ -66,6 +69,7 @@ public class WebSocketHandler {
         this.integrationInvoker = integrationInvoker;
         this.authorizerService = authorizerService;
         this.regionResolver = regionResolver;
+        this.baseHostname = config.hostname().orElse("localhost");
         this.objectMapper = objectMapper;
         this.vertx = vertx;
     }
@@ -98,7 +102,7 @@ public class WebSocketHandler {
      */
     private void handleSubdomainWebSocketUpgrade(RoutingContext ctx) {
         String host = resolveRequestHost(ctx);
-        String apiId = ApiGatewayExecuteApiHostFilter.extractApiIdForConfiguredHostname(host);
+        String apiId = ApiGatewayExecuteApiHostFilter.extractApiId(host, baseHostname);
         if (apiId == null) {
             ctx.next();
             return;

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteApiHostFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteApiHostFilterTest.java
@@ -182,6 +182,24 @@ class ApiGatewayExecuteApiHostFilterTest {
     }
 
     @Test
+    void routesRegionBearingConfiguredHost() {
+        FakeApiGatewayLookup lookup = new FakeApiGatewayLookup();
+        lookup.addApi("ap-northeast-2", API_ID, "HTTP");
+        lookup.addStage("ap-northeast-2", API_ID, "$default");
+        RecordingRequest request = new RecordingRequest(
+                "abc123.execute-api.ap-northeast-2.floci:4566",
+                URI.create("http://abc123.execute-api.ap-northeast-2.floci:4566/accounts"));
+        ApiGatewayExecuteRouteContext routeContext = new ApiGatewayExecuteRouteContext();
+
+        new ApiGatewayExecuteApiHostFilter(
+                lookup, new RegionResolver(REGION, "000000000000"), routeContext, "floci")
+                .filter(request.context());
+
+        assertEquals("/execute-api/abc123/$default/accounts", request.routedUri().getRawPath());
+        assertEquals("ap-northeast-2", routeContext.httpApiRegion());
+    }
+
+    @Test
     void routesWebSocketConnectionsManagementCall() {
         FakeApiGatewayLookup lookup = new FakeApiGatewayLookup();
         lookup.addApi(REGION, API_ID, "WEBSOCKET");

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteApiHostIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteApiHostIntegrationTest.java
@@ -2,6 +2,8 @@ package io.github.hectorvent.floci.services.apigateway;
 
 import com.sun.net.httpserver.HttpServer;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -13,12 +15,14 @@ import org.junit.jupiter.api.TestMethodOrder;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
 @QuarkusTest
+@TestProfile(ApiGatewayExecuteApiHostIntegrationTest.ConfiguredHostnameProfile.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ApiGatewayExecuteApiHostIntegrationTest {
 
@@ -138,6 +142,17 @@ class ApiGatewayExecuteApiHostIntegrationTest {
 
     @Test
     @Order(6)
+    void invokesRegionBearingConfiguredHost() {
+        given()
+                .header("Host", apiId + ".execute-api." + REGION + ".floci:4566")
+                .when().get("/accounts")
+                .then()
+                .statusCode(200)
+                .body("path", equalTo("/backend"));
+    }
+
+    @Test
+    @Order(7)
     void createsRestApiWithSameIdentifier() {
         given()
                 .contentType(ContentType.JSON)
@@ -218,7 +233,7 @@ class ApiGatewayExecuteApiHostIntegrationTest {
     }
 
     @Test
-    @Order(7)
+    @Order(8)
     void directPathPrefersRestApiWhenIdentifiersCollide() {
         given()
                 .when().get("/execute-api/" + apiId + "/dev/accounts")
@@ -228,7 +243,7 @@ class ApiGatewayExecuteApiHostIntegrationTest {
     }
 
     @Test
-    @Order(8)
+    @Order(9)
     void hostPathRetainsHttpApiRoutingWhenIdentifiersCollide() {
         given()
                 .header("Host", apiId + ".execute-api.localhost.floci.io")
@@ -239,7 +254,7 @@ class ApiGatewayExecuteApiHostIntegrationTest {
     }
 
     @Test
-    @Order(9)
+    @Order(10)
     void disabledExecuteApiEndpointReturnsNotFoundAndCanBeReenabled() {
         given()
                 .header("Authorization", AUTHORIZATION)
@@ -281,7 +296,7 @@ class ApiGatewayExecuteApiHostIntegrationTest {
      * so its direct path resolves to REST and never reaches the v2 dispatch this guards.
      */
     @Test
-    @Order(10)
+    @Order(11)
     void disabledExecuteApiEndpointAlsoRejectsTheDirectPath() {
         String isolatedApiId = given()
                 .header("Authorization", AUTHORIZATION)
@@ -313,5 +328,12 @@ class ApiGatewayExecuteApiHostIntegrationTest {
                 .when().post("/v2/apis/" + apiId + "/stages")
                 .then()
                 .statusCode(201);
+    }
+
+    public static class ConfiguredHostnameProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci.hostname", "floci");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #2284.

## Problem

`ApiGatewayExecuteApiHostFilter` only recognized region-bearing execute-api hosts ending in `localhost` or `amazonaws.com`. With `FLOCI_HOSTNAME=floci`, requests to `{apiId}.execute-api.{region}.floci` fell through to unrelated routing, including the S3 path controller for WebSocket `@connections` calls.

## Why it matters

Docker Compose and the compatibility pipeline configure Floci as `floci`. Without this fix, the AWS-shaped region-bearing execute-api endpoint cannot be used in that supported configuration and fails with a misleading response.

## Fix

The shared execute-api host parser now accepts the configured `floci.hostname` alongside the existing AWS, `localhost`, and built-in public suffix forms. HTTP execute-api routing and WebSocket upgrades share the same parser. Both application-scoped beans capture `EmulatorConfig.hostname()` once at runtime construction, following the existing `S3VirtualHostFilter` pattern and avoiding both native-image static-property capture and per-request config lookups.

## Tests

- Added a host-filter regression for `abc123.execute-api.ap-northeast-2.floci`.
- Added a Quarkus integration test with `floci.hostname=floci`.
- Added an AWS SDK for JavaScript v3 compatibility test that sends a signed region-bearing configured `Host` header through the CI Docker topology.
- Focused Java regressions (`ApiGatewayExecuteApiHostFilterTest`, `ApiGatewayExecuteApiHostIntegrationTest`, and `ApiGatewayV2WebSocketIntegrationTest`): **46 passed**.
- CI-shaped focused Node suite `apigatewayv2-execute-api-subdomain.test.ts`: **5 passed**.

## Manual verification

Ran the prescribed local Docker topology against the latest follow-up commit:

- Built `floci:test` with `docker/Dockerfile`.
- Started `floci` on `compat-net` with `FLOCI_HOSTNAME=floci`, TLS, Docker networking, and Lambda hot reload enabled.
- Built `compat-sdk-test-node` and ran `vitest run tests/apigatewayv2-execute-api-subdomain.test.ts` with `FLOCI_ENDPOINT=http://floci:4566` and the required `sdk-vhost-bucket.floci` host mapping.
- Result: **5 passed, 0 failed**.

## Native compatibility correction

The first native compatibility run exposed a startup failure when runtime `floci.hostname=floci` differed from a value injected during native static initialization. The initial revision removed constructor-time `@ConfigProperty` capture. The follow-up now uses the established runtime-initialized `EmulatorConfig` mapping once at application-bean construction, matching `S3VirtualHostFilter` without per-request lookup. The native compatibility matrix has been re-triggered for this revision.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## AWS compatibility

Preserves existing `localhost`, `amazonaws.com`, and built-in suffix host forms while adding the configured-host form that corresponds to AWS's `{apiId}.execute-api.{region}.{host}` endpoint shape.

## Checklist

- [x] Regression coverage added
- [x] Focused Java and Node compatibility validation completed
- [x] Native runtime configuration startup path addressed
- [x] Commit follows Conventional Commits


