### PR TITLE
feat(guardduty): add GuardDuty detector and organization configuration emulation

### DIFF
--- a/compatibility-tests/compat-opentofu/main.tf
+++ b/compatibility-tests/compat-opentofu/main.tf
@@ -342,3 +342,47 @@ resource "aws_ses_active_receipt_rule_set" "compat" {
 output "ses_rule_set_name" {
   value = aws_ses_receipt_rule_set.compat.rule_set_name
 }
+
+# -- GuardDuty -----------------------------------------------------------------
+# Detector, per-feature configuration, and organization configuration mirror the
+# resource set an org security-baseline stack manages. additional_configuration
+# is an ordered list block: Floci must echo it back in submitted order or every
+# re-plan proposes a replacement.
+resource "aws_guardduty_detector" "compat" {
+  enable                       = true
+  finding_publishing_frequency = "SIX_HOURS"
+
+  tags = {
+    Environment = "compat-test"
+  }
+}
+
+resource "aws_guardduty_detector_feature" "runtime_monitoring" {
+  detector_id = aws_guardduty_detector.compat.id
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+
+  additional_configuration {
+    name   = "ECS_FARGATE_AGENT_MANAGEMENT"
+    status = "ENABLED"
+  }
+
+  additional_configuration {
+    name   = "EC2_AGENT_MANAGEMENT"
+    status = "ENABLED"
+  }
+
+  additional_configuration {
+    name   = "EKS_ADDON_MANAGEMENT"
+    status = "DISABLED"
+  }
+}
+
+resource "aws_guardduty_organization_configuration" "compat" {
+  detector_id                      = aws_guardduty_detector.compat.id
+  auto_enable_organization_members = "ALL"
+}
+
+output "guardduty_detector_id" {
+  value = aws_guardduty_detector.compat.id
+}

--- a/compatibility-tests/compat-opentofu/provider.tf
+++ b/compatibility-tests/compat-opentofu/provider.tf
@@ -37,5 +37,6 @@ provider "aws" {
     ec2            = var.endpoint
     route53        = var.endpoint
     ses            = var.endpoint
+    guardduty      = var.endpoint
   }
 }

--- a/compatibility-tests/compat-opentofu/test/opentofu.bats
+++ b/compatibility-tests/compat-opentofu/test/opentofu.bats
@@ -202,3 +202,17 @@ setup() {
     assert_success
     assert_output "GZIP"
 }
+
+@test "OpenTofu: GuardDuty detector is created with organization configuration" {
+    run aws_cmd guardduty list-detectors --query "DetectorIds[0]" --output text
+    assert_success
+    DETECTOR_ID="$output"
+    run aws_cmd guardduty get-detector --detector-id "$DETECTOR_ID" \
+        --query "Status" --output text
+    assert_success
+    assert_output "ENABLED"
+    run aws_cmd guardduty describe-organization-configuration --detector-id "$DETECTOR_ID" \
+        --query "AutoEnableOrganizationMembers" --output text
+    assert_success
+    assert_output "ALL"
+}

