### PR TITLE
fix(ec2): sshd can only be started from an absolute path since OpenSSH v3.9

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
@@ -53,6 +53,8 @@ public class Ec2ContainerManager {
     private static final Logger LOG = Logger.getLogger(Ec2ContainerManager.class);
     private static final String USER_DATA_SCRIPT_PATH = "/tmp/user-data.sh";
     private static final Pattern MIME_BOUNDARY = Pattern.compile("(?im)^content-type:\\s*multipart/[^;]+;\\s*boundary=\"?([^\";\\n\\r]+)\"?.*$");
+    private static final List<String> ALLOWED_SSHD_PATHS = List.of("/usr/sbin/sshd", "/usr/local/sbin/sshd", "/sbin/sshd");
+
     static int containerBridgeIpAttempts = 30;
     static long containerBridgeIpPollMillis = 500;
 
@@ -486,12 +488,12 @@ public class Ec2ContainerManager {
             // was never installed while still logging success.
             ContainerExecResult install = execInContainerForResult(containerId, new String[]{"sh", "-c",
                     "if ! command -v sshd >/dev/null 2>&1; then" +
-                    "  if command -v dnf >/dev/null 2>&1; then dnf install -y openssh-server >/dev/null 2>&1;" +
-                    "  elif command -v apt-get >/dev/null 2>&1; then DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server >/dev/null 2>&1;" +
-                    "  elif command -v apk >/dev/null 2>&1; then apk add --no-cache openssh >/dev/null 2>&1;" +
-                    "  fi;" +
-                    "fi;" +
-                    "command -v sshd >/dev/null 2>&1"}, 120);
+                            "  if command -v dnf >/dev/null 2>&1; then dnf install -y openssh-server >/dev/null 2>&1;" +
+                            "  elif command -v apt-get >/dev/null 2>&1; then DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server >/dev/null 2>&1;" +
+                            "  elif command -v apk >/dev/null 2>&1; then apk add --no-cache openssh >/dev/null 2>&1;" +
+                            "  fi;" +
+                            "fi;" +
+                            "command -v sshd >/dev/null 2>&1"}, 120);
             if (install.exitCode() != 0) {
                 LOG.warnv("Could not install openssh-server for EC2 instance {0}: {1}",
                         instanceId, install.summary());
@@ -504,15 +506,17 @@ public class Ec2ContainerManager {
                         instanceId, keygen.summary());
                 return;
             }
-            // Start sshd without -D so it daemonizes itself and survives this exec session. Resolved
-            // via PATH (like ssh-keygen above) rather than hardcoded to /usr/sbin/sshd, since not
-            // every image installs it to that exact path.
-            ContainerExecResult start = execInContainerForResult(containerId, new String[]{"sshd"}, 5);
-            if (start.exitCode() != 0) {
-                LOG.warnv("Could not start sshd for EC2 instance {0}: {1}", instanceId, start.summary());
+            // Start sshd without -D so it daemonizes itself and survives this exec session. Since sshd
+            // requires execution with an absolute path, several paths are tried until it starts
+            for (String sshdPath : ALLOWED_SSHD_PATHS) {
+                ContainerExecResult start = execInContainerForResult(containerId, new String[]{sshdPath}, 5);
+                if (start.exitCode() != 0) {
+                    LOG.warnv("Could not start sshd using path {0} for EC2 instance {1}: {2}", sshdPath, instanceId, start.summary());
+                    continue;
+                }
+                LOG.infov("Started sshd in EC2 instance {0}", instanceId);
                 return;
             }
-            LOG.infov("Started sshd in EC2 instance {0}", instanceId);
         } catch (Exception e) {
             LOG.warnv("Could not start sshd in EC2 instance {0}: {1}", instanceId, e.getMessage());
         }
@@ -532,8 +536,8 @@ public class Ec2ContainerManager {
             // Execute the script and stream output to CloudWatch
             for (int i = 0; i < shellScripts.size(); i++) {
                 executeUserDataShellScript(
-                    containerId, instanceId, shellScripts.get(i), i + 1, shellScripts.size(),
-                    logGroup, logStream, region
+                        containerId, instanceId, shellScripts.get(i), i + 1, shellScripts.size(),
+                        logGroup, logStream, region
                 );
             }
         } catch (Exception e) {
@@ -542,8 +546,8 @@ public class Ec2ContainerManager {
     }
 
     private void executeUserDataShellScript(
-        String containerId, String instanceId, String scriptContent, int partNumber, int partCount,
-        String logGroup, String logStream, String region
+            String containerId, String instanceId, String scriptContent, int partNumber, int partCount,
+            String logGroup, String logStream, String region
     ) throws Exception {
         byte[] script = scriptContent.getBytes(StandardCharsets.UTF_8);
         byte[] tar = buildSingleFileTar("user-data.sh", script, 0755);

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
@@ -410,7 +410,7 @@ class Ec2ContainerManagerTest {
 
         awaitUntil(() -> "running".equals(instance.getState().getName()), Duration.ofSeconds(2));
         ExecCreateCmd execCreate = harness.dockerClient.execCreateCmd(TEST_CONTAINER_ID);
-        verify(execCreate, timeout(2000)).withCmd(eq(new String[]{"sshd"}));
+        verify(execCreate, timeout(2000)).withCmd(eq(new String[]{"/usr/sbin/sshd"}));
         // No key pair was supplied, so nothing should have been written to authorized_keys.
         verify(harness.dockerClient, never()).copyArchiveToContainerCmd(TEST_CONTAINER_ID);
     }
@@ -486,7 +486,7 @@ class Ec2ContainerManagerTest {
         awaitUntil(() -> "running".equals(instance.getState().getName()), Duration.ofSeconds(2));
         verify(execCreate, timeout(2000)).withCmd(eq(SSHD_INSTALL_PROBE_CMD));
         verify(execCreate, never()).withCmd(eq(new String[]{"ssh-keygen", "-A"}));
-        verify(execCreate, never()).withCmd(eq(new String[]{"sshd"}));
+        verify(execCreate, never()).withCmd(eq(new String[]{"/usr/sbin/sshd"}));
     }
 
     private static LaunchHarness launchHarness() {


### PR DESCRIPTION
## Summary

Fixes issue #2350 

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No changes to compatibility

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->

