### PR TITLE
fix: preserve Route 53 private hosted-zone VPC associations

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Route53Test.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Route53Test.java
@@ -1,0 +1,69 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.route53.Route53Client;
+import software.amazon.awssdk.services.route53.model.CreateHostedZoneRequest;
+import software.amazon.awssdk.services.route53.model.CreateHostedZoneResponse;
+import software.amazon.awssdk.services.route53.model.DeleteHostedZoneRequest;
+import software.amazon.awssdk.services.route53.model.GetHostedZoneRequest;
+import software.amazon.awssdk.services.route53.model.GetHostedZoneResponse;
+import software.amazon.awssdk.services.route53.model.VPC;
+import software.amazon.awssdk.services.route53.model.VPCRegion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Route 53")
+class Route53Test {
+
+    private static Route53Client route53;
+
+    @BeforeAll
+    static void setup() {
+        route53 = TestFixtures.route53Client();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (route53 != null) {
+            route53.close();
+        }
+    }
+
+    @Test
+    void createAndGetPrivateHostedZonePreservesVpcAssociation() {
+        VPC vpc = VPC.builder()
+                .vpcId("vpc-sdk-private")
+                .vpcRegion(VPCRegion.US_WEST_2)
+                .build();
+        String zoneId = null;
+
+        try {
+            CreateHostedZoneResponse created = route53.createHostedZone(CreateHostedZoneRequest.builder()
+                    .name(TestFixtures.uniqueName("private-zone") + ".example.com")
+                    .callerReference(TestFixtures.uniqueName("private-zone-ref"))
+                    .vpc(vpc)
+                    .build());
+            zoneId = created.hostedZone().id();
+
+            assertThat(created.hostedZone().config().privateZone()).isTrue();
+            assertThat(created.vpc().vpcId()).isEqualTo(vpc.vpcId());
+            assertThat(created.vpc().vpcRegion()).isEqualTo(vpc.vpcRegion());
+
+            GetHostedZoneResponse fetched = route53.getHostedZone(
+                    GetHostedZoneRequest.builder().id(zoneId).build());
+
+            assertThat(fetched.hostedZone().config().privateZone()).isTrue();
+            assertThat(fetched.vpcs()).singleElement().satisfies(association -> {
+                assertThat(association.vpcId()).isEqualTo(vpc.vpcId());
+                assertThat(association.vpcRegion()).isEqualTo(vpc.vpcRegion());
+            });
+        } finally {
+            if (zoneId != null) {
+                route53.deleteHostedZone(DeleteHostedZoneRequest.builder().id(zoneId).build());
+            }
+        }
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Route53Test.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Route53Test.java
@@ -56,7 +56,7 @@ class Route53Test {
                     GetHostedZoneRequest.builder().id(zoneId).build());
 
             assertThat(fetched.hostedZone().config().privateZone()).isTrue();
-            assertThat(fetched.vpcs()).singleElement().satisfies(association -> {
+            assertThat(fetched.vpCs()).singleElement().satisfies(association -> {
                 assertThat(association.vpcId()).isEqualTo(vpc.vpcId());
                 assertThat(association.vpcRegion()).isEqualTo(vpc.vpcRegion());
             });

--- a/src/main/java/io/github/hectorvent/floci/services/route53/Route53Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/route53/Route53Controller.java
@@ -640,7 +640,15 @@ public class Route53Controller {
             return null;
         }
         Map<String, String> vpc = vpcs.get(0);
-        return new VpcAssociation(vpc.get("VPCId"), vpc.get("VPCRegion"));
+        String vpcId = vpc.get("VPCId");
+        String vpcRegion = vpc.get("VPCRegion");
+        // AWS requires VPCId and VPCRegion together whenever VPC is present; a
+        // half-populated element must not mark the zone private.
+        if (vpcId == null || vpcId.isEmpty() || vpcRegion == null || vpcRegion.isEmpty()) {
+            throw new AwsException(
+                    "InvalidInput", "VPCId and VPCRegion are both required when VPC is specified.", 400);
+        }
+        return new VpcAssociation(vpcId, vpcRegion);
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/route53/Route53Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/route53/Route53Controller.java
@@ -12,6 +12,7 @@ import io.github.hectorvent.floci.services.route53.model.HealthCheckConfig;
 import io.github.hectorvent.floci.services.route53.model.HostedZone;
 import io.github.hectorvent.floci.services.route53.model.ResourceRecord;
 import io.github.hectorvent.floci.services.route53.model.ResourceRecordSet;
+import io.github.hectorvent.floci.services.route53.model.VpcAssociation;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
@@ -60,25 +61,26 @@ public class Route53Controller {
             String name = XmlParser.extractFirst(body, "Name", null);
             String callerRef = XmlParser.extractFirst(body, "CallerReference", null);
             String comment = XmlParser.extractFirst(body, "Comment", null);
-            boolean privateZone = "true".equalsIgnoreCase(
-                    XmlParser.extractFirst(body, "PrivateZone", "false"));
+            VpcAssociation vpcAssociation = parseVpcAssociation(body);
 
             if (name == null || callerRef == null) {
                 throw new AwsException("InvalidInput", "Name and CallerReference are required.", 400);
             }
 
-            CreateZoneResult result = service.createHostedZone(name, callerRef, comment, privateZone);
-            String xml = new XmlBuilder()
+            CreateZoneResult result = service.createHostedZone(name, callerRef, comment, vpcAssociation);
+            XmlBuilder xml = new XmlBuilder()
                     .start("CreateHostedZoneResponse", NS)
                     .raw(xmlHostedZone(result.zone()))
                     .raw(xmlChangeInfo(result.change()))
-                    .raw(xmlDelegationSet())
-                    .end("CreateHostedZoneResponse")
-                    .build();
+                    .raw(xmlDelegationSet());
+            if (!result.zone().getVpcAssociations().isEmpty()) {
+                xml.raw(xmlVpcAssociation(result.zone().getVpcAssociations().getFirst()));
+            }
+            xml.end("CreateHostedZoneResponse");
 
             return Response.created(URI.create("/2013-04-01/hostedzone/" + result.zone().getId()))
                     .type(XML)
-                    .entity(xml)
+                    .entity(xml.build())
                     .build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
@@ -94,6 +96,7 @@ public class Route53Controller {
                     .start("GetHostedZoneResponse", NS)
                     .raw(xmlHostedZone(zone))
                     .raw(xmlDelegationSet())
+                    .raw(xmlVpcAssociations(zone.getVpcAssociations()))
                     .end("GetHostedZoneResponse")
                     .build();
             return Response.ok(xml, XML).build();
@@ -541,6 +544,26 @@ public class Route53Controller {
         return xml.build();
     }
 
+    private String xmlVpcAssociation(VpcAssociation association) {
+        return new XmlBuilder()
+                .start("VPC")
+                .elem("VPCRegion", association.getVpcRegion())
+                .elem("VPCId", association.getVpcId())
+                .end("VPC")
+                .build();
+    }
+
+    private String xmlVpcAssociations(List<VpcAssociation> associations) {
+        if (associations == null || associations.isEmpty()) {
+            return "";
+        }
+        XmlBuilder xml = new XmlBuilder().start("VPCs");
+        for (VpcAssociation association : associations) {
+            xml.raw(xmlVpcAssociation(association));
+        }
+        return xml.end("VPCs").build();
+    }
+
     private String xmlResourceRecordSet(ResourceRecordSet rrs) {
         XmlBuilder xml = new XmlBuilder()
                 .start("ResourceRecordSet")
@@ -610,6 +633,15 @@ public class Route53Controller {
     }
 
     // ── Request parsers ───────────────────────────────────────────────────────
+
+    private VpcAssociation parseVpcAssociation(String body) {
+        List<Map<String, String>> vpcs = XmlParser.extractGroups(body, "VPC");
+        if (vpcs.isEmpty()) {
+            return null;
+        }
+        Map<String, String> vpc = vpcs.get(0);
+        return new VpcAssociation(vpc.get("VPCId"), vpc.get("VPCRegion"));
+    }
 
     /**
      * Parses the ChangeBatch XML using StAX to correctly handle multiple Change elements,

--- a/src/main/java/io/github/hectorvent/floci/services/route53/Route53Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/route53/Route53Service.java
@@ -11,6 +11,7 @@ import io.github.hectorvent.floci.services.route53.model.HealthCheckConfig;
 import io.github.hectorvent.floci.services.route53.model.HostedZone;
 import io.github.hectorvent.floci.services.route53.model.ResourceRecord;
 import io.github.hectorvent.floci.services.route53.model.ResourceRecordSet;
+import io.github.hectorvent.floci.services.route53.model.VpcAssociation;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -63,7 +64,7 @@ public class Route53Service {
     // ── Hosted Zones ──────────────────────────────────────────────────────────
 
     public synchronized CreateZoneResult createHostedZone(String name, String callerReference,
-                                                           String comment, boolean privateZone) {
+                                                           String comment, VpcAssociation vpcAssociation) {
         String normalizedName = normalizeName(name);
 
         for (HostedZone existing : zoneStore.scan(k -> true)) {
@@ -74,7 +75,7 @@ public class Route53Service {
         }
 
         String id = generateZoneId();
-        HostedZone zone = new HostedZone(id, normalizedName, callerReference, comment, privateZone);
+        HostedZone zone = new HostedZone(id, normalizedName, callerReference, comment, vpcAssociation);
         zoneStore.put(id, zone);
         recordStore.put(id, buildDefaultRecords(normalizedName));
         ChangeInfo change = newChange(null);

--- a/src/main/java/io/github/hectorvent/floci/services/route53/model/HostedZone.java
+++ b/src/main/java/io/github/hectorvent/floci/services/route53/model/HostedZone.java
@@ -2,6 +2,9 @@ package io.github.hectorvent.floci.services.route53.model;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @RegisterForReflection
 public class HostedZone {
 
@@ -11,6 +14,7 @@ public class HostedZone {
     private String comment;
     private boolean privateZone;
     private int resourceRecordSetCount;
+    private List<VpcAssociation> vpcAssociations = new ArrayList<>();
 
     public HostedZone() {}
 
@@ -22,6 +26,14 @@ public class HostedZone {
         this.comment = comment;
         this.privateZone = privateZone;
         this.resourceRecordSetCount = 2;
+    }
+
+    public HostedZone(String id, String name, String callerReference,
+                      String comment, VpcAssociation vpcAssociation) {
+        this(id, name, callerReference, comment, vpcAssociation != null);
+        if (vpcAssociation != null) {
+            this.vpcAssociations.add(vpcAssociation);
+        }
     }
 
     public String getId() { return id; }
@@ -42,5 +54,10 @@ public class HostedZone {
     public int getResourceRecordSetCount() { return resourceRecordSetCount; }
     public void setResourceRecordSetCount(int resourceRecordSetCount) {
         this.resourceRecordSetCount = resourceRecordSetCount;
+    }
+
+    public List<VpcAssociation> getVpcAssociations() { return vpcAssociations; }
+    public void setVpcAssociations(List<VpcAssociation> vpcAssociations) {
+        this.vpcAssociations = vpcAssociations != null ? vpcAssociations : new ArrayList<>();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/route53/model/VpcAssociation.java
+++ b/src/main/java/io/github/hectorvent/floci/services/route53/model/VpcAssociation.java
@@ -1,0 +1,23 @@
+package io.github.hectorvent.floci.services.route53.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public class VpcAssociation {
+
+    private String vpcId;
+    private String vpcRegion;
+
+    public VpcAssociation() {}
+
+    public VpcAssociation(String vpcId, String vpcRegion) {
+        this.vpcId = vpcId;
+        this.vpcRegion = vpcRegion;
+    }
+
+    public String getVpcId() { return vpcId; }
+    public void setVpcId(String vpcId) { this.vpcId = vpcId; }
+
+    public String getVpcRegion() { return vpcRegion; }
+    public void setVpcRegion(String vpcRegion) { this.vpcRegion = vpcRegion; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/route53/Route53IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/route53/Route53IntegrationTest.java
@@ -125,7 +125,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(3)
+    @Order(4)
     void listHostedZones_includesCreatedZone() {
         given()
                 .when().get("/2013-04-01/hostedzone")
@@ -137,7 +137,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     void listHostedZonesByName_returnsZone() {
         given()
                 .queryParam("dnsname", "example.com.")
@@ -149,7 +149,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(5)
+    @Order(6)
     void getHostedZoneCount_includesZone() {
         given()
                 .when().get("/2013-04-01/hostedzonecount")
@@ -161,7 +161,7 @@ class Route53IntegrationTest {
     // ── Resource Record Sets ──────────────────────────────────────────────────
 
     @Test
-    @Order(6)
+    @Order(7)
     void listResourceRecordSets_autoCreatedSOAandNS() {
         String body = given()
                 .when().get("/2013-04-01/hostedzone/" + zoneId + "/rrset")
@@ -176,7 +176,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(7)
+    @Order(8)
     void changeResourceRecordSets_createARecord() {
         String body = """
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -219,7 +219,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(8)
+    @Order(9)
     void listResourceRecordSets_includesARecord() {
         String body = given()
                 .when().get("/2013-04-01/hostedzone/" + zoneId + "/rrset")
@@ -232,7 +232,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(9)
+    @Order(10)
     void changeResourceRecordSets_deleteSOA_fails() {
         String body = """
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -265,7 +265,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(10)
+    @Order(11)
     void getChange_returnsInsync() {
         if (changeId == null) return;
         given()
@@ -277,7 +277,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(11)
+    @Order(12)
     void changeResourceRecordSets_deleteARecord() {
         String body = """
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -310,7 +310,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(12)
+    @Order(13)
     void deleteHostedZone_failsWhenNonDefaultRecordsExist() {
         String createBody = """
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -366,7 +366,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(13)
+    @Order(14)
     void deleteHostedZone_succeedsAfterRecordsRemoved() {
         given()
                 .when().delete("/2013-04-01/hostedzone/" + zoneId)
@@ -376,7 +376,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(14)
+    @Order(15)
     void getHostedZone_returns404AfterDelete() {
         given()
                 .when().get("/2013-04-01/hostedzone/" + zoneId)
@@ -388,7 +388,7 @@ class Route53IntegrationTest {
     // ── Health Checks ─────────────────────────────────────────────────────────
 
     @Test
-    @Order(15)
+    @Order(16)
     void createHealthCheck_returns201() {
         String body = """
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -420,7 +420,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(16)
+    @Order(17)
     void getHealthCheck_returnsCreated() {
         given()
                 .when().get("/2013-04-01/healthcheck/" + healthCheckId)
@@ -431,7 +431,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(17)
+    @Order(18)
     void listHealthChecks_includesCreated() {
         String body = given()
                 .when().get("/2013-04-01/healthcheck")
@@ -443,7 +443,7 @@ class Route53IntegrationTest {
     }
 
     @Test
-    @Order(18)
+    @Order(19)
     void deleteHealthCheck_returns200() {
         given()
                 .when().delete("/2013-04-01/healthcheck/" + healthCheckId)
@@ -460,7 +460,7 @@ class Route53IntegrationTest {
     // ── Tags ──────────────────────────────────────────────────────────────────
 
     @Test
-    @Order(19)
+    @Order(20)
     void tagging_addListRemove() {
         String createBody = """
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -528,7 +528,7 @@ class Route53IntegrationTest {
     // ── Limits ────────────────────────────────────────────────────────────────
 
     @Test
-    @Order(20)
+    @Order(21)
     void getAccountLimit_returnsValue() {
         given()
                 .when().get("/2013-04-01/accountlimit/MAX_HOSTED_ZONES_BY_OWNER")

--- a/src/test/java/io/github/hectorvent/floci/services/route53/Route53IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/route53/Route53IntegrationTest.java
@@ -32,7 +32,7 @@ class Route53IntegrationTest {
                   <CallerReference>ref-001</CallerReference>
                   <HostedZoneConfig>
                     <Comment>test zone</Comment>
-                    <PrivateZone>false</PrivateZone>
+                    <PrivateZone>true</PrivateZone>
                   </HostedZoneConfig>
                 </CreateHostedZoneRequest>
                 """;
@@ -48,8 +48,10 @@ class Route53IntegrationTest {
                 .body("CreateHostedZoneResponse.HostedZone.Name", equalTo("example.com."))
                 .body("CreateHostedZoneResponse.HostedZone.Id", startsWith("/hostedzone/Z"))
                 .body("CreateHostedZoneResponse.HostedZone.ResourceRecordSetCount", equalTo("2"))
+                .body("CreateHostedZoneResponse.HostedZone.Config.PrivateZone", equalTo("false"))
                 .body("CreateHostedZoneResponse.ChangeInfo.Status", equalTo("INSYNC"))
                 .body("CreateHostedZoneResponse.ChangeInfo.Id", startsWith("/change/C"))
+                .body(not(containsString("<VPC>")))
                 .body(containsString("ns-1.awsdns-01.org"))
                 .extract().header("Location");
 
@@ -67,7 +69,59 @@ class Route53IntegrationTest {
                 .contentType(XML)
                 .body("GetHostedZoneResponse.HostedZone.Id", equalTo("/hostedzone/" + zoneId))
                 .body("GetHostedZoneResponse.HostedZone.Name", equalTo("example.com."))
+                .body("GetHostedZoneResponse.HostedZone.Config.PrivateZone", equalTo("false"))
+                .body(not(containsString("<VPCs>")))
                 .body(containsString("ns-1.awsdns-01.org"));
+    }
+
+    @Test
+    @Order(3)
+    void createHostedZone_withVpcReturnsPrivateZoneAndAssociation() {
+        String body = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <CreateHostedZoneRequest xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+                  <Name>private.example.com</Name>
+                  <CallerReference>ref-private-001</CallerReference>
+                  <VPC>
+                    <VPCId>vpc-12345678</VPCId>
+                    <VPCRegion>us-west-2</VPCRegion>
+                  </VPC>
+                  <HostedZoneConfig>
+                    <Comment>private test zone</Comment>
+                  </HostedZoneConfig>
+                </CreateHostedZoneRequest>
+                """;
+
+        String locationHeader = given()
+                .contentType(XML)
+                .body(body)
+                .when().post("/2013-04-01/hostedzone")
+                .then()
+                .statusCode(201)
+                .contentType(XML)
+                .body("CreateHostedZoneResponse.HostedZone.Config.PrivateZone", equalTo("true"))
+                .body("CreateHostedZoneResponse.VPC.VPCId", equalTo("vpc-12345678"))
+                .body("CreateHostedZoneResponse.VPC.VPCRegion", equalTo("us-west-2"))
+                .extract().header("Location");
+
+        String privateZoneId = locationHeader.substring(locationHeader.lastIndexOf('/') + 1);
+
+        try {
+            given()
+                    .when().get("/2013-04-01/hostedzone/" + privateZoneId)
+                    .then()
+                    .statusCode(200)
+                    .contentType(XML)
+                    .body("GetHostedZoneResponse.HostedZone.Config.PrivateZone", equalTo("true"))
+                    .body("GetHostedZoneResponse.VPCs.VPC.size()", equalTo(1))
+                    .body("GetHostedZoneResponse.VPCs.VPC.VPCId", equalTo("vpc-12345678"))
+                    .body("GetHostedZoneResponse.VPCs.VPC.VPCRegion", equalTo("us-west-2"));
+        } finally {
+            given()
+                    .when().delete("/2013-04-01/hostedzone/" + privateZoneId)
+                    .then()
+                    .statusCode(200);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Add a reflection-safe Route 53 VPC association model and persist a list of associations on `HostedZone`, keeping the existing storage-backed zone lifecycle intact. Parse `VPCId` and `VPCRegion` from the optional `VPC` request member, pass that association through `Route53Service.createHostedZone`, and derive `privateZone` from its presence instead of accepting the response-only `PrivateZone` input. Serialize the association in the operation-specific AWS shapes: the singular `VPC` member on CreateHostedZone and the `VPCs` collection on GetHostedZone, while leaving public-zone responses and hosted-zone list responses unchanged.

`CreateHostedZone` currently looks for a response-only `PrivateZone` element and ignores the request's `VPC`, so SDK and Terraform requests always create public zones. The missing association is also absent from subsequent reads, causing Terraform state to drift on every plan. The issue is limited to correctly handling the existing CreateHostedZone and GetHostedZone REST XML contracts; the association-management actions tracked separately in #2298 remain out of scope. There are no prior closed attempts or open competing pull requests in the supplied issue evidence.

Closes #2294

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Not applicable to this change.

## Checklist

- [ ] `./mvnw test` passes locally
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
