### PR TITLE
docs: add MAINTAINERS.md and route application code to the repo maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,19 @@
 # CODEOWNERS for floci
 #
-# Scopes release-sensitive paths to the primary maintainer so CI, release
-# config, and Dockerfile changes always trigger a review ping. Add more
-# owners as the maintainer roster grows.
+# Routes application code to this repository's maintainers (see MAINTAINERS.md) and keeps
+# release-sensitive paths with the Lead, per the org-wide GOVERNANCE.md.
+#
+# Order matters: the LAST matching pattern wins, so the Lead-reserved paths below stay
+# authoritative over the broader area rules above them.
 #
 # Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default: no global owner (unowned files fall through to normal review rules).
+
+# Application code
+/src/                    @hectorvent @pgermosen
+/compatibility-tests/    @hectorvent @pgermosen
+/docs/                   @hectorvent @pgermosen
 
 # CI, release automation, workflow hygiene
 /.github/                @hectorvent

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,15 @@
+# Maintainers
+
+This file lists the people responsible for this repository. See the org-wide
+[GOVERNANCE.md](https://github.com/floci-io/.github/blob/main/GOVERNANCE.md) for roles and the
+path to becoming a Maintainer.
+
+## Lead Maintainer
+- Hector Ventura (@hectorvent): final authority across the project.
+
+## Maintainers (this repository)
+- Hector Ventura (@hectorvent): the AWS emulator, and its release infrastructure.
+- Priamo Germosen (@pgermosen): AWS service emulation.
+
+## Emeritus
+- (none yet)


### PR DESCRIPTION
## Why

The org-wide [GOVERNANCE.md](https://github.com/floci-io/.github/blob/main/GOVERNANCE.md) says, under the Maintainer role:

> Maintainers are listed in each repository's `MAINTAINERS.md`.

No repository in the org had one. This is part of a rollout that makes that sentence true across `floci-io`.

## What

**`MAINTAINERS.md`**, a verbatim copy of the org-level template with the entries changed, so the family stays one shape rather than seventeen dialects. `GOVERNANCE.md` is deliberately **not** copied here: it is one of GitHub's supported default community health files, so it is already inherited from `floci-io/.github`, and a local copy would silently override the inherited one. The template links it by absolute URL instead.

**`.github/CODEOWNERS`** gains area rules routing application code to this repository's maintainers.

- Every Lead-reserved path is unchanged: `/.github/`, `/.releaserc.json`, `/pom.xml`, `/docker/`.
- No `*` default owner. A default owner would auto-request one person on every PR, which turns a bus-factor fix into a bottleneck.
- The header now records that the **last** matching pattern wins, which is what keeps the Lead-reserved paths authoritative over the broader area rules above them.

## Verification

- `GET /repos/floci-io/floci/codeowners/errors?ref=docs/maintainer-roster` returns no errors. Worth checking explicitly: a `CODEOWNERS` handle without write access to the repo is ignored silently, with no error surfaced anywhere.
- @pgermosen confirmed at `write` on this repository.
- Documentation and repository config only. No source, build inputs, or runtime behavior touched.