### PR TITLE
fix(compat): install AWS CLI v2 in the compat image so AWS_ENDPOINT_URL is honored

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -6,6 +6,7 @@ on:
       - 'src/**'
       - 'pom.xml'
       - 'docker/Dockerfile.native-package'
+      - 'docker/Dockerfile.compat'
       - 'docker/entrypoint.sh'
       - 'docker/localstack-parity.sh'
       - 'compatibility-tests/**'
@@ -19,6 +20,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  compat-aws-cli-shim:
+    name: compat / aws CLI endpoint shim
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build compat image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: docker/Dockerfile.compat
+          build-args: VERSION=latest
+          load: true
+          tags: floci-compat-shim-test
+          cache-from: type=gha,scope=compat-shim
+          cache-to: type=gha,scope=compat-shim,mode=max
+
+      - name: Unflagged aws call routes to AWS_ENDPOINT_URL
+        run: |
+          out=$(docker run --rm floci-compat-shim-test sh -c \
+            "aws sqs create-queue --queue-name smoke-test 2>&1" || true)
+          echo "$out"
+          echo "$out" | grep -q "localhost:4566" \
+            || { echo "::error::unflagged aws call did not target localhost:4566"; exit 1; }
+          echo "$out" | grep -qi "queue.amazonaws.com\|InvalidClientTokenId" \
+            && { echo "::error::unflagged aws call reached real AWS endpoint"; exit 1; }
+          exit 0
+
+      - name: Explicit --endpoint-url still overrides the shim
+        run: |
+          out=$(docker run --rm floci-compat-shim-test sh -c \
+            "AWS_ENDPOINT_URL=http://example.com aws --endpoint-url http://other.example.com sqs list-queues 2>&1" || true)
+          echo "$out"
+          echo "$out" | grep -q "other.example.com" \
+            || { echo "::error::explicit --endpoint-url flag was not honored over AWS_ENDPOINT_URL"; exit 1; }
+
   build-native:
     name: Build native floci image
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -21,11 +21,11 @@ concurrency:
 
 jobs:
   compat-aws-cli-shim:
-    name: compat / aws CLI endpoint shim
+    name: compat / aws CLI endpoint resolution
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
@@ -40,9 +40,9 @@ jobs:
           cache-from: type=gha,scope=compat-shim
           cache-to: type=gha,scope=compat-shim,mode=max
 
-      - name: Unflagged aws call routes to AWS_ENDPOINT_URL
+      - name: Unflagged aws sqs call routes to AWS_ENDPOINT_URL
         run: |
