### PR TITLE
fix(cognito): restore the SecureRandom import

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -41,6 +41,7 @@ import java.security.KeyPairGenerator;
 import java.security.MessageDigest;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.SecureRandom;
 import java.security.Signature;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.PKCS8EncodedKeySpec;


### PR DESCRIPTION
## Problem

`main` does not compile. Every push since #1881 landed fails at:

```
[ERROR] .../services/cognito/CognitoService.java:[2242,17] cannot find symbol
  symbol:   class SecureRandom
  location: class io.github.hectorvent.floci.services.cognito.CognitoService
```

Failing runs: [31914427093](https://github.com/floci-io/floci/actions/runs/31914427093) (#1881), [31914660835](https://github.com/floci-io/floci/actions/runs/31914660835) (#2001). Compilation dies before any test runs, so those runs tell us nothing about the rest of the suite.

## Cause

A semantic merge conflict between two Cognito PRs that were each green on their own branch:

- c4f4181c (#2139) added `new SecureRandom()` to `ensureRefreshTokenSecret`. It compiled because the file carried a wildcard `import java.security.*`.
- d8914259 (#1881) expanded that wildcard into explicit imports and did not include `SecureRandom`. Its branch predated #2139, so its CI never saw the call site.

Neither PR is wrong in isolation; the merged tree is what breaks.

## Fix

Add the one missing import. No behavior change.

## Verification

- `./mvnw compile` and `./mvnw test-compile` pass
- `./mvnw test -Dtest=CognitoServiceTest` — 133 tests, 0 failures
- Full suite run locally to confirm nothing else on `main` is broken behind the compile error

No test is added: the failure is a compile error, and CI compiling the tree is the regression guard.