### PR TITLE
feat(ec2): support transit gateways

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/ec2.bats
+++ b/compatibility-tests/sdk-test-awscli/test/ec2.bats
@@ -277,6 +277,11 @@ create_sg_pair() {
     [ "$(json_get "$output" '.TransitGateway.Description')" = "after" ]
     [ "$(json_get "$output" '.TransitGateway.Options.DnsSupport')" = "disable" ]
     [ "$(json_get "$output" '.TransitGateway.Options.TransitGatewayCidrBlocks[0]')" = "10.100.0.0/16" ]
+
+    # Describe serializes the same list, so read it back through the CLI's own parser too.
+    run aws_cmd ec2 describe-transit-gateways --transit-gateway-ids "$TRANSIT_GATEWAY_ID"
+    assert_success
+    [ "$(json_get "$output" '.TransitGateways[0].Options.TransitGatewayCidrBlocks[0]')" = "10.100.0.0/16" ]
 }
 
 @test "EC2: delete a transit gateway" {

--- a/compatibility-tests/sdk-test-awscli/test/ec2.bats
+++ b/compatibility-tests/sdk-test-awscli/test/ec2.bats
@@ -264,6 +264,43 @@ create_sg_pair() {
     [ "$(json_get "$output" '.TransitGateways[0].Tags[0].Value')" = "bats-tgw" ]
 }
 
+@test "EC2: create a transit gateway with CIDR blocks" {
+    run aws_cmd ec2 create-transit-gateway \
+        --options 'TransitGatewayCidrBlocks=[10.99.0.0/16]'
+    assert_success
+    TRANSIT_GATEWAY_ID=$(json_get "$output" '.TransitGateway.TransitGatewayId')
+    [ "$(json_get "$output" '.TransitGateway.Options.TransitGatewayCidrBlocks[0]')" = "10.99.0.0/16" ]
+
+    run aws_cmd ec2 describe-transit-gateways --transit-gateway-ids "$TRANSIT_GATEWAY_ID"
+    assert_success
+    [ "$(json_get "$output" '.TransitGateways[0].Options.TransitGatewayCidrBlocks[0]')" = "10.99.0.0/16" ]
+}
+
+# Tags are changed after creation with create-tags rather than a tag specification, and read back
+# from describe-transit-gateways, which is how a Terraform tag update converges.
+@test "EC2: transit gateway tags changed after creation are visible on describe" {
+    local out
+    out=$(aws_cmd ec2 create-transit-gateway --tag-specifications \
+        'ResourceType=transit-gateway,Tags=[{Key=Name,Value=bats-tgw-tags}]')
+    TRANSIT_GATEWAY_ID=$(json_get "$out" '.TransitGateway.TransitGatewayId')
+
+    aws_cmd ec2 create-tags --resources "$TRANSIT_GATEWAY_ID" --tags 'Key=env,Value=prod' >/dev/null
+
+    run aws_cmd ec2 describe-transit-gateways --transit-gateway-ids "$TRANSIT_GATEWAY_ID"
+    assert_success
+    count=$(json_get "$output" '.TransitGateways[0].Tags | length')
+    [ "$count" = "2" ]
+    env_value=$(json_get "$output" '.TransitGateways[0].Tags[] | select(.Key=="env") | .Value')
+    [ "$env_value" = "prod" ]
+
+    aws_cmd ec2 delete-tags --resources "$TRANSIT_GATEWAY_ID" --tags 'Key=env' >/dev/null
+
+    run aws_cmd ec2 describe-transit-gateways --transit-gateway-ids "$TRANSIT_GATEWAY_ID"
+    assert_success
+    count=$(json_get "$output" '.TransitGateways[0].Tags | length')
+    [ "$count" = "1" ]
+}
+
 @test "EC2: modify a transit gateway" {
     local out
     out=$(aws_cmd ec2 create-transit-gateway --description "before")

--- a/compatibility-tests/sdk-test-awscli/test/ec2.bats
+++ b/compatibility-tests/sdk-test-awscli/test/ec2.bats
@@ -8,11 +8,15 @@ setup() {
     SG_VPC_ID=""
     SG_SOURCE_ID=""
     SG_TARGET_ID=""
+    TRANSIT_GATEWAY_ID=""
 }
 
 teardown() {
     if [ -n "$PREFIX_LIST_ID" ]; then
         aws_cmd ec2 delete-managed-prefix-list --prefix-list-id "$PREFIX_LIST_ID" >/dev/null 2>&1 || true
+    fi
+    if [ -n "$TRANSIT_GATEWAY_ID" ]; then
+        aws_cmd ec2 delete-transit-gateway --transit-gateway-id "$TRANSIT_GATEWAY_ID" >/dev/null 2>&1 || true
     fi
     for sg in "$SG_TARGET_ID" "$SG_SOURCE_ID"; do
         if [ -n "$sg" ]; then
@@ -234,4 +238,62 @@ create_sg_pair() {
     [ "$desc" = "from-source-sg" ]
     cidr=$(json_get "$output" '.SecurityGroupRules[] | select(.FromPort==8443) | .CidrIpv4')
     [ "$cidr" = "10.0.0.0/8" ]
+}
+
+# ─── transit gateways ───────────────────────────────────────────────────────
+
+@test "EC2: create a transit gateway and read it back" {
+    run aws_cmd ec2 create-transit-gateway \
+        --description "bats hub" \
+        --tag-specifications 'ResourceType=transit-gateway,Tags=[{Key=Name,Value=bats-tgw}]'
+    assert_success
+    TRANSIT_GATEWAY_ID=$(json_get "$output" '.TransitGateway.TransitGatewayId')
+    [ "$(json_get "$output" '.TransitGateway.State')" = "available" ]
+    [ "$(json_get "$output" '.TransitGateway.Options.AmazonSideAsn')" = "64512" ]
+    [ "$(json_get "$output" '.TransitGateway.Options.SecurityGroupReferencingSupport')" = "disable" ]
+
+    # The default route table is minted with the gateway, so both ids are already set and equal.
+    assoc=$(json_get "$output" '.TransitGateway.Options.AssociationDefaultRouteTableId')
+    prop=$(json_get "$output" '.TransitGateway.Options.PropagationDefaultRouteTableId')
+    [ "$assoc" = "$prop" ]
+    case "$assoc" in tgw-rtb-*) ;; *) return 1 ;; esac
+
+    run aws_cmd ec2 describe-transit-gateways --transit-gateway-ids "$TRANSIT_GATEWAY_ID"
+    assert_success
+    [ "$(json_get "$output" '.TransitGateways[0].TransitGatewayId')" = "$TRANSIT_GATEWAY_ID" ]
+    [ "$(json_get "$output" '.TransitGateways[0].Tags[0].Value')" = "bats-tgw" ]
+}
+
+@test "EC2: modify a transit gateway" {
+    local out
+    out=$(aws_cmd ec2 create-transit-gateway --description "before")
+    TRANSIT_GATEWAY_ID=$(json_get "$out" '.TransitGateway.TransitGatewayId')
+
+    run aws_cmd ec2 modify-transit-gateway \
+        --transit-gateway-id "$TRANSIT_GATEWAY_ID" \
+        --description "after" \
+        --options 'DnsSupport=disable,AddTransitGatewayCidrBlocks=[10.100.0.0/16]'
+    assert_success
+    [ "$(json_get "$output" '.TransitGateway.Description')" = "after" ]
+    [ "$(json_get "$output" '.TransitGateway.Options.DnsSupport')" = "disable" ]
+    [ "$(json_get "$output" '.TransitGateway.Options.TransitGatewayCidrBlocks[0]')" = "10.100.0.0/16" ]
+}
+
+@test "EC2: delete a transit gateway" {
+    local out tgw
+    out=$(aws_cmd ec2 create-transit-gateway --description "short lived")
+    tgw=$(json_get "$out" '.TransitGateway.TransitGatewayId')
+
+    run aws_cmd ec2 delete-transit-gateway --transit-gateway-id "$tgw"
+    assert_success
+
+    run aws_cmd ec2 describe-transit-gateways --transit-gateway-ids "$tgw"
+    assert_failure
+    assert_output --partial "InvalidTransitGatewayID.NotFound"
+}
+
+@test "EC2: describing an unknown transit gateway is rejected" {
+    run aws_cmd ec2 describe-transit-gateways --transit-gateway-ids tgw-0123456789abcdef0
+    assert_failure
+    assert_output --partial "InvalidTransitGatewayID.NotFound"
 }

--- a/docs/services/ec2.md
+++ b/docs/services/ec2.md
@@ -310,6 +310,36 @@ resulting rule carries `prefixListId` in place of `cidrIpv4`, and `DescribeSecur
 the reference under the permission as `prefixListIds`. Authorizing against a list that does not
 exist returns `InvalidPrefixListID.NotFound`, so a typo cannot leave a rule pointing at nothing.
 
+### Transit Gateways
+
+| Action | Description |
+|--------|-------------|
+| CreateTransitGateway | Creates a transit gateway, applying AWS's option defaults and minting its default route table. |
+| DescribeTransitGateways | Lists or returns stored transit gateways. |
+| ModifyTransitGateway | Updates a transit gateway's description, options and CIDR blocks. |
+| DeleteTransitGateway | Deletes a transit gateway and the default route table created with it. |
+
+Transit gateway metadata only: nothing routes packets, and the value is in ids that later
+resources can reference and describes that round-trip so plans converge.
+
+Options left out of `CreateTransitGateway` take the same defaults AWS applies — `amazonSideAsn`
+64512, `dnsSupport`, `vpnEcmpSupport`, `defaultRouteTableAssociation` and
+`defaultRouteTablePropagation` enabled, and `autoAcceptSharedAttachments`,
+`securityGroupReferencingSupport` and `multicastSupport` disabled. `transitGatewayCidrBlocks` is
+omitted from the response entirely when no blocks are set, rather than sent empty.
+
+Creating a gateway with either default-route-table option enabled also creates the route table
+AWS creates, and reports its id as `associationDefaultRouteTableId` and
+`propagationDefaultRouteTableId`. Both name the same table. Disabling both leaves the ids absent.
+The actions that operate on transit gateway route tables directly — creating them, associating
+attachments, enabling propagation — are not implemented yet, and neither are attachments.
+
+State is reported settled rather than transitional: AWS returns a new gateway as `pending` and
+reaches `available` roughly a minute later, and reports `deleting` before `deleted`. Nothing here
+is slow, so callers see `available` and `deleted` immediately. `ModifyTransitGateway` and
+`DeleteTransitGateway` echo the gateway without its `tagSet`, matching AWS; `CreateTransitGateway`
+and `DescribeTransitGateways` include it.
+
 ### NAT Gateways
 
 | Action | Description |

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -1275,9 +1275,11 @@ public class Ec2QueryHandler {
         List<String> cidrBlocks = gateway.getOptions().getTransitGatewayCidrBlocks();
         // AWS omits the member entirely rather than sending an empty set.
         if (cidrBlocks != null && !cidrBlocks.isEmpty()) {
+            // A plain string list (ValueStringList), so each item carries the CIDR as its own text
+            // rather than wrapping it in an element.
             xml.start("transitGatewayCidrBlocks");
             for (String cidr : cidrBlocks) {
-                xml.start("item").elem("cidrBlock", cidr).end("item");
+                xml.elem("item", cidr);
             }
             xml.end("transitGatewayCidrBlocks");
         }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -84,6 +84,11 @@ public class Ec2QueryHandler {
                 case "GetManagedPrefixListEntries" -> handleGetManagedPrefixListEntries(params, region);
                 case "ModifyManagedPrefixList" -> handleModifyManagedPrefixList(params, region);
                 case "DeleteManagedPrefixList" -> handleDeleteManagedPrefixList(params, region);
+                // Transit Gateways
+                case "CreateTransitGateway" -> handleCreateTransitGateway(params, region);
+                case "DescribeTransitGateways" -> handleDescribeTransitGateways(params, region);
+                case "ModifyTransitGateway" -> handleModifyTransitGateway(params, region);
+                case "DeleteTransitGateway" -> handleDeleteTransitGateway(params, region);
                 case "CreateDefaultVpc" -> handleCreateDefaultVpc(params, region);
                 case "AssociateVpcCidrBlock" -> handleAssociateVpcCidrBlock(params, region);
                 case "DisassociateVpcCidrBlock" -> handleDisassociateVpcCidrBlock(params, region);
@@ -1179,6 +1184,117 @@ public class Ec2QueryHandler {
                 .start("prefixList").raw(managedPrefixListXml(list)).end("prefixList")
                 .end("DeleteManagedPrefixListResponse");
         return xmlResponse(xml.build());
+    }
+
+    private Response handleCreateTransitGateway(MultivaluedMap<String, String> p, String region) {
+        TransitGateway gateway = service.createTransitGateway(
+                region,
+                p.getFirst("Description"),
+                parseTransitGatewayOptions(p, "Options"),
+                parseTagsForResource(p, "transit-gateway"));
+        XmlBuilder xml = new XmlBuilder()
+                .start("CreateTransitGatewayResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .start("transitGateway").raw(transitGatewayXml(gateway)).end("transitGateway")
+                .end("CreateTransitGatewayResponse");
+        return xmlResponse(xml.build());
+    }
+
+    private Response handleDescribeTransitGateways(MultivaluedMap<String, String> p, String region) {
+        List<TransitGateway> gateways = service.describeTransitGateways(
+                region, getList(p, "TransitGatewayIds"), getFilters(p));
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeTransitGatewaysResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .start("transitGatewaySet");
+        for (TransitGateway gateway : gateways) {
+            xml.start("item").raw(transitGatewayXml(gateway)).end("item");
+        }
+        xml.end("transitGatewaySet").end("DescribeTransitGatewaysResponse");
+        return xmlResponse(xml.build());
+    }
+
+    private Response handleModifyTransitGateway(MultivaluedMap<String, String> p, String region) {
+        TransitGateway gateway = service.modifyTransitGateway(
+                region,
+                p.getFirst("TransitGatewayId"),
+                p.getFirst("Description"),
+                parseTransitGatewayOptions(p, "Options"),
+                getList(p, "Options.AddTransitGatewayCidrBlocks"),
+                getList(p, "Options.RemoveTransitGatewayCidrBlocks"));
+        XmlBuilder xml = new XmlBuilder()
+                .start("ModifyTransitGatewayResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                // Verified against a live account: modify echoes the gateway without its tagSet,
+                // unlike create and describe.
+                .start("transitGateway").raw(transitGatewayXml(gateway, false)).end("transitGateway")
+                .end("ModifyTransitGatewayResponse");
+        return xmlResponse(xml.build());
+    }
+
+    private Response handleDeleteTransitGateway(MultivaluedMap<String, String> p, String region) {
+        TransitGateway gateway = service.deleteTransitGateway(region, p.getFirst("TransitGatewayId"));
+        XmlBuilder xml = new XmlBuilder()
+                .start("DeleteTransitGatewayResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .start("transitGateway").raw(transitGatewayXml(gateway, false)).end("transitGateway")
+                .end("DeleteTransitGatewayResponse");
+        return xmlResponse(xml.build());
+    }
+
+    private TransitGatewayOptions parseTransitGatewayOptions(MultivaluedMap<String, String> p, String prefix) {
+        TransitGatewayOptions options = new TransitGatewayOptions();
+        options.setAmazonSideAsn(longOrNull(p, prefix + ".AmazonSideAsn"));
+        options.setAutoAcceptSharedAttachments(p.getFirst(prefix + ".AutoAcceptSharedAttachments"));
+        options.setDefaultRouteTableAssociation(p.getFirst(prefix + ".DefaultRouteTableAssociation"));
+        options.setAssociationDefaultRouteTableId(p.getFirst(prefix + ".AssociationDefaultRouteTableId"));
+        options.setDefaultRouteTablePropagation(p.getFirst(prefix + ".DefaultRouteTablePropagation"));
+        options.setPropagationDefaultRouteTableId(p.getFirst(prefix + ".PropagationDefaultRouteTableId"));
+        options.setVpnEcmpSupport(p.getFirst(prefix + ".VpnEcmpSupport"));
+        options.setDnsSupport(p.getFirst(prefix + ".DnsSupport"));
+        options.setSecurityGroupReferencingSupport(p.getFirst(prefix + ".SecurityGroupReferencingSupport"));
+        options.setMulticastSupport(p.getFirst(prefix + ".MulticastSupport"));
+        options.setTransitGatewayCidrBlocks(getList(p, prefix + ".TransitGatewayCidrBlocks"));
+        return options;
+    }
+
+    private String transitGatewayXml(TransitGateway gateway) {
+        return transitGatewayXml(gateway, true);
+    }
+
+    private String transitGatewayXml(TransitGateway gateway, boolean includeTags) {
+        XmlBuilder xml = new XmlBuilder()
+                .elem("transitGatewayId", gateway.getTransitGatewayId())
+                .elem("transitGatewayArn", gateway.getTransitGatewayArn())
+                .elem("state", gateway.getState())
+                .elem("ownerId", gateway.getOwnerId())
+                .elem("description", gateway.getDescription())
+                .elem("creationTime", gateway.getCreationTime())
+                .start("options")
+                .elem("amazonSideAsn", String.valueOf(gateway.getOptions().getAmazonSideAsn()));
+        List<String> cidrBlocks = gateway.getOptions().getTransitGatewayCidrBlocks();
+        // AWS omits the member entirely rather than sending an empty set.
+        if (cidrBlocks != null && !cidrBlocks.isEmpty()) {
+            xml.start("transitGatewayCidrBlocks");
+            for (String cidr : cidrBlocks) {
+                xml.start("item").elem("cidrBlock", cidr).end("item");
+            }
+            xml.end("transitGatewayCidrBlocks");
+        }
+        xml.elem("autoAcceptSharedAttachments", gateway.getOptions().getAutoAcceptSharedAttachments())
+                .elem("defaultRouteTableAssociation", gateway.getOptions().getDefaultRouteTableAssociation())
+                .elem("associationDefaultRouteTableId", gateway.getOptions().getAssociationDefaultRouteTableId())
+                .elem("defaultRouteTablePropagation", gateway.getOptions().getDefaultRouteTablePropagation())
+                .elem("propagationDefaultRouteTableId", gateway.getOptions().getPropagationDefaultRouteTableId())
+                .elem("vpnEcmpSupport", gateway.getOptions().getVpnEcmpSupport())
+                .elem("dnsSupport", gateway.getOptions().getDnsSupport())
+                .elem("securityGroupReferencingSupport", gateway.getOptions().getSecurityGroupReferencingSupport())
+                .elem("multicastSupport", gateway.getOptions().getMulticastSupport())
+                .end("options");
+        if (includeTags) {
+            xml.raw(tagSetXml(gateway.getTags()));
+        }
+        return xml.build();
     }
 
     private String managedPrefixListXml(ManagedPrefixList list) {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1013,6 +1013,7 @@ public class Ec2Service implements ContainerTeardown {
                                                List<String> removeCidrBlocks) {
         synchronized (lockFor(key(region, transitGatewayId))) {
             TransitGateway gateway = getRequiredTransitGateway(region, transitGatewayId);
+            requireCoherentDefaultRouteTableChange(region, changes);
             if (description != null) {
                 gateway.setDescription(description);
             }
@@ -1029,6 +1030,49 @@ public class Ec2Service implements ContainerTeardown {
             }
             transitGateways.put(key(region, transitGatewayId), gateway);
             return gateway;
+        }
+    }
+
+    /**
+     * A default route table flag and its id have to move together, which is what stops the two
+     * from diverging: AWS will not enable association or propagation without being told which
+     * existing route table to use, and will not accept an id alongside a disable. Verified against
+     * a live account, including that an unknown table is reported as
+     * {@code InvalidRouteTableID.NotFound} rather than a transit-gateway-specific code.
+     */
+    private void requireCoherentDefaultRouteTableChange(String region, TransitGatewayOptions changes) {
+        if (changes == null) {
+            return;
+        }
+        requireFlagAndRouteTableAgree(changes.getDefaultRouteTableAssociation(),
+                changes.getAssociationDefaultRouteTableId(),
+                "DefaultRouteTableAssociation", "AssociationDefaultRouteTableId");
+        requireFlagAndRouteTableAgree(changes.getDefaultRouteTablePropagation(),
+                changes.getPropagationDefaultRouteTableId(),
+                "DefaultRouteTablePropagation", "PropagationDefaultRouteTableId");
+        requireKnownTransitGatewayRouteTable(region, changes.getAssociationDefaultRouteTableId());
+        requireKnownTransitGatewayRouteTable(region, changes.getPropagationDefaultRouteTableId());
+    }
+
+    private void requireFlagAndRouteTableAgree(String flag, String routeTableId,
+                                               String flagName, String routeTableIdName) {
+        if (flag == null) {
+            return;
+        }
+        boolean enabling = "enable".equals(flag);
+        if (enabling == (routeTableId == null)) {
+            throw new AwsException("InvalidParameterCombination",
+                    flag + " " + flagName + " conflicts with " + routeTableIdName + " " + routeTableId, 400);
+        }
+    }
+
+    private void requireKnownTransitGatewayRouteTable(String region, String routeTableId) {
+        if (routeTableId == null) {
+            return;
+        }
+        if (transitGatewayRouteTables.get(key(region, routeTableId)).isEmpty()) {
+            throw new AwsException("InvalidRouteTableID.NotFound",
+                    "Transit Gateway Route Table " + routeTableId + " was deleted or does not exist.", 400);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1013,7 +1013,7 @@ public class Ec2Service implements ContainerTeardown {
                                                List<String> removeCidrBlocks) {
         synchronized (lockFor(key(region, transitGatewayId))) {
             TransitGateway gateway = getRequiredTransitGateway(region, transitGatewayId);
-            requireCoherentDefaultRouteTableChange(region, changes);
+            requireCoherentDefaultRouteTableChange(region, gateway, changes);
             if (description != null) {
                 gateway.setDescription(description);
             }
@@ -1085,7 +1085,8 @@ public class Ec2Service implements ContainerTeardown {
      * a live account, including that an unknown table is reported as
      * {@code InvalidRouteTableID.NotFound} rather than a transit-gateway-specific code.
      */
-    private void requireCoherentDefaultRouteTableChange(String region, TransitGatewayOptions changes) {
+    private void requireCoherentDefaultRouteTableChange(String region, TransitGateway gateway,
+                                                        TransitGatewayOptions changes) {
         if (changes == null) {
             return;
         }
@@ -1095,8 +1096,8 @@ public class Ec2Service implements ContainerTeardown {
         requireFlagAndRouteTableAgree(changes.getDefaultRouteTablePropagation(),
                 changes.getPropagationDefaultRouteTableId(),
                 "DefaultRouteTablePropagation", "PropagationDefaultRouteTableId");
-        requireKnownTransitGatewayRouteTable(region, changes.getAssociationDefaultRouteTableId());
-        requireKnownTransitGatewayRouteTable(region, changes.getPropagationDefaultRouteTableId());
+        requireRouteTableOfGateway(region, gateway, changes.getAssociationDefaultRouteTableId());
+        requireRouteTableOfGateway(region, gateway, changes.getPropagationDefaultRouteTableId());
     }
 
     private void requireFlagAndRouteTableAgree(String flag, String routeTableId,
@@ -1111,13 +1112,24 @@ public class Ec2Service implements ContainerTeardown {
         }
     }
 
-    private void requireKnownTransitGatewayRouteTable(String region, String routeTableId) {
+    /**
+     * A default route table has to belong to the gateway naming it. AWS reports a table owned by
+     * another gateway under the same {@code InvalidRouteTableID.NotFound} code as one that exists
+     * nowhere, but qualifies the message with the gateway; both wordings are reproduced here.
+     */
+    private void requireRouteTableOfGateway(String region, TransitGateway gateway, String routeTableId) {
         if (routeTableId == null) {
             return;
         }
-        if (transitGatewayRouteTables.get(key(region, routeTableId)).isEmpty()) {
+        TransitGatewayRouteTable routeTable = transitGatewayRouteTables.get(key(region, routeTableId)).orElse(null);
+        if (routeTable == null) {
             throw new AwsException("InvalidRouteTableID.NotFound",
                     "Transit Gateway Route Table " + routeTableId + " was deleted or does not exist.", 400);
+        }
+        if (!gateway.getTransitGatewayId().equals(routeTable.getTransitGatewayId())) {
+            throw new AwsException("InvalidRouteTableID.NotFound",
+                    "Transit Gateway Route Table " + routeTableId + " was deleted or does not exist in Transit Gateway "
+                            + gateway.getTransitGatewayId() + ".", 400);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -3174,6 +3174,18 @@ public class Ec2Service implements ContainerTeardown {
         if (prefixList != null) {
             prefixList.setTags(new ArrayList<>(tagList));
             managedPrefixLists.put(storeKey, prefixList);
+            return;
+        }
+        TransitGateway gateway = transitGateways.get(storeKey).orElse(null);
+        if (gateway != null) {
+            gateway.setTags(new ArrayList<>(tagList));
+            transitGateways.put(storeKey, gateway);
+            return;
+        }
+        TransitGatewayRouteTable routeTable = transitGatewayRouteTables.get(storeKey).orElse(null);
+        if (routeTable != null) {
+            routeTable.setTags(new ArrayList<>(tagList));
+            transitGatewayRouteTables.put(storeKey, routeTable);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -18,6 +18,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.jboss.logging.Logger;
@@ -28,6 +29,7 @@ import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.AwsRegions;
 import io.github.hectorvent.floci.core.common.ContainerTeardown;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ec2.model.Address;
@@ -71,6 +73,9 @@ import io.github.hectorvent.floci.services.ec2.model.SecurityGroupRule;
 import io.github.hectorvent.floci.services.ec2.model.Snapshot;
 import io.github.hectorvent.floci.services.ec2.model.Subnet;
 import io.github.hectorvent.floci.services.ec2.model.Tag;
+import io.github.hectorvent.floci.services.ec2.model.TransitGateway;
+import io.github.hectorvent.floci.services.ec2.model.TransitGatewayOptions;
+import io.github.hectorvent.floci.services.ec2.model.TransitGatewayRouteTable;
 import io.github.hectorvent.floci.services.ec2.model.UserIdGroupPair;
 import io.github.hectorvent.floci.services.ec2.model.Volume;
 import io.github.hectorvent.floci.services.ec2.model.VolumeAttachment;
@@ -91,6 +96,9 @@ public class Ec2Service implements ContainerTeardown {
             .withZone(ZoneOffset.UTC);
     private static final int DEFAULT_ROOT_VOLUME_SIZE_GIB = 8;
     private static final String DEFAULT_ROOT_VOLUME_TYPE = "gp3";
+    // The ASN AWS assigns when CreateTransitGateway omits Options.AmazonSideAsn.
+    private static final long DEFAULT_AMAZON_SIDE_ASN = 64512L;
+    private static final Pattern TRANSIT_GATEWAY_ID_PATTERN = Pattern.compile("^tgw-[0-9a-f]{8}([0-9a-f]{9})?$");
 
     private final String accountId;
     private final EmulatorConfig config;
@@ -121,6 +129,8 @@ public class Ec2Service implements ContainerTeardown {
     private final StorageBackend<String, SpotInstanceRequest> spotInstanceRequests;
     private final StorageBackend<String, NetworkAcl> networkAcls;
     private final StorageBackend<String, ManagedPrefixList> managedPrefixLists;
+    private final StorageBackend<String, TransitGateway> transitGateways;
+    private final StorageBackend<String, TransitGatewayRouteTable> transitGatewayRouteTables;
     // resourceId → List<Tag>
     private final StorageBackend<String, List<Tag>> tags;
     private final Set<String> seededRegions = ConcurrentHashMap.newKeySet();
@@ -151,7 +161,10 @@ public class Ec2Service implements ContainerTeardown {
                 storageFactory.create("ec2", "ec2-spot-instance-requests.json", new TypeReference<Map<String, SpotInstanceRequest>>() {}),
                 storageFactory.create("ec2", "ec2-network-acls.json", new TypeReference<Map<String, NetworkAcl>>() {}),
                 storageFactory.create("ec2", "ec2-managed-prefix-lists.json", new TypeReference<Map<String, ManagedPrefixList>>() {}),
-                storageFactory.create("ec2", "ec2-tags.json", new TypeReference<Map<String, List<Tag>>>() {}));
+                storageFactory.create("ec2", "ec2-tags.json", new TypeReference<Map<String, List<Tag>>>() {}),
+                storageFactory.create("ec2", "ec2-transit-gateways.json", new TypeReference<Map<String, TransitGateway>>() {}),
+                storageFactory.create("ec2", "ec2-transit-gateway-route-tables.json",
+                        new TypeReference<Map<String, TransitGatewayRouteTable>>() {}));
     }
 
     // Package-private for hermetic tests (pass in-memory or temp-dir-backed StorageBackends directly).
@@ -178,6 +191,40 @@ public class Ec2Service implements ContainerTeardown {
                StorageBackend<String, NetworkAcl> networkAcls,
                StorageBackend<String, ManagedPrefixList> managedPrefixLists,
                StorageBackend<String, List<Tag>> tags) {
+        this(config, containerManager, portForwardManager, amiImageResolver, imageCatalog, instanceTypeCatalog,
+                vpcs, subnets, securityGroups, securityGroupRules, internetGateways, routeTables, keyPairs,
+                addresses, instances, volumes, registeredImages, snapshots, launchTemplates, vpcEndpoints,
+                natGateways, spotInstanceRequests, networkAcls, managedPrefixLists, tags,
+                new InMemoryStorage<>(), new InMemoryStorage<>());
+    }
+
+    // Package-private for hermetic tests, transit-gateway-aware. The shorter overload above keeps its
+    // arity so existing fixtures still resolve it (#2103 and #2106 both broke CI by moving it).
+    Ec2Service(EmulatorConfig config, Ec2ContainerManager containerManager,
+               Ec2PortForwardManager portForwardManager,
+               AmiImageResolver amiImageResolver, Ec2ImageCatalog imageCatalog,
+               Ec2InstanceTypeCatalog instanceTypeCatalog,
+               StorageBackend<String, Vpc> vpcs,
+               StorageBackend<String, Subnet> subnets,
+               StorageBackend<String, SecurityGroup> securityGroups,
+               StorageBackend<String, SecurityGroupRule> securityGroupRules,
+               StorageBackend<String, InternetGateway> internetGateways,
+               StorageBackend<String, RouteTable> routeTables,
+               StorageBackend<String, KeyPair> keyPairs,
+               StorageBackend<String, Address> addresses,
+               StorageBackend<String, Instance> instances,
+               StorageBackend<String, Volume> volumes,
+               StorageBackend<String, Image> registeredImages,
+               StorageBackend<String, Snapshot> snapshots,
+               StorageBackend<String, LaunchTemplate> launchTemplates,
+               StorageBackend<String, VpcEndpoint> vpcEndpoints,
+               StorageBackend<String, NatGateway> natGateways,
+               StorageBackend<String, SpotInstanceRequest> spotInstanceRequests,
+               StorageBackend<String, NetworkAcl> networkAcls,
+               StorageBackend<String, ManagedPrefixList> managedPrefixLists,
+               StorageBackend<String, List<Tag>> tags,
+               StorageBackend<String, TransitGateway> transitGateways,
+               StorageBackend<String, TransitGatewayRouteTable> transitGatewayRouteTables) {
         this.accountId = config.defaultAccountId();
         this.config = config;
         this.containerManager = containerManager;
@@ -204,6 +251,8 @@ public class Ec2Service implements ContainerTeardown {
         this.networkAcls = networkAcls;
         this.managedPrefixLists = managedPrefixLists;
         this.tags = tags;
+        this.transitGateways = transitGateways;
+        this.transitGatewayRouteTables = transitGatewayRouteTables;
     }
 
     @PostConstruct
@@ -835,6 +884,229 @@ public class Ec2Service implements ContainerTeardown {
             sb.append(Integer.toHexString(rand.nextInt(16)));
         }
         return sb.toString();
+    }
+
+    // ─── Transit Gateways ──────────────────────────────────────────────────────
+
+    /**
+     * Creates a transit gateway. Option defaults, and the fact that the default route table is
+     * minted during creation rather than afterwards, were taken from a live AWS account rather
+     * than the documentation.
+     *
+     * <p>AWS returns the gateway as {@code pending} and reaches {@code available} about 50
+     * seconds later. Nothing here is slow, so the settled state is what the caller sees, the
+     * same compression {@code createManagedPrefixList} applies.
+     */
+    public TransitGateway createTransitGateway(String region, String description,
+                                               TransitGatewayOptions requested, List<Tag> gatewayTags) {
+        String transitGatewayId = "tgw-" + randomHex(17);
+        TransitGateway gateway = new TransitGateway();
+        gateway.setTransitGatewayId(transitGatewayId);
+        gateway.setTransitGatewayArn(AwsArnUtils.Arn
+                .of("ec2", region, accountId, "transit-gateway/" + transitGatewayId).toString());
+        gateway.setState("available");
+        gateway.setOwnerId(accountId);
+        gateway.setDescription(description);
+        gateway.setCreationTime(ISO_FMT.format(Instant.now()));
+        gateway.setRegion(region);
+        gateway.setOptions(resolveTransitGatewayOptions(requested));
+
+        TransitGatewayOptions options = gateway.getOptions();
+        if ("enable".equals(options.getDefaultRouteTableAssociation())
+                || "enable".equals(options.getDefaultRouteTablePropagation())) {
+            TransitGatewayRouteTable defaultRouteTable = createDefaultTransitGatewayRouteTable(region, gateway);
+            if ("enable".equals(options.getDefaultRouteTableAssociation())) {
+                options.setAssociationDefaultRouteTableId(defaultRouteTable.getTransitGatewayRouteTableId());
+            }
+            if ("enable".equals(options.getDefaultRouteTablePropagation())) {
+                options.setPropagationDefaultRouteTableId(defaultRouteTable.getTransitGatewayRouteTableId());
+            }
+        }
+
+        if (gatewayTags != null && !gatewayTags.isEmpty()) {
+            gateway.setTags(new ArrayList<>(gatewayTags));
+            tags.put(transitGatewayId, new ArrayList<>(gatewayTags));
+        }
+        transitGateways.put(key(region, transitGatewayId), gateway);
+        return gateway;
+    }
+
+    private TransitGatewayOptions resolveTransitGatewayOptions(TransitGatewayOptions requested) {
+        TransitGatewayOptions options = new TransitGatewayOptions();
+        options.setAmazonSideAsn(DEFAULT_AMAZON_SIDE_ASN);
+        options.setAutoAcceptSharedAttachments("disable");
+        options.setDefaultRouteTableAssociation("enable");
+        options.setDefaultRouteTablePropagation("enable");
+        options.setVpnEcmpSupport("enable");
+        options.setDnsSupport("enable");
+        options.setSecurityGroupReferencingSupport("disable");
+        options.setMulticastSupport("disable");
+        if (requested == null) {
+            return options;
+        }
+        if (requested.getAmazonSideAsn() != null) {
+            options.setAmazonSideAsn(requested.getAmazonSideAsn());
+        }
+        if (requested.getAutoAcceptSharedAttachments() != null) {
+            options.setAutoAcceptSharedAttachments(requested.getAutoAcceptSharedAttachments());
+        }
+        if (requested.getDefaultRouteTableAssociation() != null) {
+            options.setDefaultRouteTableAssociation(requested.getDefaultRouteTableAssociation());
+        }
+        if (requested.getDefaultRouteTablePropagation() != null) {
+            options.setDefaultRouteTablePropagation(requested.getDefaultRouteTablePropagation());
+        }
+        if (requested.getVpnEcmpSupport() != null) {
+            options.setVpnEcmpSupport(requested.getVpnEcmpSupport());
+        }
+        if (requested.getDnsSupport() != null) {
+            options.setDnsSupport(requested.getDnsSupport());
+        }
+        if (requested.getSecurityGroupReferencingSupport() != null) {
+            options.setSecurityGroupReferencingSupport(requested.getSecurityGroupReferencingSupport());
+        }
+        if (requested.getMulticastSupport() != null) {
+            options.setMulticastSupport(requested.getMulticastSupport());
+        }
+        if (requested.getTransitGatewayCidrBlocks() != null) {
+            options.setTransitGatewayCidrBlocks(new ArrayList<>(requested.getTransitGatewayCidrBlocks()));
+        }
+        return options;
+    }
+
+    private TransitGatewayRouteTable createDefaultTransitGatewayRouteTable(String region, TransitGateway gateway) {
+        TransitGatewayRouteTable routeTable = new TransitGatewayRouteTable();
+        String routeTableId = "tgw-rtb-" + randomHex(17);
+        routeTable.setTransitGatewayRouteTableId(routeTableId);
+        routeTable.setTransitGatewayId(gateway.getTransitGatewayId());
+        routeTable.setState("available");
+        routeTable.setDefaultAssociationRouteTable("enable".equals(gateway.getOptions().getDefaultRouteTableAssociation()));
+        routeTable.setDefaultPropagationRouteTable("enable".equals(gateway.getOptions().getDefaultRouteTablePropagation()));
+        routeTable.setCreationTime(ISO_FMT.format(Instant.now()));
+        routeTable.setRegion(region);
+        transitGatewayRouteTables.put(key(region, routeTableId), routeTable);
+        return routeTable;
+    }
+
+    public List<TransitGateway> describeTransitGateways(String region, List<String> transitGatewayIds,
+                                                        Map<String, List<String>> filters) {
+        transitGatewayIds.forEach(Ec2Service::requireWellFormedTransitGatewayId);
+        List<TransitGateway> all = transitGateways.scan(k -> true).stream()
+                .filter(gateway -> region.equals(gateway.getRegion()))
+                .collect(Collectors.toList());
+
+        for (String transitGatewayId : transitGatewayIds) {
+            if (all.stream().noneMatch(gateway -> gateway.getTransitGatewayId().equals(transitGatewayId))) {
+                throw new AwsException("InvalidTransitGatewayID.NotFound",
+                        "Transit Gateway " + transitGatewayId + " was deleted or does not exist.", 400);
+            }
+        }
+        return all.stream()
+                .filter(gateway -> transitGatewayIds.isEmpty()
+                        || transitGatewayIds.contains(gateway.getTransitGatewayId()))
+                .filter(gateway -> matchesFilters(gateway, filters, region))
+                .collect(Collectors.toList());
+    }
+
+    public TransitGateway modifyTransitGateway(String region, String transitGatewayId, String description,
+                                               TransitGatewayOptions changes, List<String> addCidrBlocks,
+                                               List<String> removeCidrBlocks) {
+        synchronized (lockFor(key(region, transitGatewayId))) {
+            TransitGateway gateway = getRequiredTransitGateway(region, transitGatewayId);
+            if (description != null) {
+                gateway.setDescription(description);
+            }
+            applyTransitGatewayOptionChanges(gateway.getOptions(), changes);
+            if (removeCidrBlocks != null && !removeCidrBlocks.isEmpty()) {
+                gateway.getOptions().getTransitGatewayCidrBlocks().removeIf(removeCidrBlocks::contains);
+            }
+            if (addCidrBlocks != null) {
+                for (String cidr : addCidrBlocks) {
+                    if (!gateway.getOptions().getTransitGatewayCidrBlocks().contains(cidr)) {
+                        gateway.getOptions().getTransitGatewayCidrBlocks().add(cidr);
+                    }
+                }
+            }
+            transitGateways.put(key(region, transitGatewayId), gateway);
+            return gateway;
+        }
+    }
+
+    private void applyTransitGatewayOptionChanges(TransitGatewayOptions options, TransitGatewayOptions changes) {
+        if (changes == null) {
+            return;
+        }
+        if (changes.getAmazonSideAsn() != null) {
+            options.setAmazonSideAsn(changes.getAmazonSideAsn());
+        }
+        if (changes.getAutoAcceptSharedAttachments() != null) {
+            options.setAutoAcceptSharedAttachments(changes.getAutoAcceptSharedAttachments());
+        }
+        if (changes.getDefaultRouteTableAssociation() != null) {
+            options.setDefaultRouteTableAssociation(changes.getDefaultRouteTableAssociation());
+        }
+        if (changes.getAssociationDefaultRouteTableId() != null) {
+            options.setAssociationDefaultRouteTableId(changes.getAssociationDefaultRouteTableId());
+        }
+        if (changes.getDefaultRouteTablePropagation() != null) {
+            options.setDefaultRouteTablePropagation(changes.getDefaultRouteTablePropagation());
+        }
+        if (changes.getPropagationDefaultRouteTableId() != null) {
+            options.setPropagationDefaultRouteTableId(changes.getPropagationDefaultRouteTableId());
+        }
+        if (changes.getVpnEcmpSupport() != null) {
+            options.setVpnEcmpSupport(changes.getVpnEcmpSupport());
+        }
+        if (changes.getDnsSupport() != null) {
+            options.setDnsSupport(changes.getDnsSupport());
+        }
+        if (changes.getSecurityGroupReferencingSupport() != null) {
+            options.setSecurityGroupReferencingSupport(changes.getSecurityGroupReferencingSupport());
+        }
+        if (changes.getMulticastSupport() != null) {
+            options.setMulticastSupport(changes.getMulticastSupport());
+        }
+    }
+
+    /**
+     * Deletes a transit gateway and the default route table created with it, which is what the
+     * live API does — the route table disappears alongside the gateway rather than outliving it.
+     *
+     * <p>AWS reports {@code deleting} here and settles on {@code deleted} about a minute later;
+     * the returned object carries the settled state for the same reason creation does.
+     */
+    public TransitGateway deleteTransitGateway(String region, String transitGatewayId) {
+        synchronized (lockFor(key(region, transitGatewayId))) {
+            TransitGateway gateway = getRequiredTransitGateway(region, transitGatewayId);
+            transitGatewayRouteTables.scan(k -> true).stream()
+                    .filter(routeTable -> region.equals(routeTable.getRegion()))
+                    .filter(routeTable -> transitGatewayId.equals(routeTable.getTransitGatewayId()))
+                    .toList()
+                    .forEach(routeTable -> transitGatewayRouteTables
+                            .delete(key(region, routeTable.getTransitGatewayRouteTableId())));
+            transitGateways.delete(key(region, transitGatewayId));
+            tags.delete(transitGatewayId);
+            gateway.setState("deleted");
+            return gateway;
+        }
+    }
+
+    private TransitGateway getRequiredTransitGateway(String region, String transitGatewayId) {
+        if (transitGatewayId == null || transitGatewayId.isBlank()) {
+            throw new AwsException("MissingParameter",
+                    "The request must contain the parameter TransitGatewayId.", 400);
+        }
+        return describeTransitGateways(region, List.of(transitGatewayId), Map.of()).stream()
+                .findFirst()
+                .orElseThrow(() -> new AwsException("InvalidTransitGatewayID.NotFound",
+                        "Transit Gateway " + transitGatewayId + " was deleted or does not exist.", 400));
+    }
+
+    private static void requireWellFormedTransitGatewayId(String transitGatewayId) {
+        if (!TRANSIT_GATEWAY_ID_PATTERN.matcher(transitGatewayId).matches()) {
+            throw new AwsException("InvalidTransitGatewayID.Malformed",
+                    "Invalid Transit Gateway id " + transitGatewayId + ".", 400);
+        }
     }
 
     // ─── Instances ─────────────────────────────────────────────────────────────
@@ -2848,6 +3120,13 @@ public class Ec2Service implements ContainerTeardown {
         if (resourceId.startsWith("pl-")) {
             return "prefix-list";
         }
+        // Checked before the gateway prefix, which it starts with.
+        if (resourceId.startsWith("tgw-rtb-")) {
+            return "transit-gateway-route-table";
+        }
+        if (resourceId.startsWith("tgw-")) {
+            return "transit-gateway";
+        }
         return "unknown";
     }
 
@@ -3357,6 +3636,22 @@ public class Ec2Service implements ContainerTeardown {
                 default -> true;
             };
         }
+        if (resource instanceof TransitGateway gateway) {
+            return switch (filterName) {
+                case "transit-gateway-id" -> matchesValue(values, gateway.getTransitGatewayId());
+                case "state" -> matchesValue(values, gateway.getState());
+                case "owner-id" -> matchesValue(values, gateway.getOwnerId());
+                case "options.amazon-side-asn" ->
+                        matchesValue(values, String.valueOf(gateway.getOptions().getAmazonSideAsn()));
+                case "options.association-default-route-table-id" ->
+                        matchesValue(values, gateway.getOptions().getAssociationDefaultRouteTableId());
+                case "options.propagation-default-route-table-id" ->
+                        matchesValue(values, gateway.getOptions().getPropagationDefaultRouteTableId());
+                case "options.dns-support" -> matchesValue(values, gateway.getOptions().getDnsSupport());
+                case "options.vpn-ecmp-support" -> matchesValue(values, gateway.getOptions().getVpnEcmpSupport());
+                default -> true;
+            };
+        }
         if (resource instanceof SecurityGroup sg) {
             return switch (filterName) {
                 case "group-id" -> matchesValue(values, sg.getGroupId());
@@ -3487,6 +3782,8 @@ public class Ec2Service implements ContainerTeardown {
         if (resource instanceof VpcEndpoint endpoint) return endpoint.getTags();
         if (resource instanceof NatGateway natGateway) return natGateway.getTags();
         if (resource instanceof SpotInstanceRequest sir) return sir.getTags();
+        if (resource instanceof TransitGateway gateway) return gateway.getTags();
+        if (resource instanceof TransitGatewayRouteTable routeTable) return routeTable.getTags();
         return Collections.emptyList();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1046,21 +1046,29 @@ public class Ec2Service implements ContainerTeardown {
             return;
         }
         TransitGatewayOptions options = gateway.getOptions();
+        // The id on the options already carries any id the request supplied, so enabling without
+        // one keeps the table the gateway already names rather than dropping it.
         if (changes.getDefaultRouteTableAssociation() != null) {
-            boolean enabling = "enable".equals(changes.getDefaultRouteTableAssociation());
-            String routeTableId = enabling
-                    ? changes.getAssociationDefaultRouteTableId()
-                    : options.getAssociationDefaultRouteTableId();
-            options.setAssociationDefaultRouteTableId(enabling ? routeTableId : null);
-            markDefaultRouteTable(region, routeTableId, true, enabling);
+            if ("enable".equals(changes.getDefaultRouteTableAssociation())) {
+                markDefaultRouteTable(region, options.getAssociationDefaultRouteTableId(), true, true);
+            } else {
+                String previous = options.getAssociationDefaultRouteTableId();
+                options.setAssociationDefaultRouteTableId(null);
+                markDefaultRouteTable(region, previous, true, false);
+            }
+        } else if (changes.getAssociationDefaultRouteTableId() != null) {
+            markDefaultRouteTable(region, changes.getAssociationDefaultRouteTableId(), true, true);
         }
         if (changes.getDefaultRouteTablePropagation() != null) {
-            boolean enabling = "enable".equals(changes.getDefaultRouteTablePropagation());
-            String routeTableId = enabling
-                    ? changes.getPropagationDefaultRouteTableId()
-                    : options.getPropagationDefaultRouteTableId();
-            options.setPropagationDefaultRouteTableId(enabling ? routeTableId : null);
-            markDefaultRouteTable(region, routeTableId, false, enabling);
+            if ("enable".equals(changes.getDefaultRouteTablePropagation())) {
+                markDefaultRouteTable(region, options.getPropagationDefaultRouteTableId(), false, true);
+            } else {
+                String previous = options.getPropagationDefaultRouteTableId();
+                options.setPropagationDefaultRouteTableId(null);
+                markDefaultRouteTable(region, previous, false, false);
+            }
+        } else if (changes.getPropagationDefaultRouteTableId() != null) {
+            markDefaultRouteTable(region, changes.getPropagationDefaultRouteTableId(), false, true);
         }
     }
 
@@ -1090,25 +1098,48 @@ public class Ec2Service implements ContainerTeardown {
         if (changes == null) {
             return;
         }
+        TransitGatewayOptions current = gateway.getOptions();
         requireFlagAndRouteTableAgree(changes.getDefaultRouteTableAssociation(),
                 changes.getAssociationDefaultRouteTableId(),
+                current.getDefaultRouteTableAssociation(), current.getAssociationDefaultRouteTableId(),
                 "DefaultRouteTableAssociation", "AssociationDefaultRouteTableId");
         requireFlagAndRouteTableAgree(changes.getDefaultRouteTablePropagation(),
                 changes.getPropagationDefaultRouteTableId(),
+                current.getDefaultRouteTablePropagation(), current.getPropagationDefaultRouteTableId(),
                 "DefaultRouteTablePropagation", "PropagationDefaultRouteTableId");
         requireRouteTableOfGateway(region, gateway, changes.getAssociationDefaultRouteTableId());
         requireRouteTableOfGateway(region, gateway, changes.getPropagationDefaultRouteTableId());
     }
 
+    /**
+     * The flag and its route table id are judged against the gateway as it stands, not against the
+     * request alone — which is why an id may arrive on its own. Verified against a live account:
+     *
+     * <ul>
+     *   <li>an id on its own is accepted while the option is enabled, and rejected while it is
+     *       disabled, with the message quoting the stored flag rather than the request</li>
+     *   <li>{@code enable} on its own is accepted when the gateway already names a table, and
+     *       rejected when it does not</li>
+     *   <li>{@code disable} may not carry an id at all</li>
+     * </ul>
+     *
+     * <p>This runs before the table is looked up, matching AWS: a disabled option paired with an
+     * id that does not exist reports the combination rather than the missing table.
+     */
     private void requireFlagAndRouteTableAgree(String flag, String routeTableId,
+                                               String currentFlag, String currentRouteTableId,
                                                String flagName, String routeTableIdName) {
-        if (flag == null) {
+        String effectiveFlag = flag != null ? flag : currentFlag;
+        if (!"enable".equals(effectiveFlag)) {
+            if (routeTableId != null) {
+                throw new AwsException("InvalidParameterCombination",
+                        "disable " + flagName + " conflicts with " + routeTableIdName + " " + routeTableId, 400);
+            }
             return;
         }
-        boolean enabling = "enable".equals(flag);
-        if (enabling == (routeTableId == null)) {
+        if (flag != null && routeTableId == null && currentRouteTableId == null) {
             throw new AwsException("InvalidParameterCombination",
-                    flag + " " + flagName + " conflicts with " + routeTableIdName + " " + routeTableId, 400);
+                    "enable " + flagName + " conflicts with " + routeTableIdName + " null", 400);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1018,6 +1018,7 @@ public class Ec2Service implements ContainerTeardown {
                 gateway.setDescription(description);
             }
             applyTransitGatewayOptionChanges(gateway.getOptions(), changes);
+            applyDefaultRouteTableChanges(region, gateway, changes);
             if (removeCidrBlocks != null && !removeCidrBlocks.isEmpty()) {
                 gateway.getOptions().getTransitGatewayCidrBlocks().removeIf(removeCidrBlocks::contains);
             }
@@ -1031,6 +1032,50 @@ public class Ec2Service implements ContainerTeardown {
             transitGateways.put(key(region, transitGatewayId), gateway);
             return gateway;
         }
+    }
+
+    /**
+     * Carries a default route table flag change through to the id it governs and to the table
+     * itself. Verified against a live account: disabling drops the id from the options entirely
+     * rather than blanking it, and clears that table's own default marker while leaving the table
+     * in place — the other default, if still enabled, keeps both its id and its marker.
+     */
+    private void applyDefaultRouteTableChanges(String region, TransitGateway gateway,
+                                               TransitGatewayOptions changes) {
+        if (changes == null) {
+            return;
+        }
+        TransitGatewayOptions options = gateway.getOptions();
+        if (changes.getDefaultRouteTableAssociation() != null) {
+            boolean enabling = "enable".equals(changes.getDefaultRouteTableAssociation());
+            String routeTableId = enabling
+                    ? changes.getAssociationDefaultRouteTableId()
+                    : options.getAssociationDefaultRouteTableId();
+            options.setAssociationDefaultRouteTableId(enabling ? routeTableId : null);
+            markDefaultRouteTable(region, routeTableId, true, enabling);
+        }
+        if (changes.getDefaultRouteTablePropagation() != null) {
+            boolean enabling = "enable".equals(changes.getDefaultRouteTablePropagation());
+            String routeTableId = enabling
+                    ? changes.getPropagationDefaultRouteTableId()
+                    : options.getPropagationDefaultRouteTableId();
+            options.setPropagationDefaultRouteTableId(enabling ? routeTableId : null);
+            markDefaultRouteTable(region, routeTableId, false, enabling);
+        }
+    }
+
+    private void markDefaultRouteTable(String region, String routeTableId, boolean association, boolean isDefault) {
+        if (routeTableId == null) {
+            return;
+        }
+        transitGatewayRouteTables.get(key(region, routeTableId)).ifPresent(routeTable -> {
+            if (association) {
+                routeTable.setDefaultAssociationRouteTable(isDefault);
+            } else {
+                routeTable.setDefaultPropagationRouteTable(isDefault);
+            }
+            transitGatewayRouteTables.put(key(region, routeTableId), routeTable);
+        });
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/TransitGateway.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/TransitGateway.java
@@ -1,0 +1,51 @@
+package io.github.hectorvent.floci.services.ec2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TransitGateway {
+
+    private String transitGatewayId;
+    private String transitGatewayArn;
+    private String state;
+    private String ownerId;
+    private String description;
+    private String creationTime;
+    private String region;
+    private TransitGatewayOptions options = new TransitGatewayOptions();
+    private List<Tag> tags = new ArrayList<>();
+
+    public TransitGateway() {}
+
+    public String getTransitGatewayId() { return transitGatewayId; }
+    public void setTransitGatewayId(String transitGatewayId) { this.transitGatewayId = transitGatewayId; }
+
+    public String getTransitGatewayArn() { return transitGatewayArn; }
+    public void setTransitGatewayArn(String transitGatewayArn) { this.transitGatewayArn = transitGatewayArn; }
+
+    public String getState() { return state; }
+    public void setState(String state) { this.state = state; }
+
+    public String getOwnerId() { return ownerId; }
+    public void setOwnerId(String ownerId) { this.ownerId = ownerId; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getCreationTime() { return creationTime; }
+    public void setCreationTime(String creationTime) { this.creationTime = creationTime; }
+
+    public String getRegion() { return region; }
+    public void setRegion(String region) { this.region = region; }
+
+    public TransitGatewayOptions getOptions() { return options; }
+    public void setOptions(TransitGatewayOptions options) { this.options = options; }
+
+    public List<Tag> getTags() { return tags; }
+    public void setTags(List<Tag> tags) { this.tags = tags; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/TransitGatewayOptions.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/TransitGatewayOptions.java
@@ -1,0 +1,73 @@
+package io.github.hectorvent.floci.services.ec2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TransitGatewayOptions {
+
+    private Long amazonSideAsn;
+    private List<String> transitGatewayCidrBlocks = new ArrayList<>();
+    private String autoAcceptSharedAttachments;
+    private String defaultRouteTableAssociation;
+    private String associationDefaultRouteTableId;
+    private String defaultRouteTablePropagation;
+    private String propagationDefaultRouteTableId;
+    private String vpnEcmpSupport;
+    private String dnsSupport;
+    private String securityGroupReferencingSupport;
+    private String multicastSupport;
+
+    public TransitGatewayOptions() {}
+
+    public Long getAmazonSideAsn() { return amazonSideAsn; }
+    public void setAmazonSideAsn(Long amazonSideAsn) { this.amazonSideAsn = amazonSideAsn; }
+
+    public List<String> getTransitGatewayCidrBlocks() { return transitGatewayCidrBlocks; }
+    public void setTransitGatewayCidrBlocks(List<String> transitGatewayCidrBlocks) {
+        this.transitGatewayCidrBlocks = transitGatewayCidrBlocks;
+    }
+
+    public String getAutoAcceptSharedAttachments() { return autoAcceptSharedAttachments; }
+    public void setAutoAcceptSharedAttachments(String autoAcceptSharedAttachments) {
+        this.autoAcceptSharedAttachments = autoAcceptSharedAttachments;
+    }
+
+    public String getDefaultRouteTableAssociation() { return defaultRouteTableAssociation; }
+    public void setDefaultRouteTableAssociation(String defaultRouteTableAssociation) {
+        this.defaultRouteTableAssociation = defaultRouteTableAssociation;
+    }
+
+    public String getAssociationDefaultRouteTableId() { return associationDefaultRouteTableId; }
+    public void setAssociationDefaultRouteTableId(String associationDefaultRouteTableId) {
+        this.associationDefaultRouteTableId = associationDefaultRouteTableId;
+    }
+
+    public String getDefaultRouteTablePropagation() { return defaultRouteTablePropagation; }
+    public void setDefaultRouteTablePropagation(String defaultRouteTablePropagation) {
+        this.defaultRouteTablePropagation = defaultRouteTablePropagation;
+    }
+
+    public String getPropagationDefaultRouteTableId() { return propagationDefaultRouteTableId; }
+    public void setPropagationDefaultRouteTableId(String propagationDefaultRouteTableId) {
+        this.propagationDefaultRouteTableId = propagationDefaultRouteTableId;
+    }
+
+    public String getVpnEcmpSupport() { return vpnEcmpSupport; }
+    public void setVpnEcmpSupport(String vpnEcmpSupport) { this.vpnEcmpSupport = vpnEcmpSupport; }
+
+    public String getDnsSupport() { return dnsSupport; }
+    public void setDnsSupport(String dnsSupport) { this.dnsSupport = dnsSupport; }
+
+    public String getSecurityGroupReferencingSupport() { return securityGroupReferencingSupport; }
+    public void setSecurityGroupReferencingSupport(String securityGroupReferencingSupport) {
+        this.securityGroupReferencingSupport = securityGroupReferencingSupport;
+    }
+
+    public String getMulticastSupport() { return multicastSupport; }
+    public void setMulticastSupport(String multicastSupport) { this.multicastSupport = multicastSupport; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/TransitGatewayRouteTable.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/TransitGatewayRouteTable.java
@@ -1,0 +1,60 @@
+package io.github.hectorvent.floci.services.ec2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A transit gateway route table. Creating a transit gateway with
+ * {@code DefaultRouteTableAssociation} or {@code DefaultRouteTablePropagation} enabled makes AWS
+ * mint one of these immediately, and its id is reported back on the gateway's options, so the
+ * record exists here from part one. The actions that operate on route tables directly
+ * (create, associate, propagate, describe) are not implemented yet.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TransitGatewayRouteTable {
+
+    private String transitGatewayRouteTableId;
+    private String transitGatewayId;
+    private String state;
+    private boolean defaultAssociationRouteTable;
+    private boolean defaultPropagationRouteTable;
+    private String creationTime;
+    private String region;
+    private List<Tag> tags = new ArrayList<>();
+
+    public TransitGatewayRouteTable() {}
+
+    public String getTransitGatewayRouteTableId() { return transitGatewayRouteTableId; }
+    public void setTransitGatewayRouteTableId(String transitGatewayRouteTableId) {
+        this.transitGatewayRouteTableId = transitGatewayRouteTableId;
+    }
+
+    public String getTransitGatewayId() { return transitGatewayId; }
+    public void setTransitGatewayId(String transitGatewayId) { this.transitGatewayId = transitGatewayId; }
+
+    public String getState() { return state; }
+    public void setState(String state) { this.state = state; }
+
+    public boolean isDefaultAssociationRouteTable() { return defaultAssociationRouteTable; }
+    public void setDefaultAssociationRouteTable(boolean defaultAssociationRouteTable) {
+        this.defaultAssociationRouteTable = defaultAssociationRouteTable;
+    }
+
+    public boolean isDefaultPropagationRouteTable() { return defaultPropagationRouteTable; }
+    public void setDefaultPropagationRouteTable(boolean defaultPropagationRouteTable) {
+        this.defaultPropagationRouteTable = defaultPropagationRouteTable;
+    }
+
+    public String getCreationTime() { return creationTime; }
+    public void setCreationTime(String creationTime) { this.creationTime = creationTime; }
+
+    public String getRegion() { return region; }
+    public void setRegion(String region) { this.region = region; }
+
+    public List<Tag> getTags() { return tags; }
+    public void setTags(List<Tag> tags) { this.tags = tags; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -1477,6 +1477,39 @@ class Ec2ServiceTest {
         assertEquals(routeTableId, after.getAssociationDefaultRouteTableId());
     }
 
+    /**
+     * Verified against a live account: disabling one default drops its id from the options
+     * entirely and clears that marker on the route table, while the other default keeps both its
+     * id and its marker, and the table itself survives.
+     */
+    @Test
+    void disablingADefaultDropsItsIdAndClearsOnlyThatMarker() {
+        AccountAwareStorageBackend<TransitGatewayRouteTable> routeTables =
+                AccountAwareStorageBackend.inMemory("000000000000");
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory(Map.of("ec2-transit-gateway-route-tables.json", routeTables)));
+        TransitGateway gateway = service.createTransitGateway("us-east-1", "hub", null, List.of());
+        String routeTableId = gateway.getOptions().getAssociationDefaultRouteTableId();
+
+        TransitGatewayOptions changes = new TransitGatewayOptions();
+        changes.setDefaultRouteTableAssociation("disable");
+        TransitGatewayOptions after = service.modifyTransitGateway("us-east-1",
+                gateway.getTransitGatewayId(), null, changes, List.of(), List.of()).getOptions();
+
+        assertEquals("disable", after.getDefaultRouteTableAssociation());
+        assertNull(after.getAssociationDefaultRouteTableId(), "the id goes with the flag");
+        assertEquals("enable", after.getDefaultRouteTablePropagation());
+        assertEquals(routeTableId, after.getPropagationDefaultRouteTableId(),
+                "the other default is untouched");
+
+        TransitGatewayRouteTable stored = routeTables.scan(k -> true).getFirst();
+        assertFalse(stored.isDefaultAssociationRouteTable(), "association marker cleared");
+        assertTrue(stored.isDefaultPropagationRouteTable(), "propagation marker kept");
+        assertEquals(routeTableId, stored.getTransitGatewayRouteTableId(), "the table itself survives");
+    }
+
     @Test
     void deleteTransitGatewayRemovesTheGatewayAndItsDefaultRouteTable() {
         AccountAwareStorageBackend<TransitGatewayRouteTable> routeTables =

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -1459,6 +1459,44 @@ class Ec2ServiceTest {
         assertNull(after.getAssociationDefaultRouteTableId());
     }
 
+    /**
+     * Verified against a live account: a route table belonging to another gateway is rejected
+     * under the same code as one that exists nowhere, with the gateway named in the message.
+     * Without the ownership check the foreign table's own default markers would be rewritten.
+     */
+    @Test
+    void aRouteTableBelongingToAnotherGatewayIsRejected() {
+        AccountAwareStorageBackend<TransitGatewayRouteTable> routeTables =
+                AccountAwareStorageBackend.inMemory("000000000000");
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory(Map.of("ec2-transit-gateway-route-tables.json", routeTables)));
+        TransitGatewayOptions defaultsOff = new TransitGatewayOptions();
+        defaultsOff.setDefaultRouteTableAssociation("disable");
+        defaultsOff.setDefaultRouteTablePropagation("disable");
+        String borrower = service.createTransitGateway("us-east-1", "borrower", defaultsOff, List.of())
+                .getTransitGatewayId();
+        TransitGateway owner = service.createTransitGateway("us-east-1", "owner", null, List.of());
+        String ownersRouteTable = owner.getOptions().getAssociationDefaultRouteTableId();
+
+        TransitGatewayOptions changes = new TransitGatewayOptions();
+        changes.setDefaultRouteTableAssociation("enable");
+        changes.setAssociationDefaultRouteTableId(ownersRouteTable);
+
+        AwsException error = assertThrows(AwsException.class, () -> service.modifyTransitGateway(
+                "us-east-1", borrower, null, changes, List.of(), List.of()));
+        assertEquals("InvalidRouteTableID.NotFound", error.getErrorCode());
+        assertTrue(error.getMessage().contains(borrower),
+                "the message names the gateway the table is missing from");
+
+        // The owner's table kept its markers, and the borrower stayed disabled.
+        TransitGatewayRouteTable stored = routeTables.get("us-east-1::" + ownersRouteTable).orElseThrow();
+        assertTrue(stored.isDefaultAssociationRouteTable());
+        assertNull(service.describeTransitGateways("us-east-1", List.of(borrower), Map.of())
+                .getFirst().getOptions().getAssociationDefaultRouteTableId());
+    }
+
     /** Repointing the default route table at the gateway's own table is accepted. */
     @Test
     void aDefaultRouteTableOptionCanBeSetWhenItsRouteTableIsNamed() {

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -1497,6 +1497,66 @@ class Ec2ServiceTest {
                 .getFirst().getOptions().getAssociationDefaultRouteTableId());
     }
 
+    /**
+     * The whole flag/id contract, as observed on a live account. The pair is judged against the
+     * gateway as it stands rather than against the request alone, which is what makes an id on its
+     * own legal while the option is enabled and a conflict while it is disabled.
+     */
+    @Test
+    void aRouteTableIdOnItsOwnFollowsTheStoredFlag() {
+        Ec2Service service = prefixListService();
+        TransitGateway gateway = service.createTransitGateway("us-east-1", "hub", null, List.of());
+        String id = gateway.getTransitGatewayId();
+        String routeTableId = gateway.getOptions().getAssociationDefaultRouteTableId();
+
+        // Enabled: an id on its own is accepted, and enable on its own keeps the stored table.
+        TransitGatewayOptions idOnly = new TransitGatewayOptions();
+        idOnly.setAssociationDefaultRouteTableId(routeTableId);
+        assertEquals(routeTableId, service.modifyTransitGateway("us-east-1", id, null, idOnly,
+                List.of(), List.of()).getOptions().getAssociationDefaultRouteTableId());
+
+        TransitGatewayOptions flagOnly = new TransitGatewayOptions();
+        flagOnly.setDefaultRouteTableAssociation("enable");
+        assertEquals(routeTableId, service.modifyTransitGateway("us-east-1", id, null, flagOnly,
+                List.of(), List.of()).getOptions().getAssociationDefaultRouteTableId(),
+                "enable on its own keeps the table already named");
+
+        // Disabled: the same id-only request now conflicts, and the message quotes the stored flag.
+        TransitGatewayOptions disable = new TransitGatewayOptions();
+        disable.setDefaultRouteTableAssociation("disable");
+        service.modifyTransitGateway("us-east-1", id, null, disable, List.of(), List.of());
+
+        AwsException conflict = assertThrows(AwsException.class, () -> service.modifyTransitGateway(
+                "us-east-1", id, null, idOnly, List.of(), List.of()));
+        assertEquals("InvalidParameterCombination", conflict.getErrorCode());
+        assertTrue(conflict.getMessage().startsWith("disable DefaultRouteTableAssociation"),
+                "the stored flag is what the message reports, got: " + conflict.getMessage());
+
+        // A disabled option paired with an unknown table reports the combination, not the lookup.
+        TransitGatewayOptions unknownIdOnly = new TransitGatewayOptions();
+        unknownIdOnly.setAssociationDefaultRouteTableId("tgw-rtb-0123456789abcdef0");
+        assertEquals("InvalidParameterCombination", assertThrows(AwsException.class,
+                () -> service.modifyTransitGateway("us-east-1", id, null, unknownIdOnly,
+                        List.of(), List.of())).getErrorCode());
+
+        // And enable on its own is a conflict once there is no table left to keep.
+        assertEquals("InvalidParameterCombination", assertThrows(AwsException.class,
+                () -> service.modifyTransitGateway("us-east-1", id, null, flagOnly,
+                        List.of(), List.of())).getErrorCode());
+    }
+
+    /** Removals apply before additions, so a CIDR added and removed in one call survives. */
+    @Test
+    void aCidrBlockAddedAndRemovedInOneCallSurvives() {
+        Ec2Service service = prefixListService();
+        String id = service.createTransitGateway("us-east-1", null, null, List.of()).getTransitGatewayId();
+
+        TransitGatewayOptions after = service.modifyTransitGateway("us-east-1", id, null, null,
+                List.of("10.200.0.0/16"), List.of("10.200.0.0/16")).getOptions();
+
+        assertEquals(List.of("10.200.0.0/16"), after.getTransitGatewayCidrBlocks());
+    }
+
     /** Repointing the default route table at the gateway's own table is accepted. */
     @Test
     void aDefaultRouteTableOptionCanBeSetWhenItsRouteTableIsNamed() {

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -1410,6 +1410,73 @@ class Ec2ServiceTest {
         assertEquals("after", shrunk.getDescription(), "a null description leaves the stored one alone");
     }
 
+    /**
+     * The flag and its route table id have to move together. Verified against a live account: AWS
+     * refuses to enable association or propagation without being told which existing table to use,
+     * refuses an id alongside a disable, and reports an unknown table as
+     * {@code InvalidRouteTableID.NotFound}. Without this a gateway could report the option enabled
+     * while carrying no id at all.
+     */
+    @Test
+    void enablingADefaultRouteTableOptionRequiresAnExistingRouteTable() {
+        Ec2Service service = prefixListService();
+        TransitGatewayOptions createdWithout = new TransitGatewayOptions();
+        createdWithout.setDefaultRouteTableAssociation("disable");
+        createdWithout.setDefaultRouteTablePropagation("disable");
+        String id = service.createTransitGateway("us-east-1", null, createdWithout, List.of())
+                .getTransitGatewayId();
+
+        TransitGatewayOptions enableOnly = new TransitGatewayOptions();
+        enableOnly.setDefaultRouteTableAssociation("enable");
+        AwsException noId = assertThrows(AwsException.class, () -> service.modifyTransitGateway(
+                "us-east-1", id, null, enableOnly, List.of(), List.of()));
+        assertEquals("InvalidParameterCombination", noId.getErrorCode());
+
+        TransitGatewayOptions propagationOnly = new TransitGatewayOptions();
+        propagationOnly.setDefaultRouteTablePropagation("enable");
+        assertEquals("InvalidParameterCombination", assertThrows(AwsException.class,
+                () -> service.modifyTransitGateway("us-east-1", id, null, propagationOnly,
+                        List.of(), List.of())).getErrorCode());
+
+        TransitGatewayOptions disableWithId = new TransitGatewayOptions();
+        disableWithId.setDefaultRouteTableAssociation("disable");
+        disableWithId.setAssociationDefaultRouteTableId("tgw-rtb-0123456789abcdef0");
+        assertEquals("InvalidParameterCombination", assertThrows(AwsException.class,
+                () -> service.modifyTransitGateway("us-east-1", id, null, disableWithId,
+                        List.of(), List.of())).getErrorCode());
+
+        TransitGatewayOptions unknownTable = new TransitGatewayOptions();
+        unknownTable.setDefaultRouteTableAssociation("enable");
+        unknownTable.setAssociationDefaultRouteTableId("tgw-rtb-0123456789abcdef0");
+        assertEquals("InvalidRouteTableID.NotFound", assertThrows(AwsException.class,
+                () -> service.modifyTransitGateway("us-east-1", id, null, unknownTable,
+                        List.of(), List.of())).getErrorCode());
+
+        // The rejected calls left the gateway as it was, rather than half-applied.
+        TransitGatewayOptions after = service.describeTransitGateways("us-east-1", List.of(id), Map.of())
+                .getFirst().getOptions();
+        assertEquals("disable", after.getDefaultRouteTableAssociation());
+        assertNull(after.getAssociationDefaultRouteTableId());
+    }
+
+    /** Repointing the default route table at the gateway's own table is accepted. */
+    @Test
+    void aDefaultRouteTableOptionCanBeSetWhenItsRouteTableIsNamed() {
+        Ec2Service service = prefixListService();
+        TransitGateway gateway = service.createTransitGateway("us-east-1", null, null, List.of());
+        String routeTableId = gateway.getOptions().getAssociationDefaultRouteTableId();
+
+        TransitGatewayOptions changes = new TransitGatewayOptions();
+        changes.setDefaultRouteTableAssociation("enable");
+        changes.setAssociationDefaultRouteTableId(routeTableId);
+
+        TransitGatewayOptions after = service.modifyTransitGateway("us-east-1",
+                gateway.getTransitGatewayId(), null, changes, List.of(), List.of()).getOptions();
+
+        assertEquals("enable", after.getDefaultRouteTableAssociation());
+        assertEquals(routeTableId, after.getAssociationDefaultRouteTableId());
+    }
+
     @Test
     void deleteTransitGatewayRemovesTheGatewayAndItsDefaultRouteTable() {
         AccountAwareStorageBackend<TransitGatewayRouteTable> routeTables =

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -23,6 +23,9 @@ import io.github.hectorvent.floci.services.ec2.model.Reservation;
 import io.github.hectorvent.floci.services.ec2.model.SecurityGroup;
 import io.github.hectorvent.floci.services.ec2.model.Snapshot;
 import io.github.hectorvent.floci.services.ec2.model.Tag;
+import io.github.hectorvent.floci.services.ec2.model.TransitGateway;
+import io.github.hectorvent.floci.services.ec2.model.TransitGatewayOptions;
+import io.github.hectorvent.floci.services.ec2.model.TransitGatewayRouteTable;
 import io.github.hectorvent.floci.services.ec2.model.UserIdGroupPair;
 import io.github.hectorvent.floci.services.ec2.model.VpcEndpoint;
 import io.github.hectorvent.floci.services.ec2.model.Volume;
@@ -1277,6 +1280,166 @@ class Ec2ServiceTest {
                 Map.of("resource-id", List.of(groupId))).getFirst().get("resourceType"));
         assertEquals(1, service.describeTags("us-east-1",
                 Map.of("resource-type", List.of("security-group"))).size());
+    }
+
+    // =========================================================================
+    // Transit gateways
+    // =========================================================================
+
+    /**
+     * Every default here was read off a live AWS account rather than the documentation, including
+     * the one that is easy to assume the other way: {@code securityGroupReferencingSupport} is
+     * {@code disable} on a new gateway.
+     */
+    @Test
+    void createTransitGatewayAppliesTheDefaultsAwsApplies() {
+        Ec2Service service = prefixListService();
+
+        TransitGateway gateway = service.createTransitGateway("us-east-1", "hub", null, List.of());
+
+        assertTrue(gateway.getTransitGatewayId().startsWith("tgw-"));
+        assertEquals("arn:aws:ec2:us-east-1:000000000000:transit-gateway/" + gateway.getTransitGatewayId(),
+                gateway.getTransitGatewayArn());
+        assertEquals("available", gateway.getState());
+        assertEquals("000000000000", gateway.getOwnerId());
+        assertEquals("hub", gateway.getDescription());
+
+        TransitGatewayOptions options = gateway.getOptions();
+        assertEquals(64512L, options.getAmazonSideAsn());
+        assertEquals("disable", options.getAutoAcceptSharedAttachments());
+        assertEquals("enable", options.getDefaultRouteTableAssociation());
+        assertEquals("enable", options.getDefaultRouteTablePropagation());
+        assertEquals("enable", options.getVpnEcmpSupport());
+        assertEquals("enable", options.getDnsSupport());
+        assertEquals("disable", options.getSecurityGroupReferencingSupport());
+        assertEquals("disable", options.getMulticastSupport());
+        assertTrue(options.getTransitGatewayCidrBlocks().isEmpty());
+    }
+
+    /**
+     * AWS mints the default route table during creation, so both ids are already on the create
+     * response and both name the same table.
+     */
+    @Test
+    void createTransitGatewayMintsTheDefaultRouteTableAndReportsItsId() {
+        Ec2Service service = prefixListService();
+
+        TransitGatewayOptions options =
+                service.createTransitGateway("us-east-1", null, null, List.of()).getOptions();
+
+        assertNotNull(options.getAssociationDefaultRouteTableId());
+        assertTrue(options.getAssociationDefaultRouteTableId().startsWith("tgw-rtb-"));
+        assertEquals(options.getAssociationDefaultRouteTableId(), options.getPropagationDefaultRouteTableId(),
+                "association and propagation point at the same default table");
+    }
+
+    @Test
+    void aGatewayThatOptsOutOfBothDefaultsGetsNoRouteTable() {
+        Ec2Service service = prefixListService();
+        TransitGatewayOptions requested = new TransitGatewayOptions();
+        requested.setDefaultRouteTableAssociation("disable");
+        requested.setDefaultRouteTablePropagation("disable");
+
+        TransitGatewayOptions options =
+                service.createTransitGateway("us-east-1", null, requested, List.of()).getOptions();
+
+        assertNull(options.getAssociationDefaultRouteTableId());
+        assertNull(options.getPropagationDefaultRouteTableId());
+    }
+
+    @Test
+    void requestedOptionsOverrideTheDefaults() {
+        Ec2Service service = prefixListService();
+        TransitGatewayOptions requested = new TransitGatewayOptions();
+        requested.setAmazonSideAsn(65001L);
+        requested.setDnsSupport("disable");
+        requested.setAutoAcceptSharedAttachments("enable");
+
+        TransitGatewayOptions options =
+                service.createTransitGateway("us-east-1", null, requested, List.of()).getOptions();
+
+        assertEquals(65001L, options.getAmazonSideAsn());
+        assertEquals("disable", options.getDnsSupport());
+        assertEquals("enable", options.getAutoAcceptSharedAttachments());
+        // Untouched options keep their defaults.
+        assertEquals("enable", options.getVpnEcmpSupport());
+    }
+
+    @Test
+    void describeTransitGatewaysFiltersAndRejectsUnknownIds() {
+        Ec2Service service = prefixListService();
+        TransitGateway gateway = service.createTransitGateway("us-east-1", "hub", null,
+                List.of(new Tag("env", "prod")));
+        service.createTransitGateway("us-east-1", "spoke", null, List.of());
+
+        assertEquals(2, service.describeTransitGateways("us-east-1", List.of(), Map.of()).size());
+        assertEquals(1, service.describeTransitGateways("us-east-1", List.of(),
+                Map.of("tag:env", List.of("prod"))).size());
+        assertEquals(gateway.getTransitGatewayId(), service.describeTransitGateways("us-east-1",
+                List.of(gateway.getTransitGatewayId()), Map.of()).getFirst().getTransitGatewayId());
+        // Another region cannot see it.
+        assertTrue(service.describeTransitGateways("eu-west-1", List.of(), Map.of()).isEmpty());
+
+        AwsException notFound = assertThrows(AwsException.class, () -> service.describeTransitGateways(
+                "us-east-1", List.of("tgw-0123456789abcdef0"), Map.of()));
+        assertEquals("InvalidTransitGatewayID.NotFound", notFound.getErrorCode());
+
+        AwsException malformed = assertThrows(AwsException.class, () -> service.describeTransitGateways(
+                "us-east-1", List.of("tgw-nope"), Map.of()));
+        assertEquals("InvalidTransitGatewayID.Malformed", malformed.getErrorCode());
+    }
+
+    @Test
+    void modifyTransitGatewayUpdatesDescriptionOptionsAndCidrBlocks() {
+        Ec2Service service = prefixListService();
+        String id = service.createTransitGateway("us-east-1", "before", null, List.of()).getTransitGatewayId();
+        TransitGatewayOptions changes = new TransitGatewayOptions();
+        changes.setDnsSupport("disable");
+
+        TransitGateway modified = service.modifyTransitGateway("us-east-1", id, "after", changes,
+                List.of("10.100.0.0/16", "10.101.0.0/16"), List.of());
+
+        assertEquals("after", modified.getDescription());
+        assertEquals("disable", modified.getOptions().getDnsSupport());
+        assertEquals(List.of("10.100.0.0/16", "10.101.0.0/16"),
+                modified.getOptions().getTransitGatewayCidrBlocks());
+
+        TransitGateway shrunk = service.modifyTransitGateway("us-east-1", id, null, null,
+                List.of(), List.of("10.100.0.0/16"));
+        assertEquals(List.of("10.101.0.0/16"), shrunk.getOptions().getTransitGatewayCidrBlocks());
+        assertEquals("after", shrunk.getDescription(), "a null description leaves the stored one alone");
+    }
+
+    @Test
+    void deleteTransitGatewayRemovesTheGatewayAndItsDefaultRouteTable() {
+        AccountAwareStorageBackend<TransitGatewayRouteTable> routeTables =
+                AccountAwareStorageBackend.inMemory("000000000000");
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory(Map.of("ec2-transit-gateway-route-tables.json", routeTables)));
+        String id = service.createTransitGateway("us-east-1", "hub", null, List.of()).getTransitGatewayId();
+        assertEquals(1, routeTables.scan(k -> true).size(), "creation mints the default route table");
+
+        TransitGateway deleted = service.deleteTransitGateway("us-east-1", id);
+
+        assertEquals("deleted", deleted.getState());
+        assertTrue(routeTables.scan(k -> true).isEmpty(), "the default route table goes with the gateway");
+        AwsException gone = assertThrows(AwsException.class,
+                () -> service.describeTransitGateways("us-east-1", List.of(id), Map.of()));
+        assertEquals("InvalidTransitGatewayID.NotFound", gone.getErrorCode());
+    }
+
+    @Test
+    void tagsOnATransitGatewayAreTypedAsTransitGateway() {
+        Ec2Service service = prefixListService();
+        String id = service.createTransitGateway("us-east-1", "hub", null,
+                List.of(new Tag("env", "prod"))).getTransitGatewayId();
+
+        assertEquals("transit-gateway", service.describeTags("us-east-1",
+                Map.of("resource-id", List.of(id))).getFirst().get("resourceType"));
+        assertEquals(1, service.describeTags("us-east-1",
+                Map.of("resource-type", List.of("transit-gateway"))).size());
     }
 
     private static EmulatorConfig mockConfig(boolean ec2Mock) {

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -1628,6 +1628,32 @@ class Ec2ServiceTest {
         assertEquals("InvalidTransitGatewayID.NotFound", gone.getErrorCode());
     }
 
+    /**
+     * A provider changes tags after creation with CreateTags and DeleteTags rather than resending
+     * a TagSpecification, then re-reads them from DescribeTransitGateways. Those have to be the
+     * same tags, or the resource never converges.
+     */
+    @Test
+    void tagsChangedAfterCreationAreVisibleOnDescribe() {
+        Ec2Service service = prefixListService();
+        String id = service.createTransitGateway("us-east-1", "hub", null,
+                List.of(new Tag("Name", "hub"))).getTransitGatewayId();
+
+        service.createTags("us-east-1", List.of(id), List.of(new Tag("env", "prod")));
+
+        List<Tag> afterCreate = service.describeTransitGateways("us-east-1", List.of(id), Map.of())
+                .getFirst().getTags();
+        assertEquals(2, afterCreate.size(), "describe serves the tags CreateTags stored");
+        assertTrue(afterCreate.stream().anyMatch(t -> "env".equals(t.getKey()) && "prod".equals(t.getValue())));
+
+        service.deleteTags("us-east-1", List.of(id), List.of(new Tag("env", null)));
+
+        List<Tag> afterDelete = service.describeTransitGateways("us-east-1", List.of(id), Map.of())
+                .getFirst().getTags();
+        assertEquals(1, afterDelete.size());
+        assertEquals("Name", afterDelete.getFirst().getKey());
+    }
+
     @Test
     void tagsOnATransitGatewayAreTypedAsTransitGateway() {
         Ec2Service service = prefixListService();

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2TransitGatewayIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2TransitGatewayIntegrationTest.java
@@ -1,0 +1,168 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Transit gateways over the EC2 Query protocol: creation with and without options, the read-back
+ * shape, modification, and deletion.
+ *
+ * <p>The response shapes asserted here were captured from a live AWS account, including the one
+ * that is not obvious from the API reference: create and describe carry a {@code tagSet}, while
+ * modify and delete return the same gateway without one.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class Ec2TransitGatewayIntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/ec2/aws4_request";
+
+    private static String transitGatewayId;
+    private static String defaultRouteTableId;
+
+    @Test
+    @Order(1)
+    void createReturnsTheGatewayWithAwsDefaultsAndItsTags() {
+        transitGatewayId = given()
+            .formParam("Action", "CreateTransitGateway")
+            .formParam("Description", "hub")
+            .formParam("TagSpecification.1.ResourceType", "transit-gateway")
+            .formParam("TagSpecification.1.Tag.1.Key", "env")
+            .formParam("TagSpecification.1.Tag.1.Value", "prod")
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then().statusCode(200)
+            .body("CreateTransitGatewayResponse.transitGateway.state", equalTo("available"))
+            .body("CreateTransitGatewayResponse.transitGateway.description", equalTo("hub"))
+            .body("CreateTransitGatewayResponse.transitGateway.options.amazonSideAsn", equalTo("64512"))
+            .body("CreateTransitGatewayResponse.transitGateway.options.dnsSupport", equalTo("enable"))
+            .body("CreateTransitGatewayResponse.transitGateway.options.securityGroupReferencingSupport",
+                    equalTo("disable"))
+            .body("CreateTransitGatewayResponse.transitGateway.tagSet.item.key", equalTo("env"))
+            .extract().path("CreateTransitGatewayResponse.transitGateway.transitGatewayId");
+
+        defaultRouteTableId = given()
+            .formParam("Action", "DescribeTransitGateways")
+            .formParam("TransitGatewayIds.1", transitGatewayId)
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then().statusCode(200)
+            .body("DescribeTransitGatewaysResponse.transitGatewaySet.item.transitGatewayArn",
+                    startsWith("arn:aws:ec2:"))
+            .body("DescribeTransitGatewaysResponse.transitGatewaySet.item.tagSet.item.value", equalTo("prod"))
+            .extract()
+            .path("DescribeTransitGatewaysResponse.transitGatewaySet.item.options.associationDefaultRouteTableId");
+
+        // The default route table is minted during creation, so its id is already reported back.
+        assertTrue(defaultRouteTableId.startsWith("tgw-rtb-"),
+                "expected a default route table id, got " + defaultRouteTableId);
+    }
+
+    @Test
+    @Order(2)
+    void createHonoursExplicitOptions() {
+        String body = given()
+            .formParam("Action", "CreateTransitGateway")
+            .formParam("Options.AmazonSideAsn", "65001")
+            .formParam("Options.DnsSupport", "disable")
+            .formParam("Options.DefaultRouteTableAssociation", "disable")
+            .formParam("Options.DefaultRouteTablePropagation", "disable")
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then().statusCode(200)
+            .body("CreateTransitGatewayResponse.transitGateway.options.amazonSideAsn", equalTo("65001"))
+            .body("CreateTransitGatewayResponse.transitGateway.options.dnsSupport", equalTo("disable"))
+            .extract().asString();
+
+        // Opting out of both defaults means there is no table to point at, and AWS omits the
+        // element rather than sending it empty. Asserted on the raw body because a missing path
+        // reads back as an empty node object rather than a null string.
+        assertThat(body, not(containsString("associationDefaultRouteTableId")));
+        assertThat(body, not(containsString("propagationDefaultRouteTableId")));
+    }
+
+    @Test
+    @Order(3)
+    void modifyAppliesOptionsAndReturnsNoTagSet() {
+        String body = given()
+            .formParam("Action", "ModifyTransitGateway")
+            .formParam("TransitGatewayId", transitGatewayId)
+            .formParam("Description", "hub-modified")
+            .formParam("Options.DnsSupport", "disable")
+            .formParam("Options.AddTransitGatewayCidrBlocks.1", "10.100.0.0/16")
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then().statusCode(200)
+            .body("ModifyTransitGatewayResponse.transitGateway.description", equalTo("hub-modified"))
+            .body("ModifyTransitGatewayResponse.transitGateway.options.dnsSupport", equalTo("disable"))
+            .body("ModifyTransitGatewayResponse.transitGateway.options.transitGatewayCidrBlocks.item.cidrBlock",
+                    equalTo("10.100.0.0/16"))
+            .extract().asString();
+
+        assertThat(body, not(containsString("tagSet")));
+
+        // The tags are still there; modify just does not echo them.
+        given()
+            .formParam("Action", "DescribeTransitGateways")
+            .formParam("TransitGatewayIds.1", transitGatewayId)
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then().statusCode(200)
+            .body("DescribeTransitGatewaysResponse.transitGatewaySet.item.tagSet.item.key", equalTo("env"));
+    }
+
+    @Test
+    @Order(4)
+    void describeRejectsAnUnknownGateway() {
+        given()
+            .formParam("Action", "DescribeTransitGateways")
+            .formParam("TransitGatewayIds.1", "tgw-0123456789abcdef0")
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then().statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidTransitGatewayID.NotFound"));
+    }
+
+    @Test
+    @Order(5)
+    void deleteRemovesTheGateway() {
+        given()
+            .formParam("Action", "DeleteTransitGateway")
+            .formParam("TransitGatewayId", transitGatewayId)
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then().statusCode(200)
+            .body("DeleteTransitGatewayResponse.transitGateway.state", equalTo("deleted"))
+            .body("DeleteTransitGatewayResponse.transitGateway.transitGatewayId", equalTo(transitGatewayId));
+
+        given()
+            .formParam("Action", "DescribeTransitGateways")
+            .formParam("TransitGatewayIds.1", transitGatewayId)
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then().statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidTransitGatewayID.NotFound"));
+
+        // The gateway created in the options test is untouched by this delete.
+        given()
+            .formParam("Action", "DescribeTransitGateways")
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then().statusCode(200)
+            .body("DescribeTransitGatewaysResponse.transitGatewaySet.item.options.amazonSideAsn",
+                    not(emptyOrNullString()));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2TransitGatewayIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2TransitGatewayIntegrationTest.java
@@ -108,7 +108,9 @@ class Ec2TransitGatewayIntegrationTest {
         .then().statusCode(200)
             .body("ModifyTransitGatewayResponse.transitGateway.description", equalTo("hub-modified"))
             .body("ModifyTransitGatewayResponse.transitGateway.options.dnsSupport", equalTo("disable"))
-            .body("ModifyTransitGatewayResponse.transitGateway.options.transitGatewayCidrBlocks.item.cidrBlock",
+            // A plain string list: the CIDR is the item's own text, which is what the AWS CLI
+            // parses back into TransitGatewayCidrBlocks[0].
+            .body("ModifyTransitGatewayResponse.transitGateway.options.transitGatewayCidrBlocks.item",
                     equalTo("10.100.0.0/16"))
             .extract().asString();
 


### PR DESCRIPTION
Implements transit gateways: `CreateTransitGateway`, `DescribeTransitGateways`,
`ModifyTransitGateway` and `DeleteTransitGateway`, as EC2 Query actions in `Ec2QueryHandler`
alongside the existing VPC and route table ones.

Part one of #2308. Metadata only, as that issue sets out: nothing routes packets, and the value is
in ids later resources can reference and describes that round-trip so plans converge.

## Verified against a live AWS account

The defaults and response shapes come from creating a real gateway in a sandbox account and
deleting it again, rather than from the API reference.

| | observed |
|---|---|
| defaults with `Options` omitted | `amazonSideAsn` 64512; `dnsSupport`, `vpnEcmpSupport`, `defaultRouteTableAssociation`, `defaultRouteTablePropagation` `enable`; `autoAcceptSharedAttachments`, `securityGroupReferencingSupport`, `multicastSupport` `disable` |
| `transitGatewayCidrBlocks` | omitted from the response entirely when unset, not sent empty |
| default route table | minted during creation; its id is already on the **create** response, as both `associationDefaultRouteTableId` and `propagationDefaultRouteTableId`, naming the same table |
| `tagSet` | present on create and describe, **absent** on modify and delete |
| state | `pending`, reaching `available` after ~49s; `deleting`, reaching `deleted` after ~64s |
| unknown id | `InvalidTransitGatewayID.NotFound` — "Transit Gateway tgw-… was deleted or does not exist." |
| malformed id | `InvalidTransitGatewayID.Malformed` — "Invalid Transit Gateway id tgw-nope." |

Two of those I would have got wrong from the documentation alone:
`securityGroupReferencingSupport` defaults to `disable`, and the `tagSet` asymmetry between
create/describe and modify/delete is not something the reference calls out. Both are asserted in
the tests rather than just implemented.

## Deviations, and why

**State is reported settled rather than transitional.** A created gateway is returned as
`available` and a deleted one as `deleted`, skipping `pending` and `deleting`. Nothing here is
slow, so this is the compression `createManagedPrefixList` already applies to
`create-in-progress`, and it keeps a provider's create/delete waiter from spinning on a state that
would never change.

**The default route table is created but not otherwise reachable.** Creating a gateway with either
default-route-table option enabled mints the route table AWS mints, so the two ids on the
gateway's options are real rather than absent. The actions that operate on route tables directly —
create, associate, enable propagation, describe — are part three and are not implemented here, and
neither are attachments. Opting out of both defaults leaves both ids absent, as on AWS.

## Note on the service constructor

`Ec2Service` gains two storage backends. Rather than widening the package-private constructor that
test fixtures resolve, that overload keeps its arity and delegates with `new InMemoryStorage<>()`,
and the transit-gateway-aware constructor sits beside it — the pattern #2179 established. Moving
that slot is what broke CI on #2103 and #2106, so it seemed worth not repeating.

## Tests

- `Ec2ServiceTest`: option defaults, requested options overriding them, the minted route table and
  its absence when both defaults are disabled, filters and both id errors, modify including CIDR
  add and remove, delete removing the gateway and its route table, and `tgw-` tag classification.
- `Ec2TransitGatewayIntegrationTest`: the Query wire shapes end to end, including the `tagSet`
  asymmetry and the omitted-when-unset elements.
- `ec2.bats`: create, read back, modify, delete and the unknown-id rejection through the AWS CLI.

Full suite: 10244 tests, 0 failures. One error, `NeptuneOpenCypherIntegrationTest`, which
reproduces identically on unmodified `main` on this machine and is unrelated to this branch —
the diff is EC2 only.
