### PR TITLE
feat(opensearch): parse, store, and return AccessPolicies

### DIFF
--- a/docs/services/opensearch.md
+++ b/docs/services/opensearch.md
@@ -43,7 +43,7 @@ services:
 | `DescribeDomain` | `GET /2021-01-01/opensearch/domain/{name}` | Get domain details |
 | `DescribeDomains` | `POST /2021-01-01/opensearch/domain-info` | Batch describe domains |
 | `DescribeDomainConfig` | `GET /2021-01-01/opensearch/domain/{name}/config` | Get domain configuration |
-| `UpdateDomainConfig` | `POST /2021-01-01/opensearch/domain/{name}/config` | Update cluster config, EBS options, engine version |
+| `UpdateDomainConfig` | `POST /2021-01-01/opensearch/domain/{name}/config` | Update cluster config, EBS options, engine version, access policies |
 | `DeleteDomain` | `DELETE /2021-01-01/opensearch/domain/{name}` | Delete a domain |
 | `ListDomainNames` | `GET /2021-01-01/domain` | List all domains (supports `?engineType=` filter) |
 
@@ -236,6 +236,6 @@ os_client.delete_domain(DomainName="my-search")
 
 - In mock mode, no data-plane endpoints (`/_search`, `/_index`, etc.) are served — only the management API is emulated.
 - No Elasticsearch-compatible management endpoints (`/2015-01-01/es/domain/...`).
-- `VPCOptions`, `AdvancedSecurityOptions`, `EncryptionAtRestOptions`, `NodeToNodeEncryptionOptions`, and `DomainEndpointOptions` round-trip on `CreateDomain` / `UpdateDomainConfig` / `DescribeDomain` / `DescribeDomainConfig`, but are not enforced by the running container — Floci serves the domain over plain HTTP with the security plugin disabled regardless. Round-tripping is enough for SDK clients (Terraform, CDK, Pulumi) to detect drift correctly.
+- `AccessPolicies`, `VPCOptions`, `AdvancedSecurityOptions`, `EncryptionAtRestOptions`, `NodeToNodeEncryptionOptions`, and `DomainEndpointOptions` round-trip on `CreateDomain` / `UpdateDomainConfig` / `DescribeDomain` / `DescribeDomainConfig`, but are not enforced by the running container — Floci serves the domain over plain HTTP with the security plugin disabled regardless, and `AccessPolicies` is stored verbatim without being evaluated. Round-tripping is enough for SDK clients (Terraform, CDK, Pulumi) to detect drift correctly.
 - Master passwords for `AdvancedSecurityOptions.MasterUserOptions` are accepted but never echoed back, matching AWS behavior.
 - Cross-cluster connections, VPC endpoints, packages, applications, and data sources are not supported and return `UnsupportedOperationException`.

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchController.java
@@ -56,6 +56,7 @@ public class OpenSearchController {
             JsonNode req = objectMapper.readTree(body);
             String domainName = req.path("DomainName").asText(null);
             String engineVersion = req.path("EngineVersion").asText(null);
+            String accessPolicies = req.path("AccessPolicies").asText(null);
             ClusterConfig clusterConfig = parseClusterConfig(req.path("ClusterConfig"));
             EbsOptions ebsOptions = parseEbsOptions(req.path("EBSOptions"));
             Map<String, String> tags = parseTags(req.path("TagList"));
@@ -68,7 +69,7 @@ public class OpenSearchController {
                     parseDomainEndpointOptions(req.path("DomainEndpointOptions")));
 
             Domain domain = service.createDomain(domainName, engineVersion, clusterConfig,
-                    ebsOptions, tags, options, region);
+                    ebsOptions, tags, accessPolicies, options, region);
 
             ObjectNode response = objectMapper.createObjectNode();
             response.set("DomainStatus", toDomainStatusNode(domain));
