### PR TITLE
feat(rds): add option group CRUD

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/RdsControlPlaneTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/RdsControlPlaneTest.java
@@ -13,15 +13,24 @@ import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.ConnectionPoolConfigurationInfo;
 import software.amazon.awssdk.services.rds.model.CreateDbProxyResponse;
 import software.amazon.awssdk.services.rds.model.CreateDbSubnetGroupResponse;
+import software.amazon.awssdk.services.rds.model.CreateOptionGroupResponse;
 import software.amazon.awssdk.services.rds.model.DBProxyTarget;
 import software.amazon.awssdk.services.rds.model.DescribeDbSubnetGroupsResponse;
+import software.amazon.awssdk.services.rds.model.DescribeOptionGroupsResponse;
 import software.amazon.awssdk.services.rds.model.DescribeOrderableDbInstanceOptionsResponse;
+import software.amazon.awssdk.services.rds.model.InvalidOptionGroupStateException;
+import software.amazon.awssdk.services.rds.model.ModifyOptionGroupResponse;
+import software.amazon.awssdk.services.rds.model.OptionConfiguration;
+import software.amazon.awssdk.services.rds.model.OptionGroupNotFoundException;
+import software.amazon.awssdk.services.rds.model.OptionSetting;
 
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 
 @DisplayName("RDS Control Plane")
 class RdsControlPlaneTest {
@@ -364,6 +373,152 @@ class RdsControlPlaneTest {
                 .credentialsProvider(StaticCredentialsProvider.create(
                         AwsBasicCredentials.create("test", "test")))
                 .build();
+    }
+
+    @Test
+    void sdkRoundTripsOptionGroupCrudAndItsOptions() {
+        String optionGroupName = TestFixtures.uniqueName("rds-og");
+        try {
+            CreateOptionGroupResponse created = rds.createOptionGroup(b -> b
+                    .optionGroupName(optionGroupName)
+                    .engineName("mysql")
+                    .majorEngineVersion("8.0")
+                    .optionGroupDescription("SDK option group shape"));
+
+            assertThat(created.optionGroup().optionGroupName()).isEqualTo(optionGroupName);
+            assertThat(created.optionGroup().engineName()).isEqualTo("mysql");
+            assertThat(created.optionGroup().majorEngineVersion()).isEqualTo("8.0");
+            assertThat(created.optionGroup().optionGroupArn())
+                    .endsWith(":og:" + optionGroupName);
+            assertThat(created.optionGroup().allowsVpcAndNonVpcInstanceMemberships()).isTrue();
+            assertThat(created.optionGroup().options()).isEmpty();
+
+            ModifyOptionGroupResponse modified = rds.modifyOptionGroup(b -> b
+                    .optionGroupName(optionGroupName)
+                    .applyImmediately(true)
+                    .optionsToInclude(OptionConfiguration.builder()
+                            .optionName("MEMCACHED")
+                            .port(11211)
+                            .optionSettings(OptionSetting.builder()
+                                    .name("BACKLOG_QUEUE_LIMIT")
+                                    .value("1024")
+                                    .build())
+                            .vpcSecurityGroupMemberships("sg-00000000")
+                            .build()));
+
+            assertThat(modified.optionGroup().options()).singleElement().satisfies(option -> {
+                assertThat(option.optionName()).isEqualTo("MEMCACHED");
+                assertThat(option.port()).isEqualTo(11211);
+                assertThat(option.optionSettings())
+                        .extracting("name", "value")
+                        .containsExactly(tuple("BACKLOG_QUEUE_LIMIT", "1024"));
+                assertThat(option.vpcSecurityGroupMemberships())
+                        .extracting("vpcSecurityGroupId")
+                        .containsExactly("sg-00000000");
+            });
+
+            DescribeOptionGroupsResponse described = rds.describeOptionGroups(b -> b
+                    .optionGroupName(optionGroupName));
+            assertThat(described.optionGroupsList()).singleElement().satisfies(group ->
+                    assertThat(group.options()).extracting("optionName")
+                            .containsExactly("MEMCACHED"));
+
+            rds.modifyOptionGroup(b -> b
+                    .optionGroupName(optionGroupName)
+                    .optionsToRemove("MEMCACHED"));
+            assertThat(rds.describeOptionGroups(b -> b.optionGroupName(optionGroupName))
+                    .optionGroupsList()).singleElement()
+                    .satisfies(group -> assertThat(group.options()).isEmpty());
+
+            rds.deleteOptionGroup(b -> b.optionGroupName(optionGroupName));
+            assertThatThrownBy(() -> rds.describeOptionGroups(b -> b
+                    .optionGroupName(optionGroupName)))
+                    .isInstanceOf(OptionGroupNotFoundException.class);
+        } finally {
+            deleteOptionGroup(rds, optionGroupName);
+        }
+    }
+
+    @Test
+    void sdkDescribesImplicitDefaultOptionGroups() {
+        DescribeOptionGroupsResponse all = rds.describeOptionGroups();
+        assertThat(all.optionGroupsList()).extracting("optionGroupName")
+                .contains("default:mysql-8-0", "default:postgres-16");
+
+        DescribeOptionGroupsResponse filtered = rds.describeOptionGroups(b -> b
+                .engineName("mysql")
+                .majorEngineVersion("8.0"));
+        assertThat(filtered.optionGroupsList()).isNotEmpty();
+        assertThat(filtered.optionGroupsList())
+                .allSatisfy(group -> assertThat(group.engineName()).isEqualTo("mysql"));
+
+        assertThatThrownBy(() -> rds.deleteOptionGroup(b -> b
+                .optionGroupName("default:mysql-8-0")))
+                .isInstanceOf(InvalidOptionGroupStateException.class);
+    }
+
+    @Test
+    void sdkFaultsDeletingAnOptionGroupStillAttachedToAnInstance() {
+        String optionGroupName = TestFixtures.uniqueName("rds-og-attached");
+        String instanceName = TestFixtures.uniqueName("rds-db-og");
+        try {
+            rds.createOptionGroup(b -> b
+                    .optionGroupName(optionGroupName)
+                    .engineName("postgres")
+                    .majorEngineVersion("16")
+                    .optionGroupDescription("attached to an instance"));
+
+            var instance = rds.createDBInstance(b -> b
+                    .dbInstanceIdentifier(instanceName)
+                    .engine("postgres")
+                    .engineVersion("16.3")
+                    .masterUsername("admin")
+                    .masterUserPassword("og-secret")
+                    .dbName("app")
+                    .dbInstanceClass("db.t3.micro")
+                    .allocatedStorage(20)
+                    .optionGroupName(optionGroupName));
+
+            assertThat(instance.dbInstance().optionGroupMemberships())
+                    .singleElement()
+                    .satisfies(membership -> {
+                        assertThat(membership.optionGroupName()).isEqualTo(optionGroupName);
+                        assertThat(membership.status()).isEqualTo("in-sync");
+                    });
+
+            assertThatThrownBy(() -> rds.deleteOptionGroup(b -> b
+                    .optionGroupName(optionGroupName)))
+                    .isInstanceOf(InvalidOptionGroupStateException.class);
+
+            deleteDbInstance(rds, instanceName);
+            rds.deleteOptionGroup(b -> b.optionGroupName(optionGroupName));
+        } finally {
+            deleteDbInstance(rds, instanceName);
+            deleteOptionGroup(rds, optionGroupName);
+        }
+    }
+
+    @Test
+    void sdkReportsTheDefaultOptionGroupForAnUnattachedInstance() {
+        String instanceName = TestFixtures.uniqueName("rds-db-default-og");
+        try {
+            var instance = createDbInstance(rds, instanceName, "default-og-secret");
+
+            assertThat(instance.dbInstance().optionGroupMemberships())
+                    .singleElement()
+                    .satisfies(membership -> assertThat(membership.optionGroupName())
+                            .isEqualTo("default:postgres-16"));
+        } finally {
+            deleteDbInstance(rds, instanceName);
+        }
+    }
+
+    private static void deleteOptionGroup(RdsClient client, String name) {
+        try {
+            client.deleteOptionGroup(b -> b.optionGroupName(name));
+        } catch (Exception e) {
+            LOG.log(Level.FINE, "RDS option group already absent during cleanup " + name, e);
+        }
     }
 
     private static void deleteProxy(RdsClient client, String name) {

--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -37,6 +37,10 @@ RDS Data API (`rds-data`) is documented separately because it uses REST JSON rou
 | `DeleteDBClusterParameterGroup` | - |
 | `ModifyDBClusterParameterGroup` | - |
 | `DescribeDBClusterParameters` | - |
+| `CreateOptionGroup` | Create an option group |
+| `DescribeOptionGroups` | List option groups, including the implicit `default:` groups |
+| `ModifyOptionGroup` | Add, update, or remove options in an option group |
+| `DeleteOptionGroup` | Delete an option group |
 | `DescribeDBSnapshots` | - |
 | `DescribeDBProxies` | List DB proxies |
 | `CreateDBProxy` | Create a DB proxy |
@@ -178,6 +182,55 @@ mysql -h 127.0.0.1 -P 7002 -u root -psecret123
 | `mariadb` | `mariadb:11` |
 
 Override the image per-instance with the `--engine-version` flag or globally via environment variables.
+
+## Option Groups
+
+Option groups are metadata: Floci stores the options you add, returns them on the wire, and
+attaches a group to a DB instance, but it does not install the underlying engine feature in the
+container.
+
+As on AWS, every engine has an implicit `default:<engine>-<major version>` group that
+`DescribeOptionGroups` returns even when you have created none. Floci ships the defaults for the
+engines it can run (`postgres 13`–`18`, `mysql 8.0`/`8.4`, `mariadb 10.11`/`11.2`/`11.4`), so an
+instance created without `--option-group-name` reports the matching default. Default groups can't
+be modified, deleted, or tagged.
+
+`CreateOptionGroup` accepts any `EngineName` AWS accepts — including `oracle-*`, `sqlserver-*`,
+and `db2-*` — so a Terraform `aws_db_option_group` for an engine Floci cannot start still applies.
+Attaching one to a DB instance requires the group's engine and major engine version to match the
+instance, as on AWS: a `mysql 8.0` group can't be attached to a `mysql 8.4` instance. A mismatch
+fails with `InvalidParameterCombination`.
+
+```bash
+aws rds create-option-group \
+  --option-group-name my-og \
+  --engine-name mysql \
+  --major-engine-version 8.0 \
+  --option-group-description "MySQL options" \
+  --endpoint-url $AWS_ENDPOINT_URL
+
+aws rds modify-option-group \
+  --option-group-name my-og \
+  --options OptionName=MEMCACHED,Port=11211 \
+  --apply-immediately \
+  --endpoint-url $AWS_ENDPOINT_URL
+
+aws rds describe-option-groups \
+  --engine-name mysql \
+  --endpoint-url $AWS_ENDPOINT_URL
+```
+
+Deleting a group that is still attached to a DB instance fails with
+`InvalidOptionGroupStateFault`, matching AWS.
+
+Known gaps, all deliberate:
+
+| Behavior | Status |
+|---|---|
+| `CopyOptionGroup`, `DescribeOptionGroupOptions` | Not implemented — separate actions, not part of option group CRUD |
+| `OptionGroupQuotaExceededFault` (AWS caps an account at 20 groups) | Not enforced — capping a local emulator would only get in a test's way |
+| `OptionSetting` metadata (`DataType`, `ApplyType`, `AllowedValues`, `DefaultValue`, `Description`) | Omitted — it would require the per-engine option catalog `DescribeOptionGroupOptions` serves |
+| `MaxRecords` / `Marker` pagination | Every group is returned in one page, as with every other RDS list action |
 
 ## Persistence
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -5,6 +5,7 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.AwsNamespaces;
 import io.github.hectorvent.floci.core.common.AwsQueryResponse;
 import io.github.hectorvent.floci.core.common.XmlBuilder;
+import io.github.hectorvent.floci.services.rds.model.DatabaseEngine;
 import io.github.hectorvent.floci.services.rds.model.DbCluster;
 import io.github.hectorvent.floci.services.rds.model.DbClusterParameterGroup;
 import io.github.hectorvent.floci.services.rds.model.DbEndpoint;
@@ -16,6 +17,8 @@ import io.github.hectorvent.floci.services.rds.model.DbProxyAuth;
 import io.github.hectorvent.floci.services.rds.model.DbProxyTarget;
 import io.github.hectorvent.floci.services.rds.model.DbProxyTargetGroup;
 import io.github.hectorvent.floci.services.rds.model.DbSubnetGroup;
+import io.github.hectorvent.floci.services.rds.model.OptionGroup;
+import io.github.hectorvent.floci.services.rds.model.OptionGroupOption;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -77,6 +80,10 @@ public class RdsQueryHandler {
                 case "DeleteDBClusterParameterGroup" -> handleDeleteDbClusterParameterGroup(params, region);
                 case "ModifyDBClusterParameterGroup" -> handleModifyDbClusterParameterGroup(params, region);
                 case "DescribeDBClusterParameters" -> handleDescribeDbClusterParameters(params, region);
+                case "CreateOptionGroup" -> handleCreateOptionGroup(params, region);
+                case "DescribeOptionGroups" -> handleDescribeOptionGroups(params, region);
+                case "ModifyOptionGroup" -> handleModifyOptionGroup(params, region);
+                case "DeleteOptionGroup" -> handleDeleteOptionGroup(params, region);
                 case "DescribeDBSnapshots" -> handleDescribeDbSnapshots(params);
                 case "DescribeDBProxies" -> handleDescribeDbProxies(params, region);
                 case "CreateDBProxy" -> handleCreateDbProxy(params, region);
@@ -121,6 +128,7 @@ public class RdsQueryHandler {
         int allocatedStorage = allocatedStorageStr != null ? parseIntSafe(allocatedStorageStr, 20) : 20;
         boolean iamEnabled = "true".equalsIgnoreCase(params.getFirst("EnableIAMDatabaseAuthentication"));
         String paramGroupName = params.getFirst("DBParameterGroupName");
+        String optionGroupName = params.getFirst("OptionGroupName");
         String dbSubnetGroupName = params.getFirst("DBSubnetGroupName");
         String dbClusterIdentifier = params.getFirst("DBClusterIdentifier");
         boolean manageMasterUserPassword = "true".equalsIgnoreCase(params.getFirst("ManageMasterUserPassword"));
@@ -141,7 +149,8 @@ public class RdsQueryHandler {
             DbInstance instance = service.createDbInstance(id, engine, engineVersion, masterUsername,
                     masterPassword, dbName, dbInstanceClass, allocatedStorage, iamEnabled,
                     paramGroupName, dbSubnetGroupName, dbClusterIdentifier, availabilityZone, multiAz,
-                    manageMasterUserPassword, masterUserSecretKmsKeyId, tags, vpcSecurityGroupIds, region);
+                    manageMasterUserPassword, masterUserSecretKmsKeyId, tags, vpcSecurityGroupIds,
+                    optionGroupName, region);
             String result = dbInstanceXml(instance);
             return Response.ok(AwsQueryResponse.envelope("CreateDBInstance", AwsNamespaces.RDS, result)).build();
         } catch (AwsException e) {
@@ -210,11 +219,12 @@ public class RdsQueryHandler {
         String iamStr = params.getFirst("EnableIAMDatabaseAuthentication");
         Boolean iamEnabled = iamStr != null ? Boolean.parseBoolean(iamStr) : null;
         String dbSubnetGroupName = params.getFirst("DBSubnetGroupName");
+        String optionGroupName = params.getFirst("OptionGroupName");
         try {
             List<String> vpcSecurityGroupIds = vpcSecurityGroupIds(params);
             DbInstance instance = service.modifyDbInstance(
                     id, newPassword, iamEnabled, dbSubnetGroupName,
-                    vpcSecurityGroupIds, region);
+                    vpcSecurityGroupIds, optionGroupName, region);
             String result = dbInstanceXml(instance);
             return Response.ok(AwsQueryResponse.envelope("ModifyDBInstance", AwsNamespaces.RDS, result)).build();
         } catch (AwsException e) {
@@ -655,6 +665,139 @@ public class RdsQueryHandler {
         }
     }
 
+    // ── Option Groups ─────────────────────────────────────────────────────────
+
+    private Response handleCreateOptionGroup(
+            MultivaluedMap<String, String> params, String region) {
+        String name = params.getFirst("OptionGroupName");
+        String engineName = params.getFirst("EngineName");
+        String majorEngineVersion = params.getFirst("MajorEngineVersion");
+        String description = params.getFirst("OptionGroupDescription");
+        Response missing = firstMissingParam(
+                "OptionGroupName", name,
+                "EngineName", engineName,
+                "MajorEngineVersion", majorEngineVersion,
+                "OptionGroupDescription", description);
+        if (missing != null) {
+            return missing;
+        }
+        OptionGroup group = service.createOptionGroup(
+                name, engineName, majorEngineVersion, description, parseTags(params), region);
+        return Response.ok(AwsQueryResponse.envelope(
+                "CreateOptionGroup", AwsNamespaces.RDS, optionGroupXml(group))).build();
+    }
+
+    private Response handleDescribeOptionGroups(
+            MultivaluedMap<String, String> params, String region) {
+        Collection<OptionGroup> result = service.listOptionGroups(
+                params.getFirst("OptionGroupName"),
+                params.getFirst("EngineName"),
+                params.getFirst("MajorEngineVersion"),
+                region);
+        XmlBuilder xml = new XmlBuilder().start("OptionGroupsList");
+        for (OptionGroup group : result) {
+            xml.start("OptionGroup").raw(optionGroupInnerXml(group)).end("OptionGroup");
+        }
+        xml.end("OptionGroupsList").start("Marker").end("Marker");
+        return Response.ok(AwsQueryResponse.envelope(
+                "DescribeOptionGroups", AwsNamespaces.RDS, xml.build())).build();
+    }
+
+    private Response handleModifyOptionGroup(
+            MultivaluedMap<String, String> params, String region) {
+        String name = params.getFirst("OptionGroupName");
+        if (name == null || name.isBlank()) {
+            return AwsQueryResponse.error("InvalidParameterValue",
+                    "OptionGroupName is required.", AwsNamespaces.RDS, 400);
+        }
+        OptionGroup group = service.modifyOptionGroup(name,
+                parseOptionConfigurations(params),
+                memberList(params, "OptionsToRemove"),
+                region);
+        return Response.ok(AwsQueryResponse.envelope(
+                "ModifyOptionGroup", AwsNamespaces.RDS, optionGroupXml(group))).build();
+    }
+
+    private Response handleDeleteOptionGroup(
+            MultivaluedMap<String, String> params, String region) {
+        String name = params.getFirst("OptionGroupName");
+        if (name == null || name.isBlank()) {
+            return AwsQueryResponse.error("InvalidParameterValue",
+                    "OptionGroupName is required.", AwsNamespaces.RDS, 400);
+        }
+        service.deleteOptionGroup(name, region);
+        return Response.ok(AwsQueryResponse.envelopeNoResult(
+                "DeleteOptionGroup", AwsNamespaces.RDS)).build();
+    }
+
+    /**
+     * Returns an {@code InvalidParameterValue} response for the first blank value in the given
+     * name/value pairs, or {@code null} when they are all present.
+     */
+    private static Response firstMissingParam(String... nameValuePairs) {
+        for (int i = 0; i < nameValuePairs.length; i += 2) {
+            String value = nameValuePairs[i + 1];
+            if (value == null || value.isBlank()) {
+                return AwsQueryResponse.error("InvalidParameterValue",
+                        nameValuePairs[i] + " is required.", AwsNamespaces.RDS, 400);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Parses {@code OptionsToInclude.OptionConfiguration.N.*} (and the legacy
+     * {@code OptionsToInclude.member.N.*} encoding older SDKs emit).
+     */
+    private static List<OptionGroupOption> parseOptionConfigurations(
+            MultivaluedMap<String, String> params) {
+        List<OptionGroupOption> options = new java.util.ArrayList<>();
+        for (String prefix : List.of("OptionsToInclude.OptionConfiguration",
+                "OptionsToInclude.member")) {
+            for (int n = 1; ; n++) {
+                String base = prefix + "." + n + ".";
+                String optionName = params.getFirst(base + "OptionName");
+                if (optionName == null) {
+                    break;
+                }
+                OptionGroupOption option = new OptionGroupOption(optionName);
+                option.setOptionVersion(params.getFirst(base + "OptionVersion"));
+                String port = params.getFirst(base + "Port");
+                if (port != null && !port.isBlank()) {
+                    try {
+                        option.setPort(Integer.parseInt(port.trim()));
+                    } catch (NumberFormatException e) {
+                        throw new AwsException("InvalidParameterValue",
+                                "Port must be an integer for option " + optionName + ".", 400);
+                    }
+                }
+                option.setOptionSettings(parseOptionSettings(params, base));
+                option.setVpcSecurityGroupMemberships(
+                        memberList(params, base + "VpcSecurityGroupMemberships"));
+                option.setDbSecurityGroupMemberships(
+                        memberList(params, base + "DBSecurityGroupMemberships"));
+                options.add(option);
+            }
+        }
+        return options;
+    }
+
+    private static Map<String, String> parseOptionSettings(
+            MultivaluedMap<String, String> params, String optionPrefix) {
+        Map<String, String> settings = new LinkedHashMap<>();
+        for (String prefix : List.of("OptionSettings.OptionSetting", "OptionSettings.member")) {
+            for (int n = 1; ; n++) {
+                String settingName = params.getFirst(optionPrefix + prefix + "." + n + ".Name");
+                if (settingName == null) {
+                    break;
+                }
+                settings.put(settingName,
+                        params.getFirst(optionPrefix + prefix + "." + n + ".Value"));
+            }
+        }
+        return settings;
+    }
+
     // ── Snapshots & Proxies (not modeled — empty lists) ───────────────────────
 
     private Response handleDescribeDbSnapshots(MultivaluedMap<String, String> params) {
@@ -998,6 +1141,7 @@ public class RdsQueryHandler {
            .elem("PreferredBackupWindow", "04:00-06:00")
            .raw(vpcSecurityGroupsXml(i))
            .raw(dbParameterGroupsXml(i))
+           .raw(optionGroupMembershipsXml(i))
            .raw(dbSubnetGroupXml(dbSubnetGroupForInstance(i)))
            .elem("DbiResourceId", i.getDbiResourceId())
            .elem("DBInstanceArn", i.getDbInstanceArn());
@@ -1230,6 +1374,96 @@ public class RdsQueryHandler {
                 .build();
     }
 
+    private String optionGroupXml(OptionGroup g) {
+        return new XmlBuilder().start("OptionGroup").raw(optionGroupInnerXml(g)).end("OptionGroup").build();
+    }
+
+    private String optionGroupInnerXml(OptionGroup g) {
+        XmlBuilder xml = new XmlBuilder()
+                .elem("OptionGroupName", g.getOptionGroupName())
+                .elem("OptionGroupDescription", g.getOptionGroupDescription())
+                .elem("EngineName", g.getEngineName())
+                .elem("MajorEngineVersion", g.getMajorEngineVersion())
+                .start("Options");
+        for (OptionGroupOption option : g.getOptions()) {
+            xml.start("Option").raw(optionInnerXml(option)).end("Option");
+        }
+        return xml.end("Options")
+                .elem("AllowsVpcAndNonVpcInstanceMemberships",
+                        g.isAllowsVpcAndNonVpcInstanceMemberships())
+                .elem("OptionGroupArn", g.getOptionGroupArn())
+                .build();
+    }
+
+    private String optionInnerXml(OptionGroupOption o) {
+        XmlBuilder xml = new XmlBuilder()
+                .elem("OptionName", o.getOptionName())
+                .elem("OptionDescription", o.getOptionDescription())
+                .elem("OptionVersion", o.getOptionVersion());
+        if (o.getPort() != null) {
+            xml.elem("Port", o.getPort().longValue());
+        }
+        xml.elem("Persistent", o.isPersistent())
+           .elem("Permanent", o.isPermanent())
+           .start("OptionSettings");
+        for (Map.Entry<String, String> setting : o.getOptionSettings().entrySet()) {
+            xml.start("OptionSetting")
+               .elem("Name", setting.getKey())
+               .elem("Value", setting.getValue())
+               .elem("IsModifiable", true)
+               .elem("IsCollection", false)
+               .end("OptionSetting");
+        }
+        xml.end("OptionSettings").start("VpcSecurityGroupMemberships");
+        for (String securityGroupId : o.getVpcSecurityGroupMemberships()) {
+            xml.start("VpcSecurityGroupMembership")
+               .elem("VpcSecurityGroupId", securityGroupId)
+               .elem("Status", "active")
+               .end("VpcSecurityGroupMembership");
+        }
+        xml.end("VpcSecurityGroupMemberships").start("DBSecurityGroupMemberships");
+        for (String securityGroupName : o.getDbSecurityGroupMemberships()) {
+            xml.start("DBSecurityGroup")
+               .elem("DBSecurityGroupName", securityGroupName)
+               .elem("Status", "authorized")
+               .end("DBSecurityGroup");
+        }
+        return xml.end("DBSecurityGroupMemberships").build();
+    }
+
+    private static String optionGroupMembershipsXml(DbInstance instance) {
+        return new XmlBuilder().start("OptionGroupMemberships")
+                .start("OptionGroupMembership")
+                  .elem("OptionGroupName", instanceOptionGroupName(instance))
+                  .elem("Status", "in-sync")
+                .end("OptionGroupMembership")
+                .end("OptionGroupMemberships")
+                .build();
+    }
+
+    private static String instanceOptionGroupName(DbInstance instance) {
+        String name = instance.getOptionGroupName();
+        if (name != null && !name.isBlank()) {
+            return name;
+        }
+        String engine = instance.getEngine() != null
+                ? instance.getEngine().name().toLowerCase()
+                : "unknown";
+        String majorVersion = optionGroupMajorVersion(instance);
+        return majorVersion.isEmpty()
+                ? "default:" + engine
+                : RdsService.defaultOptionGroupName(engine, majorVersion);
+    }
+
+    private static String optionGroupMajorVersion(DbInstance instance) {
+        String engineVersion = instance.getEngineVersion();
+        if ((engineVersion == null || engineVersion.isBlank()) && instance.getEngine() != null) {
+            engineVersion = defaultEngineVersion(instance.getEngine().name());
+        }
+        String engine = instance.getEngine() == null ? null : instance.getEngine().name();
+        return RdsService.optionGroupMajorVersion(engine, engineVersion);
+    }
+
     private String clusterParamGroupXml(DbClusterParameterGroup g) {
         return new XmlBuilder().start("DBClusterParameterGroup").raw(clusterParamGroupInnerXml(g)).end("DBClusterParameterGroup").build();
     }
@@ -1308,7 +1542,18 @@ public class RdsQueryHandler {
         return switch (baseName) {
             case "SubnetIds" -> quoted + "(\\.member|\\.SubnetIdentifier)?\\.\\d+";
             case "VpcSecurityGroupIds" -> quoted + "(\\.member|\\.VpcSecurityGroupId)?\\.\\d+";
-            default -> quoted + "(\\.member)?\\.\\d+";
+            case "OptionsToRemove" -> quoted + "(\\.member|\\.OptionName)?\\.\\d+";
+            default -> {
+                // Option configurations nest their membership lists under an indexed prefix,
+                // so the alternate member names have to be matched on the suffix.
+                if (baseName.endsWith("VpcSecurityGroupMemberships")) {
+                    yield quoted + "(\\.member|\\.VpcSecurityGroupId)?\\.\\d+";
+                }
+                if (baseName.endsWith("DBSecurityGroupMemberships")) {
+                    yield quoted + "(\\.member|\\.DBSecurityGroupName)?\\.\\d+";
+                }
+                yield quoted + "(\\.member)?\\.\\d+";
+            }
         };
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -30,6 +30,8 @@ import io.github.hectorvent.floci.services.rds.model.DbProxyAuth;
 import io.github.hectorvent.floci.services.rds.model.DbProxyTarget;
 import io.github.hectorvent.floci.services.rds.model.DbProxyTargetGroup;
 import io.github.hectorvent.floci.services.rds.model.DbSubnetGroup;
+import io.github.hectorvent.floci.services.rds.model.OptionGroup;
+import io.github.hectorvent.floci.services.rds.model.OptionGroupOption;
 import io.github.hectorvent.floci.services.rds.proxy.RdsProxyManager;
 import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerService;
 import io.github.hectorvent.floci.services.secretsmanager.model.Secret;
@@ -83,10 +85,39 @@ public class RdsService implements Resettable {
             managedDefault("postgres17"),
             managedDefault("postgres18"));
 
+    /**
+     * Engines AWS accepts for {@code EngineName} on an option group. Floci can only run
+     * postgres, mysql and mariadb, but option groups are pure metadata, so a group for an
+     * engine Floci cannot start is still valid to create and describe.
+     */
+    private static final Set<String> OPTION_GROUP_ENGINES = Set.of(
+            "db2-ae", "db2-ce", "db2-se", "mariadb", "mysql",
+            "oracle-ee", "oracle-ee-cdb", "oracle-se2", "oracle-se2-cdb", "postgres",
+            "sqlserver-ee", "sqlserver-se", "sqlserver-ex", "sqlserver-web");
+
+    /**
+     * The {@code default:<engine>-<major version>} groups AWS creates implicitly. Only the
+     * engines Floci can actually run are listed, so every instance Floci creates resolves to
+     * a default option group that {@code DescribeOptionGroups} also returns.
+     */
+    private static final List<ManagedOptionGroup> MANAGED_OPTION_GROUPS = List.of(
+            managedOptionGroup("mariadb", "10.11"),
+            managedOptionGroup("mariadb", "11.2"),
+            managedOptionGroup("mariadb", "11.4"),
+            managedOptionGroup("mysql", "8.0"),
+            managedOptionGroup("mysql", "8.4"),
+            managedOptionGroup("postgres", "13"),
+            managedOptionGroup("postgres", "14"),
+            managedOptionGroup("postgres", "15"),
+            managedOptionGroup("postgres", "16"),
+            managedOptionGroup("postgres", "17"),
+            managedOptionGroup("postgres", "18"));
+
     private final StorageBackend<String, DbInstance> instances;
     private final StorageBackend<String, DbCluster> clusters;
     private final StorageBackend<String, DbParameterGroup> parameterGroups;
     private final StorageBackend<String, DbClusterParameterGroup> clusterParameterGroups;
+    private final StorageBackend<String, OptionGroup> optionGroups;
     private final StorageBackend<String, DbSubnetGroup> subnetGroups;
     private final StorageBackend<String, DbProxy> proxies;
     private final StorageBackend<String, DbProxyTargetGroup> proxyTargetGroups;
@@ -103,6 +134,14 @@ public class RdsService implements Resettable {
     private static final Pattern SAFE_IMAGE_TAG_PATTERN = Pattern.compile("[A-Za-z0-9._-]+");
     private static final Pattern DB_PROXY_NAME_PATTERN =
             Pattern.compile("[a-zA-Z](?:-?[a-zA-Z0-9]+)*");
+    /**
+     * AWS constrains a user-created option group name to 1–255 letters, numbers or hyphens,
+     * starting with a letter, without a trailing or doubled hyphen. The implicit
+     * {@code default:<engine>-<version>} groups are exempt — they are not user-creatable.
+     */
+    private static final Pattern OPTION_GROUP_NAME_PATTERN =
+            Pattern.compile("[a-zA-Z][a-zA-Z0-9]*(?:-[a-zA-Z0-9]+)*");
+    private static final int OPTION_GROUP_NAME_MAX_LENGTH = 255;
     private static final Set<String> DB_PROXY_AUTH_SCHEMES = Set.of("SECRETS");
     private static final Set<String> DB_PROXY_IAM_AUTH_MODES =
             Set.of("DISABLED", "REQUIRED", "ENABLED");
@@ -136,6 +175,8 @@ public class RdsService implements Resettable {
                 new TypeReference<Map<String, DbParameterGroup>>() {});
         this.clusterParameterGroups = storageFactory.create("rds", "rds-cluster-parameter-groups.json",
                 new TypeReference<Map<String, DbClusterParameterGroup>>() {});
+        this.optionGroups = storageFactory.create("rds", "rds-option-groups.json",
+                new TypeReference<Map<String, OptionGroup>>() {});
         this.subnetGroups = storageFactory.create("rds", "rds-subnet-groups.json",
                 new TypeReference<Map<String, DbSubnetGroup>>() {});
         this.proxies = storageFactory.create("rds", "rds-proxies.json",
@@ -231,6 +272,28 @@ public class RdsService implements Resettable {
                CurrentContainerNetworkResolver currentContainerNetworkResolver,
                StorageBackend<String, DbProxy> proxies,
                StorageBackend<String, DbProxyTargetGroup> proxyTargetGroups) {
+        this(containerManager, proxyManager, ec2Service, regionResolver, config,
+                instances, clusters, parameterGroups, clusterParameterGroups, subnetGroups,
+                secretsManagerService, dockerHostResolver, currentContainerNetworkResolver,
+                proxies, proxyTargetGroups, new InMemoryStorage<>());
+    }
+
+    RdsService(RdsContainerManager containerManager,
+               RdsProxyManager proxyManager,
+               Ec2Service ec2Service,
+               RegionResolver regionResolver,
+               EmulatorConfig config,
+               StorageBackend<String, DbInstance> instances,
+               StorageBackend<String, DbCluster> clusters,
+               StorageBackend<String, DbParameterGroup> parameterGroups,
+               StorageBackend<String, DbClusterParameterGroup> clusterParameterGroups,
+               StorageBackend<String, DbSubnetGroup> subnetGroups,
+               SecretsManagerService secretsManagerService,
+               DockerHostResolver dockerHostResolver,
+               CurrentContainerNetworkResolver currentContainerNetworkResolver,
+               StorageBackend<String, DbProxy> proxies,
+               StorageBackend<String, DbProxyTargetGroup> proxyTargetGroups,
+               StorageBackend<String, OptionGroup> optionGroups) {
         this.containerManager = containerManager;
         this.proxyManager = proxyManager;
         this.ec2Service = ec2Service;
@@ -243,6 +306,7 @@ public class RdsService implements Resettable {
         this.clusters = clusters;
         this.parameterGroups = parameterGroups;
         this.clusterParameterGroups = clusterParameterGroups;
+        this.optionGroups = optionGroups;
         this.subnetGroups = subnetGroups;
         this.proxies = proxies;
         this.proxyTargetGroups = proxyTargetGroups;
@@ -371,6 +435,25 @@ public class RdsService implements Resettable {
                                        Map<String, String> tags,
                                        List<String> vpcSecurityGroupIds,
                                        String region) {
+        return createDbInstance(id, engineParam, engineVersion, masterUsername, masterPassword,
+                dbName, dbInstanceClass, allocatedStorage, iamEnabled, paramGroupName,
+                dbSubnetGroupName, dbClusterIdentifier, availabilityZone, multiAz,
+                manageMasterUserPassword, masterUserSecretKmsKeyId, tags, vpcSecurityGroupIds,
+                null, region);
+    }
+
+    public DbInstance createDbInstance(String id, String engineParam, String engineVersion,
+                                       String masterUsername, String masterPassword,
+                                       String dbName, String dbInstanceClass,
+                                       int allocatedStorage, boolean iamEnabled,
+                                       String paramGroupName, String dbSubnetGroupName,
+                                       String dbClusterIdentifier, String availabilityZone,
+                                       boolean multiAz, boolean manageMasterUserPassword,
+                                       String masterUserSecretKmsKeyId,
+                                       Map<String, String> tags,
+                                       List<String> vpcSecurityGroupIds,
+                                       String optionGroupName,
+                                       String region) {
         String effectiveRegion = effectiveRegion(region);
         String dbiResourceId = "db-" + java.util.UUID.randomUUID().toString()
                 .replace("-", "").substring(0, 24).toUpperCase();
@@ -387,6 +470,7 @@ public class RdsService implements Resettable {
         }
         validateInstanceParameterGroup(
                 paramGroupName, engineParam, engineVersion, effectiveRegion);
+        validateInstanceOptionGroup(optionGroupName, engineParam, engineVersion, effectiveRegion);
         boolean mock = config.services().rds().mock();
         // Always reserve a unique port (even in mock) so endpoints stay distinct and usedPorts
         // is consistent; mock mode only skips starting the container and auth proxy.
@@ -455,6 +539,7 @@ public class RdsService implements Resettable {
         DbInstance instance = new DbInstance(id, engine, engineVersion, masterUsername, masterPassword,
                 dbName, dbInstanceClass, allocatedStorage, DbInstanceStatus.AVAILABLE,
                 endpoint, iamEnabled, paramGroupName, dbClusterIdentifier, Instant.now(), proxyPort);
+        instance.setOptionGroupName(optionGroupName);
         instance.setDbSubnetGroupName(dbSubnetGroupName);
         instance.setContainerId(containerId);
         instance.setContainerHost(containerHost);
@@ -625,7 +710,18 @@ public class RdsService implements Resettable {
                     proxies.put(dbProxyKey(effectiveRegion, resolvedProxy.getDbProxyName()), updatedProxy);
                 });
             }
-            // Valid RDS resource types Floci does not model yet (og, pg, snapshot, ...) — taggable
+            case "og" -> {
+                if (managedOptionGroup(resourceId) != null) {
+                    throw new AwsException("InvalidOptionGroupStateFault",
+                            "The default option group " + resourceId + " cannot be tagged.", 400);
+                }
+                OptionGroup group = getOptionGroup(resourceId, effectiveRegion);
+                yield new TagHandle(group.getTags(), updated -> {
+                    group.setTags(updated);
+                    putOptionGroupForRegion(resourceId, effectiveRegion, group);
+                });
+            }
+            // Valid RDS resource types Floci does not model yet (pg, snapshot, ...) — taggable
             // on real AWS, so the message states the Floci limitation rather than AWS semantics.
             default -> throw new AwsException("InvalidParameterValue",
                     "Tagging for resource type '" + type + "' is not yet implemented by Floci: " + resourceName, 400);
@@ -742,9 +838,23 @@ public class RdsService implements Resettable {
     public DbInstance modifyDbInstance(
             String id, String newPassword, Boolean iamEnabled,
             String dbSubnetGroupName, List<String> vpcSecurityGroupIds, String region) {
+        return modifyDbInstance(id, newPassword, iamEnabled, dbSubnetGroupName,
+                vpcSecurityGroupIds, null, region);
+    }
+
+    public DbInstance modifyDbInstance(
+            String id, String newPassword, Boolean iamEnabled,
+            String dbSubnetGroupName, List<String> vpcSecurityGroupIds,
+            String optionGroupName, String region) {
         String effectiveRegion = effectiveRegion(region);
         DbInstance instance = getDbInstance(id, effectiveRegion);
         instance.setStatus(DbInstanceStatus.AVAILABLE);
+        if (optionGroupName != null && !optionGroupName.isBlank()) {
+            validateInstanceOptionGroup(optionGroupName,
+                    instance.getEngine() == null ? null : instance.getEngine().name().toLowerCase(),
+                    instance.getEngineVersion(), effectiveRegion);
+            instance.setOptionGroupName(optionGroupName);
+        }
         if (newPassword != null && !newPassword.isBlank()) {
             instance.setMasterPassword(newPassword);
         }
@@ -2215,6 +2325,279 @@ public class RdsService implements Resettable {
         }
         putClusterParameterGroupForRegion(name, effectiveRegion, group);
         return group;
+    }
+
+    // ── Option Groups ─────────────────────────────────────────────────────────
+
+    public OptionGroup createOptionGroup(
+            String name, String engineName, String majorEngineVersion, String description) {
+        return createOptionGroup(name, engineName, majorEngineVersion, description,
+                Map.of(), regionResolver.getDefaultRegion());
+    }
+
+    public OptionGroup createOptionGroup(
+            String name, String engineName, String majorEngineVersion, String description,
+            Map<String, String> tags, String region) {
+        String effectiveRegion = effectiveRegion(region);
+        validateOptionGroupName(name);
+        validateOptionGroupEngine(engineName);
+        if (findOptionGroupForRegion(name, effectiveRegion) != null
+                || scopedKeyExists(optionGroups, currentAccountId(),
+                dbResourceKey(effectiveRegion, name))) {
+            throw new AwsException("OptionGroupAlreadyExistsFault",
+                    "Option group " + name + " already exists.", 400);
+        }
+        OptionGroup group = new OptionGroup(name, engineName, majorEngineVersion, description);
+        group.setRegion(effectiveRegion);
+        group.setOptionGroupArn(regionResolver.buildArn("rds", effectiveRegion, "og:" + name));
+        group.setTags(tags == null ? new LinkedHashMap<>() : new LinkedHashMap<>(tags));
+        putOptionGroupForRegion(name, effectiveRegion, group);
+        return group;
+    }
+
+    public OptionGroup getOptionGroup(String name) {
+        return getOptionGroup(name, regionResolver.getDefaultRegion());
+    }
+
+    public OptionGroup getOptionGroup(String name, String region) {
+        String effectiveRegion = effectiveRegion(region);
+        OptionGroup group = findOptionGroupForRegion(name, effectiveRegion);
+        if (group == null) {
+            ManagedOptionGroup managed = managedOptionGroup(name);
+            if (managed != null) {
+                group = managed.toModel(effectiveRegion, regionResolver);
+            }
+        }
+        if (group == null) {
+            throw new AwsException("OptionGroupNotFoundFault",
+                    "Option group " + name + " not found.", 404);
+        }
+        return group;
+    }
+
+    public Collection<OptionGroup> listOptionGroups(
+            String filterName, String engineName, String majorEngineVersion) {
+        return listOptionGroups(filterName, engineName, majorEngineVersion,
+                regionResolver.getDefaultRegion());
+    }
+
+    public Collection<OptionGroup> listOptionGroups(
+            String filterName, String engineName, String majorEngineVersion, String region) {
+        String effectiveRegion = effectiveRegion(region);
+        boolean hasName = filterName != null && !filterName.isBlank();
+        boolean hasEngine = engineName != null && !engineName.isBlank();
+        boolean hasVersion = majorEngineVersion != null && !majorEngineVersion.isBlank();
+        if (hasName && (hasEngine || hasVersion)) {
+            throw new AwsException("InvalidParameterCombination",
+                    "OptionGroupName can't be supplied together with EngineName "
+                            + "or MajorEngineVersion.", 400);
+        }
+        if (hasVersion && !hasEngine) {
+            throw new AwsException("InvalidParameterCombination",
+                    "MajorEngineVersion must be used with EngineName.", 400);
+        }
+        if (hasName) {
+            return List.of(getOptionGroup(filterName, effectiveRegion));
+        }
+
+        Map<String, OptionGroup> unique = new LinkedHashMap<>();
+        for (ManagedOptionGroup managed : MANAGED_OPTION_GROUPS) {
+            OptionGroup group = managed.toModel(effectiveRegion, regionResolver);
+            unique.put(group.getOptionGroupName(), group);
+        }
+        List<OptionGroup> storedGroups;
+        if (optionGroups instanceof AccountAwareStorageBackend<OptionGroup> aware) {
+            storedGroups = new ArrayList<>(aware.scanForAccount(currentAccountId(), k -> true));
+            if (Objects.equals(currentAccountId(), defaultAccountId())) {
+                storedGroups.addAll(aware.scanUnscopedLegacy(group ->
+                        optionGroupBelongsToRegion(group, effectiveRegion)));
+            }
+        } else {
+            storedGroups = optionGroups.scan(k -> true);
+        }
+        storedGroups.stream()
+                .sorted(Comparator.comparing(OptionGroup::getOptionGroupName,
+                        Comparator.nullsLast(Comparator.naturalOrder())))
+                .filter(group -> optionGroupBelongsToRegion(group, effectiveRegion))
+                .map(group -> findOptionGroupForRegion(
+                        group.getOptionGroupName(), effectiveRegion))
+                .filter(Objects::nonNull)
+                .forEach(group -> unique.put(group.getOptionGroupName(), group));
+
+        return unique.values().stream()
+                .filter(group -> !hasEngine || engineName.equalsIgnoreCase(group.getEngineName()))
+                .filter(group -> !hasVersion
+                        || majorEngineVersion.equalsIgnoreCase(group.getMajorEngineVersion()))
+                .toList();
+    }
+
+    public OptionGroup modifyOptionGroup(String name,
+                                         List<OptionGroupOption> optionsToInclude,
+                                         List<String> optionsToRemove) {
+        return modifyOptionGroup(name, optionsToInclude, optionsToRemove,
+                regionResolver.getDefaultRegion());
+    }
+
+    public OptionGroup modifyOptionGroup(String name,
+                                         List<OptionGroupOption> optionsToInclude,
+                                         List<String> optionsToRemove,
+                                         String region) {
+        String effectiveRegion = effectiveRegion(region);
+        if (managedOptionGroup(name) != null) {
+            throw new AwsException("InvalidOptionGroupStateFault",
+                    "The default option group " + name + " cannot be modified.", 400);
+        }
+        OptionGroup group = getOptionGroup(name, effectiveRegion);
+        if (optionsToRemove != null && !optionsToRemove.isEmpty()) {
+            group.getOptions().removeIf(option ->
+                    optionsToRemove.contains(option.getOptionName()));
+        }
+        if (optionsToInclude != null) {
+            for (OptionGroupOption option : optionsToInclude) {
+                mergeOption(group, option);
+            }
+        }
+        putOptionGroupForRegion(name, effectiveRegion, group);
+        return group;
+    }
+
+    public void deleteOptionGroup(String name) {
+        deleteOptionGroup(name, regionResolver.getDefaultRegion());
+    }
+
+    public void deleteOptionGroup(String name, String region) {
+        String effectiveRegion = effectiveRegion(region);
+        if (managedOptionGroup(name) != null) {
+            throw new AwsException("InvalidOptionGroupStateFault",
+                    "The default option group " + name + " cannot be deleted.", 400);
+        }
+        if (findOptionGroupForRegion(name, effectiveRegion) == null) {
+            throw new AwsException("OptionGroupNotFoundFault",
+                    "Option group " + name + " not found.", 404);
+        }
+        boolean attached = listDbInstances(null, effectiveRegion).stream()
+                .anyMatch(instance -> name.equals(instance.getOptionGroupName()));
+        if (attached) {
+            throw new AwsException("InvalidOptionGroupStateFault",
+                    "The option group " + name + " is still associated with a DB instance.", 400);
+        }
+        deleteOptionGroupForRegion(name, effectiveRegion);
+    }
+
+    /**
+     * Merges an incoming {@code OptionsToInclude} entry: an option that is already present
+     * has its configuration updated in place, mirroring the AWS upsert semantics.
+     */
+    private static void mergeOption(OptionGroup group, OptionGroupOption incoming) {
+        if (incoming == null || incoming.getOptionName() == null
+                || incoming.getOptionName().isBlank()) {
+            throw new AwsException("InvalidParameterValue",
+                    "OptionName is required for every option in OptionsToInclude.", 400);
+        }
+        OptionGroupOption existing = group.getOptions().stream()
+                .filter(option -> incoming.getOptionName().equals(option.getOptionName()))
+                .findFirst()
+                .orElse(null);
+        if (existing == null) {
+            group.getOptions().add(incoming);
+            return;
+        }
+        existing.setOptionDescription(incoming.getOptionDescription());
+        existing.setOptionVersion(incoming.getOptionVersion());
+        existing.setPort(incoming.getPort());
+        existing.getOptionSettings().putAll(incoming.getOptionSettings());
+        existing.setVpcSecurityGroupMemberships(incoming.getVpcSecurityGroupMemberships());
+        existing.setDbSecurityGroupMemberships(incoming.getDbSecurityGroupMemberships());
+    }
+
+    private static void validateOptionGroupName(String name) {
+        if (name == null || name.isBlank()
+                || name.length() > OPTION_GROUP_NAME_MAX_LENGTH
+                || !OPTION_GROUP_NAME_PATTERN.matcher(name).matches()) {
+            throw new AwsException("InvalidParameterValue",
+                    "OptionGroupName must be 1 to " + OPTION_GROUP_NAME_MAX_LENGTH
+                            + " letters, numbers or hyphens, must start with a letter, and "
+                            + "can't end with a hyphen or contain two consecutive hyphens.", 400);
+        }
+    }
+
+    private static void validateOptionGroupEngine(String engineName) {
+        if (engineName == null || engineName.isBlank()
+                || !OPTION_GROUP_ENGINES.contains(engineName.toLowerCase())) {
+            throw new AwsException("InvalidParameterValue",
+                    "EngineName " + engineName + " is not a valid option group engine.", 400);
+        }
+    }
+
+    private void validateInstanceOptionGroup(
+            String optionGroupName, String engineParam, String engineVersion, String region) {
+        if (optionGroupName == null || optionGroupName.isBlank()) {
+            return;
+        }
+        OptionGroup group = getOptionGroup(optionGroupName, region);
+        String engine = effectiveEngineName(engineParam);
+        if (!engine.equalsIgnoreCase(group.getEngineName())) {
+            throw new AwsException("InvalidParameterCombination",
+                    invalidParameterCombinationMessage(), 400);
+        }
+        // An option group is scoped to one major engine version, so a group built for another
+        // major version can't be attached even when the engine itself matches.
+        String majorVersion = optionGroupMajorVersion(engine, engineVersion);
+        if (!majorVersion.isEmpty()
+                && !majorVersion.equalsIgnoreCase(group.getMajorEngineVersion())) {
+            throw new AwsException("InvalidParameterCombination",
+                    invalidParameterCombinationMessage(), 400);
+        }
+    }
+
+    /**
+     * AWS keys an option group on the engine's major version, which is the leading component for
+     * postgres and {@code major.minor} for the MySQL-family engines. Returns an empty string when
+     * the version is unknown.
+     */
+    public static String optionGroupMajorVersion(String engineName, String engineVersion) {
+        if (engineVersion == null || engineVersion.isBlank()) {
+            return "";
+        }
+        String[] parts = engineVersion.trim().split("\\.");
+        if ("postgres".equalsIgnoreCase(engineName) || parts.length < 2) {
+            return parts[0];
+        }
+        return parts[0] + "." + parts[1];
+    }
+
+    private static ManagedOptionGroup managedOptionGroup(String name) {
+        for (ManagedOptionGroup group : MANAGED_OPTION_GROUPS) {
+            if (group.name().equals(name)) {
+                return group;
+            }
+        }
+        return null;
+    }
+
+    private static ManagedOptionGroup managedOptionGroup(
+            String engineName, String majorEngineVersion) {
+        return new ManagedOptionGroup(
+                defaultOptionGroupName(engineName, majorEngineVersion),
+                engineName,
+                majorEngineVersion,
+                "Default option group for " + engineName + " " + majorEngineVersion);
+    }
+
+    /** AWS names implicit option groups {@code default:<engine>-<major version>}, dots as dashes. */
+    public static String defaultOptionGroupName(String engineName, String majorEngineVersion) {
+        return "default:" + engineName + "-" + majorEngineVersion.replace('.', '-');
+    }
+
+    private record ManagedOptionGroup(String name, String engineName,
+                                      String majorEngineVersion, String description) {
+        private OptionGroup toModel(String region, RegionResolver regionResolver) {
+            OptionGroup group = new OptionGroup(
+                    name, engineName, majorEngineVersion, description);
+            group.setRegion(region);
+            group.setOptionGroupArn(regionResolver.buildArn("rds", region, "og:" + name));
+            return group;
+        }
     }
 
     // ── Password validation callbacks ─────────────────────────────────────────
@@ -3896,6 +4279,73 @@ public class RdsService implements Resettable {
             aware.deleteForAccount(currentAccountId(), key);
         } else {
             clusterParameterGroups.delete(key);
+        }
+    }
+
+    private synchronized OptionGroup findOptionGroupForRegion(String groupName, String region) {
+        String effectiveRegion = effectiveRegion(region);
+        String accountId = currentAccountId();
+        String key = dbResourceKey(effectiveRegion, groupName);
+        java.util.function.Predicate<OptionGroup> owner = group ->
+                Objects.equals(groupName, group.getOptionGroupName())
+                        && optionGroupBelongsToRegion(group, effectiveRegion);
+        Optional<OptionGroup> resolved;
+        if (optionGroups instanceof AccountAwareStorageBackend<OptionGroup> aware) {
+            resolved = aware.getForAccountMigratingLegacyKeys(
+                    accountId, key, List.of(groupName), owner,
+                    Objects.equals(accountId, defaultAccountId()));
+        } else {
+            Optional<OptionGroup> canonicalValue = optionGroups.get(key);
+            Optional<OptionGroup> canonical = canonicalValue.filter(owner);
+            if (canonical.isPresent()) {
+                optionGroups.get(groupName).filter(owner)
+                        .ifPresent(ignored -> optionGroups.delete(groupName));
+                resolved = canonical;
+            } else if (canonicalValue.isPresent()) {
+                resolved = Optional.empty();
+            } else {
+                Optional<OptionGroup> legacy = optionGroups.get(groupName).filter(owner);
+                if (legacy.isPresent()) {
+                    optionGroups.put(key, legacy.get());
+                    optionGroups.delete(groupName);
+                }
+                resolved = legacy;
+            }
+        }
+        resolved.ifPresent(group -> {
+            if (group.getRegion() == null || group.getRegion().isBlank()) {
+                group.setRegion(effectiveRegion);
+                putOptionGroupForRegion(groupName, effectiveRegion, group);
+            }
+        });
+        return resolved.orElse(null);
+    }
+
+    private boolean optionGroupBelongsToRegion(OptionGroup group, String region) {
+        if (group == null) {
+            return false;
+        }
+        String storedRegion = group.getRegion();
+        return storedRegion == null || storedRegion.isBlank()
+                ? Objects.equals(regionResolver.getDefaultRegion(), region)
+                : Objects.equals(storedRegion, region);
+    }
+
+    private void putOptionGroupForRegion(String groupName, String region, OptionGroup group) {
+        String key = dbResourceKey(region, groupName);
+        if (optionGroups instanceof AccountAwareStorageBackend<OptionGroup> aware) {
+            aware.putForAccount(currentAccountId(), key, group);
+        } else {
+            optionGroups.put(key, group);
+        }
+    }
+
+    private void deleteOptionGroupForRegion(String groupName, String region) {
+        String key = dbResourceKey(region, groupName);
+        if (optionGroups instanceof AccountAwareStorageBackend<OptionGroup> aware) {
+            aware.deleteForAccount(currentAccountId(), key);
+        } else {
+            optionGroups.delete(key);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstance.java
@@ -23,6 +23,7 @@ public class DbInstance {
     private DbEndpoint endpoint;
     private boolean iamDatabaseAuthenticationEnabled;
     private String parameterGroupName;
+    private String optionGroupName;
     private String dbSubnetGroupName;
     private String dbClusterIdentifier;
     private String vpcId;
@@ -109,6 +110,9 @@ public class DbInstance {
 
     public String getParameterGroupName() { return parameterGroupName; }
     public void setParameterGroupName(String parameterGroupName) { this.parameterGroupName = parameterGroupName; }
+
+    public String getOptionGroupName() { return optionGroupName; }
+    public void setOptionGroupName(String optionGroupName) { this.optionGroupName = optionGroupName; }
 
     public String getDbSubnetGroupName() { return dbSubnetGroupName; }
     public void setDbSubnetGroupName(String dbSubnetGroupName) { this.dbSubnetGroupName = dbSubnetGroupName; }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/OptionGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/OptionGroup.java
@@ -1,0 +1,70 @@
+package io.github.hectorvent.floci.services.rds.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An RDS option group — the container engine-specific options are enabled through
+ * (Oracle {@code S3_INTEGRATION}, SQL Server {@code SQLSERVER_BACKUP_RESTORE},
+ * MariaDB {@code MARIADB_AUDIT_PLUGIN}, ...).
+ */
+@RegisterForReflection
+public class OptionGroup {
+
+    private String optionGroupName;
+    private String optionGroupDescription;
+    private String engineName;
+    private String majorEngineVersion;
+    private String optionGroupArn;
+    private boolean allowsVpcAndNonVpcInstanceMemberships = true;
+    private String region;
+    private List<OptionGroupOption> options = new ArrayList<>();
+    private Map<String, String> tags = new LinkedHashMap<>();
+
+    public OptionGroup() {}
+
+    public OptionGroup(String optionGroupName, String engineName,
+                       String majorEngineVersion, String optionGroupDescription) {
+        this.optionGroupName = optionGroupName;
+        this.engineName = engineName;
+        this.majorEngineVersion = majorEngineVersion;
+        this.optionGroupDescription = optionGroupDescription;
+    }
+
+    public String getOptionGroupName() { return optionGroupName; }
+    public void setOptionGroupName(String optionGroupName) { this.optionGroupName = optionGroupName; }
+
+    public String getOptionGroupDescription() { return optionGroupDescription; }
+    public void setOptionGroupDescription(String optionGroupDescription) { this.optionGroupDescription = optionGroupDescription; }
+
+    public String getEngineName() { return engineName; }
+    public void setEngineName(String engineName) { this.engineName = engineName; }
+
+    public String getMajorEngineVersion() { return majorEngineVersion; }
+    public void setMajorEngineVersion(String majorEngineVersion) { this.majorEngineVersion = majorEngineVersion; }
+
+    public String getOptionGroupArn() { return optionGroupArn; }
+    public void setOptionGroupArn(String optionGroupArn) { this.optionGroupArn = optionGroupArn; }
+
+    public boolean isAllowsVpcAndNonVpcInstanceMemberships() { return allowsVpcAndNonVpcInstanceMemberships; }
+    public void setAllowsVpcAndNonVpcInstanceMemberships(boolean allowsVpcAndNonVpcInstanceMemberships) {
+        this.allowsVpcAndNonVpcInstanceMemberships = allowsVpcAndNonVpcInstanceMemberships;
+    }
+
+    public String getRegion() { return region; }
+    public void setRegion(String region) { this.region = region; }
+
+    public List<OptionGroupOption> getOptions() { return options; }
+    public void setOptions(List<OptionGroupOption> options) {
+        this.options = options == null ? new ArrayList<>() : options;
+    }
+
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags == null ? new LinkedHashMap<>() : tags;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/OptionGroupOption.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/OptionGroupOption.java
@@ -1,0 +1,67 @@
+package io.github.hectorvent.floci.services.rds.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A single option inside an {@link OptionGroup}, as added by {@code ModifyOptionGroup}
+ * through {@code OptionsToInclude}.
+ */
+@RegisterForReflection
+public class OptionGroupOption {
+
+    private String optionName;
+    private String optionDescription;
+    private String optionVersion;
+    private Integer port;
+    private boolean persistent;
+    private boolean permanent;
+    private Map<String, String> optionSettings = new LinkedHashMap<>();
+    private List<String> vpcSecurityGroupMemberships = new ArrayList<>();
+    private List<String> dbSecurityGroupMemberships = new ArrayList<>();
+
+    public OptionGroupOption() {}
+
+    public OptionGroupOption(String optionName) {
+        this.optionName = optionName;
+    }
+
+    public String getOptionName() { return optionName; }
+    public void setOptionName(String optionName) { this.optionName = optionName; }
+
+    public String getOptionDescription() { return optionDescription; }
+    public void setOptionDescription(String optionDescription) { this.optionDescription = optionDescription; }
+
+    public String getOptionVersion() { return optionVersion; }
+    public void setOptionVersion(String optionVersion) { this.optionVersion = optionVersion; }
+
+    public Integer getPort() { return port; }
+    public void setPort(Integer port) { this.port = port; }
+
+    public boolean isPersistent() { return persistent; }
+    public void setPersistent(boolean persistent) { this.persistent = persistent; }
+
+    public boolean isPermanent() { return permanent; }
+    public void setPermanent(boolean permanent) { this.permanent = permanent; }
+
+    public Map<String, String> getOptionSettings() { return optionSettings; }
+    public void setOptionSettings(Map<String, String> optionSettings) {
+        this.optionSettings = optionSettings == null ? new LinkedHashMap<>() : optionSettings;
+    }
+
+    public List<String> getVpcSecurityGroupMemberships() { return vpcSecurityGroupMemberships; }
+    public void setVpcSecurityGroupMemberships(List<String> vpcSecurityGroupMemberships) {
+        this.vpcSecurityGroupMemberships =
+                vpcSecurityGroupMemberships == null ? new ArrayList<>() : vpcSecurityGroupMemberships;
+    }
+
+    public List<String> getDbSecurityGroupMemberships() { return dbSecurityGroupMemberships; }
+    public void setDbSecurityGroupMemberships(List<String> dbSecurityGroupMemberships) {
+        this.dbSecurityGroupMemberships =
+                dbSecurityGroupMemberships == null ? new ArrayList<>() : dbSecurityGroupMemberships;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -12,11 +12,14 @@ import io.github.hectorvent.floci.services.rds.model.DbProxyAuth;
 import io.github.hectorvent.floci.services.rds.model.DbProxyTarget;
 import io.github.hectorvent.floci.services.rds.model.DbProxyTargetGroup;
 import io.github.hectorvent.floci.services.rds.model.DbSubnetGroup;
+import io.github.hectorvent.floci.services.rds.model.OptionGroup;
+import io.github.hectorvent.floci.services.rds.model.OptionGroupOption;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 import java.util.Map;
@@ -207,7 +210,7 @@ class RdsQueryHandlerTest {
         when(service.listDbInstances(null, "us-west-2")).thenReturn(List.of());
         when(service.getDbInstance("mydb", "us-west-2")).thenReturn(instance);
         when(service.modifyDbInstance(
-                eq("mydb"), isNull(), isNull(), isNull(), anyList(), eq("us-west-2")))
+                eq("mydb"), isNull(), isNull(), isNull(), anyList(), isNull(), eq("us-west-2")))
                 .thenReturn(instance);
         when(service.rebootDbInstance("mydb", "us-west-2")).thenReturn(instance);
         when(service.listDbClusters(null, "us-west-2")).thenReturn(List.of());
@@ -232,7 +235,7 @@ class RdsQueryHandlerTest {
         verify(service).getDbInstance("mydb", "us-west-2");
         verify(service).deleteDbInstance("mydb", "us-west-2");
         verify(service).modifyDbInstance(
-                eq("mydb"), isNull(), isNull(), isNull(), anyList(), eq("us-west-2"));
+                eq("mydb"), isNull(), isNull(), isNull(), anyList(), isNull(), eq("us-west-2"));
         verify(service).rebootDbInstance("mydb", "us-west-2");
         verify(service).listDbClusters(null, "us-west-2");
         verify(service).getDbCluster("mycluster", "us-west-2");
@@ -345,7 +348,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq(null), eq(null), eq(null), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false), eq(false), eq(null),
-                eq(java.util.Map.of("example:ClusterId", "cluster-a", "Name", "mydb")), eq(List.of()), isNull()))
+                eq(java.util.Map.of("example:ClusterId", "cluster-a", "Name", "mydb")), eq(List.of()), isNull(), isNull()))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -359,7 +362,7 @@ class RdsQueryHandlerTest {
 
         verify(service).createDbInstance("mydb", "postgres", "16.3",
                 null, null, null, "db.t3.micro", 20, false, null, null, null, null, false, false, null,
-                java.util.Map.of("example:ClusterId", "cluster-a", "Name", "mydb"), List.of(), null);
+                java.util.Map.of("example:ClusterId", "cluster-a", "Name", "mydb"), List.of(), null, null);
     }
 
     @Test
@@ -369,7 +372,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq(null), eq(null), eq(null), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false), eq(false), eq(null),
-                eq(java.util.Map.of()), eq(List.of("sg-123", "sg-456")), isNull()))
+                eq(java.util.Map.of()), eq(List.of("sg-123", "sg-456")), isNull(), isNull()))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -384,7 +387,7 @@ class RdsQueryHandlerTest {
         assertTrue(body.contains("<VpcSecurityGroupId>sg-456</VpcSecurityGroupId>"));
         verify(service).createDbInstance("mydb", "postgres", "16.3",
                 null, null, null, "db.t3.micro", 20, false, null, null, null, null, false, false, null,
-                java.util.Map.of(), List.of("sg-123", "sg-456"), null);
+                java.util.Map.of(), List.of("sg-123", "sg-456"), null, null);
     }
 
     @Test
@@ -400,7 +403,7 @@ class RdsQueryHandlerTest {
         assertTrue(((String) response.getEntity()).contains("InvalidParameterValue"));
         verify(service, never()).createDbInstance(any(), any(), any(), any(), any(), any(), any(),
                 anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(), anyBoolean(),
-                any(), any(), any(), any());
+                any(), any(), any(), any(), any());
     }
 
     @Test
@@ -414,7 +417,7 @@ class RdsQueryHandlerTest {
         assertEquals(400, response.getStatus());
         assertTrue(((String) response.getEntity()).contains("InvalidParameterValue"));
         verify(service, never()).modifyDbInstance(
-                any(), any(), any(), any(), any(), any());
+                any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -500,7 +503,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq("admin"), eq("secret"), eq("dbname"), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false), eq(false),
-                eq(null), eq(java.util.Map.of()), eq(List.of()), isNull()))
+                eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull()))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -514,7 +517,7 @@ class RdsQueryHandlerTest {
 
         verify(service).createDbInstance("mydb", "postgres", "16.3",
                 "admin", "secret", "dbname", "db.t3.micro", 20, false, null, null, null, null, false, false,
-                null, java.util.Map.of(), List.of(), null);
+                null, java.util.Map.of(), List.of(), null, null);
     }
 
     @Test
@@ -526,7 +529,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq("admin"), eq(null), eq("dbname"), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false), eq(true),
-                eq("kms-key-1"), eq(java.util.Map.of()), eq(List.of()), isNull()))
+                eq("kms-key-1"), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull()))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -545,7 +548,7 @@ class RdsQueryHandlerTest {
         assertTrue(body.contains("<KmsKeyId>kms-key-1</KmsKeyId>"));
         verify(service).createDbInstance("mydb", "postgres", "16.3",
                 "admin", null, "dbname", "db.t3.micro", 20, false, null, null, null, null, false, true,
-                "kms-key-1", java.util.Map.of(), List.of(), null);
+                "kms-key-1", java.util.Map.of(), List.of(), null, null);
     }
 
     @Test
