### PR TITLE
fix(elasticache): store the user Engine instead of hardcoding redis

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/ElastiCacheTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/ElastiCacheTest.java
@@ -155,6 +155,7 @@ class ElastiCacheTest {
 
         assertThat(response.userId()).isEqualTo(userId);
         assertThat(response.userName()).isEqualTo(userName);
+        assertThat(response.engine()).isEqualTo("redis");
         assertThat(response.authentication().typeAsString()).isEqualTo("password");
         assertThat(response.authentication().passwordCount()).isEqualTo(1);
         userCreated = true;
@@ -168,7 +169,8 @@ class ElastiCacheTest {
         var response = elasticache.describeUsers(DescribeUsersRequest.builder().build());
 
         assertThat(response.users())
-                .anyMatch(user -> user.userId().equals(userId) && user.userName().equals(userName));
+                .anyMatch(user -> user.userId().equals(userId) && user.userName().equals(userName)
+                        && "redis".equals(user.engine()));
     }
 
     @Test
@@ -271,6 +273,27 @@ class ElastiCacheTest {
 
     @Test
     @Order(11)
+    void valkeyUserRoundTripEchoesEngine() {
+        String valkeyUserId = TestFixtures.uniqueName("ec-valkey-user");
+        var created = elasticache.createUser(CreateUserRequest.builder()
+                .userId(valkeyUserId)
+                .userName(TestFixtures.uniqueName("ec-valkey-name"))
+                .engine("valkey")
+                .accessString("on ~* +@all")
+                .authenticationMode(AuthenticationMode.builder()
+                        .type(InputAuthenticationType.NO_PASSWORD_REQUIRED)
+                        .build())
+                .build());
+        assertThat(created.engine()).isEqualTo("valkey");
+
+        var deleted = elasticache.deleteUser(DeleteUserRequest.builder()
+                .userId(valkeyUserId)
+                .build());
+        assertThat(deleted.engine()).isEqualTo("valkey");
+    }
+
+    @Test
+    @Order(12)
     void deleteReplicationGroupReleasesPortForReuse() {
         requireGroup();
 

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandler.java
@@ -158,6 +158,7 @@ public class ElastiCacheQueryHandler {
         String userName = params.getFirst("UserName");
         String accessString = params.getFirst("AccessString");
         String authModeType = params.getFirst("AuthenticationMode.Type");
+        String engine = params.getFirst("Engine");
 
         if (userId == null || userId.isBlank()) {
             return AwsQueryResponse.error("InvalidParameterValue", "UserId is required.", AwsNamespaces.EC, 400);
@@ -178,7 +179,7 @@ public class ElastiCacheQueryHandler {
         }
 
         try {
-            ElastiCacheUser user = service.createUser(userId, userName, authMode, passwords, accessString);
+            ElastiCacheUser user = service.createUser(userId, userName, authMode, passwords, accessString, engine);
             return Response.ok(AwsQueryResponse.envelope("CreateUser", AwsNamespaces.EC, userXml(user))).build();
         } catch (AwsException e) {
             return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.EC, e.getHttpStatus());
@@ -187,8 +188,9 @@ public class ElastiCacheQueryHandler {
 
     private Response handleDescribeUsers(MultivaluedMap<String, String> params) {
         String filterId = params.getFirst("UserId");
+        String filterEngine = params.getFirst("Engine");
         try {
-            Collection<ElastiCacheUser> users = service.listUsers(filterId);
+            Collection<ElastiCacheUser> users = service.listUsers(filterId, filterEngine);
             var xml = new XmlBuilder().start("Users");
             for (ElastiCacheUser u : users) {
                 xml.start("member").raw(userXml(u)).end("member");
@@ -202,12 +204,13 @@ public class ElastiCacheQueryHandler {
 
     private Response handleModifyUser(MultivaluedMap<String, String> params) {
         String userId = params.getFirst("UserId");
+        String engine = params.getFirst("Engine");
         if (userId == null || userId.isBlank()) {
             return AwsQueryResponse.error("InvalidParameterValue", "UserId is required.", AwsNamespaces.EC, 400);
         }
         List<String> passwords = extractMemberList(params, "AuthenticationMode.Passwords.member.");
         try {
-            ElastiCacheUser user = service.modifyUser(userId, passwords.isEmpty() ? null : passwords);
+            ElastiCacheUser user = service.modifyUser(userId, passwords.isEmpty() ? null : passwords, engine);
             return Response.ok(AwsQueryResponse.envelope("ModifyUser", AwsNamespaces.EC, userXml(user))).build();
         } catch (AwsException e) {
             return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.EC, e.getHttpStatus());
@@ -384,7 +387,8 @@ public class ElastiCacheQueryHandler {
                   .elem("Type", authType)
                   .elem("PasswordCount", (long) pwCount)
                 .end("Authentication")
-                .elem("Engine", "redis")
+                .elem("Engine", u.getEngine())
+                // MinimumEngineVersion: the only value AWS documents; no valkey-specific one is published.
                 .elem("MinimumEngineVersion", "6.0")
                 .start("UserGroupIds").end("UserGroupIds")
                 .elem("ARN", AwsArnUtils.Arn.of("elasticache", regionResolver.getDefaultRegion(), regionResolver.getAccountId(), "user:" + u.getUserId()).toString())

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
@@ -20,6 +20,7 @@ import org.jboss.logging.Logger;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -183,17 +184,20 @@ public class ElastiCacheService {
     }
 
     public ElastiCacheUser createUser(String userId, String userName, AuthMode authMode,
-                                      List<String> passwords, String accessString) {
+                                      List<String> passwords, String accessString, String engine) {
         if (users.get(userId).isPresent()) {
             throw new AwsException("UserAlreadyExistsFault",
                     "User " + userId + " already exists.", 400);
         }
 
+        // Engine is required on AWS, but Floci's CreateUser accepted requests without
+        // it, so a missing value keeps the previous implicit redis.
+        String normalizedEngine = (engine == null || engine.isBlank()) ? "redis" : normalizeEngine(engine);
         ElastiCacheUser user = new ElastiCacheUser(
                 userId, userName, authMode,
                 passwords != null ? passwords : List.of(),
                 accessString != null ? accessString : "on ~* +@all",
-                "active", Instant.now());
+                normalizedEngine, "active", Instant.now());
 
         users.put(userId, user);
         LOG.infov("ElastiCache user {0} created with authMode={1}", userId, authMode);
@@ -205,20 +209,32 @@ public class ElastiCacheService {
                 new AwsException("UserNotFoundFault", "User " + userId + " not found.", 404));
     }
 
-    public Collection<ElastiCacheUser> listUsers(String filterUserId) {
+    public Collection<ElastiCacheUser> listUsers(String filterUserId, String filterEngine) {
+        // UserId wins when both filters are sent; AWS documents no interaction between them.
         if (filterUserId != null && !filterUserId.isBlank()) {
             return users.get(filterUserId)
                     .map(List::of)
                     .orElseThrow(() -> new AwsException("UserNotFoundFault",
                             "User " + filterUserId + " not found.", 404));
         }
+        if (filterEngine != null && !filterEngine.isBlank()) {
+            return users.scan(k -> true).stream()
+                    .filter(u -> filterEngine.equalsIgnoreCase(u.getEngine()))
+                    .toList();
+        }
         return users.scan(k -> true);
     }
 
-    public ElastiCacheUser modifyUser(String userId, List<String> passwords) {
+    public ElastiCacheUser modifyUser(String userId, List<String> passwords, String engine) {
         ElastiCacheUser user = getUser(userId);
+        // Storage backends hand back the live stored object, so validate everything
+        // before the first setter — a rejected request must not leave changes behind.
+        String normalizedEngine = (engine == null || engine.isBlank()) ? null : normalizeEngine(engine);
         if (passwords != null) {
             user.setPasswords(passwords);
+        }
+        if (normalizedEngine != null) {
+            user.setEngine(normalizedEngine);
         }
         users.put(userId, user);
         return user;
@@ -265,6 +281,16 @@ public class ElastiCacheService {
                 .map(id -> users.get(id).orElse(null))
                 .filter(u -> u != null && username.equals(u.getUserName()) && u.getAuthMode() == AuthMode.PASSWORD)
                 .anyMatch(u -> u.getPasswords() != null && u.getPasswords().contains(password));
+    }
+
+    // AWS allows only redis and valkey.
+    private static String normalizeEngine(String engine) {
+        String normalized = engine.toLowerCase(Locale.ROOT);
+        if (!"redis".equals(normalized) && !"valkey".equals(normalized)) {
+            throw new AwsException("InvalidParameterValue",
+                    "Engine must be 'redis' or 'valkey'.", 400);
+        }
+        return normalized;
     }
 
     private String resolveEndpointHost() {

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/model/ElastiCacheUser.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/model/ElastiCacheUser.java
@@ -13,19 +13,22 @@ public class ElastiCacheUser {
     private AuthMode authMode;
     private List<String> passwords;
     private String accessString;
+    // "redis" or "valkey"; the initializer keeps users persisted before this field existed on redis.
+    private String engine = "redis";
     private String status;
     private Instant createdAt;
 
     public ElastiCacheUser() {}
 
     public ElastiCacheUser(String userId, String userName, AuthMode authMode,
-                           List<String> passwords, String accessString,
+                           List<String> passwords, String accessString, String engine,
                            String status, Instant createdAt) {
         this.userId = userId;
         this.userName = userName;
         this.authMode = authMode;
         this.passwords = passwords;
         this.accessString = accessString;
+        this.engine = engine;
         this.status = status;
         this.createdAt = createdAt;
     }
@@ -44,6 +47,9 @@ public class ElastiCacheUser {
 
     public String getAccessString() { return accessString; }
     public void setAccessString(String accessString) { this.accessString = accessString; }
+
+    public String getEngine() { return engine; }
+    public void setEngine(String engine) { this.engine = engine; }
 
     public String getStatus() { return status; }
     public void setStatus(String status) { this.status = status; }

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
@@ -66,9 +66,9 @@ class ElastiCacheServiceTest {
         service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, null);
 
         service.createUser("default-user-id", "default", AuthMode.PASSWORD,
-                List.of("default-pass"), "on ~* +@all");
+                List.of("default-pass"), "on ~* +@all", null);
         service.createUser("other-user-id", "other", AuthMode.PASSWORD,
-                List.of("other-pass"), "on ~* +@all");
+                List.of("other-pass"), "on ~* +@all", null);
 
         service.modifyReplicationGroup("grp",
                 List.of("default-user-id", "other-user-id"), null);
@@ -86,7 +86,7 @@ class ElastiCacheServiceTest {
         service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, null);
 
         service.createUser("other-user-id", "other", AuthMode.PASSWORD,
-                List.of("other-pass"), "on ~* +@all");
+                List.of("other-pass"), "on ~* +@all", null);
 
         service.modifyReplicationGroup("grp", List.of("other-user-id"), null);
 

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheUserEngineIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheUserEngineIntegrationTest.java
@@ -1,0 +1,322 @@
+package io.github.hectorvent.floci.services.elasticache;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Control-plane coverage for the user Engine attribute; unlike the Docker-backed
+ * lifecycle tests these never touch a container.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ElastiCacheUserEngineIntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260412/us-east-1/elasticache/aws4_request";
+    private static final String VALKEY_USER = "engine-it-valkey-user";
+    private static final String DEFAULT_USER = "engine-it-default-user";
+
+    @Test
+    @Order(1)
+    void createUserWithValkeyEngineEchoesValkey() {
+        given()
+            .formParam("Action", "CreateUser")
+            .formParam("UserId", VALKEY_USER)
+            .formParam("UserName", "engine-it-valkey")
+            .formParam("Engine", "valkey")
+            .formParam("AccessString", "on ~* +@all")
+            .formParam("AuthenticationMode.Type", "no-password-required")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("CreateUserResponse.CreateUserResult.Engine", equalTo("valkey"))
+            // AWS documents no valkey-specific MinimumEngineVersion, so it stays at the published 6.0.
+            .body("CreateUserResponse.CreateUserResult.MinimumEngineVersion", equalTo("6.0"));
+    }
+
+    @Test
+    @Order(2)
+    void createUserWithoutEngineDefaultsToRedis() {
+        given()
+            .formParam("Action", "CreateUser")
+            .formParam("UserId", DEFAULT_USER)
+            .formParam("UserName", "engine-it-default")
+            .formParam("AccessString", "on ~* +@all")
+            .formParam("AuthenticationMode.Type", "no-password-required")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("CreateUserResponse.CreateUserResult.Engine", equalTo("redis"))
+            .body("CreateUserResponse.CreateUserResult.MinimumEngineVersion", equalTo("6.0"));
+    }
+
+    @Test
+    @Order(3)
+    void describeUsersReportsTheStoredEngine() {
+        given()
+            .formParam("Action", "DescribeUsers")
+            .formParam("UserId", VALKEY_USER)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeUsersResponse.DescribeUsersResult.Users.member.Engine", equalTo("valkey"));
+    }
+
+    /** Floci's own tolerance, mirroring the handler's memcached check — AWS documents no case handling for Engine. */
+    @Test
+    @Order(4)
+    void engineValueIsCaseInsensitiveAndStoredLowercase() {
+        given()
+            .formParam("Action", "CreateUser")
+            .formParam("UserId", "engine-it-case-user")
+            .formParam("UserName", "engine-it-case")
+            .formParam("Engine", "Valkey")
+            .formParam("AccessString", "on ~* +@all")
+            .formParam("AuthenticationMode.Type", "no-password-required")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("CreateUserResponse.CreateUserResult.Engine", equalTo("valkey"));
+    }
+
+    @Test
+    @Order(5)
+    void createUserRejectsAnUnknownEngine() {
+        given()
+            .formParam("Action", "CreateUser")
+            .formParam("UserId", "engine-it-bad-user")
+            .formParam("UserName", "engine-it-bad")
+            .formParam("Engine", "memcached")
+            .formParam("AccessString", "on ~* +@all")
+            .formParam("AuthenticationMode.Type", "no-password-required")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidParameterValue"));
+    }
+
+    @Test
+    @Order(6)
+    void modifyUserChangesTheEngine() {
+        given()
+            .formParam("Action", "ModifyUser")
+            .formParam("UserId", DEFAULT_USER)
+            .formParam("Engine", "valkey")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ModifyUserResponse.ModifyUserResult.Engine", equalTo("valkey"));
+    }
+
+    @Test
+    @Order(7)
+    void modifyUserWithoutEngineLeavesItUnchanged() {
+        given()
+            .formParam("Action", "ModifyUser")
+            .formParam("UserId", VALKEY_USER)
+            .formParam("AuthenticationMode.Passwords.member.1", "some-password-1")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ModifyUserResponse.ModifyUserResult.Engine", equalTo("valkey"));
+    }
+
+    /** A sent-but-empty Engine is treated like an absent one on both actions. */
+    @Test
+    @Order(8)
+    void blankEngineBehavesLikeAnAbsentOne() {
+        given()
+            .formParam("Action", "CreateUser")
+            .formParam("UserId", "engine-it-blank-user")
+            .formParam("UserName", "engine-it-blank")
+            .formParam("Engine", "")
+            .formParam("AccessString", "on ~* +@all")
+            .formParam("AuthenticationMode.Type", "no-password-required")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("CreateUserResponse.CreateUserResult.Engine", equalTo("redis"));
+        given()
+            .formParam("Action", "ModifyUser")
+            .formParam("UserId", VALKEY_USER)
+            .formParam("Engine", "")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ModifyUserResponse.ModifyUserResult.Engine", equalTo("valkey"));
+    }
+
+    @Test
+    @Order(9)
+    void createUserWithExplicitRedisEngineEchoesRedis() {
+        given()
+            .formParam("Action", "CreateUser")
+            .formParam("UserId", "engine-it-redis-user")
+            .formParam("UserName", "engine-it-redis")
+            .formParam("Engine", "redis")
+            .formParam("AccessString", "on ~* +@all")
+            .formParam("AuthenticationMode.Type", "no-password-required")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("CreateUserResponse.CreateUserResult.Engine", equalTo("redis"));
+    }
+
+    /** DescribeUsers documents an Engine filter, which means something now that users differ by engine. */
+    @Test
+    @Order(10)
+    void describeUsersFiltersByEngine() {
+        given()
+            .formParam("Action", "DescribeUsers")
+            .formParam("Engine", "redis")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("engine-it-redis-user"))
+            .body(not(containsString("engine-it-valkey-user")));
+        given()
+            .formParam("Action", "DescribeUsers")
+            .formParam("Engine", "REDIS")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("engine-it-redis-user"))
+            .body(not(containsString("engine-it-valkey-user")));
+        // UserId wins when both filters are sent; the engine filter is ignored.
+        given()
+            .formParam("Action", "DescribeUsers")
+            .formParam("UserId", VALKEY_USER)
+            .formParam("Engine", "redis")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString(VALKEY_USER));
+    }
+
+    /**
+     * A ModifyUser rejected for a bad Engine must leave the user untouched — the storage
+     * backends hand back the live stored object, so a password change applied before
+     * validation would survive the 400.
+     */
+    @Test
+    @Order(11)
+    void rejectedModifyUserLeavesThePasswordsUnchanged() {
+        given()
+            .formParam("Action", "CreateUser")
+            .formParam("UserId", "engine-it-atomic-user")
+            .formParam("UserName", "engine-it-atomic")
+            .formParam("AccessString", "on ~* +@all")
+            .formParam("AuthenticationMode.Type", "password")
+            .formParam("AuthenticationMode.Passwords.member.1", "atomic-password-1")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("CreateUserResponse.CreateUserResult.Authentication.PasswordCount", equalTo("1"));
+        given()
+            .formParam("Action", "ModifyUser")
+            .formParam("UserId", "engine-it-atomic-user")
+            .formParam("AuthenticationMode.Passwords.member.1", "atomic-password-1")
+            .formParam("AuthenticationMode.Passwords.member.2", "atomic-password-2")
+            .formParam("Engine", "memcached")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidParameterValue"));
+        given()
+            .formParam("Action", "DescribeUsers")
+            .formParam("UserId", "engine-it-atomic-user")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeUsersResponse.DescribeUsersResult.Users.member.Authentication.PasswordCount", equalTo("1"));
+        // The same call with a valid engine applies both changes.
+        given()
+            .formParam("Action", "ModifyUser")
+            .formParam("UserId", "engine-it-atomic-user")
+            .formParam("AuthenticationMode.Passwords.member.1", "atomic-password-1")
+            .formParam("AuthenticationMode.Passwords.member.2", "atomic-password-2")
+            .formParam("Engine", "valkey")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ModifyUserResponse.ModifyUserResult.Engine", equalTo("valkey"))
+            .body("ModifyUserResponse.ModifyUserResult.Authentication.PasswordCount", equalTo("2"));
+    }
+
+    @Test
+    @Order(12)
+    void deleteUserEchoesTheStoredEngine() {
+        given()
+            .formParam("Action", "DeleteUser")
+            .formParam("UserId", VALKEY_USER)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DeleteUserResponse.DeleteUserResult.Engine", equalTo("valkey"));
+    }
+
+    /**
+     * The user store is shared across test classes, so this class removes what it created —
+     * as an ordered test rather than an {@code @AfterAll}, which would run after Quarkus has
+     * already reset the RestAssured port, and asserting each delete so a silent no-op turns red.
+     */
+    @Test
+    @Order(13)
+    void deleteRemainingUsersSoTheSharedStoreStaysClean() {
+        for (String userId : new String[] {DEFAULT_USER, "engine-it-case-user",
+                "engine-it-blank-user", "engine-it-redis-user", "engine-it-atomic-user"}) {
+            given()
+                .formParam("Action", "DeleteUser")
+                .formParam("UserId", userId)
+                .header("Authorization", AUTH_HEADER)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheUserModelTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheUserModelTest.java
@@ -1,0 +1,29 @@
+package io.github.hectorvent.floci.services.elasticache;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.github.hectorvent.floci.services.elasticache.model.ElastiCacheUser;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Users persisted before the engine field existed must deserialize with the redis
+ * default; the field initializer is what guarantees it, through the same
+ * deserialization configuration the persistent storage backends use (ObjectMapper
+ * plus JavaTimeModule).
+ */
+class ElastiCacheUserModelTest {
+
+    @Test
+    void legacyJsonWithoutEngineDeserializesAsRedis() throws Exception {
+        ElastiCacheUser user = new ObjectMapper().registerModule(new JavaTimeModule()).readValue(
+                """
+                {"userId":"legacy","userName":"legacy","authMode":"PASSWORD",\
+                "passwords":["legacy-password-1"],"accessString":"on ~* +@all",\
+                "status":"active","createdAt":"2026-08-15T10:00:00Z"}
+                """,
+                ElastiCacheUser.class);
+        assertEquals("redis", user.getEngine());
+    }
+}


### PR DESCRIPTION
<!-- PR title (Conventional Commit): -->
<!-- fix(elasticache): store the user Engine instead of hardcoding redis -->

## Summary

`Engine` was never read from a CreateUser request and `ElastiCacheUser` had no field for it; `userXml` emitted a literal `redis`, and since that serializer is shared by `CreateUser`, `DescribeUsers`, `ModifyUser` and `DeleteUser`, all four reported `redis` regardless of what was created — the `aws_elasticache_user` diff-loop from the issue.

This is the three-step fix the issue suggests — an `engine` field on the model, threaded through `createUser`, and `u.getEngine()` in `userXml` — plus the three places the new attribute immediately matters. `ModifyUser` also accepts `Engine`, which AWS models as an optional parameter on that action ("Modifies the engine listed for a user"), and validates it before the first setter: the storage backends hand back the live stored object, so a password change applied before validation would survive the 400 — a rejected request must leave the user untouched, and a test pins exactly that. `DescribeUsers` honors its documented `Engine` filter, which was inert while every user was `redis` and would silently return wrong results now that they aren't — only that one parameter; the action's `Filters`/`Marker`/`MaxRecords` stay out of scope, since nothing in this change makes them meaningful. And a missing or blank `Engine` defaults to `redis` on create (keeping the previous behavior for callers that omit it, as the issue asks — AWS marks the parameter required, so this leniency is Floci's own back-compat choice) and is a no-change on modify.

Values are validated case-insensitively against `redis`/`valkey` and stored lowercase — Floci's own tolerance, matching the handler's existing `equalsIgnoreCase` memcached check; AWS documents no case handling for the parameter — and anything else is rejected with `InvalidParameterValue` 400, the error CreateUser documents for an invalid value. `MinimumEngineVersion` deliberately stays at `6.0`: that is the only value AWS documents for the element (its description reads "The minimum engine version required, which is Redis OSS 6.0" on both actions), and no published response sample for a valkey user turned up to say otherwise, so inventing a valkey-specific value would bake an unverifiable claim into the emulator's contract — easy to revisit if someone captures a real response. Users persisted before the field existed deserialize with the `redis` default, which is what they were reporting anyway, and a test pins that round-trip through the same deserialization configuration the persistent backends use (`ObjectMapper` plus `JavaTimeModule`), against a full pre-engine record.

Every guard is pinned by a named test — the parameter threading on both actions (handler and service side), the validation, the case-folding on create and on the filter, the redis default, the blank-input handling, the validate-before-mutate ordering and its accept path, the DescribeUsers filter and its UserId-wins precedence, the deliberate 6.0, and the legacy-deserialization default were each mutation-tested individually. The one exception is the `users.put` in `modifyUser`: no test can fail on it under the in-memory storage backend, which hands back the live object, so it is stated here rather than covered by a test that cannot fail.

Closes #2290

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against the CreateUser and ModifyUser API references: `Engine` is required on CreateUser with values `valkey`/`redis`, optional on ModifyUser, `DescribeUsers` documents an optional `Engine` filter, and `InvalidParameterValue` (400) is in CreateUser's error list. One softening: AWS marks `Engine` required on CreateUser, but Floci's CreateUser accepted requests without it, so a missing value keeps the previous implicit redis default rather than turning existing callers' requests into 400s.

The incorrect behavior, concretely: `create-user --engine valkey` succeeded and `describe-users` reported `Engine: redis`, so a Terraform `aws_elasticache_user` with `engine = "valkey"` re-planned forever.

## Checklist

- [x] `./mvnw test` run locally: 10,157 tests; the only failures (112) are confined to 22 Docker-backed classes (API Gateway/WebSocket, Lambda, ECR, DocDB, Neptune, CloudFormation/SAM, ELBv2, SWF) — no Docker daemon on this machine, and none of those services is touched by this diff. Every ElastiCache suite is fully green.
- [x] New or updated integration test added (plus SDK-based assertions in `compatibility-tests/sdk-test-java`'s ElastiCache suite: engine echo on the existing redis user and a valkey round-trip)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