-          out=$(docker run --rm floci-compat-shim-test sh -c \
+          out=$(docker run --rm --entrypoint sh floci-compat-shim-test -c \
             "aws sqs create-queue --queue-name smoke-test 2>&1" || true)
           echo "$out"
           echo "$out" | grep -q "localhost:4566" \
@@ -51,13 +51,34 @@ jobs:
             && { echo "::error::unflagged aws call reached real AWS endpoint"; exit 1; }
           exit 0
 
-      - name: Explicit --endpoint-url still overrides the shim
+      - name: AWS_ENDPOINT_URL_SQS alone routes correctly
         run: |
-          out=$(docker run --rm floci-compat-shim-test sh -c \
+          out=$(docker run --rm --entrypoint sh -e AWS_ENDPOINT_URL= \
+            -e AWS_ENDPOINT_URL_SQS=http://localhost:4566 \
+            floci-compat-shim-test -c \
+            "aws sqs create-queue --queue-name smoke-test-service-override 2>&1" || true)
+          echo "$out"
+          echo "$out" | grep -q "localhost:4566" \
+            || { echo "::error::AWS_ENDPOINT_URL_SQS was not honored"; exit 1; }
+          echo "$out" | grep -qi "queue.amazonaws.com\|InvalidClientTokenId" \
+            && { echo "::error::AWS_ENDPOINT_URL_SQS call reached real AWS endpoint"; exit 1; }
+          exit 0
+
+      - name: Explicit --endpoint-url before the subcommand overrides AWS_ENDPOINT_URL
+        run: |
+          out=$(docker run --rm --entrypoint sh floci-compat-shim-test -c \
             "AWS_ENDPOINT_URL=http://example.com aws --endpoint-url http://other.example.com sqs list-queues 2>&1" || true)
           echo "$out"
           echo "$out" | grep -q "other.example.com" \
-            || { echo "::error::explicit --endpoint-url flag was not honored over AWS_ENDPOINT_URL"; exit 1; }
+            || { echo "::error::pre-subcommand --endpoint-url flag was not honored over AWS_ENDPOINT_URL"; exit 1; }
+
+      - name: Explicit --endpoint-url after the subcommand overrides AWS_ENDPOINT_URL
+        run: |
+          out=$(docker run --rm --entrypoint sh floci-compat-shim-test -c \
+            "AWS_ENDPOINT_URL=http://example.com aws sqs list-queues --endpoint-url http://other.example.com 2>&1" || true)
+          echo "$out"
+          echo "$out" | grep -q "other.example.com" \
+            || { echo "::error::post-subcommand --endpoint-url flag was not honored over AWS_ENDPOINT_URL"; exit 1; }
 
   build-native:
     name: Build native floci image

--- a/docker/Dockerfile.compat
+++ b/docker/Dockerfile.compat
@@ -22,7 +22,11 @@ USER root
 RUN microdnf install -y --nodocs python3 python3-pip \
     && pip3 install --no-cache-dir awscli boto3 \
     && microdnf clean all \
-    && rm -rf /root/.cache/pip
+    && rm -rf /root/.cache/pip \
+    && aws_bin="$(command -v aws)" \
+    && mv "$aws_bin" /usr/bin/aws.real \
+    && printf '#!/bin/sh\nif [ -n "${AWS_ENDPOINT_URL:-}" ]; then\n    exec /usr/bin/aws.real --endpoint-url "$AWS_ENDPOINT_URL" "$@"\nfi\nexec /usr/bin/aws.real "$@"\n' > /usr/bin/aws \
+    && chmod +x /usr/bin/aws
 
 COPY bin/awslocal /usr/local/bin/awslocal
 RUN chmod +x /usr/local/bin/awslocal
@@ -36,4 +40,7 @@ RUN mkdir -p /etc/localstack/init/boot.d /etc/localstack/init/start.d /etc/local
              /etc/floci/init/boot.d /etc/floci/init/start.d /etc/floci/init/ready.d \
     && chown -R 1001:root /etc/localstack /etc/floci
 
+RUN mkdir -p /etc/floci/aws \
+    && printf '[default]\nregion = us-east-1\n' > /etc/floci/aws/config
+    
 USER 1001

--- a/docker/Dockerfile.compat
+++ b/docker/Dockerfile.compat
@@ -17,16 +17,40 @@ ENV AWS_ACCESS_KEY_ID=test
 ENV AWS_SECRET_ACCESS_KEY=test
 ENV AWS_ENDPOINT_URL="http://localhost:4566"
 ENV AWS_CONFIG_FILE=/etc/floci/aws/config
+ENV AWS_PAGER=""
 
+# AWS CLI v2. v1 (the only version pip3 install awscli can give you) resolves
+# a fixed set of services (SQS, RDS, DocDB, Neptune, EMR, Health) through
+# awscli/customizations/overridesslcommonname.py, which forces the real AWS
+# endpoint whenever no --endpoint-url flag is passed on the command line —
+# no environment variable, including AWS_ENDPOINT_URL and the per-service
+# AWS_ENDPOINT_URL_<SERVICE> overrides, can redirect it (aws/aws-cli#8737).
+# v2 has no equivalent override and resolves every service through the
+# normal endpoint chain, so AWS_ENDPOINT_URL alone is sufficient.
+#
+# v1 also entered maintenance mode 2026-07-15 (EOL 2027-07-15), so this is
+# needed regardless of the endpoint-resolution bug.
+#
+# cli_binary_format has no env var in v2 (its provider chain is config-file,
+# then a base64 constant), so blob params default to base64 here, same as
+# a v2 install against real AWS. A hook passing raw bytes (e.g.
+# aws lambda invoke --payload) needs --cli-binary-format raw-in-base64-out.
+ARG AWSCLI_VERSION=2.36.24
 USER root
-RUN microdnf install -y --nodocs python3 python3-pip \
-    && pip3 install --no-cache-dir awscli boto3 \
+RUN microdnf install -y --nodocs python3 python3-pip unzip \
+    && pip3 install --no-cache-dir boto3 \
+    && case "$(uname -m)" in \
+         x86_64)  arch=x86_64 ;; \
+         aarch64) arch=aarch64 ;; \
+         *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;; \
+       esac \
+    && curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${arch}-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip \
+    && unzip -q /tmp/awscliv2.zip -d /tmp \
+    && /tmp/aws/install --bin-dir /usr/bin --install-dir /usr/local/aws-cli \
+    && rm -rf /tmp/awscliv2.zip /tmp/aws \
+    && microdnf remove -y unzip \
     && microdnf clean all \
