### PR TITLE
test(ses): guard LastKeyGenerationTimestamp fractional-epoch wire format

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesIdentityAttributesTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesIdentityAttributesTest.java
@@ -45,6 +45,7 @@ import software.amazon.awssdk.services.sesv2.model.PutEmailIdentityDkimSigningAt
 import software.amazon.awssdk.services.sesv2.model.PutEmailIdentityMailFromAttributesRequest;
 import software.amazon.awssdk.services.sesv2.model.VerificationStatus;
 
+import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -279,6 +280,16 @@ class SesIdentityAttributesTest {
                         .build());
         assertThat(resp.dkimTokens()).hasSize(3);
         assertThat(resp.dkimTokens()).isNotEqualTo(before);
+
+        // Regression guard for the fractional-epoch wire form of LastKeyGenerationTimestamp: SES v2
+        // types it as a unix-epoch number, and AWS emits sub-second precision, so Floci serializes
+        // toEpochMilli()/1000.0 rather than getEpochSecond() (which would silently drop the millis the
+        // SDK unmarshalls happily). Assert the round-tripped timestamp keeps a sub-second component so
+        // a switch to whole-second epoch is caught here.
+        Instant lastKeyGen = sesV2.getEmailIdentity(GetEmailIdentityRequest.builder()
+                .emailIdentity(dkimDomain).build()).dkimAttributes().lastKeyGenerationTimestamp();
+        assertThat(lastKeyGen).isNotNull();
+        assertThat(lastKeyGen.getNano()).isNotZero();
     }
 
     @Test

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesIdentityAttributesTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesIdentityAttributesTest.java
@@ -289,7 +289,26 @@ class SesIdentityAttributesTest {
         Instant lastKeyGen = sesV2.getEmailIdentity(GetEmailIdentityRequest.builder()
                 .emailIdentity(dkimDomain).build()).dkimAttributes().lastKeyGenerationTimestamp();
         assertThat(lastKeyGen).isNotNull();
-        assertThat(lastKeyGen.getNano()).isNotZero();
+        // The timestamp comes from an uncontrolled server clock; toEpochMilli()/1000.0 yields
+        // millisecond precision, so getNano() is a multiple of 1e6 and is zero only when the instant
+        // lands on a whole millisecond-of-second (~0.1%) — a boundary where whole-second epoch would
+        // also round-trip and the guard is blind. Regenerate the key (alternating length so a fresh
+        // key is minted each time) until a sub-second component appears, keeping the check meaningful
+        // without the rare flake.
+        DkimSigningKeyLength[] lengths = {DkimSigningKeyLength.RSA_2048_BIT, DkimSigningKeyLength.RSA_1024_BIT};
+        for (int attempt = 0; lastKeyGen.getNano() == 0 && attempt < 5; attempt++) {
+            sesV2.putEmailIdentityDkimSigningAttributes(PutEmailIdentityDkimSigningAttributesRequest.builder()
+                    .emailIdentity(dkimDomain)
+                    .signingAttributesOrigin(DkimSigningAttributesOrigin.AWS_SES)
+                    .signingAttributes(DkimSigningAttributes.builder()
+                            .nextSigningKeyLength(lengths[attempt % 2]).build())
+                    .build());
+            lastKeyGen = sesV2.getEmailIdentity(GetEmailIdentityRequest.builder()
+                    .emailIdentity(dkimDomain).build()).dkimAttributes().lastKeyGenerationTimestamp();
+        }
+        assertThat(lastKeyGen.getNano())
+                .as("LastKeyGenerationTimestamp must retain sub-second precision (fractional epoch), not whole seconds")
+                .isNotZero();
     }
 
     @Test

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesIdentityAttributesTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesIdentityAttributesTest.java
@@ -267,7 +267,7 @@ class SesIdentityAttributesTest {
 
     @Test
     @Order(23)
-    void putEmailIdentityDkimSigningAttributes_regeneratesTokensOnKeyLengthChange() {
+    void putEmailIdentityDkimSigningAttributes_regeneratesTokensOnKeyLengthChange() throws InterruptedException {
         List<String> before = sesV2.getEmailIdentity(GetEmailIdentityRequest.builder()
                 .emailIdentity(dkimDomain).build()).dkimAttributes().tokens();
 
@@ -291,12 +291,14 @@ class SesIdentityAttributesTest {
         assertThat(lastKeyGen).isNotNull();
         // The timestamp comes from an uncontrolled server clock; toEpochMilli()/1000.0 yields
         // millisecond precision, so getNano() is a multiple of 1e6 and is zero only when the instant
-        // lands on a whole millisecond-of-second (~0.1%) — a boundary where whole-second epoch would
-        // also round-trip and the guard is blind. Regenerate the key (alternating length so a fresh
-        // key is minted each time) until a sub-second component appears, keeping the check meaningful
-        // without the rare flake.
+        // lands on a whole second (~0.1%) — a boundary where whole-second epoch would also round-trip
+        // and the guard is blind. Regenerate the key (alternating length so a fresh key is minted each
+        // time) until a sub-second component appears, keeping the check meaningful without the rare
+        // flake. The wait before each retry forces the next regeneration into a later millisecond, so
+        // the samples are independent and can't all collapse onto one zero-nanosecond instant.
         DkimSigningKeyLength[] lengths = {DkimSigningKeyLength.RSA_2048_BIT, DkimSigningKeyLength.RSA_1024_BIT};
         for (int attempt = 0; lastKeyGen.getNano() == 0 && attempt < 5; attempt++) {
+            Thread.sleep(2);
             sesV2.putEmailIdentityDkimSigningAttributes(PutEmailIdentityDkimSigningAttributesRequest.builder()
                     .emailIdentity(dkimDomain)
                     .signingAttributesOrigin(DkimSigningAttributesOrigin.AWS_SES)


### PR DESCRIPTION
## Summary

Follow-up to the DKIM actions work (#1904): adds the regression guard the reviewer asked for but that landed after the squash-merge.

`GetEmailIdentity` serializes `LastKeyGenerationTimestamp` as a fractional unix epoch (`toEpochMilli() / 1000.0`) so the SDK's number unmarshaller keeps the sub-second precision AWS sends; `getEpochSecond()` would silently drop it, and nothing in the suite caught that change. This adds an assertion to the existing compat test so the fractional form is guarded.

- `SesIdentityAttributesTest.putEmailIdentityDkimSigningAttributes_regeneratesTokensOnKeyLengthChange` now reads `dkimAttributes().lastKeyGenerationTimestamp()` back after the signing PUT and asserts it retains a sub-second component (`getNano()` is non-zero).

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

Verified against real AWS SES v2: `LastKeyGenerationTimestamp` is a `Timestamp` under `rest-json` with no explicit format, so the wire form is a unix-epoch number carrying sub-second precision. The guard asserts the SDK-unmarshalled value keeps that precision, catching a regression to whole-second epoch.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