@@ -163,6 +164,7 @@ public class OpenSearchController {
         try {
             JsonNode req = objectMapper.readTree(body);
             String engineVersion = req.path("EngineVersion").asText(null);
+            String accessPolicies = req.path("AccessPolicies").asText(null);
             ClusterConfig clusterConfig = parseClusterConfig(req.path("ClusterConfig"));
             EbsOptions ebsOptions = parseEbsOptions(req.path("EBSOptions"));
 
@@ -174,7 +176,7 @@ public class OpenSearchController {
                     parseDomainEndpointOptions(req.path("DomainEndpointOptions")));
 
             Domain domain = service.updateDomainConfig(domainName, engineVersion, clusterConfig,
-                    ebsOptions, options, region);
+                    ebsOptions, accessPolicies, options, region);
 
             long epochSeconds = domain.getCreatedAt() != null ? domain.getCreatedAt().getEpochSecond() : 0;
             ObjectNode response = objectMapper.createObjectNode();
@@ -492,6 +494,9 @@ public class OpenSearchController {
         node.put("Processing", domain.isProcessing());
         node.put("Deleted", domain.isDeleted());
         node.put("Endpoint", domain.getEndpoint() != null ? domain.getEndpoint() : "");
+        if (domain.getAccessPolicies() != null) {
+            node.put("AccessPolicies", domain.getAccessPolicies());
+        }
         node.set("ClusterConfig", toClusterConfigNode(domain.getClusterConfig()));
         node.set("EBSOptions", toEbsOptionsNode(domain.getEbsOptions()));
         if (domain.getVpcOptions() != null) {
@@ -519,6 +524,11 @@ public class OpenSearchController {
      * unset, rather than emitting empty objects.
      */
     private void attachDomainOptionConfigs(ObjectNode domainConfig, Domain domain, long epochSeconds) {
+        if (domain.getAccessPolicies() != null) {
+            ObjectNode section = domainConfig.putObject("AccessPolicies");
+            section.put("Options", domain.getAccessPolicies());
+            section.set("Status", configStatusNode(epochSeconds));
+        }
         if (domain.getVpcOptions() != null) {
             ObjectNode section = domainConfig.putObject("VPCOptions");
             section.set("Options", toVpcOptionsNode(domain.getVpcOptions()));

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchController.java
@@ -160,7 +160,6 @@ public class OpenSearchController {
     public Response updateDomainConfig(@Context HttpHeaders headers,
                                         @PathParam("domainName") String domainName,
                                         String body) {
-        String region = regionResolver.resolveRegion(headers);
         try {
             JsonNode req = objectMapper.readTree(body);
             String engineVersion = req.path("EngineVersion").asText(null);
@@ -176,7 +175,7 @@ public class OpenSearchController {
                     parseDomainEndpointOptions(req.path("DomainEndpointOptions")));
 
             Domain domain = service.updateDomainConfig(domainName, engineVersion, clusterConfig,
-                    ebsOptions, accessPolicies, options, region);
+                    ebsOptions, accessPolicies, options);
 
             long epochSeconds = domain.getCreatedAt() != null ? domain.getCreatedAt().getEpochSecond() : 0;
             ObjectNode response = objectMapper.createObjectNode();

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchService.java
@@ -96,12 +96,12 @@ public class OpenSearchService {
 
     public Domain createDomain(String domainName, String engineVersion, ClusterConfig clusterConfig,
                                 EbsOptions ebsOptions, Map<String, String> tags, String region) {
-        return createDomain(domainName, engineVersion, clusterConfig, ebsOptions, tags,
+        return createDomain(domainName, engineVersion, clusterConfig, ebsOptions, tags, null,
                 DomainOptions.EMPTY, region);
     }
 
     public Domain createDomain(String domainName, String engineVersion, ClusterConfig clusterConfig,
-                                EbsOptions ebsOptions, Map<String, String> tags,
+                                EbsOptions ebsOptions, Map<String, String> tags, String accessPolicies,
                                 DomainOptions options, String region) {
         validateDomainName(domainName);
         OpenSearchVersions.validate(engineVersion);
@@ -119,6 +119,7 @@ public class OpenSearchService {
         domain.setAccountId(accountId);
         domain.setArn(AwsArnUtils.Arn.of("es", region, accountId, "domain/" + domainName).toString());
         domain.setEngineVersion(engineVersion != null ? engineVersion : DEFAULT_ENGINE_VERSION);
+        domain.setAccessPolicies(accessPolicies);
         domain.setProcessing(false);
         domain.setDeleted(false);
         domain.setEndpoint("");
@@ -173,19 +174,22 @@ public class OpenSearchService {
     public Domain updateDomainConfig(String domainName, String engineVersion,
                                       ClusterConfig clusterConfig, EbsOptions ebsOptions,
                                       String region) {
-        return updateDomainConfig(domainName, engineVersion, clusterConfig, ebsOptions,
+        return updateDomainConfig(domainName, engineVersion, clusterConfig, ebsOptions, null,
                 DomainOptions.EMPTY, region);
     }
 
     public Domain updateDomainConfig(String domainName, String engineVersion,
                                       ClusterConfig clusterConfig, EbsOptions ebsOptions,
-                                      DomainOptions options, String region) {
+                                      String accessPolicies, DomainOptions options, String region) {
         Domain domain = describeDomain(domainName);
         OpenSearchVersions.validate(engineVersion);
         validateOptions(options);
 
         if (engineVersion != null && !engineVersion.isBlank()) {
             domain.setEngineVersion(engineVersion);
+        }
+        if (accessPolicies != null) {
+            domain.setAccessPolicies(accessPolicies);
         }
         if (clusterConfig != null) {
             ClusterConfig existing = domain.getClusterConfig();

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchService.java
@@ -172,15 +172,14 @@ public class OpenSearchService {
     }
 
     public Domain updateDomainConfig(String domainName, String engineVersion,
-                                      ClusterConfig clusterConfig, EbsOptions ebsOptions,
-                                      String region) {
+                                      ClusterConfig clusterConfig, EbsOptions ebsOptions) {
         return updateDomainConfig(domainName, engineVersion, clusterConfig, ebsOptions, null,
-                DomainOptions.EMPTY, region);
+                DomainOptions.EMPTY);
     }
 
     public Domain updateDomainConfig(String domainName, String engineVersion,
                                       ClusterConfig clusterConfig, EbsOptions ebsOptions,
-                                      String accessPolicies, DomainOptions options, String region) {
+                                      String accessPolicies, DomainOptions options) {
         Domain domain = describeDomain(domainName);
         OpenSearchVersions.validate(engineVersion);
         validateOptions(options);

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/model/Domain.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/model/Domain.java
@@ -26,6 +26,9 @@ public class Domain {
     @JsonProperty("EngineVersion")
     private String engineVersion;
 
+    @JsonProperty("AccessPolicies")
+    private String accessPolicies;
+
     @JsonProperty("Processing")
     private boolean processing = false;
 
@@ -104,6 +107,14 @@ public class Domain {
 
     public void setEngineVersion(String engineVersion) {
         this.engineVersion = engineVersion;
+    }
+
+    public String getAccessPolicies() {
+        return accessPolicies;
+    }
+
+    public void setAccessPolicies(String accessPolicies) {
+        this.accessPolicies = accessPolicies;
     }
 
     public boolean isProcessing() {

--- a/src/test/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainOptionsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainOptionsIntegrationTest.java
@@ -30,7 +30,7 @@ class OpenSearchDomainOptionsIntegrationTest {
     @AfterEach
     void cleanup() {
         // Delete every domain we touch so test order is irrelevant.
-        for (String name : new String[]{"opts-vpc", "opts-adv", "opts-enc", "opts-endpoint", "opts-update"}) {
+        for (String name : new String[]{"opts-vpc", "opts-adv", "opts-enc", "opts-endpoint", "opts-update", "opts-access"}) {
             given().header("Authorization", AUTH_HEADER)
                 .when().delete("/2021-01-01/opensearch/domain/" + name);
         }
@@ -179,5 +179,57 @@ class OpenSearchDomainOptionsIntegrationTest {
             .then().statusCode(200)
             .body("DomainStatus.VPCOptions.SubnetIds", contains("subnet-new"))
             .body("DomainStatus.VPCOptions.SubnetIds", not(hasItem("subnet-old")));
+    }
+
+    @Test
+    void accessPoliciesRoundTrip() {
+        String policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\","
+                + "\"Principal\":{\"AWS\":\"*\"},\"Action\":\"es:*\"}]}";
+        String body = "{"
+                + "\"DomainName\":\"opts-access\","
+                + "\"EngineVersion\":\"OpenSearch_2.19\","
+                + "\"AccessPolicies\":\"" + policy.replace("\"", "\\\"") + "\""
+                + "}";
+
+        given().contentType("application/json").header("Authorization", AUTH_HEADER).body(body)
+            .when().post("/2021-01-01/opensearch/domain")
+            .then().statusCode(200)
+            .body("DomainStatus.AccessPolicies", equalTo(policy));
+
+        given().header("Authorization", AUTH_HEADER)
+            .when().get("/2021-01-01/opensearch/domain/opts-access")
+            .then().statusCode(200)
+            .body("DomainStatus.AccessPolicies", equalTo(policy));
+
+        given().header("Authorization", AUTH_HEADER)
+            .when().get("/2021-01-01/opensearch/domain/opts-access/config")
+            .then().statusCode(200)
+            .body("DomainConfig.AccessPolicies.Options", equalTo(policy))
+            .body("DomainConfig.AccessPolicies.Status.State", equalTo("Active"));
+    }
+
+    @Test
+    void updateDomainConfigPersistsNewAccessPolicies() {
+        String originalPolicy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\","
+                + "\"Principal\":{\"AWS\":\"arn:aws:iam::000000000000:root\"},\"Action\":\"es:*\"}]}";
+        String updatedPolicy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Deny\","
+                + "\"Principal\":\"*\",\"Action\":\"es:*\"}]}";
+
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"DomainName\":\"opts-access\",\"EngineVersion\":\"OpenSearch_2.19\","
+                    + "\"AccessPolicies\":\"" + originalPolicy.replace("\"", "\\\"") + "\"}")
+            .when().post("/2021-01-01/opensearch/domain")
+            .then().statusCode(200);
+
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"AccessPolicies\":\"" + updatedPolicy.replace("\"", "\\\"") + "\"}")
+            .when().post("/2021-01-01/opensearch/domain/opts-access/config")
+            .then().statusCode(200)
+            .body("DomainConfig.AccessPolicies.Options", equalTo(updatedPolicy));
+
+        given().header("Authorization", AUTH_HEADER)
+            .when().get("/2021-01-01/opensearch/domain/opts-access")
+            .then().statusCode(200)
+            .body("DomainStatus.AccessPolicies", equalTo(updatedPolicy));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainOptionsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainOptionsIntegrationTest.java
@@ -232,4 +232,30 @@ class OpenSearchDomainOptionsIntegrationTest {
             .then().statusCode(200)
             .body("DomainStatus.AccessPolicies", equalTo(updatedPolicy));
     }
+
+    @Test
+    void updateDomainConfigClearsAccessPoliciesWithEmptyString() {
+        // AccessPolicies has a documented minimum length of 0, unlike EngineVersion where a
+        // blank value means "leave untouched" - an empty string here is a real "clear the
+        // policy" request and must not be treated as absent.
+        String originalPolicy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\","
+                + "\"Principal\":\"*\",\"Action\":\"es:*\"}]}";
+
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"DomainName\":\"opts-access\",\"EngineVersion\":\"OpenSearch_2.19\","
+                    + "\"AccessPolicies\":\"" + originalPolicy.replace("\"", "\\\"") + "\"}")
+            .when().post("/2021-01-01/opensearch/domain")
+            .then().statusCode(200);
+
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"AccessPolicies\":\"\"}")
+            .when().post("/2021-01-01/opensearch/domain/opts-access/config")
+            .then().statusCode(200)
+            .body("DomainConfig.AccessPolicies.Options", equalTo(""));
+
+        given().header("Authorization", AUTH_HEADER)
+            .when().get("/2021-01-01/opensearch/domain/opts-access")
+            .then().statusCode(200)
+            .body("DomainStatus.AccessPolicies", equalTo(""));
+    }
 }


### PR DESCRIPTION
## Summary

Implements `AccessPolicies` support for OpenSearch domains. Closes #2305.

`AccessPolicies` — the domain's IAM resource policy — was never parsed on `CreateDomain` /
`UpdateDomainConfig`, never stored on the `Domain` model, and never returned by
`DescribeDomain(s)` / `DescribeDomainConfig`. In practice this meant `aws_opensearch_domain_policy`
couldn't be created at all, and setting `access_policies` inline on `aws_opensearch_domain` was
silently discarded — apply succeeded but every subsequent plan showed a diff.

Threaded through exactly like the existing `EngineVersion` string field (per the issue's scoping):

- `Domain.accessPolicies` — plain `String` field, no new model class needed.
- `OpenSearchController`: parsed via `req.path("AccessPolicies").asText(null)` in both
  `createDomain` and `updateDomainConfig`, same idiom as `EngineVersion`.
- `OpenSearchService`: threaded as its own parameter (not folded into the `DomainOptions` record,
  which is reserved for object-shaped blocks) through `createDomain`/`updateDomainConfig`. On
  update, a non-null value (including `""`) replaces the stored policy — AWS's `AccessPolicies`
  has a documented minimum length of 0, so an empty string is a valid "clear the policy" value,
  unlike `EngineVersion`'s blank-is-a-no-op handling.
- Response shape matches the two documented forms: bare string in `DomainStatus`
  (`CreateDomain`/`DescribeDomain`/`DescribeDomains`), and `{Options, Status}` in `DomainConfig`
  (`DescribeDomainConfig`/`UpdateDomainConfig`) — mirroring `EngineVersion`'s existing wrapping in
  `DomainConfig`, which is the one other bare-string field there.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against [`API_CreateDomain`](https://docs.aws.amazon.com/opensearch-service/latest/APIReference/API_CreateDomain.html)
and [`API_UpdateDomainConfig`](https://docs.aws.amazon.com/opensearch-service/latest/APIReference/API_UpdateDomainConfig.html):
request field name/type, the bare-string `DomainStatus.AccessPolicies` shape, and the
`DomainConfig.AccessPolicies.{Options,Status}` shape.

Manually verified end-to-end against a running `./mvnw quarkus:dev` instance (mock mode) with the
real AWS CLI (`aws-cli/1.45.62`): `create-domain --access-policies` → `describe-domain` returns
the same bare-string policy → `describe-domain-config` returns it wrapped in `Options`/`Status` →
`update-domain-config --access-policies` with a different policy → `describe-domain` reflects the
new policy.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)