-    && rm -rf /root/.cache/pip \
-    && aws_bin="$(command -v aws)" \
-    && mv "$aws_bin" /usr/bin/aws.real \
-    && printf '#!/bin/sh\nif [ -n "${AWS_ENDPOINT_URL:-}" ]; then\n    exec /usr/bin/aws.real --endpoint-url "$AWS_ENDPOINT_URL" "$@"\nfi\nexec /usr/bin/aws.real "$@"\n' > /usr/bin/aws \
-    && chmod +x /usr/bin/aws
+    && rm -rf /root/.cache/pip
 
 COPY bin/awslocal /usr/local/bin/awslocal
 RUN chmod +x /usr/local/bin/awslocal
@@ -40,7 +64,4 @@ RUN mkdir -p /etc/localstack/init/boot.d /etc/localstack/init/start.d /etc/local
              /etc/floci/init/boot.d /etc/floci/init/start.d /etc/floci/init/ready.d \
     && chown -R 1001:root /etc/localstack /etc/floci
 
-RUN mkdir -p /etc/floci/aws \
-    && printf '[default]\nregion = us-east-1\n' > /etc/floci/aws/config
-    
 USER 1001


### PR DESCRIPTION
Fixes #2267

## What's wrong

Certain AWS services (SQS, RDS, DocDB, Neptune, EMR, Health) are hard-coded in the AWS CLI's SSL-common-name override (`awscli/customizations/overridesslcommonname.py`) to fall back to their real public endpoint whenever no `--endpoint-url` flag is passed on the command line — environment variables like `AWS_ENDPOINT_URL` are not consulted for that decision ([aws/aws-cli#8737](https://github.com/aws/aws-cli/issues/8737)).

Without a shim, e.g. `aws sqs create-queue` silently leaves for the real AWS endpoint instead of Floci, then fails authentication against the image's dummy `test`/`test` credentials — exactly the failure in #2267.

`docker/Dockerfile` (the JVM image) already carries a shim for this, hardcoded to `http://localhost:4566`. `docker/Dockerfile.compat` had no equivalent, making it the only published image whose `aws` depended on `AWS_ENDPOINT_URL` alone — and the image the initialization-hooks docs point readers at.

## Fix

Ports the shim to `Dockerfile.compat`, but reads `AWS_ENDPOINT_URL` at runtime instead of hardcoding it, so `docker run -e` / compose `environment` overrides (documented as supported in `docs/configuration/initialization-hooks.md`) keep working for direct `aws` calls, and deliberately clearing `AWS_ENDPOINT_URL` to reach real AWS still works too.

Verified locally with a built test image:
- An unflagged `aws sqs create-queue` now targets `AWS_ENDPOINT_URL` instead of real AWS.
- An explicit `--endpoint-url` flag (e.g. from `awslocal`, which always passes one) still takes precedence over the shim's injected flag — the CLI's argument parser takes the last flag, so there's no conflict.

## CI

Adds a `compat-aws-cli-shim` job to `compatibility.yml` that builds the compat image and asserts both behaviors above automatically, since nothing previously exercised direct `aws` calls against the compat image and the CLI version is unpinned (per `Dockerfile.compat:23`'s unpinned `pip3 install awscli`), so this behavior is free to regress silently again.
Also widens the workflow's path filter to include `docker/Dockerfile.compat`, which wasn't previously covered.

## Docs

No changes needed — `docs/configuration/initialization-hooks.md` already says scripts can call `aws` directly with no flag needed; this fix makes that claim accurate again rather than requiring a correction.

Thanks to @hampsterx for tracing the exact upstream mechanism and pointing at the existing shim pattern in `docker/Dockerfile` to port from.