--- a/compatibility-tests/compat-terraform/main.tf
+++ b/compatibility-tests/compat-terraform/main.tf
@@ -115,13 +115,13 @@ resource "aws_secretsmanager_secret_version" "db_creds" {
 
 # -- RDS DB Instance -----------------------------------------------------------
 resource "aws_db_instance" "app" {
-  identifier        = "floci-compat-db"
-  engine            = "postgres"
-  engine_version    = "15"
-  instance_class    = "db.t3.micro"
-  allocated_storage = 20
-  username          = "admin"
-  password          = "Password1!"
+  identifier          = "floci-compat-db"
+  engine              = "postgres"
+  engine_version      = "15"
+  instance_class      = "db.t3.micro"
+  allocated_storage   = 20
+  username            = "admin"
+  password            = "Password1!"
   skip_final_snapshot = true
 }
 
@@ -495,4 +495,75 @@ output "tagged_role_arn" {
 
 output "tagged_policy_arn" {
   value = aws_iam_policy.tagged.arn
+}
+
+# -- GuardDuty -----------------------------------------------------------------
+# Detector, per-feature configuration, and organization configuration mirror the
+# resource set an org security-baseline stack manages. additional_configuration
+# is an ordered list block: Floci must echo it back in submitted order or every
+# re-plan proposes a replacement.
+resource "aws_guardduty_detector" "compat" {
+  enable                       = true
+  finding_publishing_frequency = "SIX_HOURS"
+
+  tags = {
+    Environment = "compat-test"
+  }
+}
+
+resource "aws_guardduty_detector_feature" "runtime_monitoring" {
+  detector_id = aws_guardduty_detector.compat.id
+  name        = "RUNTIME_MONITORING"
+  status      = "ENABLED"
+
+  additional_configuration {
+    name   = "ECS_FARGATE_AGENT_MANAGEMENT"
+    status = "ENABLED"
+  }
+
+  additional_configuration {
+    name   = "EC2_AGENT_MANAGEMENT"
+    status = "ENABLED"
+  }
+
+  additional_configuration {
+    name   = "EKS_ADDON_MANAGEMENT"
+    status = "DISABLED"
+  }
+}
+
+resource "aws_guardduty_organization_configuration" "compat" {
+  detector_id                      = aws_guardduty_detector.compat.id
+  auto_enable_organization_members = "ALL"
+}
+
+resource "aws_guardduty_organization_configuration_feature" "runtime_monitoring" {
+  detector_id = aws_guardduty_detector.compat.id
+  name        = "RUNTIME_MONITORING"
+  auto_enable = "ALL"
+
+  additional_configuration {
+    name        = "ECS_FARGATE_AGENT_MANAGEMENT"
+    auto_enable = "ALL"
+  }
+
+  additional_configuration {
+    name        = "EC2_AGENT_MANAGEMENT"
+    auto_enable = "ALL"
+  }
+
+  additional_configuration {
+    name        = "EKS_ADDON_MANAGEMENT"
+    auto_enable = "NONE"
+  }
+
+  depends_on = [aws_guardduty_organization_configuration.compat]
+}
+
+output "guardduty_detector_id" {
+  value = aws_guardduty_detector.compat.id
+}
+
+output "guardduty_detector_arn" {
+  value = aws_guardduty_detector.compat.arn
 }

--- a/compatibility-tests/compat-terraform/provider.tf
+++ b/compatibility-tests/compat-terraform/provider.tf
@@ -41,5 +41,6 @@ provider "aws" {
     route53        = var.endpoint
     appautoscaling = var.endpoint
     ses            = var.endpoint
+    guardduty      = var.endpoint
   }
 }

--- a/compatibility-tests/compat-terraform/test/terraform.bats
+++ b/compatibility-tests/compat-terraform/test/terraform.bats
@@ -347,3 +347,40 @@ setup() {
     fi
     [ "$status" -eq 0 ]
 }
+
+@test "Terraform: GuardDuty detector is created with features" {
+    run aws_cmd guardduty list-detectors --query "DetectorIds[0]" --output text
+    assert_success
+    DETECTOR_ID="$output"
+    run aws_cmd guardduty get-detector --detector-id "$DETECTOR_ID" \
+        --query "[Status, FindingPublishingFrequency]" --output text
+    assert_success
+    assert_output --partial "ENABLED"
+    assert_output --partial "SIX_HOURS"
+}
+
+@test "Terraform: GuardDuty organization configuration round-trips" {
+    run aws_cmd guardduty list-detectors --query "DetectorIds[0]" --output text
+    assert_success
+    DETECTOR_ID="$output"
+    run aws_cmd guardduty describe-organization-configuration --detector-id "$DETECTOR_ID" \
+        --query "AutoEnableOrganizationMembers" --output text
+    assert_success
+    assert_output "ALL"
+}
+
+# additional_configuration is an ordered list block; drift here means the
+# emulator reordered the list on read-back.
+@test "Terraform: re-planning GuardDuty reports no changes" {
+    cd "$TF_DIR"
+    run terraform plan -var="endpoint=${FLOCI_ENDPOINT}" -input=false -no-color -detailed-exitcode \
+        -target=aws_guardduty_detector.compat \
+        -target=aws_guardduty_detector_feature.runtime_monitoring \
+        -target=aws_guardduty_organization_configuration.compat \
+        -target=aws_guardduty_organization_configuration_feature.runtime_monitoring
+    if [ "$status" -eq 2 ]; then
+        echo "# drift detected on re-plan:" >&3
+        echo "$output" >&3
+    fi
+    [ "$status" -eq 0 ]
+}

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -253,6 +253,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>rum</artifactId>
         </dependency>
+        <!-- GuardDuty client -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>guardduty</artifactId>
+        </dependency>
         <!-- Secrets Manager client -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.opensearch.OpenSearchClient;
 import software.amazon.awssdk.services.neptune.NeptuneClient;
 import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.guardduty.GuardDutyClient;
 import software.amazon.awssdk.services.rum.RumClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.endpoints.Endpoint;
@@ -704,6 +705,14 @@ public final class TestFixtures {
 
     public static RumClient rumClient() {
         return RumClient.builder()
+                .endpointOverride(ENDPOINT)
+                .region(REGION)
+                .credentialsProvider(CREDENTIALS)
+                .build();
+    }
+
+    public static GuardDutyClient guardDutyClient() {
+        return GuardDutyClient.builder()
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
                 .credentialsProvider(CREDENTIALS)

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/GuardDutyTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/GuardDutyTest.java
@@ -1,0 +1,192 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.guardduty.GuardDutyClient;
+import software.amazon.awssdk.services.guardduty.model.AdminStatus;
+import software.amazon.awssdk.services.guardduty.model.AutoEnableMembers;
+import software.amazon.awssdk.services.guardduty.model.BadRequestException;
+import software.amazon.awssdk.services.guardduty.model.CreateDetectorResponse;
+import software.amazon.awssdk.services.guardduty.model.DescribeOrganizationConfigurationResponse;
+import software.amazon.awssdk.services.guardduty.model.DetectorFeature;
+import software.amazon.awssdk.services.guardduty.model.DetectorFeatureConfiguration;
+import software.amazon.awssdk.services.guardduty.model.DetectorAdditionalConfiguration;
+import software.amazon.awssdk.services.guardduty.model.DetectorStatus;
+import software.amazon.awssdk.services.guardduty.model.FeatureAdditionalConfiguration;
+import software.amazon.awssdk.services.guardduty.model.FeatureStatus;
+import software.amazon.awssdk.services.guardduty.model.FindingPublishingFrequency;
+import software.amazon.awssdk.services.guardduty.model.GetDetectorResponse;
+import software.amazon.awssdk.services.guardduty.model.ListOrganizationAdminAccountsResponse;
+import software.amazon.awssdk.services.guardduty.model.OrgFeature;
+import software.amazon.awssdk.services.guardduty.model.OrgFeatureAdditionalConfiguration;
+import software.amazon.awssdk.services.guardduty.model.OrgFeatureStatus;
+import software.amazon.awssdk.services.guardduty.model.OrganizationAdditionalConfiguration;
+import software.amazon.awssdk.services.guardduty.model.OrganizationFeatureConfiguration;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("GuardDuty")
+class GuardDutyTest {
+
+    @Test
+    void detectorLifecycleUsesAwsSdkWireShapes() throws Exception {
+        try (GuardDutyClient guardduty = TestFixtures.guardDutyClient()) {
+            CreateDetectorResponse created = guardduty.createDetector(request -> request
+                    .enable(true)
+                    .findingPublishingFrequency(FindingPublishingFrequency.SIX_HOURS)
+                    .features(List.of(
+                            DetectorFeatureConfiguration.builder()
+                                    .name(DetectorFeature.RUNTIME_MONITORING)
+                                    .status(FeatureStatus.ENABLED)
+                                    .additionalConfiguration(List.of(
+                                            DetectorAdditionalConfiguration.builder()
+                                                    .name(FeatureAdditionalConfiguration
+                                                            .ECS_FARGATE_AGENT_MANAGEMENT)
+                                                    .status(FeatureStatus.ENABLED)
+                                                    .build(),
+                                            DetectorAdditionalConfiguration.builder()
+                                                    .name(FeatureAdditionalConfiguration.EC2_AGENT_MANAGEMENT)
+                                                    .status(FeatureStatus.ENABLED)
+                                                    .build(),
+                                            DetectorAdditionalConfiguration.builder()
+                                                    .name(FeatureAdditionalConfiguration.EKS_ADDON_MANAGEMENT)
+                                                    .status(FeatureStatus.DISABLED)
+                                                    .build()))
+                                    .build(),
+                            DetectorFeatureConfiguration.builder()
+                                    .name(DetectorFeature.S3_DATA_EVENTS)
+                                    .status(FeatureStatus.ENABLED)
+                                    .build()))
+                    .tags(Map.of("env", "compat")));
+            String detectorId = created.detectorId();
+            assertThat(detectorId).hasSize(32);
+
+            try (AutoCloseable deleteDetector = () ->
+                    guardduty.deleteDetector(request -> request.detectorId(detectorId))) {
+                GetDetectorResponse detector =
+                        guardduty.getDetector(request -> request.detectorId(detectorId));
+                assertThat(detector.status()).isEqualTo(DetectorStatus.ENABLED);
+                assertThat(detector.findingPublishingFrequency())
+                        .isEqualTo(FindingPublishingFrequency.SIX_HOURS);
+                assertThat(detector.serviceRole()).contains(":role/aws-service-role/guardduty");
+                assertThat(detector.tags()).containsEntry("env", "compat");
+                assertThat(detector.features())
+                        .extracting(feature -> feature.name().toString())
+                        .containsExactly("RUNTIME_MONITORING", "S3_DATA_EVENTS");
+                assertThat(detector.features().get(0).additionalConfiguration())
+                        .extracting(configuration -> configuration.name().toString())
+                        .containsExactly(
+                                "ECS_FARGATE_AGENT_MANAGEMENT",
+                                "EC2_AGENT_MANAGEMENT",
+                                "EKS_ADDON_MANAGEMENT");
+
+                assertThat(guardduty.listDetectors(request -> {
+                }).detectorIds()).contains(detectorId);
+
+                guardduty.updateDetector(request -> request
+                        .detectorId(detectorId)
+                        .enable(false)
+                        .findingPublishingFrequency(FindingPublishingFrequency.ONE_HOUR));
+                GetDetectorResponse updated =
+                        guardduty.getDetector(request -> request.detectorId(detectorId));
+                assertThat(updated.status()).isEqualTo(DetectorStatus.DISABLED);
+                assertThat(updated.findingPublishingFrequency())
+                        .isEqualTo(FindingPublishingFrequency.ONE_HOUR);
+
+                String detectorArn =
+                        "arn:aws:guardduty:us-east-1:000000000000:detector/" + detectorId;
+                guardduty.tagResource(request -> request
+                        .resourceArn(detectorArn)
+                        .tags(Map.of("team", "security")));
+                assertThat(guardduty.listTagsForResource(request -> request.resourceArn(detectorArn))
+                        .tags()).containsEntry("team", "security").containsEntry("env", "compat");
+                guardduty.untagResource(request -> request
+                        .resourceArn(detectorArn)
+                        .tagKeys(List.of("env")));
+                assertThat(guardduty.listTagsForResource(request -> request.resourceArn(detectorArn))
+                        .tags()).containsOnlyKeys("team");
+            }
+
+            assertThatThrownBy(() -> guardduty.getDetector(request -> request.detectorId(detectorId)))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessageContaining("is not owned by the current account");
+        }
+    }
+
+    @Test
+    void organizationConfigurationRoundTripsThroughTheSdk() throws Exception {
+        try (GuardDutyClient guardduty = TestFixtures.guardDutyClient()) {
+            String detectorId = guardduty.createDetector(request -> request.enable(true)).detectorId();
+
+            try (AutoCloseable deleteDetector = () ->
+                    guardduty.deleteDetector(request -> request.detectorId(detectorId))) {
+                guardduty.updateOrganizationConfiguration(request -> request
+                        .detectorId(detectorId)
+                        .autoEnableOrganizationMembers(AutoEnableMembers.ALL)
+                        .features(List.of(OrganizationFeatureConfiguration.builder()
+                                .name(OrgFeature.RUNTIME_MONITORING)
+                                .autoEnable(OrgFeatureStatus.ALL)
+                                .additionalConfiguration(List.of(
+                                        OrganizationAdditionalConfiguration.builder()
+                                                .name(OrgFeatureAdditionalConfiguration
+                                                        .ECS_FARGATE_AGENT_MANAGEMENT)
+                                                .autoEnable(OrgFeatureStatus.ALL)
+                                                .build(),
+                                        OrganizationAdditionalConfiguration.builder()
+                                                .name(OrgFeatureAdditionalConfiguration.EC2_AGENT_MANAGEMENT)
+                                                .autoEnable(OrgFeatureStatus.ALL)
+                                                .build(),
+                                        OrganizationAdditionalConfiguration.builder()
+                                                .name(OrgFeatureAdditionalConfiguration.EKS_ADDON_MANAGEMENT)
+                                                .autoEnable(OrgFeatureStatus.NONE)
+                                                .build()))
+                                .build())));
+
+                DescribeOrganizationConfigurationResponse configuration =
+                        guardduty.describeOrganizationConfiguration(request ->
+                                request.detectorId(detectorId));
+                assertThat(configuration.autoEnableOrganizationMembers()).isEqualTo(AutoEnableMembers.ALL);
+                assertThat(configuration.memberAccountLimitReached()).isFalse();
+                assertThat(configuration.features())
+                        .extracting(feature -> feature.name().toString())
+                        .containsExactly("RUNTIME_MONITORING");
+                assertThat(configuration.features().get(0).additionalConfiguration())
+                        .extracting(feature -> feature.name().toString())
+                        .containsExactly(
+                                "ECS_FARGATE_AGENT_MANAGEMENT",
+                                "EC2_AGENT_MANAGEMENT",
+                                "EKS_ADDON_MANAGEMENT");
+            }
+        }
+    }
+
+    @Test
+    void organizationAdminAccountLifecycle() {
+        try (GuardDutyClient guardduty = TestFixtures.guardDutyClient()) {
+            guardduty.enableOrganizationAdminAccount(request ->
+                    request.adminAccountId("111111111111"));
+            try {
+                ListOrganizationAdminAccountsResponse accounts =
+                        guardduty.listOrganizationAdminAccounts(request -> {
+                        });
+                assertThat(accounts.adminAccounts())
+                        .anySatisfy(account -> {
+                            assertThat(account.adminAccountId()).isEqualTo("111111111111");
+                            assertThat(account.adminStatus()).isEqualTo(AdminStatus.ENABLED);
+                        });
+            } finally {
+                guardduty.disableOrganizationAdminAccount(request ->
+                        request.adminAccountId("111111111111"));
+            }
+
+            assertThatThrownBy(() -> guardduty.disableOrganizationAdminAccount(request ->
+                    request.adminAccountId("111111111111")))
+                    .isInstanceOf(BadRequestException.class)
+                    .hasMessageContaining("already been disabled");
+        }
+    }
+}

--- a/docs/services/guardduty.md
+++ b/docs/services/guardduty.md
@@ -1,0 +1,83 @@
+# GuardDuty
+
+**Protocol:** REST JSON
+
+**Endpoint:** `http://localhost:4566`
+
+Floci implements the GuardDuty detector management lifecycle and organization-configuration
+readback for local SDK, CLI, and Terraform workflows. Detectors are isolated by account and
+region and use the configured Floci storage mode.
+
+## Supported Operations
+
+| Operation | Method and path | Description |
+|---|---|---|
+| `CreateDetector` | `POST /detector` | Create the account's detector (one per account and region) |
+| `GetDetector` | `GET /detector/{detectorId}` | Return detector status, frequency, features, and tags |
+| `UpdateDetector` | `POST /detector/{detectorId}` | Update status, frequency, and features |
+| `DeleteDetector` | `DELETE /detector/{detectorId}` | Delete the detector |
+| `ListDetectors` | `GET /detector` | List detector IDs with pagination |
+| `DescribeOrganizationConfiguration` | `GET /detector/{detectorId}/admin` | Return organization auto-enablement configuration |
+| `UpdateOrganizationConfiguration` | `POST /detector/{detectorId}/admin` | Update organization auto-enablement configuration |
+| `EnableOrganizationAdminAccount` | `POST /admin/enable` | Designate the delegated administrator account |
+| `DisableOrganizationAdminAccount` | `POST /admin/disable` | Remove the delegated administrator account |
+| `ListOrganizationAdminAccounts` | `GET /admin` | List the delegated administrator account |
+| `TagResource` | `POST /tags/{resourceArn}` | Add tags to a detector |
+| `UntagResource` | `DELETE /tags/{resourceArn}` | Remove tags from a detector |
+| `ListTagsForResource` | `GET /tags/{resourceArn}` | List detector tags |
+
+Feature lists and each feature's `additionalConfiguration` list are returned in the order
+they were submitted, so Terraform's ordered list blocks re-plan cleanly. A missing detector
+is reported as `BadRequestException` with the exact message the Terraform AWS provider
+matches for not-found detection, mirroring AWS.
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_SERVICES_GUARDDUTY_ENABLED` | `true` | Enable or disable GuardDuty |
+| `FLOCI_STORAGE_SERVICES_GUARDDUTY_MODE` | *(inherits global)* | Optional GuardDuty storage-mode override |
+| `FLOCI_STORAGE_SERVICES_GUARDDUTY_FLUSH_INTERVAL_MS` | `5000` | Hybrid storage flush interval in milliseconds |
+
+Unless a GuardDuty-specific override is set, detector state follows the global
+`FLOCI_STORAGE_MODE` setting. Persistent, hybrid, and write-ahead-log modes restore
+detectors across restarts.
+
+## Example
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:4566
+
+DETECTOR_ID=$(aws guardduty create-detector \
+  --enable \
+  --finding-publishing-frequency SIX_HOURS \
+  --tags env=local \
+  --query DetectorId --output text)
+
+aws guardduty get-detector --detector-id "$DETECTOR_ID"
+aws guardduty list-detectors
+
+aws guardduty update-organization-configuration \
+  --detector-id "$DETECTOR_ID" \
+  --auto-enable-organization-members ALL
+aws guardduty describe-organization-configuration --detector-id "$DETECTOR_ID"
+
+aws guardduty delete-detector --detector-id "$DETECTOR_ID"
+```
+
+## Current Scope
+
+- Detector status, finding-publishing frequency, features (including
+  `additionalConfiguration` sub-features), tags, and timestamps are modeled.
+- Organization semantics are readback-only. Floci has no Organizations service, so
+  `adminAccountId` membership is not validated, delegated-administrator permissions are not
+  enforced on the organization endpoints, and auto-enablement is never fanned out to member
+  accounts. Organization configuration is stored per calling account and echoed back as
+  submitted — sufficient for Terraform's `aws_guardduty_organization_configuration`,
+  `aws_guardduty_organization_configuration_feature`, and
+  `aws_guardduty_organization_admin_account` resources in a single-account workflow.
+- No findings are generated: detection, malware scans, and the findings APIs
+  (`ListFindings`, `GetFindings`, filters, and publishing destinations) are not implemented.
+- Member, invitation, IP-set, threat-intel, and coverage APIs are not implemented.
+- The deprecated `dataSources` request/response structures are not modeled; the Terraform
+  provider treats their absence as "not configured".

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -1,6 +1,6 @@
 # Services Overview
 
-Floci emulates 70 AWS services on a single port (`4566`). All services use the real AWS wire protocol, your existing AWS CLI commands and SDK clients work without modification.
+Floci emulates 71 AWS services on a single port (`4566`). All services use the real AWS wire protocol, your existing AWS CLI commands and SDK clients work without modification.
 
 This page is the canonical reference for supported service and operation counts. Some services expose separate control-plane and data-plane rows below. Other docs (and the README) should link here rather than duplicating the table.
 
@@ -37,6 +37,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [CloudWatch Logs](cloudwatch.md) | `POST /` + `X-Amz-Target: Logs.*` | JSON 1.1 | 17 |
 | [CloudWatch Metrics](cloudwatch.md#metrics) | `POST /` with `Action=` or JSON 1.1 | Query / JSON | 11 |
 | [CloudWatch RUM](rum.md) | `/appmonitor`, `/appmonitor/{name}`, `/appmonitors` | REST JSON | 5 |
+| [GuardDuty](guardduty.md) | `/detector`, `/detector/{detectorId}`, `/detector/{detectorId}/admin`, `/admin/*`, `/tags/*` | REST JSON | 13 |
 | [ElastiCache](elasticache.md) | `POST /` with `Action=` param + TCP proxy | Query + RESP | 8 |
 | [MemoryDB](memorydb.md) | `POST /` + `X-Amz-Target: AmazonMemoryDB.*` + TCP proxy | JSON 1.1 + RESP | 7 |
 | [RDS](rds.md) | `POST /` with `Action=` param + TCP proxy | Query + wire | 14 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
     - EventBridge Scheduler: services/scheduler.md
     - CloudWatch: services/cloudwatch.md
     - CloudWatch RUM: services/rum.md
+    - GuardDuty: services/guardduty.md
     - ACM: services/acm.md
     - ECS: services/ecs.md
     - ECR: services/ecr.md

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -282,6 +282,7 @@ public interface EmulatorConfig {
         ElasticBeanstalkStorageConfig elasticbeanstalk();
         CloudTrailStorageConfig cloudtrail();
         RumStorageConfig rum();
+        GuardDutyStorageConfig guardduty();
     }
 
     interface SsmStorageConfig {
@@ -504,6 +505,13 @@ public interface EmulatorConfig {
         long flushIntervalMs();
     }
 
+    interface GuardDutyStorageConfig {
+        Optional<String> mode();
+
+        @WithDefault("5000")
+        long flushIntervalMs();
+    }
+
     interface CodeDeployStorageConfig {
         Optional<String> mode();
 
@@ -609,6 +617,7 @@ public interface EmulatorConfig {
         IotServiceConfig iot();
         IotDataServiceConfig iotdata();
         RumServiceConfig rum();
+        GuardDutyServiceConfig guardduty();
     }
 
     interface IotServiceConfig {
@@ -638,6 +647,11 @@ public interface EmulatorConfig {
     }
 
     interface RumServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
+    }
+
+    interface GuardDutyServiceConfig {
         @WithDefault("true")
         boolean enabled();
     }

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -28,6 +28,7 @@ import io.github.hectorvent.floci.services.route53.Route53Controller;
 import io.github.hectorvent.floci.services.ses.SesController;
 import io.github.hectorvent.floci.services.appsync.AppSyncController;
 import io.github.hectorvent.floci.services.rdsdata.RdsDataController;
+import io.github.hectorvent.floci.services.guardduty.GuardDutyController;
 import io.github.hectorvent.floci.services.rum.RumController;
 import io.github.hectorvent.floci.services.s3vectors.S3VectorsController;
 import io.github.hectorvent.floci.services.s3tables.S3TablesController;
@@ -457,7 +458,13 @@ public class ResolvedServiceCatalog {
                         "rum", storageMode(config.storage().services().rum().mode(), config.storage().mode()),
                         config.storage().services().rum().flushIntervalMs(), null, ServiceProtocol.REST_JSON,
                         protocols(ServiceProtocol.REST_JSON),
-                        Set.of(), Set.of("rum"), Set.of(), Set.of(RumController.class))
+                        Set.of(), Set.of("rum"), Set.of(), Set.of(RumController.class)),
+                descriptor("guardduty", "guardduty", config.services().guardduty().enabled(), true,
+                        "guardduty",
+                        storageMode(config.storage().services().guardduty().mode(), config.storage().mode()),
+                        config.storage().services().guardduty().flushIntervalMs(), null, ServiceProtocol.REST_JSON,
+                        protocols(ServiceProtocol.REST_JSON),
+                        Set.of(), Set.of("guardduty"), Set.of(), Set.of(GuardDutyController.class))
         ));
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/guardduty/GuardDutyController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/guardduty/GuardDutyController.java
@@ -1,0 +1,202 @@
+package io.github.hectorvent.floci.services.guardduty;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.guardduty.model.AdminAccount;
+import io.github.hectorvent.floci.services.guardduty.model.Detector;
+import io.github.hectorvent.floci.services.guardduty.model.DetectorFeature;
+import io.github.hectorvent.floci.services.guardduty.model.OrganizationConfiguration;
+import io.github.hectorvent.floci.services.guardduty.model.OrganizationFeature;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * GuardDuty (Smithy restJson1) — detector lifecycle and organization configuration.
+ *
+ * <p>The literal {@code /detector} and {@code /admin} paths take JAX-RS precedence over S3's
+ * {@code /{bucket}} and {@code /{bucket}/{key}} template routes, so these routes win with no
+ * extra routing wiring. Tag operations ({@code /tags/{arn}}) are served by
+ * {@code SharedTagsController} via {@link GuardDutyTagHandler}.
+ *
+ * <p>GuardDuty reports every client error as {@code BadRequestException} (HTTP 400); the
+ * Terraform AWS provider matches specific message texts to detect missing resources, so those
+ * messages must not change.
+ */
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class GuardDutyController {
+
+    private final GuardDutyService service;
+    private final ObjectMapper objectMapper;
+    private final RegionResolver regionResolver;
+
+    @Inject
+    public GuardDutyController(
+            GuardDutyService service, ObjectMapper objectMapper, RegionResolver regionResolver) {
+        this.service = service;
+        this.objectMapper = objectMapper;
+        this.regionResolver = regionResolver;
+    }
+
+    private JsonNode parse(String body) {
+        if (body == null || body.isBlank()) {
+            return objectMapper.createObjectNode();
+        }
+        try {
+            JsonNode request = objectMapper.readTree(body);
+            if (request == null || !request.isObject()) {
+                throw new AwsException("BadRequestException", "Request body must be a JSON object.", 400);
+            }
+            return request;
+        } catch (AwsException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AwsException("BadRequestException", "Request body is not valid JSON.", 400);
+        }
+    }
+
+    @POST
+    @Path("/detector")
+    public Response createDetector(@Context HttpHeaders headers, String body) {
+        Detector detector = service.createDetector(
+                regionResolver.resolveRegion(headers), regionResolver.getAccountId(), parse(body));
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("detectorId", detector.getId());
+        return Response.ok(response).build();
+    }
+
+    @GET
+    @Path("/detector")
+    public Response listDetectors(
+            @Context HttpHeaders headers,
+            @QueryParam("maxResults") String maxResults,
+            @QueryParam("nextToken") String nextToken) {
+        GuardDutyService.Page<String> page = service.listDetectorIds(
+                regionResolver.resolveRegion(headers), maxResults, nextToken);
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode ids = response.putArray("detectorIds");
+        page.items().forEach(ids::add);
+        if (page.nextToken() != null) {
+            response.put("nextToken", page.nextToken());
+        }
+        return Response.ok(response).build();
+    }
+
+    @GET
+    @Path("/detector/{detectorId}")
+    public Response getDetector(@Context HttpHeaders headers, @PathParam("detectorId") String detectorId) {
+        Detector detector = service.getDetector(regionResolver.resolveRegion(headers), detectorId);
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("createdAt", detector.getCreatedAt());
+        if (detector.getFindingPublishingFrequency() != null) {
+            response.put("findingPublishingFrequency", detector.getFindingPublishingFrequency());
+        }
+        response.put("serviceRole", detector.getServiceRole());
+        response.put("status", detector.getStatus());
+        response.put("updatedAt", detector.getUpdatedAt());
+        if (detector.getTags() != null && !detector.getTags().isEmpty()) {
+            ObjectNode tags = response.putObject("tags");
+            detector.getTags().forEach(tags::put);
+        }
+        if (detector.getFeatures() != null) {
+            ArrayNode features = response.putArray("features");
+            for (DetectorFeature feature : detector.getFeatures()) {
+                features.add(objectMapper.valueToTree(feature));
+            }
+        }
+        return Response.ok(response).build();
+    }
+
+    @POST
+    @Path("/detector/{detectorId}")
+    public Response updateDetector(
+            @Context HttpHeaders headers, @PathParam("detectorId") String detectorId, String body) {
+        service.updateDetector(regionResolver.resolveRegion(headers), detectorId, parse(body));
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    @DELETE
+    @Path("/detector/{detectorId}")
+    public Response deleteDetector(
+            @Context HttpHeaders headers, @PathParam("detectorId") String detectorId) {
+        service.deleteDetector(regionResolver.resolveRegion(headers), detectorId);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    @GET
+    @Path("/detector/{detectorId}/admin")
+    public Response describeOrganizationConfiguration(
+            @Context HttpHeaders headers, @PathParam("detectorId") String detectorId) {
+        OrganizationConfiguration configuration = service.describeOrganizationConfiguration(
+                regionResolver.resolveRegion(headers), detectorId);
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("autoEnable", Boolean.TRUE.equals(configuration.getAutoEnable()));
+        response.put("memberAccountLimitReached", false);
+        response.put("autoEnableOrganizationMembers", configuration.getAutoEnableOrganizationMembers());
+        ArrayNode features = response.putArray("features");
+        if (configuration.getFeatures() != null) {
+            for (OrganizationFeature feature : configuration.getFeatures()) {
+                features.add(objectMapper.valueToTree(feature));
+            }
+        }
+        return Response.ok(response).build();
+    }
+
+    @POST
+    @Path("/detector/{detectorId}/admin")
+    public Response updateOrganizationConfiguration(
+            @Context HttpHeaders headers, @PathParam("detectorId") String detectorId, String body) {
+        service.updateOrganizationConfiguration(
+                regionResolver.resolveRegion(headers), detectorId, parse(body));
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    @POST
+    @Path("/admin/enable")
+    public Response enableOrganizationAdminAccount(@Context HttpHeaders headers, String body) {
+        service.enableOrganizationAdminAccount(regionResolver.resolveRegion(headers), parse(body));
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    @POST
+    @Path("/admin/disable")
+    public Response disableOrganizationAdminAccount(@Context HttpHeaders headers, String body) {
+        service.disableOrganizationAdminAccount(regionResolver.resolveRegion(headers), parse(body));
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    @GET
+    @Path("/admin")
+    public Response listOrganizationAdminAccounts(
+            @Context HttpHeaders headers,
+            @QueryParam("maxResults") String maxResults,
+            @QueryParam("nextToken") String nextToken) {
+        GuardDutyService.Page<AdminAccount> page = service.listOrganizationAdminAccounts(
+                regionResolver.resolveRegion(headers), maxResults, nextToken);
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode accounts = response.putArray("adminAccounts");
+        for (AdminAccount account : page.items()) {
+            accounts.add(objectMapper.valueToTree(account));
+        }
+        if (page.nextToken() != null) {
+            response.put("nextToken", page.nextToken());
+        }
+        return Response.ok(response).build();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/guardduty/GuardDutyService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/guardduty/GuardDutyService.java
@@ -1,0 +1,549 @@
+package io.github.hectorvent.floci.services.guardduty;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.guardduty.model.AdminAccount;
+import io.github.hectorvent.floci.services.guardduty.model.Detector;
+import io.github.hectorvent.floci.services.guardduty.model.DetectorAdditionalConfiguration;
+import io.github.hectorvent.floci.services.guardduty.model.DetectorFeature;
+import io.github.hectorvent.floci.services.guardduty.model.OrganizationAdditionalConfiguration;
+import io.github.hectorvent.floci.services.guardduty.model.OrganizationConfiguration;
+import io.github.hectorvent.floci.services.guardduty.model.OrganizationFeature;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+/**
+ * GuardDuty detector lifecycle and organization configuration backed by the configured
+ * Floci storage mode.
+ *
+ * <p>Organization semantics are readback-only: Floci has no Organizations service, so
+ * {@code adminAccountId} membership is not validated, delegated-administrator permissions are
+ * not enforced, and member accounts are not fanned out. Organization configuration is stored
+ * per calling account and echoed back as submitted.
+ */
+@ApplicationScoped
+public class GuardDutyService {
+
+    /**
+     * The Terraform AWS provider matches this exact message to translate a
+     * {@code BadRequestException} into resource removal from state.
+     */
+    static final String DETECTOR_NOT_FOUND_MESSAGE =
+            "The request is rejected because the input detectorId is not owned by the current account.";
+
+    /** Also matched verbatim by the Terraform AWS provider on delegated-admin delete. */
+    static final String ADMIN_ALREADY_DISABLED_MESSAGE =
+            "The request failed because the delegated administrator account has already been disabled "
+                    + "and/or GuardDuty protection has been disabled.";
+
+    private static final int DEFAULT_MAX_RESULTS = 50;
+    private static final int MAX_RESULTS = 50;
+    private static final String TOKEN_PREFIX = "guardduty:v1:";
+    private static final Pattern ACCOUNT_ID_PATTERN = Pattern.compile("[0-9]{12}");
+    private static final Set<String> FINDING_PUBLISHING_FREQUENCIES =
+            Set.of("FIFTEEN_MINUTES", "ONE_HOUR", "SIX_HOURS");
+    private static final Set<String> FEATURE_STATUSES = Set.of("ENABLED", "DISABLED");
+    private static final Set<String> ORG_AUTO_ENABLE_VALUES = Set.of("NEW", "NONE", "ALL");
+    private static final Set<String> DETECTOR_FEATURE_NAMES = Set.of(
+            "S3_DATA_EVENTS", "EKS_AUDIT_LOGS", "EBS_MALWARE_PROTECTION", "RDS_LOGIN_EVENTS",
+            "LAMBDA_NETWORK_LOGS", "EKS_RUNTIME_MONITORING", "RUNTIME_MONITORING",
+            "AI_PROTECTION", "AI_ANALYST");
+    private static final Set<String> ORG_FEATURE_NAMES = Set.of(
+            "S3_DATA_EVENTS", "EKS_AUDIT_LOGS", "EBS_MALWARE_PROTECTION", "RDS_LOGIN_EVENTS",
+            "LAMBDA_NETWORK_LOGS", "EKS_RUNTIME_MONITORING", "RUNTIME_MONITORING", "AI_PROTECTION");
+    private static final Set<String> ADDITIONAL_CONFIGURATION_NAMES =
+            Set.of("EKS_ADDON_MANAGEMENT", "ECS_FARGATE_AGENT_MANAGEMENT", "EC2_AGENT_MANAGEMENT");
+
+    private final StorageBackend<String, Detector> detectorStore;
+    private final StorageBackend<String, AdminAccount> adminAccountStore;
+
+    @Inject
+    public GuardDutyService(StorageFactory storageFactory) {
+        this(storageFactory.create(
+                        "guardduty",
+                        "guardduty-detectors.json",
+                        new TypeReference<Map<String, Detector>>() {
+                        }),
+                storageFactory.create(
+                        "guardduty",
+                        "guardduty-admin-accounts.json",
+                        new TypeReference<Map<String, AdminAccount>>() {
+                        }));
+    }
+
+    GuardDutyService(
+            StorageBackend<String, Detector> detectorStore,
+            StorageBackend<String, AdminAccount> adminAccountStore) {
+        this.detectorStore = detectorStore;
+        this.adminAccountStore = adminAccountStore;
+    }
+
+    public synchronized Detector createDetector(String region, String accountId, JsonNode request) {
+        boolean enable = requireBoolean(request, "enable");
+        String frequency = readFindingPublishingFrequency(request, "SIX_HOURS");
+        List<DetectorFeature> features = readDetectorFeatures(request);
+        Map<String, String> tags = readTags(request);
+
+        if (!detectorStore.scan(key -> key.startsWith(region + "::")).isEmpty()) {
+            throw badRequest("The request is rejected because a detector already exists for the current account.");
+        }
+
+        String now = isoTimestamp();
+        Detector detector = new Detector(
+                UUID.randomUUID().toString().replace("-", ""),
+                enable ? "ENABLED" : "DISABLED",
+                frequency,
+                serviceRoleArn(accountId),
+                now,
+                now,
+                tags,
+                features,
+                null);
+        detectorStore.put(storageKey(region, detector.getId()), detector);
+        return detector;
+    }
+
+    public Detector getDetector(String region, String detectorId) {
+        return detectorStore.get(storageKey(region, detectorId)).orElseThrow(GuardDutyService::detectorNotFound);
+    }
+
+    public synchronized void updateDetector(String region, String detectorId, JsonNode request) {
+        String key = storageKey(region, detectorId);
+        Detector detector = detectorStore.get(key).orElseThrow(GuardDutyService::detectorNotFound);
+
+        if (request.has("enable")) {
+            detector.setStatus(requireBoolean(request, "enable") ? "ENABLED" : "DISABLED");
+        }
+        if (request.has("findingPublishingFrequency")) {
+            detector.setFindingPublishingFrequency(readFindingPublishingFrequency(request, null));
+        }
+        if (request.has("features")) {
+            detector.setFeatures(mergeDetectorFeatures(detector.getFeatures(), readDetectorFeatures(request)));
+        }
+        detector.setUpdatedAt(isoTimestamp());
+        detectorStore.put(key, detector);
+    }
+
+    public synchronized void deleteDetector(String region, String detectorId) {
+        String key = storageKey(region, detectorId);
+        if (detectorStore.get(key).isEmpty()) {
+            throw detectorNotFound();
+        }
+        detectorStore.delete(key);
+    }
+
+    public Page<String> listDetectorIds(String region, String maxResultsValue, String nextToken) {
+        int maxResults = parseMaxResults(maxResultsValue);
+        List<Detector> detectors = detectorStore.scan(key -> key.startsWith(region + "::"));
+        detectors.sort(Comparator.comparing(Detector::getId));
+        List<String> ids = detectors.stream().map(Detector::getId).toList();
+
+        int offset = decodeOffset(nextToken, ids.size());
+        int end = Math.min(offset + maxResults, ids.size());
+        String responseToken = end < ids.size() ? encodeOffset(end) : null;
+        return new Page<>(ids.subList(offset, end), responseToken);
+    }
+
+    public OrganizationConfiguration describeOrganizationConfiguration(String region, String detectorId) {
+        Detector detector = getDetector(region, detectorId);
+        OrganizationConfiguration configuration = detector.getOrganizationConfiguration();
+        if (configuration == null) {
+            return new OrganizationConfiguration(false, "NONE", List.of());
+        }
+        return configuration;
+    }
+
+    public synchronized void updateOrganizationConfiguration(String region, String detectorId, JsonNode request) {
+        String key = storageKey(region, detectorId);
+        Detector detector = detectorStore.get(key).orElseThrow(GuardDutyService::detectorNotFound);
+
+        OrganizationConfiguration current = detector.getOrganizationConfiguration();
+        boolean autoEnable = current != null && Boolean.TRUE.equals(current.getAutoEnable());
+        String members = current == null ? "NONE" : current.getAutoEnableOrganizationMembers();
+        List<OrganizationFeature> features = current == null ? List.of() : current.getFeatures();
+
+        if (request.has("autoEnableOrganizationMembers")) {
+            members = requireText(request, "autoEnableOrganizationMembers");
+            if (!ORG_AUTO_ENABLE_VALUES.contains(members)) {
+                throw badRequest("autoEnableOrganizationMembers must be one of NEW, ALL, or NONE.");
+            }
+            autoEnable = !"NONE".equals(members);
+        } else if (request.has("autoEnable")) {
+            autoEnable = requireBoolean(request, "autoEnable");
+            members = autoEnable ? "NEW" : "NONE";
+        }
+        if (request.has("features")) {
+            features = mergeOrganizationFeatures(features, readOrganizationFeatures(request));
+        }
+
+        detector.setOrganizationConfiguration(new OrganizationConfiguration(autoEnable, members, features));
+        detectorStore.put(key, detector);
+    }
+
+    public synchronized void enableOrganizationAdminAccount(String region, JsonNode request) {
+        String adminAccountId = readAdminAccountId(request);
+        List<AdminAccount> existing = adminAccountStore.scan(key -> key.startsWith(region + "::"));
+        if (!existing.isEmpty() && !existing.get(0).getAdminAccountId().equals(adminAccountId)) {
+            throw badRequest("The request is rejected because the organization already has a "
+                    + "delegated administrator account for GuardDuty.");
+        }
+        adminAccountStore.put(storageKey(region, adminAccountId), new AdminAccount(adminAccountId, "ENABLED"));
+    }
+
+    public synchronized void disableOrganizationAdminAccount(String region, JsonNode request) {
+        String adminAccountId = readAdminAccountId(request);
+        String key = storageKey(region, adminAccountId);
+        if (adminAccountStore.get(key).isEmpty()) {
+            throw badRequest(ADMIN_ALREADY_DISABLED_MESSAGE);
+        }
+        adminAccountStore.delete(key);
+    }
+
+    public Page<AdminAccount> listOrganizationAdminAccounts(
+            String region, String maxResultsValue, String nextToken) {
+        int maxResults = parseMaxResults(maxResultsValue);
+        List<AdminAccount> accounts = adminAccountStore.scan(key -> key.startsWith(region + "::"));
+        accounts.sort(Comparator.comparing(AdminAccount::getAdminAccountId));
+
+        int offset = decodeOffset(nextToken, accounts.size());
+        int end = Math.min(offset + maxResults, accounts.size());
+        String responseToken = end < accounts.size() ? encodeOffset(end) : null;
+        return new Page<>(accounts.subList(offset, end), responseToken);
+    }
+
+    public Map<String, String> listTags(String arn) {
+        Detector detector = detectorFromArn(arn);
+        return detector.getTags() == null ? Map.of() : detector.getTags();
+    }
+
+    public synchronized void tagResource(String arn, Map<String, String> tags) {
+        DetectorRef ref = parseDetectorArn(arn);
+        Detector detector = detectorStore.get(ref.key()).orElseThrow(GuardDutyService::detectorNotFound);
+        Map<String, String> merged = new LinkedHashMap<>();
+        if (detector.getTags() != null) {
+            merged.putAll(detector.getTags());
+        }
+        merged.putAll(tags);
+        detector.setTags(merged);
+        detectorStore.put(ref.key(), detector);
+    }
+
+    public synchronized void untagResource(String arn, List<String> tagKeys) {
+        DetectorRef ref = parseDetectorArn(arn);
+        Detector detector = detectorStore.get(ref.key()).orElseThrow(GuardDutyService::detectorNotFound);
+        if (detector.getTags() == null) {
+            return;
+        }
+        Map<String, String> remaining = new LinkedHashMap<>(detector.getTags());
+        tagKeys.forEach(remaining::remove);
+        detector.setTags(remaining);
+        detectorStore.put(ref.key(), detector);
+    }
+
+    private Detector detectorFromArn(String arn) {
+        DetectorRef ref = parseDetectorArn(arn);
+        return detectorStore.get(ref.key()).orElseThrow(GuardDutyService::detectorNotFound);
+    }
+
+    private static DetectorRef parseDetectorArn(String arn) {
+        AwsArnUtils.Arn parsed;
+        try {
+            parsed = AwsArnUtils.parse(arn);
+        } catch (IllegalArgumentException e) {
+            throw badRequest("The request is rejected because an invalid resource ARN is specified: " + arn);
+        }
+        String prefix = "detector/";
+        String resource = parsed.resource();
+        if (!resource.startsWith(prefix) || resource.length() == prefix.length()) {
+            throw badRequest("The request is rejected because an invalid resource ARN is specified: " + arn);
+        }
+        return new DetectorRef(parsed.region(), resource.substring(prefix.length()));
+    }
+
+    private static List<DetectorFeature> mergeDetectorFeatures(
+            List<DetectorFeature> current, List<DetectorFeature> submitted) {
+        List<DetectorFeature> merged = current == null ? new ArrayList<>() : new ArrayList<>(current);
+        for (DetectorFeature update : submitted) {
+            DetectorFeature existing = merged.stream()
+                    .filter(feature -> feature.getName().equals(update.getName()))
+                    .findFirst()
+                    .orElse(null);
+            if (existing == null) {
+                merged.add(update);
+            } else {
+                existing.setStatus(update.getStatus());
+                existing.setUpdatedAt(update.getUpdatedAt());
+                if (update.getAdditionalConfiguration() != null) {
+                    existing.setAdditionalConfiguration(update.getAdditionalConfiguration());
+                }
+            }
+        }
+        return merged;
+    }
+
+    private static List<OrganizationFeature> mergeOrganizationFeatures(
+            List<OrganizationFeature> current, List<OrganizationFeature> submitted) {
+        List<OrganizationFeature> merged = current == null ? new ArrayList<>() : new ArrayList<>(current);
+        for (OrganizationFeature update : submitted) {
+            OrganizationFeature existing = merged.stream()
+                    .filter(feature -> feature.getName().equals(update.getName()))
+                    .findFirst()
+                    .orElse(null);
+            if (existing == null) {
+                merged.add(update);
+            } else {
+                existing.setAutoEnable(update.getAutoEnable());
+                if (update.getAdditionalConfiguration() != null) {
+                    existing.setAdditionalConfiguration(update.getAdditionalConfiguration());
+                }
+            }
+        }
+        return merged;
+    }
+
+    private static List<DetectorFeature> readDetectorFeatures(JsonNode request) {
+        if (!request.has("features")) {
+            return null;
+        }
+        JsonNode featuresNode = request.get("features");
+        if (!featuresNode.isArray()) {
+            throw badRequest("features must be an array.");
+        }
+        long now = Instant.now().getEpochSecond();
+        List<DetectorFeature> features = new ArrayList<>(featuresNode.size());
+        for (JsonNode featureNode : featuresNode) {
+            requireObject(featureNode, "features member");
+            String name = requireText(featureNode, "name");
+            if (!DETECTOR_FEATURE_NAMES.contains(name)) {
+                throw badRequest("features contains an unsupported feature name: " + name);
+            }
+            String status = requireText(featureNode, "status");
+            if (!FEATURE_STATUSES.contains(status)) {
+                throw badRequest("features contains an invalid status: " + status);
+            }
+            features.add(new DetectorFeature(
+                    name, status, now, readDetectorAdditionalConfiguration(featureNode, now)));
+        }
+        return features;
+    }
+
+    private static List<DetectorAdditionalConfiguration> readDetectorAdditionalConfiguration(
+            JsonNode featureNode, long now) {
+        if (!featureNode.has("additionalConfiguration")) {
+            return null;
+        }
+        JsonNode configurationNode = featureNode.get("additionalConfiguration");
+        if (!configurationNode.isArray()) {
+            throw badRequest("additionalConfiguration must be an array.");
+        }
+        List<DetectorAdditionalConfiguration> configurations = new ArrayList<>(configurationNode.size());
+        for (JsonNode node : configurationNode) {
+            requireObject(node, "additionalConfiguration member");
+            String name = requireText(node, "name");
+            if (!ADDITIONAL_CONFIGURATION_NAMES.contains(name)) {
+                throw badRequest("additionalConfiguration contains an unsupported name: " + name);
+            }
+            String status = requireText(node, "status");
+            if (!FEATURE_STATUSES.contains(status)) {
+                throw badRequest("additionalConfiguration contains an invalid status: " + status);
+            }
+            configurations.add(new DetectorAdditionalConfiguration(name, status, now));
+        }
+        return configurations;
+    }
+
+    private static List<OrganizationFeature> readOrganizationFeatures(JsonNode request) {
+        JsonNode featuresNode = request.get("features");
+        if (!featuresNode.isArray()) {
+            throw badRequest("features must be an array.");
+        }
+        List<OrganizationFeature> features = new ArrayList<>(featuresNode.size());
+        for (JsonNode featureNode : featuresNode) {
+            requireObject(featureNode, "features member");
+            String name = requireText(featureNode, "name");
+            if (!ORG_FEATURE_NAMES.contains(name)) {
+                throw badRequest("features contains an unsupported feature name: " + name);
+            }
+            String autoEnable = requireText(featureNode, "autoEnable");
+            if (!ORG_AUTO_ENABLE_VALUES.contains(autoEnable)) {
+                throw badRequest("features contains an invalid autoEnable value: " + autoEnable);
+            }
+            features.add(new OrganizationFeature(
+                    name, autoEnable, readOrganizationAdditionalConfiguration(featureNode)));
+        }
+        return features;
+    }
+
+    private static List<OrganizationAdditionalConfiguration> readOrganizationAdditionalConfiguration(
+            JsonNode featureNode) {
+        if (!featureNode.has("additionalConfiguration")) {
+            return null;
+        }
+        JsonNode configurationNode = featureNode.get("additionalConfiguration");
+        if (!configurationNode.isArray()) {
+            throw badRequest("additionalConfiguration must be an array.");
+        }
+        List<OrganizationAdditionalConfiguration> configurations = new ArrayList<>(configurationNode.size());
+        for (JsonNode node : configurationNode) {
+            requireObject(node, "additionalConfiguration member");
+            String name = requireText(node, "name");
+            if (!ADDITIONAL_CONFIGURATION_NAMES.contains(name)) {
+                throw badRequest("additionalConfiguration contains an unsupported name: " + name);
+            }
+            String autoEnable = requireText(node, "autoEnable");
+            if (!ORG_AUTO_ENABLE_VALUES.contains(autoEnable)) {
+                throw badRequest("additionalConfiguration contains an invalid autoEnable value: " + autoEnable);
+            }
+            configurations.add(new OrganizationAdditionalConfiguration(name, autoEnable));
+        }
+        return configurations;
+    }
+
+    private static String readFindingPublishingFrequency(JsonNode request, String defaultValue) {
+        if (!request.has("findingPublishingFrequency")) {
+            return defaultValue;
+        }
+        String frequency = requireText(request, "findingPublishingFrequency");
+        if (!FINDING_PUBLISHING_FREQUENCIES.contains(frequency)) {
+            throw badRequest("findingPublishingFrequency must be one of FIFTEEN_MINUTES, ONE_HOUR, or SIX_HOURS.");
+        }
+        return frequency;
+    }
+
+    private static Map<String, String> readTags(JsonNode request) {
+        if (!request.has("tags")) {
+            return null;
+        }
+        JsonNode tagsNode = request.get("tags");
+        if (!tagsNode.isObject() || tagsNode.size() > 50) {
+            throw badRequest("tags must be an object with at most 50 entries.");
+        }
+        Map<String, String> tags = new LinkedHashMap<>();
+        tagsNode.fields().forEachRemaining(entry -> {
+            JsonNode valueNode = entry.getValue();
+            if (!valueNode.isTextual()) {
+                throw badRequest("tags contains a non-string value.");
+            }
+            tags.put(entry.getKey(), valueNode.textValue());
+        });
+        return tags;
+    }
+
+    private static String readAdminAccountId(JsonNode request) {
+        String adminAccountId = requireText(request, "adminAccountId");
+        if (!ACCOUNT_ID_PATTERN.matcher(adminAccountId).matches()) {
+            throw badRequest("adminAccountId must be a 12-digit account ID.");
+        }
+        return adminAccountId;
+    }
+
+    private static String storageKey(String region, String id) {
+        return region + "::" + id;
+    }
+
+    private static String serviceRoleArn(String accountId) {
+        return "arn:aws:iam::" + accountId
+                + ":role/aws-service-role/guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDuty";
+    }
+
+    private static String isoTimestamp() {
+        return Instant.now().truncatedTo(java.time.temporal.ChronoUnit.MILLIS).toString();
+    }
+
+    private static void requireObject(JsonNode value, String field) {
+        if (value == null || !value.isObject()) {
+            throw badRequest(field + " must be a JSON object.");
+        }
+    }
+
+    private static String requireText(JsonNode parent, String field) {
+        JsonNode value = parent.get(field);
+        if (value == null || !value.isTextual()) {
+            throw badRequest(field + " must be a string.");
+        }
+        return value.textValue();
+    }
+
+    private static boolean requireBoolean(JsonNode parent, String field) {
+        JsonNode value = parent.get(field);
+        if (value == null || !value.isBoolean()) {
+            throw badRequest(field + " must be a boolean.");
+        }
+        return value.booleanValue();
+    }
+
+    private static int parseMaxResults(String value) {
+        if (value == null) {
+            return DEFAULT_MAX_RESULTS;
+        }
+        try {
+            int parsed = Integer.parseInt(value);
+            if (parsed < 1 || parsed > MAX_RESULTS) {
+                throw badRequest("maxResults must be between 1 and " + MAX_RESULTS + ".");
+            }
+            return parsed;
+        } catch (NumberFormatException e) {
+            throw badRequest("maxResults must be an integer between 1 and " + MAX_RESULTS + ".");
+        }
+    }
+
+    private static int decodeOffset(String token, int resultSize) {
+        if (token == null) {
+            return 0;
+        }
+        try {
+            String decoded = new String(Base64.getUrlDecoder().decode(token), StandardCharsets.UTF_8);
+            if (!decoded.startsWith(TOKEN_PREFIX)) {
+                throw badRequest("nextToken is invalid.");
+            }
+            int offset = Integer.parseInt(decoded.substring(TOKEN_PREFIX.length()));
+            if (offset < 1 || offset >= resultSize) {
+                throw badRequest("nextToken is invalid.");
+            }
+            return offset;
+        } catch (IllegalArgumentException e) {
+            throw badRequest("nextToken is invalid.");
+        }
+    }
+
+    private static String encodeOffset(int offset) {
+        return Base64.getUrlEncoder().withoutPadding()
+                .encodeToString((TOKEN_PREFIX + offset).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static AwsException detectorNotFound() {
+        return badRequest(DETECTOR_NOT_FOUND_MESSAGE);
+    }
+
+    private static AwsException badRequest(String message) {
+        return new AwsException("BadRequestException", message, 400);
+    }
+
+    public record Page<T>(List<T> items, String nextToken) {
+        public Page {
+            items = List.copyOf(items);
+        }
+    }
+
+    private record DetectorRef(String region, String detectorId) {
+        String key() {
+            return storageKey(region, detectorId);
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/guardduty/GuardDutyTagHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/guardduty/GuardDutyTagHandler.java
@@ -1,0 +1,46 @@
+package io.github.hectorvent.floci.services.guardduty;
+
+import io.github.hectorvent.floci.core.common.TagHandler;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@link TagHandler} implementation for GuardDuty.
+ *
+ * <p>ARN format: {@code arn:aws:guardduty:<region>:<account>:detector/<detectorId>}. GuardDuty's
+ * tag wire shape matches every {@code TagHandler} default: a {@code tags} map in the body and a
+ * {@code tagKeys} query parameter on untag.
+ */
+@ApplicationScoped
+public class GuardDutyTagHandler implements TagHandler {
+
+    private final GuardDutyService service;
+
+    @Inject
+    public GuardDutyTagHandler(GuardDutyService service) {
+        this.service = service;
+    }
+
+    @Override
+    public String serviceKey() {
+        return "guardduty";
+    }
+
+    @Override
+    public Map<String, String> listTags(String region, String arn) {
+        return service.listTags(arn);
+    }
+
+    @Override
+    public void tagResource(String region, String arn, Map<String, String> tags) {
+        service.tagResource(arn, tags);
+    }
+
+    @Override
+    public void untagResource(String region, String arn, List<String> tagKeys) {
+        service.untagResource(arn, tagKeys);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/guardduty/model/AdminAccount.java
+++ b/src/main/java/io/github/hectorvent/floci/services/guardduty/model/AdminAccount.java
@@ -1,0 +1,36 @@
+package io.github.hectorvent.floci.services.guardduty.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/** The GuardDuty delegated administrator account for a region. */
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AdminAccount {
+    private String adminAccountId;
+    private String adminStatus;
+
+    public AdminAccount() {
+    }
+
+    public AdminAccount(String adminAccountId, String adminStatus) {
+        this.adminAccountId = adminAccountId;
+        this.adminStatus = adminStatus;
+    }
+
+    public String getAdminAccountId() {
+        return adminAccountId;
+    }
+
+    public void setAdminAccountId(String adminAccountId) {
+        this.adminAccountId = adminAccountId;
+    }
+
+    public String getAdminStatus() {
+        return adminStatus;
+    }
+
+    public void setAdminStatus(String adminStatus) {
+        this.adminStatus = adminStatus;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/guardduty/model/Detector.java
+++ b/src/main/java/io/github/hectorvent/floci/services/guardduty/model/Detector.java
@@ -1,0 +1,118 @@
+package io.github.hectorvent.floci.services.guardduty.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+import java.util.Map;
+
+/** A GuardDuty detector. Serialized with GuardDuty's lowerCamelCase member names. */
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Detector {
+    private String id;
+    private String status;
+    private String findingPublishingFrequency;
+    private String serviceRole;
+    private String createdAt;
+    private String updatedAt;
+    private Map<String, String> tags;
+    private List<DetectorFeature> features;
+    private OrganizationConfiguration organizationConfiguration;
+
+    public Detector() {
+    }
+
+    public Detector(
+            String id,
+            String status,
+            String findingPublishingFrequency,
+            String serviceRole,
+            String createdAt,
+            String updatedAt,
+            Map<String, String> tags,
+            List<DetectorFeature> features,
+            OrganizationConfiguration organizationConfiguration) {
+        this.id = id;
+        this.status = status;
+        this.findingPublishingFrequency = findingPublishingFrequency;
+        this.serviceRole = serviceRole;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        setTags(tags);
+        setFeatures(features);
+        this.organizationConfiguration = organizationConfiguration;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getFindingPublishingFrequency() {
+        return findingPublishingFrequency;
+    }
+
+    public void setFindingPublishingFrequency(String findingPublishingFrequency) {
+        this.findingPublishingFrequency = findingPublishingFrequency;
+    }
+
+    public String getServiceRole() {
+        return serviceRole;
+    }
+
+    public void setServiceRole(String serviceRole) {
+        this.serviceRole = serviceRole;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(String updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags == null ? null : Map.copyOf(tags);
+    }
+
+    public List<DetectorFeature> getFeatures() {
+        return features;
+    }
+
+    public void setFeatures(List<DetectorFeature> features) {
+        this.features = features == null ? null : List.copyOf(features);
+    }
+
+    public OrganizationConfiguration getOrganizationConfiguration() {
+        return organizationConfiguration;
+    }
+
+    public void setOrganizationConfiguration(OrganizationConfiguration organizationConfiguration) {
+        this.organizationConfiguration = organizationConfiguration;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/guardduty/model/DetectorAdditionalConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/guardduty/model/DetectorAdditionalConfiguration.java
@@ -1,0 +1,46 @@
+package io.github.hectorvent.floci.services.guardduty.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/** Sub-feature configuration of a detector feature (e.g. EKS_ADDON_MANAGEMENT). */
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DetectorAdditionalConfiguration {
+    private String name;
+    private String status;
+    private Long updatedAt;
+
+    public DetectorAdditionalConfiguration() {
+    }
+
+    public DetectorAdditionalConfiguration(String name, String status, Long updatedAt) {
+        this.name = name;
+        this.status = status;
+        this.updatedAt = updatedAt;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Long getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Long updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/guardduty/model/DetectorFeature.java
+++ b/src/main/java/io/github/hectorvent/floci/services/guardduty/model/DetectorFeature.java
@@ -1,0 +1,67 @@
+package io.github.hectorvent.floci.services.guardduty.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+
+/**
+ * A detector feature (e.g. S3_DATA_EVENTS). List positions are preserved as submitted:
+ * {@code additionalConfiguration} is a list block in the Terraform provider, so a reordered
+ * read-back makes every subsequent plan propose a replacement.
+ */
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DetectorFeature {
+    private String name;
+    private String status;
+    private Long updatedAt;
+    private List<DetectorAdditionalConfiguration> additionalConfiguration;
+
+    public DetectorFeature() {
+    }
+
+    public DetectorFeature(
+            String name,
+            String status,
+            Long updatedAt,
+            List<DetectorAdditionalConfiguration> additionalConfiguration) {
+        this.name = name;
+        this.status = status;
+        this.updatedAt = updatedAt;
+        setAdditionalConfiguration(additionalConfiguration);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Long getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Long updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public List<DetectorAdditionalConfiguration> getAdditionalConfiguration() {
+        return additionalConfiguration;
+    }
+
+    public void setAdditionalConfiguration(List<DetectorAdditionalConfiguration> additionalConfiguration) {
+        this.additionalConfiguration =
+                additionalConfiguration == null ? null : List.copyOf(additionalConfiguration);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/guardduty/model/OrganizationAdditionalConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/guardduty/model/OrganizationAdditionalConfiguration.java
@@ -1,0 +1,36 @@
+package io.github.hectorvent.floci.services.guardduty.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/** Organization auto-enablement for a sub-feature (e.g. EKS_ADDON_MANAGEMENT). */
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OrganizationAdditionalConfiguration {
+    private String name;
+    private String autoEnable;
+
+    public OrganizationAdditionalConfiguration() {
+    }
+
+    public OrganizationAdditionalConfiguration(String name, String autoEnable) {
+        this.name = name;
+        this.autoEnable = autoEnable;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAutoEnable() {
+        return autoEnable;
+    }
+
+    public void setAutoEnable(String autoEnable) {
+        this.autoEnable = autoEnable;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/guardduty/model/OrganizationConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/guardduty/model/OrganizationConfiguration.java
@@ -1,0 +1,49 @@
+package io.github.hectorvent.floci.services.guardduty.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+
+/** Organization-wide GuardDuty configuration attached to a detector. */
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OrganizationConfiguration {
+    private Boolean autoEnable;
+    private String autoEnableOrganizationMembers;
+    private List<OrganizationFeature> features;
+
+    public OrganizationConfiguration() {
+    }
+
+    public OrganizationConfiguration(
+            Boolean autoEnable, String autoEnableOrganizationMembers, List<OrganizationFeature> features) {
+        this.autoEnable = autoEnable;
+        this.autoEnableOrganizationMembers = autoEnableOrganizationMembers;
+        setFeatures(features);
+    }
+
+    public Boolean getAutoEnable() {
+        return autoEnable;
+    }
+
+    public void setAutoEnable(Boolean autoEnable) {
+        this.autoEnable = autoEnable;
+    }
+
+    public String getAutoEnableOrganizationMembers() {
+        return autoEnableOrganizationMembers;
+    }
+
+    public void setAutoEnableOrganizationMembers(String autoEnableOrganizationMembers) {
+        this.autoEnableOrganizationMembers = autoEnableOrganizationMembers;
+    }
+
+    public List<OrganizationFeature> getFeatures() {
+        return features;
+    }
+
+    public void setFeatures(List<OrganizationFeature> features) {
+        this.features = features == null ? null : List.copyOf(features);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/guardduty/model/OrganizationFeature.java
+++ b/src/main/java/io/github/hectorvent/floci/services/guardduty/model/OrganizationFeature.java
@@ -1,0 +1,55 @@
+package io.github.hectorvent.floci.services.guardduty.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+
+/**
+ * Organization auto-enablement for a detector feature. {@code additionalConfiguration}
+ * order is preserved as submitted; see {@link DetectorFeature}.
+ */
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OrganizationFeature {
+    private String name;
+    private String autoEnable;
+    private List<OrganizationAdditionalConfiguration> additionalConfiguration;
+
+    public OrganizationFeature() {
+    }
+
+    public OrganizationFeature(
+            String name,
+            String autoEnable,
+            List<OrganizationAdditionalConfiguration> additionalConfiguration) {
+        this.name = name;
+        this.autoEnable = autoEnable;
+        setAdditionalConfiguration(additionalConfiguration);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAutoEnable() {
+        return autoEnable;
+    }
+
+    public void setAutoEnable(String autoEnable) {
+        this.autoEnable = autoEnable;
+    }
+
+    public List<OrganizationAdditionalConfiguration> getAdditionalConfiguration() {
+        return additionalConfiguration;
+    }
+
+    public void setAdditionalConfiguration(List<OrganizationAdditionalConfiguration> additionalConfiguration) {
+        this.additionalConfiguration =
+                additionalConfiguration == null ? null : List.copyOf(additionalConfiguration);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -144,6 +144,8 @@ floci:
         flush-interval-ms: 5000
       rum:
         flush-interval-ms: 5000
+      guardduty:
+        flush-interval-ms: 5000
 
   dns:
     # Extra hostname suffixes resolved to Floci's container IP by the embedded DNS server.
@@ -491,4 +493,6 @@ floci:
     iotdata:
       enabled: true
     rum:
+      enabled: true
+    guardduty:
       enabled: true

--- a/src/test/java/io/github/hectorvent/floci/services/guardduty/GuardDutyControllerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/guardduty/GuardDutyControllerIntegrationTest.java
@@ -1,0 +1,314 @@
+package io.github.hectorvent.floci.services.guardduty;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Verifies the GuardDuty restJson1 detector lifecycle, organization readback, and isolation. */
+@QuarkusTest
+class GuardDutyControllerIntegrationTest {
+
+    private static final String EAST = "us-east-1";
+    private static final String WEST = "us-west-2";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void detectorCreateGetUpdateDeleteLifecycle() {
+        String authorization = auth("000000000201", EAST);
+        String detectorId = createDetector(authorization, """
+                {"enable":true,"findingPublishingFrequency":"SIX_HOURS","tags":{"env":"compat"}}
+                """);
+
+        Response detector = given()
+                .header("Authorization", authorization)
+                .when()
+                .get("/detector/" + detectorId)
+                .then()
+                .statusCode(200)
+                .body("status", equalTo("ENABLED"))
+                .body("findingPublishingFrequency", equalTo("SIX_HOURS"))
+                .body("serviceRole", notNullValue())
+                .body("tags.env", equalTo("compat"))
+                .extract().response();
+        assertTrue(detector.path("createdAt").toString().endsWith("Z"));
+
+        given()
+                .contentType("application/json")
+                .header("Authorization", authorization)
+                .body("{\"enable\":false,\"findingPublishingFrequency\":\"ONE_HOUR\"}")
+                .when()
+                .post("/detector/" + detectorId)
+                .then()
+                .statusCode(200);
+
+        given()
+                .header("Authorization", authorization)
+                .when()
+                .get("/detector/" + detectorId)
+                .then()
+                .statusCode(200)
+                .body("status", equalTo("DISABLED"))
+                .body("findingPublishingFrequency", equalTo("ONE_HOUR"));
+
+        given()
+                .header("Authorization", authorization)
+                .when()
+                .get("/detector")
+                .then()
+                .statusCode(200)
+                .body("detectorIds", equalTo(List.of(detectorId)));
+
+        given()
+                .header("Authorization", authorization)
+                .when()
+                .delete("/detector/" + detectorId)
+                .then()
+                .statusCode(200);
+
+        given()
+                .header("Authorization", authorization)
+                .when()
+                .get("/detector/" + detectorId)
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("BadRequestException"))
+                .body("message", equalTo(GuardDutyService.DETECTOR_NOT_FOUND_MESSAGE));
+    }
+
+    @Test
+    void featureOrderIsPreservedOnReadBack() {
+        String authorization = auth("000000000202", EAST);
+        String detectorId = createDetector(authorization, """
+                {"enable":true,"features":[
+                  {"name":"RUNTIME_MONITORING","status":"ENABLED","additionalConfiguration":[
+                    {"name":"ECS_FARGATE_AGENT_MANAGEMENT","status":"ENABLED"},
+                    {"name":"EC2_AGENT_MANAGEMENT","status":"ENABLED"},
+                    {"name":"EKS_ADDON_MANAGEMENT","status":"DISABLED"}
+                  ]},
+                  {"name":"S3_DATA_EVENTS","status":"ENABLED"}
+                ]}
+                """);
+
+        Response detector = given()
+                .header("Authorization", authorization)
+                .when()
+                .get("/detector/" + detectorId)
+                .then()
+                .statusCode(200)
+                .extract().response();
+
+        assertEquals(List.of("RUNTIME_MONITORING", "S3_DATA_EVENTS"),
+                detector.path("features.name"));
+        assertEquals(
+                List.of("ECS_FARGATE_AGENT_MANAGEMENT", "EC2_AGENT_MANAGEMENT", "EKS_ADDON_MANAGEMENT"),
+                detector.path("features[0].additionalConfiguration.name"));
+    }
+
+    @Test
+    void organizationConfigurationLifecycle() {
+        String authorization = auth("000000000203", EAST);
+        String detectorId = createDetector(authorization, "{\"enable\":true}");
+
+        given()
+                .header("Authorization", authorization)
+                .when()
+                .get("/detector/" + detectorId + "/admin")
+                .then()
+                .statusCode(200)
+                .body("autoEnable", equalTo(false))
+                .body("memberAccountLimitReached", equalTo(false))
+                .body("autoEnableOrganizationMembers", equalTo("NONE"));
+
+        given()
+                .contentType("application/json")
+                .header("Authorization", authorization)
+                .body("""
+                        {"autoEnableOrganizationMembers":"ALL","features":[
+                          {"name":"RUNTIME_MONITORING","autoEnable":"ALL","additionalConfiguration":[
+                            {"name":"ECS_FARGATE_AGENT_MANAGEMENT","autoEnable":"ALL"},
+                            {"name":"EC2_AGENT_MANAGEMENT","autoEnable":"ALL"},
+                            {"name":"EKS_ADDON_MANAGEMENT","autoEnable":"NONE"}
+                          ]}
+                        ]}
+                        """)
+                .when()
+                .post("/detector/" + detectorId + "/admin")
+                .then()
+                .statusCode(200);
+
+        Response configuration = given()
+                .header("Authorization", authorization)
+                .when()
+                .get("/detector/" + detectorId + "/admin")
+                .then()
+                .statusCode(200)
+                .body("autoEnable", equalTo(true))
+                .body("autoEnableOrganizationMembers", equalTo("ALL"))
+                .extract().response();
+        assertEquals(
+                List.of("ECS_FARGATE_AGENT_MANAGEMENT", "EC2_AGENT_MANAGEMENT", "EKS_ADDON_MANAGEMENT"),
+                configuration.path("features[0].additionalConfiguration.name"));
+    }
+
+    @Test
+    void organizationAdminAccountLifecycle() {
+        String authorization = auth("000000000204", EAST);
+
+        given()
+                .contentType("application/json")
+                .header("Authorization", authorization)
+                .body("{\"adminAccountId\":\"111111111111\"}")
+                .when()
+                .post("/admin/enable")
+                .then()
+                .statusCode(200);
+
+        given()
+                .header("Authorization", authorization)
+                .when()
+                .get("/admin")
+                .then()
+                .statusCode(200)
+                .body("adminAccounts[0].adminAccountId", equalTo("111111111111"))
+                .body("adminAccounts[0].adminStatus", equalTo("ENABLED"));
+
+        given()
+                .contentType("application/json")
+                .header("Authorization", authorization)
+                .body("{\"adminAccountId\":\"111111111111\"}")
+                .when()
+                .post("/admin/disable")
+                .then()
+                .statusCode(200);
+
+        given()
+                .contentType("application/json")
+                .header("Authorization", authorization)
+                .body("{\"adminAccountId\":\"111111111111\"}")
+                .when()
+                .post("/admin/disable")
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("BadRequestException"))
+                .body("message", equalTo(GuardDutyService.ADMIN_ALREADY_DISABLED_MESSAGE));
+    }
+
+    @Test
+    void detectorsAreIsolatedByAccountAndRegion() {
+        String eastAccountA = auth("000000000205", EAST);
+        String eastAccountB = auth("000000000206", EAST);
+        String westAccountA = auth("000000000205", WEST);
+        String detectorId = createDetector(eastAccountA, "{\"enable\":true}");
+
+        given()
+                .header("Authorization", eastAccountB)
+                .when()
+                .get("/detector/" + detectorId)
+                .then()
+                .statusCode(400)
+                .body("message", equalTo(GuardDutyService.DETECTOR_NOT_FOUND_MESSAGE));
+
+        given()
+                .header("Authorization", westAccountA)
+                .when()
+                .get("/detector/" + detectorId)
+                .then()
+                .statusCode(400)
+                .body("message", equalTo(GuardDutyService.DETECTOR_NOT_FOUND_MESSAGE));
+
+        given()
+                .header("Authorization", eastAccountA)
+                .when()
+                .get("/detector/" + detectorId)
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    void secondCreateInSameAccountAndRegionIsRejected() {
+        String authorization = auth("000000000207", EAST);
+        createDetector(authorization, "{\"enable\":true}");
+
+        given()
+                .contentType("application/json")
+                .header("Authorization", authorization)
+                .body("{\"enable\":true}")
+                .when()
+                .post("/detector")
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test
+    void detectorTagsAreServedThroughTheSharedTagsRoutes() {
+        String authorization = auth("000000000208", EAST);
+        String detectorId = createDetector(authorization, "{\"enable\":true,\"tags\":{\"env\":\"test\"}}");
+        String arn = "arn:aws:guardduty:" + EAST + ":000000000208:detector/" + detectorId;
+
+        given()
+                .contentType("application/json")
+                .header("Authorization", authorization)
+                .body("{\"tags\":{\"team\":\"security\"}}")
+                .when()
+                .post("/tags/" + arn)
+                .then()
+                .statusCode(204);
+
+        given()
+                .header("Authorization", authorization)
+                .when()
+                .get("/tags/" + arn)
+                .then()
+                .statusCode(200)
+                .body("tags.env", equalTo("test"))
+                .body("tags.team", equalTo("security"));
+
+        given()
+                .header("Authorization", authorization)
+                .queryParam("tagKeys", "env")
+                .when()
+                .delete("/tags/" + arn)
+                .then()
+                .statusCode(204);
+
+        given()
+                .header("Authorization", authorization)
+                .when()
+                .get("/tags/" + arn)
+                .then()
+                .statusCode(200)
+                .body("tags.team", equalTo("security"));
+    }
+
+    private static String auth(String accountId, String region) {
+        return "AWS4-HMAC-SHA256 Credential=" + accountId + "/20260215/" + region + "/guardduty/aws4_request";
+    }
+
+    private static String createDetector(String authorization, String body) {
+        return given()
+                .contentType("application/json")
+                .header("Authorization", authorization)
+                .body(body)
+                .when()
+                .post("/detector")
+                .then()
+                .statusCode(200)
+                .body("detectorId", notNullValue())
+                .extract().path("detectorId");
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/guardduty/GuardDutyServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/guardduty/GuardDutyServiceTest.java
@@ -1,0 +1,373 @@
+package io.github.hectorvent.floci.services.guardduty;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.PersistentStorage;
+import io.github.hectorvent.floci.services.guardduty.model.AdminAccount;
+import io.github.hectorvent.floci.services.guardduty.model.Detector;
+import io.github.hectorvent.floci.services.guardduty.model.DetectorAdditionalConfiguration;
+import io.github.hectorvent.floci.services.guardduty.model.DetectorFeature;
+import io.github.hectorvent.floci.services.guardduty.model.OrganizationAdditionalConfiguration;
+import io.github.hectorvent.floci.services.guardduty.model.OrganizationConfiguration;
+import io.github.hectorvent.floci.services.guardduty.model.OrganizationFeature;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GuardDutyServiceTest {
+
+    private static final String REGION = "us-east-1";
+    private static final String ACCOUNT = "000000000000";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final GuardDutyService service =
+            new GuardDutyService(new InMemoryStorage<>(), new InMemoryStorage<>());
+
+    @Test
+    void createDetectorAppliesDefaultsAndGeneratesIdentifiers() throws Exception {
+        Detector detector = service.createDetector(REGION, ACCOUNT, request("{\"enable\":true}"));
+
+        assertEquals(32, detector.getId().length());
+        assertEquals("ENABLED", detector.getStatus());
+        assertEquals("SIX_HOURS", detector.getFindingPublishingFrequency());
+        assertEquals(
+                "arn:aws:iam::" + ACCOUNT
+                        + ":role/aws-service-role/guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDuty",
+                detector.getServiceRole());
+        assertEquals(detector.getCreatedAt(), detector.getUpdatedAt());
+        assertNull(detector.getFeatures());
+    }
+
+    @Test
+    void createDetectorRejectsSecondDetectorInSameRegion() throws Exception {
+        service.createDetector(REGION, ACCOUNT, request("{\"enable\":true}"));
+
+        AwsException error = assertThrows(
+                AwsException.class,
+                () -> service.createDetector(REGION, ACCOUNT, request("{\"enable\":true}")));
+
+        assertEquals("BadRequestException", error.getErrorCode());
+        assertEquals(400, error.getHttpStatus());
+        assertEquals(
+                "The request is rejected because a detector already exists for the current account.",
+                error.getMessage());
+    }
+
+    @Test
+    void detectorsAreRegionScoped() throws Exception {
+        Detector detector = service.createDetector(REGION, ACCOUNT, request("{\"enable\":true}"));
+        service.createDetector("us-west-2", ACCOUNT, request("{\"enable\":true}"));
+
+        AwsException error = assertThrows(
+                AwsException.class, () -> service.getDetector("us-west-2", detector.getId()));
+
+        assertEquals("BadRequestException", error.getErrorCode());
+        assertEquals(GuardDutyService.DETECTOR_NOT_FOUND_MESSAGE, error.getMessage());
+    }
+
+    @Test
+    void getDetectorRejectsMissingDetectorWithProviderMatchedMessage() {
+        AwsException error = assertThrows(
+                AwsException.class, () -> service.getDetector(REGION, "does-not-exist"));
+
+        assertEquals("BadRequestException", error.getErrorCode());
+        assertEquals(400, error.getHttpStatus());
+        assertEquals(GuardDutyService.DETECTOR_NOT_FOUND_MESSAGE, error.getMessage());
+    }
+
+    @Test
+    void updateDetectorTogglesStatusAndFrequency() throws Exception {
+        Detector detector = service.createDetector(REGION, ACCOUNT, request("{\"enable\":true}"));
+
+        service.updateDetector(REGION, detector.getId(), request(
+                "{\"enable\":false,\"findingPublishingFrequency\":\"ONE_HOUR\"}"));
+
+        Detector updated = service.getDetector(REGION, detector.getId());
+        assertEquals("DISABLED", updated.getStatus());
+        assertEquals("ONE_HOUR", updated.getFindingPublishingFrequency());
+    }
+
+    @Test
+    void featureAdditionalConfigurationPreservesSubmittedOrder() throws Exception {
+        Detector detector = service.createDetector(REGION, ACCOUNT, request("""
+                {"enable":true,"features":[
+                  {"name":"RUNTIME_MONITORING","status":"ENABLED","additionalConfiguration":[
+                    {"name":"ECS_FARGATE_AGENT_MANAGEMENT","status":"ENABLED"},
+                    {"name":"EC2_AGENT_MANAGEMENT","status":"ENABLED"},
+                    {"name":"EKS_ADDON_MANAGEMENT","status":"DISABLED"}
+                  ]},
+                  {"name":"S3_DATA_EVENTS","status":"ENABLED"}
+                ]}
+                """));
+
+        List<DetectorFeature> features = service.getDetector(REGION, detector.getId()).getFeatures();
+        assertEquals(List.of("RUNTIME_MONITORING", "S3_DATA_EVENTS"),
+                features.stream().map(DetectorFeature::getName).toList());
+        assertEquals(
+                List.of("ECS_FARGATE_AGENT_MANAGEMENT", "EC2_AGENT_MANAGEMENT", "EKS_ADDON_MANAGEMENT"),
+                features.get(0).getAdditionalConfiguration().stream()
+                        .map(DetectorAdditionalConfiguration::getName)
+                        .toList());
+    }
+
+    @Test
+    void updateDetectorMergesFeaturesByNameAndAppendsNewOnes() throws Exception {
+        Detector detector = service.createDetector(REGION, ACCOUNT, request("""
+                {"enable":true,"features":[
+                  {"name":"S3_DATA_EVENTS","status":"ENABLED"},
+                  {"name":"RDS_LOGIN_EVENTS","status":"ENABLED"}
+                ]}
+                """));
+
+        service.updateDetector(REGION, detector.getId(), request("""
+                {"features":[
+                  {"name":"RDS_LOGIN_EVENTS","status":"DISABLED"},
+                  {"name":"LAMBDA_NETWORK_LOGS","status":"ENABLED"}
+                ]}
+                """));
+
+        List<DetectorFeature> features = service.getDetector(REGION, detector.getId()).getFeatures();
+        assertEquals(List.of("S3_DATA_EVENTS", "RDS_LOGIN_EVENTS", "LAMBDA_NETWORK_LOGS"),
+                features.stream().map(DetectorFeature::getName).toList());
+        assertEquals("ENABLED", features.get(0).getStatus());
+        assertEquals("DISABLED", features.get(1).getStatus());
+        assertEquals("ENABLED", features.get(2).getStatus());
+    }
+
+    @Test
+    void createDetectorRejectsUnknownFeatureName() {
+        AwsException error = assertThrows(
+                AwsException.class,
+                () -> service.createDetector(REGION, ACCOUNT, request(
+                        "{\"enable\":true,\"features\":[{\"name\":\"NOT_A_FEATURE\",\"status\":\"ENABLED\"}]}")));
+
+        assertEquals("BadRequestException", error.getErrorCode());
+    }
+
+    @Test
+    void createDetectorRejectsInvalidFrequencyAndMissingEnable() {
+        AwsException frequencyError = assertThrows(
+                AwsException.class,
+                () -> service.createDetector(REGION, ACCOUNT, request(
+                        "{\"enable\":true,\"findingPublishingFrequency\":\"NEVER\"}")));
+        assertEquals("BadRequestException", frequencyError.getErrorCode());
+
+        AwsException enableError = assertThrows(
+                AwsException.class, () -> service.createDetector(REGION, ACCOUNT, request("{}")));
+        assertEquals("BadRequestException", enableError.getErrorCode());
+    }
+
+    @Test
+    void deleteDetectorRemovesItAndRejectsSecondDelete() throws Exception {
+        Detector detector = service.createDetector(REGION, ACCOUNT, request("{\"enable\":true}"));
+
+        service.deleteDetector(REGION, detector.getId());
+
+        AwsException error = assertThrows(
+                AwsException.class, () -> service.deleteDetector(REGION, detector.getId()));
+        assertEquals(GuardDutyService.DETECTOR_NOT_FOUND_MESSAGE, error.getMessage());
+        assertTrue(service.listDetectorIds(REGION, null, null).items().isEmpty());
+    }
+
+    @Test
+    void listDetectorIdsReturnsTheRegionalDetector() throws Exception {
+        Detector detector = service.createDetector(REGION, ACCOUNT, request("{\"enable\":true}"));
+
+        GuardDutyService.Page<String> page = service.listDetectorIds(REGION, null, null);
+
+        assertEquals(List.of(detector.getId()), page.items());
+        assertNull(page.nextToken());
+    }
+
+    @Test
+    void describeOrganizationConfigurationDefaultsToNone() throws Exception {
+        Detector detector = service.createDetector(REGION, ACCOUNT, request("{\"enable\":true}"));
+
+        OrganizationConfiguration configuration =
+                service.describeOrganizationConfiguration(REGION, detector.getId());
+
+        assertEquals(false, configuration.getAutoEnable());
+        assertEquals("NONE", configuration.getAutoEnableOrganizationMembers());
+        assertTrue(configuration.getFeatures().isEmpty());
+    }
+
+    @Test
+    void organizationConfigurationEchoesMembersAndDerivesAutoEnable() throws Exception {
+        Detector detector = service.createDetector(REGION, ACCOUNT, request("{\"enable\":true}"));
+
+        service.updateOrganizationConfiguration(REGION, detector.getId(), request(
+                "{\"autoEnableOrganizationMembers\":\"ALL\"}"));
+
+        OrganizationConfiguration configuration =
+                service.describeOrganizationConfiguration(REGION, detector.getId());
+        assertEquals(true, configuration.getAutoEnable());
+        assertEquals("ALL", configuration.getAutoEnableOrganizationMembers());
+    }
+
+    @Test
+    void organizationFeatureUpdatesMergeWithoutClobberingOtherFeatures() throws Exception {
+        Detector detector = service.createDetector(REGION, ACCOUNT, request("{\"enable\":true}"));
+        service.updateOrganizationConfiguration(REGION, detector.getId(), request(
+                "{\"autoEnableOrganizationMembers\":\"ALL\"}"));
+
+        service.updateOrganizationConfiguration(REGION, detector.getId(), request("""
+                {"features":[
+                  {"name":"RUNTIME_MONITORING","autoEnable":"ALL","additionalConfiguration":[
+                    {"name":"ECS_FARGATE_AGENT_MANAGEMENT","autoEnable":"ALL"},
+                    {"name":"EC2_AGENT_MANAGEMENT","autoEnable":"ALL"},
+                    {"name":"EKS_ADDON_MANAGEMENT","autoEnable":"NONE"}
+                  ]}
+                ]}
+                """));
+        service.updateOrganizationConfiguration(REGION, detector.getId(), request(
+                "{\"features\":[{\"name\":\"S3_DATA_EVENTS\",\"autoEnable\":\"NEW\"}]}"));
+
+        OrganizationConfiguration configuration =
+                service.describeOrganizationConfiguration(REGION, detector.getId());
+        assertEquals("ALL", configuration.getAutoEnableOrganizationMembers());
+        assertEquals(List.of("RUNTIME_MONITORING", "S3_DATA_EVENTS"),
+                configuration.getFeatures().stream().map(OrganizationFeature::getName).toList());
+        assertEquals(
+                List.of("ECS_FARGATE_AGENT_MANAGEMENT", "EC2_AGENT_MANAGEMENT", "EKS_ADDON_MANAGEMENT"),
+                configuration.getFeatures().get(0).getAdditionalConfiguration().stream()
+                        .map(OrganizationAdditionalConfiguration::getName)
+                        .toList());
+    }
+
+    @Test
+    void updateOrganizationConfigurationRejectsMissingDetectorAndBadValues() throws Exception {
+        AwsException notFound = assertThrows(
+                AwsException.class,
+                () -> service.updateOrganizationConfiguration(REGION, "missing", request(
+                        "{\"autoEnableOrganizationMembers\":\"ALL\"}")));
+        assertEquals(GuardDutyService.DETECTOR_NOT_FOUND_MESSAGE, notFound.getMessage());
+
+        Detector detector = service.createDetector(REGION, ACCOUNT, request("{\"enable\":true}"));
+        AwsException badValue = assertThrows(
+                AwsException.class,
+                () -> service.updateOrganizationConfiguration(REGION, detector.getId(), request(
+                        "{\"autoEnableOrganizationMembers\":\"SOME\"}")));
+        assertEquals("BadRequestException", badValue.getErrorCode());
+    }
+
+    @Test
+    void adminAccountLifecycle() throws Exception {
+        service.enableOrganizationAdminAccount(REGION, request("{\"adminAccountId\":\"111111111111\"}"));
+
+        GuardDutyService.Page<AdminAccount> accounts =
+                service.listOrganizationAdminAccounts(REGION, null, null);
+        assertEquals(1, accounts.items().size());
+        assertEquals("111111111111", accounts.items().get(0).getAdminAccountId());
+        assertEquals("ENABLED", accounts.items().get(0).getAdminStatus());
+
+        AwsException conflict = assertThrows(
+                AwsException.class,
+                () -> service.enableOrganizationAdminAccount(REGION, request(
+                        "{\"adminAccountId\":\"222222222222\"}")));
+        assertEquals("BadRequestException", conflict.getErrorCode());
+
+        service.disableOrganizationAdminAccount(REGION, request("{\"adminAccountId\":\"111111111111\"}"));
+        assertTrue(service.listOrganizationAdminAccounts(REGION, null, null).items().isEmpty());
+
+        AwsException alreadyDisabled = assertThrows(
+                AwsException.class,
+                () -> service.disableOrganizationAdminAccount(REGION, request(
+                        "{\"adminAccountId\":\"111111111111\"}")));
+        assertEquals(GuardDutyService.ADMIN_ALREADY_DISABLED_MESSAGE, alreadyDisabled.getMessage());
+    }
+
+    @Test
+    void enableOrganizationAdminAccountRejectsMalformedAccountId() {
+        AwsException error = assertThrows(
+                AwsException.class,
+                () -> service.enableOrganizationAdminAccount(REGION, request(
+                        "{\"adminAccountId\":\"not-an-account\"}")));
+
+        assertEquals("BadRequestException", error.getErrorCode());
+    }
+
+    @Test
+    void tagOperationsRoundTripThroughTheDetectorArn() throws Exception {
+        Detector detector = service.createDetector(REGION, ACCOUNT, request(
+                "{\"enable\":true,\"tags\":{\"env\":\"test\"}}"));
+        String arn = "arn:aws:guardduty:" + REGION + ":" + ACCOUNT + ":detector/" + detector.getId();
+
+        service.tagResource(arn, Map.of("team", "security"));
+        assertEquals(Map.of("env", "test", "team", "security"), service.listTags(arn));
+
+        service.untagResource(arn, List.of("env"));
+        assertEquals(Map.of("team", "security"), service.listTags(arn));
+
+        AwsException error = assertThrows(
+                AwsException.class,
+                () -> service.listTags("arn:aws:guardduty:" + REGION + ":" + ACCOUNT + ":detector/missing"));
+        assertEquals(GuardDutyService.DETECTOR_NOT_FOUND_MESSAGE, error.getMessage());
+    }
+
+    @Test
+    void detectorSurvivesPersistentStorageReloadWithOrderIntact(@TempDir Path tempDir) throws Exception {
+        Path detectorFile = tempDir.resolve("detectors.json");
+        Path adminFile = tempDir.resolve("admins.json");
+        GuardDutyService firstService = new GuardDutyService(
+                loadedStore(detectorFile, new TypeReference<Map<String, Detector>>() {
+                }),
+                loadedStore(adminFile, new TypeReference<Map<String, AdminAccount>>() {
+                }));
+        Detector created = firstService.createDetector(REGION, ACCOUNT, request("""
+                {"enable":true,"tags":{"env":"test"},"features":[
+                  {"name":"RUNTIME_MONITORING","status":"ENABLED","additionalConfiguration":[
+                    {"name":"ECS_FARGATE_AGENT_MANAGEMENT","status":"ENABLED"},
+                    {"name":"EC2_AGENT_MANAGEMENT","status":"ENABLED"},
+                    {"name":"EKS_ADDON_MANAGEMENT","status":"DISABLED"}
+                  ]}
+                ]}
+                """));
+        firstService.updateOrganizationConfiguration(REGION, created.getId(), request(
+                "{\"autoEnableOrganizationMembers\":\"ALL\"}"));
+
+        GuardDutyService reloadedService = new GuardDutyService(
+                loadedStore(detectorFile, new TypeReference<Map<String, Detector>>() {
+                }),
+                loadedStore(adminFile, new TypeReference<Map<String, AdminAccount>>() {
+                }));
+        Detector reloaded = reloadedService.getDetector(REGION, created.getId());
+
+        assertEquals(created.getId(), reloaded.getId());
+        assertEquals(created.getCreatedAt(), reloaded.getCreatedAt());
+        assertEquals("test", reloaded.getTags().get("env"));
+        assertEquals(
+                List.of("ECS_FARGATE_AGENT_MANAGEMENT", "EC2_AGENT_MANAGEMENT", "EKS_ADDON_MANAGEMENT"),
+                reloaded.getFeatures().get(0).getAdditionalConfiguration().stream()
+                        .map(DetectorAdditionalConfiguration::getName)
+                        .toList());
+        assertEquals("ALL",
+                reloadedService.describeOrganizationConfiguration(REGION, created.getId())
+                        .getAutoEnableOrganizationMembers());
+    }
+
+    private static <V> PersistentStorage<String, V> loadedStore(
+            Path file, TypeReference<Map<String, V>> type) {
+        PersistentStorage<String, V> store = new PersistentStorage<>(file, type);
+        store.load();
+        return store;
+    }
+
+    private JsonNode request(String json) {
+        try {
+            return objectMapper.readTree(json);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -65,6 +65,8 @@ floci:
         flush-interval-ms: 60000
       rum:
         flush-interval-ms: 60000
+      guardduty:
+        flush-interval-ms: 60000
 
   auth:
     validate-signatures: false
@@ -303,4 +305,6 @@ floci:
     iotdata:
       enabled: true
     rum:
+      enabled: true
+    guardduty:
       enabled: true


### PR DESCRIPTION
## Summary

Adds a GuardDuty service: detector CRUD, detector features, organization
configuration, delegated-administrator accounts, and detector tagging via the
shared `/tags` routes. Mirrors the `rum` service pattern (REST JSON, JAX-RS
literal paths over the S3 templates, `AwsException` errors).

Closes #2196.

Scope notes:
- Organization semantics are readback-only: Floci has no Organizations service
  (contrary to a premise in #2196), so `adminAccountId` membership is not
  validated and nothing fans out to member accounts. Configuration is stored per
  calling account and echoed back — sufficient for Terraform's four
  `aws_guardduty_*` organization resources in single-account use. Member APIs
  (`CreateMembers` etc.) are left for a follow-up if LZA needs them.
- Feature lists and `additionalConfiguration` lists are returned in submitted
  order: they are ordered list blocks in the Terraform provider, and a
  reordered read-back forces resource replacement on every plan.
- A missing detector returns `BadRequestException` with the exact message the
  Terraform provider string-matches for not-found detection (GuardDuty has no
  404s); the delegated-admin "already disabled" message is likewise matched
  verbatim. Other error messages are descriptive rather than AWS's generic
  "invalid or out-of-range value" text.
- `dataSources` (deprecated) is omitted from GetDetector; the provider treats
  absence as "not configured".

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Wire shapes (routes, members, enums, status codes including the 204 tag
responses) pinned from the botocore `guardduty/2017-11-28` service model.
Verified against:

- AWS SDK for Java v2 (`sdk-test-java` BOM): the new `GuardDutyTest` drives the
  real client through the detector, organization-configuration, and
  delegated-admin lifecycles, including `BadRequestException` unmarshalling and
  epoch-seconds feature timestamps.
- AWS CLI v2: compat-terraform bats spot checks (`get-detector`,
  `describe-organization-configuration`).
- Terraform `hashicorp/aws ~> 6.0` and OpenTofu: full apply of
  detector + detector feature + organization configuration (+ feature), then a
  `plan -detailed-exitcode` asserting zero drift — the regression test for
  list ordering. Provider not-found handling verified against
  terraform-provider-aws source (`internal/service/guardduty/detector.go`).

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