@@ -558,7 +561,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq("admin"), eq("secret"), eq("dbname"), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq("default"), eq(null), eq("ap-northeast-1a"), eq(true),
-                eq(false), eq(null), eq(java.util.Map.of()), eq(List.of()), isNull()))
+                eq(false), eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull()))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -586,7 +589,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq("admin"), eq("secret"), eq("dbname"), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq("missing-subnet-group"), eq(null), eq(null), eq(false),
-                eq(false), eq(null), eq(java.util.Map.of()), eq(List.of()), isNull()))
+                eq(false), eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull()))
                 .thenThrow(new AwsException("DBSubnetGroupNotFoundFault",
                         "DB subnet group missing-subnet-group not found.", 404));
 
@@ -678,7 +681,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("oracle"), eq("1.0"),
                 eq(null), eq(null), eq(null), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false), eq(false),
-                eq(null), eq(java.util.Map.of()), eq(List.of()), isNull()))
+                eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull()))
                 .thenThrow(new AwsException("InvalidParameterValue",
                         "Unsupported engine: oracle. Supported: postgres, mysql, mariadb.", 400));
 
@@ -1504,7 +1507,329 @@ class RdsQueryHandlerTest {
         assertFalse(body.contains("DBClusterNotFoundFault"));
     }
 
