### PR TITLE
fix(docker): label containers and volumes per emulator

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilder.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilder.java
@@ -120,6 +120,7 @@ public class ContainerBuilder {
         private final List<Mount> mounts = new ArrayList<>();
         private final List<Bind> binds = new ArrayList<>();
         private final List<String> extraHosts = new ArrayList<>();
+        private final Map<String, String> labels = new HashMap<>();
         private LogConfig logConfig;
         private boolean privileged;
         private String cgroupnsMode;
@@ -320,6 +321,24 @@ public class ContainerBuilder {
         }
 
         /**
+         * Adds a single Docker label. Merged over the default floci-aws labels at
+         * container creation; a per-spec label wins on key conflicts.
+         */
+        public Builder withLabel(String key, String value) {
+            this.labels.put(key, value);
+            return this;
+        }
+
+        /**
+         * Adds multiple Docker labels. Merged over the default floci-aws labels at
+         * container creation; per-spec labels win on key conflicts.
+         */
+        public Builder withLabels(Map<String, String> labels) {
+            this.labels.putAll(labels);
+            return this;
+        }
+
+        /**
          * Enables log rotation with default settings from configuration.
          * Uses json-file driver with max-size and max-file from config.
          */
@@ -426,6 +445,7 @@ public class ContainerBuilder {
                     List.copyOf(mounts),
                     List.copyOf(binds),
                     List.copyOf(extraHosts),
+                    Map.copyOf(labels),
                     logConfig,
                     privileged,
                     cgroupnsMode,

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.core.common.docker;
 
+import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.services.lambda.launcher.ImageCacheService;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
@@ -45,6 +46,7 @@ public class ContainerLifecycleManager {
     private final ImageCacheService imageCacheService;
     private final ContainerDetector containerDetector;
     private final PortAllocator portAllocator;
+    private final EmulatorConfig config;
 
     /** Volumes whose shared-ownership root has already been initialised this process (run-once guard). */
     private final ConcurrentHashMap<String, Boolean> initializedSharedVolumes = new ConcurrentHashMap<>();
@@ -53,11 +55,13 @@ public class ContainerLifecycleManager {
     public ContainerLifecycleManager(DockerClient dockerClient,
                                      ImageCacheService imageCacheService,
                                      ContainerDetector containerDetector,
-                                     PortAllocator portAllocator) {
+                                     PortAllocator portAllocator,
+                                     EmulatorConfig config) {
         this.dockerClient = dockerClient;
         this.imageCacheService = imageCacheService;
         this.containerDetector = containerDetector;
         this.portAllocator = portAllocator;
+        this.config = config;
     }
 
     /**
@@ -123,6 +127,7 @@ public class ContainerLifecycleManager {
                     .toArray(ExposedPort[]::new);
             createCmd.withExposedPorts(exposed);
         }
+        createCmd.withLabels(mergedLabels(spec.labels()));
 
         CreateContainerResponse response = createCmd.exec();
         String containerId = response.getId();
@@ -267,17 +272,31 @@ public class ContainerLifecycleManager {
 
     /**
      * Creates a named volume if it does not already exist. Idempotent — safe to call on every
-     * container start. Labels the volume {@code floci=true} so
-     * {@code docker volume prune --filter label=floci} works.
+     * container start. Labels the volume {@code floci=true} and
+     * {@code floci_emulator=floci-aws} (plus {@code floci_namespace} when configured) so both
+     * {@code docker volume prune --filter label=floci=true} (all emulators) and
+     * {@code --filter label=floci_emulator=floci-aws} (this emulator only) work.
      */
     public void ensureVolume(String volumeName) {
         if (!volumeExists(volumeName)) {
             dockerClient.createVolumeCmd()
                     .withName(volumeName)
-                    .withLabels(Map.of("floci", "true"))
+                    .withLabels(ContainerStorageHelper.defaultLabels(config))
                     .exec();
             LOG.debugv("Created volume {0}", volumeName);
         }
+    }
+
+    /**
+     * Default emulator labels overlaid with the spec's labels; a per-spec label
+     * wins on key conflicts.
+     */
+    private Map<String, String> mergedLabels(Map<String, String> specLabels) {
+        Map<String, String> labels = ContainerStorageHelper.defaultLabels(config);
+        if (specLabels != null) {
+            labels.putAll(specLabels);
+        }
+        return labels;
     }
 
     /**
@@ -358,6 +377,7 @@ public class ContainerLifecycleManager {
         CreateContainerResponse created = dockerClient.createContainerCmd(image)
                 .withHostConfig(hostConfig)
                 .withCmd("sh", "-c", script.toString())
+                .withLabels(ContainerStorageHelper.defaultLabels(config))
                 .exec();
         String helperId = created.getId();
         try {

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerSpec.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerSpec.java
@@ -23,6 +23,7 @@ import java.util.Map;
  * @param mounts Volume mounts (named volumes, bind mounts, tmpfs)
  * @param binds Legacy bind mounts (prefer mounts for new code)
  * @param extraHosts Extra /etc/hosts entries as "hostname:ip" strings
+ * @param labels Container labels merged over the default floci-aws labels
  * @param logConfig Docker log driver configuration (null = daemon default)
  * @param privileged Whether to run the container in privileged mode (required for k3s)
  * @param cgroupnsMode Docker cgroup namespace mode (for example, "host")
@@ -44,6 +45,7 @@ public record ContainerSpec(
         List<Mount> mounts,
         List<Bind> binds,
         List<String> extraHosts,
+        Map<String, String> labels,
         LogConfig logConfig,
         boolean privileged,
         String cgroupnsMode,
@@ -57,7 +59,7 @@ public record ContainerSpec(
      * All other fields will be null or empty lists.
      */
     public ContainerSpec(String image) {
-        this(image, null, List.of(), null, null, null, Map.of(), List.of(), null, List.of(), List.of(), List.of(), null, false, null, List.of(), null, null, List.of());
+        this(image, null, List.of(), null, null, null, Map.of(), List.of(), null, List.of(), List.of(), List.of(), Map.of(), null, false, null, List.of(), null, null, List.of());
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerStorageHelper.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerStorageHelper.java
@@ -6,6 +6,8 @@ import org.jboss.logging.Logger;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Central helper for child-container volume management across RDS, OpenSearch, MSK, and ECR.
@@ -21,6 +23,8 @@ import java.nio.file.Path;
 public final class ContainerStorageHelper {
 
     private static final Logger LOG = Logger.getLogger(ContainerStorageHelper.class);
+
+    static final String CLOUD = "aws";
 
     private ContainerStorageHelper() {}
 
@@ -46,6 +50,23 @@ public final class ContainerStorageHelper {
             return "floci-" + namespace + "-" + baseName.substring("floci-".length());
         }
         return "floci-" + namespace + "-" + baseName;
+    }
+
+    /**
+     * Labels applied to every emulator-created container and volume:
+     * {@code floci=true} (umbrella across all Floci emulators),
+     * {@code floci_emulator=floci-aws} (per-emulator discriminator), and
+     * {@code floci_namespace} when a resource namespace is configured.
+     */
+    public static Map<String, String> defaultLabels(EmulatorConfig config) {
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("floci", "true");
+        labels.put("floci_emulator", "floci-" + CLOUD);
+        String namespace = resourceNamespace(config);
+        if (!namespace.isBlank()) {
+            labels.put("floci_namespace", namespace);
+        }
+        return labels;
     }
 
     public static Path hostResourcePath(EmulatorConfig config, String service, String resourceId) {

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManagerLabelsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManagerLabelsTest.java
@@ -1,0 +1,190 @@
+package io.github.hectorvent.floci.core.common.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.command.CreateVolumeCmd;
+import com.github.dockerjava.api.command.InspectVolumeCmd;
+import com.github.dockerjava.api.command.RemoveContainerCmd;
+import com.github.dockerjava.api.command.StartContainerCmd;
+import com.github.dockerjava.api.command.WaitContainerCmd;
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.core.command.WaitContainerResultCallback;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.lambda.launcher.ImageCacheService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Asserts the default Docker labels at the single choke point every emulator-created
+ * container and volume passes through. All container-backed services funnel into
+ * {@link ContainerLifecycleManager#create}, so asserting here covers every service
+ * by construction.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ContainerLifecycleManager — default emulator labels")
+class ContainerLifecycleManagerLabelsTest {
+
+    @Mock
+    DockerClient dockerClient;
+
+    @Mock
+    ImageCacheService imageCacheService;
+
+    @Mock
+    ContainerDetector containerDetector;
+
+    @Mock
+    PortAllocator portAllocator;
+
+    @Mock
+    EmulatorConfig config;
+
+    @Mock
+    EmulatorConfig.DockerConfig dockerConfig;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(config.docker()).thenReturn(dockerConfig);
+        lenient().when(dockerConfig.resourceNamespace()).thenReturn(Optional.empty());
+    }
+
+    @Test
+    void createAppliesDefaultLabelsToEveryContainer() {
+        CreateContainerCmd createCmd = stubCreateContainer();
+
+        manager().create(new ContainerSpec("busybox:stable"));
+
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-aws"),
+                capturedLabels(createCmd));
+    }
+
+    @Test
+    void createMergesSpecLabelsOverDefaults() {
+        CreateContainerCmd createCmd = stubCreateContainer();
+        ContainerSpec spec = specWithLabels(Map.of("floci_service", "lambda"));
+
+        manager().create(spec);
+
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-aws", "floci_service", "lambda"),
+                capturedLabels(createCmd));
+    }
+
+    @Test
+    void specLabelWinsOverDefaultOnKeyConflict() {
+        CreateContainerCmd createCmd = stubCreateContainer();
+        ContainerSpec spec = specWithLabels(Map.of("floci_emulator", "custom-value"));
+
+        manager().create(spec);
+
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "custom-value"),
+                capturedLabels(createCmd));
+    }
+
+    @Test
+    void createIncludesNamespaceLabelWhenConfigured() {
+        when(dockerConfig.resourceNamespace()).thenReturn(Optional.of("run-one"));
+        CreateContainerCmd createCmd = stubCreateContainer();
+
+        manager().create(new ContainerSpec("busybox:stable"));
+
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-aws", "floci_namespace", "run-one"),
+                capturedLabels(createCmd));
+    }
+
+    @Test
+    void ensureVolumeAppliesTheSameDefaultLabels() {
+        InspectVolumeCmd inspectVolumeCmd = mock(InspectVolumeCmd.class);
+        when(dockerClient.inspectVolumeCmd("volume-1")).thenReturn(inspectVolumeCmd);
+        when(inspectVolumeCmd.exec()).thenThrow(new NotFoundException("missing"));
+        CreateVolumeCmd createVolumeCmd = mock(CreateVolumeCmd.class, RETURNS_SELF);
+        when(dockerClient.createVolumeCmd()).thenReturn(createVolumeCmd);
+
+        manager().ensureVolume("volume-1");
+
+        ArgumentCaptor<Map<String, String>> labels = labelsCaptor();
+        verify(createVolumeCmd).withLabels(labels.capture());
+        assertEquals(Map.of("floci", "true", "floci_emulator", "floci-aws"), labels.getValue());
+    }
+
+    @Test
+    void sharedVolumeInitHelperCarriesDefaultLabels() {
+        InspectVolumeCmd inspectVolumeCmd = mock(InspectVolumeCmd.class);
+        when(dockerClient.inspectVolumeCmd("shared")).thenReturn(inspectVolumeCmd);
+        when(inspectVolumeCmd.exec()).thenThrow(new NotFoundException("missing"));
+        CreateVolumeCmd createVolumeCmd = mock(CreateVolumeCmd.class, RETURNS_SELF);
+        when(dockerClient.createVolumeCmd()).thenReturn(createVolumeCmd);
+
+        CreateContainerCmd createCmd = stubCreateContainer();
+        when(dockerClient.startContainerCmd("container-id")).thenReturn(mock(StartContainerCmd.class));
+        WaitContainerCmd waitCmd = mock(WaitContainerCmd.class);
+        when(dockerClient.waitContainerCmd("container-id")).thenReturn(waitCmd);
+        WaitContainerResultCallback waitCallback = mock(WaitContainerResultCallback.class);
+        when(waitCmd.exec(any(WaitContainerResultCallback.class))).thenReturn(waitCallback);
+        when(waitCallback.awaitStatusCode(anyLong(), any())).thenReturn(0);
+        when(dockerClient.removeContainerCmd("container-id"))
+                .thenReturn(mock(RemoveContainerCmd.class, RETURNS_SELF));
+
+        manager().ensureSharedVolume("shared", OptionalInt.of(1001), OptionalInt.of(1001),
+                Optional.of("2775"), "busybox:stable");
+
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-aws"),
+                capturedLabels(createCmd));
+    }
+
+    private ContainerLifecycleManager manager() {
+        return new ContainerLifecycleManager(
+                dockerClient, imageCacheService, containerDetector, portAllocator, config);
+    }
+
+    private static ContainerSpec specWithLabels(Map<String, String> labels) {
+        return new ContainerSpec(
+                "busybox:stable", null, List.of(), null, null, null, Map.of(), List.of(), null,
+                List.of(), List.of(), List.of(), labels, null, false, null, List.of(), null,
+                null, List.of());
+    }
+
+    private CreateContainerCmd stubCreateContainer() {
+        CreateContainerCmd createCmd = mock(CreateContainerCmd.class, RETURNS_SELF);
+        when(dockerClient.createContainerCmd("busybox:stable")).thenReturn(createCmd);
+        CreateContainerResponse response = mock(CreateContainerResponse.class);
+        when(response.getId()).thenReturn("container-id");
+        when(createCmd.exec()).thenReturn(response);
+        return createCmd;
+    }
+
+    private Map<String, String> capturedLabels(CreateContainerCmd createCmd) {
+        ArgumentCaptor<Map<String, String>> labels = labelsCaptor();
+        verify(createCmd).withLabels(labels.capture());
+        return labels.getValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ArgumentCaptor<Map<String, String>> labelsCaptor() {
+        return ArgumentCaptor.forClass((Class<Map<String, String>>) (Class<?>) Map.class);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManagerStartFailureTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManagerStartFailureTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.core.common.docker;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.RemoveContainerCmd;
+import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.services.lambda.launcher.ImageCacheService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,13 +44,16 @@ class ContainerLifecycleManagerStartFailureTest {
     @Mock
     private PortAllocator portAllocator;
 
+    @Mock
+    private EmulatorConfig config;
+
     private ContainerLifecycleManager manager;
     private final ContainerSpec spec = new ContainerSpec("busybox:latest");
 
     @BeforeEach
     void setUp() {
         manager = spy(new ContainerLifecycleManager(
-                dockerClient, imageCacheService, containerDetector, portAllocator));
+                dockerClient, imageCacheService, containerDetector, portAllocator, config));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManagerVolumeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManagerVolumeTest.java
@@ -15,6 +15,7 @@ import com.github.dockerjava.api.command.WaitContainerCmd;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.core.command.WaitContainerResultCallback;
+import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.services.lambda.launcher.ImageCacheService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,11 +47,15 @@ class ContainerLifecycleManagerVolumeTest {
     @Mock
     private PortAllocator portAllocator;
 
+    @Mock
+    private EmulatorConfig config;
+
     private ContainerLifecycleManager manager;
 
     @BeforeEach
     void setUp() {
-        manager = new ContainerLifecycleManager(dockerClient, imageCacheService, containerDetector, portAllocator);
+        manager = new ContainerLifecycleManager(
+                dockerClient, imageCacheService, containerDetector, portAllocator, config);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerStorageHelperTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerStorageHelperTest.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,6 +44,22 @@ class ContainerStorageHelperTest {
 
         assertEquals(Path.of("/tmp/floci/rds/db1"), ContainerStorageHelper.hostResourcePath(config, "rds", "db1"));
         assertEquals("floci-rds-db1", ContainerStorageHelper.resourceName(config, "rds", null, "db1"));
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-aws"),
+                ContainerStorageHelper.defaultLabels(config));
+    }
+
+    @Test
+    void defaultLabelsIdentifyThisEmulator() {
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-aws"),
+                ContainerStorageHelper.defaultLabels(config("")));
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-aws", "floci_namespace", "run-one"),
+                ContainerStorageHelper.defaultLabels(config(" run/one ")));
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-aws"),
+                ContainerStorageHelper.defaultLabels(null));
     }
 
     private static EmulatorConfig config(String namespace) {


### PR DESCRIPTION
## Summary

Every container and volume Floci creates now carries `floci=true`, `floci_emulator=floci-aws`, and `floci_namespace=<value>` when `docker.resource-namespace` is configured.

Previously only volumes were labelled, with a bare `floci=true`. That key is shared across floci-aws, floci-gcp and floci-az, so `docker volume prune --filter label=floci=true` destroyed volumes belonging to all three emulators at once. `floci_emulator` discriminates between them; `floci=true` still prunes everything when that is the intent.

Labels are applied at the single `createContainerCmd` choke point in `ContainerLifecycleManager`, with per-spec labels layered over the defaults via `ContainerBuilder.withLabel`/`withLabels` (a spec label wins on key conflict), so every service is covered by construction rather than per call site. Verified that the previously suspected bypass sites (RabbitMq, Ec2PortForward, ContainerLauncher, EcsContainerManager, CodeBuildRunner) all funnel through that choke point.

Note for reviewers: `ContainerLifecycleManager`'s constructor gains an `EmulatorConfig` parameter. It is CDI-injected, so no production call site changes; three unit tests that construct it directly were updated.

Volume prefix renames and persisted volume names are deliberately out of scope.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

N/A for the wire protocol: this touches Floci's Docker container and volume plumbing, not an emulated AWS API surface. The incorrect behavior was that a `docker volume prune --filter label=floci=true` issued against one emulator destroyed the durable volumes of any other Floci emulator running on the same Docker daemon.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)