### PR TITLE
fix(test): pass the managed prefix list store in Ec2PublicIpOnLaunchTest

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2PublicIpOnLaunchTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2PublicIpOnLaunchTest.java
@@ -10,6 +10,7 @@ import io.github.hectorvent.floci.services.ec2.model.InternetGateway;
 import io.github.hectorvent.floci.services.ec2.model.KeyPair;
 import io.github.hectorvent.floci.services.ec2.model.LaunchTemplate;
 import io.github.hectorvent.floci.services.ec2.model.NatGateway;
+import io.github.hectorvent.floci.services.ec2.model.ManagedPrefixList;
 import io.github.hectorvent.floci.services.ec2.model.NetworkAcl;
 import io.github.hectorvent.floci.services.ec2.model.Instance;
 import io.github.hectorvent.floci.services.ec2.model.Reservation;
@@ -159,6 +160,7 @@ class Ec2PublicIpOnLaunchTest {
                 load(dir, "ec2-nat-gateways.json", new TypeReference<Map<String, NatGateway>>() {}),
                 load(dir, "ec2-spot-instance-requests.json", new TypeReference<Map<String, SpotInstanceRequest>>() {}),
                 load(dir, "ec2-network-acls.json", new TypeReference<Map<String, NetworkAcl>>() {}),
+                load(dir, "ec2-managed-prefix-lists.json", new TypeReference<Map<String, ManagedPrefixList>>() {}),
                 load(dir, "ec2-tags.json", new TypeReference<Map<String, List<Tag>>>() {}));
     }
 


### PR DESCRIPTION
Closes #2287.

`main` does not compile: `Ec2PublicIpOnLaunchTest` calls the package-private `Ec2Service` constructor with the parameter list it had before #2105 added the managed prefix list store. The call goes straight from `ec2-network-acls.json` to `ec2-tags.json`, missing `ec2-managed-prefix-lists.json` between them.

`#2023` was written before #2105 landed and merged after it without a rebase. Worth saying plainly that #2105 is mine — the parameter that moved is the one I added, so this is my change colliding with an in-flight PR rather than a defect in #2023's own work.

## Verified

CI on `main` reproduces the failure independently of my machine — [run 31767114963](https://github.com/floci-io/floci/actions/runs/31767114963) at 03:32, same file and line, and the `Nightly` run failed with it at 04:31.

With this one argument added, `main` compiles and `Ec2PublicIpOnLaunchTest` passes 2/2. The full EC2 suite is green at 331 tests, so #2023's behaviour is intact — it only ever needed the extra store.

## Note

This is the second time an added store has broken a caller that was in flight: @hampsterx caught the same shape on #2106, where `IamServiceTestHelper` resolves the constructor reflectively and so broke at run time rather than compile time. If these long package-private constructors became a builder, an added store could not break callers that never mention it. Happy to open that separately if it is wanted.