+    // ──────────────────────────── Option groups ────────────────────────────
+
+    @Test
+    void createOptionGroup_returnsOptionGroupShape() {
+        when(service.createOptionGroup("og1", "mysql", "8.0", "my og", Map.of(), null))
+                .thenReturn(makeOptionGroup("og1"));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("OptionGroupName", "og1");
+        p.add("EngineName", "mysql");
+        p.add("MajorEngineVersion", "8.0");
+        p.add("OptionGroupDescription", "my og");
+        Response response = handler.handle("CreateOptionGroup", p);
+
+        assertEquals(200, response.getStatus());
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<CreateOptionGroupResult>"), body);
+        assertTrue(body.contains("<OptionGroup>"), body);
+        assertTrue(body.contains("<OptionGroupName>og1</OptionGroupName>"), body);
+        assertTrue(body.contains("<EngineName>mysql</EngineName>"), body);
+        assertTrue(body.contains("<MajorEngineVersion>8.0</MajorEngineVersion>"), body);
+        assertTrue(body.contains("<OptionGroupDescription>my og</OptionGroupDescription>"), body);
+        assertTrue(body.contains(
+                "<OptionGroupArn>arn:aws:rds:us-east-1:123456789012:og:og1</OptionGroupArn>"), body);
+        assertTrue(body.contains(
+                "<AllowsVpcAndNonVpcInstanceMemberships>true</AllowsVpcAndNonVpcInstanceMemberships>"), body);
+        assertTrue(body.contains("<Options></Options>"), body);
+    }
+
+    @Test
+    void createOptionGroup_passesTags() {
+        when(service.createOptionGroup(eq("og1"), eq("mysql"), eq("8.0"), eq("my og"),
+                eq(Map.of("env", "dev")), isNull()))
+                .thenReturn(makeOptionGroup("og1"));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("OptionGroupName", "og1");
+        p.add("EngineName", "mysql");
+        p.add("MajorEngineVersion", "8.0");
+        p.add("OptionGroupDescription", "my og");
+        p.add("Tags.Tag.1.Key", "env");
+        p.add("Tags.Tag.1.Value", "dev");
+        Response response = handler.handle("CreateOptionGroup", p);
+
+        assertEquals(200, response.getStatus());
+        verify(service).createOptionGroup("og1", "mysql", "8.0", "my og", Map.of("env", "dev"), null);
+    }
+
+    @Test
+    void createOptionGroup_requiresMandatoryParameters() {
+        assertEquals(400, handler.handle("CreateOptionGroup", params()).getStatus());
+
+        MultivaluedMap<String, String> noEngine = params();
+        noEngine.add("OptionGroupName", "og1");
+        assertEquals(400, handler.handle("CreateOptionGroup", noEngine).getStatus());
+
+        MultivaluedMap<String, String> noVersion = params();
+        noVersion.add("OptionGroupName", "og1");
+        noVersion.add("EngineName", "mysql");
+        assertEquals(400, handler.handle("CreateOptionGroup", noVersion).getStatus());
+
+        MultivaluedMap<String, String> noDescription = params();
+        noDescription.add("OptionGroupName", "og1");
+        noDescription.add("EngineName", "mysql");
+        noDescription.add("MajorEngineVersion", "8.0");
+        assertEquals(400, handler.handle("CreateOptionGroup", noDescription).getStatus());
+
+        verify(service, never()).createOptionGroup(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void describeOptionGroups_usesOptionGroupsListWrapper() {
+        when(service.listOptionGroups(null, null, null, null))
+                .thenReturn(List.of(makeOptionGroup("og1")));
+
+        Response response = handler.handle("DescribeOptionGroups", params());
+
+        assertEquals(200, response.getStatus());
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<OptionGroupsList>"), body);
+        assertTrue(body.contains("<OptionGroupsList><OptionGroup>"), body);
+        assertTrue(body.contains("</OptionGroup></OptionGroupsList>"), body);
+        assertTrue(body.contains("<Marker></Marker>"), body);
+        assertFalse(body.contains("<member>"), body);
+    }
+
+    @Test
+    void describeOptionGroups_passesFilters() {
+        when(service.listOptionGroups("og1", "mysql", "8.0", null)).thenReturn(List.of());
+
+        MultivaluedMap<String, String> p = params();
+        p.add("OptionGroupName", "og1");
+        p.add("EngineName", "mysql");
+        p.add("MajorEngineVersion", "8.0");
+        handler.handle("DescribeOptionGroups", p);
+
+        verify(service).listOptionGroups("og1", "mysql", "8.0", null);
+    }
+
+    @Test
+    void describeOptionGroups_propagatesNotFoundFault() {
+        when(service.listOptionGroups("missing", null, null, null))
+                .thenThrow(new AwsException("OptionGroupNotFoundFault",
+                        "Option group missing not found.", 404));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("OptionGroupName", "missing");
+        Response response = handler.handle("DescribeOptionGroups", p);
+
+        assertEquals(404, response.getStatus());
+        assertTrue(((String) response.getEntity()).contains("OptionGroupNotFoundFault"));
+    }
+
+    @Test
+    void describeOptionGroups_rendersOptionsWithSettingsAndSecurityGroups() {
+        OptionGroup group = makeOptionGroup("og1");
+        OptionGroupOption option = new OptionGroupOption("MEMCACHED");
+        option.setOptionDescription("Innodb Memcached for MySQL");
+        option.setPort(11211);
+        option.setOptionSettings(new java.util.LinkedHashMap<>(
+                Map.of("BACKLOG_QUEUE_LIMIT", "1024")));
+        option.setVpcSecurityGroupMemberships(List.of("sg-123"));
+        option.setDbSecurityGroupMemberships(List.of("default"));
+        group.setOptions(new java.util.ArrayList<>(List.of(option)));
+        when(service.listOptionGroups(null, null, null, null)).thenReturn(List.of(group));
+
+        Response response = handler.handle("DescribeOptionGroups", params());
+
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<Options><Option>"), body);
+        assertTrue(body.contains("<OptionName>MEMCACHED</OptionName>"), body);
+        assertTrue(body.contains(
+                "<OptionDescription>Innodb Memcached for MySQL</OptionDescription>"), body);
+        assertTrue(body.contains("<Port>11211</Port>"), body);
+        assertTrue(body.contains("<Persistent>false</Persistent>"), body);
+        assertTrue(body.contains("<Permanent>false</Permanent>"), body);
+        assertTrue(body.contains("<OptionSettings><OptionSetting>"
+                + "<Name>BACKLOG_QUEUE_LIMIT</Name><Value>1024</Value>"), body);
+        assertTrue(body.contains("<VpcSecurityGroupMemberships><VpcSecurityGroupMembership>"
+                + "<VpcSecurityGroupId>sg-123</VpcSecurityGroupId>"
+                + "<Status>active</Status>"), body);
+        assertTrue(body.contains("<DBSecurityGroupMemberships><DBSecurityGroup>"
+                + "<DBSecurityGroupName>default</DBSecurityGroupName>"
+                + "<Status>authorized</Status>"), body);
+    }
+
+    @Test
+    void modifyOptionGroup_parsesOptionConfigurations() {
+        when(service.modifyOptionGroup(eq("og1"), anyList(), anyList(), isNull()))
+                .thenReturn(makeOptionGroup("og1"));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("OptionGroupName", "og1");
+        p.add("ApplyImmediately", "true");
+        p.add("OptionsToInclude.OptionConfiguration.1.OptionName", "MEMCACHED");
+        p.add("OptionsToInclude.OptionConfiguration.1.Port", "11211");
+        p.add("OptionsToInclude.OptionConfiguration.1.OptionVersion", "1.0");
+        p.add("OptionsToInclude.OptionConfiguration.1.OptionSettings.OptionSetting.1.Name",
+                "BACKLOG_QUEUE_LIMIT");
+        p.add("OptionsToInclude.OptionConfiguration.1.OptionSettings.OptionSetting.1.Value", "1024");
+        p.add("OptionsToInclude.OptionConfiguration.1.VpcSecurityGroupMemberships"
+                + ".VpcSecurityGroupId.1", "sg-123");
+        p.add("OptionsToInclude.OptionConfiguration.1.DBSecurityGroupMemberships"
+                + ".DBSecurityGroupName.1", "default");
+        Response response = handler.handle("ModifyOptionGroup", p);
+
+        assertEquals(200, response.getStatus());
+        assertTrue(((String) response.getEntity()).contains("<ModifyOptionGroupResult>"));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<OptionGroupOption>> include = ArgumentCaptor.forClass(List.class);
+        verify(service).modifyOptionGroup(eq("og1"), include.capture(), anyList(), isNull());
+        assertEquals(1, include.getValue().size());
+        OptionGroupOption parsed = include.getValue().getFirst();
+        assertEquals("MEMCACHED", parsed.getOptionName());
+        assertEquals(11211, parsed.getPort());
+        assertEquals("1.0", parsed.getOptionVersion());
+        assertEquals(Map.of("BACKLOG_QUEUE_LIMIT", "1024"), parsed.getOptionSettings());
+        assertEquals(List.of("sg-123"), parsed.getVpcSecurityGroupMemberships());
+        assertEquals(List.of("default"), parsed.getDbSecurityGroupMemberships());
+    }
+
+    @Test
+    void modifyOptionGroup_acceptsLegacyMemberEncodingForOptionsToInclude() {
+        when(service.modifyOptionGroup(eq("og1"), anyList(), anyList(), isNull()))
+                .thenReturn(makeOptionGroup("og1"));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("OptionGroupName", "og1");
+        p.add("OptionsToInclude.member.1.OptionName", "MEMCACHED");
+        handler.handle("ModifyOptionGroup", p);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<OptionGroupOption>> include = ArgumentCaptor.forClass(List.class);
+        verify(service).modifyOptionGroup(eq("og1"), include.capture(), anyList(), isNull());
+        assertEquals(1, include.getValue().size());
+        assertEquals("MEMCACHED", include.getValue().getFirst().getOptionName());
+    }
+
+    @Test
+    void modifyOptionGroup_parsesOptionsToRemove() {
+        when(service.modifyOptionGroup(eq("og1"), anyList(), anyList(), isNull()))
+                .thenReturn(makeOptionGroup("og1"));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("OptionGroupName", "og1");
+        p.add("OptionsToRemove.member.1", "MEMCACHED");
+        p.add("OptionsToRemove.member.2", "MARIADB_AUDIT_PLUGIN");
+        handler.handle("ModifyOptionGroup", p);
+
+        verify(service).modifyOptionGroup(eq("og1"), anyList(),
+                eq(List.of("MEMCACHED", "MARIADB_AUDIT_PLUGIN")), isNull());
+    }
+
+    @Test
+    void modifyOptionGroup_rejectsNonNumericPort() {
+        MultivaluedMap<String, String> p = params();
+        p.add("OptionGroupName", "og1");
+        p.add("OptionsToInclude.OptionConfiguration.1.OptionName", "MEMCACHED");
+        p.add("OptionsToInclude.OptionConfiguration.1.Port", "not-a-number");
+        Response response = handler.handle("ModifyOptionGroup", p);
+
+        assertEquals(400, response.getStatus());
+        assertTrue(((String) response.getEntity()).contains("InvalidParameterValue"));
+        verify(service, never()).modifyOptionGroup(any(), anyList(), anyList(), any());
+    }
+
+    @Test
+    void modifyOptionGroup_requiresOptionGroupName() {
+        Response response = handler.handle("ModifyOptionGroup", params());
+
+        assertEquals(400, response.getStatus());
+        verify(service, never()).modifyOptionGroup(any(), anyList(), anyList(), any());
+    }
+
+    @Test
+    void deleteOptionGroup_returnsResultlessEnvelope() {
+        MultivaluedMap<String, String> p = params();
+        p.add("OptionGroupName", "og1");
+        Response response = handler.handle("DeleteOptionGroup", p);
+
+        assertEquals(200, response.getStatus());
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<DeleteOptionGroupResponse"), body);
+        assertFalse(body.contains("<DeleteOptionGroupResult>"), body);
+        verify(service).deleteOptionGroup("og1", null);
+    }
+
+    @Test
+    void deleteOptionGroup_requiresOptionGroupName() {
+        Response response = handler.handle("DeleteOptionGroup", params());
+
+        assertEquals(400, response.getStatus());
+        verify(service, never()).deleteOptionGroup(any(), any());
+    }
+
+    @Test
+    void deleteOptionGroup_propagatesInvalidStateFault() {
+        doThrow(new AwsException("InvalidOptionGroupStateFault",
+                "The option group og1 is in use.", 400))
+                .when(service).deleteOptionGroup("og1", null);
+
+        MultivaluedMap<String, String> p = params();
+        p.add("OptionGroupName", "og1");
+        Response response = handler.handle("DeleteOptionGroup", p);
+
+        assertEquals(400, response.getStatus());
+        assertTrue(((String) response.getEntity()).contains("InvalidOptionGroupStateFault"));
+    }
+
+    @Test
+    void describeDbInstances_includesAttachedOptionGroupMembership() {
+        DbInstance instance = makeInstance("mydb");
+        instance.setOptionGroupName("og1");
+        when(service.listDbInstances(null, null)).thenReturn(List.of(instance));
+
+        Response response = handler.handle("DescribeDBInstances", params());
+
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<OptionGroupMemberships><OptionGroupMembership>"
+                + "<OptionGroupName>og1</OptionGroupName><Status>in-sync</Status>"), body);
+    }
+
+    @Test
+    void describeDbInstances_reportsDefaultOptionGroupWhenUnattached() {
+        DbInstance instance = makeInstance("mydb");
+        instance.setEngineVersion("16.3");
+        when(service.listDbInstances(null, null)).thenReturn(List.of(instance));
+
+        Response response = handler.handle("DescribeDBInstances", params());
+
+        String body = (String) response.getEntity();
+        assertTrue(body.contains(
+                "<OptionGroupName>default:postgres-16</OptionGroupName>"), body);
+    }
+
+    @Test
+    void createDbInstance_passesOptionGroupName() {
+        DbInstance instance = makeInstance("mydb");
+        when(service.createDbInstance(any(), any(), any(), any(), any(), any(), any(),
+                anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(), anyBoolean(),
+                any(), any(), anyList(), any(), any()))
+                .thenReturn(instance);
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBInstanceIdentifier", "mydb");
+        p.add("Engine", "mysql");
+        p.add("OptionGroupName", "og1");
+        Response response = handler.handle("CreateDBInstance", p);
+
+        assertEquals(200, response.getStatus());
+        verify(service).createDbInstance(eq("mydb"), eq("mysql"), any(), any(), any(), any(),
+                any(), anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(),
+                anyBoolean(), any(), any(), anyList(), eq("og1"), any());
+    }
+
     // ──────────────────────────── Helpers ────────────────────────────
+
+    private static OptionGroup makeOptionGroup(String name) {
+        OptionGroup group = new OptionGroup(name, "mysql", "8.0", "my og");
+        group.setOptionGroupArn("arn:aws:rds:us-east-1:123456789012:og:" + name);
+        return group;
+    }
 
     private static MultivaluedMap<String, String> params() {
         return new MultivaluedHashMap<>();

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -24,6 +24,8 @@ import io.github.hectorvent.floci.services.rds.model.DbProxyAuth;
 import io.github.hectorvent.floci.services.rds.model.DbProxyTarget;
 import io.github.hectorvent.floci.services.rds.model.DbProxyTargetGroup;
 import io.github.hectorvent.floci.services.rds.model.DbSubnetGroup;
+import io.github.hectorvent.floci.services.rds.model.OptionGroup;
+import io.github.hectorvent.floci.services.rds.model.OptionGroupOption;
 import io.github.hectorvent.floci.services.rds.proxy.RdsAuthProxy;
 import io.github.hectorvent.floci.services.rds.proxy.RdsProxyManager;
 import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerService;
@@ -559,7 +561,7 @@ class RdsServiceTest {
     @Test
     void tagOperationsRejectUnsupportedResourceArn() {
         AwsException exception = assertThrows(AwsException.class, () ->
-                rdsService.listTagsForResource("arn:aws:rds:us-east-1:123456789012:og:some-option-group"));
+                rdsService.listTagsForResource("arn:aws:rds:us-east-1:123456789012:pg:some-parameter-group"));
 
         assertEquals("InvalidParameterValue", exception.getErrorCode());
         // The type is valid on real AWS; the message must present this as a Floci limitation.
@@ -3724,6 +3726,479 @@ class RdsServiceTest {
         assertTrue(rawTargetGroups.get(targetAccount + "/us-east-1::app-proxy").isPresent());
         assertTrue(rawProxies.get(targetAccount + "/app-proxy").isEmpty());
         assertTrue(rawTargetGroups.get(targetAccount + "/app-proxy").isEmpty());
+    }
+
+    // ── Option Groups ─────────────────────────────────────────────────────────
+
+    @Test
+    void createOptionGroupReturnsArnAndNoOptions() {
+        OptionGroup group = rdsService.createOptionGroup(
+                "og1", "mysql", "8.0", "my option group");
+
+        assertEquals("og1", group.getOptionGroupName());
+        assertEquals("mysql", group.getEngineName());
+        assertEquals("8.0", group.getMajorEngineVersion());
+        assertEquals("my option group", group.getOptionGroupDescription());
+        assertEquals("arn:aws:rds:us-east-1:123456789012:og:og1", group.getOptionGroupArn());
+        assertTrue(group.isAllowsVpcAndNonVpcInstanceMemberships());
+        assertTrue(group.getOptions().isEmpty());
+    }
+
+    @Test
+    void createOptionGroupRejectsDuplicateName() {
+        rdsService.createOptionGroup("og1", "mysql", "8.0", "first");
+
+        AwsException exception = assertThrows(AwsException.class,
+                () -> rdsService.createOptionGroup("og1", "mysql", "8.0", "second"));
+
+        assertEquals("OptionGroupAlreadyExistsFault", exception.getErrorCode());
+        assertEquals(400, exception.getHttpStatus());
+    }
+
+    @Test
+    void createOptionGroupCannotShadowAManagedDefaultName() {
+        // A default group's name contains ':', which the AWS name constraint forbids, so the
+        // name check rejects it before the already-exists check can ever be reached.
+        AwsException exception = assertThrows(AwsException.class,
+                () -> rdsService.createOptionGroup(
+                        "default:mysql-8-0", "mysql", "8.0", "shadowing a default"));
+
+        assertEquals("InvalidParameterValue", exception.getErrorCode());
+        assertEquals("mysql", rdsService.getOptionGroup("default:mysql-8-0").getEngineName());
+    }
+
+    @Test
+    void createOptionGroupRejectsUnknownEngine() {
+        AwsException exception = assertThrows(AwsException.class,
+                () -> rdsService.createOptionGroup("og1", "cassandra", "5.0", "nope"));
+
+        assertEquals("InvalidParameterValue", exception.getErrorCode());
+        assertEquals(400, exception.getHttpStatus());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "1og",              // must start with a letter
+            "-og",              // must start with a letter
+            "og-",              // can't end with a hyphen
+            "og--1",            // can't contain two consecutive hyphens
+            "og_1",             // only letters, numbers and hyphens
+            "og name"           // only letters, numbers and hyphens
+    })
+    void createOptionGroupRejectsNamesThatViolateAwsConstraints(String name) {
+        AwsException exception = assertThrows(AwsException.class,
+                () -> rdsService.createOptionGroup(name, "mysql", "8.0", "bad name"));
+
+        assertEquals("InvalidParameterValue", exception.getErrorCode());
+        assertEquals(400, exception.getHttpStatus());
+    }
+
+    @Test
+    void createOptionGroupRejectsNameLongerThan255Characters() {
+        String name = "o" + "g".repeat(255);
+
+        AwsException exception = assertThrows(AwsException.class,
+                () -> rdsService.createOptionGroup(name, "mysql", "8.0", "too long"));
+
+        assertEquals("InvalidParameterValue", exception.getErrorCode());
+    }
+
+    @Test
+    void createOptionGroupAcceptsHyphenatedAlphanumericName() {
+        OptionGroup group = rdsService.createOptionGroup(
+                "my-og-1", "mysql", "8.0", "valid name");
+
+        assertEquals("my-og-1", group.getOptionGroupName());
+    }
+
+    @Test
+    void getOptionGroupThrowsOptionGroupNotFoundFaultForUnknownName() {
+        AwsException exception = assertThrows(AwsException.class,
+                () -> rdsService.getOptionGroup("missing"));
+
+        assertEquals("OptionGroupNotFoundFault", exception.getErrorCode());
+        assertEquals(404, exception.getHttpStatus());
+    }
+
+    @Test
+    void listOptionGroupsAlwaysIncludesManagedDefaults() {
+        List<String> names = rdsService.listOptionGroups(null, null, null).stream()
+                .map(OptionGroup::getOptionGroupName)
+                .toList();
+
+        assertTrue(names.contains("default:mysql-8-0"), names.toString());
+        assertTrue(names.contains("default:postgres-16"), names.toString());
+        assertTrue(names.contains("default:mariadb-11-4"), names.toString());
+    }
+
+    @Test
+    void listOptionGroupsIncludesCreatedGroupsAlongsideDefaults() {
+        rdsService.createOptionGroup("og1", "mysql", "8.0", "mine");
+
+        List<String> names = rdsService.listOptionGroups(null, null, null).stream()
+                .map(OptionGroup::getOptionGroupName)
+                .toList();
+
+        assertTrue(names.contains("og1"), names.toString());
+        assertTrue(names.contains("default:mysql-8-0"), names.toString());
+    }
+
+    @Test
+    void listOptionGroupsFiltersByEngineName() {
+        rdsService.createOptionGroup("og-oracle", "oracle-ee", "19", "oracle");
+
+        Collection<OptionGroup> groups = rdsService.listOptionGroups(null, "oracle-ee", null);
+
+        assertFalse(groups.isEmpty());
+        assertTrue(groups.stream().allMatch(group -> "oracle-ee".equals(group.getEngineName())));
+        assertTrue(groups.stream()
+                .anyMatch(group -> "og-oracle".equals(group.getOptionGroupName())));
+    }
+
+    @Test
+    void listOptionGroupsFiltersByMajorEngineVersion() {
+        Collection<OptionGroup> groups = rdsService.listOptionGroups(null, "mysql", "8.4");
+
+        assertEquals(1, groups.size());
+        assertEquals("default:mysql-8-4", groups.iterator().next().getOptionGroupName());
+    }
+
+    @Test
+    void listOptionGroupsRejectsMajorEngineVersionWithoutEngineName() {
+        AwsException exception = assertThrows(AwsException.class,
+                () -> rdsService.listOptionGroups(null, null, "8.0"));
+
+        assertEquals("InvalidParameterCombination", exception.getErrorCode());
+    }
+
+    @Test
+    void listOptionGroupsByUnknownNameThrowsInsteadOfReturningEmptyList() {
+        AwsException exception = assertThrows(AwsException.class,
+                () -> rdsService.listOptionGroups("missing", null, null));
+
+        assertEquals("OptionGroupNotFoundFault", exception.getErrorCode());
+        assertEquals(404, exception.getHttpStatus());
+    }
+
+    @Test
+    void listOptionGroupsByNameResolvesManagedDefault() {
+        Collection<OptionGroup> groups =
+                rdsService.listOptionGroups("default:postgres-16", null, null);
+
+        assertEquals(1, groups.size());
+        OptionGroup group = groups.iterator().next();
+        assertEquals("postgres", group.getEngineName());
+        assertEquals("16", group.getMajorEngineVersion());
+    }
+
+    @Test
+    void modifyOptionGroupAddsOptions() {
+        rdsService.createOptionGroup("og1", "mariadb", "11.4", "mine");
+        OptionGroupOption option = new OptionGroupOption("MARIADB_AUDIT_PLUGIN");
+        option.setPort(11211);
+        option.setOptionSettings(new java.util.LinkedHashMap<>(
+                Map.of("SERVER_AUDIT_EVENTS", "CONNECT")));
+        option.setVpcSecurityGroupMemberships(List.of("sg-123"));
+
+        OptionGroup group = rdsService.modifyOptionGroup("og1", List.of(option), List.of());
+
+        assertEquals(1, group.getOptions().size());
+        OptionGroupOption stored = group.getOptions().getFirst();
+        assertEquals("MARIADB_AUDIT_PLUGIN", stored.getOptionName());
+        assertEquals(11211, stored.getPort());
+        assertEquals("CONNECT", stored.getOptionSettings().get("SERVER_AUDIT_EVENTS"));
+        assertEquals(List.of("sg-123"), stored.getVpcSecurityGroupMemberships());
+        assertEquals(1, rdsService.getOptionGroup("og1").getOptions().size());
+    }
+
+    @Test
+    void modifyOptionGroupUpdatesAnExistingOptionInPlace() {
+        rdsService.createOptionGroup("og1", "mariadb", "11.4", "mine");
+        OptionGroupOption first = new OptionGroupOption("MARIADB_AUDIT_PLUGIN");
+        first.setOptionSettings(new java.util.LinkedHashMap<>(
+                Map.of("SERVER_AUDIT_EVENTS", "CONNECT")));
+        rdsService.modifyOptionGroup("og1", List.of(first), List.of());
+
+        OptionGroupOption update = new OptionGroupOption("MARIADB_AUDIT_PLUGIN");
+        update.setOptionSettings(new java.util.LinkedHashMap<>(
+                Map.of("SERVER_AUDIT_EVENTS", "CONNECT,QUERY")));
+        OptionGroup group = rdsService.modifyOptionGroup("og1", List.of(update), List.of());
+
+        assertEquals(1, group.getOptions().size());
+        assertEquals("CONNECT,QUERY",
+                group.getOptions().getFirst().getOptionSettings().get("SERVER_AUDIT_EVENTS"));
+    }
+
+    @Test
+    void modifyOptionGroupRemovesOptions() {
+        rdsService.createOptionGroup("og1", "mysql", "8.0", "mine");
+        rdsService.modifyOptionGroup(
+                "og1", List.of(new OptionGroupOption("MEMCACHED")), List.of());
+
+        OptionGroup group = rdsService.modifyOptionGroup("og1", List.of(), List.of("MEMCACHED"));
+
+        assertTrue(group.getOptions().isEmpty());
+        assertTrue(rdsService.getOptionGroup("og1").getOptions().isEmpty());
+    }
+
+    @Test
+    void modifyOptionGroupThrowsForUnknownGroup() {
+        AwsException exception = assertThrows(AwsException.class,
+                () -> rdsService.modifyOptionGroup("missing", List.of(), List.of()));
+
+        assertEquals("OptionGroupNotFoundFault", exception.getErrorCode());
+        assertEquals(404, exception.getHttpStatus());
+    }
+
+    @Test
+    void modifyOptionGroupRejectsManagedDefault() {
+        AwsException exception = assertThrows(AwsException.class,
+                () -> rdsService.modifyOptionGroup("default:mysql-8-0",
+                        List.of(new OptionGroupOption("MEMCACHED")), List.of()));
+
+        assertEquals("InvalidOptionGroupStateFault", exception.getErrorCode());
+        assertEquals(400, exception.getHttpStatus());
+    }
+
+    @Test
+    void deleteOptionGroupRemovesTheGroup() {
+        rdsService.createOptionGroup("og1", "mysql", "8.0", "mine");
+
+        rdsService.deleteOptionGroup("og1");
+
+        AwsException exception = assertThrows(AwsException.class,
+                () -> rdsService.getOptionGroup("og1"));
+        assertEquals("OptionGroupNotFoundFault", exception.getErrorCode());
+    }
+
+    @Test
+    void deleteOptionGroupThrowsForUnknownGroup() {
+        AwsException exception = assertThrows(AwsException.class,
+                () -> rdsService.deleteOptionGroup("missing"));
+
+        assertEquals("OptionGroupNotFoundFault", exception.getErrorCode());
+        assertEquals(404, exception.getHttpStatus());
+    }
+
+    @Test
+    void deleteOptionGroupRejectsManagedDefault() {
+        AwsException exception = assertThrows(AwsException.class,
+                () -> rdsService.deleteOptionGroup("default:mysql-8-0"));
+
+        assertEquals("InvalidOptionGroupStateFault", exception.getErrorCode());
+        assertEquals(400, exception.getHttpStatus());
+    }
+
+    @Test
+    void deleteOptionGroupRejectsGroupStillAttachedToAnInstance() {
+        rdsService.createOptionGroup("og1", "mysql", "8.0", "mine");
+        createInstanceWithOptionGroup("mydb", "mysql", "8.0", "og1");
+
+        AwsException exception = assertThrows(AwsException.class,
+                () -> rdsService.deleteOptionGroup("og1"));
+
+        assertEquals("InvalidOptionGroupStateFault", exception.getErrorCode());
+        assertEquals(400, exception.getHttpStatus());
+    }
+
+    @Test
+    void optionGroupsAreScopedByRegion() {
+        rdsService.createOptionGroup("og1", "mysql", "8.0", "mine", Map.of(), "us-east-1");
+
+        AwsException exception = assertThrows(AwsException.class,
+                () -> rdsService.getOptionGroup("og1", "eu-west-1"));
+
+        assertEquals("OptionGroupNotFoundFault", exception.getErrorCode());
+        assertEquals("arn:aws:rds:us-east-1:123456789012:og:og1",
+                rdsService.getOptionGroup("og1", "us-east-1").getOptionGroupArn());
+    }
+
+    @Test
+    void createDbInstanceStoresAttachedOptionGroup() {
+        rdsService.createOptionGroup("og1", "mysql", "8.0", "mine");
+
+        DbInstance instance = createInstanceWithOptionGroup("mydb", "mysql", "8.0", "og1");
+
+        assertEquals("og1", instance.getOptionGroupName());
+        assertEquals("og1", rdsService.getDbInstance("mydb").getOptionGroupName());
+    }
+
+    @Test
+    void createDbInstanceRejectsUnknownOptionGroup() {
+        AwsException exception = assertThrows(AwsException.class,
+                () -> createInstanceWithOptionGroup("mydb", "mysql", "8.0", "missing"));
+
+        assertEquals("OptionGroupNotFoundFault", exception.getErrorCode());
+    }
+
+    @Test
+    void createDbInstanceRejectsOptionGroupForAnotherEngine() {
+        rdsService.createOptionGroup("og1", "mysql", "8.0", "mine");
+
+        AwsException exception = assertThrows(AwsException.class,
+                () -> createInstanceWithOptionGroup("mydb", "postgres", "16.3", "og1"));
+
+        assertEquals("InvalidParameterCombination", exception.getErrorCode());
+    }
+
+    @Test
+    void createDbInstanceRejectsOptionGroupForAnotherMajorEngineVersion() {
+        rdsService.createOptionGroup("og1", "mysql", "8.0", "mine");
+
+        AwsException exception = assertThrows(AwsException.class,
+                () -> createInstanceWithOptionGroup("mydb", "mysql", "8.4.3", "og1"));
+
+        assertEquals("InvalidParameterCombination", exception.getErrorCode());
+    }
+
+    @Test
+    void createDbInstanceRejectsPostgresOptionGroupForAnotherMajorEngineVersion() {
+        rdsService.createOptionGroup("og1", "postgres", "13", "mine");
+
+        AwsException exception = assertThrows(AwsException.class,
+                () -> createInstanceWithOptionGroup("mydb", "postgres", "16.3", "og1"));
+
+        assertEquals("InvalidParameterCombination", exception.getErrorCode());
+    }
+
+    @Test
+    void createDbInstanceAcceptsOptionGroupMatchingTheInstanceMajorEngineVersion() {
+        rdsService.createOptionGroup("og1", "mysql", "8.0", "mine");
+
+        DbInstance instance = createInstanceWithOptionGroup("mydb", "mysql", "8.0.36", "og1");
+
+        assertEquals("og1", instance.getOptionGroupName());
+    }
+
+    @Test
+    void createDbInstanceAcceptsPostgresOptionGroupRegardlessOfTheMinorVersion() {
+        rdsService.createOptionGroup("og1", "postgres", "16", "mine");
+
+        DbInstance instance = createInstanceWithOptionGroup("mydb", "postgres", "16.3", "og1");
+
+        assertEquals("og1", instance.getOptionGroupName());
+    }
+
+    @Test
+    void createDbInstanceAcceptsManagedDefaultOptionGroup() {
+        DbInstance instance =
+                createInstanceWithOptionGroup("mydb", "mysql", "8.0", "default:mysql-8-0");
+
+        assertEquals("default:mysql-8-0", instance.getOptionGroupName());
+    }
+
+    @Test
+    void optionGroupIsTaggableByArn() {
+        OptionGroup group = rdsService.createOptionGroup("og1", "mysql", "8.0", "mine");
+
+        rdsService.addTagsToResource(group.getOptionGroupArn(), Map.of("env", "dev"));
+
+        assertEquals(Map.of("env", "dev"),
+                rdsService.listTagsForResource(group.getOptionGroupArn()));
+    }
+
+    @Test
+    void defaultOptionGroupCannotBeTagged() {
+        AwsException exception = assertThrows(AwsException.class, () ->
+                rdsService.addTagsToResource(
+                        "arn:aws:rds:us-east-1:123456789012:og:default:mysql-8-0",
+                        Map.of("env", "dev")));
+
+        assertEquals("InvalidOptionGroupStateFault", exception.getErrorCode());
+    }
+
+    @Test
+    void modifyDbInstanceAttachesOptionGroup() {
+        rdsService.createOptionGroup("og1", "mysql", "8.0", "mine");
+        createInstanceWithOptionGroup("mydb", "mysql", "8.0", null);
+
+        DbInstance modified = rdsService.modifyDbInstance(
+                "mydb", null, null, null, List.of(), "og1", "us-east-1");
+
+        assertEquals("og1", modified.getOptionGroupName());
+        assertEquals("og1", rdsService.getDbInstance("mydb").getOptionGroupName());
+    }
+
+    @Test
+    void modifyDbInstanceRejectsOptionGroupForAnotherEngine() {
+        rdsService.createOptionGroup("og1", "postgres", "16", "mine");
+        createInstanceWithOptionGroup("mydb", "mysql", "8.0", null);
+
+        AwsException exception = assertThrows(AwsException.class, () ->
+                rdsService.modifyDbInstance(
+                        "mydb", null, null, null, List.of(), "og1", "us-east-1"));
+
+        assertEquals("InvalidParameterCombination", exception.getErrorCode());
+    }
+
+    @Test
+    void modifyDbInstanceRejectsOptionGroupForAnotherMajorEngineVersion() {
+        rdsService.createOptionGroup("og1", "mysql", "8.4", "mine");
+        createInstanceWithOptionGroup("mydb", "mysql", "8.0.36", null);
+
+        AwsException exception = assertThrows(AwsException.class, () ->
+                rdsService.modifyDbInstance(
+                        "mydb", null, null, null, List.of(), "og1", "us-east-1"));
+
+        assertEquals("InvalidParameterCombination", exception.getErrorCode());
+    }
+
+    @Test
+    void modifyDbInstanceAcceptsOptionGroupMatchingTheInstanceMajorEngineVersion() {
+        rdsService.createOptionGroup("og1", "mysql", "8.0", "mine");
+        createInstanceWithOptionGroup("mydb", "mysql", "8.0.36", null);
+
+        DbInstance modified = rdsService.modifyDbInstance(
+                "mydb", null, null, null, List.of(), "og1", "us-east-1");
+
+        assertEquals("og1", modified.getOptionGroupName());
+    }
+
+    @Test
+    void optionGroupsUseTheInjectedAccountAwareStorage() {
+        String accountId = "123456789012";
+        InMemoryStorage<String, OptionGroup> rawOptionGroups = new InMemoryStorage<>();
+        RdsService service = optionGroupStoreService(regionResolver,
+                new AccountAwareStorageBackend<>(rawOptionGroups, null, accountId));
+
+        service.createOptionGroup("og1", "mysql", "8.0", "mine", Map.of(), "us-east-1");
+
+        assertTrue(rawOptionGroups.get(accountId + "/us-east-1::og1").isPresent());
+    }
+
+    @Test
+    void sameNamedOptionGroupsInDifferentAccountsAreIsolated() {
+        String accountA = "111111111111";
+        String accountB = "222222222222";
+        InMemoryStorage<String, OptionGroup> rawOptionGroups = new InMemoryStorage<>();
+        RdsService serviceA = optionGroupStoreService(
+                new RegionResolver("us-east-1", accountA),
+                new AccountAwareStorageBackend<>(rawOptionGroups, null, accountA));
+        RdsService serviceB = optionGroupStoreService(
+                new RegionResolver("us-east-1", accountB),
+                new AccountAwareStorageBackend<>(rawOptionGroups, null, accountB));
+
+        serviceA.createOptionGroup("og1", "mysql", "8.0", "account a", Map.of(), "us-east-1");
+        serviceB.createOptionGroup("og1", "postgres", "16", "account b", Map.of(), "us-east-1");
+        serviceA.deleteOptionGroup("og1", "us-east-1");
+
+        assertThrows(AwsException.class, () -> serviceA.getOptionGroup("og1", "us-east-1"));
+        assertEquals("postgres", serviceB.getOptionGroup("og1", "us-east-1").getEngineName());
+    }
+
+    private RdsService optionGroupStoreService(
+            RegionResolver resolver, StorageBackend<String, OptionGroup> optionGroups) {
+        return new RdsService(containerManager, proxyManager, ec2Service, resolver, config,
+                new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
+                new InMemoryStorage<>(), new InMemoryStorage<>(), null, null, null,
+                new InMemoryStorage<>(), new InMemoryStorage<>(), optionGroups);
+    }
+
+    private DbInstance createInstanceWithOptionGroup(
+            String id, String engine, String engineVersion, String optionGroupName) {
+        return rdsService.createDbInstance(id, engine, engineVersion, "admin", "password",
+                "dbname", "db.t3.micro", 20, false, null, null, null, null, false, false,
+                null, Map.of(), List.of(), optionGroupName, null);
     }
 
     private RdsService newService(RdsContainerManager containerManager,

--- a/tools/docs/services.yaml
+++ b/tools/docs/services.yaml
@@ -74,7 +74,7 @@ services:
     doc: docs/services/rds.md
     sources:
       - { path: src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java, mode: switch }
-    exclude_actions: [SubnetIds, VpcSecurityGroupIds]
+    exclude_actions: [SubnetIds, VpcSecurityGroupIds, OptionsToRemove]
   - service: secretsmanager
     doc: docs/services/secrets-manager.md
     sources:


### PR DESCRIPTION
## Summary

Implements the four RDS option group actions. Closes #2304.

`CreateOptionGroup`, `DescribeOptionGroups`, `ModifyOptionGroup` and `DeleteOptionGroup` follow the
shape the two sibling group types already use in `services/rds`: a `StorageFactory` backing store,
per-account and per-region keys via `dbResourceKey`, and a managed-defaults list mirroring
`MANAGED_CLUSTER_PARAMETER_GROUPS`. Option groups are also taggable through the `og:` ARN form of
`AddTagsToResource`, which `resolveTagHandle` previously listed as not yet implemented.

`DescribeOptionGroups` returns the implicit `default:<engine>-<major version>` groups even when the
caller has created none, as AWS does. That list is scoped to the engines Floci can actually run
(`postgres 13` to `18`, `mysql 8.0`/`8.4`, `mariadb 10.11`/`11.2`/`11.4`), so every instance Floci
can create resolves to a default the action also returns; inventing the Oracle and SQL Server
version matrix would be fabricating data. `CreateOptionGroup` still validates `EngineName` against
the full list AWS accepts, so an `aws_db_option_group` for `oracle-ee` or `sqlserver-ex` applies
normally; option groups are metadata, they don't need the engine running.

DB instances now carry an option group too: `CreateDBInstance` and `ModifyDBInstance` accept
`OptionGroupName` (validated against the instance engine and major engine version) and
`DescribeDBInstances` reports
`OptionGroupMemberships`. This is one step past the four actions, but the issue requires
`DeleteOptionGroup` to fault with `InvalidOptionGroupStateFault` for a group still attached to an
instance, and without modelling the association that error would be unreachable code. It is also
what the issue's "Why is this needed?" describes.

Three things I deliberately left out, happy to open them as issues if you agree they're worth having:

1. **`CopyOptionGroup`**, small now that the model is complete. It is also where `SourceOptionGroup`,
   `SourceAccountId` and `CopyTimestamp` would finally get populated; they are omitted today because
   nothing can set them.
2. **`DescribeOptionGroupOptions`**, the per-engine option catalog. Bigger than it looks: it is what
   would let `DescribeOptionGroups` return real `OptionSetting` metadata, so the two are effectively
   one piece of work.
3. **Pagination for the RDS list actions.** All eight emit an empty `<Marker>` today. Worth doing
   across all of them at once rather than only here, so the service stays internally consistent.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified with **AWS SDK for Java v2 `2.44.14`** against a running Floci, via the new
`RdsControlPlaneTest` cases. Not verified with the AWS CLI.

Wire shapes came from the RDS API Reference rather than from memory, which caught several things:

- the `DescribeOptionGroups` list wrapper is `OptionGroupsList`, not `OptionGroups`
- `DeleteOptionGroup` returns **no** `Result` element, only `ResponseMetadata`
- an unknown `OptionGroupName` faults with `OptionGroupNotFoundFault` (404) rather than returning an
  empty list, which is what a Terraform refresh relies on to detect a deleted group
- the list member name differs between request and response for the same data:
  `DBSecurityGroupMemberships.DBSecurityGroupName.N` inbound vs `.DBSecurityGroup.N` outbound
- `OptionsToInclude` uses the custom `.OptionConfiguration.N` member name while `OptionsToRemove`
  uses plain `.member.N`; both are parsed, plus the legacy `.member.N` form older SDKs emit for
  `OptionsToInclude`
- the `OptionGroupName` constraints mean a name can never collide with a default, since `:` is not
  an allowed character, so shadowing `default:mysql-8-0` fails with `InvalidParameterValue` rather
  than `OptionGroupAlreadyExistsFault`
- an option group is scoped to one major engine version, so attaching a `mysql 8.0` group to a
  `mysql 8.4` instance fails with `InvalidParameterCombination` even though the engine matches.
  The major version is the leading component for postgres and `major.minor` for the MySQL-family
  engines, which is the same rule that names the implicit `default:` groups

Known deviations, documented in `docs/services/rds.md` so they read as choices rather than misses:
the 20-group `OptionGroupQuotaExceededFault` is not enforced (capping a local emulator would only
get in a test's way); `OptionSetting` metadata (`DataType`, `AllowedValues`, `DefaultValue`, and so
on) is omitted, since it needs the catalog `DescribeOptionGroupOptions` serves and a partial one
would be worse than a consistent omission; and results are returned in a single page, as with every
other RDS list action.

`make docs-sync` was run. `OptionsToRemove` was added to `exclude_actions` in
`tools/docs/services.yaml` because the generator reads every `case "X" ->` in the handler as an
action, and that label belongs to `memberKeyRegex`, not the action dispatcher. `SubnetIds` and
`VpcSecurityGroupIds` were already excluded for the same reason.

## Checklist

- [x] `./mvnw test` passes locally, with the caveat below
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

47 new unit tests in `RdsServiceTest` and `RdsQueryHandlerTest`, written before the implementation,
plus 4 SDK round-trip tests in `RdsControlPlaneTest` that assert the official SDK unmarshals the XML
and that `OptionGroupNotFoundException` and `InvalidOptionGroupStateException` surface as typed
exceptions on the client. 355 unit tests and 11 compatibility tests green.

On the first box: the full `./mvnw test` reports errors in the API Gateway v2 WebSocket suites and
in `LambdaReactiveSyncIntegrationTest`, `SwfLambdaIntegrationTest`,
`LambdaExecutionRoleDockerIntegrationTest` and `ElbV2LambdaTargetDataPlaneIntegrationTest`
(`WebSocketHandshakeException`, `SocketTimeout` on Lambda prewarm). They are pre-existing on my
machine rather than caused by this change: `WebSocketProxyEventFormatTest` fails with the identical
12 errors in a clean `git worktree` at `main` (`d819c00d`). No RDS suite fails.

